### PR TITLE
Use a blank indentifier instead of an anonymous field for SDKShapeTraits

### DIFF
--- a/aws/corehandlers/param_validator_test.go
+++ b/aws/corehandlers/param_validator_test.go
@@ -32,17 +32,12 @@ type StructShape struct {
 	OptionalStruct *ConditionalStructShape
 
 	hiddenParameter *string
-
-	metadataStructureShape
-}
-
-type metadataStructureShape struct {
-	SDKShapeTraits bool
+	_               struct{}
 }
 
 type ConditionalStructShape struct {
-	Name           *string `required:"true"`
-	SDKShapeTraits bool
+	Name *string `required:"true"`
+	_    struct{}
 }
 
 func TestNoErrors(t *testing.T) {

--- a/private/model/api/passes.go
+++ b/private/model/api/passes.go
@@ -182,8 +182,8 @@ func (a *API) renameExportable() {
 				}
 			}
 
-			if newName == "SDKShapeTraits" {
-				panic("Shape " + s.ShapeName + " uses reserved member name SDKShapeTraits")
+			if newName == "_" {
+				panic("Shape " + s.ShapeName + " uses reserved member name '_'")
 			}
 		}
 

--- a/private/model/api/shape.go
+++ b/private/model/api/shape.go
@@ -318,9 +318,13 @@ func (s *Shape) GoCode() string {
 	if !s.IsEnum() {
 		code += "type " + s.ShapeName + " "
 	}
+
 	switch {
 	case s.Type == "structure":
+		ref := &ShapeRef{ShapeName: s.ShapeName, API: s.API, Shape: s}
+
 		code += "struct {\n"
+		code += "_ struct{} " + ref.GoTags(true, false) + "\n\n"
 		for _, n := range s.MemberNames() {
 			m := s.MemberRefs[n]
 			code += m.Docstring()
@@ -338,8 +342,6 @@ func (s *Shape) GoCode() string {
 				code += n + " " + m.GoType() + " " + m.GoTags(false, s.IsRequired(n)) + "\n\n"
 			}
 		}
-		ref := &ShapeRef{ShapeName: s.ShapeName, API: s.API, Shape: s}
-		code += "_ struct{} " + ref.GoTags(true, false)
 		code += "}"
 
 		if !s.API.NoStringerMethods {

--- a/private/model/api/shape.go
+++ b/private/model/api/shape.go
@@ -338,12 +338,8 @@ func (s *Shape) GoCode() string {
 				code += n + " " + m.GoType() + " " + m.GoTags(false, s.IsRequired(n)) + "\n\n"
 			}
 		}
-		metaStruct := "metadata" + s.ShapeName
 		ref := &ShapeRef{ShapeName: s.ShapeName, API: s.API, Shape: s}
-		code += "\n" + metaStruct + "  `json:\"-\" xml:\"-\"`\n"
-		code += "}\n\n"
-		code += "type " + metaStruct + " struct {\n"
-		code += "SDKShapeTraits bool " + ref.GoTags(true, false)
+		code += "_ struct{} " + ref.GoTags(true, false)
 		code += "}"
 
 		if !s.API.NoStringerMethods {

--- a/private/protocol/ec2query/build_test.go
+++ b/private/protocol/ec2query/build_test.go
@@ -120,19 +120,11 @@ type InputService1TestShapeInputService1TestCaseOperation1Input struct {
 
 	Foo *string `type:"string"`
 
-	metadataInputService1TestShapeInputService1TestCaseOperation1Input `json:"-" xml:"-"`
-}
-
-type metadataInputService1TestShapeInputService1TestCaseOperation1Input struct {
-	SDKShapeTraits bool `type:"structure"`
+	_ struct{} `type:"structure"`
 }
 
 type InputService1TestShapeInputService1TestCaseOperation1Output struct {
-	metadataInputService1TestShapeInputService1TestCaseOperation1Output `json:"-" xml:"-"`
-}
-
-type metadataInputService1TestShapeInputService1TestCaseOperation1Output struct {
-	SDKShapeTraits bool `type:"structure"`
+	_ struct{} `type:"structure"`
 }
 
 //The service client's operations are safe to be used concurrently.
@@ -220,19 +212,11 @@ type InputService2TestShapeInputService2TestCaseOperation1Input struct {
 
 	Yuck *string `locationName:"yuckLocationName" queryName:"yuckQueryName" type:"string"`
 
-	metadataInputService2TestShapeInputService2TestCaseOperation1Input `json:"-" xml:"-"`
-}
-
-type metadataInputService2TestShapeInputService2TestCaseOperation1Input struct {
-	SDKShapeTraits bool `type:"structure"`
+	_ struct{} `type:"structure"`
 }
 
 type InputService2TestShapeInputService2TestCaseOperation1Output struct {
-	metadataInputService2TestShapeInputService2TestCaseOperation1Output `json:"-" xml:"-"`
-}
-
-type metadataInputService2TestShapeInputService2TestCaseOperation1Output struct {
-	SDKShapeTraits bool `type:"structure"`
+	_ struct{} `type:"structure"`
 }
 
 //The service client's operations are safe to be used concurrently.
@@ -316,29 +300,17 @@ func (c *InputService3ProtocolTest) InputService3TestCaseOperation1(input *Input
 type InputService3TestShapeInputService3TestCaseOperation1Input struct {
 	StructArg *InputService3TestShapeStructType `locationName:"Struct" type:"structure"`
 
-	metadataInputService3TestShapeInputService3TestCaseOperation1Input `json:"-" xml:"-"`
-}
-
-type metadataInputService3TestShapeInputService3TestCaseOperation1Input struct {
-	SDKShapeTraits bool `type:"structure"`
+	_ struct{} `type:"structure"`
 }
 
 type InputService3TestShapeInputService3TestCaseOperation1Output struct {
-	metadataInputService3TestShapeInputService3TestCaseOperation1Output `json:"-" xml:"-"`
-}
-
-type metadataInputService3TestShapeInputService3TestCaseOperation1Output struct {
-	SDKShapeTraits bool `type:"structure"`
+	_ struct{} `type:"structure"`
 }
 
 type InputService3TestShapeStructType struct {
 	ScalarArg *string `locationName:"Scalar" type:"string"`
 
-	metadataInputService3TestShapeStructType `json:"-" xml:"-"`
-}
-
-type metadataInputService3TestShapeStructType struct {
-	SDKShapeTraits bool `type:"structure"`
+	_ struct{} `type:"structure"`
 }
 
 //The service client's operations are safe to be used concurrently.
@@ -422,19 +394,11 @@ func (c *InputService4ProtocolTest) InputService4TestCaseOperation1(input *Input
 type InputService4TestShapeInputService4TestCaseOperation1Input struct {
 	ListArg []*string `type:"list"`
 
-	metadataInputService4TestShapeInputService4TestCaseOperation1Input `json:"-" xml:"-"`
-}
-
-type metadataInputService4TestShapeInputService4TestCaseOperation1Input struct {
-	SDKShapeTraits bool `type:"structure"`
+	_ struct{} `type:"structure"`
 }
 
 type InputService4TestShapeInputService4TestCaseOperation1Output struct {
-	metadataInputService4TestShapeInputService4TestCaseOperation1Output `json:"-" xml:"-"`
-}
-
-type metadataInputService4TestShapeInputService4TestCaseOperation1Output struct {
-	SDKShapeTraits bool `type:"structure"`
+	_ struct{} `type:"structure"`
 }
 
 //The service client's operations are safe to be used concurrently.
@@ -518,19 +482,11 @@ func (c *InputService5ProtocolTest) InputService5TestCaseOperation1(input *Input
 type InputService5TestShapeInputService5TestCaseOperation1Input struct {
 	ListArg []*string `locationName:"ListMemberName" locationNameList:"item" type:"list"`
 
-	metadataInputService5TestShapeInputService5TestCaseOperation1Input `json:"-" xml:"-"`
-}
-
-type metadataInputService5TestShapeInputService5TestCaseOperation1Input struct {
-	SDKShapeTraits bool `type:"structure"`
+	_ struct{} `type:"structure"`
 }
 
 type InputService5TestShapeInputService5TestCaseOperation1Output struct {
-	metadataInputService5TestShapeInputService5TestCaseOperation1Output `json:"-" xml:"-"`
-}
-
-type metadataInputService5TestShapeInputService5TestCaseOperation1Output struct {
-	SDKShapeTraits bool `type:"structure"`
+	_ struct{} `type:"structure"`
 }
 
 //The service client's operations are safe to be used concurrently.
@@ -614,19 +570,11 @@ func (c *InputService6ProtocolTest) InputService6TestCaseOperation1(input *Input
 type InputService6TestShapeInputService6TestCaseOperation1Input struct {
 	ListArg []*string `locationName:"ListMemberName" queryName:"ListQueryName" locationNameList:"item" type:"list"`
 
-	metadataInputService6TestShapeInputService6TestCaseOperation1Input `json:"-" xml:"-"`
-}
-
-type metadataInputService6TestShapeInputService6TestCaseOperation1Input struct {
-	SDKShapeTraits bool `type:"structure"`
+	_ struct{} `type:"structure"`
 }
 
 type InputService6TestShapeInputService6TestCaseOperation1Output struct {
-	metadataInputService6TestShapeInputService6TestCaseOperation1Output `json:"-" xml:"-"`
-}
-
-type metadataInputService6TestShapeInputService6TestCaseOperation1Output struct {
-	SDKShapeTraits bool `type:"structure"`
+	_ struct{} `type:"structure"`
 }
 
 //The service client's operations are safe to be used concurrently.
@@ -710,19 +658,11 @@ func (c *InputService7ProtocolTest) InputService7TestCaseOperation1(input *Input
 type InputService7TestShapeInputService7TestCaseOperation1Input struct {
 	BlobArg []byte `type:"blob"`
 
-	metadataInputService7TestShapeInputService7TestCaseOperation1Input `json:"-" xml:"-"`
-}
-
-type metadataInputService7TestShapeInputService7TestCaseOperation1Input struct {
-	SDKShapeTraits bool `type:"structure"`
+	_ struct{} `type:"structure"`
 }
 
 type InputService7TestShapeInputService7TestCaseOperation1Output struct {
-	metadataInputService7TestShapeInputService7TestCaseOperation1Output `json:"-" xml:"-"`
-}
-
-type metadataInputService7TestShapeInputService7TestCaseOperation1Output struct {
-	SDKShapeTraits bool `type:"structure"`
+	_ struct{} `type:"structure"`
 }
 
 //The service client's operations are safe to be used concurrently.
@@ -806,19 +746,11 @@ func (c *InputService8ProtocolTest) InputService8TestCaseOperation1(input *Input
 type InputService8TestShapeInputService8TestCaseOperation1Input struct {
 	TimeArg *time.Time `type:"timestamp" timestampFormat:"iso8601"`
 
-	metadataInputService8TestShapeInputService8TestCaseOperation1Input `json:"-" xml:"-"`
-}
-
-type metadataInputService8TestShapeInputService8TestCaseOperation1Input struct {
-	SDKShapeTraits bool `type:"structure"`
+	_ struct{} `type:"structure"`
 }
 
 type InputService8TestShapeInputService8TestCaseOperation1Output struct {
-	metadataInputService8TestShapeInputService8TestCaseOperation1Output `json:"-" xml:"-"`
-}
-
-type metadataInputService8TestShapeInputService8TestCaseOperation1Output struct {
-	SDKShapeTraits bool `type:"structure"`
+	_ struct{} `type:"structure"`
 }
 
 //

--- a/private/protocol/ec2query/build_test.go
+++ b/private/protocol/ec2query/build_test.go
@@ -116,11 +116,11 @@ func (c *InputService1ProtocolTest) InputService1TestCaseOperation1(input *Input
 }
 
 type InputService1TestShapeInputService1TestCaseOperation1Input struct {
+	_ struct{} `type:"structure"`
+
 	Bar *string `type:"string"`
 
 	Foo *string `type:"string"`
-
-	_ struct{} `type:"structure"`
 }
 
 type InputService1TestShapeInputService1TestCaseOperation1Output struct {
@@ -206,13 +206,13 @@ func (c *InputService2ProtocolTest) InputService2TestCaseOperation1(input *Input
 }
 
 type InputService2TestShapeInputService2TestCaseOperation1Input struct {
+	_ struct{} `type:"structure"`
+
 	Bar *string `locationName:"barLocationName" type:"string"`
 
 	Foo *string `type:"string"`
 
 	Yuck *string `locationName:"yuckLocationName" queryName:"yuckQueryName" type:"string"`
-
-	_ struct{} `type:"structure"`
 }
 
 type InputService2TestShapeInputService2TestCaseOperation1Output struct {
@@ -298,9 +298,9 @@ func (c *InputService3ProtocolTest) InputService3TestCaseOperation1(input *Input
 }
 
 type InputService3TestShapeInputService3TestCaseOperation1Input struct {
-	StructArg *InputService3TestShapeStructType `locationName:"Struct" type:"structure"`
-
 	_ struct{} `type:"structure"`
+
+	StructArg *InputService3TestShapeStructType `locationName:"Struct" type:"structure"`
 }
 
 type InputService3TestShapeInputService3TestCaseOperation1Output struct {
@@ -308,9 +308,9 @@ type InputService3TestShapeInputService3TestCaseOperation1Output struct {
 }
 
 type InputService3TestShapeStructType struct {
-	ScalarArg *string `locationName:"Scalar" type:"string"`
-
 	_ struct{} `type:"structure"`
+
+	ScalarArg *string `locationName:"Scalar" type:"string"`
 }
 
 //The service client's operations are safe to be used concurrently.
@@ -392,9 +392,9 @@ func (c *InputService4ProtocolTest) InputService4TestCaseOperation1(input *Input
 }
 
 type InputService4TestShapeInputService4TestCaseOperation1Input struct {
-	ListArg []*string `type:"list"`
-
 	_ struct{} `type:"structure"`
+
+	ListArg []*string `type:"list"`
 }
 
 type InputService4TestShapeInputService4TestCaseOperation1Output struct {
@@ -480,9 +480,9 @@ func (c *InputService5ProtocolTest) InputService5TestCaseOperation1(input *Input
 }
 
 type InputService5TestShapeInputService5TestCaseOperation1Input struct {
-	ListArg []*string `locationName:"ListMemberName" locationNameList:"item" type:"list"`
-
 	_ struct{} `type:"structure"`
+
+	ListArg []*string `locationName:"ListMemberName" locationNameList:"item" type:"list"`
 }
 
 type InputService5TestShapeInputService5TestCaseOperation1Output struct {
@@ -568,9 +568,9 @@ func (c *InputService6ProtocolTest) InputService6TestCaseOperation1(input *Input
 }
 
 type InputService6TestShapeInputService6TestCaseOperation1Input struct {
-	ListArg []*string `locationName:"ListMemberName" queryName:"ListQueryName" locationNameList:"item" type:"list"`
-
 	_ struct{} `type:"structure"`
+
+	ListArg []*string `locationName:"ListMemberName" queryName:"ListQueryName" locationNameList:"item" type:"list"`
 }
 
 type InputService6TestShapeInputService6TestCaseOperation1Output struct {
@@ -656,9 +656,9 @@ func (c *InputService7ProtocolTest) InputService7TestCaseOperation1(input *Input
 }
 
 type InputService7TestShapeInputService7TestCaseOperation1Input struct {
-	BlobArg []byte `type:"blob"`
-
 	_ struct{} `type:"structure"`
+
+	BlobArg []byte `type:"blob"`
 }
 
 type InputService7TestShapeInputService7TestCaseOperation1Output struct {
@@ -744,9 +744,9 @@ func (c *InputService8ProtocolTest) InputService8TestCaseOperation1(input *Input
 }
 
 type InputService8TestShapeInputService8TestCaseOperation1Input struct {
-	TimeArg *time.Time `type:"timestamp" timestampFormat:"iso8601"`
-
 	_ struct{} `type:"structure"`
+
+	TimeArg *time.Time `type:"timestamp" timestampFormat:"iso8601"`
 }
 
 type InputService8TestShapeInputService8TestCaseOperation1Output struct {

--- a/private/protocol/ec2query/unmarshal_test.go
+++ b/private/protocol/ec2query/unmarshal_test.go
@@ -116,11 +116,7 @@ func (c *OutputService1ProtocolTest) OutputService1TestCaseOperation1(input *Out
 }
 
 type OutputService1TestShapeOutputService1TestCaseOperation1Input struct {
-	metadataOutputService1TestShapeOutputService1TestCaseOperation1Input `json:"-" xml:"-"`
-}
-
-type metadataOutputService1TestShapeOutputService1TestCaseOperation1Input struct {
-	SDKShapeTraits bool `type:"structure"`
+	_ struct{} `type:"structure"`
 }
 
 type OutputService1TestShapeOutputService1TestCaseOperation1Output struct {
@@ -140,11 +136,7 @@ type OutputService1TestShapeOutputService1TestCaseOperation1Output struct {
 
 	TrueBool *bool `type:"boolean"`
 
-	metadataOutputService1TestShapeOutputService1TestCaseOperation1Output `json:"-" xml:"-"`
-}
-
-type metadataOutputService1TestShapeOutputService1TestCaseOperation1Output struct {
-	SDKShapeTraits bool `type:"structure"`
+	_ struct{} `type:"structure"`
 }
 
 //The service client's operations are safe to be used concurrently.
@@ -226,21 +218,13 @@ func (c *OutputService2ProtocolTest) OutputService2TestCaseOperation1(input *Out
 }
 
 type OutputService2TestShapeOutputService2TestCaseOperation1Input struct {
-	metadataOutputService2TestShapeOutputService2TestCaseOperation1Input `json:"-" xml:"-"`
-}
-
-type metadataOutputService2TestShapeOutputService2TestCaseOperation1Input struct {
-	SDKShapeTraits bool `type:"structure"`
+	_ struct{} `type:"structure"`
 }
 
 type OutputService2TestShapeOutputService2TestCaseOperation1Output struct {
 	Blob []byte `type:"blob"`
 
-	metadataOutputService2TestShapeOutputService2TestCaseOperation1Output `json:"-" xml:"-"`
-}
-
-type metadataOutputService2TestShapeOutputService2TestCaseOperation1Output struct {
-	SDKShapeTraits bool `type:"structure"`
+	_ struct{} `type:"structure"`
 }
 
 //The service client's operations are safe to be used concurrently.
@@ -322,21 +306,13 @@ func (c *OutputService3ProtocolTest) OutputService3TestCaseOperation1(input *Out
 }
 
 type OutputService3TestShapeOutputService3TestCaseOperation1Input struct {
-	metadataOutputService3TestShapeOutputService3TestCaseOperation1Input `json:"-" xml:"-"`
-}
-
-type metadataOutputService3TestShapeOutputService3TestCaseOperation1Input struct {
-	SDKShapeTraits bool `type:"structure"`
+	_ struct{} `type:"structure"`
 }
 
 type OutputService3TestShapeOutputService3TestCaseOperation1Output struct {
 	ListMember []*string `type:"list"`
 
-	metadataOutputService3TestShapeOutputService3TestCaseOperation1Output `json:"-" xml:"-"`
-}
-
-type metadataOutputService3TestShapeOutputService3TestCaseOperation1Output struct {
-	SDKShapeTraits bool `type:"structure"`
+	_ struct{} `type:"structure"`
 }
 
 //The service client's operations are safe to be used concurrently.
@@ -418,21 +394,13 @@ func (c *OutputService4ProtocolTest) OutputService4TestCaseOperation1(input *Out
 }
 
 type OutputService4TestShapeOutputService4TestCaseOperation1Input struct {
-	metadataOutputService4TestShapeOutputService4TestCaseOperation1Input `json:"-" xml:"-"`
-}
-
-type metadataOutputService4TestShapeOutputService4TestCaseOperation1Input struct {
-	SDKShapeTraits bool `type:"structure"`
+	_ struct{} `type:"structure"`
 }
 
 type OutputService4TestShapeOutputService4TestCaseOperation1Output struct {
 	ListMember []*string `locationNameList:"item" type:"list"`
 
-	metadataOutputService4TestShapeOutputService4TestCaseOperation1Output `json:"-" xml:"-"`
-}
-
-type metadataOutputService4TestShapeOutputService4TestCaseOperation1Output struct {
-	SDKShapeTraits bool `type:"structure"`
+	_ struct{} `type:"structure"`
 }
 
 //The service client's operations are safe to be used concurrently.
@@ -514,21 +482,13 @@ func (c *OutputService5ProtocolTest) OutputService5TestCaseOperation1(input *Out
 }
 
 type OutputService5TestShapeOutputService5TestCaseOperation1Input struct {
-	metadataOutputService5TestShapeOutputService5TestCaseOperation1Input `json:"-" xml:"-"`
-}
-
-type metadataOutputService5TestShapeOutputService5TestCaseOperation1Input struct {
-	SDKShapeTraits bool `type:"structure"`
+	_ struct{} `type:"structure"`
 }
 
 type OutputService5TestShapeOutputService5TestCaseOperation1Output struct {
 	ListMember []*string `type:"list" flattened:"true"`
 
-	metadataOutputService5TestShapeOutputService5TestCaseOperation1Output `json:"-" xml:"-"`
-}
-
-type metadataOutputService5TestShapeOutputService5TestCaseOperation1Output struct {
-	SDKShapeTraits bool `type:"structure"`
+	_ struct{} `type:"structure"`
 }
 
 //The service client's operations are safe to be used concurrently.
@@ -610,31 +570,19 @@ func (c *OutputService6ProtocolTest) OutputService6TestCaseOperation1(input *Out
 }
 
 type OutputService6TestShapeOutputService6TestCaseOperation1Input struct {
-	metadataOutputService6TestShapeOutputService6TestCaseOperation1Input `json:"-" xml:"-"`
-}
-
-type metadataOutputService6TestShapeOutputService6TestCaseOperation1Input struct {
-	SDKShapeTraits bool `type:"structure"`
+	_ struct{} `type:"structure"`
 }
 
 type OutputService6TestShapeOutputService6TestCaseOperation1Output struct {
 	Map map[string]*OutputService6TestShapeStructureType `type:"map"`
 
-	metadataOutputService6TestShapeOutputService6TestCaseOperation1Output `json:"-" xml:"-"`
-}
-
-type metadataOutputService6TestShapeOutputService6TestCaseOperation1Output struct {
-	SDKShapeTraits bool `type:"structure"`
+	_ struct{} `type:"structure"`
 }
 
 type OutputService6TestShapeStructureType struct {
 	Foo *string `locationName:"foo" type:"string"`
 
-	metadataOutputService6TestShapeStructureType `json:"-" xml:"-"`
-}
-
-type metadataOutputService6TestShapeStructureType struct {
-	SDKShapeTraits bool `type:"structure"`
+	_ struct{} `type:"structure"`
 }
 
 //The service client's operations are safe to be used concurrently.
@@ -716,21 +664,13 @@ func (c *OutputService7ProtocolTest) OutputService7TestCaseOperation1(input *Out
 }
 
 type OutputService7TestShapeOutputService7TestCaseOperation1Input struct {
-	metadataOutputService7TestShapeOutputService7TestCaseOperation1Input `json:"-" xml:"-"`
-}
-
-type metadataOutputService7TestShapeOutputService7TestCaseOperation1Input struct {
-	SDKShapeTraits bool `type:"structure"`
+	_ struct{} `type:"structure"`
 }
 
 type OutputService7TestShapeOutputService7TestCaseOperation1Output struct {
 	Map map[string]*string `type:"map" flattened:"true"`
 
-	metadataOutputService7TestShapeOutputService7TestCaseOperation1Output `json:"-" xml:"-"`
-}
-
-type metadataOutputService7TestShapeOutputService7TestCaseOperation1Output struct {
-	SDKShapeTraits bool `type:"structure"`
+	_ struct{} `type:"structure"`
 }
 
 //The service client's operations are safe to be used concurrently.
@@ -812,21 +752,13 @@ func (c *OutputService8ProtocolTest) OutputService8TestCaseOperation1(input *Out
 }
 
 type OutputService8TestShapeOutputService8TestCaseOperation1Input struct {
-	metadataOutputService8TestShapeOutputService8TestCaseOperation1Input `json:"-" xml:"-"`
-}
-
-type metadataOutputService8TestShapeOutputService8TestCaseOperation1Input struct {
-	SDKShapeTraits bool `type:"structure"`
+	_ struct{} `type:"structure"`
 }
 
 type OutputService8TestShapeOutputService8TestCaseOperation1Output struct {
 	Map map[string]*string `locationNameKey:"foo" locationNameValue:"bar" type:"map" flattened:"true"`
 
-	metadataOutputService8TestShapeOutputService8TestCaseOperation1Output `json:"-" xml:"-"`
-}
-
-type metadataOutputService8TestShapeOutputService8TestCaseOperation1Output struct {
-	SDKShapeTraits bool `type:"structure"`
+	_ struct{} `type:"structure"`
 }
 
 //The service client's operations are safe to be used concurrently.
@@ -908,21 +840,13 @@ func (c *OutputService9ProtocolTest) OutputService9TestCaseOperation1(input *Out
 }
 
 type OutputService9TestShapeOutputService9TestCaseOperation1Input struct {
-	metadataOutputService9TestShapeOutputService9TestCaseOperation1Input `json:"-" xml:"-"`
-}
-
-type metadataOutputService9TestShapeOutputService9TestCaseOperation1Input struct {
-	SDKShapeTraits bool `type:"structure"`
+	_ struct{} `type:"structure"`
 }
 
 type OutputService9TestShapeOutputService9TestCaseOperation1Output struct {
 	Foo *string `type:"string"`
 
-	metadataOutputService9TestShapeOutputService9TestCaseOperation1Output `json:"-" xml:"-"`
-}
-
-type metadataOutputService9TestShapeOutputService9TestCaseOperation1Output struct {
-	SDKShapeTraits bool `type:"structure"`
+	_ struct{} `type:"structure"`
 }
 
 //

--- a/private/protocol/ec2query/unmarshal_test.go
+++ b/private/protocol/ec2query/unmarshal_test.go
@@ -120,6 +120,8 @@ type OutputService1TestShapeOutputService1TestCaseOperation1Input struct {
 }
 
 type OutputService1TestShapeOutputService1TestCaseOperation1Output struct {
+	_ struct{} `type:"structure"`
+
 	Char *string `type:"character"`
 
 	Double *float64 `type:"double"`
@@ -135,8 +137,6 @@ type OutputService1TestShapeOutputService1TestCaseOperation1Output struct {
 	Str *string `type:"string"`
 
 	TrueBool *bool `type:"boolean"`
-
-	_ struct{} `type:"structure"`
 }
 
 //The service client's operations are safe to be used concurrently.
@@ -222,9 +222,9 @@ type OutputService2TestShapeOutputService2TestCaseOperation1Input struct {
 }
 
 type OutputService2TestShapeOutputService2TestCaseOperation1Output struct {
-	Blob []byte `type:"blob"`
-
 	_ struct{} `type:"structure"`
+
+	Blob []byte `type:"blob"`
 }
 
 //The service client's operations are safe to be used concurrently.
@@ -310,9 +310,9 @@ type OutputService3TestShapeOutputService3TestCaseOperation1Input struct {
 }
 
 type OutputService3TestShapeOutputService3TestCaseOperation1Output struct {
-	ListMember []*string `type:"list"`
-
 	_ struct{} `type:"structure"`
+
+	ListMember []*string `type:"list"`
 }
 
 //The service client's operations are safe to be used concurrently.
@@ -398,9 +398,9 @@ type OutputService4TestShapeOutputService4TestCaseOperation1Input struct {
 }
 
 type OutputService4TestShapeOutputService4TestCaseOperation1Output struct {
-	ListMember []*string `locationNameList:"item" type:"list"`
-
 	_ struct{} `type:"structure"`
+
+	ListMember []*string `locationNameList:"item" type:"list"`
 }
 
 //The service client's operations are safe to be used concurrently.
@@ -486,9 +486,9 @@ type OutputService5TestShapeOutputService5TestCaseOperation1Input struct {
 }
 
 type OutputService5TestShapeOutputService5TestCaseOperation1Output struct {
-	ListMember []*string `type:"list" flattened:"true"`
-
 	_ struct{} `type:"structure"`
+
+	ListMember []*string `type:"list" flattened:"true"`
 }
 
 //The service client's operations are safe to be used concurrently.
@@ -574,15 +574,15 @@ type OutputService6TestShapeOutputService6TestCaseOperation1Input struct {
 }
 
 type OutputService6TestShapeOutputService6TestCaseOperation1Output struct {
-	Map map[string]*OutputService6TestShapeStructureType `type:"map"`
-
 	_ struct{} `type:"structure"`
+
+	Map map[string]*OutputService6TestShapeStructureType `type:"map"`
 }
 
 type OutputService6TestShapeStructureType struct {
-	Foo *string `locationName:"foo" type:"string"`
-
 	_ struct{} `type:"structure"`
+
+	Foo *string `locationName:"foo" type:"string"`
 }
 
 //The service client's operations are safe to be used concurrently.
@@ -668,9 +668,9 @@ type OutputService7TestShapeOutputService7TestCaseOperation1Input struct {
 }
 
 type OutputService7TestShapeOutputService7TestCaseOperation1Output struct {
-	Map map[string]*string `type:"map" flattened:"true"`
-
 	_ struct{} `type:"structure"`
+
+	Map map[string]*string `type:"map" flattened:"true"`
 }
 
 //The service client's operations are safe to be used concurrently.
@@ -756,9 +756,9 @@ type OutputService8TestShapeOutputService8TestCaseOperation1Input struct {
 }
 
 type OutputService8TestShapeOutputService8TestCaseOperation1Output struct {
-	Map map[string]*string `locationNameKey:"foo" locationNameValue:"bar" type:"map" flattened:"true"`
-
 	_ struct{} `type:"structure"`
+
+	Map map[string]*string `locationNameKey:"foo" locationNameValue:"bar" type:"map" flattened:"true"`
 }
 
 //The service client's operations are safe to be used concurrently.
@@ -844,9 +844,9 @@ type OutputService9TestShapeOutputService9TestCaseOperation1Input struct {
 }
 
 type OutputService9TestShapeOutputService9TestCaseOperation1Output struct {
-	Foo *string `type:"string"`
-
 	_ struct{} `type:"structure"`
+
+	Foo *string `type:"string"`
 }
 
 //

--- a/private/protocol/json/jsonutil/build.go
+++ b/private/protocol/json/jsonutil/build.go
@@ -50,7 +50,7 @@ func buildAny(value reflect.Value, buf *bytes.Buffer, tag reflect.StructTag) err
 
 	switch t {
 	case "structure":
-		if field, ok := vtype.FieldByName("SDKShapeTraits"); ok {
+		if field, ok := vtype.FieldByName("_"); ok {
 			tag = field.Tag
 		}
 		return buildStruct(value, buf, tag)

--- a/private/protocol/json/jsonutil/unmarshal.go
+++ b/private/protocol/json/jsonutil/unmarshal.go
@@ -56,7 +56,7 @@ func unmarshalAny(value reflect.Value, data interface{}, tag reflect.StructTag) 
 
 	switch t {
 	case "structure":
-		if field, ok := vtype.FieldByName("SDKShapeTraits"); ok {
+		if field, ok := vtype.FieldByName("_"); ok {
 			tag = field.Tag
 		}
 		return unmarshalStruct(value, data, tag)

--- a/private/protocol/jsonrpc/build_test.go
+++ b/private/protocol/jsonrpc/build_test.go
@@ -121,19 +121,11 @@ func (c *InputService1ProtocolTest) InputService1TestCaseOperation1(input *Input
 type InputService1TestShapeInputService1TestCaseOperation1Input struct {
 	Name *string `type:"string"`
 
-	metadataInputService1TestShapeInputService1TestCaseOperation1Input `json:"-" xml:"-"`
-}
-
-type metadataInputService1TestShapeInputService1TestCaseOperation1Input struct {
-	SDKShapeTraits bool `type:"structure"`
+	_ struct{} `type:"structure"`
 }
 
 type InputService1TestShapeInputService1TestCaseOperation1Output struct {
-	metadataInputService1TestShapeInputService1TestCaseOperation1Output `json:"-" xml:"-"`
-}
-
-type metadataInputService1TestShapeInputService1TestCaseOperation1Output struct {
-	SDKShapeTraits bool `type:"structure"`
+	_ struct{} `type:"structure"`
 }
 
 //The service client's operations are safe to be used concurrently.
@@ -219,19 +211,11 @@ func (c *InputService2ProtocolTest) InputService2TestCaseOperation1(input *Input
 type InputService2TestShapeInputService2TestCaseOperation1Input struct {
 	TimeArg *time.Time `type:"timestamp" timestampFormat:"unix"`
 
-	metadataInputService2TestShapeInputService2TestCaseOperation1Input `json:"-" xml:"-"`
-}
-
-type metadataInputService2TestShapeInputService2TestCaseOperation1Input struct {
-	SDKShapeTraits bool `type:"structure"`
+	_ struct{} `type:"structure"`
 }
 
 type InputService2TestShapeInputService2TestCaseOperation1Output struct {
-	metadataInputService2TestShapeInputService2TestCaseOperation1Output `json:"-" xml:"-"`
-}
-
-type metadataInputService2TestShapeInputService2TestCaseOperation1Output struct {
-	SDKShapeTraits bool `type:"structure"`
+	_ struct{} `type:"structure"`
 }
 
 //The service client's operations are safe to be used concurrently.
@@ -339,19 +323,11 @@ func (c *InputService3ProtocolTest) InputService3TestCaseOperation2(input *Input
 }
 
 type InputService3TestShapeInputService3TestCaseOperation1Output struct {
-	metadataInputService3TestShapeInputService3TestCaseOperation1Output `json:"-" xml:"-"`
-}
-
-type metadataInputService3TestShapeInputService3TestCaseOperation1Output struct {
-	SDKShapeTraits bool `type:"structure"`
+	_ struct{} `type:"structure"`
 }
 
 type InputService3TestShapeInputService3TestCaseOperation2Output struct {
-	metadataInputService3TestShapeInputService3TestCaseOperation2Output `json:"-" xml:"-"`
-}
-
-type metadataInputService3TestShapeInputService3TestCaseOperation2Output struct {
-	SDKShapeTraits bool `type:"structure"`
+	_ struct{} `type:"structure"`
 }
 
 type InputService3TestShapeInputShape struct {
@@ -359,11 +335,7 @@ type InputService3TestShapeInputShape struct {
 
 	BlobMap map[string][]byte `type:"map"`
 
-	metadataInputService3TestShapeInputShape `json:"-" xml:"-"`
-}
-
-type metadataInputService3TestShapeInputShape struct {
-	SDKShapeTraits bool `type:"structure"`
+	_ struct{} `type:"structure"`
 }
 
 //The service client's operations are safe to be used concurrently.
@@ -450,19 +422,11 @@ func (c *InputService4ProtocolTest) InputService4TestCaseOperation1(input *Input
 type InputService4TestShapeInputService4TestCaseOperation1Input struct {
 	ListParam [][]byte `type:"list"`
 
-	metadataInputService4TestShapeInputService4TestCaseOperation1Input `json:"-" xml:"-"`
-}
-
-type metadataInputService4TestShapeInputService4TestCaseOperation1Input struct {
-	SDKShapeTraits bool `type:"structure"`
+	_ struct{} `type:"structure"`
 }
 
 type InputService4TestShapeInputService4TestCaseOperation1Output struct {
-	metadataInputService4TestShapeInputService4TestCaseOperation1Output `json:"-" xml:"-"`
-}
-
-type metadataInputService4TestShapeInputService4TestCaseOperation1Output struct {
-	SDKShapeTraits bool `type:"structure"`
+	_ struct{} `type:"structure"`
 }
 
 //The service client's operations are safe to be used concurrently.
@@ -666,61 +630,33 @@ func (c *InputService5ProtocolTest) InputService5TestCaseOperation6(input *Input
 }
 
 type InputService5TestShapeInputService5TestCaseOperation1Output struct {
-	metadataInputService5TestShapeInputService5TestCaseOperation1Output `json:"-" xml:"-"`
-}
-
-type metadataInputService5TestShapeInputService5TestCaseOperation1Output struct {
-	SDKShapeTraits bool `type:"structure"`
+	_ struct{} `type:"structure"`
 }
 
 type InputService5TestShapeInputService5TestCaseOperation2Output struct {
-	metadataInputService5TestShapeInputService5TestCaseOperation2Output `json:"-" xml:"-"`
-}
-
-type metadataInputService5TestShapeInputService5TestCaseOperation2Output struct {
-	SDKShapeTraits bool `type:"structure"`
+	_ struct{} `type:"structure"`
 }
 
 type InputService5TestShapeInputService5TestCaseOperation3Output struct {
-	metadataInputService5TestShapeInputService5TestCaseOperation3Output `json:"-" xml:"-"`
-}
-
-type metadataInputService5TestShapeInputService5TestCaseOperation3Output struct {
-	SDKShapeTraits bool `type:"structure"`
+	_ struct{} `type:"structure"`
 }
 
 type InputService5TestShapeInputService5TestCaseOperation4Output struct {
-	metadataInputService5TestShapeInputService5TestCaseOperation4Output `json:"-" xml:"-"`
-}
-
-type metadataInputService5TestShapeInputService5TestCaseOperation4Output struct {
-	SDKShapeTraits bool `type:"structure"`
+	_ struct{} `type:"structure"`
 }
 
 type InputService5TestShapeInputService5TestCaseOperation5Output struct {
-	metadataInputService5TestShapeInputService5TestCaseOperation5Output `json:"-" xml:"-"`
-}
-
-type metadataInputService5TestShapeInputService5TestCaseOperation5Output struct {
-	SDKShapeTraits bool `type:"structure"`
+	_ struct{} `type:"structure"`
 }
 
 type InputService5TestShapeInputService5TestCaseOperation6Output struct {
-	metadataInputService5TestShapeInputService5TestCaseOperation6Output `json:"-" xml:"-"`
-}
-
-type metadataInputService5TestShapeInputService5TestCaseOperation6Output struct {
-	SDKShapeTraits bool `type:"structure"`
+	_ struct{} `type:"structure"`
 }
 
 type InputService5TestShapeInputShape struct {
 	RecursiveStruct *InputService5TestShapeRecursiveStructType `type:"structure"`
 
-	metadataInputService5TestShapeInputShape `json:"-" xml:"-"`
-}
-
-type metadataInputService5TestShapeInputShape struct {
-	SDKShapeTraits bool `type:"structure"`
+	_ struct{} `type:"structure"`
 }
 
 type InputService5TestShapeRecursiveStructType struct {
@@ -732,11 +668,7 @@ type InputService5TestShapeRecursiveStructType struct {
 
 	RecursiveStruct *InputService5TestShapeRecursiveStructType `type:"structure"`
 
-	metadataInputService5TestShapeRecursiveStructType `json:"-" xml:"-"`
-}
-
-type metadataInputService5TestShapeRecursiveStructType struct {
-	SDKShapeTraits bool `type:"structure"`
+	_ struct{} `type:"structure"`
 }
 
 //The service client's operations are safe to be used concurrently.
@@ -823,19 +755,11 @@ func (c *InputService6ProtocolTest) InputService6TestCaseOperation1(input *Input
 type InputService6TestShapeInputService6TestCaseOperation1Input struct {
 	Map map[string]*string `type:"map"`
 
-	metadataInputService6TestShapeInputService6TestCaseOperation1Input `json:"-" xml:"-"`
-}
-
-type metadataInputService6TestShapeInputService6TestCaseOperation1Input struct {
-	SDKShapeTraits bool `type:"structure"`
+	_ struct{} `type:"structure"`
 }
 
 type InputService6TestShapeInputService6TestCaseOperation1Output struct {
-	metadataInputService6TestShapeInputService6TestCaseOperation1Output `json:"-" xml:"-"`
-}
-
-type metadataInputService6TestShapeInputService6TestCaseOperation1Output struct {
-	SDKShapeTraits bool `type:"structure"`
+	_ struct{} `type:"structure"`
 }
 
 //

--- a/private/protocol/jsonrpc/build_test.go
+++ b/private/protocol/jsonrpc/build_test.go
@@ -119,9 +119,9 @@ func (c *InputService1ProtocolTest) InputService1TestCaseOperation1(input *Input
 }
 
 type InputService1TestShapeInputService1TestCaseOperation1Input struct {
-	Name *string `type:"string"`
-
 	_ struct{} `type:"structure"`
+
+	Name *string `type:"string"`
 }
 
 type InputService1TestShapeInputService1TestCaseOperation1Output struct {
@@ -209,9 +209,9 @@ func (c *InputService2ProtocolTest) InputService2TestCaseOperation1(input *Input
 }
 
 type InputService2TestShapeInputService2TestCaseOperation1Input struct {
-	TimeArg *time.Time `type:"timestamp" timestampFormat:"unix"`
-
 	_ struct{} `type:"structure"`
+
+	TimeArg *time.Time `type:"timestamp" timestampFormat:"unix"`
 }
 
 type InputService2TestShapeInputService2TestCaseOperation1Output struct {
@@ -331,11 +331,11 @@ type InputService3TestShapeInputService3TestCaseOperation2Output struct {
 }
 
 type InputService3TestShapeInputShape struct {
+	_ struct{} `type:"structure"`
+
 	BlobArg []byte `type:"blob"`
 
 	BlobMap map[string][]byte `type:"map"`
-
-	_ struct{} `type:"structure"`
 }
 
 //The service client's operations are safe to be used concurrently.
@@ -420,9 +420,9 @@ func (c *InputService4ProtocolTest) InputService4TestCaseOperation1(input *Input
 }
 
 type InputService4TestShapeInputService4TestCaseOperation1Input struct {
-	ListParam [][]byte `type:"list"`
-
 	_ struct{} `type:"structure"`
+
+	ListParam [][]byte `type:"list"`
 }
 
 type InputService4TestShapeInputService4TestCaseOperation1Output struct {
@@ -654,12 +654,14 @@ type InputService5TestShapeInputService5TestCaseOperation6Output struct {
 }
 
 type InputService5TestShapeInputShape struct {
-	RecursiveStruct *InputService5TestShapeRecursiveStructType `type:"structure"`
-
 	_ struct{} `type:"structure"`
+
+	RecursiveStruct *InputService5TestShapeRecursiveStructType `type:"structure"`
 }
 
 type InputService5TestShapeRecursiveStructType struct {
+	_ struct{} `type:"structure"`
+
 	NoRecurse *string `type:"string"`
 
 	RecursiveList []*InputService5TestShapeRecursiveStructType `type:"list"`
@@ -667,8 +669,6 @@ type InputService5TestShapeRecursiveStructType struct {
 	RecursiveMap map[string]*InputService5TestShapeRecursiveStructType `type:"map"`
 
 	RecursiveStruct *InputService5TestShapeRecursiveStructType `type:"structure"`
-
-	_ struct{} `type:"structure"`
 }
 
 //The service client's operations are safe to be used concurrently.
@@ -753,9 +753,9 @@ func (c *InputService6ProtocolTest) InputService6TestCaseOperation1(input *Input
 }
 
 type InputService6TestShapeInputService6TestCaseOperation1Input struct {
-	Map map[string]*string `type:"map"`
-
 	_ struct{} `type:"structure"`
+
+	Map map[string]*string `type:"map"`
 }
 
 type InputService6TestShapeInputService6TestCaseOperation1Output struct {

--- a/private/protocol/jsonrpc/unmarshal_test.go
+++ b/private/protocol/jsonrpc/unmarshal_test.go
@@ -118,11 +118,7 @@ func (c *OutputService1ProtocolTest) OutputService1TestCaseOperation1(input *Out
 }
 
 type OutputService1TestShapeOutputService1TestCaseOperation1Input struct {
-	metadataOutputService1TestShapeOutputService1TestCaseOperation1Input `json:"-" xml:"-"`
-}
-
-type metadataOutputService1TestShapeOutputService1TestCaseOperation1Input struct {
-	SDKShapeTraits bool `type:"structure"`
+	_ struct{} `type:"structure"`
 }
 
 type OutputService1TestShapeOutputService1TestCaseOperation1Output struct {
@@ -142,11 +138,7 @@ type OutputService1TestShapeOutputService1TestCaseOperation1Output struct {
 
 	TrueBool *bool `type:"boolean"`
 
-	metadataOutputService1TestShapeOutputService1TestCaseOperation1Output `json:"-" xml:"-"`
-}
-
-type metadataOutputService1TestShapeOutputService1TestCaseOperation1Output struct {
-	SDKShapeTraits bool `type:"structure"`
+	_ struct{} `type:"structure"`
 }
 
 //The service client's operations are safe to be used concurrently.
@@ -232,19 +224,11 @@ func (c *OutputService2ProtocolTest) OutputService2TestCaseOperation1(input *Out
 type OutputService2TestShapeBlobContainer struct {
 	Foo []byte `locationName:"foo" type:"blob"`
 
-	metadataOutputService2TestShapeBlobContainer `json:"-" xml:"-"`
-}
-
-type metadataOutputService2TestShapeBlobContainer struct {
-	SDKShapeTraits bool `type:"structure"`
+	_ struct{} `type:"structure"`
 }
 
 type OutputService2TestShapeOutputService2TestCaseOperation1Input struct {
-	metadataOutputService2TestShapeOutputService2TestCaseOperation1Input `json:"-" xml:"-"`
-}
-
-type metadataOutputService2TestShapeOutputService2TestCaseOperation1Input struct {
-	SDKShapeTraits bool `type:"structure"`
+	_ struct{} `type:"structure"`
 }
 
 type OutputService2TestShapeOutputService2TestCaseOperation1Output struct {
@@ -252,11 +236,7 @@ type OutputService2TestShapeOutputService2TestCaseOperation1Output struct {
 
 	StructMember *OutputService2TestShapeBlobContainer `type:"structure"`
 
-	metadataOutputService2TestShapeOutputService2TestCaseOperation1Output `json:"-" xml:"-"`
-}
-
-type metadataOutputService2TestShapeOutputService2TestCaseOperation1Output struct {
-	SDKShapeTraits bool `type:"structure"`
+	_ struct{} `type:"structure"`
 }
 
 //The service client's operations are safe to be used concurrently.
@@ -340,11 +320,7 @@ func (c *OutputService3ProtocolTest) OutputService3TestCaseOperation1(input *Out
 }
 
 type OutputService3TestShapeOutputService3TestCaseOperation1Input struct {
-	metadataOutputService3TestShapeOutputService3TestCaseOperation1Input `json:"-" xml:"-"`
-}
-
-type metadataOutputService3TestShapeOutputService3TestCaseOperation1Input struct {
-	SDKShapeTraits bool `type:"structure"`
+	_ struct{} `type:"structure"`
 }
 
 type OutputService3TestShapeOutputService3TestCaseOperation1Output struct {
@@ -352,21 +328,13 @@ type OutputService3TestShapeOutputService3TestCaseOperation1Output struct {
 
 	TimeMember *time.Time `type:"timestamp" timestampFormat:"unix"`
 
-	metadataOutputService3TestShapeOutputService3TestCaseOperation1Output `json:"-" xml:"-"`
-}
-
-type metadataOutputService3TestShapeOutputService3TestCaseOperation1Output struct {
-	SDKShapeTraits bool `type:"structure"`
+	_ struct{} `type:"structure"`
 }
 
 type OutputService3TestShapeTimeContainer struct {
 	Foo *time.Time `locationName:"foo" type:"timestamp" timestampFormat:"unix"`
 
-	metadataOutputService3TestShapeTimeContainer `json:"-" xml:"-"`
-}
-
-type metadataOutputService3TestShapeTimeContainer struct {
-	SDKShapeTraits bool `type:"structure"`
+	_ struct{} `type:"structure"`
 }
 
 //The service client's operations are safe to be used concurrently.
@@ -474,19 +442,11 @@ func (c *OutputService4ProtocolTest) OutputService4TestCaseOperation2(input *Out
 }
 
 type OutputService4TestShapeOutputService4TestCaseOperation1Input struct {
-	metadataOutputService4TestShapeOutputService4TestCaseOperation1Input `json:"-" xml:"-"`
-}
-
-type metadataOutputService4TestShapeOutputService4TestCaseOperation1Input struct {
-	SDKShapeTraits bool `type:"structure"`
+	_ struct{} `type:"structure"`
 }
 
 type OutputService4TestShapeOutputService4TestCaseOperation2Input struct {
-	metadataOutputService4TestShapeOutputService4TestCaseOperation2Input `json:"-" xml:"-"`
-}
-
-type metadataOutputService4TestShapeOutputService4TestCaseOperation2Input struct {
-	SDKShapeTraits bool `type:"structure"`
+	_ struct{} `type:"structure"`
 }
 
 type OutputService4TestShapeOutputShape struct {
@@ -496,19 +456,11 @@ type OutputService4TestShapeOutputShape struct {
 
 	ListMemberStruct []*OutputService4TestShapeStructType `type:"list"`
 
-	metadataOutputService4TestShapeOutputShape `json:"-" xml:"-"`
-}
-
-type metadataOutputService4TestShapeOutputShape struct {
-	SDKShapeTraits bool `type:"structure"`
+	_ struct{} `type:"structure"`
 }
 
 type OutputService4TestShapeStructType struct {
-	metadataOutputService4TestShapeStructType `json:"-" xml:"-"`
-}
-
-type metadataOutputService4TestShapeStructType struct {
-	SDKShapeTraits bool `type:"structure"`
+	_ struct{} `type:"structure"`
 }
 
 //The service client's operations are safe to be used concurrently.
@@ -592,21 +544,13 @@ func (c *OutputService5ProtocolTest) OutputService5TestCaseOperation1(input *Out
 }
 
 type OutputService5TestShapeOutputService5TestCaseOperation1Input struct {
-	metadataOutputService5TestShapeOutputService5TestCaseOperation1Input `json:"-" xml:"-"`
-}
-
-type metadataOutputService5TestShapeOutputService5TestCaseOperation1Input struct {
-	SDKShapeTraits bool `type:"structure"`
+	_ struct{} `type:"structure"`
 }
 
 type OutputService5TestShapeOutputService5TestCaseOperation1Output struct {
 	MapMember map[string][]*int64 `type:"map"`
 
-	metadataOutputService5TestShapeOutputService5TestCaseOperation1Output `json:"-" xml:"-"`
-}
-
-type metadataOutputService5TestShapeOutputService5TestCaseOperation1Output struct {
-	SDKShapeTraits bool `type:"structure"`
+	_ struct{} `type:"structure"`
 }
 
 //The service client's operations are safe to be used concurrently.
@@ -690,21 +634,13 @@ func (c *OutputService6ProtocolTest) OutputService6TestCaseOperation1(input *Out
 }
 
 type OutputService6TestShapeOutputService6TestCaseOperation1Input struct {
-	metadataOutputService6TestShapeOutputService6TestCaseOperation1Input `json:"-" xml:"-"`
-}
-
-type metadataOutputService6TestShapeOutputService6TestCaseOperation1Input struct {
-	SDKShapeTraits bool `type:"structure"`
+	_ struct{} `type:"structure"`
 }
 
 type OutputService6TestShapeOutputService6TestCaseOperation1Output struct {
 	StrType *string `type:"string"`
 
-	metadataOutputService6TestShapeOutputService6TestCaseOperation1Output `json:"-" xml:"-"`
-}
-
-type metadataOutputService6TestShapeOutputService6TestCaseOperation1Output struct {
-	SDKShapeTraits bool `type:"structure"`
+	_ struct{} `type:"structure"`
 }
 
 //

--- a/private/protocol/jsonrpc/unmarshal_test.go
+++ b/private/protocol/jsonrpc/unmarshal_test.go
@@ -122,6 +122,8 @@ type OutputService1TestShapeOutputService1TestCaseOperation1Input struct {
 }
 
 type OutputService1TestShapeOutputService1TestCaseOperation1Output struct {
+	_ struct{} `type:"structure"`
+
 	Char *string `type:"character"`
 
 	Double *float64 `type:"double"`
@@ -137,8 +139,6 @@ type OutputService1TestShapeOutputService1TestCaseOperation1Output struct {
 	Str *string `type:"string"`
 
 	TrueBool *bool `type:"boolean"`
-
-	_ struct{} `type:"structure"`
 }
 
 //The service client's operations are safe to be used concurrently.
@@ -222,9 +222,9 @@ func (c *OutputService2ProtocolTest) OutputService2TestCaseOperation1(input *Out
 }
 
 type OutputService2TestShapeBlobContainer struct {
-	Foo []byte `locationName:"foo" type:"blob"`
-
 	_ struct{} `type:"structure"`
+
+	Foo []byte `locationName:"foo" type:"blob"`
 }
 
 type OutputService2TestShapeOutputService2TestCaseOperation1Input struct {
@@ -232,11 +232,11 @@ type OutputService2TestShapeOutputService2TestCaseOperation1Input struct {
 }
 
 type OutputService2TestShapeOutputService2TestCaseOperation1Output struct {
+	_ struct{} `type:"structure"`
+
 	BlobMember []byte `type:"blob"`
 
 	StructMember *OutputService2TestShapeBlobContainer `type:"structure"`
-
-	_ struct{} `type:"structure"`
 }
 
 //The service client's operations are safe to be used concurrently.
@@ -324,17 +324,17 @@ type OutputService3TestShapeOutputService3TestCaseOperation1Input struct {
 }
 
 type OutputService3TestShapeOutputService3TestCaseOperation1Output struct {
+	_ struct{} `type:"structure"`
+
 	StructMember *OutputService3TestShapeTimeContainer `type:"structure"`
 
 	TimeMember *time.Time `type:"timestamp" timestampFormat:"unix"`
-
-	_ struct{} `type:"structure"`
 }
 
 type OutputService3TestShapeTimeContainer struct {
-	Foo *time.Time `locationName:"foo" type:"timestamp" timestampFormat:"unix"`
-
 	_ struct{} `type:"structure"`
+
+	Foo *time.Time `locationName:"foo" type:"timestamp" timestampFormat:"unix"`
 }
 
 //The service client's operations are safe to be used concurrently.
@@ -450,13 +450,13 @@ type OutputService4TestShapeOutputService4TestCaseOperation2Input struct {
 }
 
 type OutputService4TestShapeOutputShape struct {
+	_ struct{} `type:"structure"`
+
 	ListMember []*string `type:"list"`
 
 	ListMemberMap []map[string]*string `type:"list"`
 
 	ListMemberStruct []*OutputService4TestShapeStructType `type:"list"`
-
-	_ struct{} `type:"structure"`
 }
 
 type OutputService4TestShapeStructType struct {
@@ -548,9 +548,9 @@ type OutputService5TestShapeOutputService5TestCaseOperation1Input struct {
 }
 
 type OutputService5TestShapeOutputService5TestCaseOperation1Output struct {
-	MapMember map[string][]*int64 `type:"map"`
-
 	_ struct{} `type:"structure"`
+
+	MapMember map[string][]*int64 `type:"map"`
 }
 
 //The service client's operations are safe to be used concurrently.
@@ -638,9 +638,9 @@ type OutputService6TestShapeOutputService6TestCaseOperation1Input struct {
 }
 
 type OutputService6TestShapeOutputService6TestCaseOperation1Output struct {
-	StrType *string `type:"string"`
-
 	_ struct{} `type:"structure"`
+
+	StrType *string `type:"string"`
 }
 
 //

--- a/private/protocol/query/build_test.go
+++ b/private/protocol/query/build_test.go
@@ -164,27 +164,15 @@ func (c *InputService1ProtocolTest) InputService1TestCaseOperation3(input *Input
 }
 
 type InputService1TestShapeInputService1TestCaseOperation1Output struct {
-	metadataInputService1TestShapeInputService1TestCaseOperation1Output `json:"-" xml:"-"`
-}
-
-type metadataInputService1TestShapeInputService1TestCaseOperation1Output struct {
-	SDKShapeTraits bool `type:"structure"`
+	_ struct{} `type:"structure"`
 }
 
 type InputService1TestShapeInputService1TestCaseOperation2Output struct {
-	metadataInputService1TestShapeInputService1TestCaseOperation2Output `json:"-" xml:"-"`
-}
-
-type metadataInputService1TestShapeInputService1TestCaseOperation2Output struct {
-	SDKShapeTraits bool `type:"structure"`
+	_ struct{} `type:"structure"`
 }
 
 type InputService1TestShapeInputService1TestCaseOperation3Output struct {
-	metadataInputService1TestShapeInputService1TestCaseOperation3Output `json:"-" xml:"-"`
-}
-
-type metadataInputService1TestShapeInputService1TestCaseOperation3Output struct {
-	SDKShapeTraits bool `type:"structure"`
+	_ struct{} `type:"structure"`
 }
 
 type InputService1TestShapeInputShape struct {
@@ -194,11 +182,7 @@ type InputService1TestShapeInputShape struct {
 
 	Foo *string `type:"string"`
 
-	metadataInputService1TestShapeInputShape `json:"-" xml:"-"`
-}
-
-type metadataInputService1TestShapeInputShape struct {
-	SDKShapeTraits bool `type:"structure"`
+	_ struct{} `type:"structure"`
 }
 
 //The service client's operations are safe to be used concurrently.
@@ -282,29 +266,17 @@ func (c *InputService2ProtocolTest) InputService2TestCaseOperation1(input *Input
 type InputService2TestShapeInputService2TestCaseOperation1Input struct {
 	StructArg *InputService2TestShapeStructType `type:"structure"`
 
-	metadataInputService2TestShapeInputService2TestCaseOperation1Input `json:"-" xml:"-"`
-}
-
-type metadataInputService2TestShapeInputService2TestCaseOperation1Input struct {
-	SDKShapeTraits bool `type:"structure"`
+	_ struct{} `type:"structure"`
 }
 
 type InputService2TestShapeInputService2TestCaseOperation1Output struct {
-	metadataInputService2TestShapeInputService2TestCaseOperation1Output `json:"-" xml:"-"`
-}
-
-type metadataInputService2TestShapeInputService2TestCaseOperation1Output struct {
-	SDKShapeTraits bool `type:"structure"`
+	_ struct{} `type:"structure"`
 }
 
 type InputService2TestShapeStructType struct {
 	ScalarArg *string `type:"string"`
 
-	metadataInputService2TestShapeStructType `json:"-" xml:"-"`
-}
-
-type metadataInputService2TestShapeStructType struct {
-	SDKShapeTraits bool `type:"structure"`
+	_ struct{} `type:"structure"`
 }
 
 //The service client's operations are safe to be used concurrently.
@@ -410,29 +382,17 @@ func (c *InputService3ProtocolTest) InputService3TestCaseOperation2(input *Input
 }
 
 type InputService3TestShapeInputService3TestCaseOperation1Output struct {
-	metadataInputService3TestShapeInputService3TestCaseOperation1Output `json:"-" xml:"-"`
-}
-
-type metadataInputService3TestShapeInputService3TestCaseOperation1Output struct {
-	SDKShapeTraits bool `type:"structure"`
+	_ struct{} `type:"structure"`
 }
 
 type InputService3TestShapeInputService3TestCaseOperation2Output struct {
-	metadataInputService3TestShapeInputService3TestCaseOperation2Output `json:"-" xml:"-"`
-}
-
-type metadataInputService3TestShapeInputService3TestCaseOperation2Output struct {
-	SDKShapeTraits bool `type:"structure"`
+	_ struct{} `type:"structure"`
 }
 
 type InputService3TestShapeInputShape struct {
 	ListArg []*string `type:"list"`
 
-	metadataInputService3TestShapeInputShape `json:"-" xml:"-"`
-}
-
-type metadataInputService3TestShapeInputShape struct {
-	SDKShapeTraits bool `type:"structure"`
+	_ struct{} `type:"structure"`
 }
 
 //The service client's operations are safe to be used concurrently.
@@ -538,19 +498,11 @@ func (c *InputService4ProtocolTest) InputService4TestCaseOperation2(input *Input
 }
 
 type InputService4TestShapeInputService4TestCaseOperation1Output struct {
-	metadataInputService4TestShapeInputService4TestCaseOperation1Output `json:"-" xml:"-"`
-}
-
-type metadataInputService4TestShapeInputService4TestCaseOperation1Output struct {
-	SDKShapeTraits bool `type:"structure"`
+	_ struct{} `type:"structure"`
 }
 
 type InputService4TestShapeInputService4TestCaseOperation2Output struct {
-	metadataInputService4TestShapeInputService4TestCaseOperation2Output `json:"-" xml:"-"`
-}
-
-type metadataInputService4TestShapeInputService4TestCaseOperation2Output struct {
-	SDKShapeTraits bool `type:"structure"`
+	_ struct{} `type:"structure"`
 }
 
 type InputService4TestShapeInputShape struct {
@@ -560,11 +512,7 @@ type InputService4TestShapeInputShape struct {
 
 	ScalarArg *string `type:"string"`
 
-	metadataInputService4TestShapeInputShape `json:"-" xml:"-"`
-}
-
-type metadataInputService4TestShapeInputShape struct {
-	SDKShapeTraits bool `type:"structure"`
+	_ struct{} `type:"structure"`
 }
 
 //The service client's operations are safe to be used concurrently.
@@ -648,19 +596,11 @@ func (c *InputService5ProtocolTest) InputService5TestCaseOperation1(input *Input
 type InputService5TestShapeInputService5TestCaseOperation1Input struct {
 	MapArg map[string]*string `type:"map" flattened:"true"`
 
-	metadataInputService5TestShapeInputService5TestCaseOperation1Input `json:"-" xml:"-"`
-}
-
-type metadataInputService5TestShapeInputService5TestCaseOperation1Input struct {
-	SDKShapeTraits bool `type:"structure"`
+	_ struct{} `type:"structure"`
 }
 
 type InputService5TestShapeInputService5TestCaseOperation1Output struct {
-	metadataInputService5TestShapeInputService5TestCaseOperation1Output `json:"-" xml:"-"`
-}
-
-type metadataInputService5TestShapeInputService5TestCaseOperation1Output struct {
-	SDKShapeTraits bool `type:"structure"`
+	_ struct{} `type:"structure"`
 }
 
 //The service client's operations are safe to be used concurrently.
@@ -744,19 +684,11 @@ func (c *InputService6ProtocolTest) InputService6TestCaseOperation1(input *Input
 type InputService6TestShapeInputService6TestCaseOperation1Input struct {
 	ListArg []*string `locationNameList:"item" type:"list"`
 
-	metadataInputService6TestShapeInputService6TestCaseOperation1Input `json:"-" xml:"-"`
-}
-
-type metadataInputService6TestShapeInputService6TestCaseOperation1Input struct {
-	SDKShapeTraits bool `type:"structure"`
+	_ struct{} `type:"structure"`
 }
 
 type InputService6TestShapeInputService6TestCaseOperation1Output struct {
-	metadataInputService6TestShapeInputService6TestCaseOperation1Output `json:"-" xml:"-"`
-}
-
-type metadataInputService6TestShapeInputService6TestCaseOperation1Output struct {
-	SDKShapeTraits bool `type:"structure"`
+	_ struct{} `type:"structure"`
 }
 
 //The service client's operations are safe to be used concurrently.
@@ -842,19 +774,11 @@ type InputService7TestShapeInputService7TestCaseOperation1Input struct {
 
 	ScalarArg *string `type:"string"`
 
-	metadataInputService7TestShapeInputService7TestCaseOperation1Input `json:"-" xml:"-"`
-}
-
-type metadataInputService7TestShapeInputService7TestCaseOperation1Input struct {
-	SDKShapeTraits bool `type:"structure"`
+	_ struct{} `type:"structure"`
 }
 
 type InputService7TestShapeInputService7TestCaseOperation1Output struct {
-	metadataInputService7TestShapeInputService7TestCaseOperation1Output `json:"-" xml:"-"`
-}
-
-type metadataInputService7TestShapeInputService7TestCaseOperation1Output struct {
-	SDKShapeTraits bool `type:"structure"`
+	_ struct{} `type:"structure"`
 }
 
 //The service client's operations are safe to be used concurrently.
@@ -938,19 +862,11 @@ func (c *InputService8ProtocolTest) InputService8TestCaseOperation1(input *Input
 type InputService8TestShapeInputService8TestCaseOperation1Input struct {
 	MapArg map[string]*string `type:"map"`
 
-	metadataInputService8TestShapeInputService8TestCaseOperation1Input `json:"-" xml:"-"`
-}
-
-type metadataInputService8TestShapeInputService8TestCaseOperation1Input struct {
-	SDKShapeTraits bool `type:"structure"`
+	_ struct{} `type:"structure"`
 }
 
 type InputService8TestShapeInputService8TestCaseOperation1Output struct {
-	metadataInputService8TestShapeInputService8TestCaseOperation1Output `json:"-" xml:"-"`
-}
-
-type metadataInputService8TestShapeInputService8TestCaseOperation1Output struct {
-	SDKShapeTraits bool `type:"structure"`
+	_ struct{} `type:"structure"`
 }
 
 //The service client's operations are safe to be used concurrently.
@@ -1034,19 +950,11 @@ func (c *InputService9ProtocolTest) InputService9TestCaseOperation1(input *Input
 type InputService9TestShapeInputService9TestCaseOperation1Input struct {
 	MapArg map[string]*string `locationNameKey:"TheKey" locationNameValue:"TheValue" type:"map"`
 
-	metadataInputService9TestShapeInputService9TestCaseOperation1Input `json:"-" xml:"-"`
-}
-
-type metadataInputService9TestShapeInputService9TestCaseOperation1Input struct {
-	SDKShapeTraits bool `type:"structure"`
+	_ struct{} `type:"structure"`
 }
 
 type InputService9TestShapeInputService9TestCaseOperation1Output struct {
-	metadataInputService9TestShapeInputService9TestCaseOperation1Output `json:"-" xml:"-"`
-}
-
-type metadataInputService9TestShapeInputService9TestCaseOperation1Output struct {
-	SDKShapeTraits bool `type:"structure"`
+	_ struct{} `type:"structure"`
 }
 
 //The service client's operations are safe to be used concurrently.
@@ -1130,19 +1038,11 @@ func (c *InputService10ProtocolTest) InputService10TestCaseOperation1(input *Inp
 type InputService10TestShapeInputService10TestCaseOperation1Input struct {
 	BlobArg []byte `type:"blob"`
 
-	metadataInputService10TestShapeInputService10TestCaseOperation1Input `json:"-" xml:"-"`
-}
-
-type metadataInputService10TestShapeInputService10TestCaseOperation1Input struct {
-	SDKShapeTraits bool `type:"structure"`
+	_ struct{} `type:"structure"`
 }
 
 type InputService10TestShapeInputService10TestCaseOperation1Output struct {
-	metadataInputService10TestShapeInputService10TestCaseOperation1Output `json:"-" xml:"-"`
-}
-
-type metadataInputService10TestShapeInputService10TestCaseOperation1Output struct {
-	SDKShapeTraits bool `type:"structure"`
+	_ struct{} `type:"structure"`
 }
 
 //The service client's operations are safe to be used concurrently.
@@ -1226,19 +1126,11 @@ func (c *InputService11ProtocolTest) InputService11TestCaseOperation1(input *Inp
 type InputService11TestShapeInputService11TestCaseOperation1Input struct {
 	TimeArg *time.Time `type:"timestamp" timestampFormat:"iso8601"`
 
-	metadataInputService11TestShapeInputService11TestCaseOperation1Input `json:"-" xml:"-"`
-}
-
-type metadataInputService11TestShapeInputService11TestCaseOperation1Input struct {
-	SDKShapeTraits bool `type:"structure"`
+	_ struct{} `type:"structure"`
 }
 
 type InputService11TestShapeInputService11TestCaseOperation1Output struct {
-	metadataInputService11TestShapeInputService11TestCaseOperation1Output `json:"-" xml:"-"`
-}
-
-type metadataInputService11TestShapeInputService11TestCaseOperation1Output struct {
-	SDKShapeTraits bool `type:"structure"`
+	_ struct{} `type:"structure"`
 }
 
 //The service client's operations are safe to be used concurrently.
@@ -1440,61 +1332,33 @@ func (c *InputService12ProtocolTest) InputService12TestCaseOperation6(input *Inp
 }
 
 type InputService12TestShapeInputService12TestCaseOperation1Output struct {
-	metadataInputService12TestShapeInputService12TestCaseOperation1Output `json:"-" xml:"-"`
-}
-
-type metadataInputService12TestShapeInputService12TestCaseOperation1Output struct {
-	SDKShapeTraits bool `type:"structure"`
+	_ struct{} `type:"structure"`
 }
 
 type InputService12TestShapeInputService12TestCaseOperation2Output struct {
-	metadataInputService12TestShapeInputService12TestCaseOperation2Output `json:"-" xml:"-"`
-}
-
-type metadataInputService12TestShapeInputService12TestCaseOperation2Output struct {
-	SDKShapeTraits bool `type:"structure"`
+	_ struct{} `type:"structure"`
 }
 
 type InputService12TestShapeInputService12TestCaseOperation3Output struct {
-	metadataInputService12TestShapeInputService12TestCaseOperation3Output `json:"-" xml:"-"`
-}
-
-type metadataInputService12TestShapeInputService12TestCaseOperation3Output struct {
-	SDKShapeTraits bool `type:"structure"`
+	_ struct{} `type:"structure"`
 }
 
 type InputService12TestShapeInputService12TestCaseOperation4Output struct {
-	metadataInputService12TestShapeInputService12TestCaseOperation4Output `json:"-" xml:"-"`
-}
-
-type metadataInputService12TestShapeInputService12TestCaseOperation4Output struct {
-	SDKShapeTraits bool `type:"structure"`
+	_ struct{} `type:"structure"`
 }
 
 type InputService12TestShapeInputService12TestCaseOperation5Output struct {
-	metadataInputService12TestShapeInputService12TestCaseOperation5Output `json:"-" xml:"-"`
-}
-
-type metadataInputService12TestShapeInputService12TestCaseOperation5Output struct {
-	SDKShapeTraits bool `type:"structure"`
+	_ struct{} `type:"structure"`
 }
 
 type InputService12TestShapeInputService12TestCaseOperation6Output struct {
-	metadataInputService12TestShapeInputService12TestCaseOperation6Output `json:"-" xml:"-"`
-}
-
-type metadataInputService12TestShapeInputService12TestCaseOperation6Output struct {
-	SDKShapeTraits bool `type:"structure"`
+	_ struct{} `type:"structure"`
 }
 
 type InputService12TestShapeInputShape struct {
 	RecursiveStruct *InputService12TestShapeRecursiveStructType `type:"structure"`
 
-	metadataInputService12TestShapeInputShape `json:"-" xml:"-"`
-}
-
-type metadataInputService12TestShapeInputShape struct {
-	SDKShapeTraits bool `type:"structure"`
+	_ struct{} `type:"structure"`
 }
 
 type InputService12TestShapeRecursiveStructType struct {
@@ -1506,11 +1370,7 @@ type InputService12TestShapeRecursiveStructType struct {
 
 	RecursiveStruct *InputService12TestShapeRecursiveStructType `type:"structure"`
 
-	metadataInputService12TestShapeRecursiveStructType `json:"-" xml:"-"`
-}
-
-type metadataInputService12TestShapeRecursiveStructType struct {
-	SDKShapeTraits bool `type:"structure"`
+	_ struct{} `type:"structure"`
 }
 
 //

--- a/private/protocol/query/build_test.go
+++ b/private/protocol/query/build_test.go
@@ -176,13 +176,13 @@ type InputService1TestShapeInputService1TestCaseOperation3Output struct {
 }
 
 type InputService1TestShapeInputShape struct {
+	_ struct{} `type:"structure"`
+
 	Bar *string `type:"string"`
 
 	Baz *bool `type:"boolean"`
 
 	Foo *string `type:"string"`
-
-	_ struct{} `type:"structure"`
 }
 
 //The service client's operations are safe to be used concurrently.
@@ -264,9 +264,9 @@ func (c *InputService2ProtocolTest) InputService2TestCaseOperation1(input *Input
 }
 
 type InputService2TestShapeInputService2TestCaseOperation1Input struct {
-	StructArg *InputService2TestShapeStructType `type:"structure"`
-
 	_ struct{} `type:"structure"`
+
+	StructArg *InputService2TestShapeStructType `type:"structure"`
 }
 
 type InputService2TestShapeInputService2TestCaseOperation1Output struct {
@@ -274,9 +274,9 @@ type InputService2TestShapeInputService2TestCaseOperation1Output struct {
 }
 
 type InputService2TestShapeStructType struct {
-	ScalarArg *string `type:"string"`
-
 	_ struct{} `type:"structure"`
+
+	ScalarArg *string `type:"string"`
 }
 
 //The service client's operations are safe to be used concurrently.
@@ -390,9 +390,9 @@ type InputService3TestShapeInputService3TestCaseOperation2Output struct {
 }
 
 type InputService3TestShapeInputShape struct {
-	ListArg []*string `type:"list"`
-
 	_ struct{} `type:"structure"`
+
+	ListArg []*string `type:"list"`
 }
 
 //The service client's operations are safe to be used concurrently.
@@ -506,13 +506,13 @@ type InputService4TestShapeInputService4TestCaseOperation2Output struct {
 }
 
 type InputService4TestShapeInputShape struct {
+	_ struct{} `type:"structure"`
+
 	ListArg []*string `type:"list" flattened:"true"`
 
 	NamedListArg []*string `locationNameList:"Foo" type:"list" flattened:"true"`
 
 	ScalarArg *string `type:"string"`
-
-	_ struct{} `type:"structure"`
 }
 
 //The service client's operations are safe to be used concurrently.
@@ -594,9 +594,9 @@ func (c *InputService5ProtocolTest) InputService5TestCaseOperation1(input *Input
 }
 
 type InputService5TestShapeInputService5TestCaseOperation1Input struct {
-	MapArg map[string]*string `type:"map" flattened:"true"`
-
 	_ struct{} `type:"structure"`
+
+	MapArg map[string]*string `type:"map" flattened:"true"`
 }
 
 type InputService5TestShapeInputService5TestCaseOperation1Output struct {
@@ -682,9 +682,9 @@ func (c *InputService6ProtocolTest) InputService6TestCaseOperation1(input *Input
 }
 
 type InputService6TestShapeInputService6TestCaseOperation1Input struct {
-	ListArg []*string `locationNameList:"item" type:"list"`
-
 	_ struct{} `type:"structure"`
+
+	ListArg []*string `locationNameList:"item" type:"list"`
 }
 
 type InputService6TestShapeInputService6TestCaseOperation1Output struct {
@@ -770,11 +770,11 @@ func (c *InputService7ProtocolTest) InputService7TestCaseOperation1(input *Input
 }
 
 type InputService7TestShapeInputService7TestCaseOperation1Input struct {
+	_ struct{} `type:"structure"`
+
 	ListArg []*string `locationNameList:"ListArgLocation" type:"list" flattened:"true"`
 
 	ScalarArg *string `type:"string"`
-
-	_ struct{} `type:"structure"`
 }
 
 type InputService7TestShapeInputService7TestCaseOperation1Output struct {
@@ -860,9 +860,9 @@ func (c *InputService8ProtocolTest) InputService8TestCaseOperation1(input *Input
 }
 
 type InputService8TestShapeInputService8TestCaseOperation1Input struct {
-	MapArg map[string]*string `type:"map"`
-
 	_ struct{} `type:"structure"`
+
+	MapArg map[string]*string `type:"map"`
 }
 
 type InputService8TestShapeInputService8TestCaseOperation1Output struct {
@@ -948,9 +948,9 @@ func (c *InputService9ProtocolTest) InputService9TestCaseOperation1(input *Input
 }
 
 type InputService9TestShapeInputService9TestCaseOperation1Input struct {
-	MapArg map[string]*string `locationNameKey:"TheKey" locationNameValue:"TheValue" type:"map"`
-
 	_ struct{} `type:"structure"`
+
+	MapArg map[string]*string `locationNameKey:"TheKey" locationNameValue:"TheValue" type:"map"`
 }
 
 type InputService9TestShapeInputService9TestCaseOperation1Output struct {
@@ -1036,9 +1036,9 @@ func (c *InputService10ProtocolTest) InputService10TestCaseOperation1(input *Inp
 }
 
 type InputService10TestShapeInputService10TestCaseOperation1Input struct {
-	BlobArg []byte `type:"blob"`
-
 	_ struct{} `type:"structure"`
+
+	BlobArg []byte `type:"blob"`
 }
 
 type InputService10TestShapeInputService10TestCaseOperation1Output struct {
@@ -1124,9 +1124,9 @@ func (c *InputService11ProtocolTest) InputService11TestCaseOperation1(input *Inp
 }
 
 type InputService11TestShapeInputService11TestCaseOperation1Input struct {
-	TimeArg *time.Time `type:"timestamp" timestampFormat:"iso8601"`
-
 	_ struct{} `type:"structure"`
+
+	TimeArg *time.Time `type:"timestamp" timestampFormat:"iso8601"`
 }
 
 type InputService11TestShapeInputService11TestCaseOperation1Output struct {
@@ -1356,12 +1356,14 @@ type InputService12TestShapeInputService12TestCaseOperation6Output struct {
 }
 
 type InputService12TestShapeInputShape struct {
-	RecursiveStruct *InputService12TestShapeRecursiveStructType `type:"structure"`
-
 	_ struct{} `type:"structure"`
+
+	RecursiveStruct *InputService12TestShapeRecursiveStructType `type:"structure"`
 }
 
 type InputService12TestShapeRecursiveStructType struct {
+	_ struct{} `type:"structure"`
+
 	NoRecurse *string `type:"string"`
 
 	RecursiveList []*InputService12TestShapeRecursiveStructType `type:"list"`
@@ -1369,8 +1371,6 @@ type InputService12TestShapeRecursiveStructType struct {
 	RecursiveMap map[string]*InputService12TestShapeRecursiveStructType `type:"map"`
 
 	RecursiveStruct *InputService12TestShapeRecursiveStructType `type:"structure"`
-
-	_ struct{} `type:"structure"`
 }
 
 //

--- a/private/protocol/query/unmarshal_test.go
+++ b/private/protocol/query/unmarshal_test.go
@@ -120,6 +120,8 @@ type OutputService1TestShapeOutputService1TestCaseOperation1Input struct {
 }
 
 type OutputService1TestShapeOutputService1TestCaseOperation1Output struct {
+	_ struct{} `type:"structure"`
+
 	Char *string `type:"character"`
 
 	Double *float64 `type:"double"`
@@ -137,8 +139,6 @@ type OutputService1TestShapeOutputService1TestCaseOperation1Output struct {
 	Timestamp *time.Time `type:"timestamp" timestampFormat:"iso8601"`
 
 	TrueBool *bool `type:"boolean"`
-
-	_ struct{} `type:"structure"`
 }
 
 //The service client's operations are safe to be used concurrently.
@@ -224,11 +224,11 @@ type OutputService2TestShapeOutputService2TestCaseOperation1Input struct {
 }
 
 type OutputService2TestShapeOutputService2TestCaseOperation1Output struct {
+	_ struct{} `type:"structure"`
+
 	Num *int64 `type:"integer"`
 
 	Str *string `type:"string"`
-
-	_ struct{} `type:"structure"`
 }
 
 //The service client's operations are safe to be used concurrently.
@@ -314,9 +314,9 @@ type OutputService3TestShapeOutputService3TestCaseOperation1Input struct {
 }
 
 type OutputService3TestShapeOutputService3TestCaseOperation1Output struct {
-	Blob []byte `type:"blob"`
-
 	_ struct{} `type:"structure"`
+
+	Blob []byte `type:"blob"`
 }
 
 //The service client's operations are safe to be used concurrently.
@@ -402,9 +402,9 @@ type OutputService4TestShapeOutputService4TestCaseOperation1Input struct {
 }
 
 type OutputService4TestShapeOutputService4TestCaseOperation1Output struct {
-	ListMember []*string `type:"list"`
-
 	_ struct{} `type:"structure"`
+
+	ListMember []*string `type:"list"`
 }
 
 //The service client's operations are safe to be used concurrently.
@@ -490,9 +490,9 @@ type OutputService5TestShapeOutputService5TestCaseOperation1Input struct {
 }
 
 type OutputService5TestShapeOutputService5TestCaseOperation1Output struct {
-	ListMember []*string `locationNameList:"item" type:"list"`
-
 	_ struct{} `type:"structure"`
+
+	ListMember []*string `locationNameList:"item" type:"list"`
 }
 
 //The service client's operations are safe to be used concurrently.
@@ -578,9 +578,9 @@ type OutputService6TestShapeOutputService6TestCaseOperation1Input struct {
 }
 
 type OutputService6TestShapeOutputService6TestCaseOperation1Output struct {
-	ListMember []*string `type:"list" flattened:"true"`
-
 	_ struct{} `type:"structure"`
+
+	ListMember []*string `type:"list" flattened:"true"`
 }
 
 //The service client's operations are safe to be used concurrently.
@@ -666,9 +666,9 @@ type OutputService7TestShapeOutputService7TestCaseOperation1Input struct {
 }
 
 type OutputService7TestShapeOutputService7TestCaseOperation1Output struct {
-	ListMember []*string `type:"list" flattened:"true"`
-
 	_ struct{} `type:"structure"`
+
+	ListMember []*string `type:"list" flattened:"true"`
 }
 
 //The service client's operations are safe to be used concurrently.
@@ -754,19 +754,19 @@ type OutputService8TestShapeOutputService8TestCaseOperation1Input struct {
 }
 
 type OutputService8TestShapeOutputService8TestCaseOperation1Output struct {
-	List []*OutputService8TestShapeStructureShape `type:"list"`
-
 	_ struct{} `type:"structure"`
+
+	List []*OutputService8TestShapeStructureShape `type:"list"`
 }
 
 type OutputService8TestShapeStructureShape struct {
+	_ struct{} `type:"structure"`
+
 	Bar *string `type:"string"`
 
 	Baz *string `type:"string"`
 
 	Foo *string `type:"string"`
-
-	_ struct{} `type:"structure"`
 }
 
 //The service client's operations are safe to be used concurrently.
@@ -852,19 +852,19 @@ type OutputService9TestShapeOutputService9TestCaseOperation1Input struct {
 }
 
 type OutputService9TestShapeOutputService9TestCaseOperation1Output struct {
-	List []*OutputService9TestShapeStructureShape `type:"list" flattened:"true"`
-
 	_ struct{} `type:"structure"`
+
+	List []*OutputService9TestShapeStructureShape `type:"list" flattened:"true"`
 }
 
 type OutputService9TestShapeStructureShape struct {
+	_ struct{} `type:"structure"`
+
 	Bar *string `type:"string"`
 
 	Baz *string `type:"string"`
 
 	Foo *string `type:"string"`
-
-	_ struct{} `type:"structure"`
 }
 
 //The service client's operations are safe to be used concurrently.
@@ -950,9 +950,9 @@ type OutputService10TestShapeOutputService10TestCaseOperation1Input struct {
 }
 
 type OutputService10TestShapeOutputService10TestCaseOperation1Output struct {
-	List []*string `locationNameList:"NamedList" type:"list" flattened:"true"`
-
 	_ struct{} `type:"structure"`
+
+	List []*string `locationNameList:"NamedList" type:"list" flattened:"true"`
 }
 
 //The service client's operations are safe to be used concurrently.
@@ -1038,15 +1038,15 @@ type OutputService11TestShapeOutputService11TestCaseOperation1Input struct {
 }
 
 type OutputService11TestShapeOutputService11TestCaseOperation1Output struct {
-	Map map[string]*OutputService11TestShapeStructType `type:"map"`
-
 	_ struct{} `type:"structure"`
+
+	Map map[string]*OutputService11TestShapeStructType `type:"map"`
 }
 
 type OutputService11TestShapeStructType struct {
-	Foo *string `locationName:"foo" type:"string"`
-
 	_ struct{} `type:"structure"`
+
+	Foo *string `locationName:"foo" type:"string"`
 }
 
 //The service client's operations are safe to be used concurrently.
@@ -1132,9 +1132,9 @@ type OutputService12TestShapeOutputService12TestCaseOperation1Input struct {
 }
 
 type OutputService12TestShapeOutputService12TestCaseOperation1Output struct {
-	Map map[string]*string `type:"map" flattened:"true"`
-
 	_ struct{} `type:"structure"`
+
+	Map map[string]*string `type:"map" flattened:"true"`
 }
 
 //The service client's operations are safe to be used concurrently.
@@ -1220,9 +1220,9 @@ type OutputService13TestShapeOutputService13TestCaseOperation1Input struct {
 }
 
 type OutputService13TestShapeOutputService13TestCaseOperation1Output struct {
-	Map map[string]*string `locationName:"Attribute" locationNameKey:"Name" locationNameValue:"Value" type:"map" flattened:"true"`
-
 	_ struct{} `type:"structure"`
+
+	Map map[string]*string `locationName:"Attribute" locationNameKey:"Name" locationNameValue:"Value" type:"map" flattened:"true"`
 }
 
 //The service client's operations are safe to be used concurrently.
@@ -1308,9 +1308,9 @@ type OutputService14TestShapeOutputService14TestCaseOperation1Input struct {
 }
 
 type OutputService14TestShapeOutputService14TestCaseOperation1Output struct {
-	Map map[string]*string `locationNameKey:"foo" locationNameValue:"bar" type:"map" flattened:"true"`
-
 	_ struct{} `type:"structure"`
+
+	Map map[string]*string `locationNameKey:"foo" locationNameValue:"bar" type:"map" flattened:"true"`
 }
 
 //The service client's operations are safe to be used concurrently.
@@ -1396,9 +1396,9 @@ type OutputService15TestShapeOutputService15TestCaseOperation1Input struct {
 }
 
 type OutputService15TestShapeOutputService15TestCaseOperation1Output struct {
-	Foo *string `type:"string"`
-
 	_ struct{} `type:"structure"`
+
+	Foo *string `type:"string"`
 }
 
 //

--- a/private/protocol/query/unmarshal_test.go
+++ b/private/protocol/query/unmarshal_test.go
@@ -116,11 +116,7 @@ func (c *OutputService1ProtocolTest) OutputService1TestCaseOperation1(input *Out
 }
 
 type OutputService1TestShapeOutputService1TestCaseOperation1Input struct {
-	metadataOutputService1TestShapeOutputService1TestCaseOperation1Input `json:"-" xml:"-"`
-}
-
-type metadataOutputService1TestShapeOutputService1TestCaseOperation1Input struct {
-	SDKShapeTraits bool `type:"structure"`
+	_ struct{} `type:"structure"`
 }
 
 type OutputService1TestShapeOutputService1TestCaseOperation1Output struct {
@@ -142,11 +138,7 @@ type OutputService1TestShapeOutputService1TestCaseOperation1Output struct {
 
 	TrueBool *bool `type:"boolean"`
 
-	metadataOutputService1TestShapeOutputService1TestCaseOperation1Output `json:"-" xml:"-"`
-}
-
-type metadataOutputService1TestShapeOutputService1TestCaseOperation1Output struct {
-	SDKShapeTraits bool `type:"structure"`
+	_ struct{} `type:"structure"`
 }
 
 //The service client's operations are safe to be used concurrently.
@@ -228,11 +220,7 @@ func (c *OutputService2ProtocolTest) OutputService2TestCaseOperation1(input *Out
 }
 
 type OutputService2TestShapeOutputService2TestCaseOperation1Input struct {
-	metadataOutputService2TestShapeOutputService2TestCaseOperation1Input `json:"-" xml:"-"`
-}
-
-type metadataOutputService2TestShapeOutputService2TestCaseOperation1Input struct {
-	SDKShapeTraits bool `type:"structure"`
+	_ struct{} `type:"structure"`
 }
 
 type OutputService2TestShapeOutputService2TestCaseOperation1Output struct {
@@ -240,11 +228,7 @@ type OutputService2TestShapeOutputService2TestCaseOperation1Output struct {
 
 	Str *string `type:"string"`
 
-	metadataOutputService2TestShapeOutputService2TestCaseOperation1Output `json:"-" xml:"-"`
-}
-
-type metadataOutputService2TestShapeOutputService2TestCaseOperation1Output struct {
-	SDKShapeTraits bool `type:"structure"`
+	_ struct{} `type:"structure"`
 }
 
 //The service client's operations are safe to be used concurrently.
@@ -326,21 +310,13 @@ func (c *OutputService3ProtocolTest) OutputService3TestCaseOperation1(input *Out
 }
 
 type OutputService3TestShapeOutputService3TestCaseOperation1Input struct {
-	metadataOutputService3TestShapeOutputService3TestCaseOperation1Input `json:"-" xml:"-"`
-}
-
-type metadataOutputService3TestShapeOutputService3TestCaseOperation1Input struct {
-	SDKShapeTraits bool `type:"structure"`
+	_ struct{} `type:"structure"`
 }
 
 type OutputService3TestShapeOutputService3TestCaseOperation1Output struct {
 	Blob []byte `type:"blob"`
 
-	metadataOutputService3TestShapeOutputService3TestCaseOperation1Output `json:"-" xml:"-"`
-}
-
-type metadataOutputService3TestShapeOutputService3TestCaseOperation1Output struct {
-	SDKShapeTraits bool `type:"structure"`
+	_ struct{} `type:"structure"`
 }
 
 //The service client's operations are safe to be used concurrently.
@@ -422,21 +398,13 @@ func (c *OutputService4ProtocolTest) OutputService4TestCaseOperation1(input *Out
 }
 
 type OutputService4TestShapeOutputService4TestCaseOperation1Input struct {
-	metadataOutputService4TestShapeOutputService4TestCaseOperation1Input `json:"-" xml:"-"`
-}
-
-type metadataOutputService4TestShapeOutputService4TestCaseOperation1Input struct {
-	SDKShapeTraits bool `type:"structure"`
+	_ struct{} `type:"structure"`
 }
 
 type OutputService4TestShapeOutputService4TestCaseOperation1Output struct {
 	ListMember []*string `type:"list"`
 
-	metadataOutputService4TestShapeOutputService4TestCaseOperation1Output `json:"-" xml:"-"`
-}
-
-type metadataOutputService4TestShapeOutputService4TestCaseOperation1Output struct {
-	SDKShapeTraits bool `type:"structure"`
+	_ struct{} `type:"structure"`
 }
 
 //The service client's operations are safe to be used concurrently.
@@ -518,21 +486,13 @@ func (c *OutputService5ProtocolTest) OutputService5TestCaseOperation1(input *Out
 }
 
 type OutputService5TestShapeOutputService5TestCaseOperation1Input struct {
-	metadataOutputService5TestShapeOutputService5TestCaseOperation1Input `json:"-" xml:"-"`
-}
-
-type metadataOutputService5TestShapeOutputService5TestCaseOperation1Input struct {
-	SDKShapeTraits bool `type:"structure"`
+	_ struct{} `type:"structure"`
 }
 
 type OutputService5TestShapeOutputService5TestCaseOperation1Output struct {
 	ListMember []*string `locationNameList:"item" type:"list"`
 
-	metadataOutputService5TestShapeOutputService5TestCaseOperation1Output `json:"-" xml:"-"`
-}
-
-type metadataOutputService5TestShapeOutputService5TestCaseOperation1Output struct {
-	SDKShapeTraits bool `type:"structure"`
+	_ struct{} `type:"structure"`
 }
 
 //The service client's operations are safe to be used concurrently.
@@ -614,21 +574,13 @@ func (c *OutputService6ProtocolTest) OutputService6TestCaseOperation1(input *Out
 }
 
 type OutputService6TestShapeOutputService6TestCaseOperation1Input struct {
-	metadataOutputService6TestShapeOutputService6TestCaseOperation1Input `json:"-" xml:"-"`
-}
-
-type metadataOutputService6TestShapeOutputService6TestCaseOperation1Input struct {
-	SDKShapeTraits bool `type:"structure"`
+	_ struct{} `type:"structure"`
 }
 
 type OutputService6TestShapeOutputService6TestCaseOperation1Output struct {
 	ListMember []*string `type:"list" flattened:"true"`
 
-	metadataOutputService6TestShapeOutputService6TestCaseOperation1Output `json:"-" xml:"-"`
-}
-
-type metadataOutputService6TestShapeOutputService6TestCaseOperation1Output struct {
-	SDKShapeTraits bool `type:"structure"`
+	_ struct{} `type:"structure"`
 }
 
 //The service client's operations are safe to be used concurrently.
@@ -710,21 +662,13 @@ func (c *OutputService7ProtocolTest) OutputService7TestCaseOperation1(input *Out
 }
 
 type OutputService7TestShapeOutputService7TestCaseOperation1Input struct {
-	metadataOutputService7TestShapeOutputService7TestCaseOperation1Input `json:"-" xml:"-"`
-}
-
-type metadataOutputService7TestShapeOutputService7TestCaseOperation1Input struct {
-	SDKShapeTraits bool `type:"structure"`
+	_ struct{} `type:"structure"`
 }
 
 type OutputService7TestShapeOutputService7TestCaseOperation1Output struct {
 	ListMember []*string `type:"list" flattened:"true"`
 
-	metadataOutputService7TestShapeOutputService7TestCaseOperation1Output `json:"-" xml:"-"`
-}
-
-type metadataOutputService7TestShapeOutputService7TestCaseOperation1Output struct {
-	SDKShapeTraits bool `type:"structure"`
+	_ struct{} `type:"structure"`
 }
 
 //The service client's operations are safe to be used concurrently.
@@ -806,21 +750,13 @@ func (c *OutputService8ProtocolTest) OutputService8TestCaseOperation1(input *Out
 }
 
 type OutputService8TestShapeOutputService8TestCaseOperation1Input struct {
-	metadataOutputService8TestShapeOutputService8TestCaseOperation1Input `json:"-" xml:"-"`
-}
-
-type metadataOutputService8TestShapeOutputService8TestCaseOperation1Input struct {
-	SDKShapeTraits bool `type:"structure"`
+	_ struct{} `type:"structure"`
 }
 
 type OutputService8TestShapeOutputService8TestCaseOperation1Output struct {
 	List []*OutputService8TestShapeStructureShape `type:"list"`
 
-	metadataOutputService8TestShapeOutputService8TestCaseOperation1Output `json:"-" xml:"-"`
-}
-
-type metadataOutputService8TestShapeOutputService8TestCaseOperation1Output struct {
-	SDKShapeTraits bool `type:"structure"`
+	_ struct{} `type:"structure"`
 }
 
 type OutputService8TestShapeStructureShape struct {
@@ -830,11 +766,7 @@ type OutputService8TestShapeStructureShape struct {
 
 	Foo *string `type:"string"`
 
-	metadataOutputService8TestShapeStructureShape `json:"-" xml:"-"`
-}
-
-type metadataOutputService8TestShapeStructureShape struct {
-	SDKShapeTraits bool `type:"structure"`
+	_ struct{} `type:"structure"`
 }
 
 //The service client's operations are safe to be used concurrently.
@@ -916,21 +848,13 @@ func (c *OutputService9ProtocolTest) OutputService9TestCaseOperation1(input *Out
 }
 
 type OutputService9TestShapeOutputService9TestCaseOperation1Input struct {
-	metadataOutputService9TestShapeOutputService9TestCaseOperation1Input `json:"-" xml:"-"`
-}
-
-type metadataOutputService9TestShapeOutputService9TestCaseOperation1Input struct {
-	SDKShapeTraits bool `type:"structure"`
+	_ struct{} `type:"structure"`
 }
 
 type OutputService9TestShapeOutputService9TestCaseOperation1Output struct {
 	List []*OutputService9TestShapeStructureShape `type:"list" flattened:"true"`
 
-	metadataOutputService9TestShapeOutputService9TestCaseOperation1Output `json:"-" xml:"-"`
-}
-
-type metadataOutputService9TestShapeOutputService9TestCaseOperation1Output struct {
-	SDKShapeTraits bool `type:"structure"`
+	_ struct{} `type:"structure"`
 }
 
 type OutputService9TestShapeStructureShape struct {
@@ -940,11 +864,7 @@ type OutputService9TestShapeStructureShape struct {
 
 	Foo *string `type:"string"`
 
-	metadataOutputService9TestShapeStructureShape `json:"-" xml:"-"`
-}
-
-type metadataOutputService9TestShapeStructureShape struct {
-	SDKShapeTraits bool `type:"structure"`
+	_ struct{} `type:"structure"`
 }
 
 //The service client's operations are safe to be used concurrently.
@@ -1026,21 +946,13 @@ func (c *OutputService10ProtocolTest) OutputService10TestCaseOperation1(input *O
 }
 
 type OutputService10TestShapeOutputService10TestCaseOperation1Input struct {
-	metadataOutputService10TestShapeOutputService10TestCaseOperation1Input `json:"-" xml:"-"`
-}
-
-type metadataOutputService10TestShapeOutputService10TestCaseOperation1Input struct {
-	SDKShapeTraits bool `type:"structure"`
+	_ struct{} `type:"structure"`
 }
 
 type OutputService10TestShapeOutputService10TestCaseOperation1Output struct {
 	List []*string `locationNameList:"NamedList" type:"list" flattened:"true"`
 
-	metadataOutputService10TestShapeOutputService10TestCaseOperation1Output `json:"-" xml:"-"`
-}
-
-type metadataOutputService10TestShapeOutputService10TestCaseOperation1Output struct {
-	SDKShapeTraits bool `type:"structure"`
+	_ struct{} `type:"structure"`
 }
 
 //The service client's operations are safe to be used concurrently.
@@ -1122,31 +1034,19 @@ func (c *OutputService11ProtocolTest) OutputService11TestCaseOperation1(input *O
 }
 
 type OutputService11TestShapeOutputService11TestCaseOperation1Input struct {
-	metadataOutputService11TestShapeOutputService11TestCaseOperation1Input `json:"-" xml:"-"`
-}
-
-type metadataOutputService11TestShapeOutputService11TestCaseOperation1Input struct {
-	SDKShapeTraits bool `type:"structure"`
+	_ struct{} `type:"structure"`
 }
 
 type OutputService11TestShapeOutputService11TestCaseOperation1Output struct {
 	Map map[string]*OutputService11TestShapeStructType `type:"map"`
 
-	metadataOutputService11TestShapeOutputService11TestCaseOperation1Output `json:"-" xml:"-"`
-}
-
-type metadataOutputService11TestShapeOutputService11TestCaseOperation1Output struct {
-	SDKShapeTraits bool `type:"structure"`
+	_ struct{} `type:"structure"`
 }
 
 type OutputService11TestShapeStructType struct {
 	Foo *string `locationName:"foo" type:"string"`
 
-	metadataOutputService11TestShapeStructType `json:"-" xml:"-"`
-}
-
-type metadataOutputService11TestShapeStructType struct {
-	SDKShapeTraits bool `type:"structure"`
+	_ struct{} `type:"structure"`
 }
 
 //The service client's operations are safe to be used concurrently.
@@ -1228,21 +1128,13 @@ func (c *OutputService12ProtocolTest) OutputService12TestCaseOperation1(input *O
 }
 
 type OutputService12TestShapeOutputService12TestCaseOperation1Input struct {
-	metadataOutputService12TestShapeOutputService12TestCaseOperation1Input `json:"-" xml:"-"`
-}
-
-type metadataOutputService12TestShapeOutputService12TestCaseOperation1Input struct {
-	SDKShapeTraits bool `type:"structure"`
+	_ struct{} `type:"structure"`
 }
 
 type OutputService12TestShapeOutputService12TestCaseOperation1Output struct {
 	Map map[string]*string `type:"map" flattened:"true"`
 
-	metadataOutputService12TestShapeOutputService12TestCaseOperation1Output `json:"-" xml:"-"`
-}
-
-type metadataOutputService12TestShapeOutputService12TestCaseOperation1Output struct {
-	SDKShapeTraits bool `type:"structure"`
+	_ struct{} `type:"structure"`
 }
 
 //The service client's operations are safe to be used concurrently.
@@ -1324,21 +1216,13 @@ func (c *OutputService13ProtocolTest) OutputService13TestCaseOperation1(input *O
 }
 
 type OutputService13TestShapeOutputService13TestCaseOperation1Input struct {
-	metadataOutputService13TestShapeOutputService13TestCaseOperation1Input `json:"-" xml:"-"`
-}
-
-type metadataOutputService13TestShapeOutputService13TestCaseOperation1Input struct {
-	SDKShapeTraits bool `type:"structure"`
+	_ struct{} `type:"structure"`
 }
 
 type OutputService13TestShapeOutputService13TestCaseOperation1Output struct {
 	Map map[string]*string `locationName:"Attribute" locationNameKey:"Name" locationNameValue:"Value" type:"map" flattened:"true"`
 
-	metadataOutputService13TestShapeOutputService13TestCaseOperation1Output `json:"-" xml:"-"`
-}
-
-type metadataOutputService13TestShapeOutputService13TestCaseOperation1Output struct {
-	SDKShapeTraits bool `type:"structure"`
+	_ struct{} `type:"structure"`
 }
 
 //The service client's operations are safe to be used concurrently.
@@ -1420,21 +1304,13 @@ func (c *OutputService14ProtocolTest) OutputService14TestCaseOperation1(input *O
 }
 
 type OutputService14TestShapeOutputService14TestCaseOperation1Input struct {
-	metadataOutputService14TestShapeOutputService14TestCaseOperation1Input `json:"-" xml:"-"`
-}
-
-type metadataOutputService14TestShapeOutputService14TestCaseOperation1Input struct {
-	SDKShapeTraits bool `type:"structure"`
+	_ struct{} `type:"structure"`
 }
 
 type OutputService14TestShapeOutputService14TestCaseOperation1Output struct {
 	Map map[string]*string `locationNameKey:"foo" locationNameValue:"bar" type:"map" flattened:"true"`
 
-	metadataOutputService14TestShapeOutputService14TestCaseOperation1Output `json:"-" xml:"-"`
-}
-
-type metadataOutputService14TestShapeOutputService14TestCaseOperation1Output struct {
-	SDKShapeTraits bool `type:"structure"`
+	_ struct{} `type:"structure"`
 }
 
 //The service client's operations are safe to be used concurrently.
@@ -1516,21 +1392,13 @@ func (c *OutputService15ProtocolTest) OutputService15TestCaseOperation1(input *O
 }
 
 type OutputService15TestShapeOutputService15TestCaseOperation1Input struct {
-	metadataOutputService15TestShapeOutputService15TestCaseOperation1Input `json:"-" xml:"-"`
-}
-
-type metadataOutputService15TestShapeOutputService15TestCaseOperation1Input struct {
-	SDKShapeTraits bool `type:"structure"`
+	_ struct{} `type:"structure"`
 }
 
 type OutputService15TestShapeOutputService15TestCaseOperation1Output struct {
 	Foo *string `type:"string"`
 
-	metadataOutputService15TestShapeOutputService15TestCaseOperation1Output `json:"-" xml:"-"`
-}
-
-type metadataOutputService15TestShapeOutputService15TestCaseOperation1Output struct {
-	SDKShapeTraits bool `type:"structure"`
+	_ struct{} `type:"structure"`
 }
 
 //

--- a/private/protocol/rest/build.go
+++ b/private/protocol/rest/build.go
@@ -93,7 +93,7 @@ func buildLocationElements(r *request.Request, v reflect.Value) {
 }
 
 func buildBody(r *request.Request, v reflect.Value) {
-	if field, ok := v.Type().FieldByName("SDKShapeTraits"); ok {
+	if field, ok := v.Type().FieldByName("_"); ok {
 		if payloadName := field.Tag.Get("payload"); payloadName != "" {
 			pfield, _ := v.Type().FieldByName(payloadName)
 			if ptag := pfield.Tag.Get("type"); ptag != "" && ptag != "structure" {

--- a/private/protocol/rest/payload.go
+++ b/private/protocol/rest/payload.go
@@ -12,7 +12,7 @@ func PayloadMember(i interface{}) interface{} {
 	if !v.IsValid() {
 		return nil
 	}
-	if field, ok := v.Type().FieldByName("SDKShapeTraits"); ok {
+	if field, ok := v.Type().FieldByName("_"); ok {
 		if payloadName := field.Tag.Get("payload"); payloadName != "" {
 			field, _ := v.Type().FieldByName(payloadName)
 			if field.Tag.Get("type") != "structure" {
@@ -34,7 +34,7 @@ func PayloadType(i interface{}) string {
 	if !v.IsValid() {
 		return ""
 	}
-	if field, ok := v.Type().FieldByName("SDKShapeTraits"); ok {
+	if field, ok := v.Type().FieldByName("_"); ok {
 		if payloadName := field.Tag.Get("payload"); payloadName != "" {
 			if member, ok := v.Type().FieldByName(payloadName); ok {
 				return member.Tag.Get("type")

--- a/private/protocol/rest/unmarshal.go
+++ b/private/protocol/rest/unmarshal.go
@@ -33,7 +33,7 @@ func UnmarshalMeta(r *request.Request) {
 }
 
 func unmarshalBody(r *request.Request, v reflect.Value) {
-	if field, ok := v.Type().FieldByName("SDKShapeTraits"); ok {
+	if field, ok := v.Type().FieldByName("_"); ok {
 		if payloadName := field.Tag.Get("payload"); payloadName != "" {
 			pfield, _ := v.Type().FieldByName(payloadName)
 			if ptag := pfield.Tag.Get("type"); ptag != "" && ptag != "structure" {

--- a/private/protocol/restjson/build_test.go
+++ b/private/protocol/restjson/build_test.go
@@ -118,9 +118,9 @@ func (c *InputService1ProtocolTest) InputService1TestCaseOperation1(input *Input
 }
 
 type InputService1TestShapeInputService1TestCaseOperation1Input struct {
-	PipelineId *string `location:"uri" type:"string"`
-
 	_ struct{} `type:"structure"`
+
+	PipelineId *string `location:"uri" type:"string"`
 }
 
 type InputService1TestShapeInputService1TestCaseOperation1Output struct {
@@ -208,9 +208,9 @@ func (c *InputService2ProtocolTest) InputService2TestCaseOperation1(input *Input
 }
 
 type InputService2TestShapeInputService2TestCaseOperation1Input struct {
-	Foo *string `location:"uri" locationName:"PipelineId" type:"string"`
-
 	_ struct{} `type:"structure"`
+
+	Foo *string `location:"uri" locationName:"PipelineId" type:"string"`
 }
 
 type InputService2TestShapeInputService2TestCaseOperation1Output struct {
@@ -298,11 +298,11 @@ func (c *InputService3ProtocolTest) InputService3TestCaseOperation1(input *Input
 }
 
 type InputService3TestShapeInputService3TestCaseOperation1Input struct {
+	_ struct{} `type:"structure"`
+
 	PipelineId *string `location:"uri" type:"string"`
 
 	QueryDoc map[string]*string `location:"querystring" type:"map"`
-
-	_ struct{} `type:"structure"`
 }
 
 type InputService3TestShapeInputService3TestCaseOperation1Output struct {
@@ -390,11 +390,11 @@ func (c *InputService4ProtocolTest) InputService4TestCaseOperation1(input *Input
 }
 
 type InputService4TestShapeInputService4TestCaseOperation1Input struct {
+	_ struct{} `type:"structure"`
+
 	PipelineId *string `location:"uri" type:"string"`
 
 	QueryDoc map[string][]*string `location:"querystring" type:"map"`
-
-	_ struct{} `type:"structure"`
 }
 
 type InputService4TestShapeInputService4TestCaseOperation1Output struct {
@@ -482,13 +482,13 @@ func (c *InputService5ProtocolTest) InputService5TestCaseOperation1(input *Input
 }
 
 type InputService5TestShapeInputService5TestCaseOperation1Input struct {
+	_ struct{} `type:"structure"`
+
 	Ascending *string `location:"querystring" locationName:"Ascending" type:"string"`
 
 	PageToken *string `location:"querystring" locationName:"PageToken" type:"string"`
 
 	PipelineId *string `location:"uri" locationName:"PipelineId" type:"string"`
-
-	_ struct{} `type:"structure"`
 }
 
 type InputService5TestShapeInputService5TestCaseOperation1Output struct {
@@ -576,6 +576,8 @@ func (c *InputService6ProtocolTest) InputService6TestCaseOperation1(input *Input
 }
 
 type InputService6TestShapeInputService6TestCaseOperation1Input struct {
+	_ struct{} `type:"structure"`
+
 	Ascending *string `location:"querystring" locationName:"Ascending" type:"string"`
 
 	Config *InputService6TestShapeStructType `type:"structure"`
@@ -583,8 +585,6 @@ type InputService6TestShapeInputService6TestCaseOperation1Input struct {
 	PageToken *string `location:"querystring" locationName:"PageToken" type:"string"`
 
 	PipelineId *string `location:"uri" locationName:"PipelineId" type:"string"`
-
-	_ struct{} `type:"structure"`
 }
 
 type InputService6TestShapeInputService6TestCaseOperation1Output struct {
@@ -592,11 +592,11 @@ type InputService6TestShapeInputService6TestCaseOperation1Output struct {
 }
 
 type InputService6TestShapeStructType struct {
+	_ struct{} `type:"structure"`
+
 	A *string `type:"string"`
 
 	B *string `type:"string"`
-
-	_ struct{} `type:"structure"`
 }
 
 //The service client's operations are safe to be used concurrently.
@@ -680,6 +680,8 @@ func (c *InputService7ProtocolTest) InputService7TestCaseOperation1(input *Input
 }
 
 type InputService7TestShapeInputService7TestCaseOperation1Input struct {
+	_ struct{} `type:"structure"`
+
 	Ascending *string `location:"querystring" locationName:"Ascending" type:"string"`
 
 	Checksum *string `location:"header" locationName:"x-amz-checksum" type:"string"`
@@ -689,8 +691,6 @@ type InputService7TestShapeInputService7TestCaseOperation1Input struct {
 	PageToken *string `location:"querystring" locationName:"PageToken" type:"string"`
 
 	PipelineId *string `location:"uri" locationName:"PipelineId" type:"string"`
-
-	_ struct{} `type:"structure"`
 }
 
 type InputService7TestShapeInputService7TestCaseOperation1Output struct {
@@ -698,11 +698,11 @@ type InputService7TestShapeInputService7TestCaseOperation1Output struct {
 }
 
 type InputService7TestShapeStructType struct {
+	_ struct{} `type:"structure"`
+
 	A *string `type:"string"`
 
 	B *string `type:"string"`
-
-	_ struct{} `type:"structure"`
 }
 
 //The service client's operations are safe to be used concurrently.
@@ -786,13 +786,13 @@ func (c *InputService8ProtocolTest) InputService8TestCaseOperation1(input *Input
 }
 
 type InputService8TestShapeInputService8TestCaseOperation1Input struct {
+	_ struct{} `type:"structure" payload:"Body"`
+
 	Body io.ReadSeeker `locationName:"body" type:"blob"`
 
 	Checksum *string `location:"header" locationName:"x-amz-sha256-tree-hash" type:"string"`
 
 	VaultName *string `location:"uri" locationName:"vaultName" type:"string" required:"true"`
-
-	_ struct{} `type:"structure" payload:"Body"`
 }
 
 type InputService8TestShapeInputService8TestCaseOperation1Output struct {
@@ -880,9 +880,9 @@ func (c *InputService9ProtocolTest) InputService9TestCaseOperation1(input *Input
 }
 
 type InputService9TestShapeInputService9TestCaseOperation1Input struct {
-	Foo *string `locationName:"foo" type:"string"`
-
 	_ struct{} `type:"structure" payload:"Foo"`
+
+	Foo *string `locationName:"foo" type:"string"`
 }
 
 type InputService9TestShapeInputService9TestCaseOperation1Output struct {
@@ -1004,9 +1004,9 @@ type InputService10TestShapeInputService10TestCaseOperation2Output struct {
 }
 
 type InputService10TestShapeInputShape struct {
-	Foo []byte `locationName:"foo" type:"blob"`
-
 	_ struct{} `type:"structure" payload:"Foo"`
+
+	Foo []byte `locationName:"foo" type:"blob"`
 }
 
 //The service client's operations are safe to be used concurrently.
@@ -1116,9 +1116,9 @@ func (c *InputService11ProtocolTest) InputService11TestCaseOperation2(input *Inp
 }
 
 type InputService11TestShapeFooShape struct {
-	Baz *string `locationName:"baz" type:"string"`
-
 	_ struct{} `locationName:"foo" type:"structure"`
+
+	Baz *string `locationName:"baz" type:"string"`
 }
 
 type InputService11TestShapeInputService11TestCaseOperation1Output struct {
@@ -1130,9 +1130,9 @@ type InputService11TestShapeInputService11TestCaseOperation2Output struct {
 }
 
 type InputService11TestShapeInputShape struct {
-	Foo *InputService11TestShapeFooShape `locationName:"foo" type:"structure"`
-
 	_ struct{} `type:"structure" payload:"Foo"`
+
+	Foo *InputService11TestShapeFooShape `locationName:"foo" type:"structure"`
 }
 
 //The service client's operations are safe to be used concurrently.
@@ -1250,9 +1250,9 @@ type InputService12TestShapeInputService12TestCaseOperation2Output struct {
 }
 
 type InputService12TestShapeInputShape struct {
-	Foo *string `location:"querystring" locationName:"param-name" type:"string"`
-
 	_ struct{} `type:"structure"`
+
+	Foo *string `location:"querystring" locationName:"param-name" type:"string"`
 }
 
 //The service client's operations are safe to be used concurrently.
@@ -1490,12 +1490,14 @@ type InputService13TestShapeInputService13TestCaseOperation6Output struct {
 }
 
 type InputService13TestShapeInputShape struct {
-	RecursiveStruct *InputService13TestShapeRecursiveStructType `type:"structure"`
-
 	_ struct{} `type:"structure"`
+
+	RecursiveStruct *InputService13TestShapeRecursiveStructType `type:"structure"`
 }
 
 type InputService13TestShapeRecursiveStructType struct {
+	_ struct{} `type:"structure"`
+
 	NoRecurse *string `type:"string"`
 
 	RecursiveList []*InputService13TestShapeRecursiveStructType `type:"list"`
@@ -1503,8 +1505,6 @@ type InputService13TestShapeRecursiveStructType struct {
 	RecursiveMap map[string]*InputService13TestShapeRecursiveStructType `type:"map"`
 
 	RecursiveStruct *InputService13TestShapeRecursiveStructType `type:"structure"`
-
-	_ struct{} `type:"structure"`
 }
 
 //The service client's operations are safe to be used concurrently.
@@ -1622,11 +1622,11 @@ type InputService14TestShapeInputService14TestCaseOperation2Output struct {
 }
 
 type InputService14TestShapeInputShape struct {
+	_ struct{} `type:"structure"`
+
 	TimeArg *time.Time `type:"timestamp" timestampFormat:"unix"`
 
 	TimeArgInHeader *time.Time `location:"header" locationName:"x-amz-timearg" type:"timestamp" timestampFormat:"rfc822"`
-
-	_ struct{} `type:"structure"`
 }
 
 //

--- a/private/protocol/restjson/build_test.go
+++ b/private/protocol/restjson/build_test.go
@@ -120,19 +120,11 @@ func (c *InputService1ProtocolTest) InputService1TestCaseOperation1(input *Input
 type InputService1TestShapeInputService1TestCaseOperation1Input struct {
 	PipelineId *string `location:"uri" type:"string"`
 
-	metadataInputService1TestShapeInputService1TestCaseOperation1Input `json:"-" xml:"-"`
-}
-
-type metadataInputService1TestShapeInputService1TestCaseOperation1Input struct {
-	SDKShapeTraits bool `type:"structure"`
+	_ struct{} `type:"structure"`
 }
 
 type InputService1TestShapeInputService1TestCaseOperation1Output struct {
-	metadataInputService1TestShapeInputService1TestCaseOperation1Output `json:"-" xml:"-"`
-}
-
-type metadataInputService1TestShapeInputService1TestCaseOperation1Output struct {
-	SDKShapeTraits bool `type:"structure"`
+	_ struct{} `type:"structure"`
 }
 
 //The service client's operations are safe to be used concurrently.
@@ -218,19 +210,11 @@ func (c *InputService2ProtocolTest) InputService2TestCaseOperation1(input *Input
 type InputService2TestShapeInputService2TestCaseOperation1Input struct {
 	Foo *string `location:"uri" locationName:"PipelineId" type:"string"`
 
-	metadataInputService2TestShapeInputService2TestCaseOperation1Input `json:"-" xml:"-"`
-}
-
-type metadataInputService2TestShapeInputService2TestCaseOperation1Input struct {
-	SDKShapeTraits bool `type:"structure"`
+	_ struct{} `type:"structure"`
 }
 
 type InputService2TestShapeInputService2TestCaseOperation1Output struct {
-	metadataInputService2TestShapeInputService2TestCaseOperation1Output `json:"-" xml:"-"`
-}
-
-type metadataInputService2TestShapeInputService2TestCaseOperation1Output struct {
-	SDKShapeTraits bool `type:"structure"`
+	_ struct{} `type:"structure"`
 }
 
 //The service client's operations are safe to be used concurrently.
@@ -318,19 +302,11 @@ type InputService3TestShapeInputService3TestCaseOperation1Input struct {
 
 	QueryDoc map[string]*string `location:"querystring" type:"map"`
 
-	metadataInputService3TestShapeInputService3TestCaseOperation1Input `json:"-" xml:"-"`
-}
-
-type metadataInputService3TestShapeInputService3TestCaseOperation1Input struct {
-	SDKShapeTraits bool `type:"structure"`
+	_ struct{} `type:"structure"`
 }
 
 type InputService3TestShapeInputService3TestCaseOperation1Output struct {
-	metadataInputService3TestShapeInputService3TestCaseOperation1Output `json:"-" xml:"-"`
-}
-
-type metadataInputService3TestShapeInputService3TestCaseOperation1Output struct {
-	SDKShapeTraits bool `type:"structure"`
+	_ struct{} `type:"structure"`
 }
 
 //The service client's operations are safe to be used concurrently.
@@ -418,19 +394,11 @@ type InputService4TestShapeInputService4TestCaseOperation1Input struct {
 
 	QueryDoc map[string][]*string `location:"querystring" type:"map"`
 
-	metadataInputService4TestShapeInputService4TestCaseOperation1Input `json:"-" xml:"-"`
-}
-
-type metadataInputService4TestShapeInputService4TestCaseOperation1Input struct {
-	SDKShapeTraits bool `type:"structure"`
+	_ struct{} `type:"structure"`
 }
 
 type InputService4TestShapeInputService4TestCaseOperation1Output struct {
-	metadataInputService4TestShapeInputService4TestCaseOperation1Output `json:"-" xml:"-"`
-}
-
-type metadataInputService4TestShapeInputService4TestCaseOperation1Output struct {
-	SDKShapeTraits bool `type:"structure"`
+	_ struct{} `type:"structure"`
 }
 
 //The service client's operations are safe to be used concurrently.
@@ -520,19 +488,11 @@ type InputService5TestShapeInputService5TestCaseOperation1Input struct {
 
 	PipelineId *string `location:"uri" locationName:"PipelineId" type:"string"`
 
-	metadataInputService5TestShapeInputService5TestCaseOperation1Input `json:"-" xml:"-"`
-}
-
-type metadataInputService5TestShapeInputService5TestCaseOperation1Input struct {
-	SDKShapeTraits bool `type:"structure"`
+	_ struct{} `type:"structure"`
 }
 
 type InputService5TestShapeInputService5TestCaseOperation1Output struct {
-	metadataInputService5TestShapeInputService5TestCaseOperation1Output `json:"-" xml:"-"`
-}
-
-type metadataInputService5TestShapeInputService5TestCaseOperation1Output struct {
-	SDKShapeTraits bool `type:"structure"`
+	_ struct{} `type:"structure"`
 }
 
 //The service client's operations are safe to be used concurrently.
@@ -624,19 +584,11 @@ type InputService6TestShapeInputService6TestCaseOperation1Input struct {
 
 	PipelineId *string `location:"uri" locationName:"PipelineId" type:"string"`
 
-	metadataInputService6TestShapeInputService6TestCaseOperation1Input `json:"-" xml:"-"`
-}
-
-type metadataInputService6TestShapeInputService6TestCaseOperation1Input struct {
-	SDKShapeTraits bool `type:"structure"`
+	_ struct{} `type:"structure"`
 }
 
 type InputService6TestShapeInputService6TestCaseOperation1Output struct {
-	metadataInputService6TestShapeInputService6TestCaseOperation1Output `json:"-" xml:"-"`
-}
-
-type metadataInputService6TestShapeInputService6TestCaseOperation1Output struct {
-	SDKShapeTraits bool `type:"structure"`
+	_ struct{} `type:"structure"`
 }
 
 type InputService6TestShapeStructType struct {
@@ -644,11 +596,7 @@ type InputService6TestShapeStructType struct {
 
 	B *string `type:"string"`
 
-	metadataInputService6TestShapeStructType `json:"-" xml:"-"`
-}
-
-type metadataInputService6TestShapeStructType struct {
-	SDKShapeTraits bool `type:"structure"`
+	_ struct{} `type:"structure"`
 }
 
 //The service client's operations are safe to be used concurrently.
@@ -742,19 +690,11 @@ type InputService7TestShapeInputService7TestCaseOperation1Input struct {
 
 	PipelineId *string `location:"uri" locationName:"PipelineId" type:"string"`
 
-	metadataInputService7TestShapeInputService7TestCaseOperation1Input `json:"-" xml:"-"`
-}
-
-type metadataInputService7TestShapeInputService7TestCaseOperation1Input struct {
-	SDKShapeTraits bool `type:"structure"`
+	_ struct{} `type:"structure"`
 }
 
 type InputService7TestShapeInputService7TestCaseOperation1Output struct {
-	metadataInputService7TestShapeInputService7TestCaseOperation1Output `json:"-" xml:"-"`
-}
-
-type metadataInputService7TestShapeInputService7TestCaseOperation1Output struct {
-	SDKShapeTraits bool `type:"structure"`
+	_ struct{} `type:"structure"`
 }
 
 type InputService7TestShapeStructType struct {
@@ -762,11 +702,7 @@ type InputService7TestShapeStructType struct {
 
 	B *string `type:"string"`
 
-	metadataInputService7TestShapeStructType `json:"-" xml:"-"`
-}
-
-type metadataInputService7TestShapeStructType struct {
-	SDKShapeTraits bool `type:"structure"`
+	_ struct{} `type:"structure"`
 }
 
 //The service client's operations are safe to be used concurrently.
@@ -856,19 +792,11 @@ type InputService8TestShapeInputService8TestCaseOperation1Input struct {
 
 	VaultName *string `location:"uri" locationName:"vaultName" type:"string" required:"true"`
 
-	metadataInputService8TestShapeInputService8TestCaseOperation1Input `json:"-" xml:"-"`
-}
-
-type metadataInputService8TestShapeInputService8TestCaseOperation1Input struct {
-	SDKShapeTraits bool `type:"structure" payload:"Body"`
+	_ struct{} `type:"structure" payload:"Body"`
 }
 
 type InputService8TestShapeInputService8TestCaseOperation1Output struct {
-	metadataInputService8TestShapeInputService8TestCaseOperation1Output `json:"-" xml:"-"`
-}
-
-type metadataInputService8TestShapeInputService8TestCaseOperation1Output struct {
-	SDKShapeTraits bool `type:"structure"`
+	_ struct{} `type:"structure"`
 }
 
 //The service client's operations are safe to be used concurrently.
@@ -954,19 +882,11 @@ func (c *InputService9ProtocolTest) InputService9TestCaseOperation1(input *Input
 type InputService9TestShapeInputService9TestCaseOperation1Input struct {
 	Foo *string `locationName:"foo" type:"string"`
 
-	metadataInputService9TestShapeInputService9TestCaseOperation1Input `json:"-" xml:"-"`
-}
-
-type metadataInputService9TestShapeInputService9TestCaseOperation1Input struct {
-	SDKShapeTraits bool `type:"structure" payload:"Foo"`
+	_ struct{} `type:"structure" payload:"Foo"`
 }
 
 type InputService9TestShapeInputService9TestCaseOperation1Output struct {
-	metadataInputService9TestShapeInputService9TestCaseOperation1Output `json:"-" xml:"-"`
-}
-
-type metadataInputService9TestShapeInputService9TestCaseOperation1Output struct {
-	SDKShapeTraits bool `type:"structure"`
+	_ struct{} `type:"structure"`
 }
 
 //The service client's operations are safe to be used concurrently.
@@ -1076,29 +996,17 @@ func (c *InputService10ProtocolTest) InputService10TestCaseOperation2(input *Inp
 }
 
 type InputService10TestShapeInputService10TestCaseOperation1Output struct {
-	metadataInputService10TestShapeInputService10TestCaseOperation1Output `json:"-" xml:"-"`
-}
-
-type metadataInputService10TestShapeInputService10TestCaseOperation1Output struct {
-	SDKShapeTraits bool `type:"structure"`
+	_ struct{} `type:"structure"`
 }
 
 type InputService10TestShapeInputService10TestCaseOperation2Output struct {
-	metadataInputService10TestShapeInputService10TestCaseOperation2Output `json:"-" xml:"-"`
-}
-
-type metadataInputService10TestShapeInputService10TestCaseOperation2Output struct {
-	SDKShapeTraits bool `type:"structure"`
+	_ struct{} `type:"structure"`
 }
 
 type InputService10TestShapeInputShape struct {
 	Foo []byte `locationName:"foo" type:"blob"`
 
-	metadataInputService10TestShapeInputShape `json:"-" xml:"-"`
-}
-
-type metadataInputService10TestShapeInputShape struct {
-	SDKShapeTraits bool `type:"structure" payload:"Foo"`
+	_ struct{} `type:"structure" payload:"Foo"`
 }
 
 //The service client's operations are safe to be used concurrently.
@@ -1210,37 +1118,21 @@ func (c *InputService11ProtocolTest) InputService11TestCaseOperation2(input *Inp
 type InputService11TestShapeFooShape struct {
 	Baz *string `locationName:"baz" type:"string"`
 
-	metadataInputService11TestShapeFooShape `json:"-" xml:"-"`
-}
-
-type metadataInputService11TestShapeFooShape struct {
-	SDKShapeTraits bool `locationName:"foo" type:"structure"`
+	_ struct{} `locationName:"foo" type:"structure"`
 }
 
 type InputService11TestShapeInputService11TestCaseOperation1Output struct {
-	metadataInputService11TestShapeInputService11TestCaseOperation1Output `json:"-" xml:"-"`
-}
-
-type metadataInputService11TestShapeInputService11TestCaseOperation1Output struct {
-	SDKShapeTraits bool `type:"structure"`
+	_ struct{} `type:"structure"`
 }
 
 type InputService11TestShapeInputService11TestCaseOperation2Output struct {
-	metadataInputService11TestShapeInputService11TestCaseOperation2Output `json:"-" xml:"-"`
-}
-
-type metadataInputService11TestShapeInputService11TestCaseOperation2Output struct {
-	SDKShapeTraits bool `type:"structure"`
+	_ struct{} `type:"structure"`
 }
 
 type InputService11TestShapeInputShape struct {
 	Foo *InputService11TestShapeFooShape `locationName:"foo" type:"structure"`
 
-	metadataInputService11TestShapeInputShape `json:"-" xml:"-"`
-}
-
-type metadataInputService11TestShapeInputShape struct {
-	SDKShapeTraits bool `type:"structure" payload:"Foo"`
+	_ struct{} `type:"structure" payload:"Foo"`
 }
 
 //The service client's operations are safe to be used concurrently.
@@ -1350,29 +1242,17 @@ func (c *InputService12ProtocolTest) InputService12TestCaseOperation2(input *Inp
 }
 
 type InputService12TestShapeInputService12TestCaseOperation1Output struct {
-	metadataInputService12TestShapeInputService12TestCaseOperation1Output `json:"-" xml:"-"`
-}
-
-type metadataInputService12TestShapeInputService12TestCaseOperation1Output struct {
-	SDKShapeTraits bool `type:"structure"`
+	_ struct{} `type:"structure"`
 }
 
 type InputService12TestShapeInputService12TestCaseOperation2Output struct {
-	metadataInputService12TestShapeInputService12TestCaseOperation2Output `json:"-" xml:"-"`
-}
-
-type metadataInputService12TestShapeInputService12TestCaseOperation2Output struct {
-	SDKShapeTraits bool `type:"structure"`
+	_ struct{} `type:"structure"`
 }
 
 type InputService12TestShapeInputShape struct {
 	Foo *string `location:"querystring" locationName:"param-name" type:"string"`
 
-	metadataInputService12TestShapeInputShape `json:"-" xml:"-"`
-}
-
-type metadataInputService12TestShapeInputShape struct {
-	SDKShapeTraits bool `type:"structure"`
+	_ struct{} `type:"structure"`
 }
 
 //The service client's operations are safe to be used concurrently.
@@ -1586,61 +1466,33 @@ func (c *InputService13ProtocolTest) InputService13TestCaseOperation6(input *Inp
 }
 
 type InputService13TestShapeInputService13TestCaseOperation1Output struct {
-	metadataInputService13TestShapeInputService13TestCaseOperation1Output `json:"-" xml:"-"`
-}
-
-type metadataInputService13TestShapeInputService13TestCaseOperation1Output struct {
-	SDKShapeTraits bool `type:"structure"`
+	_ struct{} `type:"structure"`
 }
 
 type InputService13TestShapeInputService13TestCaseOperation2Output struct {
-	metadataInputService13TestShapeInputService13TestCaseOperation2Output `json:"-" xml:"-"`
-}
-
-type metadataInputService13TestShapeInputService13TestCaseOperation2Output struct {
-	SDKShapeTraits bool `type:"structure"`
+	_ struct{} `type:"structure"`
 }
 
 type InputService13TestShapeInputService13TestCaseOperation3Output struct {
-	metadataInputService13TestShapeInputService13TestCaseOperation3Output `json:"-" xml:"-"`
-}
-
-type metadataInputService13TestShapeInputService13TestCaseOperation3Output struct {
-	SDKShapeTraits bool `type:"structure"`
+	_ struct{} `type:"structure"`
 }
 
 type InputService13TestShapeInputService13TestCaseOperation4Output struct {
-	metadataInputService13TestShapeInputService13TestCaseOperation4Output `json:"-" xml:"-"`
-}
-
-type metadataInputService13TestShapeInputService13TestCaseOperation4Output struct {
-	SDKShapeTraits bool `type:"structure"`
+	_ struct{} `type:"structure"`
 }
 
 type InputService13TestShapeInputService13TestCaseOperation5Output struct {
-	metadataInputService13TestShapeInputService13TestCaseOperation5Output `json:"-" xml:"-"`
-}
-
-type metadataInputService13TestShapeInputService13TestCaseOperation5Output struct {
-	SDKShapeTraits bool `type:"structure"`
+	_ struct{} `type:"structure"`
 }
 
 type InputService13TestShapeInputService13TestCaseOperation6Output struct {
-	metadataInputService13TestShapeInputService13TestCaseOperation6Output `json:"-" xml:"-"`
-}
-
-type metadataInputService13TestShapeInputService13TestCaseOperation6Output struct {
-	SDKShapeTraits bool `type:"structure"`
+	_ struct{} `type:"structure"`
 }
 
 type InputService13TestShapeInputShape struct {
 	RecursiveStruct *InputService13TestShapeRecursiveStructType `type:"structure"`
 
-	metadataInputService13TestShapeInputShape `json:"-" xml:"-"`
-}
-
-type metadataInputService13TestShapeInputShape struct {
-	SDKShapeTraits bool `type:"structure"`
+	_ struct{} `type:"structure"`
 }
 
 type InputService13TestShapeRecursiveStructType struct {
@@ -1652,11 +1504,7 @@ type InputService13TestShapeRecursiveStructType struct {
 
 	RecursiveStruct *InputService13TestShapeRecursiveStructType `type:"structure"`
 
-	metadataInputService13TestShapeRecursiveStructType `json:"-" xml:"-"`
-}
-
-type metadataInputService13TestShapeRecursiveStructType struct {
-	SDKShapeTraits bool `type:"structure"`
+	_ struct{} `type:"structure"`
 }
 
 //The service client's operations are safe to be used concurrently.
@@ -1766,19 +1614,11 @@ func (c *InputService14ProtocolTest) InputService14TestCaseOperation2(input *Inp
 }
 
 type InputService14TestShapeInputService14TestCaseOperation1Output struct {
-	metadataInputService14TestShapeInputService14TestCaseOperation1Output `json:"-" xml:"-"`
-}
-
-type metadataInputService14TestShapeInputService14TestCaseOperation1Output struct {
-	SDKShapeTraits bool `type:"structure"`
+	_ struct{} `type:"structure"`
 }
 
 type InputService14TestShapeInputService14TestCaseOperation2Output struct {
-	metadataInputService14TestShapeInputService14TestCaseOperation2Output `json:"-" xml:"-"`
-}
-
-type metadataInputService14TestShapeInputService14TestCaseOperation2Output struct {
-	SDKShapeTraits bool `type:"structure"`
+	_ struct{} `type:"structure"`
 }
 
 type InputService14TestShapeInputShape struct {
@@ -1786,11 +1626,7 @@ type InputService14TestShapeInputShape struct {
 
 	TimeArgInHeader *time.Time `location:"header" locationName:"x-amz-timearg" type:"timestamp" timestampFormat:"rfc822"`
 
-	metadataInputService14TestShapeInputShape `json:"-" xml:"-"`
-}
-
-type metadataInputService14TestShapeInputShape struct {
-	SDKShapeTraits bool `type:"structure"`
+	_ struct{} `type:"structure"`
 }
 
 //

--- a/private/protocol/restjson/unmarshal_test.go
+++ b/private/protocol/restjson/unmarshal_test.go
@@ -116,11 +116,7 @@ func (c *OutputService1ProtocolTest) OutputService1TestCaseOperation1(input *Out
 }
 
 type OutputService1TestShapeOutputService1TestCaseOperation1Input struct {
-	metadataOutputService1TestShapeOutputService1TestCaseOperation1Input `json:"-" xml:"-"`
-}
-
-type metadataOutputService1TestShapeOutputService1TestCaseOperation1Input struct {
-	SDKShapeTraits bool `type:"structure"`
+	_ struct{} `type:"structure"`
 }
 
 type OutputService1TestShapeOutputService1TestCaseOperation1Output struct {
@@ -146,11 +142,7 @@ type OutputService1TestShapeOutputService1TestCaseOperation1Output struct {
 
 	TrueBool *bool `type:"boolean"`
 
-	metadataOutputService1TestShapeOutputService1TestCaseOperation1Output `json:"-" xml:"-"`
-}
-
-type metadataOutputService1TestShapeOutputService1TestCaseOperation1Output struct {
-	SDKShapeTraits bool `type:"structure"`
+	_ struct{} `type:"structure"`
 }
 
 //The service client's operations are safe to be used concurrently.
@@ -234,19 +226,11 @@ func (c *OutputService2ProtocolTest) OutputService2TestCaseOperation1(input *Out
 type OutputService2TestShapeBlobContainer struct {
 	Foo []byte `locationName:"foo" type:"blob"`
 
-	metadataOutputService2TestShapeBlobContainer `json:"-" xml:"-"`
-}
-
-type metadataOutputService2TestShapeBlobContainer struct {
-	SDKShapeTraits bool `type:"structure"`
+	_ struct{} `type:"structure"`
 }
 
 type OutputService2TestShapeOutputService2TestCaseOperation1Input struct {
-	metadataOutputService2TestShapeOutputService2TestCaseOperation1Input `json:"-" xml:"-"`
-}
-
-type metadataOutputService2TestShapeOutputService2TestCaseOperation1Input struct {
-	SDKShapeTraits bool `type:"structure"`
+	_ struct{} `type:"structure"`
 }
 
 type OutputService2TestShapeOutputService2TestCaseOperation1Output struct {
@@ -254,11 +238,7 @@ type OutputService2TestShapeOutputService2TestCaseOperation1Output struct {
 
 	StructMember *OutputService2TestShapeBlobContainer `type:"structure"`
 
-	metadataOutputService2TestShapeOutputService2TestCaseOperation1Output `json:"-" xml:"-"`
-}
-
-type metadataOutputService2TestShapeOutputService2TestCaseOperation1Output struct {
-	SDKShapeTraits bool `type:"structure"`
+	_ struct{} `type:"structure"`
 }
 
 //The service client's operations are safe to be used concurrently.
@@ -340,11 +320,7 @@ func (c *OutputService3ProtocolTest) OutputService3TestCaseOperation1(input *Out
 }
 
 type OutputService3TestShapeOutputService3TestCaseOperation1Input struct {
-	metadataOutputService3TestShapeOutputService3TestCaseOperation1Input `json:"-" xml:"-"`
-}
-
-type metadataOutputService3TestShapeOutputService3TestCaseOperation1Input struct {
-	SDKShapeTraits bool `type:"structure"`
+	_ struct{} `type:"structure"`
 }
 
 type OutputService3TestShapeOutputService3TestCaseOperation1Output struct {
@@ -352,21 +328,13 @@ type OutputService3TestShapeOutputService3TestCaseOperation1Output struct {
 
 	TimeMember *time.Time `type:"timestamp" timestampFormat:"unix"`
 
-	metadataOutputService3TestShapeOutputService3TestCaseOperation1Output `json:"-" xml:"-"`
-}
-
-type metadataOutputService3TestShapeOutputService3TestCaseOperation1Output struct {
-	SDKShapeTraits bool `type:"structure"`
+	_ struct{} `type:"structure"`
 }
 
 type OutputService3TestShapeTimeContainer struct {
 	Foo *time.Time `locationName:"foo" type:"timestamp" timestampFormat:"unix"`
 
-	metadataOutputService3TestShapeTimeContainer `json:"-" xml:"-"`
-}
-
-type metadataOutputService3TestShapeTimeContainer struct {
-	SDKShapeTraits bool `type:"structure"`
+	_ struct{} `type:"structure"`
 }
 
 //The service client's operations are safe to be used concurrently.
@@ -448,21 +416,13 @@ func (c *OutputService4ProtocolTest) OutputService4TestCaseOperation1(input *Out
 }
 
 type OutputService4TestShapeOutputService4TestCaseOperation1Input struct {
-	metadataOutputService4TestShapeOutputService4TestCaseOperation1Input `json:"-" xml:"-"`
-}
-
-type metadataOutputService4TestShapeOutputService4TestCaseOperation1Input struct {
-	SDKShapeTraits bool `type:"structure"`
+	_ struct{} `type:"structure"`
 }
 
 type OutputService4TestShapeOutputService4TestCaseOperation1Output struct {
 	ListMember []*string `type:"list"`
 
-	metadataOutputService4TestShapeOutputService4TestCaseOperation1Output `json:"-" xml:"-"`
-}
-
-type metadataOutputService4TestShapeOutputService4TestCaseOperation1Output struct {
-	SDKShapeTraits bool `type:"structure"`
+	_ struct{} `type:"structure"`
 }
 
 //The service client's operations are safe to be used concurrently.
@@ -544,31 +504,19 @@ func (c *OutputService5ProtocolTest) OutputService5TestCaseOperation1(input *Out
 }
 
 type OutputService5TestShapeOutputService5TestCaseOperation1Input struct {
-	metadataOutputService5TestShapeOutputService5TestCaseOperation1Input `json:"-" xml:"-"`
-}
-
-type metadataOutputService5TestShapeOutputService5TestCaseOperation1Input struct {
-	SDKShapeTraits bool `type:"structure"`
+	_ struct{} `type:"structure"`
 }
 
 type OutputService5TestShapeOutputService5TestCaseOperation1Output struct {
 	ListMember []*OutputService5TestShapeSingleStruct `type:"list"`
 
-	metadataOutputService5TestShapeOutputService5TestCaseOperation1Output `json:"-" xml:"-"`
-}
-
-type metadataOutputService5TestShapeOutputService5TestCaseOperation1Output struct {
-	SDKShapeTraits bool `type:"structure"`
+	_ struct{} `type:"structure"`
 }
 
 type OutputService5TestShapeSingleStruct struct {
 	Foo *string `type:"string"`
 
-	metadataOutputService5TestShapeSingleStruct `json:"-" xml:"-"`
-}
-
-type metadataOutputService5TestShapeSingleStruct struct {
-	SDKShapeTraits bool `type:"structure"`
+	_ struct{} `type:"structure"`
 }
 
 //The service client's operations are safe to be used concurrently.
@@ -650,21 +598,13 @@ func (c *OutputService6ProtocolTest) OutputService6TestCaseOperation1(input *Out
 }
 
 type OutputService6TestShapeOutputService6TestCaseOperation1Input struct {
-	metadataOutputService6TestShapeOutputService6TestCaseOperation1Input `json:"-" xml:"-"`
-}
-
-type metadataOutputService6TestShapeOutputService6TestCaseOperation1Input struct {
-	SDKShapeTraits bool `type:"structure"`
+	_ struct{} `type:"structure"`
 }
 
 type OutputService6TestShapeOutputService6TestCaseOperation1Output struct {
 	MapMember map[string][]*int64 `type:"map"`
 
-	metadataOutputService6TestShapeOutputService6TestCaseOperation1Output `json:"-" xml:"-"`
-}
-
-type metadataOutputService6TestShapeOutputService6TestCaseOperation1Output struct {
-	SDKShapeTraits bool `type:"structure"`
+	_ struct{} `type:"structure"`
 }
 
 //The service client's operations are safe to be used concurrently.
@@ -746,21 +686,13 @@ func (c *OutputService7ProtocolTest) OutputService7TestCaseOperation1(input *Out
 }
 
 type OutputService7TestShapeOutputService7TestCaseOperation1Input struct {
-	metadataOutputService7TestShapeOutputService7TestCaseOperation1Input `json:"-" xml:"-"`
-}
-
-type metadataOutputService7TestShapeOutputService7TestCaseOperation1Input struct {
-	SDKShapeTraits bool `type:"structure"`
+	_ struct{} `type:"structure"`
 }
 
 type OutputService7TestShapeOutputService7TestCaseOperation1Output struct {
 	MapMember map[string]*time.Time `type:"map"`
 
-	metadataOutputService7TestShapeOutputService7TestCaseOperation1Output `json:"-" xml:"-"`
-}
-
-type metadataOutputService7TestShapeOutputService7TestCaseOperation1Output struct {
-	SDKShapeTraits bool `type:"structure"`
+	_ struct{} `type:"structure"`
 }
 
 //The service client's operations are safe to be used concurrently.
@@ -842,21 +774,13 @@ func (c *OutputService8ProtocolTest) OutputService8TestCaseOperation1(input *Out
 }
 
 type OutputService8TestShapeOutputService8TestCaseOperation1Input struct {
-	metadataOutputService8TestShapeOutputService8TestCaseOperation1Input `json:"-" xml:"-"`
-}
-
-type metadataOutputService8TestShapeOutputService8TestCaseOperation1Input struct {
-	SDKShapeTraits bool `type:"structure"`
+	_ struct{} `type:"structure"`
 }
 
 type OutputService8TestShapeOutputService8TestCaseOperation1Output struct {
 	StrType *string `type:"string"`
 
-	metadataOutputService8TestShapeOutputService8TestCaseOperation1Output `json:"-" xml:"-"`
-}
-
-type metadataOutputService8TestShapeOutputService8TestCaseOperation1Output struct {
-	SDKShapeTraits bool `type:"structure"`
+	_ struct{} `type:"structure"`
 }
 
 //The service client's operations are safe to be used concurrently.
@@ -938,11 +862,7 @@ func (c *OutputService9ProtocolTest) OutputService9TestCaseOperation1(input *Out
 }
 
 type OutputService9TestShapeOutputService9TestCaseOperation1Input struct {
-	metadataOutputService9TestShapeOutputService9TestCaseOperation1Input `json:"-" xml:"-"`
-}
-
-type metadataOutputService9TestShapeOutputService9TestCaseOperation1Input struct {
-	SDKShapeTraits bool `type:"structure"`
+	_ struct{} `type:"structure"`
 }
 
 type OutputService9TestShapeOutputService9TestCaseOperation1Output struct {
@@ -950,11 +870,7 @@ type OutputService9TestShapeOutputService9TestCaseOperation1Output struct {
 
 	PrefixedHeaders map[string]*string `location:"headers" locationName:"X-" type:"map"`
 
-	metadataOutputService9TestShapeOutputService9TestCaseOperation1Output `json:"-" xml:"-"`
-}
-
-type metadataOutputService9TestShapeOutputService9TestCaseOperation1Output struct {
-	SDKShapeTraits bool `type:"structure"`
+	_ struct{} `type:"structure"`
 }
 
 //The service client's operations are safe to be used concurrently.
@@ -1038,19 +954,11 @@ func (c *OutputService10ProtocolTest) OutputService10TestCaseOperation1(input *O
 type OutputService10TestShapeBodyStructure struct {
 	Foo *string `type:"string"`
 
-	metadataOutputService10TestShapeBodyStructure `json:"-" xml:"-"`
-}
-
-type metadataOutputService10TestShapeBodyStructure struct {
-	SDKShapeTraits bool `type:"structure"`
+	_ struct{} `type:"structure"`
 }
 
 type OutputService10TestShapeOutputService10TestCaseOperation1Input struct {
-	metadataOutputService10TestShapeOutputService10TestCaseOperation1Input `json:"-" xml:"-"`
-}
-
-type metadataOutputService10TestShapeOutputService10TestCaseOperation1Input struct {
-	SDKShapeTraits bool `type:"structure"`
+	_ struct{} `type:"structure"`
 }
 
 type OutputService10TestShapeOutputService10TestCaseOperation1Output struct {
@@ -1058,11 +966,7 @@ type OutputService10TestShapeOutputService10TestCaseOperation1Output struct {
 
 	Header *string `location:"header" locationName:"X-Foo" type:"string"`
 
-	metadataOutputService10TestShapeOutputService10TestCaseOperation1Output `json:"-" xml:"-"`
-}
-
-type metadataOutputService10TestShapeOutputService10TestCaseOperation1Output struct {
-	SDKShapeTraits bool `type:"structure" payload:"Data"`
+	_ struct{} `type:"structure" payload:"Data"`
 }
 
 //The service client's operations are safe to be used concurrently.
@@ -1144,21 +1048,13 @@ func (c *OutputService11ProtocolTest) OutputService11TestCaseOperation1(input *O
 }
 
 type OutputService11TestShapeOutputService11TestCaseOperation1Input struct {
-	metadataOutputService11TestShapeOutputService11TestCaseOperation1Input `json:"-" xml:"-"`
-}
-
-type metadataOutputService11TestShapeOutputService11TestCaseOperation1Input struct {
-	SDKShapeTraits bool `type:"structure"`
+	_ struct{} `type:"structure"`
 }
 
 type OutputService11TestShapeOutputService11TestCaseOperation1Output struct {
 	Stream []byte `type:"blob"`
 
-	metadataOutputService11TestShapeOutputService11TestCaseOperation1Output `json:"-" xml:"-"`
-}
-
-type metadataOutputService11TestShapeOutputService11TestCaseOperation1Output struct {
-	SDKShapeTraits bool `type:"structure" payload:"Stream"`
+	_ struct{} `type:"structure" payload:"Stream"`
 }
 
 //

--- a/private/protocol/restjson/unmarshal_test.go
+++ b/private/protocol/restjson/unmarshal_test.go
@@ -120,6 +120,8 @@ type OutputService1TestShapeOutputService1TestCaseOperation1Input struct {
 }
 
 type OutputService1TestShapeOutputService1TestCaseOperation1Output struct {
+	_ struct{} `type:"structure"`
+
 	Char *string `type:"character"`
 
 	Double *float64 `type:"double"`
@@ -141,8 +143,6 @@ type OutputService1TestShapeOutputService1TestCaseOperation1Output struct {
 	Str *string `type:"string"`
 
 	TrueBool *bool `type:"boolean"`
-
-	_ struct{} `type:"structure"`
 }
 
 //The service client's operations are safe to be used concurrently.
@@ -224,9 +224,9 @@ func (c *OutputService2ProtocolTest) OutputService2TestCaseOperation1(input *Out
 }
 
 type OutputService2TestShapeBlobContainer struct {
-	Foo []byte `locationName:"foo" type:"blob"`
-
 	_ struct{} `type:"structure"`
+
+	Foo []byte `locationName:"foo" type:"blob"`
 }
 
 type OutputService2TestShapeOutputService2TestCaseOperation1Input struct {
@@ -234,11 +234,11 @@ type OutputService2TestShapeOutputService2TestCaseOperation1Input struct {
 }
 
 type OutputService2TestShapeOutputService2TestCaseOperation1Output struct {
+	_ struct{} `type:"structure"`
+
 	BlobMember []byte `type:"blob"`
 
 	StructMember *OutputService2TestShapeBlobContainer `type:"structure"`
-
-	_ struct{} `type:"structure"`
 }
 
 //The service client's operations are safe to be used concurrently.
@@ -324,17 +324,17 @@ type OutputService3TestShapeOutputService3TestCaseOperation1Input struct {
 }
 
 type OutputService3TestShapeOutputService3TestCaseOperation1Output struct {
+	_ struct{} `type:"structure"`
+
 	StructMember *OutputService3TestShapeTimeContainer `type:"structure"`
 
 	TimeMember *time.Time `type:"timestamp" timestampFormat:"unix"`
-
-	_ struct{} `type:"structure"`
 }
 
 type OutputService3TestShapeTimeContainer struct {
-	Foo *time.Time `locationName:"foo" type:"timestamp" timestampFormat:"unix"`
-
 	_ struct{} `type:"structure"`
+
+	Foo *time.Time `locationName:"foo" type:"timestamp" timestampFormat:"unix"`
 }
 
 //The service client's operations are safe to be used concurrently.
@@ -420,9 +420,9 @@ type OutputService4TestShapeOutputService4TestCaseOperation1Input struct {
 }
 
 type OutputService4TestShapeOutputService4TestCaseOperation1Output struct {
-	ListMember []*string `type:"list"`
-
 	_ struct{} `type:"structure"`
+
+	ListMember []*string `type:"list"`
 }
 
 //The service client's operations are safe to be used concurrently.
@@ -508,15 +508,15 @@ type OutputService5TestShapeOutputService5TestCaseOperation1Input struct {
 }
 
 type OutputService5TestShapeOutputService5TestCaseOperation1Output struct {
-	ListMember []*OutputService5TestShapeSingleStruct `type:"list"`
-
 	_ struct{} `type:"structure"`
+
+	ListMember []*OutputService5TestShapeSingleStruct `type:"list"`
 }
 
 type OutputService5TestShapeSingleStruct struct {
-	Foo *string `type:"string"`
-
 	_ struct{} `type:"structure"`
+
+	Foo *string `type:"string"`
 }
 
 //The service client's operations are safe to be used concurrently.
@@ -602,9 +602,9 @@ type OutputService6TestShapeOutputService6TestCaseOperation1Input struct {
 }
 
 type OutputService6TestShapeOutputService6TestCaseOperation1Output struct {
-	MapMember map[string][]*int64 `type:"map"`
-
 	_ struct{} `type:"structure"`
+
+	MapMember map[string][]*int64 `type:"map"`
 }
 
 //The service client's operations are safe to be used concurrently.
@@ -690,9 +690,9 @@ type OutputService7TestShapeOutputService7TestCaseOperation1Input struct {
 }
 
 type OutputService7TestShapeOutputService7TestCaseOperation1Output struct {
-	MapMember map[string]*time.Time `type:"map"`
-
 	_ struct{} `type:"structure"`
+
+	MapMember map[string]*time.Time `type:"map"`
 }
 
 //The service client's operations are safe to be used concurrently.
@@ -778,9 +778,9 @@ type OutputService8TestShapeOutputService8TestCaseOperation1Input struct {
 }
 
 type OutputService8TestShapeOutputService8TestCaseOperation1Output struct {
-	StrType *string `type:"string"`
-
 	_ struct{} `type:"structure"`
+
+	StrType *string `type:"string"`
 }
 
 //The service client's operations are safe to be used concurrently.
@@ -866,11 +866,11 @@ type OutputService9TestShapeOutputService9TestCaseOperation1Input struct {
 }
 
 type OutputService9TestShapeOutputService9TestCaseOperation1Output struct {
+	_ struct{} `type:"structure"`
+
 	AllHeaders map[string]*string `location:"headers" type:"map"`
 
 	PrefixedHeaders map[string]*string `location:"headers" locationName:"X-" type:"map"`
-
-	_ struct{} `type:"structure"`
 }
 
 //The service client's operations are safe to be used concurrently.
@@ -952,9 +952,9 @@ func (c *OutputService10ProtocolTest) OutputService10TestCaseOperation1(input *O
 }
 
 type OutputService10TestShapeBodyStructure struct {
-	Foo *string `type:"string"`
-
 	_ struct{} `type:"structure"`
+
+	Foo *string `type:"string"`
 }
 
 type OutputService10TestShapeOutputService10TestCaseOperation1Input struct {
@@ -962,11 +962,11 @@ type OutputService10TestShapeOutputService10TestCaseOperation1Input struct {
 }
 
 type OutputService10TestShapeOutputService10TestCaseOperation1Output struct {
+	_ struct{} `type:"structure" payload:"Data"`
+
 	Data *OutputService10TestShapeBodyStructure `type:"structure"`
 
 	Header *string `location:"header" locationName:"X-Foo" type:"string"`
-
-	_ struct{} `type:"structure" payload:"Data"`
 }
 
 //The service client's operations are safe to be used concurrently.
@@ -1052,9 +1052,9 @@ type OutputService11TestShapeOutputService11TestCaseOperation1Input struct {
 }
 
 type OutputService11TestShapeOutputService11TestCaseOperation1Output struct {
-	Stream []byte `type:"blob"`
-
 	_ struct{} `type:"structure" payload:"Stream"`
+
+	Stream []byte `type:"blob"`
 }
 
 //

--- a/private/protocol/restxml/build_test.go
+++ b/private/protocol/restxml/build_test.go
@@ -170,35 +170,19 @@ func (c *InputService1ProtocolTest) InputService1TestCaseOperation3(input *Input
 }
 
 type InputService1TestShapeInputService1TestCaseOperation1Output struct {
-	metadataInputService1TestShapeInputService1TestCaseOperation1Output `json:"-" xml:"-"`
-}
-
-type metadataInputService1TestShapeInputService1TestCaseOperation1Output struct {
-	SDKShapeTraits bool `type:"structure"`
+	_ struct{} `type:"structure"`
 }
 
 type InputService1TestShapeInputService1TestCaseOperation2Output struct {
-	metadataInputService1TestShapeInputService1TestCaseOperation2Output `json:"-" xml:"-"`
-}
-
-type metadataInputService1TestShapeInputService1TestCaseOperation2Output struct {
-	SDKShapeTraits bool `type:"structure"`
+	_ struct{} `type:"structure"`
 }
 
 type InputService1TestShapeInputService1TestCaseOperation3Input struct {
-	metadataInputService1TestShapeInputService1TestCaseOperation3Input `json:"-" xml:"-"`
-}
-
-type metadataInputService1TestShapeInputService1TestCaseOperation3Input struct {
-	SDKShapeTraits bool `type:"structure"`
+	_ struct{} `type:"structure"`
 }
 
 type InputService1TestShapeInputService1TestCaseOperation3Output struct {
-	metadataInputService1TestShapeInputService1TestCaseOperation3Output `json:"-" xml:"-"`
-}
-
-type metadataInputService1TestShapeInputService1TestCaseOperation3Output struct {
-	SDKShapeTraits bool `type:"structure"`
+	_ struct{} `type:"structure"`
 }
 
 type InputService1TestShapeInputShape struct {
@@ -206,11 +190,7 @@ type InputService1TestShapeInputShape struct {
 
 	Name *string `type:"string"`
 
-	metadataInputService1TestShapeInputShape `json:"-" xml:"-"`
-}
-
-type metadataInputService1TestShapeInputShape struct {
-	SDKShapeTraits bool `locationName:"OperationRequest" type:"structure" xmlURI:"https://foo/"`
+	_ struct{} `locationName:"OperationRequest" type:"structure" xmlURI:"https://foo/"`
 }
 
 //The service client's operations are safe to be used concurrently.
@@ -302,19 +282,11 @@ type InputService2TestShapeInputService2TestCaseOperation1Input struct {
 
 	Third *float64 `type:"float"`
 
-	metadataInputService2TestShapeInputService2TestCaseOperation1Input `json:"-" xml:"-"`
-}
-
-type metadataInputService2TestShapeInputService2TestCaseOperation1Input struct {
-	SDKShapeTraits bool `locationName:"OperationRequest" type:"structure" xmlURI:"https://foo/"`
+	_ struct{} `locationName:"OperationRequest" type:"structure" xmlURI:"https://foo/"`
 }
 
 type InputService2TestShapeInputService2TestCaseOperation1Output struct {
-	metadataInputService2TestShapeInputService2TestCaseOperation1Output `json:"-" xml:"-"`
-}
-
-type metadataInputService2TestShapeInputService2TestCaseOperation1Output struct {
-	SDKShapeTraits bool `type:"structure"`
+	_ struct{} `type:"structure"`
 }
 
 //The service client's operations are safe to be used concurrently.
@@ -424,19 +396,11 @@ func (c *InputService3ProtocolTest) InputService3TestCaseOperation2(input *Input
 }
 
 type InputService3TestShapeInputService3TestCaseOperation1Output struct {
-	metadataInputService3TestShapeInputService3TestCaseOperation1Output `json:"-" xml:"-"`
-}
-
-type metadataInputService3TestShapeInputService3TestCaseOperation1Output struct {
-	SDKShapeTraits bool `type:"structure"`
+	_ struct{} `type:"structure"`
 }
 
 type InputService3TestShapeInputService3TestCaseOperation2Output struct {
-	metadataInputService3TestShapeInputService3TestCaseOperation2Output `json:"-" xml:"-"`
-}
-
-type metadataInputService3TestShapeInputService3TestCaseOperation2Output struct {
-	SDKShapeTraits bool `type:"structure"`
+	_ struct{} `type:"structure"`
 }
 
 type InputService3TestShapeInputShape struct {
@@ -444,11 +408,7 @@ type InputService3TestShapeInputShape struct {
 
 	SubStructure *InputService3TestShapeSubStructure `type:"structure"`
 
-	metadataInputService3TestShapeInputShape `json:"-" xml:"-"`
-}
-
-type metadataInputService3TestShapeInputShape struct {
-	SDKShapeTraits bool `locationName:"OperationRequest" type:"structure" xmlURI:"https://foo/"`
+	_ struct{} `locationName:"OperationRequest" type:"structure" xmlURI:"https://foo/"`
 }
 
 type InputService3TestShapeSubStructure struct {
@@ -456,11 +416,7 @@ type InputService3TestShapeSubStructure struct {
 
 	Foo *string `type:"string"`
 
-	metadataInputService3TestShapeSubStructure `json:"-" xml:"-"`
-}
-
-type metadataInputService3TestShapeSubStructure struct {
-	SDKShapeTraits bool `type:"structure"`
+	_ struct{} `type:"structure"`
 }
 
 //The service client's operations are safe to be used concurrently.
@@ -548,19 +504,11 @@ type InputService4TestShapeInputService4TestCaseOperation1Input struct {
 
 	SubStructure *InputService4TestShapeSubStructure `type:"structure"`
 
-	metadataInputService4TestShapeInputService4TestCaseOperation1Input `json:"-" xml:"-"`
-}
-
-type metadataInputService4TestShapeInputService4TestCaseOperation1Input struct {
-	SDKShapeTraits bool `locationName:"OperationRequest" type:"structure" xmlURI:"https://foo/"`
+	_ struct{} `locationName:"OperationRequest" type:"structure" xmlURI:"https://foo/"`
 }
 
 type InputService4TestShapeInputService4TestCaseOperation1Output struct {
-	metadataInputService4TestShapeInputService4TestCaseOperation1Output `json:"-" xml:"-"`
-}
-
-type metadataInputService4TestShapeInputService4TestCaseOperation1Output struct {
-	SDKShapeTraits bool `type:"structure"`
+	_ struct{} `type:"structure"`
 }
 
 type InputService4TestShapeSubStructure struct {
@@ -568,11 +516,7 @@ type InputService4TestShapeSubStructure struct {
 
 	Foo *string `type:"string"`
 
-	metadataInputService4TestShapeSubStructure `json:"-" xml:"-"`
-}
-
-type metadataInputService4TestShapeSubStructure struct {
-	SDKShapeTraits bool `type:"structure"`
+	_ struct{} `type:"structure"`
 }
 
 //The service client's operations are safe to be used concurrently.
@@ -658,19 +602,11 @@ func (c *InputService5ProtocolTest) InputService5TestCaseOperation1(input *Input
 type InputService5TestShapeInputService5TestCaseOperation1Input struct {
 	ListParam []*string `type:"list"`
 
-	metadataInputService5TestShapeInputService5TestCaseOperation1Input `json:"-" xml:"-"`
-}
-
-type metadataInputService5TestShapeInputService5TestCaseOperation1Input struct {
-	SDKShapeTraits bool `locationName:"OperationRequest" type:"structure" xmlURI:"https://foo/"`
+	_ struct{} `locationName:"OperationRequest" type:"structure" xmlURI:"https://foo/"`
 }
 
 type InputService5TestShapeInputService5TestCaseOperation1Output struct {
-	metadataInputService5TestShapeInputService5TestCaseOperation1Output `json:"-" xml:"-"`
-}
-
-type metadataInputService5TestShapeInputService5TestCaseOperation1Output struct {
-	SDKShapeTraits bool `type:"structure"`
+	_ struct{} `type:"structure"`
 }
 
 //The service client's operations are safe to be used concurrently.
@@ -756,19 +692,11 @@ func (c *InputService6ProtocolTest) InputService6TestCaseOperation1(input *Input
 type InputService6TestShapeInputService6TestCaseOperation1Input struct {
 	ListParam []*string `locationName:"AlternateName" locationNameList:"NotMember" type:"list"`
 
-	metadataInputService6TestShapeInputService6TestCaseOperation1Input `json:"-" xml:"-"`
-}
-
-type metadataInputService6TestShapeInputService6TestCaseOperation1Input struct {
-	SDKShapeTraits bool `locationName:"OperationRequest" type:"structure" xmlURI:"https://foo/"`
+	_ struct{} `locationName:"OperationRequest" type:"structure" xmlURI:"https://foo/"`
 }
 
 type InputService6TestShapeInputService6TestCaseOperation1Output struct {
-	metadataInputService6TestShapeInputService6TestCaseOperation1Output `json:"-" xml:"-"`
-}
-
-type metadataInputService6TestShapeInputService6TestCaseOperation1Output struct {
-	SDKShapeTraits bool `type:"structure"`
+	_ struct{} `type:"structure"`
 }
 
 //The service client's operations are safe to be used concurrently.
@@ -854,19 +782,11 @@ func (c *InputService7ProtocolTest) InputService7TestCaseOperation1(input *Input
 type InputService7TestShapeInputService7TestCaseOperation1Input struct {
 	ListParam []*string `type:"list" flattened:"true"`
 
-	metadataInputService7TestShapeInputService7TestCaseOperation1Input `json:"-" xml:"-"`
-}
-
-type metadataInputService7TestShapeInputService7TestCaseOperation1Input struct {
-	SDKShapeTraits bool `locationName:"OperationRequest" type:"structure" xmlURI:"https://foo/"`
+	_ struct{} `locationName:"OperationRequest" type:"structure" xmlURI:"https://foo/"`
 }
 
 type InputService7TestShapeInputService7TestCaseOperation1Output struct {
-	metadataInputService7TestShapeInputService7TestCaseOperation1Output `json:"-" xml:"-"`
-}
-
-type metadataInputService7TestShapeInputService7TestCaseOperation1Output struct {
-	SDKShapeTraits bool `type:"structure"`
+	_ struct{} `type:"structure"`
 }
 
 //The service client's operations are safe to be used concurrently.
@@ -952,19 +872,11 @@ func (c *InputService8ProtocolTest) InputService8TestCaseOperation1(input *Input
 type InputService8TestShapeInputService8TestCaseOperation1Input struct {
 	ListParam []*string `locationName:"item" type:"list" flattened:"true"`
 
-	metadataInputService8TestShapeInputService8TestCaseOperation1Input `json:"-" xml:"-"`
-}
-
-type metadataInputService8TestShapeInputService8TestCaseOperation1Input struct {
-	SDKShapeTraits bool `locationName:"OperationRequest" type:"structure" xmlURI:"https://foo/"`
+	_ struct{} `locationName:"OperationRequest" type:"structure" xmlURI:"https://foo/"`
 }
 
 type InputService8TestShapeInputService8TestCaseOperation1Output struct {
-	metadataInputService8TestShapeInputService8TestCaseOperation1Output `json:"-" xml:"-"`
-}
-
-type metadataInputService8TestShapeInputService8TestCaseOperation1Output struct {
-	SDKShapeTraits bool `type:"structure"`
+	_ struct{} `type:"structure"`
 }
 
 //The service client's operations are safe to be used concurrently.
@@ -1050,29 +962,17 @@ func (c *InputService9ProtocolTest) InputService9TestCaseOperation1(input *Input
 type InputService9TestShapeInputService9TestCaseOperation1Input struct {
 	ListParam []*InputService9TestShapeSingleFieldStruct `locationName:"item" type:"list" flattened:"true"`
 
-	metadataInputService9TestShapeInputService9TestCaseOperation1Input `json:"-" xml:"-"`
-}
-
-type metadataInputService9TestShapeInputService9TestCaseOperation1Input struct {
-	SDKShapeTraits bool `locationName:"OperationRequest" type:"structure" xmlURI:"https://foo/"`
+	_ struct{} `locationName:"OperationRequest" type:"structure" xmlURI:"https://foo/"`
 }
 
 type InputService9TestShapeInputService9TestCaseOperation1Output struct {
-	metadataInputService9TestShapeInputService9TestCaseOperation1Output `json:"-" xml:"-"`
-}
-
-type metadataInputService9TestShapeInputService9TestCaseOperation1Output struct {
-	SDKShapeTraits bool `type:"structure"`
+	_ struct{} `type:"structure"`
 }
 
 type InputService9TestShapeSingleFieldStruct struct {
 	Element *string `locationName:"value" type:"string"`
 
-	metadataInputService9TestShapeSingleFieldStruct `json:"-" xml:"-"`
-}
-
-type metadataInputService9TestShapeSingleFieldStruct struct {
-	SDKShapeTraits bool `type:"structure"`
+	_ struct{} `type:"structure"`
 }
 
 //The service client's operations are safe to be used concurrently.
@@ -1158,19 +1058,11 @@ func (c *InputService10ProtocolTest) InputService10TestCaseOperation1(input *Inp
 type InputService10TestShapeInputService10TestCaseOperation1Input struct {
 	StructureParam *InputService10TestShapeStructureShape `type:"structure"`
 
-	metadataInputService10TestShapeInputService10TestCaseOperation1Input `json:"-" xml:"-"`
-}
-
-type metadataInputService10TestShapeInputService10TestCaseOperation1Input struct {
-	SDKShapeTraits bool `locationName:"OperationRequest" type:"structure" xmlURI:"https://foo/"`
+	_ struct{} `locationName:"OperationRequest" type:"structure" xmlURI:"https://foo/"`
 }
 
 type InputService10TestShapeInputService10TestCaseOperation1Output struct {
-	metadataInputService10TestShapeInputService10TestCaseOperation1Output `json:"-" xml:"-"`
-}
-
-type metadataInputService10TestShapeInputService10TestCaseOperation1Output struct {
-	SDKShapeTraits bool `type:"structure"`
+	_ struct{} `type:"structure"`
 }
 
 type InputService10TestShapeStructureShape struct {
@@ -1178,11 +1070,7 @@ type InputService10TestShapeStructureShape struct {
 
 	T *time.Time `locationName:"t" type:"timestamp" timestampFormat:"iso8601"`
 
-	metadataInputService10TestShapeStructureShape `json:"-" xml:"-"`
-}
-
-type metadataInputService10TestShapeStructureShape struct {
-	SDKShapeTraits bool `type:"structure"`
+	_ struct{} `type:"structure"`
 }
 
 //The service client's operations are safe to be used concurrently.
@@ -1268,19 +1156,11 @@ func (c *InputService11ProtocolTest) InputService11TestCaseOperation1(input *Inp
 type InputService11TestShapeInputService11TestCaseOperation1Input struct {
 	Foo map[string]*string `location:"headers" locationName:"x-foo-" type:"map"`
 
-	metadataInputService11TestShapeInputService11TestCaseOperation1Input `json:"-" xml:"-"`
-}
-
-type metadataInputService11TestShapeInputService11TestCaseOperation1Input struct {
-	SDKShapeTraits bool `locationName:"OperationRequest" type:"structure" xmlURI:"https://foo/"`
+	_ struct{} `locationName:"OperationRequest" type:"structure" xmlURI:"https://foo/"`
 }
 
 type InputService11TestShapeInputService11TestCaseOperation1Output struct {
-	metadataInputService11TestShapeInputService11TestCaseOperation1Output `json:"-" xml:"-"`
-}
-
-type metadataInputService11TestShapeInputService11TestCaseOperation1Output struct {
-	SDKShapeTraits bool `type:"structure"`
+	_ struct{} `type:"structure"`
 }
 
 //The service client's operations are safe to be used concurrently.
@@ -1368,19 +1248,11 @@ type InputService12TestShapeInputService12TestCaseOperation1Input struct {
 
 	QueryDoc map[string]*string `location:"querystring" type:"map"`
 
-	metadataInputService12TestShapeInputService12TestCaseOperation1Input `json:"-" xml:"-"`
-}
-
-type metadataInputService12TestShapeInputService12TestCaseOperation1Input struct {
-	SDKShapeTraits bool `type:"structure"`
+	_ struct{} `type:"structure"`
 }
 
 type InputService12TestShapeInputService12TestCaseOperation1Output struct {
-	metadataInputService12TestShapeInputService12TestCaseOperation1Output `json:"-" xml:"-"`
-}
-
-type metadataInputService12TestShapeInputService12TestCaseOperation1Output struct {
-	SDKShapeTraits bool `type:"structure"`
+	_ struct{} `type:"structure"`
 }
 
 //The service client's operations are safe to be used concurrently.
@@ -1468,19 +1340,11 @@ type InputService13TestShapeInputService13TestCaseOperation1Input struct {
 
 	QueryDoc map[string][]*string `location:"querystring" type:"map"`
 
-	metadataInputService13TestShapeInputService13TestCaseOperation1Input `json:"-" xml:"-"`
-}
-
-type metadataInputService13TestShapeInputService13TestCaseOperation1Input struct {
-	SDKShapeTraits bool `type:"structure"`
+	_ struct{} `type:"structure"`
 }
 
 type InputService13TestShapeInputService13TestCaseOperation1Output struct {
-	metadataInputService13TestShapeInputService13TestCaseOperation1Output `json:"-" xml:"-"`
-}
-
-type metadataInputService13TestShapeInputService13TestCaseOperation1Output struct {
-	SDKShapeTraits bool `type:"structure"`
+	_ struct{} `type:"structure"`
 }
 
 //The service client's operations are safe to be used concurrently.
@@ -1566,19 +1430,11 @@ func (c *InputService14ProtocolTest) InputService14TestCaseOperation1(input *Inp
 type InputService14TestShapeInputService14TestCaseOperation1Input struct {
 	Foo *string `locationName:"foo" type:"string"`
 
-	metadataInputService14TestShapeInputService14TestCaseOperation1Input `json:"-" xml:"-"`
-}
-
-type metadataInputService14TestShapeInputService14TestCaseOperation1Input struct {
-	SDKShapeTraits bool `type:"structure" payload:"Foo"`
+	_ struct{} `type:"structure" payload:"Foo"`
 }
 
 type InputService14TestShapeInputService14TestCaseOperation1Output struct {
-	metadataInputService14TestShapeInputService14TestCaseOperation1Output `json:"-" xml:"-"`
-}
-
-type metadataInputService14TestShapeInputService14TestCaseOperation1Output struct {
-	SDKShapeTraits bool `type:"structure"`
+	_ struct{} `type:"structure"`
 }
 
 //The service client's operations are safe to be used concurrently.
@@ -1688,29 +1544,17 @@ func (c *InputService15ProtocolTest) InputService15TestCaseOperation2(input *Inp
 }
 
 type InputService15TestShapeInputService15TestCaseOperation1Output struct {
-	metadataInputService15TestShapeInputService15TestCaseOperation1Output `json:"-" xml:"-"`
-}
-
-type metadataInputService15TestShapeInputService15TestCaseOperation1Output struct {
-	SDKShapeTraits bool `type:"structure"`
+	_ struct{} `type:"structure"`
 }
 
 type InputService15TestShapeInputService15TestCaseOperation2Output struct {
-	metadataInputService15TestShapeInputService15TestCaseOperation2Output `json:"-" xml:"-"`
-}
-
-type metadataInputService15TestShapeInputService15TestCaseOperation2Output struct {
-	SDKShapeTraits bool `type:"structure"`
+	_ struct{} `type:"structure"`
 }
 
 type InputService15TestShapeInputShape struct {
 	Foo []byte `locationName:"foo" type:"blob"`
 
-	metadataInputService15TestShapeInputShape `json:"-" xml:"-"`
-}
-
-type metadataInputService15TestShapeInputShape struct {
-	SDKShapeTraits bool `type:"structure" payload:"Foo"`
+	_ struct{} `type:"structure" payload:"Foo"`
 }
 
 //The service client's operations are safe to be used concurrently.
@@ -1874,53 +1718,29 @@ func (c *InputService16ProtocolTest) InputService16TestCaseOperation4(input *Inp
 type InputService16TestShapeFooShape struct {
 	Baz *string `locationName:"baz" type:"string"`
 
-	metadataInputService16TestShapeFooShape `json:"-" xml:"-"`
-}
-
-type metadataInputService16TestShapeFooShape struct {
-	SDKShapeTraits bool `locationName:"foo" type:"structure"`
+	_ struct{} `locationName:"foo" type:"structure"`
 }
 
 type InputService16TestShapeInputService16TestCaseOperation1Output struct {
-	metadataInputService16TestShapeInputService16TestCaseOperation1Output `json:"-" xml:"-"`
-}
-
-type metadataInputService16TestShapeInputService16TestCaseOperation1Output struct {
-	SDKShapeTraits bool `type:"structure"`
+	_ struct{} `type:"structure"`
 }
 
 type InputService16TestShapeInputService16TestCaseOperation2Output struct {
-	metadataInputService16TestShapeInputService16TestCaseOperation2Output `json:"-" xml:"-"`
-}
-
-type metadataInputService16TestShapeInputService16TestCaseOperation2Output struct {
-	SDKShapeTraits bool `type:"structure"`
+	_ struct{} `type:"structure"`
 }
 
 type InputService16TestShapeInputService16TestCaseOperation3Output struct {
-	metadataInputService16TestShapeInputService16TestCaseOperation3Output `json:"-" xml:"-"`
-}
-
-type metadataInputService16TestShapeInputService16TestCaseOperation3Output struct {
-	SDKShapeTraits bool `type:"structure"`
+	_ struct{} `type:"structure"`
 }
 
 type InputService16TestShapeInputService16TestCaseOperation4Output struct {
-	metadataInputService16TestShapeInputService16TestCaseOperation4Output `json:"-" xml:"-"`
-}
-
-type metadataInputService16TestShapeInputService16TestCaseOperation4Output struct {
-	SDKShapeTraits bool `type:"structure"`
+	_ struct{} `type:"structure"`
 }
 
 type InputService16TestShapeInputShape struct {
 	Foo *InputService16TestShapeFooShape `locationName:"foo" type:"structure"`
 
-	metadataInputService16TestShapeInputShape `json:"-" xml:"-"`
-}
-
-type metadataInputService16TestShapeInputShape struct {
-	SDKShapeTraits bool `type:"structure" payload:"Foo"`
+	_ struct{} `type:"structure" payload:"Foo"`
 }
 
 //The service client's operations are safe to be used concurrently.
@@ -2006,11 +1826,7 @@ func (c *InputService17ProtocolTest) InputService17TestCaseOperation1(input *Inp
 type InputService17TestShapeGrant struct {
 	Grantee *InputService17TestShapeGrantee `type:"structure"`
 
-	metadataInputService17TestShapeGrant `json:"-" xml:"-"`
-}
-
-type metadataInputService17TestShapeGrant struct {
-	SDKShapeTraits bool `locationName:"Grant" type:"structure"`
+	_ struct{} `locationName:"Grant" type:"structure"`
 }
 
 type InputService17TestShapeGrantee struct {
@@ -2018,29 +1834,17 @@ type InputService17TestShapeGrantee struct {
 
 	Type *string `locationName:"xsi:type" type:"string" xmlAttribute:"true"`
 
-	metadataInputService17TestShapeGrantee `json:"-" xml:"-"`
-}
-
-type metadataInputService17TestShapeGrantee struct {
-	SDKShapeTraits bool `type:"structure" xmlPrefix:"xsi" xmlURI:"http://www.w3.org/2001/XMLSchema-instance"`
+	_ struct{} `type:"structure" xmlPrefix:"xsi" xmlURI:"http://www.w3.org/2001/XMLSchema-instance"`
 }
 
 type InputService17TestShapeInputService17TestCaseOperation1Input struct {
 	Grant *InputService17TestShapeGrant `locationName:"Grant" type:"structure"`
 
-	metadataInputService17TestShapeInputService17TestCaseOperation1Input `json:"-" xml:"-"`
-}
-
-type metadataInputService17TestShapeInputService17TestCaseOperation1Input struct {
-	SDKShapeTraits bool `type:"structure" payload:"Grant"`
+	_ struct{} `type:"structure" payload:"Grant"`
 }
 
 type InputService17TestShapeInputService17TestCaseOperation1Output struct {
-	metadataInputService17TestShapeInputService17TestCaseOperation1Output `json:"-" xml:"-"`
-}
-
-type metadataInputService17TestShapeInputService17TestCaseOperation1Output struct {
-	SDKShapeTraits bool `type:"structure"`
+	_ struct{} `type:"structure"`
 }
 
 //The service client's operations are safe to be used concurrently.
@@ -2128,19 +1932,11 @@ type InputService18TestShapeInputService18TestCaseOperation1Input struct {
 
 	Key *string `location:"uri" type:"string"`
 
-	metadataInputService18TestShapeInputService18TestCaseOperation1Input `json:"-" xml:"-"`
-}
-
-type metadataInputService18TestShapeInputService18TestCaseOperation1Input struct {
-	SDKShapeTraits bool `type:"structure"`
+	_ struct{} `type:"structure"`
 }
 
 type InputService18TestShapeInputService18TestCaseOperation1Output struct {
-	metadataInputService18TestShapeInputService18TestCaseOperation1Output `json:"-" xml:"-"`
-}
-
-type metadataInputService18TestShapeInputService18TestCaseOperation1Output struct {
-	SDKShapeTraits bool `type:"structure"`
+	_ struct{} `type:"structure"`
 }
 
 //The service client's operations are safe to be used concurrently.
@@ -2250,29 +2046,17 @@ func (c *InputService19ProtocolTest) InputService19TestCaseOperation2(input *Inp
 }
 
 type InputService19TestShapeInputService19TestCaseOperation1Output struct {
-	metadataInputService19TestShapeInputService19TestCaseOperation1Output `json:"-" xml:"-"`
-}
-
-type metadataInputService19TestShapeInputService19TestCaseOperation1Output struct {
-	SDKShapeTraits bool `type:"structure"`
+	_ struct{} `type:"structure"`
 }
 
 type InputService19TestShapeInputService19TestCaseOperation2Output struct {
-	metadataInputService19TestShapeInputService19TestCaseOperation2Output `json:"-" xml:"-"`
-}
-
-type metadataInputService19TestShapeInputService19TestCaseOperation2Output struct {
-	SDKShapeTraits bool `type:"structure"`
+	_ struct{} `type:"structure"`
 }
 
 type InputService19TestShapeInputShape struct {
 	Foo *string `location:"querystring" locationName:"param-name" type:"string"`
 
-	metadataInputService19TestShapeInputShape `json:"-" xml:"-"`
-}
-
-type metadataInputService19TestShapeInputShape struct {
-	SDKShapeTraits bool `type:"structure"`
+	_ struct{} `type:"structure"`
 }
 
 //The service client's operations are safe to be used concurrently.
@@ -2486,61 +2270,33 @@ func (c *InputService20ProtocolTest) InputService20TestCaseOperation6(input *Inp
 }
 
 type InputService20TestShapeInputService20TestCaseOperation1Output struct {
-	metadataInputService20TestShapeInputService20TestCaseOperation1Output `json:"-" xml:"-"`
-}
-
-type metadataInputService20TestShapeInputService20TestCaseOperation1Output struct {
-	SDKShapeTraits bool `type:"structure"`
+	_ struct{} `type:"structure"`
 }
 
 type InputService20TestShapeInputService20TestCaseOperation2Output struct {
-	metadataInputService20TestShapeInputService20TestCaseOperation2Output `json:"-" xml:"-"`
-}
-
-type metadataInputService20TestShapeInputService20TestCaseOperation2Output struct {
-	SDKShapeTraits bool `type:"structure"`
+	_ struct{} `type:"structure"`
 }
 
 type InputService20TestShapeInputService20TestCaseOperation3Output struct {
-	metadataInputService20TestShapeInputService20TestCaseOperation3Output `json:"-" xml:"-"`
-}
-
-type metadataInputService20TestShapeInputService20TestCaseOperation3Output struct {
-	SDKShapeTraits bool `type:"structure"`
+	_ struct{} `type:"structure"`
 }
 
 type InputService20TestShapeInputService20TestCaseOperation4Output struct {
-	metadataInputService20TestShapeInputService20TestCaseOperation4Output `json:"-" xml:"-"`
-}
-
-type metadataInputService20TestShapeInputService20TestCaseOperation4Output struct {
-	SDKShapeTraits bool `type:"structure"`
+	_ struct{} `type:"structure"`
 }
 
 type InputService20TestShapeInputService20TestCaseOperation5Output struct {
-	metadataInputService20TestShapeInputService20TestCaseOperation5Output `json:"-" xml:"-"`
-}
-
-type metadataInputService20TestShapeInputService20TestCaseOperation5Output struct {
-	SDKShapeTraits bool `type:"structure"`
+	_ struct{} `type:"structure"`
 }
 
 type InputService20TestShapeInputService20TestCaseOperation6Output struct {
-	metadataInputService20TestShapeInputService20TestCaseOperation6Output `json:"-" xml:"-"`
-}
-
-type metadataInputService20TestShapeInputService20TestCaseOperation6Output struct {
-	SDKShapeTraits bool `type:"structure"`
+	_ struct{} `type:"structure"`
 }
 
 type InputService20TestShapeInputShape struct {
 	RecursiveStruct *InputService20TestShapeRecursiveStructType `type:"structure"`
 
-	metadataInputService20TestShapeInputShape `json:"-" xml:"-"`
-}
-
-type metadataInputService20TestShapeInputShape struct {
-	SDKShapeTraits bool `locationName:"OperationRequest" type:"structure" xmlURI:"https://foo/"`
+	_ struct{} `locationName:"OperationRequest" type:"structure" xmlURI:"https://foo/"`
 }
 
 type InputService20TestShapeRecursiveStructType struct {
@@ -2552,11 +2308,7 @@ type InputService20TestShapeRecursiveStructType struct {
 
 	RecursiveStruct *InputService20TestShapeRecursiveStructType `type:"structure"`
 
-	metadataInputService20TestShapeRecursiveStructType `json:"-" xml:"-"`
-}
-
-type metadataInputService20TestShapeRecursiveStructType struct {
-	SDKShapeTraits bool `type:"structure"`
+	_ struct{} `type:"structure"`
 }
 
 //The service client's operations are safe to be used concurrently.
@@ -2642,19 +2394,11 @@ func (c *InputService21ProtocolTest) InputService21TestCaseOperation1(input *Inp
 type InputService21TestShapeInputService21TestCaseOperation1Input struct {
 	TimeArgInHeader *time.Time `location:"header" locationName:"x-amz-timearg" type:"timestamp" timestampFormat:"rfc822"`
 
-	metadataInputService21TestShapeInputService21TestCaseOperation1Input `json:"-" xml:"-"`
-}
-
-type metadataInputService21TestShapeInputService21TestCaseOperation1Input struct {
-	SDKShapeTraits bool `type:"structure"`
+	_ struct{} `type:"structure"`
 }
 
 type InputService21TestShapeInputService21TestCaseOperation1Output struct {
-	metadataInputService21TestShapeInputService21TestCaseOperation1Output `json:"-" xml:"-"`
-}
-
-type metadataInputService21TestShapeInputService21TestCaseOperation1Output struct {
-	SDKShapeTraits bool `type:"structure"`
+	_ struct{} `type:"structure"`
 }
 
 //

--- a/private/protocol/restxml/build_test.go
+++ b/private/protocol/restxml/build_test.go
@@ -186,11 +186,11 @@ type InputService1TestShapeInputService1TestCaseOperation3Output struct {
 }
 
 type InputService1TestShapeInputShape struct {
+	_ struct{} `locationName:"OperationRequest" type:"structure" xmlURI:"https://foo/"`
+
 	Description *string `type:"string"`
 
 	Name *string `type:"string"`
-
-	_ struct{} `locationName:"OperationRequest" type:"structure" xmlURI:"https://foo/"`
 }
 
 //The service client's operations are safe to be used concurrently.
@@ -274,6 +274,8 @@ func (c *InputService2ProtocolTest) InputService2TestCaseOperation1(input *Input
 }
 
 type InputService2TestShapeInputService2TestCaseOperation1Input struct {
+	_ struct{} `locationName:"OperationRequest" type:"structure" xmlURI:"https://foo/"`
+
 	First *bool `type:"boolean"`
 
 	Fourth *int64 `type:"integer"`
@@ -281,8 +283,6 @@ type InputService2TestShapeInputService2TestCaseOperation1Input struct {
 	Second *bool `type:"boolean"`
 
 	Third *float64 `type:"float"`
-
-	_ struct{} `locationName:"OperationRequest" type:"structure" xmlURI:"https://foo/"`
 }
 
 type InputService2TestShapeInputService2TestCaseOperation1Output struct {
@@ -404,19 +404,19 @@ type InputService3TestShapeInputService3TestCaseOperation2Output struct {
 }
 
 type InputService3TestShapeInputShape struct {
+	_ struct{} `locationName:"OperationRequest" type:"structure" xmlURI:"https://foo/"`
+
 	Description *string `type:"string"`
 
 	SubStructure *InputService3TestShapeSubStructure `type:"structure"`
-
-	_ struct{} `locationName:"OperationRequest" type:"structure" xmlURI:"https://foo/"`
 }
 
 type InputService3TestShapeSubStructure struct {
+	_ struct{} `type:"structure"`
+
 	Bar *string `type:"string"`
 
 	Foo *string `type:"string"`
-
-	_ struct{} `type:"structure"`
 }
 
 //The service client's operations are safe to be used concurrently.
@@ -500,11 +500,11 @@ func (c *InputService4ProtocolTest) InputService4TestCaseOperation1(input *Input
 }
 
 type InputService4TestShapeInputService4TestCaseOperation1Input struct {
+	_ struct{} `locationName:"OperationRequest" type:"structure" xmlURI:"https://foo/"`
+
 	Description *string `type:"string"`
 
 	SubStructure *InputService4TestShapeSubStructure `type:"structure"`
-
-	_ struct{} `locationName:"OperationRequest" type:"structure" xmlURI:"https://foo/"`
 }
 
 type InputService4TestShapeInputService4TestCaseOperation1Output struct {
@@ -512,11 +512,11 @@ type InputService4TestShapeInputService4TestCaseOperation1Output struct {
 }
 
 type InputService4TestShapeSubStructure struct {
+	_ struct{} `type:"structure"`
+
 	Bar *string `type:"string"`
 
 	Foo *string `type:"string"`
-
-	_ struct{} `type:"structure"`
 }
 
 //The service client's operations are safe to be used concurrently.
@@ -600,9 +600,9 @@ func (c *InputService5ProtocolTest) InputService5TestCaseOperation1(input *Input
 }
 
 type InputService5TestShapeInputService5TestCaseOperation1Input struct {
-	ListParam []*string `type:"list"`
-
 	_ struct{} `locationName:"OperationRequest" type:"structure" xmlURI:"https://foo/"`
+
+	ListParam []*string `type:"list"`
 }
 
 type InputService5TestShapeInputService5TestCaseOperation1Output struct {
@@ -690,9 +690,9 @@ func (c *InputService6ProtocolTest) InputService6TestCaseOperation1(input *Input
 }
 
 type InputService6TestShapeInputService6TestCaseOperation1Input struct {
-	ListParam []*string `locationName:"AlternateName" locationNameList:"NotMember" type:"list"`
-
 	_ struct{} `locationName:"OperationRequest" type:"structure" xmlURI:"https://foo/"`
+
+	ListParam []*string `locationName:"AlternateName" locationNameList:"NotMember" type:"list"`
 }
 
 type InputService6TestShapeInputService6TestCaseOperation1Output struct {
@@ -780,9 +780,9 @@ func (c *InputService7ProtocolTest) InputService7TestCaseOperation1(input *Input
 }
 
 type InputService7TestShapeInputService7TestCaseOperation1Input struct {
-	ListParam []*string `type:"list" flattened:"true"`
-
 	_ struct{} `locationName:"OperationRequest" type:"structure" xmlURI:"https://foo/"`
+
+	ListParam []*string `type:"list" flattened:"true"`
 }
 
 type InputService7TestShapeInputService7TestCaseOperation1Output struct {
@@ -870,9 +870,9 @@ func (c *InputService8ProtocolTest) InputService8TestCaseOperation1(input *Input
 }
 
 type InputService8TestShapeInputService8TestCaseOperation1Input struct {
-	ListParam []*string `locationName:"item" type:"list" flattened:"true"`
-
 	_ struct{} `locationName:"OperationRequest" type:"structure" xmlURI:"https://foo/"`
+
+	ListParam []*string `locationName:"item" type:"list" flattened:"true"`
 }
 
 type InputService8TestShapeInputService8TestCaseOperation1Output struct {
@@ -960,9 +960,9 @@ func (c *InputService9ProtocolTest) InputService9TestCaseOperation1(input *Input
 }
 
 type InputService9TestShapeInputService9TestCaseOperation1Input struct {
-	ListParam []*InputService9TestShapeSingleFieldStruct `locationName:"item" type:"list" flattened:"true"`
-
 	_ struct{} `locationName:"OperationRequest" type:"structure" xmlURI:"https://foo/"`
+
+	ListParam []*InputService9TestShapeSingleFieldStruct `locationName:"item" type:"list" flattened:"true"`
 }
 
 type InputService9TestShapeInputService9TestCaseOperation1Output struct {
@@ -970,9 +970,9 @@ type InputService9TestShapeInputService9TestCaseOperation1Output struct {
 }
 
 type InputService9TestShapeSingleFieldStruct struct {
-	Element *string `locationName:"value" type:"string"`
-
 	_ struct{} `type:"structure"`
+
+	Element *string `locationName:"value" type:"string"`
 }
 
 //The service client's operations are safe to be used concurrently.
@@ -1056,9 +1056,9 @@ func (c *InputService10ProtocolTest) InputService10TestCaseOperation1(input *Inp
 }
 
 type InputService10TestShapeInputService10TestCaseOperation1Input struct {
-	StructureParam *InputService10TestShapeStructureShape `type:"structure"`
-
 	_ struct{} `locationName:"OperationRequest" type:"structure" xmlURI:"https://foo/"`
+
+	StructureParam *InputService10TestShapeStructureShape `type:"structure"`
 }
 
 type InputService10TestShapeInputService10TestCaseOperation1Output struct {
@@ -1066,11 +1066,11 @@ type InputService10TestShapeInputService10TestCaseOperation1Output struct {
 }
 
 type InputService10TestShapeStructureShape struct {
+	_ struct{} `type:"structure"`
+
 	B []byte `locationName:"b" type:"blob"`
 
 	T *time.Time `locationName:"t" type:"timestamp" timestampFormat:"iso8601"`
-
-	_ struct{} `type:"structure"`
 }
 
 //The service client's operations are safe to be used concurrently.
@@ -1154,9 +1154,9 @@ func (c *InputService11ProtocolTest) InputService11TestCaseOperation1(input *Inp
 }
 
 type InputService11TestShapeInputService11TestCaseOperation1Input struct {
-	Foo map[string]*string `location:"headers" locationName:"x-foo-" type:"map"`
-
 	_ struct{} `locationName:"OperationRequest" type:"structure" xmlURI:"https://foo/"`
+
+	Foo map[string]*string `location:"headers" locationName:"x-foo-" type:"map"`
 }
 
 type InputService11TestShapeInputService11TestCaseOperation1Output struct {
@@ -1244,11 +1244,11 @@ func (c *InputService12ProtocolTest) InputService12TestCaseOperation1(input *Inp
 }
 
 type InputService12TestShapeInputService12TestCaseOperation1Input struct {
+	_ struct{} `type:"structure"`
+
 	PipelineId *string `location:"uri" type:"string"`
 
 	QueryDoc map[string]*string `location:"querystring" type:"map"`
-
-	_ struct{} `type:"structure"`
 }
 
 type InputService12TestShapeInputService12TestCaseOperation1Output struct {
@@ -1336,11 +1336,11 @@ func (c *InputService13ProtocolTest) InputService13TestCaseOperation1(input *Inp
 }
 
 type InputService13TestShapeInputService13TestCaseOperation1Input struct {
+	_ struct{} `type:"structure"`
+
 	PipelineId *string `location:"uri" type:"string"`
 
 	QueryDoc map[string][]*string `location:"querystring" type:"map"`
-
-	_ struct{} `type:"structure"`
 }
 
 type InputService13TestShapeInputService13TestCaseOperation1Output struct {
@@ -1428,9 +1428,9 @@ func (c *InputService14ProtocolTest) InputService14TestCaseOperation1(input *Inp
 }
 
 type InputService14TestShapeInputService14TestCaseOperation1Input struct {
-	Foo *string `locationName:"foo" type:"string"`
-
 	_ struct{} `type:"structure" payload:"Foo"`
+
+	Foo *string `locationName:"foo" type:"string"`
 }
 
 type InputService14TestShapeInputService14TestCaseOperation1Output struct {
@@ -1552,9 +1552,9 @@ type InputService15TestShapeInputService15TestCaseOperation2Output struct {
 }
 
 type InputService15TestShapeInputShape struct {
-	Foo []byte `locationName:"foo" type:"blob"`
-
 	_ struct{} `type:"structure" payload:"Foo"`
+
+	Foo []byte `locationName:"foo" type:"blob"`
 }
 
 //The service client's operations are safe to be used concurrently.
@@ -1716,9 +1716,9 @@ func (c *InputService16ProtocolTest) InputService16TestCaseOperation4(input *Inp
 }
 
 type InputService16TestShapeFooShape struct {
-	Baz *string `locationName:"baz" type:"string"`
-
 	_ struct{} `locationName:"foo" type:"structure"`
+
+	Baz *string `locationName:"baz" type:"string"`
 }
 
 type InputService16TestShapeInputService16TestCaseOperation1Output struct {
@@ -1738,9 +1738,9 @@ type InputService16TestShapeInputService16TestCaseOperation4Output struct {
 }
 
 type InputService16TestShapeInputShape struct {
-	Foo *InputService16TestShapeFooShape `locationName:"foo" type:"structure"`
-
 	_ struct{} `type:"structure" payload:"Foo"`
+
+	Foo *InputService16TestShapeFooShape `locationName:"foo" type:"structure"`
 }
 
 //The service client's operations are safe to be used concurrently.
@@ -1824,23 +1824,23 @@ func (c *InputService17ProtocolTest) InputService17TestCaseOperation1(input *Inp
 }
 
 type InputService17TestShapeGrant struct {
-	Grantee *InputService17TestShapeGrantee `type:"structure"`
-
 	_ struct{} `locationName:"Grant" type:"structure"`
+
+	Grantee *InputService17TestShapeGrantee `type:"structure"`
 }
 
 type InputService17TestShapeGrantee struct {
+	_ struct{} `type:"structure" xmlPrefix:"xsi" xmlURI:"http://www.w3.org/2001/XMLSchema-instance"`
+
 	EmailAddress *string `type:"string"`
 
 	Type *string `locationName:"xsi:type" type:"string" xmlAttribute:"true"`
-
-	_ struct{} `type:"structure" xmlPrefix:"xsi" xmlURI:"http://www.w3.org/2001/XMLSchema-instance"`
 }
 
 type InputService17TestShapeInputService17TestCaseOperation1Input struct {
-	Grant *InputService17TestShapeGrant `locationName:"Grant" type:"structure"`
-
 	_ struct{} `type:"structure" payload:"Grant"`
+
+	Grant *InputService17TestShapeGrant `locationName:"Grant" type:"structure"`
 }
 
 type InputService17TestShapeInputService17TestCaseOperation1Output struct {
@@ -1928,11 +1928,11 @@ func (c *InputService18ProtocolTest) InputService18TestCaseOperation1(input *Inp
 }
 
 type InputService18TestShapeInputService18TestCaseOperation1Input struct {
+	_ struct{} `type:"structure"`
+
 	Bucket *string `location:"uri" type:"string"`
 
 	Key *string `location:"uri" type:"string"`
-
-	_ struct{} `type:"structure"`
 }
 
 type InputService18TestShapeInputService18TestCaseOperation1Output struct {
@@ -2054,9 +2054,9 @@ type InputService19TestShapeInputService19TestCaseOperation2Output struct {
 }
 
 type InputService19TestShapeInputShape struct {
-	Foo *string `location:"querystring" locationName:"param-name" type:"string"`
-
 	_ struct{} `type:"structure"`
+
+	Foo *string `location:"querystring" locationName:"param-name" type:"string"`
 }
 
 //The service client's operations are safe to be used concurrently.
@@ -2294,12 +2294,14 @@ type InputService20TestShapeInputService20TestCaseOperation6Output struct {
 }
 
 type InputService20TestShapeInputShape struct {
-	RecursiveStruct *InputService20TestShapeRecursiveStructType `type:"structure"`
-
 	_ struct{} `locationName:"OperationRequest" type:"structure" xmlURI:"https://foo/"`
+
+	RecursiveStruct *InputService20TestShapeRecursiveStructType `type:"structure"`
 }
 
 type InputService20TestShapeRecursiveStructType struct {
+	_ struct{} `type:"structure"`
+
 	NoRecurse *string `type:"string"`
 
 	RecursiveList []*InputService20TestShapeRecursiveStructType `type:"list"`
@@ -2307,8 +2309,6 @@ type InputService20TestShapeRecursiveStructType struct {
 	RecursiveMap map[string]*InputService20TestShapeRecursiveStructType `type:"map"`
 
 	RecursiveStruct *InputService20TestShapeRecursiveStructType `type:"structure"`
-
-	_ struct{} `type:"structure"`
 }
 
 //The service client's operations are safe to be used concurrently.
@@ -2392,9 +2392,9 @@ func (c *InputService21ProtocolTest) InputService21TestCaseOperation1(input *Inp
 }
 
 type InputService21TestShapeInputService21TestCaseOperation1Input struct {
-	TimeArgInHeader *time.Time `location:"header" locationName:"x-amz-timearg" type:"timestamp" timestampFormat:"rfc822"`
-
 	_ struct{} `type:"structure"`
+
+	TimeArgInHeader *time.Time `location:"header" locationName:"x-amz-timearg" type:"timestamp" timestampFormat:"rfc822"`
 }
 
 type InputService21TestShapeInputService21TestCaseOperation1Output struct {

--- a/private/protocol/restxml/unmarshal_test.go
+++ b/private/protocol/restxml/unmarshal_test.go
@@ -148,6 +148,8 @@ type OutputService1TestShapeOutputService1TestCaseOperation2Input struct {
 }
 
 type OutputService1TestShapeOutputShape struct {
+	_ struct{} `type:"structure"`
+
 	Char *string `type:"character"`
 
 	Double *float64 `type:"double"`
@@ -169,8 +171,6 @@ type OutputService1TestShapeOutputShape struct {
 	Timestamp *time.Time `type:"timestamp" timestampFormat:"iso8601"`
 
 	TrueBool *bool `type:"boolean"`
-
-	_ struct{} `type:"structure"`
 }
 
 //The service client's operations are safe to be used concurrently.
@@ -256,9 +256,9 @@ type OutputService2TestShapeOutputService2TestCaseOperation1Input struct {
 }
 
 type OutputService2TestShapeOutputService2TestCaseOperation1Output struct {
-	Blob []byte `type:"blob"`
-
 	_ struct{} `type:"structure"`
+
+	Blob []byte `type:"blob"`
 }
 
 //The service client's operations are safe to be used concurrently.
@@ -344,9 +344,9 @@ type OutputService3TestShapeOutputService3TestCaseOperation1Input struct {
 }
 
 type OutputService3TestShapeOutputService3TestCaseOperation1Output struct {
-	ListMember []*string `type:"list"`
-
 	_ struct{} `type:"structure"`
+
+	ListMember []*string `type:"list"`
 }
 
 //The service client's operations are safe to be used concurrently.
@@ -432,9 +432,9 @@ type OutputService4TestShapeOutputService4TestCaseOperation1Input struct {
 }
 
 type OutputService4TestShapeOutputService4TestCaseOperation1Output struct {
-	ListMember []*string `locationNameList:"item" type:"list"`
-
 	_ struct{} `type:"structure"`
+
+	ListMember []*string `locationNameList:"item" type:"list"`
 }
 
 //The service client's operations are safe to be used concurrently.
@@ -520,9 +520,9 @@ type OutputService5TestShapeOutputService5TestCaseOperation1Input struct {
 }
 
 type OutputService5TestShapeOutputService5TestCaseOperation1Output struct {
-	ListMember []*string `type:"list" flattened:"true"`
-
 	_ struct{} `type:"structure"`
+
+	ListMember []*string `type:"list" flattened:"true"`
 }
 
 //The service client's operations are safe to be used concurrently.
@@ -608,15 +608,15 @@ type OutputService6TestShapeOutputService6TestCaseOperation1Input struct {
 }
 
 type OutputService6TestShapeOutputService6TestCaseOperation1Output struct {
-	Map map[string]*OutputService6TestShapeSingleStructure `type:"map"`
-
 	_ struct{} `type:"structure"`
+
+	Map map[string]*OutputService6TestShapeSingleStructure `type:"map"`
 }
 
 type OutputService6TestShapeSingleStructure struct {
-	Foo *string `locationName:"foo" type:"string"`
-
 	_ struct{} `type:"structure"`
+
+	Foo *string `locationName:"foo" type:"string"`
 }
 
 //The service client's operations are safe to be used concurrently.
@@ -702,9 +702,9 @@ type OutputService7TestShapeOutputService7TestCaseOperation1Input struct {
 }
 
 type OutputService7TestShapeOutputService7TestCaseOperation1Output struct {
-	Map map[string]*string `type:"map" flattened:"true"`
-
 	_ struct{} `type:"structure"`
+
+	Map map[string]*string `type:"map" flattened:"true"`
 }
 
 //The service client's operations are safe to be used concurrently.
@@ -790,9 +790,9 @@ type OutputService8TestShapeOutputService8TestCaseOperation1Input struct {
 }
 
 type OutputService8TestShapeOutputService8TestCaseOperation1Output struct {
-	Map map[string]*string `locationNameKey:"foo" locationNameValue:"bar" type:"map"`
-
 	_ struct{} `type:"structure"`
+
+	Map map[string]*string `locationNameKey:"foo" locationNameValue:"bar" type:"map"`
 }
 
 //The service client's operations are safe to be used concurrently.
@@ -878,17 +878,17 @@ type OutputService9TestShapeOutputService9TestCaseOperation1Input struct {
 }
 
 type OutputService9TestShapeOutputService9TestCaseOperation1Output struct {
+	_ struct{} `type:"structure" payload:"Data"`
+
 	Data *OutputService9TestShapeSingleStructure `type:"structure"`
 
 	Header *string `location:"header" locationName:"X-Foo" type:"string"`
-
-	_ struct{} `type:"structure" payload:"Data"`
 }
 
 type OutputService9TestShapeSingleStructure struct {
-	Foo *string `type:"string"`
-
 	_ struct{} `type:"structure"`
+
+	Foo *string `type:"string"`
 }
 
 //The service client's operations are safe to be used concurrently.
@@ -974,9 +974,9 @@ type OutputService10TestShapeOutputService10TestCaseOperation1Input struct {
 }
 
 type OutputService10TestShapeOutputService10TestCaseOperation1Output struct {
-	Stream []byte `type:"blob"`
-
 	_ struct{} `type:"structure" payload:"Stream"`
+
+	Stream []byte `type:"blob"`
 }
 
 //The service client's operations are safe to be used concurrently.
@@ -1062,6 +1062,8 @@ type OutputService11TestShapeOutputService11TestCaseOperation1Input struct {
 }
 
 type OutputService11TestShapeOutputService11TestCaseOperation1Output struct {
+	_ struct{} `type:"structure"`
+
 	Char *string `location:"header" locationName:"x-char" type:"character"`
 
 	Double *float64 `location:"header" locationName:"x-double" type:"double"`
@@ -1079,8 +1081,6 @@ type OutputService11TestShapeOutputService11TestCaseOperation1Output struct {
 	Timestamp *time.Time `location:"header" locationName:"x-timestamp" type:"timestamp" timestampFormat:"iso8601"`
 
 	TrueBool *bool `location:"header" locationName:"x-true-bool" type:"boolean"`
-
-	_ struct{} `type:"structure"`
 }
 
 //The service client's operations are safe to be used concurrently.
@@ -1166,9 +1166,9 @@ type OutputService12TestShapeOutputService12TestCaseOperation1Input struct {
 }
 
 type OutputService12TestShapeOutputService12TestCaseOperation1Output struct {
-	Foo *string `type:"string"`
-
 	_ struct{} `type:"structure"`
+
+	Foo *string `type:"string"`
 }
 
 //

--- a/private/protocol/restxml/unmarshal_test.go
+++ b/private/protocol/restxml/unmarshal_test.go
@@ -140,19 +140,11 @@ func (c *OutputService1ProtocolTest) OutputService1TestCaseOperation2(input *Out
 }
 
 type OutputService1TestShapeOutputService1TestCaseOperation1Input struct {
-	metadataOutputService1TestShapeOutputService1TestCaseOperation1Input `json:"-" xml:"-"`
-}
-
-type metadataOutputService1TestShapeOutputService1TestCaseOperation1Input struct {
-	SDKShapeTraits bool `type:"structure"`
+	_ struct{} `type:"structure"`
 }
 
 type OutputService1TestShapeOutputService1TestCaseOperation2Input struct {
-	metadataOutputService1TestShapeOutputService1TestCaseOperation2Input `json:"-" xml:"-"`
-}
-
-type metadataOutputService1TestShapeOutputService1TestCaseOperation2Input struct {
-	SDKShapeTraits bool `type:"structure"`
+	_ struct{} `type:"structure"`
 }
 
 type OutputService1TestShapeOutputShape struct {
@@ -178,11 +170,7 @@ type OutputService1TestShapeOutputShape struct {
 
 	TrueBool *bool `type:"boolean"`
 
-	metadataOutputService1TestShapeOutputShape `json:"-" xml:"-"`
-}
-
-type metadataOutputService1TestShapeOutputShape struct {
-	SDKShapeTraits bool `type:"structure"`
+	_ struct{} `type:"structure"`
 }
 
 //The service client's operations are safe to be used concurrently.
@@ -264,21 +252,13 @@ func (c *OutputService2ProtocolTest) OutputService2TestCaseOperation1(input *Out
 }
 
 type OutputService2TestShapeOutputService2TestCaseOperation1Input struct {
-	metadataOutputService2TestShapeOutputService2TestCaseOperation1Input `json:"-" xml:"-"`
-}
-
-type metadataOutputService2TestShapeOutputService2TestCaseOperation1Input struct {
-	SDKShapeTraits bool `type:"structure"`
+	_ struct{} `type:"structure"`
 }
 
 type OutputService2TestShapeOutputService2TestCaseOperation1Output struct {
 	Blob []byte `type:"blob"`
 
-	metadataOutputService2TestShapeOutputService2TestCaseOperation1Output `json:"-" xml:"-"`
-}
-
-type metadataOutputService2TestShapeOutputService2TestCaseOperation1Output struct {
-	SDKShapeTraits bool `type:"structure"`
+	_ struct{} `type:"structure"`
 }
 
 //The service client's operations are safe to be used concurrently.
@@ -360,21 +340,13 @@ func (c *OutputService3ProtocolTest) OutputService3TestCaseOperation1(input *Out
 }
 
 type OutputService3TestShapeOutputService3TestCaseOperation1Input struct {
-	metadataOutputService3TestShapeOutputService3TestCaseOperation1Input `json:"-" xml:"-"`
-}
-
-type metadataOutputService3TestShapeOutputService3TestCaseOperation1Input struct {
-	SDKShapeTraits bool `type:"structure"`
+	_ struct{} `type:"structure"`
 }
 
 type OutputService3TestShapeOutputService3TestCaseOperation1Output struct {
 	ListMember []*string `type:"list"`
 
-	metadataOutputService3TestShapeOutputService3TestCaseOperation1Output `json:"-" xml:"-"`
-}
-
-type metadataOutputService3TestShapeOutputService3TestCaseOperation1Output struct {
-	SDKShapeTraits bool `type:"structure"`
+	_ struct{} `type:"structure"`
 }
 
 //The service client's operations are safe to be used concurrently.
@@ -456,21 +428,13 @@ func (c *OutputService4ProtocolTest) OutputService4TestCaseOperation1(input *Out
 }
 
 type OutputService4TestShapeOutputService4TestCaseOperation1Input struct {
-	metadataOutputService4TestShapeOutputService4TestCaseOperation1Input `json:"-" xml:"-"`
-}
-
-type metadataOutputService4TestShapeOutputService4TestCaseOperation1Input struct {
-	SDKShapeTraits bool `type:"structure"`
+	_ struct{} `type:"structure"`
 }
 
 type OutputService4TestShapeOutputService4TestCaseOperation1Output struct {
 	ListMember []*string `locationNameList:"item" type:"list"`
 
-	metadataOutputService4TestShapeOutputService4TestCaseOperation1Output `json:"-" xml:"-"`
-}
-
-type metadataOutputService4TestShapeOutputService4TestCaseOperation1Output struct {
-	SDKShapeTraits bool `type:"structure"`
+	_ struct{} `type:"structure"`
 }
 
 //The service client's operations are safe to be used concurrently.
@@ -552,21 +516,13 @@ func (c *OutputService5ProtocolTest) OutputService5TestCaseOperation1(input *Out
 }
 
 type OutputService5TestShapeOutputService5TestCaseOperation1Input struct {
-	metadataOutputService5TestShapeOutputService5TestCaseOperation1Input `json:"-" xml:"-"`
-}
-
-type metadataOutputService5TestShapeOutputService5TestCaseOperation1Input struct {
-	SDKShapeTraits bool `type:"structure"`
+	_ struct{} `type:"structure"`
 }
 
 type OutputService5TestShapeOutputService5TestCaseOperation1Output struct {
 	ListMember []*string `type:"list" flattened:"true"`
 
-	metadataOutputService5TestShapeOutputService5TestCaseOperation1Output `json:"-" xml:"-"`
-}
-
-type metadataOutputService5TestShapeOutputService5TestCaseOperation1Output struct {
-	SDKShapeTraits bool `type:"structure"`
+	_ struct{} `type:"structure"`
 }
 
 //The service client's operations are safe to be used concurrently.
@@ -648,31 +604,19 @@ func (c *OutputService6ProtocolTest) OutputService6TestCaseOperation1(input *Out
 }
 
 type OutputService6TestShapeOutputService6TestCaseOperation1Input struct {
-	metadataOutputService6TestShapeOutputService6TestCaseOperation1Input `json:"-" xml:"-"`
-}
-
-type metadataOutputService6TestShapeOutputService6TestCaseOperation1Input struct {
-	SDKShapeTraits bool `type:"structure"`
+	_ struct{} `type:"structure"`
 }
 
 type OutputService6TestShapeOutputService6TestCaseOperation1Output struct {
 	Map map[string]*OutputService6TestShapeSingleStructure `type:"map"`
 
-	metadataOutputService6TestShapeOutputService6TestCaseOperation1Output `json:"-" xml:"-"`
-}
-
-type metadataOutputService6TestShapeOutputService6TestCaseOperation1Output struct {
-	SDKShapeTraits bool `type:"structure"`
+	_ struct{} `type:"structure"`
 }
 
 type OutputService6TestShapeSingleStructure struct {
 	Foo *string `locationName:"foo" type:"string"`
 
-	metadataOutputService6TestShapeSingleStructure `json:"-" xml:"-"`
-}
-
-type metadataOutputService6TestShapeSingleStructure struct {
-	SDKShapeTraits bool `type:"structure"`
+	_ struct{} `type:"structure"`
 }
 
 //The service client's operations are safe to be used concurrently.
@@ -754,21 +698,13 @@ func (c *OutputService7ProtocolTest) OutputService7TestCaseOperation1(input *Out
 }
 
 type OutputService7TestShapeOutputService7TestCaseOperation1Input struct {
-	metadataOutputService7TestShapeOutputService7TestCaseOperation1Input `json:"-" xml:"-"`
-}
-
-type metadataOutputService7TestShapeOutputService7TestCaseOperation1Input struct {
-	SDKShapeTraits bool `type:"structure"`
+	_ struct{} `type:"structure"`
 }
 
 type OutputService7TestShapeOutputService7TestCaseOperation1Output struct {
 	Map map[string]*string `type:"map" flattened:"true"`
 
-	metadataOutputService7TestShapeOutputService7TestCaseOperation1Output `json:"-" xml:"-"`
-}
-
-type metadataOutputService7TestShapeOutputService7TestCaseOperation1Output struct {
-	SDKShapeTraits bool `type:"structure"`
+	_ struct{} `type:"structure"`
 }
 
 //The service client's operations are safe to be used concurrently.
@@ -850,21 +786,13 @@ func (c *OutputService8ProtocolTest) OutputService8TestCaseOperation1(input *Out
 }
 
 type OutputService8TestShapeOutputService8TestCaseOperation1Input struct {
-	metadataOutputService8TestShapeOutputService8TestCaseOperation1Input `json:"-" xml:"-"`
-}
-
-type metadataOutputService8TestShapeOutputService8TestCaseOperation1Input struct {
-	SDKShapeTraits bool `type:"structure"`
+	_ struct{} `type:"structure"`
 }
 
 type OutputService8TestShapeOutputService8TestCaseOperation1Output struct {
 	Map map[string]*string `locationNameKey:"foo" locationNameValue:"bar" type:"map"`
 
-	metadataOutputService8TestShapeOutputService8TestCaseOperation1Output `json:"-" xml:"-"`
-}
-
-type metadataOutputService8TestShapeOutputService8TestCaseOperation1Output struct {
-	SDKShapeTraits bool `type:"structure"`
+	_ struct{} `type:"structure"`
 }
 
 //The service client's operations are safe to be used concurrently.
@@ -946,11 +874,7 @@ func (c *OutputService9ProtocolTest) OutputService9TestCaseOperation1(input *Out
 }
 
 type OutputService9TestShapeOutputService9TestCaseOperation1Input struct {
-	metadataOutputService9TestShapeOutputService9TestCaseOperation1Input `json:"-" xml:"-"`
-}
-
-type metadataOutputService9TestShapeOutputService9TestCaseOperation1Input struct {
-	SDKShapeTraits bool `type:"structure"`
+	_ struct{} `type:"structure"`
 }
 
 type OutputService9TestShapeOutputService9TestCaseOperation1Output struct {
@@ -958,21 +882,13 @@ type OutputService9TestShapeOutputService9TestCaseOperation1Output struct {
 
 	Header *string `location:"header" locationName:"X-Foo" type:"string"`
 
-	metadataOutputService9TestShapeOutputService9TestCaseOperation1Output `json:"-" xml:"-"`
-}
-
-type metadataOutputService9TestShapeOutputService9TestCaseOperation1Output struct {
-	SDKShapeTraits bool `type:"structure" payload:"Data"`
+	_ struct{} `type:"structure" payload:"Data"`
 }
 
 type OutputService9TestShapeSingleStructure struct {
 	Foo *string `type:"string"`
 
-	metadataOutputService9TestShapeSingleStructure `json:"-" xml:"-"`
-}
-
-type metadataOutputService9TestShapeSingleStructure struct {
-	SDKShapeTraits bool `type:"structure"`
+	_ struct{} `type:"structure"`
 }
 
 //The service client's operations are safe to be used concurrently.
@@ -1054,21 +970,13 @@ func (c *OutputService10ProtocolTest) OutputService10TestCaseOperation1(input *O
 }
 
 type OutputService10TestShapeOutputService10TestCaseOperation1Input struct {
-	metadataOutputService10TestShapeOutputService10TestCaseOperation1Input `json:"-" xml:"-"`
-}
-
-type metadataOutputService10TestShapeOutputService10TestCaseOperation1Input struct {
-	SDKShapeTraits bool `type:"structure"`
+	_ struct{} `type:"structure"`
 }
 
 type OutputService10TestShapeOutputService10TestCaseOperation1Output struct {
 	Stream []byte `type:"blob"`
 
-	metadataOutputService10TestShapeOutputService10TestCaseOperation1Output `json:"-" xml:"-"`
-}
-
-type metadataOutputService10TestShapeOutputService10TestCaseOperation1Output struct {
-	SDKShapeTraits bool `type:"structure" payload:"Stream"`
+	_ struct{} `type:"structure" payload:"Stream"`
 }
 
 //The service client's operations are safe to be used concurrently.
@@ -1150,11 +1058,7 @@ func (c *OutputService11ProtocolTest) OutputService11TestCaseOperation1(input *O
 }
 
 type OutputService11TestShapeOutputService11TestCaseOperation1Input struct {
-	metadataOutputService11TestShapeOutputService11TestCaseOperation1Input `json:"-" xml:"-"`
-}
-
-type metadataOutputService11TestShapeOutputService11TestCaseOperation1Input struct {
-	SDKShapeTraits bool `type:"structure"`
+	_ struct{} `type:"structure"`
 }
 
 type OutputService11TestShapeOutputService11TestCaseOperation1Output struct {
@@ -1176,11 +1080,7 @@ type OutputService11TestShapeOutputService11TestCaseOperation1Output struct {
 
 	TrueBool *bool `location:"header" locationName:"x-true-bool" type:"boolean"`
 
-	metadataOutputService11TestShapeOutputService11TestCaseOperation1Output `json:"-" xml:"-"`
-}
-
-type metadataOutputService11TestShapeOutputService11TestCaseOperation1Output struct {
-	SDKShapeTraits bool `type:"structure"`
+	_ struct{} `type:"structure"`
 }
 
 //The service client's operations are safe to be used concurrently.
@@ -1262,21 +1162,13 @@ func (c *OutputService12ProtocolTest) OutputService12TestCaseOperation1(input *O
 }
 
 type OutputService12TestShapeOutputService12TestCaseOperation1Input struct {
-	metadataOutputService12TestShapeOutputService12TestCaseOperation1Input `json:"-" xml:"-"`
-}
-
-type metadataOutputService12TestShapeOutputService12TestCaseOperation1Input struct {
-	SDKShapeTraits bool `type:"structure"`
+	_ struct{} `type:"structure"`
 }
 
 type OutputService12TestShapeOutputService12TestCaseOperation1Output struct {
 	Foo *string `type:"string"`
 
-	metadataOutputService12TestShapeOutputService12TestCaseOperation1Output `json:"-" xml:"-"`
-}
-
-type metadataOutputService12TestShapeOutputService12TestCaseOperation1Output struct {
-	SDKShapeTraits bool `type:"structure"`
+	_ struct{} `type:"structure"`
 }
 
 //

--- a/private/protocol/xml/xmlutil/build.go
+++ b/private/protocol/xml/xmlutil/build.go
@@ -69,7 +69,7 @@ func (b *xmlBuilder) buildValue(value reflect.Value, current *XMLNode, tag refle
 
 	switch t {
 	case "structure":
-		if field, ok := value.Type().FieldByName("SDKShapeTraits"); ok {
+		if field, ok := value.Type().FieldByName("_"); ok {
 			tag = tag + reflect.StructTag(" ") + field.Tag
 		}
 		return b.buildStruct(value, current, tag)

--- a/private/protocol/xml/xmlutil/unmarshal.go
+++ b/private/protocol/xml/xmlutil/unmarshal.go
@@ -59,7 +59,7 @@ func parse(r reflect.Value, node *XMLNode, tag reflect.StructTag) error {
 
 	switch t {
 	case "structure":
-		if field, ok := rtype.FieldByName("SDKShapeTraits"); ok {
+		if field, ok := rtype.FieldByName("_"); ok {
 			tag = field.Tag
 		}
 		return parseStruct(r, node, tag)

--- a/service/apigateway/api.go
+++ b/service/apigateway/api.go
@@ -1937,11 +1937,7 @@ type Account struct {
 	// the current Account resource.
 	ThrottleSettings *ThrottleSettings `locationName:"throttleSettings" type:"structure"`
 
-	metadataAccount `json:"-" xml:"-"`
-}
-
-type metadataAccount struct {
-	SDKShapeTraits bool `type:"structure"`
+	_ struct{} `type:"structure"`
 }
 
 // String returns the string representation
@@ -1980,11 +1976,7 @@ type ApiKey struct {
 	// A list of Stage resources that are associated with the ApiKey resource.
 	StageKeys []*string `locationName:"stageKeys" type:"list"`
 
-	metadataApiKey `json:"-" xml:"-"`
-}
-
-type metadataApiKey struct {
-	SDKShapeTraits bool `type:"structure"`
+	_ struct{} `type:"structure"`
 }
 
 // String returns the string representation
@@ -2010,11 +2002,7 @@ type BasePathMapping struct {
 	// The name of the API's stage.
 	Stage *string `locationName:"stage" type:"string"`
 
-	metadataBasePathMapping `json:"-" xml:"-"`
-}
-
-type metadataBasePathMapping struct {
-	SDKShapeTraits bool `type:"structure"`
+	_ struct{} `type:"structure"`
 }
 
 // String returns the string representation
@@ -2038,11 +2026,7 @@ type ClientCertificate struct {
 
 	PemEncodedCertificate *string `locationName:"pemEncodedCertificate" type:"string"`
 
-	metadataClientCertificate `json:"-" xml:"-"`
-}
-
-type metadataClientCertificate struct {
-	SDKShapeTraits bool `type:"structure"`
+	_ struct{} `type:"structure"`
 }
 
 // String returns the string representation
@@ -2068,11 +2052,7 @@ type CreateApiKeyInput struct {
 	// Specifies whether the ApiKey can be used by callers.
 	StageKeys []*StageKey `locationName:"stageKeys" type:"list"`
 
-	metadataCreateApiKeyInput `json:"-" xml:"-"`
-}
-
-type metadataCreateApiKeyInput struct {
-	SDKShapeTraits bool `type:"structure"`
+	_ struct{} `type:"structure"`
 }
 
 // String returns the string representation
@@ -2104,11 +2084,7 @@ type CreateBasePathMappingInput struct {
 	// after any base path name.
 	Stage *string `locationName:"stage" type:"string"`
 
-	metadataCreateBasePathMappingInput `json:"-" xml:"-"`
-}
-
-type metadataCreateBasePathMappingInput struct {
-	SDKShapeTraits bool `type:"structure"`
+	_ struct{} `type:"structure"`
 }
 
 // String returns the string representation
@@ -2147,11 +2123,7 @@ type CreateDeploymentInput struct {
 	// the values must match [A-Za-z0-9-._~:/?#&=,]+
 	Variables map[string]*string `locationName:"variables" type:"map"`
 
-	metadataCreateDeploymentInput `json:"-" xml:"-"`
-}
-
-type metadataCreateDeploymentInput struct {
-	SDKShapeTraits bool `type:"structure"`
+	_ struct{} `type:"structure"`
 }
 
 // String returns the string representation
@@ -2186,11 +2158,7 @@ type CreateDomainNameInput struct {
 	// The name of the DomainName resource.
 	DomainName *string `locationName:"domainName" type:"string" required:"true"`
 
-	metadataCreateDomainNameInput `json:"-" xml:"-"`
-}
-
-type metadataCreateDomainNameInput struct {
-	SDKShapeTraits bool `type:"structure"`
+	_ struct{} `type:"structure"`
 }
 
 // String returns the string representation
@@ -2221,11 +2189,7 @@ type CreateModelInput struct {
 	// draft v4 model.
 	Schema *string `locationName:"schema" type:"string"`
 
-	metadataCreateModelInput `json:"-" xml:"-"`
-}
-
-type metadataCreateModelInput struct {
-	SDKShapeTraits bool `type:"structure"`
+	_ struct{} `type:"structure"`
 }
 
 // String returns the string representation
@@ -2249,11 +2213,7 @@ type CreateResourceInput struct {
 	// The identifier of the RestApi for the resource.
 	RestApiId *string `location:"uri" locationName:"restapi_id" type:"string" required:"true"`
 
-	metadataCreateResourceInput `json:"-" xml:"-"`
-}
-
-type metadataCreateResourceInput struct {
-	SDKShapeTraits bool `type:"structure"`
+	_ struct{} `type:"structure"`
 }
 
 // String returns the string representation
@@ -2277,11 +2237,7 @@ type CreateRestApiInput struct {
 	// The name of the RestApi.
 	Name *string `locationName:"name" type:"string" required:"true"`
 
-	metadataCreateRestApiInput `json:"-" xml:"-"`
-}
-
-type metadataCreateRestApiInput struct {
-	SDKShapeTraits bool `type:"structure"`
+	_ struct{} `type:"structure"`
 }
 
 // String returns the string representation
@@ -2318,11 +2274,7 @@ type CreateStageInput struct {
 	// names can have alphabetic characters, and the values must match [A-Za-z0-9-._~:/?#&=,]+
 	Variables map[string]*string `locationName:"variables" type:"map"`
 
-	metadataCreateStageInput `json:"-" xml:"-"`
-}
-
-type metadataCreateStageInput struct {
-	SDKShapeTraits bool `type:"structure"`
+	_ struct{} `type:"structure"`
 }
 
 // String returns the string representation
@@ -2340,11 +2292,7 @@ type DeleteApiKeyInput struct {
 	// The identifier of the ApiKey resource to be deleted.
 	ApiKey *string `location:"uri" locationName:"api_Key" type:"string" required:"true"`
 
-	metadataDeleteApiKeyInput `json:"-" xml:"-"`
-}
-
-type metadataDeleteApiKeyInput struct {
-	SDKShapeTraits bool `type:"structure"`
+	_ struct{} `type:"structure"`
 }
 
 // String returns the string representation
@@ -2358,11 +2306,7 @@ func (s DeleteApiKeyInput) GoString() string {
 }
 
 type DeleteApiKeyOutput struct {
-	metadataDeleteApiKeyOutput `json:"-" xml:"-"`
-}
-
-type metadataDeleteApiKeyOutput struct {
-	SDKShapeTraits bool `type:"structure"`
+	_ struct{} `type:"structure"`
 }
 
 // String returns the string representation
@@ -2383,11 +2327,7 @@ type DeleteBasePathMappingInput struct {
 	// The domain name of the BasePathMapping resource to delete.
 	DomainName *string `location:"uri" locationName:"domain_name" type:"string" required:"true"`
 
-	metadataDeleteBasePathMappingInput `json:"-" xml:"-"`
-}
-
-type metadataDeleteBasePathMappingInput struct {
-	SDKShapeTraits bool `type:"structure"`
+	_ struct{} `type:"structure"`
 }
 
 // String returns the string representation
@@ -2401,11 +2341,7 @@ func (s DeleteBasePathMappingInput) GoString() string {
 }
 
 type DeleteBasePathMappingOutput struct {
-	metadataDeleteBasePathMappingOutput `json:"-" xml:"-"`
-}
-
-type metadataDeleteBasePathMappingOutput struct {
-	SDKShapeTraits bool `type:"structure"`
+	_ struct{} `type:"structure"`
 }
 
 // String returns the string representation
@@ -2421,11 +2357,7 @@ func (s DeleteBasePathMappingOutput) GoString() string {
 type DeleteClientCertificateInput struct {
 	ClientCertificateId *string `location:"uri" locationName:"clientcertificate_id" type:"string" required:"true"`
 
-	metadataDeleteClientCertificateInput `json:"-" xml:"-"`
-}
-
-type metadataDeleteClientCertificateInput struct {
-	SDKShapeTraits bool `type:"structure"`
+	_ struct{} `type:"structure"`
 }
 
 // String returns the string representation
@@ -2439,11 +2371,7 @@ func (s DeleteClientCertificateInput) GoString() string {
 }
 
 type DeleteClientCertificateOutput struct {
-	metadataDeleteClientCertificateOutput `json:"-" xml:"-"`
-}
-
-type metadataDeleteClientCertificateOutput struct {
-	SDKShapeTraits bool `type:"structure"`
+	_ struct{} `type:"structure"`
 }
 
 // String returns the string representation
@@ -2464,11 +2392,7 @@ type DeleteDeploymentInput struct {
 	// The identifier of the RestApi resource for the Deployment resource to delete.
 	RestApiId *string `location:"uri" locationName:"restapi_id" type:"string" required:"true"`
 
-	metadataDeleteDeploymentInput `json:"-" xml:"-"`
-}
-
-type metadataDeleteDeploymentInput struct {
-	SDKShapeTraits bool `type:"structure"`
+	_ struct{} `type:"structure"`
 }
 
 // String returns the string representation
@@ -2482,11 +2406,7 @@ func (s DeleteDeploymentInput) GoString() string {
 }
 
 type DeleteDeploymentOutput struct {
-	metadataDeleteDeploymentOutput `json:"-" xml:"-"`
-}
-
-type metadataDeleteDeploymentOutput struct {
-	SDKShapeTraits bool `type:"structure"`
+	_ struct{} `type:"structure"`
 }
 
 // String returns the string representation
@@ -2504,11 +2424,7 @@ type DeleteDomainNameInput struct {
 	// The name of the DomainName resource to be deleted.
 	DomainName *string `location:"uri" locationName:"domain_name" type:"string" required:"true"`
 
-	metadataDeleteDomainNameInput `json:"-" xml:"-"`
-}
-
-type metadataDeleteDomainNameInput struct {
-	SDKShapeTraits bool `type:"structure"`
+	_ struct{} `type:"structure"`
 }
 
 // String returns the string representation
@@ -2522,11 +2438,7 @@ func (s DeleteDomainNameInput) GoString() string {
 }
 
 type DeleteDomainNameOutput struct {
-	metadataDeleteDomainNameOutput `json:"-" xml:"-"`
-}
-
-type metadataDeleteDomainNameOutput struct {
-	SDKShapeTraits bool `type:"structure"`
+	_ struct{} `type:"structure"`
 }
 
 // String returns the string representation
@@ -2550,11 +2462,7 @@ type DeleteIntegrationInput struct {
 	// Specifies a delete integration request's API identifier.
 	RestApiId *string `location:"uri" locationName:"restapi_id" type:"string" required:"true"`
 
-	metadataDeleteIntegrationInput `json:"-" xml:"-"`
-}
-
-type metadataDeleteIntegrationInput struct {
-	SDKShapeTraits bool `type:"structure"`
+	_ struct{} `type:"structure"`
 }
 
 // String returns the string representation
@@ -2568,11 +2476,7 @@ func (s DeleteIntegrationInput) GoString() string {
 }
 
 type DeleteIntegrationOutput struct {
-	metadataDeleteIntegrationOutput `json:"-" xml:"-"`
-}
-
-type metadataDeleteIntegrationOutput struct {
-	SDKShapeTraits bool `type:"structure"`
+	_ struct{} `type:"structure"`
 }
 
 // String returns the string representation
@@ -2599,11 +2503,7 @@ type DeleteIntegrationResponseInput struct {
 	// Specifies a delete integration response request's status code.
 	StatusCode *string `location:"uri" locationName:"status_code" type:"string" required:"true"`
 
-	metadataDeleteIntegrationResponseInput `json:"-" xml:"-"`
-}
-
-type metadataDeleteIntegrationResponseInput struct {
-	SDKShapeTraits bool `type:"structure"`
+	_ struct{} `type:"structure"`
 }
 
 // String returns the string representation
@@ -2617,11 +2517,7 @@ func (s DeleteIntegrationResponseInput) GoString() string {
 }
 
 type DeleteIntegrationResponseOutput struct {
-	metadataDeleteIntegrationResponseOutput `json:"-" xml:"-"`
-}
-
-type metadataDeleteIntegrationResponseOutput struct {
-	SDKShapeTraits bool `type:"structure"`
+	_ struct{} `type:"structure"`
 }
 
 // String returns the string representation
@@ -2645,11 +2541,7 @@ type DeleteMethodInput struct {
 	// The RestApi identifier for the Method resource.
 	RestApiId *string `location:"uri" locationName:"restapi_id" type:"string" required:"true"`
 
-	metadataDeleteMethodInput `json:"-" xml:"-"`
-}
-
-type metadataDeleteMethodInput struct {
-	SDKShapeTraits bool `type:"structure"`
+	_ struct{} `type:"structure"`
 }
 
 // String returns the string representation
@@ -2663,11 +2555,7 @@ func (s DeleteMethodInput) GoString() string {
 }
 
 type DeleteMethodOutput struct {
-	metadataDeleteMethodOutput `json:"-" xml:"-"`
-}
-
-type metadataDeleteMethodOutput struct {
-	SDKShapeTraits bool `type:"structure"`
+	_ struct{} `type:"structure"`
 }
 
 // String returns the string representation
@@ -2694,11 +2582,7 @@ type DeleteMethodResponseInput struct {
 	// The status code identifier for the MethodResponse resource.
 	StatusCode *string `location:"uri" locationName:"status_code" type:"string" required:"true"`
 
-	metadataDeleteMethodResponseInput `json:"-" xml:"-"`
-}
-
-type metadataDeleteMethodResponseInput struct {
-	SDKShapeTraits bool `type:"structure"`
+	_ struct{} `type:"structure"`
 }
 
 // String returns the string representation
@@ -2712,11 +2596,7 @@ func (s DeleteMethodResponseInput) GoString() string {
 }
 
 type DeleteMethodResponseOutput struct {
-	metadataDeleteMethodResponseOutput `json:"-" xml:"-"`
-}
-
-type metadataDeleteMethodResponseOutput struct {
-	SDKShapeTraits bool `type:"structure"`
+	_ struct{} `type:"structure"`
 }
 
 // String returns the string representation
@@ -2737,11 +2617,7 @@ type DeleteModelInput struct {
 	// The RestApi under which the model will be deleted.
 	RestApiId *string `location:"uri" locationName:"restapi_id" type:"string" required:"true"`
 
-	metadataDeleteModelInput `json:"-" xml:"-"`
-}
-
-type metadataDeleteModelInput struct {
-	SDKShapeTraits bool `type:"structure"`
+	_ struct{} `type:"structure"`
 }
 
 // String returns the string representation
@@ -2755,11 +2631,7 @@ func (s DeleteModelInput) GoString() string {
 }
 
 type DeleteModelOutput struct {
-	metadataDeleteModelOutput `json:"-" xml:"-"`
-}
-
-type metadataDeleteModelOutput struct {
-	SDKShapeTraits bool `type:"structure"`
+	_ struct{} `type:"structure"`
 }
 
 // String returns the string representation
@@ -2780,11 +2652,7 @@ type DeleteResourceInput struct {
 	// The RestApi identifier for the Resource resource.
 	RestApiId *string `location:"uri" locationName:"restapi_id" type:"string" required:"true"`
 
-	metadataDeleteResourceInput `json:"-" xml:"-"`
-}
-
-type metadataDeleteResourceInput struct {
-	SDKShapeTraits bool `type:"structure"`
+	_ struct{} `type:"structure"`
 }
 
 // String returns the string representation
@@ -2798,11 +2666,7 @@ func (s DeleteResourceInput) GoString() string {
 }
 
 type DeleteResourceOutput struct {
-	metadataDeleteResourceOutput `json:"-" xml:"-"`
-}
-
-type metadataDeleteResourceOutput struct {
-	SDKShapeTraits bool `type:"structure"`
+	_ struct{} `type:"structure"`
 }
 
 // String returns the string representation
@@ -2820,11 +2684,7 @@ type DeleteRestApiInput struct {
 	// The ID of the RestApi you want to delete.
 	RestApiId *string `location:"uri" locationName:"restapi_id" type:"string" required:"true"`
 
-	metadataDeleteRestApiInput `json:"-" xml:"-"`
-}
-
-type metadataDeleteRestApiInput struct {
-	SDKShapeTraits bool `type:"structure"`
+	_ struct{} `type:"structure"`
 }
 
 // String returns the string representation
@@ -2838,11 +2698,7 @@ func (s DeleteRestApiInput) GoString() string {
 }
 
 type DeleteRestApiOutput struct {
-	metadataDeleteRestApiOutput `json:"-" xml:"-"`
-}
-
-type metadataDeleteRestApiOutput struct {
-	SDKShapeTraits bool `type:"structure"`
+	_ struct{} `type:"structure"`
 }
 
 // String returns the string representation
@@ -2863,11 +2719,7 @@ type DeleteStageInput struct {
 	// The name of the Stage resource to delete.
 	StageName *string `location:"uri" locationName:"stage_name" type:"string" required:"true"`
 
-	metadataDeleteStageInput `json:"-" xml:"-"`
-}
-
-type metadataDeleteStageInput struct {
-	SDKShapeTraits bool `type:"structure"`
+	_ struct{} `type:"structure"`
 }
 
 // String returns the string representation
@@ -2881,11 +2733,7 @@ func (s DeleteStageInput) GoString() string {
 }
 
 type DeleteStageOutput struct {
-	metadataDeleteStageOutput `json:"-" xml:"-"`
-}
-
-type metadataDeleteStageOutput struct {
-	SDKShapeTraits bool `type:"structure"`
+	_ struct{} `type:"structure"`
 }
 
 // String returns the string representation
@@ -2915,11 +2763,7 @@ type Deployment struct {
 	// The identifier for the deployment resource.
 	Id *string `locationName:"id" type:"string"`
 
-	metadataDeployment `json:"-" xml:"-"`
-}
-
-type metadataDeployment struct {
-	SDKShapeTraits bool `type:"structure"`
+	_ struct{} `type:"structure"`
 }
 
 // String returns the string representation
@@ -2948,11 +2792,7 @@ type DomainName struct {
 	// The name of the DomainName resource.
 	DomainName *string `locationName:"domainName" type:"string"`
 
-	metadataDomainName `json:"-" xml:"-"`
-}
-
-type metadataDomainName struct {
-	SDKShapeTraits bool `type:"structure"`
+	_ struct{} `type:"structure"`
 }
 
 // String returns the string representation
@@ -2973,11 +2813,7 @@ type FlushStageCacheInput struct {
 	// The name of the stage to flush its cache.
 	StageName *string `location:"uri" locationName:"stage_name" type:"string" required:"true"`
 
-	metadataFlushStageCacheInput `json:"-" xml:"-"`
-}
-
-type metadataFlushStageCacheInput struct {
-	SDKShapeTraits bool `type:"structure"`
+	_ struct{} `type:"structure"`
 }
 
 // String returns the string representation
@@ -2991,11 +2827,7 @@ func (s FlushStageCacheInput) GoString() string {
 }
 
 type FlushStageCacheOutput struct {
-	metadataFlushStageCacheOutput `json:"-" xml:"-"`
-}
-
-type metadataFlushStageCacheOutput struct {
-	SDKShapeTraits bool `type:"structure"`
+	_ struct{} `type:"structure"`
 }
 
 // String returns the string representation
@@ -3011,11 +2843,7 @@ func (s FlushStageCacheOutput) GoString() string {
 type GenerateClientCertificateInput struct {
 	Description *string `locationName:"description" type:"string"`
 
-	metadataGenerateClientCertificateInput `json:"-" xml:"-"`
-}
-
-type metadataGenerateClientCertificateInput struct {
-	SDKShapeTraits bool `type:"structure"`
+	_ struct{} `type:"structure"`
 }
 
 // String returns the string representation
@@ -3031,11 +2859,7 @@ func (s GenerateClientCertificateInput) GoString() string {
 // Requests Amazon API Gateway to get information about the current Account
 // resource.
 type GetAccountInput struct {
-	metadataGetAccountInput `json:"-" xml:"-"`
-}
-
-type metadataGetAccountInput struct {
-	SDKShapeTraits bool `type:"structure"`
+	_ struct{} `type:"structure"`
 }
 
 // String returns the string representation
@@ -3053,11 +2877,7 @@ type GetApiKeyInput struct {
 	// The identifier of the ApiKey resource.
 	ApiKey *string `location:"uri" locationName:"api_Key" type:"string" required:"true"`
 
-	metadataGetApiKeyInput `json:"-" xml:"-"`
-}
-
-type metadataGetApiKeyInput struct {
-	SDKShapeTraits bool `type:"structure"`
+	_ struct{} `type:"structure"`
 }
 
 // String returns the string representation
@@ -3078,11 +2898,7 @@ type GetApiKeysInput struct {
 	// The position of the current ApiKeys resource to get information about.
 	Position *string `location:"querystring" locationName:"position" type:"string"`
 
-	metadataGetApiKeysInput `json:"-" xml:"-"`
-}
-
-type metadataGetApiKeysInput struct {
-	SDKShapeTraits bool `type:"structure"`
+	_ struct{} `type:"structure"`
 }
 
 // String returns the string representation
@@ -3102,11 +2918,7 @@ type GetApiKeysOutput struct {
 
 	Position *string `locationName:"position" type:"string"`
 
-	metadataGetApiKeysOutput `json:"-" xml:"-"`
-}
-
-type metadataGetApiKeysOutput struct {
-	SDKShapeTraits bool `type:"structure"`
+	_ struct{} `type:"structure"`
 }
 
 // String returns the string representation
@@ -3130,11 +2942,7 @@ type GetBasePathMappingInput struct {
 	// The domain name of the BasePathMapping resource to be described.
 	DomainName *string `location:"uri" locationName:"domain_name" type:"string" required:"true"`
 
-	metadataGetBasePathMappingInput `json:"-" xml:"-"`
-}
-
-type metadataGetBasePathMappingInput struct {
-	SDKShapeTraits bool `type:"structure"`
+	_ struct{} `type:"structure"`
 }
 
 // String returns the string representation
@@ -3161,11 +2969,7 @@ type GetBasePathMappingsInput struct {
 	// get information about.
 	Position *string `location:"querystring" locationName:"position" type:"string"`
 
-	metadataGetBasePathMappingsInput `json:"-" xml:"-"`
-}
-
-type metadataGetBasePathMappingsInput struct {
-	SDKShapeTraits bool `type:"structure"`
+	_ struct{} `type:"structure"`
 }
 
 // String returns the string representation
@@ -3186,11 +2990,7 @@ type GetBasePathMappingsOutput struct {
 
 	Position *string `locationName:"position" type:"string"`
 
-	metadataGetBasePathMappingsOutput `json:"-" xml:"-"`
-}
-
-type metadataGetBasePathMappingsOutput struct {
-	SDKShapeTraits bool `type:"structure"`
+	_ struct{} `type:"structure"`
 }
 
 // String returns the string representation
@@ -3206,11 +3006,7 @@ func (s GetBasePathMappingsOutput) GoString() string {
 type GetClientCertificateInput struct {
 	ClientCertificateId *string `location:"uri" locationName:"clientcertificate_id" type:"string" required:"true"`
 
-	metadataGetClientCertificateInput `json:"-" xml:"-"`
-}
-
-type metadataGetClientCertificateInput struct {
-	SDKShapeTraits bool `type:"structure"`
+	_ struct{} `type:"structure"`
 }
 
 // String returns the string representation
@@ -3228,11 +3024,7 @@ type GetClientCertificatesInput struct {
 
 	Position *string `location:"querystring" locationName:"position" type:"string"`
 
-	metadataGetClientCertificatesInput `json:"-" xml:"-"`
-}
-
-type metadataGetClientCertificatesInput struct {
-	SDKShapeTraits bool `type:"structure"`
+	_ struct{} `type:"structure"`
 }
 
 // String returns the string representation
@@ -3250,11 +3042,7 @@ type GetClientCertificatesOutput struct {
 
 	Position *string `locationName:"position" type:"string"`
 
-	metadataGetClientCertificatesOutput `json:"-" xml:"-"`
-}
-
-type metadataGetClientCertificatesOutput struct {
-	SDKShapeTraits bool `type:"structure"`
+	_ struct{} `type:"structure"`
 }
 
 // String returns the string representation
@@ -3276,11 +3064,7 @@ type GetDeploymentInput struct {
 	// information about.
 	RestApiId *string `location:"uri" locationName:"restapi_id" type:"string" required:"true"`
 
-	metadataGetDeploymentInput `json:"-" xml:"-"`
-}
-
-type metadataGetDeploymentInput struct {
-	SDKShapeTraits bool `type:"structure"`
+	_ struct{} `type:"structure"`
 }
 
 // String returns the string representation
@@ -3307,11 +3091,7 @@ type GetDeploymentsInput struct {
 	// to get information about.
 	RestApiId *string `location:"uri" locationName:"restapi_id" type:"string" required:"true"`
 
-	metadataGetDeploymentsInput `json:"-" xml:"-"`
-}
-
-type metadataGetDeploymentsInput struct {
-	SDKShapeTraits bool `type:"structure"`
+	_ struct{} `type:"structure"`
 }
 
 // String returns the string representation
@@ -3335,11 +3115,7 @@ type GetDeploymentsOutput struct {
 
 	Position *string `locationName:"position" type:"string"`
 
-	metadataGetDeploymentsOutput `json:"-" xml:"-"`
-}
-
-type metadataGetDeploymentsOutput struct {
-	SDKShapeTraits bool `type:"structure"`
+	_ struct{} `type:"structure"`
 }
 
 // String returns the string representation
@@ -3357,11 +3133,7 @@ type GetDomainNameInput struct {
 	// The name of the DomainName resource.
 	DomainName *string `location:"uri" locationName:"domain_name" type:"string" required:"true"`
 
-	metadataGetDomainNameInput `json:"-" xml:"-"`
-}
-
-type metadataGetDomainNameInput struct {
-	SDKShapeTraits bool `type:"structure"`
+	_ struct{} `type:"structure"`
 }
 
 // String returns the string representation
@@ -3383,11 +3155,7 @@ type GetDomainNamesInput struct {
 	// The position of the current domain names to get information about.
 	Position *string `location:"querystring" locationName:"position" type:"string"`
 
-	metadataGetDomainNamesInput `json:"-" xml:"-"`
-}
-
-type metadataGetDomainNamesInput struct {
-	SDKShapeTraits bool `type:"structure"`
+	_ struct{} `type:"structure"`
 }
 
 // String returns the string representation
@@ -3408,11 +3176,7 @@ type GetDomainNamesOutput struct {
 
 	Position *string `locationName:"position" type:"string"`
 
-	metadataGetDomainNamesOutput `json:"-" xml:"-"`
-}
-
-type metadataGetDomainNamesOutput struct {
-	SDKShapeTraits bool `type:"structure"`
+	_ struct{} `type:"structure"`
 }
 
 // String returns the string representation
@@ -3436,11 +3200,7 @@ type GetIntegrationInput struct {
 	// Specifies a get integration request's API identifier.
 	RestApiId *string `location:"uri" locationName:"restapi_id" type:"string" required:"true"`
 
-	metadataGetIntegrationInput `json:"-" xml:"-"`
-}
-
-type metadataGetIntegrationInput struct {
-	SDKShapeTraits bool `type:"structure"`
+	_ struct{} `type:"structure"`
 }
 
 // String returns the string representation
@@ -3467,11 +3227,7 @@ type GetIntegrationResponseInput struct {
 	// Specifies a get integration response request's status code.
 	StatusCode *string `location:"uri" locationName:"status_code" type:"string" required:"true"`
 
-	metadataGetIntegrationResponseInput `json:"-" xml:"-"`
-}
-
-type metadataGetIntegrationResponseInput struct {
-	SDKShapeTraits bool `type:"structure"`
+	_ struct{} `type:"structure"`
 }
 
 // String returns the string representation
@@ -3495,11 +3251,7 @@ type GetMethodInput struct {
 	// The RestApi identifier for the Method resource.
 	RestApiId *string `location:"uri" locationName:"restapi_id" type:"string" required:"true"`
 
-	metadataGetMethodInput `json:"-" xml:"-"`
-}
-
-type metadataGetMethodInput struct {
-	SDKShapeTraits bool `type:"structure"`
+	_ struct{} `type:"structure"`
 }
 
 // String returns the string representation
@@ -3526,11 +3278,7 @@ type GetMethodResponseInput struct {
 	// The status code identifier for the MethodResponse resource.
 	StatusCode *string `location:"uri" locationName:"status_code" type:"string" required:"true"`
 
-	metadataGetMethodResponseInput `json:"-" xml:"-"`
-}
-
-type metadataGetMethodResponseInput struct {
-	SDKShapeTraits bool `type:"structure"`
+	_ struct{} `type:"structure"`
 }
 
 // String returns the string representation
@@ -3554,11 +3302,7 @@ type GetModelInput struct {
 	// The RestApi identifier under which the Model exists.
 	RestApiId *string `location:"uri" locationName:"restapi_id" type:"string" required:"true"`
 
-	metadataGetModelInput `json:"-" xml:"-"`
-}
-
-type metadataGetModelInput struct {
-	SDKShapeTraits bool `type:"structure"`
+	_ struct{} `type:"structure"`
 }
 
 // String returns the string representation
@@ -3579,11 +3323,7 @@ type GetModelTemplateInput struct {
 	// The ID of the RestApi under which the model exists.
 	RestApiId *string `location:"uri" locationName:"restapi_id" type:"string" required:"true"`
 
-	metadataGetModelTemplateInput `json:"-" xml:"-"`
-}
-
-type metadataGetModelTemplateInput struct {
-	SDKShapeTraits bool `type:"structure"`
+	_ struct{} `type:"structure"`
 }
 
 // String returns the string representation
@@ -3602,11 +3342,7 @@ type GetModelTemplateOutput struct {
 	// template resource.
 	Value *string `locationName:"value" type:"string"`
 
-	metadataGetModelTemplateOutput `json:"-" xml:"-"`
-}
-
-type metadataGetModelTemplateOutput struct {
-	SDKShapeTraits bool `type:"structure"`
+	_ struct{} `type:"structure"`
 }
 
 // String returns the string representation
@@ -3632,11 +3368,7 @@ type GetModelsInput struct {
 	// The RestApi identifier.
 	RestApiId *string `location:"uri" locationName:"restapi_id" type:"string" required:"true"`
 
-	metadataGetModelsInput `json:"-" xml:"-"`
-}
-
-type metadataGetModelsInput struct {
-	SDKShapeTraits bool `type:"structure"`
+	_ struct{} `type:"structure"`
 }
 
 // String returns the string representation
@@ -3656,11 +3388,7 @@ type GetModelsOutput struct {
 
 	Position *string `locationName:"position" type:"string"`
 
-	metadataGetModelsOutput `json:"-" xml:"-"`
-}
-
-type metadataGetModelsOutput struct {
-	SDKShapeTraits bool `type:"structure"`
+	_ struct{} `type:"structure"`
 }
 
 // String returns the string representation
@@ -3681,11 +3409,7 @@ type GetResourceInput struct {
 	// The RestApi identifier for the resource.
 	RestApiId *string `location:"uri" locationName:"restapi_id" type:"string" required:"true"`
 
-	metadataGetResourceInput `json:"-" xml:"-"`
-}
-
-type metadataGetResourceInput struct {
-	SDKShapeTraits bool `type:"structure"`
+	_ struct{} `type:"structure"`
 }
 
 // String returns the string representation
@@ -3711,11 +3435,7 @@ type GetResourcesInput struct {
 	// The RestApi identifier for the Resource.
 	RestApiId *string `location:"uri" locationName:"restapi_id" type:"string" required:"true"`
 
-	metadataGetResourcesInput `json:"-" xml:"-"`
-}
-
-type metadataGetResourcesInput struct {
-	SDKShapeTraits bool `type:"structure"`
+	_ struct{} `type:"structure"`
 }
 
 // String returns the string representation
@@ -3735,11 +3455,7 @@ type GetResourcesOutput struct {
 
 	Position *string `locationName:"position" type:"string"`
 
-	metadataGetResourcesOutput `json:"-" xml:"-"`
-}
-
-type metadataGetResourcesOutput struct {
-	SDKShapeTraits bool `type:"structure"`
+	_ struct{} `type:"structure"`
 }
 
 // String returns the string representation
@@ -3757,11 +3473,7 @@ type GetRestApiInput struct {
 	// The identifier of the RestApi resource.
 	RestApiId *string `location:"uri" locationName:"restapi_id" type:"string" required:"true"`
 
-	metadataGetRestApiInput `json:"-" xml:"-"`
-}
-
-type metadataGetRestApiInput struct {
-	SDKShapeTraits bool `type:"structure"`
+	_ struct{} `type:"structure"`
 }
 
 // String returns the string representation
@@ -3784,11 +3496,7 @@ type GetRestApisInput struct {
 	// about.
 	Position *string `location:"querystring" locationName:"position" type:"string"`
 
-	metadataGetRestApisInput `json:"-" xml:"-"`
-}
-
-type metadataGetRestApisInput struct {
-	SDKShapeTraits bool `type:"structure"`
+	_ struct{} `type:"structure"`
 }
 
 // String returns the string representation
@@ -3809,11 +3517,7 @@ type GetRestApisOutput struct {
 
 	Position *string `locationName:"position" type:"string"`
 
-	metadataGetRestApisOutput `json:"-" xml:"-"`
-}
-
-type metadataGetRestApisOutput struct {
-	SDKShapeTraits bool `type:"structure"`
+	_ struct{} `type:"structure"`
 }
 
 // String returns the string representation
@@ -3835,11 +3539,7 @@ type GetSdkInput struct {
 
 	StageName *string `location:"uri" locationName:"stage_name" type:"string" required:"true"`
 
-	metadataGetSdkInput `json:"-" xml:"-"`
-}
-
-type metadataGetSdkInput struct {
-	SDKShapeTraits bool `type:"structure"`
+	_ struct{} `type:"structure"`
 }
 
 // String returns the string representation
@@ -3859,11 +3559,7 @@ type GetSdkOutput struct {
 
 	ContentType *string `location:"header" locationName:"Content-Type" type:"string"`
 
-	metadataGetSdkOutput `json:"-" xml:"-"`
-}
-
-type metadataGetSdkOutput struct {
-	SDKShapeTraits bool `type:"structure" payload:"Body"`
+	_ struct{} `type:"structure" payload:"Body"`
 }
 
 // String returns the string representation
@@ -3885,11 +3581,7 @@ type GetStageInput struct {
 	// The name of the Stage resource to get information about.
 	StageName *string `location:"uri" locationName:"stage_name" type:"string" required:"true"`
 
-	metadataGetStageInput `json:"-" xml:"-"`
-}
-
-type metadataGetStageInput struct {
-	SDKShapeTraits bool `type:"structure"`
+	_ struct{} `type:"structure"`
 }
 
 // String returns the string representation
@@ -3910,11 +3602,7 @@ type GetStagesInput struct {
 	// The stages' API identifiers.
 	RestApiId *string `location:"uri" locationName:"restapi_id" type:"string" required:"true"`
 
-	metadataGetStagesInput `json:"-" xml:"-"`
-}
-
-type metadataGetStagesInput struct {
-	SDKShapeTraits bool `type:"structure"`
+	_ struct{} `type:"structure"`
 }
 
 // String returns the string representation
@@ -3932,11 +3620,7 @@ type GetStagesOutput struct {
 	// An individual Stage resource.
 	Item []*Stage `locationName:"item" type:"list"`
 
-	metadataGetStagesOutput `json:"-" xml:"-"`
-}
-
-type metadataGetStagesOutput struct {
-	SDKShapeTraits bool `type:"structure"`
+	_ struct{} `type:"structure"`
 }
 
 // String returns the string representation
@@ -3997,11 +3681,7 @@ type Integration struct {
 	// the path to the resource, including the initial /.
 	Uri *string `locationName:"uri" type:"string"`
 
-	metadataIntegration `json:"-" xml:"-"`
-}
-
-type metadataIntegration struct {
-	SDKShapeTraits bool `type:"structure"`
+	_ struct{} `type:"structure"`
 }
 
 // String returns the string representation
@@ -4042,11 +3722,7 @@ type IntegrationResponse struct {
 	// an existing MethodResponse.
 	StatusCode *string `locationName:"statusCode" type:"string"`
 
-	metadataIntegrationResponse `json:"-" xml:"-"`
-}
-
-type metadataIntegrationResponse struct {
-	SDKShapeTraits bool `type:"structure"`
+	_ struct{} `type:"structure"`
 }
 
 // String returns the string representation
@@ -4093,11 +3769,7 @@ type Method struct {
 	// mapping to integration request parameters or templates.
 	RequestParameters map[string]*bool `locationName:"requestParameters" type:"map"`
 
-	metadataMethod `json:"-" xml:"-"`
-}
-
-type metadataMethod struct {
-	SDKShapeTraits bool `type:"structure"`
+	_ struct{} `type:"structure"`
 }
 
 // String returns the string representation
@@ -4131,11 +3803,7 @@ type MethodResponse struct {
 	// The method response's status code.
 	StatusCode *string `locationName:"statusCode" type:"string"`
 
-	metadataMethodResponse `json:"-" xml:"-"`
-}
-
-type metadataMethodResponse struct {
-	SDKShapeTraits bool `type:"structure"`
+	_ struct{} `type:"structure"`
 }
 
 // String returns the string representation
@@ -4191,11 +3859,7 @@ type MethodSetting struct {
 	// and the value is a double.
 	ThrottlingRateLimit *float64 `locationName:"throttlingRateLimit" type:"double"`
 
-	metadataMethodSetting `json:"-" xml:"-"`
-}
-
-type metadataMethodSetting struct {
-	SDKShapeTraits bool `type:"structure"`
+	_ struct{} `type:"structure"`
 }
 
 // String returns the string representation
@@ -4216,11 +3880,7 @@ type MethodSnapshot struct {
 	// Specifies the type of authorization used for the method.
 	AuthorizationType *string `locationName:"authorizationType" type:"string"`
 
-	metadataMethodSnapshot `json:"-" xml:"-"`
-}
-
-type metadataMethodSnapshot struct {
-	SDKShapeTraits bool `type:"structure"`
+	_ struct{} `type:"structure"`
 }
 
 // String returns the string representation
@@ -4251,11 +3911,7 @@ type Model struct {
 	// draft v4 model.
 	Schema *string `locationName:"schema" type:"string"`
 
-	metadataModel `json:"-" xml:"-"`
-}
-
-type metadataModel struct {
-	SDKShapeTraits bool `type:"structure"`
+	_ struct{} `type:"structure"`
 }
 
 // String returns the string representation
@@ -4291,11 +3947,7 @@ type PatchOperation struct {
 	// The actual value content.
 	Value *string `locationName:"value" type:"string"`
 
-	metadataPatchOperation `json:"-" xml:"-"`
-}
-
-type metadataPatchOperation struct {
-	SDKShapeTraits bool `type:"structure"`
+	_ struct{} `type:"structure"`
 }
 
 // String returns the string representation
@@ -4352,11 +4004,7 @@ type PutIntegrationInput struct {
 	// Specifies a put integration input's Uniform Resource Identifier (URI).
 	Uri *string `locationName:"uri" type:"string"`
 
-	metadataPutIntegrationInput `json:"-" xml:"-"`
-}
-
-type metadataPutIntegrationInput struct {
-	SDKShapeTraits bool `type:"structure"`
+	_ struct{} `type:"structure"`
 }
 
 // String returns the string representation
@@ -4399,11 +4047,7 @@ type PutIntegrationResponseInput struct {
 	// an existing MethodResponse.
 	StatusCode *string `location:"uri" locationName:"status_code" type:"string" required:"true"`
 
-	metadataPutIntegrationResponseInput `json:"-" xml:"-"`
-}
-
-type metadataPutIntegrationResponseInput struct {
-	SDKShapeTraits bool `type:"structure"`
+	_ struct{} `type:"structure"`
 }
 
 // String returns the string representation
@@ -4448,11 +4092,7 @@ type PutMethodInput struct {
 	// The RestApi identifier for the new Method resource.
 	RestApiId *string `location:"uri" locationName:"restapi_id" type:"string" required:"true"`
 
-	metadataPutMethodInput `json:"-" xml:"-"`
-}
-
-type metadataPutMethodInput struct {
-	SDKShapeTraits bool `type:"structure"`
+	_ struct{} `type:"structure"`
 }
 
 // String returns the string representation
@@ -4493,11 +4133,7 @@ type PutMethodResponseInput struct {
 	// The method response's status code.
 	StatusCode *string `location:"uri" locationName:"status_code" type:"string" required:"true"`
 
-	metadataPutMethodResponseInput `json:"-" xml:"-"`
-}
-
-type metadataPutMethodResponseInput struct {
-	SDKShapeTraits bool `type:"structure"`
+	_ struct{} `type:"structure"`
 }
 
 // String returns the string representation
@@ -4528,11 +4164,7 @@ type Resource struct {
 	// the embed option.
 	ResourceMethods map[string]*Method `locationName:"resourceMethods" type:"map"`
 
-	metadataResource `json:"-" xml:"-"`
-}
-
-type metadataResource struct {
-	SDKShapeTraits bool `type:"structure"`
+	_ struct{} `type:"structure"`
 }
 
 // String returns the string representation
@@ -4560,11 +4192,7 @@ type RestApi struct {
 	// The API's name.
 	Name *string `locationName:"name" type:"string"`
 
-	metadataRestApi `json:"-" xml:"-"`
-}
-
-type metadataRestApi struct {
-	SDKShapeTraits bool `type:"structure"`
+	_ struct{} `type:"structure"`
 }
 
 // String returns the string representation
@@ -4617,11 +4245,7 @@ type Stage struct {
 	// can have alphabetic characters, and the values must match [A-Za-z0-9-._~:/?#&=,]+
 	Variables map[string]*string `locationName:"variables" type:"map"`
 
-	metadataStage `json:"-" xml:"-"`
-}
-
-type metadataStage struct {
-	SDKShapeTraits bool `type:"structure"`
+	_ struct{} `type:"structure"`
 }
 
 // String returns the string representation
@@ -4642,11 +4266,7 @@ type StageKey struct {
 	// The stage name in the RestApi that the stage key references.
 	StageName *string `locationName:"stageName" type:"string"`
 
-	metadataStageKey `json:"-" xml:"-"`
-}
-
-type metadataStageKey struct {
-	SDKShapeTraits bool `type:"structure"`
+	_ struct{} `type:"structure"`
 }
 
 // String returns the string representation
@@ -4676,11 +4296,7 @@ type TestInvokeMethodInput struct {
 
 	StageVariables map[string]*string `locationName:"stageVariables" type:"map"`
 
-	metadataTestInvokeMethodInput `json:"-" xml:"-"`
-}
-
-type metadataTestInvokeMethodInput struct {
-	SDKShapeTraits bool `type:"structure"`
+	_ struct{} `type:"structure"`
 }
 
 // String returns the string representation
@@ -4710,11 +4326,7 @@ type TestInvokeMethodOutput struct {
 	// The HTTP status code.
 	Status *int64 `locationName:"status" type:"integer"`
 
-	metadataTestInvokeMethodOutput `json:"-" xml:"-"`
-}
-
-type metadataTestInvokeMethodOutput struct {
-	SDKShapeTraits bool `type:"structure"`
+	_ struct{} `type:"structure"`
 }
 
 // String returns the string representation
@@ -4735,11 +4347,7 @@ type ThrottleSettings struct {
 	// Returns the rateLimit when ThrottleSettings is called.
 	RateLimit *float64 `locationName:"rateLimit" type:"double"`
 
-	metadataThrottleSettings `json:"-" xml:"-"`
-}
-
-type metadataThrottleSettings struct {
-	SDKShapeTraits bool `type:"structure"`
+	_ struct{} `type:"structure"`
 }
 
 // String returns the string representation
@@ -4759,11 +4367,7 @@ type UpdateAccountInput struct {
 	// The patches are applied in the order specified in the list.
 	PatchOperations []*PatchOperation `locationName:"patchOperations" type:"list"`
 
-	metadataUpdateAccountInput `json:"-" xml:"-"`
-}
-
-type metadataUpdateAccountInput struct {
-	SDKShapeTraits bool `type:"structure"`
+	_ struct{} `type:"structure"`
 }
 
 // String returns the string representation
@@ -4785,11 +4389,7 @@ type UpdateApiKeyInput struct {
 	// The patches are applied in the order specified in the list.
 	PatchOperations []*PatchOperation `locationName:"patchOperations" type:"list"`
 
-	metadataUpdateApiKeyInput `json:"-" xml:"-"`
-}
-
-type metadataUpdateApiKeyInput struct {
-	SDKShapeTraits bool `type:"structure"`
+	_ struct{} `type:"structure"`
 }
 
 // String returns the string representation
@@ -4814,11 +4414,7 @@ type UpdateBasePathMappingInput struct {
 	// The patches are applied in the order specified in the list.
 	PatchOperations []*PatchOperation `locationName:"patchOperations" type:"list"`
 
-	metadataUpdateBasePathMappingInput `json:"-" xml:"-"`
-}
-
-type metadataUpdateBasePathMappingInput struct {
-	SDKShapeTraits bool `type:"structure"`
+	_ struct{} `type:"structure"`
 }
 
 // String returns the string representation
@@ -4838,11 +4434,7 @@ type UpdateClientCertificateInput struct {
 	// The patches are applied in the order specified in the list.
 	PatchOperations []*PatchOperation `locationName:"patchOperations" type:"list"`
 
-	metadataUpdateClientCertificateInput `json:"-" xml:"-"`
-}
-
-type metadataUpdateClientCertificateInput struct {
-	SDKShapeTraits bool `type:"structure"`
+	_ struct{} `type:"structure"`
 }
 
 // String returns the string representation
@@ -4869,11 +4461,7 @@ type UpdateDeploymentInput struct {
 	// to change information about.
 	RestApiId *string `location:"uri" locationName:"restapi_id" type:"string" required:"true"`
 
-	metadataUpdateDeploymentInput `json:"-" xml:"-"`
-}
-
-type metadataUpdateDeploymentInput struct {
-	SDKShapeTraits bool `type:"structure"`
+	_ struct{} `type:"structure"`
 }
 
 // String returns the string representation
@@ -4895,11 +4483,7 @@ type UpdateDomainNameInput struct {
 	// The patches are applied in the order specified in the list.
 	PatchOperations []*PatchOperation `locationName:"patchOperations" type:"list"`
 
-	metadataUpdateDomainNameInput `json:"-" xml:"-"`
-}
-
-type metadataUpdateDomainNameInput struct {
-	SDKShapeTraits bool `type:"structure"`
+	_ struct{} `type:"structure"`
 }
 
 // String returns the string representation
@@ -4927,11 +4511,7 @@ type UpdateIntegrationInput struct {
 	// Represents an update integration request's API identifier.
 	RestApiId *string `location:"uri" locationName:"restapi_id" type:"string" required:"true"`
 
-	metadataUpdateIntegrationInput `json:"-" xml:"-"`
-}
-
-type metadataUpdateIntegrationInput struct {
-	SDKShapeTraits bool `type:"structure"`
+	_ struct{} `type:"structure"`
 }
 
 // String returns the string representation
@@ -4962,11 +4542,7 @@ type UpdateIntegrationResponseInput struct {
 	// Specifies an update integration response request's status code.
 	StatusCode *string `location:"uri" locationName:"status_code" type:"string" required:"true"`
 
-	metadataUpdateIntegrationResponseInput `json:"-" xml:"-"`
-}
-
-type metadataUpdateIntegrationResponseInput struct {
-	SDKShapeTraits bool `type:"structure"`
+	_ struct{} `type:"structure"`
 }
 
 // String returns the string representation
@@ -4994,11 +4570,7 @@ type UpdateMethodInput struct {
 	// The RestApi identifier for the Method resource.
 	RestApiId *string `location:"uri" locationName:"restapi_id" type:"string" required:"true"`
 
-	metadataUpdateMethodInput `json:"-" xml:"-"`
-}
-
-type metadataUpdateMethodInput struct {
-	SDKShapeTraits bool `type:"structure"`
+	_ struct{} `type:"structure"`
 }
 
 // String returns the string representation
@@ -5029,11 +4601,7 @@ type UpdateMethodResponseInput struct {
 	// The status code identifier for the MethodResponse resource.
 	StatusCode *string `location:"uri" locationName:"status_code" type:"string" required:"true"`
 
-	metadataUpdateMethodResponseInput `json:"-" xml:"-"`
-}
-
-type metadataUpdateMethodResponseInput struct {
-	SDKShapeTraits bool `type:"structure"`
+	_ struct{} `type:"structure"`
 }
 
 // String returns the string representation
@@ -5058,11 +4626,7 @@ type UpdateModelInput struct {
 	// The RestApi identifier under which the model exists.
 	RestApiId *string `location:"uri" locationName:"restapi_id" type:"string" required:"true"`
 
-	metadataUpdateModelInput `json:"-" xml:"-"`
-}
-
-type metadataUpdateModelInput struct {
-	SDKShapeTraits bool `type:"structure"`
+	_ struct{} `type:"structure"`
 }
 
 // String returns the string representation
@@ -5087,11 +4651,7 @@ type UpdateResourceInput struct {
 	// The RestApi identifier for the Resource resource.
 	RestApiId *string `location:"uri" locationName:"restapi_id" type:"string" required:"true"`
 
-	metadataUpdateResourceInput `json:"-" xml:"-"`
-}
-
-type metadataUpdateResourceInput struct {
-	SDKShapeTraits bool `type:"structure"`
+	_ struct{} `type:"structure"`
 }
 
 // String returns the string representation
@@ -5113,11 +4673,7 @@ type UpdateRestApiInput struct {
 	// The ID of the RestApi you want to update.
 	RestApiId *string `location:"uri" locationName:"restapi_id" type:"string" required:"true"`
 
-	metadataUpdateRestApiInput `json:"-" xml:"-"`
-}
-
-type metadataUpdateRestApiInput struct {
-	SDKShapeTraits bool `type:"structure"`
+	_ struct{} `type:"structure"`
 }
 
 // String returns the string representation
@@ -5143,11 +4699,7 @@ type UpdateStageInput struct {
 	// The name of the Stage resource to change information about.
 	StageName *string `location:"uri" locationName:"stage_name" type:"string" required:"true"`
 
-	metadataUpdateStageInput `json:"-" xml:"-"`
-}
-
-type metadataUpdateStageInput struct {
-	SDKShapeTraits bool `type:"structure"`
+	_ struct{} `type:"structure"`
 }
 
 // String returns the string representation

--- a/service/apigateway/api.go
+++ b/service/apigateway/api.go
@@ -1929,6 +1929,8 @@ func (c *APIGateway) UpdateStage(input *UpdateStageInput) (*Stage, error) {
 
 // Represents an AWS account that is associated with Amazon API Gateway.
 type Account struct {
+	_ struct{} `type:"structure"`
+
 	// Specifies the Amazon resource name (ARN) of an Amazon CloudWatch role for
 	// the current Account resource.
 	CloudwatchRoleArn *string `locationName:"cloudwatchRoleArn" type:"string"`
@@ -1936,8 +1938,6 @@ type Account struct {
 	// Specifies the application programming interface (API) throttle settings for
 	// the current Account resource.
 	ThrottleSettings *ThrottleSettings `locationName:"throttleSettings" type:"structure"`
-
-	_ struct{} `type:"structure"`
 }
 
 // String returns the string representation
@@ -1955,6 +1955,8 @@ func (s Account) GoString() string {
 // which indicates that the callers with the API key can make requests to that
 // stage.
 type ApiKey struct {
+	_ struct{} `type:"structure"`
+
 	// The date when the API Key was created, in ISO 8601 format.
 	CreatedDate *time.Time `locationName:"createdDate" type:"timestamp" timestampFormat:"unix"`
 
@@ -1975,8 +1977,6 @@ type ApiKey struct {
 
 	// A list of Stage resources that are associated with the ApiKey resource.
 	StageKeys []*string `locationName:"stageKeys" type:"list"`
-
-	_ struct{} `type:"structure"`
 }
 
 // String returns the string representation
@@ -1992,6 +1992,8 @@ func (s ApiKey) GoString() string {
 // Represents the base path that callers of the API that must provide as part
 // of the URL after the domain name.
 type BasePathMapping struct {
+	_ struct{} `type:"structure"`
+
 	// The base path name that callers of the API must provide as part of the URL
 	// after the domain name.
 	BasePath *string `locationName:"basePath" type:"string"`
@@ -2001,8 +2003,6 @@ type BasePathMapping struct {
 
 	// The name of the API's stage.
 	Stage *string `locationName:"stage" type:"string"`
-
-	_ struct{} `type:"structure"`
 }
 
 // String returns the string representation
@@ -2016,6 +2016,8 @@ func (s BasePathMapping) GoString() string {
 }
 
 type ClientCertificate struct {
+	_ struct{} `type:"structure"`
+
 	ClientCertificateId *string `locationName:"clientCertificateId" type:"string"`
 
 	CreatedDate *time.Time `locationName:"createdDate" type:"timestamp" timestampFormat:"unix"`
@@ -2025,8 +2027,6 @@ type ClientCertificate struct {
 	ExpirationDate *time.Time `locationName:"expirationDate" type:"timestamp" timestampFormat:"unix"`
 
 	PemEncodedCertificate *string `locationName:"pemEncodedCertificate" type:"string"`
-
-	_ struct{} `type:"structure"`
 }
 
 // String returns the string representation
@@ -2040,6 +2040,8 @@ func (s ClientCertificate) GoString() string {
 }
 
 type CreateApiKeyInput struct {
+	_ struct{} `type:"structure"`
+
 	// The description of the ApiKey.
 	Description *string `locationName:"description" type:"string"`
 
@@ -2051,8 +2053,6 @@ type CreateApiKeyInput struct {
 
 	// Specifies whether the ApiKey can be used by callers.
 	StageKeys []*StageKey `locationName:"stageKeys" type:"list"`
-
-	_ struct{} `type:"structure"`
 }
 
 // String returns the string representation
@@ -2067,6 +2067,8 @@ func (s CreateApiKeyInput) GoString() string {
 
 // Requests Amazon API Gateway to create a new BasePathMapping resource.
 type CreateBasePathMappingInput struct {
+	_ struct{} `type:"structure"`
+
 	// The base path name that callers of the API must provide as part of the URL
 	// after the domain name. This value must be unique for all of the mappings
 	// across a single API. Leave this blank if you do not want callers to specify
@@ -2083,8 +2085,6 @@ type CreateBasePathMappingInput struct {
 	// this blank if you do not want callers to explicitly specify the stage name
 	// after any base path name.
 	Stage *string `locationName:"stage" type:"string"`
-
-	_ struct{} `type:"structure"`
 }
 
 // String returns the string representation
@@ -2099,6 +2099,8 @@ func (s CreateBasePathMappingInput) GoString() string {
 
 // Requests Amazon API Gateway to create a Deployment resource.
 type CreateDeploymentInput struct {
+	_ struct{} `type:"structure"`
+
 	// Enables a cache cluster for the Stage resource specified in the input.
 	CacheClusterEnabled *bool `locationName:"cacheClusterEnabled" type:"boolean"`
 
@@ -2122,8 +2124,6 @@ type CreateDeploymentInput struct {
 	// with the new deployment. Variable names can have alphabetic characters, and
 	// the values must match [A-Za-z0-9-._~:/?#&=,]+
 	Variables map[string]*string `locationName:"variables" type:"map"`
-
-	_ struct{} `type:"structure"`
 }
 
 // String returns the string representation
@@ -2138,6 +2138,8 @@ func (s CreateDeploymentInput) GoString() string {
 
 // A request to create a new domain name.
 type CreateDomainNameInput struct {
+	_ struct{} `type:"structure"`
+
 	// The body of the server certificate provided by your certificate authority.
 	CertificateBody *string `locationName:"certificateBody" type:"string" required:"true"`
 
@@ -2157,8 +2159,6 @@ type CreateDomainNameInput struct {
 
 	// The name of the DomainName resource.
 	DomainName *string `locationName:"domainName" type:"string" required:"true"`
-
-	_ struct{} `type:"structure"`
 }
 
 // String returns the string representation
@@ -2173,6 +2173,8 @@ func (s CreateDomainNameInput) GoString() string {
 
 // Request to add a new Model to an existing RestApi resource.
 type CreateModelInput struct {
+	_ struct{} `type:"structure"`
+
 	// The content-type for the model.
 	ContentType *string `locationName:"contentType" type:"string" required:"true"`
 
@@ -2188,8 +2190,6 @@ type CreateModelInput struct {
 	// The schema for the model. For application/json models, this should be JSON-schema
 	// draft v4 model.
 	Schema *string `locationName:"schema" type:"string"`
-
-	_ struct{} `type:"structure"`
 }
 
 // String returns the string representation
@@ -2204,6 +2204,8 @@ func (s CreateModelInput) GoString() string {
 
 // Requests Amazon API Gateway to create a Resource resource.
 type CreateResourceInput struct {
+	_ struct{} `type:"structure"`
+
 	// The parent resource's identifier.
 	ParentId *string `location:"uri" locationName:"parent_id" type:"string" required:"true"`
 
@@ -2212,8 +2214,6 @@ type CreateResourceInput struct {
 
 	// The identifier of the RestApi for the resource.
 	RestApiId *string `location:"uri" locationName:"restapi_id" type:"string" required:"true"`
-
-	_ struct{} `type:"structure"`
 }
 
 // String returns the string representation
@@ -2228,6 +2228,8 @@ func (s CreateResourceInput) GoString() string {
 
 // Request to add a new RestApi resource to your collection.
 type CreateRestApiInput struct {
+	_ struct{} `type:"structure"`
+
 	// The name of the RestApi that you want to clone from.
 	CloneFrom *string `locationName:"cloneFrom" type:"string"`
 
@@ -2236,8 +2238,6 @@ type CreateRestApiInput struct {
 
 	// The name of the RestApi.
 	Name *string `locationName:"name" type:"string" required:"true"`
-
-	_ struct{} `type:"structure"`
 }
 
 // String returns the string representation
@@ -2252,6 +2252,8 @@ func (s CreateRestApiInput) GoString() string {
 
 // Requests Amazon API Gateway to create a Stage resource.
 type CreateStageInput struct {
+	_ struct{} `type:"structure"`
+
 	// Whether cache clustering is enabled for the stage.
 	CacheClusterEnabled *bool `locationName:"cacheClusterEnabled" type:"boolean"`
 
@@ -2273,8 +2275,6 @@ type CreateStageInput struct {
 	// A map that defines the stage variables for the new Stage resource. Variable
 	// names can have alphabetic characters, and the values must match [A-Za-z0-9-._~:/?#&=,]+
 	Variables map[string]*string `locationName:"variables" type:"map"`
-
-	_ struct{} `type:"structure"`
 }
 
 // String returns the string representation
@@ -2289,10 +2289,10 @@ func (s CreateStageInput) GoString() string {
 
 // A request to delete the ApiKey resource.
 type DeleteApiKeyInput struct {
+	_ struct{} `type:"structure"`
+
 	// The identifier of the ApiKey resource to be deleted.
 	ApiKey *string `location:"uri" locationName:"api_Key" type:"string" required:"true"`
-
-	_ struct{} `type:"structure"`
 }
 
 // String returns the string representation
@@ -2321,13 +2321,13 @@ func (s DeleteApiKeyOutput) GoString() string {
 
 // A request to delete the BasePathMapping resource.
 type DeleteBasePathMappingInput struct {
+	_ struct{} `type:"structure"`
+
 	// The base path name of the BasePathMapping resource to delete.
 	BasePath *string `location:"uri" locationName:"base_path" type:"string" required:"true"`
 
 	// The domain name of the BasePathMapping resource to delete.
 	DomainName *string `location:"uri" locationName:"domain_name" type:"string" required:"true"`
-
-	_ struct{} `type:"structure"`
 }
 
 // String returns the string representation
@@ -2355,9 +2355,9 @@ func (s DeleteBasePathMappingOutput) GoString() string {
 }
 
 type DeleteClientCertificateInput struct {
-	ClientCertificateId *string `location:"uri" locationName:"clientcertificate_id" type:"string" required:"true"`
-
 	_ struct{} `type:"structure"`
+
+	ClientCertificateId *string `location:"uri" locationName:"clientcertificate_id" type:"string" required:"true"`
 }
 
 // String returns the string representation
@@ -2386,13 +2386,13 @@ func (s DeleteClientCertificateOutput) GoString() string {
 
 // Requests Amazon API Gateway to delete a Deployment resource.
 type DeleteDeploymentInput struct {
+	_ struct{} `type:"structure"`
+
 	// The identifier of the Deployment resource to delete.
 	DeploymentId *string `location:"uri" locationName:"deployment_id" type:"string" required:"true"`
 
 	// The identifier of the RestApi resource for the Deployment resource to delete.
 	RestApiId *string `location:"uri" locationName:"restapi_id" type:"string" required:"true"`
-
-	_ struct{} `type:"structure"`
 }
 
 // String returns the string representation
@@ -2421,10 +2421,10 @@ func (s DeleteDeploymentOutput) GoString() string {
 
 // A request to delete the DomainName resource.
 type DeleteDomainNameInput struct {
+	_ struct{} `type:"structure"`
+
 	// The name of the DomainName resource to be deleted.
 	DomainName *string `location:"uri" locationName:"domain_name" type:"string" required:"true"`
-
-	_ struct{} `type:"structure"`
 }
 
 // String returns the string representation
@@ -2453,6 +2453,8 @@ func (s DeleteDomainNameOutput) GoString() string {
 
 // Represents a delete integration request.
 type DeleteIntegrationInput struct {
+	_ struct{} `type:"structure"`
+
 	// Specifies a delete integration request's HTTP method.
 	HttpMethod *string `location:"uri" locationName:"http_method" type:"string" required:"true"`
 
@@ -2461,8 +2463,6 @@ type DeleteIntegrationInput struct {
 
 	// Specifies a delete integration request's API identifier.
 	RestApiId *string `location:"uri" locationName:"restapi_id" type:"string" required:"true"`
-
-	_ struct{} `type:"structure"`
 }
 
 // String returns the string representation
@@ -2491,6 +2491,8 @@ func (s DeleteIntegrationOutput) GoString() string {
 
 // Represents a delete integration response request.
 type DeleteIntegrationResponseInput struct {
+	_ struct{} `type:"structure"`
+
 	// Specifies a delete integration response request's HTTP method.
 	HttpMethod *string `location:"uri" locationName:"http_method" type:"string" required:"true"`
 
@@ -2502,8 +2504,6 @@ type DeleteIntegrationResponseInput struct {
 
 	// Specifies a delete integration response request's status code.
 	StatusCode *string `location:"uri" locationName:"status_code" type:"string" required:"true"`
-
-	_ struct{} `type:"structure"`
 }
 
 // String returns the string representation
@@ -2532,6 +2532,8 @@ func (s DeleteIntegrationResponseOutput) GoString() string {
 
 // Request to delete an existing Method resource.
 type DeleteMethodInput struct {
+	_ struct{} `type:"structure"`
+
 	// The HTTP verb that identifies the Method resource.
 	HttpMethod *string `location:"uri" locationName:"http_method" type:"string" required:"true"`
 
@@ -2540,8 +2542,6 @@ type DeleteMethodInput struct {
 
 	// The RestApi identifier for the Method resource.
 	RestApiId *string `location:"uri" locationName:"restapi_id" type:"string" required:"true"`
-
-	_ struct{} `type:"structure"`
 }
 
 // String returns the string representation
@@ -2570,6 +2570,8 @@ func (s DeleteMethodOutput) GoString() string {
 
 // A request to delete an existing MethodResponse resource.
 type DeleteMethodResponseInput struct {
+	_ struct{} `type:"structure"`
+
 	// The HTTP verb identifier for the parent Method resource.
 	HttpMethod *string `location:"uri" locationName:"http_method" type:"string" required:"true"`
 
@@ -2581,8 +2583,6 @@ type DeleteMethodResponseInput struct {
 
 	// The status code identifier for the MethodResponse resource.
 	StatusCode *string `location:"uri" locationName:"status_code" type:"string" required:"true"`
-
-	_ struct{} `type:"structure"`
 }
 
 // String returns the string representation
@@ -2611,13 +2611,13 @@ func (s DeleteMethodResponseOutput) GoString() string {
 
 // Request to delete an existing model in an existing RestApi resource.
 type DeleteModelInput struct {
+	_ struct{} `type:"structure"`
+
 	// The name of the model to delete.
 	ModelName *string `location:"uri" locationName:"model_name" type:"string" required:"true"`
 
 	// The RestApi under which the model will be deleted.
 	RestApiId *string `location:"uri" locationName:"restapi_id" type:"string" required:"true"`
-
-	_ struct{} `type:"structure"`
 }
 
 // String returns the string representation
@@ -2646,13 +2646,13 @@ func (s DeleteModelOutput) GoString() string {
 
 // Request to delete a Resource.
 type DeleteResourceInput struct {
+	_ struct{} `type:"structure"`
+
 	// The identifier of the Resource resource.
 	ResourceId *string `location:"uri" locationName:"resource_id" type:"string" required:"true"`
 
 	// The RestApi identifier for the Resource resource.
 	RestApiId *string `location:"uri" locationName:"restapi_id" type:"string" required:"true"`
-
-	_ struct{} `type:"structure"`
 }
 
 // String returns the string representation
@@ -2681,10 +2681,10 @@ func (s DeleteResourceOutput) GoString() string {
 
 // Request to delete the specified API from your collection.
 type DeleteRestApiInput struct {
+	_ struct{} `type:"structure"`
+
 	// The ID of the RestApi you want to delete.
 	RestApiId *string `location:"uri" locationName:"restapi_id" type:"string" required:"true"`
-
-	_ struct{} `type:"structure"`
 }
 
 // String returns the string representation
@@ -2713,13 +2713,13 @@ func (s DeleteRestApiOutput) GoString() string {
 
 // Requests Amazon API Gateway to delete a Stage resource.
 type DeleteStageInput struct {
+	_ struct{} `type:"structure"`
+
 	// The identifier of the RestApi resource for the Stage resource to delete.
 	RestApiId *string `location:"uri" locationName:"restapi_id" type:"string" required:"true"`
 
 	// The name of the Stage resource to delete.
 	StageName *string `location:"uri" locationName:"stage_name" type:"string" required:"true"`
-
-	_ struct{} `type:"structure"`
 }
 
 // String returns the string representation
@@ -2750,6 +2750,8 @@ func (s DeleteStageOutput) GoString() string {
 // using Stages. A deployment must be associated with a Stage for it to be callable
 // over the Internet.
 type Deployment struct {
+	_ struct{} `type:"structure"`
+
 	// Gets a summary of the RestApi at the date and time that the deployment resource
 	// was created.
 	ApiSummary map[string]map[string]*MethodSnapshot `locationName:"apiSummary" type:"map"`
@@ -2762,8 +2764,6 @@ type Deployment struct {
 
 	// The identifier for the deployment resource.
 	Id *string `locationName:"id" type:"string"`
-
-	_ struct{} `type:"structure"`
 }
 
 // String returns the string representation
@@ -2779,6 +2779,8 @@ func (s Deployment) GoString() string {
 // Represents a domain name that is contained in a simpler, more intuitive URL
 // that can be called.
 type DomainName struct {
+	_ struct{} `type:"structure"`
+
 	// The name of the certificate.
 	CertificateName *string `locationName:"certificateName" type:"string"`
 
@@ -2791,8 +2793,6 @@ type DomainName struct {
 
 	// The name of the DomainName resource.
 	DomainName *string `locationName:"domainName" type:"string"`
-
-	_ struct{} `type:"structure"`
 }
 
 // String returns the string representation
@@ -2807,13 +2807,13 @@ func (s DomainName) GoString() string {
 
 // Requests Amazon API Gateway to flush a stage's cache.
 type FlushStageCacheInput struct {
+	_ struct{} `type:"structure"`
+
 	// The API identifier of the stage to flush its cache.
 	RestApiId *string `location:"uri" locationName:"restapi_id" type:"string" required:"true"`
 
 	// The name of the stage to flush its cache.
 	StageName *string `location:"uri" locationName:"stage_name" type:"string" required:"true"`
-
-	_ struct{} `type:"structure"`
 }
 
 // String returns the string representation
@@ -2841,9 +2841,9 @@ func (s FlushStageCacheOutput) GoString() string {
 }
 
 type GenerateClientCertificateInput struct {
-	Description *string `locationName:"description" type:"string"`
-
 	_ struct{} `type:"structure"`
+
+	Description *string `locationName:"description" type:"string"`
 }
 
 // String returns the string representation
@@ -2874,10 +2874,10 @@ func (s GetAccountInput) GoString() string {
 
 // A request to get information about the current ApiKey resource.
 type GetApiKeyInput struct {
+	_ struct{} `type:"structure"`
+
 	// The identifier of the ApiKey resource.
 	ApiKey *string `location:"uri" locationName:"api_Key" type:"string" required:"true"`
-
-	_ struct{} `type:"structure"`
 }
 
 // String returns the string representation
@@ -2892,13 +2892,13 @@ func (s GetApiKeyInput) GoString() string {
 
 // A request to get information about the current ApiKeys resource.
 type GetApiKeysInput struct {
+	_ struct{} `type:"structure"`
+
 	// The maximum number of ApiKeys to get information about.
 	Limit *int64 `location:"querystring" locationName:"limit" type:"integer"`
 
 	// The position of the current ApiKeys resource to get information about.
 	Position *string `location:"querystring" locationName:"position" type:"string"`
-
-	_ struct{} `type:"structure"`
 }
 
 // String returns the string representation
@@ -2913,12 +2913,12 @@ func (s GetApiKeysInput) GoString() string {
 
 // Represents a collection of ApiKey resources.
 type GetApiKeysOutput struct {
+	_ struct{} `type:"structure"`
+
 	// The current page of any ApiKey resources in the collection of ApiKey resources.
 	Items []*ApiKey `locationName:"item" type:"list"`
 
 	Position *string `locationName:"position" type:"string"`
-
-	_ struct{} `type:"structure"`
 }
 
 // String returns the string representation
@@ -2933,6 +2933,8 @@ func (s GetApiKeysOutput) GoString() string {
 
 // Request to describe a BasePathMapping resource.
 type GetBasePathMappingInput struct {
+	_ struct{} `type:"structure"`
+
 	// The base path name that callers of the API must provide as part of the URL
 	// after the domain name. This value must be unique for all of the mappings
 	// across a single API. Leave this blank if you do not want callers to specify
@@ -2941,8 +2943,6 @@ type GetBasePathMappingInput struct {
 
 	// The domain name of the BasePathMapping resource to be described.
 	DomainName *string `location:"uri" locationName:"domain_name" type:"string" required:"true"`
-
-	_ struct{} `type:"structure"`
 }
 
 // String returns the string representation
@@ -2957,6 +2957,8 @@ func (s GetBasePathMappingInput) GoString() string {
 
 // A request to get information about a collection of BasePathMapping resources.
 type GetBasePathMappingsInput struct {
+	_ struct{} `type:"structure"`
+
 	// The domain name of a BasePathMapping resource.
 	DomainName *string `location:"uri" locationName:"domain_name" type:"string" required:"true"`
 
@@ -2968,8 +2970,6 @@ type GetBasePathMappingsInput struct {
 	// The position of the current BasePathMapping resource in the collection to
 	// get information about.
 	Position *string `location:"querystring" locationName:"position" type:"string"`
-
-	_ struct{} `type:"structure"`
 }
 
 // String returns the string representation
@@ -2984,13 +2984,13 @@ func (s GetBasePathMappingsInput) GoString() string {
 
 // Represents a collection of BasePathMapping resources.
 type GetBasePathMappingsOutput struct {
+	_ struct{} `type:"structure"`
+
 	// The current page of any BasePathMapping resources in the collection of base
 	// path mapping resources.
 	Items []*BasePathMapping `locationName:"item" type:"list"`
 
 	Position *string `locationName:"position" type:"string"`
-
-	_ struct{} `type:"structure"`
 }
 
 // String returns the string representation
@@ -3004,9 +3004,9 @@ func (s GetBasePathMappingsOutput) GoString() string {
 }
 
 type GetClientCertificateInput struct {
-	ClientCertificateId *string `location:"uri" locationName:"clientcertificate_id" type:"string" required:"true"`
-
 	_ struct{} `type:"structure"`
+
+	ClientCertificateId *string `location:"uri" locationName:"clientcertificate_id" type:"string" required:"true"`
 }
 
 // String returns the string representation
@@ -3020,11 +3020,11 @@ func (s GetClientCertificateInput) GoString() string {
 }
 
 type GetClientCertificatesInput struct {
+	_ struct{} `type:"structure"`
+
 	Limit *int64 `location:"querystring" locationName:"limit" type:"integer"`
 
 	Position *string `location:"querystring" locationName:"position" type:"string"`
-
-	_ struct{} `type:"structure"`
 }
 
 // String returns the string representation
@@ -3038,11 +3038,11 @@ func (s GetClientCertificatesInput) GoString() string {
 }
 
 type GetClientCertificatesOutput struct {
+	_ struct{} `type:"structure"`
+
 	Items []*ClientCertificate `locationName:"item" type:"list"`
 
 	Position *string `locationName:"position" type:"string"`
-
-	_ struct{} `type:"structure"`
 }
 
 // String returns the string representation
@@ -3057,14 +3057,14 @@ func (s GetClientCertificatesOutput) GoString() string {
 
 // Requests Amazon API Gateway to get information about a Deployment resource.
 type GetDeploymentInput struct {
+	_ struct{} `type:"structure"`
+
 	// The identifier of the Deployment resource to get information about.
 	DeploymentId *string `location:"uri" locationName:"deployment_id" type:"string" required:"true"`
 
 	// The identifier of the RestApi resource for the Deployment resource to get
 	// information about.
 	RestApiId *string `location:"uri" locationName:"restapi_id" type:"string" required:"true"`
-
-	_ struct{} `type:"structure"`
 }
 
 // String returns the string representation
@@ -3079,6 +3079,8 @@ func (s GetDeploymentInput) GoString() string {
 
 // Requests Amazon API Gateway to get information about a Deployments collection.
 type GetDeploymentsInput struct {
+	_ struct{} `type:"structure"`
+
 	// The maximum number of Deployment resources in the collection to get information
 	// about. The default limit is 25. It should be an integer between 1 - 500.
 	Limit *int64 `location:"querystring" locationName:"limit" type:"integer"`
@@ -3090,8 +3092,6 @@ type GetDeploymentsInput struct {
 	// The identifier of the RestApi resource for the collection of Deployment resources
 	// to get information about.
 	RestApiId *string `location:"uri" locationName:"restapi_id" type:"string" required:"true"`
-
-	_ struct{} `type:"structure"`
 }
 
 // String returns the string representation
@@ -3109,13 +3109,13 @@ func (s GetDeploymentsInput) GoString() string {
 // your collection. The collection offers a paginated view of the contained
 // deployments.
 type GetDeploymentsOutput struct {
+	_ struct{} `type:"structure"`
+
 	// The current page of any Deployment resources in the collection of deployment
 	// resources.
 	Items []*Deployment `locationName:"item" type:"list"`
 
 	Position *string `locationName:"position" type:"string"`
-
-	_ struct{} `type:"structure"`
 }
 
 // String returns the string representation
@@ -3130,10 +3130,10 @@ func (s GetDeploymentsOutput) GoString() string {
 
 // Request to get the name of a DomainName resource.
 type GetDomainNameInput struct {
+	_ struct{} `type:"structure"`
+
 	// The name of the DomainName resource.
 	DomainName *string `location:"uri" locationName:"domain_name" type:"string" required:"true"`
-
-	_ struct{} `type:"structure"`
 }
 
 // String returns the string representation
@@ -3148,14 +3148,14 @@ func (s GetDomainNameInput) GoString() string {
 
 // Request to describe a collection of DomainName resources.
 type GetDomainNamesInput struct {
+	_ struct{} `type:"structure"`
+
 	// The maximum number of DomainName resources in the collection to get information
 	// about. The default limit is 25. It should be an integer between 1 - 500.
 	Limit *int64 `location:"querystring" locationName:"limit" type:"integer"`
 
 	// The position of the current domain names to get information about.
 	Position *string `location:"querystring" locationName:"position" type:"string"`
-
-	_ struct{} `type:"structure"`
 }
 
 // String returns the string representation
@@ -3170,13 +3170,13 @@ func (s GetDomainNamesInput) GoString() string {
 
 // Represents a collection of DomainName resources.
 type GetDomainNamesOutput struct {
+	_ struct{} `type:"structure"`
+
 	// The current page of any DomainName resources in the collection of DomainName
 	// resources.
 	Items []*DomainName `locationName:"item" type:"list"`
 
 	Position *string `locationName:"position" type:"string"`
-
-	_ struct{} `type:"structure"`
 }
 
 // String returns the string representation
@@ -3191,6 +3191,8 @@ func (s GetDomainNamesOutput) GoString() string {
 
 // Represents a get integration request.
 type GetIntegrationInput struct {
+	_ struct{} `type:"structure"`
+
 	// Specifies a get integration request's HTTP method.
 	HttpMethod *string `location:"uri" locationName:"http_method" type:"string" required:"true"`
 
@@ -3199,8 +3201,6 @@ type GetIntegrationInput struct {
 
 	// Specifies a get integration request's API identifier.
 	RestApiId *string `location:"uri" locationName:"restapi_id" type:"string" required:"true"`
-
-	_ struct{} `type:"structure"`
 }
 
 // String returns the string representation
@@ -3215,6 +3215,8 @@ func (s GetIntegrationInput) GoString() string {
 
 // Represents a get integration response request.
 type GetIntegrationResponseInput struct {
+	_ struct{} `type:"structure"`
+
 	// Specifies a get integration response request's HTTP method.
 	HttpMethod *string `location:"uri" locationName:"http_method" type:"string" required:"true"`
 
@@ -3226,8 +3228,6 @@ type GetIntegrationResponseInput struct {
 
 	// Specifies a get integration response request's status code.
 	StatusCode *string `location:"uri" locationName:"status_code" type:"string" required:"true"`
-
-	_ struct{} `type:"structure"`
 }
 
 // String returns the string representation
@@ -3242,6 +3242,8 @@ func (s GetIntegrationResponseInput) GoString() string {
 
 // Request to describe an existing Method resource.
 type GetMethodInput struct {
+	_ struct{} `type:"structure"`
+
 	// Specifies the put method request's HTTP method type.
 	HttpMethod *string `location:"uri" locationName:"http_method" type:"string" required:"true"`
 
@@ -3250,8 +3252,6 @@ type GetMethodInput struct {
 
 	// The RestApi identifier for the Method resource.
 	RestApiId *string `location:"uri" locationName:"restapi_id" type:"string" required:"true"`
-
-	_ struct{} `type:"structure"`
 }
 
 // String returns the string representation
@@ -3266,6 +3266,8 @@ func (s GetMethodInput) GoString() string {
 
 // Request to describe a MethodResponse resource.
 type GetMethodResponseInput struct {
+	_ struct{} `type:"structure"`
+
 	// The HTTP verb identifier for the parent Method resource.
 	HttpMethod *string `location:"uri" locationName:"http_method" type:"string" required:"true"`
 
@@ -3277,8 +3279,6 @@ type GetMethodResponseInput struct {
 
 	// The status code identifier for the MethodResponse resource.
 	StatusCode *string `location:"uri" locationName:"status_code" type:"string" required:"true"`
-
-	_ struct{} `type:"structure"`
 }
 
 // String returns the string representation
@@ -3293,6 +3293,8 @@ func (s GetMethodResponseInput) GoString() string {
 
 // Request to list information about a model in an existing RestApi resource.
 type GetModelInput struct {
+	_ struct{} `type:"structure"`
+
 	// Resolves all external model references and returns a flattened model schema.
 	Flatten *bool `location:"querystring" locationName:"flatten" type:"boolean"`
 
@@ -3301,8 +3303,6 @@ type GetModelInput struct {
 
 	// The RestApi identifier under which the Model exists.
 	RestApiId *string `location:"uri" locationName:"restapi_id" type:"string" required:"true"`
-
-	_ struct{} `type:"structure"`
 }
 
 // String returns the string representation
@@ -3317,13 +3317,13 @@ func (s GetModelInput) GoString() string {
 
 // Request to generate a sample mapping template used to transform the payload.
 type GetModelTemplateInput struct {
+	_ struct{} `type:"structure"`
+
 	// The name of the model for which to generate a template.
 	ModelName *string `location:"uri" locationName:"model_name" type:"string" required:"true"`
 
 	// The ID of the RestApi under which the model exists.
 	RestApiId *string `location:"uri" locationName:"restapi_id" type:"string" required:"true"`
-
-	_ struct{} `type:"structure"`
 }
 
 // String returns the string representation
@@ -3338,11 +3338,11 @@ func (s GetModelTemplateInput) GoString() string {
 
 // Represents a mapping template used to transform a payload.
 type GetModelTemplateOutput struct {
+	_ struct{} `type:"structure"`
+
 	// The Apache Velocity Template Language (VTL) template content used for the
 	// template resource.
 	Value *string `locationName:"value" type:"string"`
-
-	_ struct{} `type:"structure"`
 }
 
 // String returns the string representation
@@ -3357,6 +3357,8 @@ func (s GetModelTemplateOutput) GoString() string {
 
 // Request to list existing Models defined for a RestApi resource.
 type GetModelsInput struct {
+	_ struct{} `type:"structure"`
+
 	// The maximum number of models in the collection to get information about.
 	// The default limit is 25. It should be an integer between 1 - 500.
 	Limit *int64 `location:"querystring" locationName:"limit" type:"integer"`
@@ -3367,8 +3369,6 @@ type GetModelsInput struct {
 
 	// The RestApi identifier.
 	RestApiId *string `location:"uri" locationName:"restapi_id" type:"string" required:"true"`
-
-	_ struct{} `type:"structure"`
 }
 
 // String returns the string representation
@@ -3383,12 +3383,12 @@ func (s GetModelsInput) GoString() string {
 
 // Represents a collection of Model resources.
 type GetModelsOutput struct {
+	_ struct{} `type:"structure"`
+
 	// Gets the current Model resource in the collection.
 	Items []*Model `locationName:"item" type:"list"`
 
 	Position *string `locationName:"position" type:"string"`
-
-	_ struct{} `type:"structure"`
 }
 
 // String returns the string representation
@@ -3403,13 +3403,13 @@ func (s GetModelsOutput) GoString() string {
 
 // Request to list information about a resource.
 type GetResourceInput struct {
+	_ struct{} `type:"structure"`
+
 	// The identifier for the Resource resource.
 	ResourceId *string `location:"uri" locationName:"resource_id" type:"string" required:"true"`
 
 	// The RestApi identifier for the resource.
 	RestApiId *string `location:"uri" locationName:"restapi_id" type:"string" required:"true"`
-
-	_ struct{} `type:"structure"`
 }
 
 // String returns the string representation
@@ -3424,6 +3424,8 @@ func (s GetResourceInput) GoString() string {
 
 // Request to list information about a collection of resources.
 type GetResourcesInput struct {
+	_ struct{} `type:"structure"`
+
 	// The maximum number of Resource resources in the collection to get information
 	// about. The default limit is 25. It should be an integer between 1 - 500.
 	Limit *int64 `location:"querystring" locationName:"limit" type:"integer"`
@@ -3434,8 +3436,6 @@ type GetResourcesInput struct {
 
 	// The RestApi identifier for the Resource.
 	RestApiId *string `location:"uri" locationName:"restapi_id" type:"string" required:"true"`
-
-	_ struct{} `type:"structure"`
 }
 
 // String returns the string representation
@@ -3450,12 +3450,12 @@ func (s GetResourcesInput) GoString() string {
 
 // Represents a collection of Resource resources.
 type GetResourcesOutput struct {
+	_ struct{} `type:"structure"`
+
 	// Gets the current Resource resource in the collection.
 	Items []*Resource `locationName:"item" type:"list"`
 
 	Position *string `locationName:"position" type:"string"`
-
-	_ struct{} `type:"structure"`
 }
 
 // String returns the string representation
@@ -3470,10 +3470,10 @@ func (s GetResourcesOutput) GoString() string {
 
 // Request to list an existing RestApi defined for your collection.
 type GetRestApiInput struct {
+	_ struct{} `type:"structure"`
+
 	// The identifier of the RestApi resource.
 	RestApiId *string `location:"uri" locationName:"restapi_id" type:"string" required:"true"`
-
-	_ struct{} `type:"structure"`
 }
 
 // String returns the string representation
@@ -3488,6 +3488,8 @@ func (s GetRestApiInput) GoString() string {
 
 // Request to list existing RestApis defined for your collection.
 type GetRestApisInput struct {
+	_ struct{} `type:"structure"`
+
 	// The maximum number of RestApi resources in the collection to get information
 	// about. The default limit is 25. It should be an integer between 1 - 500.
 	Limit *int64 `location:"querystring" locationName:"limit" type:"integer"`
@@ -3495,8 +3497,6 @@ type GetRestApisInput struct {
 	// The position of the current RestApis resource in the collection to get information
 	// about.
 	Position *string `location:"querystring" locationName:"position" type:"string"`
-
-	_ struct{} `type:"structure"`
 }
 
 // String returns the string representation
@@ -3512,12 +3512,12 @@ func (s GetRestApisInput) GoString() string {
 // Contains references to your APIs and links that guide you in ways to interact
 // with your collection. A collection offers a paginated view of your APIs.
 type GetRestApisOutput struct {
+	_ struct{} `type:"structure"`
+
 	// An array of links to the current page of RestApi resources.
 	Items []*RestApi `locationName:"item" type:"list"`
 
 	Position *string `locationName:"position" type:"string"`
-
-	_ struct{} `type:"structure"`
 }
 
 // String returns the string representation
@@ -3531,6 +3531,8 @@ func (s GetRestApisOutput) GoString() string {
 }
 
 type GetSdkInput struct {
+	_ struct{} `type:"structure"`
+
 	Parameters map[string]*string `location:"querystring" locationName:"parameters" type:"map"`
 
 	RestApiId *string `location:"uri" locationName:"restapi_id" type:"string" required:"true"`
@@ -3538,8 +3540,6 @@ type GetSdkInput struct {
 	SdkType *string `location:"uri" locationName:"sdk_type" type:"string" required:"true"`
 
 	StageName *string `location:"uri" locationName:"stage_name" type:"string" required:"true"`
-
-	_ struct{} `type:"structure"`
 }
 
 // String returns the string representation
@@ -3553,13 +3553,13 @@ func (s GetSdkInput) GoString() string {
 }
 
 type GetSdkOutput struct {
+	_ struct{} `type:"structure" payload:"Body"`
+
 	Body []byte `locationName:"body" type:"blob"`
 
 	ContentDisposition *string `location:"header" locationName:"Content-Disposition" type:"string"`
 
 	ContentType *string `location:"header" locationName:"Content-Type" type:"string"`
-
-	_ struct{} `type:"structure" payload:"Body"`
 }
 
 // String returns the string representation
@@ -3574,14 +3574,14 @@ func (s GetSdkOutput) GoString() string {
 
 // Requests Amazon API Gateway to get information about a Stage resource.
 type GetStageInput struct {
+	_ struct{} `type:"structure"`
+
 	// The identifier of the RestApi resource for the Stage resource to get information
 	// about.
 	RestApiId *string `location:"uri" locationName:"restapi_id" type:"string" required:"true"`
 
 	// The name of the Stage resource to get information about.
 	StageName *string `location:"uri" locationName:"stage_name" type:"string" required:"true"`
-
-	_ struct{} `type:"structure"`
 }
 
 // String returns the string representation
@@ -3596,13 +3596,13 @@ func (s GetStageInput) GoString() string {
 
 // Requests Amazon API Gateway to get information about one or more Stage resources.
 type GetStagesInput struct {
+	_ struct{} `type:"structure"`
+
 	// The stages' deployment identifiers.
 	DeploymentId *string `location:"querystring" locationName:"deploymentId" type:"string"`
 
 	// The stages' API identifiers.
 	RestApiId *string `location:"uri" locationName:"restapi_id" type:"string" required:"true"`
-
-	_ struct{} `type:"structure"`
 }
 
 // String returns the string representation
@@ -3617,10 +3617,10 @@ func (s GetStagesInput) GoString() string {
 
 // A list of Stage resource that are associated with the ApiKey resource.
 type GetStagesOutput struct {
+	_ struct{} `type:"structure"`
+
 	// An individual Stage resource.
 	Item []*Stage `locationName:"item" type:"list"`
-
-	_ struct{} `type:"structure"`
 }
 
 // String returns the string representation
@@ -3635,6 +3635,8 @@ func (s GetStagesOutput) GoString() string {
 
 // Represents a HTTP, AWS, or Mock integration.
 type Integration struct {
+	_ struct{} `type:"structure"`
+
 	// Specifies the integration's cache key parameters.
 	CacheKeyParameters []*string `locationName:"cacheKeyParameters" type:"list"`
 
@@ -3680,8 +3682,6 @@ type Integration struct {
 	// to indicate that the remaining substring in the URI should be treated as
 	// the path to the resource, including the initial /.
 	Uri *string `locationName:"uri" type:"string"`
-
-	_ struct{} `type:"structure"`
 }
 
 // String returns the string representation
@@ -3698,6 +3698,8 @@ func (s Integration) GoString() string {
 // MethodResponse, and parameters and templates can be used to transform the
 // backend response.
 type IntegrationResponse struct {
+	_ struct{} `type:"structure"`
+
 	// Represents response parameters that can be read from the backend response.
 	// Response parameters are represented as a key/value map, with a destination
 	// as the key and a source as the value. A destination must match an existing
@@ -3721,8 +3723,6 @@ type IntegrationResponse struct {
 	// Specifies the status code that is used to map the integration response to
 	// an existing MethodResponse.
 	StatusCode *string `locationName:"statusCode" type:"string"`
-
-	_ struct{} `type:"structure"`
 }
 
 // String returns the string representation
@@ -3737,6 +3737,8 @@ func (s IntegrationResponse) GoString() string {
 
 // Represents a method.
 type Method struct {
+	_ struct{} `type:"structure"`
+
 	// Specifies whether the method requires a valid ApiKey.
 	ApiKeyRequired *bool `locationName:"apiKeyRequired" type:"boolean"`
 
@@ -3768,8 +3770,6 @@ type Method struct {
 	// parameter name. Sources specified here are available to the integration for
 	// mapping to integration request parameters or templates.
 	RequestParameters map[string]*bool `locationName:"requestParameters" type:"map"`
-
-	_ struct{} `type:"structure"`
 }
 
 // String returns the string representation
@@ -3786,6 +3786,8 @@ func (s Method) GoString() string {
 // to the caller as the HTTP status code. Parameters and models can be used
 // to transform the response from the method's integration.
 type MethodResponse struct {
+	_ struct{} `type:"structure"`
+
 	// Specifies the Model resources used for the response's content-type. Response
 	// models are represented as a key/value map, with a content-type as the key
 	// and a Model name as the value.
@@ -3802,8 +3804,6 @@ type MethodResponse struct {
 
 	// The method response's status code.
 	StatusCode *string `locationName:"statusCode" type:"string"`
-
-	_ struct{} `type:"structure"`
 }
 
 // String returns the string representation
@@ -3818,6 +3818,8 @@ func (s MethodResponse) GoString() string {
 
 // Specifies the method setting properties.
 type MethodSetting struct {
+	_ struct{} `type:"structure"`
+
 	// Specifies whether the cached responses are encrypted. The PATCH path for
 	// this setting is /{method_setting_key}/caching/dataEncrypted, and the value
 	// is a Boolean.
@@ -3858,8 +3860,6 @@ type MethodSetting struct {
 	// Specifies the throttling rate limit. The PATCH path for this setting is /{method_setting_key}/throttling/rateLimit,
 	// and the value is a double.
 	ThrottlingRateLimit *float64 `locationName:"throttlingRateLimit" type:"double"`
-
-	_ struct{} `type:"structure"`
 }
 
 // String returns the string representation
@@ -3874,13 +3874,13 @@ func (s MethodSetting) GoString() string {
 
 // Represents a summary of a Method resource, given a particular date and time.
 type MethodSnapshot struct {
+	_ struct{} `type:"structure"`
+
 	// Specifies whether the method requires a valid ApiKey.
 	ApiKeyRequired *bool `locationName:"apiKeyRequired" type:"boolean"`
 
 	// Specifies the type of authorization used for the method.
 	AuthorizationType *string `locationName:"authorizationType" type:"string"`
-
-	_ struct{} `type:"structure"`
 }
 
 // String returns the string representation
@@ -3895,6 +3895,8 @@ func (s MethodSnapshot) GoString() string {
 
 // Represents the structure of a request or response payload for a method.
 type Model struct {
+	_ struct{} `type:"structure"`
+
 	// The content-type for the model.
 	ContentType *string `locationName:"contentType" type:"string"`
 
@@ -3910,8 +3912,6 @@ type Model struct {
 	// The schema for the model. For application/json models, this should be JSON-schema
 	// draft v4 model.
 	Schema *string `locationName:"schema" type:"string"`
-
-	_ struct{} `type:"structure"`
 }
 
 // String returns the string representation
@@ -3928,6 +3928,8 @@ func (s Model) GoString() string {
 // to http://tools.ietf.org/html/rfc6902#section-4 for an explanation of how
 // each operation is used.
 type PatchOperation struct {
+	_ struct{} `type:"structure"`
+
 	// The "move" and "copy" operation object MUST contain a "from" member, which
 	// is a string containing a JSON Pointer value that references the location
 	// in the target document to move the value from.
@@ -3946,8 +3948,6 @@ type PatchOperation struct {
 
 	// The actual value content.
 	Value *string `locationName:"value" type:"string"`
-
-	_ struct{} `type:"structure"`
 }
 
 // String returns the string representation
@@ -3962,6 +3962,8 @@ func (s PatchOperation) GoString() string {
 
 // Represents a put integration request.
 type PutIntegrationInput struct {
+	_ struct{} `type:"structure"`
+
 	// Specifies a put integration input's cache key parameters.
 	CacheKeyParameters []*string `locationName:"cacheKeyParameters" type:"list"`
 
@@ -4003,8 +4005,6 @@ type PutIntegrationInput struct {
 
 	// Specifies a put integration input's Uniform Resource Identifier (URI).
 	Uri *string `locationName:"uri" type:"string"`
-
-	_ struct{} `type:"structure"`
 }
 
 // String returns the string representation
@@ -4019,6 +4019,8 @@ func (s PutIntegrationInput) GoString() string {
 
 // Represents a put integration response request.
 type PutIntegrationResponseInput struct {
+	_ struct{} `type:"structure"`
+
 	// Specifies a put integration response request's HTTP method.
 	HttpMethod *string `location:"uri" locationName:"http_method" type:"string" required:"true"`
 
@@ -4046,8 +4048,6 @@ type PutIntegrationResponseInput struct {
 	// Specifies the status code that is used to map the integration response to
 	// an existing MethodResponse.
 	StatusCode *string `location:"uri" locationName:"status_code" type:"string" required:"true"`
-
-	_ struct{} `type:"structure"`
 }
 
 // String returns the string representation
@@ -4062,6 +4062,8 @@ func (s PutIntegrationResponseInput) GoString() string {
 
 // Request to add a method to an existing Resource resource.
 type PutMethodInput struct {
+	_ struct{} `type:"structure"`
+
 	// Specifies whether the method required a valid ApiKey.
 	ApiKeyRequired *bool `locationName:"apiKeyRequired" type:"boolean"`
 
@@ -4091,8 +4093,6 @@ type PutMethodInput struct {
 
 	// The RestApi identifier for the new Method resource.
 	RestApiId *string `location:"uri" locationName:"restapi_id" type:"string" required:"true"`
-
-	_ struct{} `type:"structure"`
 }
 
 // String returns the string representation
@@ -4107,6 +4107,8 @@ func (s PutMethodInput) GoString() string {
 
 // Request to add a MethodResponse to an existing Method resource.
 type PutMethodResponseInput struct {
+	_ struct{} `type:"structure"`
+
 	// The HTTP verb that identifies the Method resource.
 	HttpMethod *string `location:"uri" locationName:"http_method" type:"string" required:"true"`
 
@@ -4132,8 +4134,6 @@ type PutMethodResponseInput struct {
 
 	// The method response's status code.
 	StatusCode *string `location:"uri" locationName:"status_code" type:"string" required:"true"`
-
-	_ struct{} `type:"structure"`
 }
 
 // String returns the string representation
@@ -4148,6 +4148,8 @@ func (s PutMethodResponseInput) GoString() string {
 
 // Represents a resource.
 type Resource struct {
+	_ struct{} `type:"structure"`
+
 	// The resource's identifier.
 	Id *string `locationName:"id" type:"string"`
 
@@ -4163,8 +4165,6 @@ type Resource struct {
 	// Map of methods for this resource, which is included only if requested using
 	// the embed option.
 	ResourceMethods map[string]*Method `locationName:"resourceMethods" type:"map"`
-
-	_ struct{} `type:"structure"`
 }
 
 // String returns the string representation
@@ -4179,6 +4179,8 @@ func (s Resource) GoString() string {
 
 // Represents a REST API.
 type RestApi struct {
+	_ struct{} `type:"structure"`
+
 	// The date when the API was created, in ISO 8601 format.
 	CreatedDate *time.Time `locationName:"createdDate" type:"timestamp" timestampFormat:"unix"`
 
@@ -4191,8 +4193,6 @@ type RestApi struct {
 
 	// The API's name.
 	Name *string `locationName:"name" type:"string"`
-
-	_ struct{} `type:"structure"`
 }
 
 // String returns the string representation
@@ -4208,6 +4208,8 @@ func (s RestApi) GoString() string {
 // Represents a unique identifier for a version of a deployed RestApi that is
 // callable by users.
 type Stage struct {
+	_ struct{} `type:"structure"`
+
 	// Specifies whether a cache cluster is enabled for the stage.
 	CacheClusterEnabled *bool `locationName:"cacheClusterEnabled" type:"boolean"`
 
@@ -4244,8 +4246,6 @@ type Stage struct {
 	// A map that defines the stage variables for a Stage resource. Variable names
 	// can have alphabetic characters, and the values must match [A-Za-z0-9-._~:/?#&=,]+
 	Variables map[string]*string `locationName:"variables" type:"map"`
-
-	_ struct{} `type:"structure"`
 }
 
 // String returns the string representation
@@ -4260,13 +4260,13 @@ func (s Stage) GoString() string {
 
 // A reference to a unique stage identified in the format {restApiId}/{stage}.
 type StageKey struct {
+	_ struct{} `type:"structure"`
+
 	// A list of Stage resources that are associated with the ApiKey resource.
 	RestApiId *string `locationName:"restApiId" type:"string"`
 
 	// The stage name in the RestApi that the stage key references.
 	StageName *string `locationName:"stageName" type:"string"`
-
-	_ struct{} `type:"structure"`
 }
 
 // String returns the string representation
@@ -4280,6 +4280,8 @@ func (s StageKey) GoString() string {
 }
 
 type TestInvokeMethodInput struct {
+	_ struct{} `type:"structure"`
+
 	Body *string `locationName:"body" type:"string"`
 
 	ClientCertificateId *string `locationName:"clientCertificateId" type:"string"`
@@ -4295,8 +4297,6 @@ type TestInvokeMethodInput struct {
 	RestApiId *string `location:"uri" locationName:"restapi_id" type:"string" required:"true"`
 
 	StageVariables map[string]*string `locationName:"stageVariables" type:"map"`
-
-	_ struct{} `type:"structure"`
 }
 
 // String returns the string representation
@@ -4311,6 +4311,8 @@ func (s TestInvokeMethodInput) GoString() string {
 
 // Represents the response of the test invoke request in HTTP method.
 type TestInvokeMethodOutput struct {
+	_ struct{} `type:"structure"`
+
 	// The body of HTTP response.
 	Body *string `locationName:"body" type:"string"`
 
@@ -4325,8 +4327,6 @@ type TestInvokeMethodOutput struct {
 
 	// The HTTP status code.
 	Status *int64 `locationName:"status" type:"integer"`
-
-	_ struct{} `type:"structure"`
 }
 
 // String returns the string representation
@@ -4341,13 +4341,13 @@ func (s TestInvokeMethodOutput) GoString() string {
 
 // Returns the throttle settings.
 type ThrottleSettings struct {
+	_ struct{} `type:"structure"`
+
 	// Returns the burstLimit when ThrottleSettings is called.
 	BurstLimit *int64 `locationName:"burstLimit" type:"integer"`
 
 	// Returns the rateLimit when ThrottleSettings is called.
 	RateLimit *float64 `locationName:"rateLimit" type:"double"`
-
-	_ struct{} `type:"structure"`
 }
 
 // String returns the string representation
@@ -4363,11 +4363,11 @@ func (s ThrottleSettings) GoString() string {
 // Requests Amazon API Gateway to change information about the current Account
 // resource.
 type UpdateAccountInput struct {
+	_ struct{} `type:"structure"`
+
 	// A list of operations describing the updates to apply to the specified resource.
 	// The patches are applied in the order specified in the list.
 	PatchOperations []*PatchOperation `locationName:"patchOperations" type:"list"`
-
-	_ struct{} `type:"structure"`
 }
 
 // String returns the string representation
@@ -4382,14 +4382,14 @@ func (s UpdateAccountInput) GoString() string {
 
 // A request to change information about an ApiKey resource.
 type UpdateApiKeyInput struct {
+	_ struct{} `type:"structure"`
+
 	// The identifier of the ApiKey resource to be updated.
 	ApiKey *string `location:"uri" locationName:"api_Key" type:"string" required:"true"`
 
 	// A list of operations describing the updates to apply to the specified resource.
 	// The patches are applied in the order specified in the list.
 	PatchOperations []*PatchOperation `locationName:"patchOperations" type:"list"`
-
-	_ struct{} `type:"structure"`
 }
 
 // String returns the string representation
@@ -4404,6 +4404,8 @@ func (s UpdateApiKeyInput) GoString() string {
 
 // A request to change information about the BasePathMapping resource.
 type UpdateBasePathMappingInput struct {
+	_ struct{} `type:"structure"`
+
 	// The base path of the BasePathMapping resource to change.
 	BasePath *string `location:"uri" locationName:"base_path" type:"string" required:"true"`
 
@@ -4413,8 +4415,6 @@ type UpdateBasePathMappingInput struct {
 	// A list of operations describing the updates to apply to the specified resource.
 	// The patches are applied in the order specified in the list.
 	PatchOperations []*PatchOperation `locationName:"patchOperations" type:"list"`
-
-	_ struct{} `type:"structure"`
 }
 
 // String returns the string representation
@@ -4428,13 +4428,13 @@ func (s UpdateBasePathMappingInput) GoString() string {
 }
 
 type UpdateClientCertificateInput struct {
+	_ struct{} `type:"structure"`
+
 	ClientCertificateId *string `location:"uri" locationName:"clientcertificate_id" type:"string" required:"true"`
 
 	// A list of operations describing the updates to apply to the specified resource.
 	// The patches are applied in the order specified in the list.
 	PatchOperations []*PatchOperation `locationName:"patchOperations" type:"list"`
-
-	_ struct{} `type:"structure"`
 }
 
 // String returns the string representation
@@ -4449,6 +4449,8 @@ func (s UpdateClientCertificateInput) GoString() string {
 
 // Requests Amazon API Gateway to change information about a Deployment resource.
 type UpdateDeploymentInput struct {
+	_ struct{} `type:"structure"`
+
 	// The replacment identifier for the Deployment resource to change information
 	// about.
 	DeploymentId *string `location:"uri" locationName:"deployment_id" type:"string" required:"true"`
@@ -4460,8 +4462,6 @@ type UpdateDeploymentInput struct {
 	// The replacement identifier of the RestApi resource for the Deployment resource
 	// to change information about.
 	RestApiId *string `location:"uri" locationName:"restapi_id" type:"string" required:"true"`
-
-	_ struct{} `type:"structure"`
 }
 
 // String returns the string representation
@@ -4476,14 +4476,14 @@ func (s UpdateDeploymentInput) GoString() string {
 
 // A request to change information about the DomainName resource.
 type UpdateDomainNameInput struct {
+	_ struct{} `type:"structure"`
+
 	// The name of the DomainName resource to be changed.
 	DomainName *string `location:"uri" locationName:"domain_name" type:"string" required:"true"`
 
 	// A list of operations describing the updates to apply to the specified resource.
 	// The patches are applied in the order specified in the list.
 	PatchOperations []*PatchOperation `locationName:"patchOperations" type:"list"`
-
-	_ struct{} `type:"structure"`
 }
 
 // String returns the string representation
@@ -4498,6 +4498,8 @@ func (s UpdateDomainNameInput) GoString() string {
 
 // Represents an update integration request.
 type UpdateIntegrationInput struct {
+	_ struct{} `type:"structure"`
+
 	// Represents an update integration request's HTTP method.
 	HttpMethod *string `location:"uri" locationName:"http_method" type:"string" required:"true"`
 
@@ -4510,8 +4512,6 @@ type UpdateIntegrationInput struct {
 
 	// Represents an update integration request's API identifier.
 	RestApiId *string `location:"uri" locationName:"restapi_id" type:"string" required:"true"`
-
-	_ struct{} `type:"structure"`
 }
 
 // String returns the string representation
@@ -4526,6 +4526,8 @@ func (s UpdateIntegrationInput) GoString() string {
 
 // Represents an update integration response request.
 type UpdateIntegrationResponseInput struct {
+	_ struct{} `type:"structure"`
+
 	// Specifies an update integration response request's HTTP method.
 	HttpMethod *string `location:"uri" locationName:"http_method" type:"string" required:"true"`
 
@@ -4541,8 +4543,6 @@ type UpdateIntegrationResponseInput struct {
 
 	// Specifies an update integration response request's status code.
 	StatusCode *string `location:"uri" locationName:"status_code" type:"string" required:"true"`
-
-	_ struct{} `type:"structure"`
 }
 
 // String returns the string representation
@@ -4557,6 +4557,8 @@ func (s UpdateIntegrationResponseInput) GoString() string {
 
 // Request to update an existing Method resource.
 type UpdateMethodInput struct {
+	_ struct{} `type:"structure"`
+
 	// The HTTP verb that identifies the Method resource.
 	HttpMethod *string `location:"uri" locationName:"http_method" type:"string" required:"true"`
 
@@ -4569,8 +4571,6 @@ type UpdateMethodInput struct {
 
 	// The RestApi identifier for the Method resource.
 	RestApiId *string `location:"uri" locationName:"restapi_id" type:"string" required:"true"`
-
-	_ struct{} `type:"structure"`
 }
 
 // String returns the string representation
@@ -4585,6 +4585,8 @@ func (s UpdateMethodInput) GoString() string {
 
 // A request to update an existing MethodResponse resource.
 type UpdateMethodResponseInput struct {
+	_ struct{} `type:"structure"`
+
 	// The HTTP verb identifier for the parent Method resource.
 	HttpMethod *string `location:"uri" locationName:"http_method" type:"string" required:"true"`
 
@@ -4600,8 +4602,6 @@ type UpdateMethodResponseInput struct {
 
 	// The status code identifier for the MethodResponse resource.
 	StatusCode *string `location:"uri" locationName:"status_code" type:"string" required:"true"`
-
-	_ struct{} `type:"structure"`
 }
 
 // String returns the string representation
@@ -4616,6 +4616,8 @@ func (s UpdateMethodResponseInput) GoString() string {
 
 // Request to update an existing model in an existing RestApi resource.
 type UpdateModelInput struct {
+	_ struct{} `type:"structure"`
+
 	// The name of the model to update.
 	ModelName *string `location:"uri" locationName:"model_name" type:"string" required:"true"`
 
@@ -4625,8 +4627,6 @@ type UpdateModelInput struct {
 
 	// The RestApi identifier under which the model exists.
 	RestApiId *string `location:"uri" locationName:"restapi_id" type:"string" required:"true"`
-
-	_ struct{} `type:"structure"`
 }
 
 // String returns the string representation
@@ -4641,6 +4641,8 @@ func (s UpdateModelInput) GoString() string {
 
 // Request to change information about a Resource resource.
 type UpdateResourceInput struct {
+	_ struct{} `type:"structure"`
+
 	// A list of operations describing the updates to apply to the specified resource.
 	// The patches are applied in the order specified in the list.
 	PatchOperations []*PatchOperation `locationName:"patchOperations" type:"list"`
@@ -4650,8 +4652,6 @@ type UpdateResourceInput struct {
 
 	// The RestApi identifier for the Resource resource.
 	RestApiId *string `location:"uri" locationName:"restapi_id" type:"string" required:"true"`
-
-	_ struct{} `type:"structure"`
 }
 
 // String returns the string representation
@@ -4666,14 +4666,14 @@ func (s UpdateResourceInput) GoString() string {
 
 // Request to update an existing RestApi resource in your collection.
 type UpdateRestApiInput struct {
+	_ struct{} `type:"structure"`
+
 	// A list of operations describing the updates to apply to the specified resource.
 	// The patches are applied in the order specified in the list.
 	PatchOperations []*PatchOperation `locationName:"patchOperations" type:"list"`
 
 	// The ID of the RestApi you want to update.
 	RestApiId *string `location:"uri" locationName:"restapi_id" type:"string" required:"true"`
-
-	_ struct{} `type:"structure"`
 }
 
 // String returns the string representation
@@ -4688,6 +4688,8 @@ func (s UpdateRestApiInput) GoString() string {
 
 // Requests Amazon API Gateway to change information about a Stage resource.
 type UpdateStageInput struct {
+	_ struct{} `type:"structure"`
+
 	// A list of operations describing the updates to apply to the specified resource.
 	// The patches are applied in the order specified in the list.
 	PatchOperations []*PatchOperation `locationName:"patchOperations" type:"list"`
@@ -4698,8 +4700,6 @@ type UpdateStageInput struct {
 
 	// The name of the Stage resource to change information about.
 	StageName *string `location:"uri" locationName:"stage_name" type:"string" required:"true"`
-
-	_ struct{} `type:"structure"`
 }
 
 // String returns the string representation

--- a/service/autoscaling/api.go
+++ b/service/autoscaling/api.go
@@ -1667,11 +1667,7 @@ type Activity struct {
 	// A friendly, more verbose description of the activity status.
 	StatusMessage *string `min:"1" type:"string"`
 
-	metadataActivity `json:"-" xml:"-"`
-}
-
-type metadataActivity struct {
-	SDKShapeTraits bool `type:"structure"`
+	_ struct{} `type:"structure"`
 }
 
 // String returns the string representation
@@ -1693,11 +1689,7 @@ type AdjustmentType struct {
 	// and PercentChangeInCapacity.
 	AdjustmentType *string `min:"1" type:"string"`
 
-	metadataAdjustmentType `json:"-" xml:"-"`
-}
-
-type metadataAdjustmentType struct {
-	SDKShapeTraits bool `type:"structure"`
+	_ struct{} `type:"structure"`
 }
 
 // String returns the string representation
@@ -1718,11 +1710,7 @@ type Alarm struct {
 	// The name of the alarm.
 	AlarmName *string `min:"1" type:"string"`
 
-	metadataAlarm `json:"-" xml:"-"`
-}
-
-type metadataAlarm struct {
-	SDKShapeTraits bool `type:"structure"`
+	_ struct{} `type:"structure"`
 }
 
 // String returns the string representation
@@ -1742,11 +1730,7 @@ type AttachInstancesInput struct {
 	// One or more EC2 instance IDs.
 	InstanceIds []*string `type:"list"`
 
-	metadataAttachInstancesInput `json:"-" xml:"-"`
-}
-
-type metadataAttachInstancesInput struct {
-	SDKShapeTraits bool `type:"structure"`
+	_ struct{} `type:"structure"`
 }
 
 // String returns the string representation
@@ -1760,11 +1744,7 @@ func (s AttachInstancesInput) GoString() string {
 }
 
 type AttachInstancesOutput struct {
-	metadataAttachInstancesOutput `json:"-" xml:"-"`
-}
-
-type metadataAttachInstancesOutput struct {
-	SDKShapeTraits bool `type:"structure"`
+	_ struct{} `type:"structure"`
 }
 
 // String returns the string representation
@@ -1784,11 +1764,7 @@ type AttachLoadBalancersInput struct {
 	// One or more load balancer names.
 	LoadBalancerNames []*string `type:"list"`
 
-	metadataAttachLoadBalancersInput `json:"-" xml:"-"`
-}
-
-type metadataAttachLoadBalancersInput struct {
-	SDKShapeTraits bool `type:"structure"`
+	_ struct{} `type:"structure"`
 }
 
 // String returns the string representation
@@ -1802,11 +1778,7 @@ func (s AttachLoadBalancersInput) GoString() string {
 }
 
 type AttachLoadBalancersOutput struct {
-	metadataAttachLoadBalancersOutput `json:"-" xml:"-"`
-}
-
-type metadataAttachLoadBalancersOutput struct {
-	SDKShapeTraits bool `type:"structure"`
+	_ struct{} `type:"structure"`
 }
 
 // String returns the string representation
@@ -1837,11 +1809,7 @@ type BlockDeviceMapping struct {
 	// The name of the virtual device (for example, ephemeral0).
 	VirtualName *string `min:"1" type:"string"`
 
-	metadataBlockDeviceMapping `json:"-" xml:"-"`
-}
-
-type metadataBlockDeviceMapping struct {
-	SDKShapeTraits bool `type:"structure"`
+	_ struct{} `type:"structure"`
 }
 
 // String returns the string representation
@@ -1870,11 +1838,7 @@ type CompleteLifecycleActionInput struct {
 	// The name of the lifecycle hook.
 	LifecycleHookName *string `min:"1" type:"string" required:"true"`
 
-	metadataCompleteLifecycleActionInput `json:"-" xml:"-"`
-}
-
-type metadataCompleteLifecycleActionInput struct {
-	SDKShapeTraits bool `type:"structure"`
+	_ struct{} `type:"structure"`
 }
 
 // String returns the string representation
@@ -1888,11 +1852,7 @@ func (s CompleteLifecycleActionInput) GoString() string {
 }
 
 type CompleteLifecycleActionOutput struct {
-	metadataCompleteLifecycleActionOutput `json:"-" xml:"-"`
-}
-
-type metadataCompleteLifecycleActionOutput struct {
-	SDKShapeTraits bool `type:"structure"`
+	_ struct{} `type:"structure"`
 }
 
 // String returns the string representation
@@ -2010,11 +1970,7 @@ type CreateAutoScalingGroupInput struct {
 	// in the Auto Scaling Developer Guide.
 	VPCZoneIdentifier *string `min:"1" type:"string"`
 
-	metadataCreateAutoScalingGroupInput `json:"-" xml:"-"`
-}
-
-type metadataCreateAutoScalingGroupInput struct {
-	SDKShapeTraits bool `type:"structure"`
+	_ struct{} `type:"structure"`
 }
 
 // String returns the string representation
@@ -2028,11 +1984,7 @@ func (s CreateAutoScalingGroupInput) GoString() string {
 }
 
 type CreateAutoScalingGroupOutput struct {
-	metadataCreateAutoScalingGroupOutput `json:"-" xml:"-"`
-}
-
-type metadataCreateAutoScalingGroupOutput struct {
-	SDKShapeTraits bool `type:"structure"`
+	_ struct{} `type:"structure"`
 }
 
 // String returns the string representation
@@ -2189,11 +2141,7 @@ type CreateLaunchConfigurationInput struct {
 	// data files.
 	UserData *string `type:"string"`
 
-	metadataCreateLaunchConfigurationInput `json:"-" xml:"-"`
-}
-
-type metadataCreateLaunchConfigurationInput struct {
-	SDKShapeTraits bool `type:"structure"`
+	_ struct{} `type:"structure"`
 }
 
 // String returns the string representation
@@ -2207,11 +2155,7 @@ func (s CreateLaunchConfigurationInput) GoString() string {
 }
 
 type CreateLaunchConfigurationOutput struct {
-	metadataCreateLaunchConfigurationOutput `json:"-" xml:"-"`
-}
-
-type metadataCreateLaunchConfigurationOutput struct {
-	SDKShapeTraits bool `type:"structure"`
+	_ struct{} `type:"structure"`
 }
 
 // String returns the string representation
@@ -2228,11 +2172,7 @@ type CreateOrUpdateTagsInput struct {
 	// One or more tags.
 	Tags []*Tag `type:"list" required:"true"`
 
-	metadataCreateOrUpdateTagsInput `json:"-" xml:"-"`
-}
-
-type metadataCreateOrUpdateTagsInput struct {
-	SDKShapeTraits bool `type:"structure"`
+	_ struct{} `type:"structure"`
 }
 
 // String returns the string representation
@@ -2246,11 +2186,7 @@ func (s CreateOrUpdateTagsInput) GoString() string {
 }
 
 type CreateOrUpdateTagsOutput struct {
-	metadataCreateOrUpdateTagsOutput `json:"-" xml:"-"`
-}
-
-type metadataCreateOrUpdateTagsOutput struct {
-	SDKShapeTraits bool `type:"structure"`
+	_ struct{} `type:"structure"`
 }
 
 // String returns the string representation
@@ -2272,11 +2208,7 @@ type DeleteAutoScalingGroupInput struct {
 	// parameter also deletes any lifecycle actions associated with the group.
 	ForceDelete *bool `type:"boolean"`
 
-	metadataDeleteAutoScalingGroupInput `json:"-" xml:"-"`
-}
-
-type metadataDeleteAutoScalingGroupInput struct {
-	SDKShapeTraits bool `type:"structure"`
+	_ struct{} `type:"structure"`
 }
 
 // String returns the string representation
@@ -2290,11 +2222,7 @@ func (s DeleteAutoScalingGroupInput) GoString() string {
 }
 
 type DeleteAutoScalingGroupOutput struct {
-	metadataDeleteAutoScalingGroupOutput `json:"-" xml:"-"`
-}
-
-type metadataDeleteAutoScalingGroupOutput struct {
-	SDKShapeTraits bool `type:"structure"`
+	_ struct{} `type:"structure"`
 }
 
 // String returns the string representation
@@ -2311,11 +2239,7 @@ type DeleteLaunchConfigurationInput struct {
 	// The name of the launch configuration.
 	LaunchConfigurationName *string `min:"1" type:"string" required:"true"`
 
-	metadataDeleteLaunchConfigurationInput `json:"-" xml:"-"`
-}
-
-type metadataDeleteLaunchConfigurationInput struct {
-	SDKShapeTraits bool `type:"structure"`
+	_ struct{} `type:"structure"`
 }
 
 // String returns the string representation
@@ -2329,11 +2253,7 @@ func (s DeleteLaunchConfigurationInput) GoString() string {
 }
 
 type DeleteLaunchConfigurationOutput struct {
-	metadataDeleteLaunchConfigurationOutput `json:"-" xml:"-"`
-}
-
-type metadataDeleteLaunchConfigurationOutput struct {
-	SDKShapeTraits bool `type:"structure"`
+	_ struct{} `type:"structure"`
 }
 
 // String returns the string representation
@@ -2353,11 +2273,7 @@ type DeleteLifecycleHookInput struct {
 	// The name of the lifecycle hook.
 	LifecycleHookName *string `min:"1" type:"string" required:"true"`
 
-	metadataDeleteLifecycleHookInput `json:"-" xml:"-"`
-}
-
-type metadataDeleteLifecycleHookInput struct {
-	SDKShapeTraits bool `type:"structure"`
+	_ struct{} `type:"structure"`
 }
 
 // String returns the string representation
@@ -2371,11 +2287,7 @@ func (s DeleteLifecycleHookInput) GoString() string {
 }
 
 type DeleteLifecycleHookOutput struct {
-	metadataDeleteLifecycleHookOutput `json:"-" xml:"-"`
-}
-
-type metadataDeleteLifecycleHookOutput struct {
-	SDKShapeTraits bool `type:"structure"`
+	_ struct{} `type:"structure"`
 }
 
 // String returns the string representation
@@ -2396,11 +2308,7 @@ type DeleteNotificationConfigurationInput struct {
 	// (SNS) topic.
 	TopicARN *string `min:"1" type:"string" required:"true"`
 
-	metadataDeleteNotificationConfigurationInput `json:"-" xml:"-"`
-}
-
-type metadataDeleteNotificationConfigurationInput struct {
-	SDKShapeTraits bool `type:"structure"`
+	_ struct{} `type:"structure"`
 }
 
 // String returns the string representation
@@ -2414,11 +2322,7 @@ func (s DeleteNotificationConfigurationInput) GoString() string {
 }
 
 type DeleteNotificationConfigurationOutput struct {
-	metadataDeleteNotificationConfigurationOutput `json:"-" xml:"-"`
-}
-
-type metadataDeleteNotificationConfigurationOutput struct {
-	SDKShapeTraits bool `type:"structure"`
+	_ struct{} `type:"structure"`
 }
 
 // String returns the string representation
@@ -2438,11 +2342,7 @@ type DeletePolicyInput struct {
 	// The name or Amazon Resource Name (ARN) of the policy.
 	PolicyName *string `min:"1" type:"string" required:"true"`
 
-	metadataDeletePolicyInput `json:"-" xml:"-"`
-}
-
-type metadataDeletePolicyInput struct {
-	SDKShapeTraits bool `type:"structure"`
+	_ struct{} `type:"structure"`
 }
 
 // String returns the string representation
@@ -2456,11 +2356,7 @@ func (s DeletePolicyInput) GoString() string {
 }
 
 type DeletePolicyOutput struct {
-	metadataDeletePolicyOutput `json:"-" xml:"-"`
-}
-
-type metadataDeletePolicyOutput struct {
-	SDKShapeTraits bool `type:"structure"`
+	_ struct{} `type:"structure"`
 }
 
 // String returns the string representation
@@ -2480,11 +2376,7 @@ type DeleteScheduledActionInput struct {
 	// The name of the action to delete.
 	ScheduledActionName *string `min:"1" type:"string" required:"true"`
 
-	metadataDeleteScheduledActionInput `json:"-" xml:"-"`
-}
-
-type metadataDeleteScheduledActionInput struct {
-	SDKShapeTraits bool `type:"structure"`
+	_ struct{} `type:"structure"`
 }
 
 // String returns the string representation
@@ -2498,11 +2390,7 @@ func (s DeleteScheduledActionInput) GoString() string {
 }
 
 type DeleteScheduledActionOutput struct {
-	metadataDeleteScheduledActionOutput `json:"-" xml:"-"`
-}
-
-type metadataDeleteScheduledActionOutput struct {
-	SDKShapeTraits bool `type:"structure"`
+	_ struct{} `type:"structure"`
 }
 
 // String returns the string representation
@@ -2522,11 +2410,7 @@ type DeleteTagsInput struct {
 	// or false.
 	Tags []*Tag `type:"list" required:"true"`
 
-	metadataDeleteTagsInput `json:"-" xml:"-"`
-}
-
-type metadataDeleteTagsInput struct {
-	SDKShapeTraits bool `type:"structure"`
+	_ struct{} `type:"structure"`
 }
 
 // String returns the string representation
@@ -2540,11 +2424,7 @@ func (s DeleteTagsInput) GoString() string {
 }
 
 type DeleteTagsOutput struct {
-	metadataDeleteTagsOutput `json:"-" xml:"-"`
-}
-
-type metadataDeleteTagsOutput struct {
-	SDKShapeTraits bool `type:"structure"`
+	_ struct{} `type:"structure"`
 }
 
 // String returns the string representation
@@ -2558,11 +2438,7 @@ func (s DeleteTagsOutput) GoString() string {
 }
 
 type DescribeAccountLimitsInput struct {
-	metadataDescribeAccountLimitsInput `json:"-" xml:"-"`
-}
-
-type metadataDescribeAccountLimitsInput struct {
-	SDKShapeTraits bool `type:"structure"`
+	_ struct{} `type:"structure"`
 }
 
 // String returns the string representation
@@ -2584,11 +2460,7 @@ type DescribeAccountLimitsOutput struct {
 	// The default limit is 100 per region.
 	MaxNumberOfLaunchConfigurations *int64 `type:"integer"`
 
-	metadataDescribeAccountLimitsOutput `json:"-" xml:"-"`
-}
-
-type metadataDescribeAccountLimitsOutput struct {
-	SDKShapeTraits bool `type:"structure"`
+	_ struct{} `type:"structure"`
 }
 
 // String returns the string representation
@@ -2602,11 +2474,7 @@ func (s DescribeAccountLimitsOutput) GoString() string {
 }
 
 type DescribeAdjustmentTypesInput struct {
-	metadataDescribeAdjustmentTypesInput `json:"-" xml:"-"`
-}
-
-type metadataDescribeAdjustmentTypesInput struct {
-	SDKShapeTraits bool `type:"structure"`
+	_ struct{} `type:"structure"`
 }
 
 // String returns the string representation
@@ -2623,11 +2491,7 @@ type DescribeAdjustmentTypesOutput struct {
 	// The policy adjustment types.
 	AdjustmentTypes []*AdjustmentType `type:"list"`
 
-	metadataDescribeAdjustmentTypesOutput `json:"-" xml:"-"`
-}
-
-type metadataDescribeAdjustmentTypesOutput struct {
-	SDKShapeTraits bool `type:"structure"`
+	_ struct{} `type:"structure"`
 }
 
 // String returns the string representation
@@ -2651,11 +2515,7 @@ type DescribeAutoScalingGroupsInput struct {
 	// a previous call.)
 	NextToken *string `type:"string"`
 
-	metadataDescribeAutoScalingGroupsInput `json:"-" xml:"-"`
-}
-
-type metadataDescribeAutoScalingGroupsInput struct {
-	SDKShapeTraits bool `type:"structure"`
+	_ struct{} `type:"structure"`
 }
 
 // String returns the string representation
@@ -2676,11 +2536,7 @@ type DescribeAutoScalingGroupsOutput struct {
 	// items to return, the string is empty.
 	NextToken *string `type:"string"`
 
-	metadataDescribeAutoScalingGroupsOutput `json:"-" xml:"-"`
-}
-
-type metadataDescribeAutoScalingGroupsOutput struct {
-	SDKShapeTraits bool `type:"structure"`
+	_ struct{} `type:"structure"`
 }
 
 // String returns the string representation
@@ -2706,11 +2562,7 @@ type DescribeAutoScalingInstancesInput struct {
 	// a previous call.)
 	NextToken *string `type:"string"`
 
-	metadataDescribeAutoScalingInstancesInput `json:"-" xml:"-"`
-}
-
-type metadataDescribeAutoScalingInstancesInput struct {
-	SDKShapeTraits bool `type:"structure"`
+	_ struct{} `type:"structure"`
 }
 
 // String returns the string representation
@@ -2731,11 +2583,7 @@ type DescribeAutoScalingInstancesOutput struct {
 	// items to return, the string is empty.
 	NextToken *string `type:"string"`
 
-	metadataDescribeAutoScalingInstancesOutput `json:"-" xml:"-"`
-}
-
-type metadataDescribeAutoScalingInstancesOutput struct {
-	SDKShapeTraits bool `type:"structure"`
+	_ struct{} `type:"structure"`
 }
 
 // String returns the string representation
@@ -2749,11 +2597,7 @@ func (s DescribeAutoScalingInstancesOutput) GoString() string {
 }
 
 type DescribeAutoScalingNotificationTypesInput struct {
-	metadataDescribeAutoScalingNotificationTypesInput `json:"-" xml:"-"`
-}
-
-type metadataDescribeAutoScalingNotificationTypesInput struct {
-	SDKShapeTraits bool `type:"structure"`
+	_ struct{} `type:"structure"`
 }
 
 // String returns the string representation
@@ -2780,11 +2624,7 @@ type DescribeAutoScalingNotificationTypesOutput struct {
 	// autoscaling:TEST_NOTIFICATION
 	AutoScalingNotificationTypes []*string `type:"list"`
 
-	metadataDescribeAutoScalingNotificationTypesOutput `json:"-" xml:"-"`
-}
-
-type metadataDescribeAutoScalingNotificationTypesOutput struct {
-	SDKShapeTraits bool `type:"structure"`
+	_ struct{} `type:"structure"`
 }
 
 // String returns the string representation
@@ -2808,11 +2648,7 @@ type DescribeLaunchConfigurationsInput struct {
 	// a previous call.)
 	NextToken *string `type:"string"`
 
-	metadataDescribeLaunchConfigurationsInput `json:"-" xml:"-"`
-}
-
-type metadataDescribeLaunchConfigurationsInput struct {
-	SDKShapeTraits bool `type:"structure"`
+	_ struct{} `type:"structure"`
 }
 
 // String returns the string representation
@@ -2833,11 +2669,7 @@ type DescribeLaunchConfigurationsOutput struct {
 	// items to return, the string is empty.
 	NextToken *string `type:"string"`
 
-	metadataDescribeLaunchConfigurationsOutput `json:"-" xml:"-"`
-}
-
-type metadataDescribeLaunchConfigurationsOutput struct {
-	SDKShapeTraits bool `type:"structure"`
+	_ struct{} `type:"structure"`
 }
 
 // String returns the string representation
@@ -2851,11 +2683,7 @@ func (s DescribeLaunchConfigurationsOutput) GoString() string {
 }
 
 type DescribeLifecycleHookTypesInput struct {
-	metadataDescribeLifecycleHookTypesInput `json:"-" xml:"-"`
-}
-
-type metadataDescribeLifecycleHookTypesInput struct {
-	SDKShapeTraits bool `type:"structure"`
+	_ struct{} `type:"structure"`
 }
 
 // String returns the string representation
@@ -2876,11 +2704,7 @@ type DescribeLifecycleHookTypesOutput struct {
 	// autoscaling:EC2_INSTANCE_TERMINATING
 	LifecycleHookTypes []*string `type:"list"`
 
-	metadataDescribeLifecycleHookTypesOutput `json:"-" xml:"-"`
-}
-
-type metadataDescribeLifecycleHookTypesOutput struct {
-	SDKShapeTraits bool `type:"structure"`
+	_ struct{} `type:"structure"`
 }
 
 // String returns the string representation
@@ -2900,11 +2724,7 @@ type DescribeLifecycleHooksInput struct {
 	// The names of one or more lifecycle hooks.
 	LifecycleHookNames []*string `type:"list"`
 
-	metadataDescribeLifecycleHooksInput `json:"-" xml:"-"`
-}
-
-type metadataDescribeLifecycleHooksInput struct {
-	SDKShapeTraits bool `type:"structure"`
+	_ struct{} `type:"structure"`
 }
 
 // String returns the string representation
@@ -2921,11 +2741,7 @@ type DescribeLifecycleHooksOutput struct {
 	// The lifecycle hooks for the specified group.
 	LifecycleHooks []*LifecycleHook `type:"list"`
 
-	metadataDescribeLifecycleHooksOutput `json:"-" xml:"-"`
-}
-
-type metadataDescribeLifecycleHooksOutput struct {
-	SDKShapeTraits bool `type:"structure"`
+	_ struct{} `type:"structure"`
 }
 
 // String returns the string representation
@@ -2949,11 +2765,7 @@ type DescribeLoadBalancersInput struct {
 	// a previous call.)
 	NextToken *string `type:"string"`
 
-	metadataDescribeLoadBalancersInput `json:"-" xml:"-"`
-}
-
-type metadataDescribeLoadBalancersInput struct {
-	SDKShapeTraits bool `type:"structure"`
+	_ struct{} `type:"structure"`
 }
 
 // String returns the string representation
@@ -2974,11 +2786,7 @@ type DescribeLoadBalancersOutput struct {
 	// items to return, the string is empty.
 	NextToken *string `type:"string"`
 
-	metadataDescribeLoadBalancersOutput `json:"-" xml:"-"`
-}
-
-type metadataDescribeLoadBalancersOutput struct {
-	SDKShapeTraits bool `type:"structure"`
+	_ struct{} `type:"structure"`
 }
 
 // String returns the string representation
@@ -2992,11 +2800,7 @@ func (s DescribeLoadBalancersOutput) GoString() string {
 }
 
 type DescribeMetricCollectionTypesInput struct {
-	metadataDescribeMetricCollectionTypesInput `json:"-" xml:"-"`
-}
-
-type metadataDescribeMetricCollectionTypesInput struct {
-	SDKShapeTraits bool `type:"structure"`
+	_ struct{} `type:"structure"`
 }
 
 // String returns the string representation
@@ -3016,11 +2820,7 @@ type DescribeMetricCollectionTypesOutput struct {
 	// One or more metrics.
 	Metrics []*MetricCollectionType `type:"list"`
 
-	metadataDescribeMetricCollectionTypesOutput `json:"-" xml:"-"`
-}
-
-type metadataDescribeMetricCollectionTypesOutput struct {
-	SDKShapeTraits bool `type:"structure"`
+	_ struct{} `type:"structure"`
 }
 
 // String returns the string representation
@@ -3044,11 +2844,7 @@ type DescribeNotificationConfigurationsInput struct {
 	// a previous call.)
 	NextToken *string `type:"string"`
 
-	metadataDescribeNotificationConfigurationsInput `json:"-" xml:"-"`
-}
-
-type metadataDescribeNotificationConfigurationsInput struct {
-	SDKShapeTraits bool `type:"structure"`
+	_ struct{} `type:"structure"`
 }
 
 // String returns the string representation
@@ -3069,11 +2865,7 @@ type DescribeNotificationConfigurationsOutput struct {
 	// The notification configurations.
 	NotificationConfigurations []*NotificationConfiguration `type:"list" required:"true"`
 
-	metadataDescribeNotificationConfigurationsOutput `json:"-" xml:"-"`
-}
-
-type metadataDescribeNotificationConfigurationsOutput struct {
-	SDKShapeTraits bool `type:"structure"`
+	_ struct{} `type:"structure"`
 }
 
 // String returns the string representation
@@ -3106,11 +2898,7 @@ type DescribePoliciesInput struct {
 	// One or more policy types. Valid values are SimpleScaling and StepScaling.
 	PolicyTypes []*string `type:"list"`
 
-	metadataDescribePoliciesInput `json:"-" xml:"-"`
-}
-
-type metadataDescribePoliciesInput struct {
-	SDKShapeTraits bool `type:"structure"`
+	_ struct{} `type:"structure"`
 }
 
 // String returns the string representation
@@ -3131,11 +2919,7 @@ type DescribePoliciesOutput struct {
 	// The scaling policies.
 	ScalingPolicies []*ScalingPolicy `type:"list"`
 
-	metadataDescribePoliciesOutput `json:"-" xml:"-"`
-}
-
-type metadataDescribePoliciesOutput struct {
-	SDKShapeTraits bool `type:"structure"`
+	_ struct{} `type:"structure"`
 }
 
 // String returns the string representation
@@ -3166,11 +2950,7 @@ type DescribeScalingActivitiesInput struct {
 	// a previous call.)
 	NextToken *string `type:"string"`
 
-	metadataDescribeScalingActivitiesInput `json:"-" xml:"-"`
-}
-
-type metadataDescribeScalingActivitiesInput struct {
-	SDKShapeTraits bool `type:"structure"`
+	_ struct{} `type:"structure"`
 }
 
 // String returns the string representation
@@ -3191,11 +2971,7 @@ type DescribeScalingActivitiesOutput struct {
 	// items to return, the string is empty.
 	NextToken *string `type:"string"`
 
-	metadataDescribeScalingActivitiesOutput `json:"-" xml:"-"`
-}
-
-type metadataDescribeScalingActivitiesOutput struct {
-	SDKShapeTraits bool `type:"structure"`
+	_ struct{} `type:"structure"`
 }
 
 // String returns the string representation
@@ -3209,11 +2985,7 @@ func (s DescribeScalingActivitiesOutput) GoString() string {
 }
 
 type DescribeScalingProcessTypesInput struct {
-	metadataDescribeScalingProcessTypesInput `json:"-" xml:"-"`
-}
-
-type metadataDescribeScalingProcessTypesInput struct {
-	SDKShapeTraits bool `type:"structure"`
+	_ struct{} `type:"structure"`
 }
 
 // String returns the string representation
@@ -3230,11 +3002,7 @@ type DescribeScalingProcessTypesOutput struct {
 	// The names of the process types.
 	Processes []*ProcessType `type:"list"`
 
-	metadataDescribeScalingProcessTypesOutput `json:"-" xml:"-"`
-}
-
-type metadataDescribeScalingProcessTypesOutput struct {
-	SDKShapeTraits bool `type:"structure"`
+	_ struct{} `type:"structure"`
 }
 
 // String returns the string representation
@@ -3275,11 +3043,7 @@ type DescribeScheduledActionsInput struct {
 	// provided, this parameter is ignored.
 	StartTime *time.Time `type:"timestamp" timestampFormat:"iso8601"`
 
-	metadataDescribeScheduledActionsInput `json:"-" xml:"-"`
-}
-
-type metadataDescribeScheduledActionsInput struct {
-	SDKShapeTraits bool `type:"structure"`
+	_ struct{} `type:"structure"`
 }
 
 // String returns the string representation
@@ -3300,11 +3064,7 @@ type DescribeScheduledActionsOutput struct {
 	// The scheduled actions.
 	ScheduledUpdateGroupActions []*ScheduledUpdateGroupAction `type:"list"`
 
-	metadataDescribeScheduledActionsOutput `json:"-" xml:"-"`
-}
-
-type metadataDescribeScheduledActionsOutput struct {
-	SDKShapeTraits bool `type:"structure"`
+	_ struct{} `type:"structure"`
 }
 
 // String returns the string representation
@@ -3328,11 +3088,7 @@ type DescribeTagsInput struct {
 	// a previous call.)
 	NextToken *string `type:"string"`
 
-	metadataDescribeTagsInput `json:"-" xml:"-"`
-}
-
-type metadataDescribeTagsInput struct {
-	SDKShapeTraits bool `type:"structure"`
+	_ struct{} `type:"structure"`
 }
 
 // String returns the string representation
@@ -3353,11 +3109,7 @@ type DescribeTagsOutput struct {
 	// The tags.
 	Tags []*TagDescription `type:"list"`
 
-	metadataDescribeTagsOutput `json:"-" xml:"-"`
-}
-
-type metadataDescribeTagsOutput struct {
-	SDKShapeTraits bool `type:"structure"`
+	_ struct{} `type:"structure"`
 }
 
 // String returns the string representation
@@ -3371,11 +3123,7 @@ func (s DescribeTagsOutput) GoString() string {
 }
 
 type DescribeTerminationPolicyTypesInput struct {
-	metadataDescribeTerminationPolicyTypesInput `json:"-" xml:"-"`
-}
-
-type metadataDescribeTerminationPolicyTypesInput struct {
-	SDKShapeTraits bool `type:"structure"`
+	_ struct{} `type:"structure"`
 }
 
 // String returns the string representation
@@ -3393,11 +3141,7 @@ type DescribeTerminationPolicyTypesOutput struct {
 	// NewestInstance, ClosestToNextInstanceHour, and Default).
 	TerminationPolicyTypes []*string `type:"list"`
 
-	metadataDescribeTerminationPolicyTypesOutput `json:"-" xml:"-"`
-}
-
-type metadataDescribeTerminationPolicyTypesOutput struct {
-	SDKShapeTraits bool `type:"structure"`
+	_ struct{} `type:"structure"`
 }
 
 // String returns the string representation
@@ -3421,11 +3165,7 @@ type DetachInstancesInput struct {
 	// the number of instances detached.
 	ShouldDecrementDesiredCapacity *bool `type:"boolean" required:"true"`
 
-	metadataDetachInstancesInput `json:"-" xml:"-"`
-}
-
-type metadataDetachInstancesInput struct {
-	SDKShapeTraits bool `type:"structure"`
+	_ struct{} `type:"structure"`
 }
 
 // String returns the string representation
@@ -3442,11 +3182,7 @@ type DetachInstancesOutput struct {
 	// The activities related to detaching the instances from the Auto Scaling group.
 	Activities []*Activity `type:"list"`
 
-	metadataDetachInstancesOutput `json:"-" xml:"-"`
-}
-
-type metadataDetachInstancesOutput struct {
-	SDKShapeTraits bool `type:"structure"`
+	_ struct{} `type:"structure"`
 }
 
 // String returns the string representation
@@ -3466,11 +3202,7 @@ type DetachLoadBalancersInput struct {
 	// One or more load balancer names.
 	LoadBalancerNames []*string `type:"list"`
 
-	metadataDetachLoadBalancersInput `json:"-" xml:"-"`
-}
-
-type metadataDetachLoadBalancersInput struct {
-	SDKShapeTraits bool `type:"structure"`
+	_ struct{} `type:"structure"`
 }
 
 // String returns the string representation
@@ -3484,11 +3216,7 @@ func (s DetachLoadBalancersInput) GoString() string {
 }
 
 type DetachLoadBalancersOutput struct {
-	metadataDetachLoadBalancersOutput `json:"-" xml:"-"`
-}
-
-type metadataDetachLoadBalancersOutput struct {
-	SDKShapeTraits bool `type:"structure"`
+	_ struct{} `type:"structure"`
 }
 
 // String returns the string representation
@@ -3525,11 +3253,7 @@ type DisableMetricsCollectionInput struct {
 	// GroupTotalInstances
 	Metrics []*string `type:"list"`
 
-	metadataDisableMetricsCollectionInput `json:"-" xml:"-"`
-}
-
-type metadataDisableMetricsCollectionInput struct {
-	SDKShapeTraits bool `type:"structure"`
+	_ struct{} `type:"structure"`
 }
 
 // String returns the string representation
@@ -3543,11 +3267,7 @@ func (s DisableMetricsCollectionInput) GoString() string {
 }
 
 type DisableMetricsCollectionOutput struct {
-	metadataDisableMetricsCollectionOutput `json:"-" xml:"-"`
-}
-
-type metadataDisableMetricsCollectionOutput struct {
-	SDKShapeTraits bool `type:"structure"`
+	_ struct{} `type:"structure"`
 }
 
 // String returns the string representation
@@ -3604,11 +3324,7 @@ type Ebs struct {
 	// Default: standard
 	VolumeType *string `min:"1" type:"string"`
 
-	metadataEbs `json:"-" xml:"-"`
-}
-
-type metadataEbs struct {
-	SDKShapeTraits bool `type:"structure"`
+	_ struct{} `type:"structure"`
 }
 
 // String returns the string representation
@@ -3652,11 +3368,7 @@ type EnableMetricsCollectionInput struct {
 	// must explicitly request this metric.
 	Metrics []*string `type:"list"`
 
-	metadataEnableMetricsCollectionInput `json:"-" xml:"-"`
-}
-
-type metadataEnableMetricsCollectionInput struct {
-	SDKShapeTraits bool `type:"structure"`
+	_ struct{} `type:"structure"`
 }
 
 // String returns the string representation
@@ -3670,11 +3382,7 @@ func (s EnableMetricsCollectionInput) GoString() string {
 }
 
 type EnableMetricsCollectionOutput struct {
-	metadataEnableMetricsCollectionOutput `json:"-" xml:"-"`
-}
-
-type metadataEnableMetricsCollectionOutput struct {
-	SDKShapeTraits bool `type:"structure"`
+	_ struct{} `type:"structure"`
 }
 
 // String returns the string representation
@@ -3711,11 +3419,7 @@ type EnabledMetric struct {
 	// GroupTotalInstances
 	Metric *string `min:"1" type:"string"`
 
-	metadataEnabledMetric `json:"-" xml:"-"`
-}
-
-type metadataEnabledMetric struct {
-	SDKShapeTraits bool `type:"structure"`
+	_ struct{} `type:"structure"`
 }
 
 // String returns the string representation
@@ -3742,11 +3446,7 @@ type EnterStandbyInput struct {
 	// mode.
 	ShouldDecrementDesiredCapacity *bool `type:"boolean" required:"true"`
 
-	metadataEnterStandbyInput `json:"-" xml:"-"`
-}
-
-type metadataEnterStandbyInput struct {
-	SDKShapeTraits bool `type:"structure"`
+	_ struct{} `type:"structure"`
 }
 
 // String returns the string representation
@@ -3763,11 +3463,7 @@ type EnterStandbyOutput struct {
 	// The activities related to moving instances into Standby mode.
 	Activities []*Activity `type:"list"`
 
-	metadataEnterStandbyOutput `json:"-" xml:"-"`
-}
-
-type metadataEnterStandbyOutput struct {
-	SDKShapeTraits bool `type:"structure"`
+	_ struct{} `type:"structure"`
 }
 
 // String returns the string representation
@@ -3816,11 +3512,7 @@ type ExecutePolicyInput struct {
 	// The name or ARN of the policy.
 	PolicyName *string `min:"1" type:"string" required:"true"`
 
-	metadataExecutePolicyInput `json:"-" xml:"-"`
-}
-
-type metadataExecutePolicyInput struct {
-	SDKShapeTraits bool `type:"structure"`
+	_ struct{} `type:"structure"`
 }
 
 // String returns the string representation
@@ -3834,11 +3526,7 @@ func (s ExecutePolicyInput) GoString() string {
 }
 
 type ExecutePolicyOutput struct {
-	metadataExecutePolicyOutput `json:"-" xml:"-"`
-}
-
-type metadataExecutePolicyOutput struct {
-	SDKShapeTraits bool `type:"structure"`
+	_ struct{} `type:"structure"`
 }
 
 // String returns the string representation
@@ -3858,11 +3546,7 @@ type ExitStandbyInput struct {
 	// One or more instance IDs. You must specify at least one instance ID.
 	InstanceIds []*string `type:"list"`
 
-	metadataExitStandbyInput `json:"-" xml:"-"`
-}
-
-type metadataExitStandbyInput struct {
-	SDKShapeTraits bool `type:"structure"`
+	_ struct{} `type:"structure"`
 }
 
 // String returns the string representation
@@ -3879,11 +3563,7 @@ type ExitStandbyOutput struct {
 	// The activities related to moving instances out of Standby mode.
 	Activities []*Activity `type:"list"`
 
-	metadataExitStandbyOutput `json:"-" xml:"-"`
-}
-
-type metadataExitStandbyOutput struct {
-	SDKShapeTraits bool `type:"structure"`
+	_ struct{} `type:"structure"`
 }
 
 // String returns the string representation
@@ -3905,11 +3585,7 @@ type Filter struct {
 	// The value of the filter.
 	Values []*string `type:"list"`
 
-	metadataFilter `json:"-" xml:"-"`
-}
-
-type metadataFilter struct {
-	SDKShapeTraits bool `type:"structure"`
+	_ struct{} `type:"structure"`
 }
 
 // String returns the string representation
@@ -3992,11 +3668,7 @@ type Group struct {
 	// Availability Zones of the subnets match the values for AvailabilityZones.
 	VPCZoneIdentifier *string `min:"1" type:"string"`
 
-	metadataGroup `json:"-" xml:"-"`
-}
-
-type metadataGroup struct {
-	SDKShapeTraits bool `type:"structure"`
+	_ struct{} `type:"structure"`
 }
 
 // String returns the string representation
@@ -4027,11 +3699,7 @@ type Instance struct {
 	// is not used.
 	LifecycleState *string `type:"string" required:"true" enum:"LifecycleState"`
 
-	metadataInstance `json:"-" xml:"-"`
-}
-
-type metadataInstance struct {
-	SDKShapeTraits bool `type:"structure"`
+	_ struct{} `type:"structure"`
 }
 
 // String returns the string representation
@@ -4068,11 +3736,7 @@ type InstanceDetails struct {
 	// in the Auto Scaling Developer Guide.
 	LifecycleState *string `min:"1" type:"string" required:"true"`
 
-	metadataInstanceDetails `json:"-" xml:"-"`
-}
-
-type metadataInstanceDetails struct {
-	SDKShapeTraits bool `type:"structure"`
+	_ struct{} `type:"structure"`
 }
 
 // String returns the string representation
@@ -4090,11 +3754,7 @@ type InstanceMonitoring struct {
 	// If True, instance monitoring is enabled.
 	Enabled *bool `type:"boolean"`
 
-	metadataInstanceMonitoring `json:"-" xml:"-"`
-}
-
-type metadataInstanceMonitoring struct {
-	SDKShapeTraits bool `type:"structure"`
+	_ struct{} `type:"structure"`
 }
 
 // String returns the string representation
@@ -4175,11 +3835,7 @@ type LaunchConfiguration struct {
 	// The user data available to the instances.
 	UserData *string `type:"string"`
 
-	metadataLaunchConfiguration `json:"-" xml:"-"`
-}
-
-type metadataLaunchConfiguration struct {
-	SDKShapeTraits bool `type:"structure"`
+	_ struct{} `type:"structure"`
 }
 
 // String returns the string representation
@@ -4244,11 +3900,7 @@ type LifecycleHook struct {
 	// the specified notification target.
 	RoleARN *string `min:"1" type:"string"`
 
-	metadataLifecycleHook `json:"-" xml:"-"`
-}
-
-type metadataLifecycleHook struct {
-	SDKShapeTraits bool `type:"structure"`
+	_ struct{} `type:"structure"`
 }
 
 // String returns the string representation
@@ -4280,11 +3932,7 @@ type LoadBalancerState struct {
 	// requests to complete before deregistering the instances.
 	State *string `min:"1" type:"string"`
 
-	metadataLoadBalancerState `json:"-" xml:"-"`
-}
-
-type metadataLoadBalancerState struct {
-	SDKShapeTraits bool `type:"structure"`
+	_ struct{} `type:"structure"`
 }
 
 // String returns the string representation
@@ -4318,11 +3966,7 @@ type MetricCollectionType struct {
 	// GroupTotalInstances
 	Metric *string `min:"1" type:"string"`
 
-	metadataMetricCollectionType `json:"-" xml:"-"`
-}
-
-type metadataMetricCollectionType struct {
-	SDKShapeTraits bool `type:"structure"`
+	_ struct{} `type:"structure"`
 }
 
 // String returns the string representation
@@ -4340,11 +3984,7 @@ type MetricGranularityType struct {
 	// The granularity. The only valid value is 1Minute.
 	Granularity *string `min:"1" type:"string"`
 
-	metadataMetricGranularityType `json:"-" xml:"-"`
-}
-
-type metadataMetricGranularityType struct {
-	SDKShapeTraits bool `type:"structure"`
+	_ struct{} `type:"structure"`
 }
 
 // String returns the string representation
@@ -4379,11 +4019,7 @@ type NotificationConfiguration struct {
 	// (SNS) topic.
 	TopicARN *string `min:"1" type:"string"`
 
-	metadataNotificationConfiguration `json:"-" xml:"-"`
-}
-
-type metadataNotificationConfiguration struct {
-	SDKShapeTraits bool `type:"structure"`
+	_ struct{} `type:"structure"`
 }
 
 // String returns the string representation
@@ -4420,11 +4056,7 @@ type ProcessType struct {
 	// ScheduledActions
 	ProcessName *string `min:"1" type:"string" required:"true"`
 
-	metadataProcessType `json:"-" xml:"-"`
-}
-
-type metadataProcessType struct {
-	SDKShapeTraits bool `type:"structure"`
+	_ struct{} `type:"structure"`
 }
 
 // String returns the string representation
@@ -4497,11 +4129,7 @@ type PutLifecycleHookInput struct {
 	// existing hooks.
 	RoleARN *string `min:"1" type:"string"`
 
-	metadataPutLifecycleHookInput `json:"-" xml:"-"`
-}
-
-type metadataPutLifecycleHookInput struct {
-	SDKShapeTraits bool `type:"structure"`
+	_ struct{} `type:"structure"`
 }
 
 // String returns the string representation
@@ -4515,11 +4143,7 @@ func (s PutLifecycleHookInput) GoString() string {
 }
 
 type PutLifecycleHookOutput struct {
-	metadataPutLifecycleHookOutput `json:"-" xml:"-"`
-}
-
-type metadataPutLifecycleHookOutput struct {
-	SDKShapeTraits bool `type:"structure"`
+	_ struct{} `type:"structure"`
 }
 
 // String returns the string representation
@@ -4544,11 +4168,7 @@ type PutNotificationConfigurationInput struct {
 	// (SNS) topic.
 	TopicARN *string `min:"1" type:"string" required:"true"`
 
-	metadataPutNotificationConfigurationInput `json:"-" xml:"-"`
-}
-
-type metadataPutNotificationConfigurationInput struct {
-	SDKShapeTraits bool `type:"structure"`
+	_ struct{} `type:"structure"`
 }
 
 // String returns the string representation
@@ -4562,11 +4182,7 @@ func (s PutNotificationConfigurationInput) GoString() string {
 }
 
 type PutNotificationConfigurationOutput struct {
-	metadataPutNotificationConfigurationOutput `json:"-" xml:"-"`
-}
-
-type metadataPutNotificationConfigurationOutput struct {
-	SDKShapeTraits bool `type:"structure"`
+	_ struct{} `type:"structure"`
 }
 
 // String returns the string representation
@@ -4645,11 +4261,7 @@ type PutScalingPolicyInput struct {
 	// otherwise.
 	StepAdjustments []*StepAdjustment `type:"list"`
 
-	metadataPutScalingPolicyInput `json:"-" xml:"-"`
-}
-
-type metadataPutScalingPolicyInput struct {
-	SDKShapeTraits bool `type:"structure"`
+	_ struct{} `type:"structure"`
 }
 
 // String returns the string representation
@@ -4666,11 +4278,7 @@ type PutScalingPolicyOutput struct {
 	// The Amazon Resource Name (ARN) of the policy.
 	PolicyARN *string `min:"1" type:"string"`
 
-	metadataPutScalingPolicyOutput `json:"-" xml:"-"`
-}
-
-type metadataPutScalingPolicyOutput struct {
-	SDKShapeTraits bool `type:"structure"`
+	_ struct{} `type:"structure"`
 }
 
 // String returns the string representation
@@ -4726,11 +4334,7 @@ type PutScheduledUpdateGroupActionInput struct {
 	// their values must be identical.
 	Time *time.Time `type:"timestamp" timestampFormat:"iso8601"`
 
-	metadataPutScheduledUpdateGroupActionInput `json:"-" xml:"-"`
-}
-
-type metadataPutScheduledUpdateGroupActionInput struct {
-	SDKShapeTraits bool `type:"structure"`
+	_ struct{} `type:"structure"`
 }
 
 // String returns the string representation
@@ -4744,11 +4348,7 @@ func (s PutScheduledUpdateGroupActionInput) GoString() string {
 }
 
 type PutScheduledUpdateGroupActionOutput struct {
-	metadataPutScheduledUpdateGroupActionOutput `json:"-" xml:"-"`
-}
-
-type metadataPutScheduledUpdateGroupActionOutput struct {
-	SDKShapeTraits bool `type:"structure"`
+	_ struct{} `type:"structure"`
 }
 
 // String returns the string representation
@@ -4773,11 +4373,7 @@ type RecordLifecycleActionHeartbeatInput struct {
 	// The name of the lifecycle hook.
 	LifecycleHookName *string `min:"1" type:"string" required:"true"`
 
-	metadataRecordLifecycleActionHeartbeatInput `json:"-" xml:"-"`
-}
-
-type metadataRecordLifecycleActionHeartbeatInput struct {
-	SDKShapeTraits bool `type:"structure"`
+	_ struct{} `type:"structure"`
 }
 
 // String returns the string representation
@@ -4791,11 +4387,7 @@ func (s RecordLifecycleActionHeartbeatInput) GoString() string {
 }
 
 type RecordLifecycleActionHeartbeatOutput struct {
-	metadataRecordLifecycleActionHeartbeatOutput `json:"-" xml:"-"`
-}
-
-type metadataRecordLifecycleActionHeartbeatOutput struct {
-	SDKShapeTraits bool `type:"structure"`
+	_ struct{} `type:"structure"`
 }
 
 // String returns the string representation
@@ -4809,11 +4401,7 @@ func (s RecordLifecycleActionHeartbeatOutput) GoString() string {
 }
 
 type ResumeProcessesOutput struct {
-	metadataResumeProcessesOutput `json:"-" xml:"-"`
-}
-
-type metadataResumeProcessesOutput struct {
-	SDKShapeTraits bool `type:"structure"`
+	_ struct{} `type:"structure"`
 }
 
 // String returns the string representation
@@ -4877,11 +4465,7 @@ type ScalingPolicy struct {
 	// breach.
 	StepAdjustments []*StepAdjustment `type:"list"`
 
-	metadataScalingPolicy `json:"-" xml:"-"`
-}
-
-type metadataScalingPolicy struct {
-	SDKShapeTraits bool `type:"structure"`
+	_ struct{} `type:"structure"`
 }
 
 // String returns the string representation
@@ -4917,11 +4501,7 @@ type ScalingProcessQuery struct {
 	// AddToLoadBalancer
 	ScalingProcesses []*string `type:"list"`
 
-	metadataScalingProcessQuery `json:"-" xml:"-"`
-}
-
-type metadataScalingProcessQuery struct {
-	SDKShapeTraits bool `type:"structure"`
+	_ struct{} `type:"structure"`
 }
 
 // String returns the string representation
@@ -4971,11 +4551,7 @@ type ScheduledUpdateGroupAction struct {
 	// This parameter is deprecated; use StartTime instead.
 	Time *time.Time `type:"timestamp" timestampFormat:"iso8601"`
 
-	metadataScheduledUpdateGroupAction `json:"-" xml:"-"`
-}
-
-type metadataScheduledUpdateGroupAction struct {
-	SDKShapeTraits bool `type:"structure"`
+	_ struct{} `type:"structure"`
 }
 
 // String returns the string representation
@@ -5001,11 +4577,7 @@ type SetDesiredCapacityInput struct {
 	// initiating a scaling activity to set your Auto Scaling group to its new capacity.
 	HonorCooldown *bool `type:"boolean"`
 
-	metadataSetDesiredCapacityInput `json:"-" xml:"-"`
-}
-
-type metadataSetDesiredCapacityInput struct {
-	SDKShapeTraits bool `type:"structure"`
+	_ struct{} `type:"structure"`
 }
 
 // String returns the string representation
@@ -5019,11 +4591,7 @@ func (s SetDesiredCapacityInput) GoString() string {
 }
 
 type SetDesiredCapacityOutput struct {
-	metadataSetDesiredCapacityOutput `json:"-" xml:"-"`
-}
-
-type metadataSetDesiredCapacityOutput struct {
-	SDKShapeTraits bool `type:"structure"`
+	_ struct{} `type:"structure"`
 }
 
 // String returns the string representation
@@ -5054,11 +4622,7 @@ type SetInstanceHealthInput struct {
 	// for CreateAutoScalingGroup.
 	ShouldRespectGracePeriod *bool `type:"boolean"`
 
-	metadataSetInstanceHealthInput `json:"-" xml:"-"`
-}
-
-type metadataSetInstanceHealthInput struct {
-	SDKShapeTraits bool `type:"structure"`
+	_ struct{} `type:"structure"`
 }
 
 // String returns the string representation
@@ -5072,11 +4636,7 @@ func (s SetInstanceHealthInput) GoString() string {
 }
 
 type SetInstanceHealthOutput struct {
-	metadataSetInstanceHealthOutput `json:"-" xml:"-"`
-}
-
-type metadataSetInstanceHealthOutput struct {
-	SDKShapeTraits bool `type:"structure"`
+	_ struct{} `type:"structure"`
 }
 
 // String returns the string representation
@@ -5140,11 +4700,7 @@ type StepAdjustment struct {
 	// current capacity.
 	ScalingAdjustment *int64 `type:"integer" required:"true"`
 
-	metadataStepAdjustment `json:"-" xml:"-"`
-}
-
-type metadataStepAdjustment struct {
-	SDKShapeTraits bool `type:"structure"`
+	_ struct{} `type:"structure"`
 }
 
 // String returns the string representation
@@ -5158,11 +4714,7 @@ func (s StepAdjustment) GoString() string {
 }
 
 type SuspendProcessesOutput struct {
-	metadataSuspendProcessesOutput `json:"-" xml:"-"`
-}
-
-type metadataSuspendProcessesOutput struct {
-	SDKShapeTraits bool `type:"structure"`
+	_ struct{} `type:"structure"`
 }
 
 // String returns the string representation
@@ -5184,11 +4736,7 @@ type SuspendedProcess struct {
 	// The reason that the process was suspended.
 	SuspensionReason *string `min:"1" type:"string"`
 
-	metadataSuspendedProcess `json:"-" xml:"-"`
-}
-
-type metadataSuspendedProcess struct {
-	SDKShapeTraits bool `type:"structure"`
+	_ struct{} `type:"structure"`
 }
 
 // String returns the string representation
@@ -5219,11 +4767,7 @@ type Tag struct {
 	// The tag value.
 	Value *string `type:"string"`
 
-	metadataTag `json:"-" xml:"-"`
-}
-
-type metadataTag struct {
-	SDKShapeTraits bool `type:"structure"`
+	_ struct{} `type:"structure"`
 }
 
 // String returns the string representation
@@ -5254,11 +4798,7 @@ type TagDescription struct {
 	// The tag value.
 	Value *string `type:"string"`
 
-	metadataTagDescription `json:"-" xml:"-"`
-}
-
-type metadataTagDescription struct {
-	SDKShapeTraits bool `type:"structure"`
+	_ struct{} `type:"structure"`
 }
 
 // String returns the string representation
@@ -5279,11 +4819,7 @@ type TerminateInstanceInAutoScalingGroupInput struct {
 	// group.
 	ShouldDecrementDesiredCapacity *bool `type:"boolean" required:"true"`
 
-	metadataTerminateInstanceInAutoScalingGroupInput `json:"-" xml:"-"`
-}
-
-type metadataTerminateInstanceInAutoScalingGroupInput struct {
-	SDKShapeTraits bool `type:"structure"`
+	_ struct{} `type:"structure"`
 }
 
 // String returns the string representation
@@ -5300,11 +4836,7 @@ type TerminateInstanceInAutoScalingGroupOutput struct {
 	// A scaling activity.
 	Activity *Activity `type:"structure"`
 
-	metadataTerminateInstanceInAutoScalingGroupOutput `json:"-" xml:"-"`
-}
-
-type metadataTerminateInstanceInAutoScalingGroupOutput struct {
-	SDKShapeTraits bool `type:"structure"`
+	_ struct{} `type:"structure"`
 }
 
 // String returns the string representation
@@ -5381,11 +4913,7 @@ type UpdateAutoScalingGroupInput struct {
 	// in the Auto Scaling Developer Guide.
 	VPCZoneIdentifier *string `min:"1" type:"string"`
 
-	metadataUpdateAutoScalingGroupInput `json:"-" xml:"-"`
-}
-
-type metadataUpdateAutoScalingGroupInput struct {
-	SDKShapeTraits bool `type:"structure"`
+	_ struct{} `type:"structure"`
 }
 
 // String returns the string representation
@@ -5399,11 +4927,7 @@ func (s UpdateAutoScalingGroupInput) GoString() string {
 }
 
 type UpdateAutoScalingGroupOutput struct {
-	metadataUpdateAutoScalingGroupOutput `json:"-" xml:"-"`
-}
-
-type metadataUpdateAutoScalingGroupOutput struct {
-	SDKShapeTraits bool `type:"structure"`
+	_ struct{} `type:"structure"`
 }
 
 // String returns the string representation

--- a/service/autoscaling/api.go
+++ b/service/autoscaling/api.go
@@ -1637,6 +1637,8 @@ func (c *AutoScaling) UpdateAutoScalingGroup(input *UpdateAutoScalingGroupInput)
 // a change to your Auto Scaling group, such as changing its size or replacing
 // an instance.
 type Activity struct {
+	_ struct{} `type:"structure"`
+
 	// The ID of the activity.
 	ActivityId *string `type:"string" required:"true"`
 
@@ -1666,8 +1668,6 @@ type Activity struct {
 
 	// A friendly, more verbose description of the activity status.
 	StatusMessage *string `min:"1" type:"string"`
-
-	_ struct{} `type:"structure"`
 }
 
 // String returns the string representation
@@ -1685,11 +1685,11 @@ func (s Activity) GoString() string {
 // For more information, see Dynamic Scaling (http://docs.aws.amazon.com/AutoScaling/latest/DeveloperGuide/as-scale-based-on-demand.html)
 // in the Auto Scaling Developer Guide.
 type AdjustmentType struct {
+	_ struct{} `type:"structure"`
+
 	// The policy adjustment type. The valid values are ChangeInCapacity, ExactCapacity,
 	// and PercentChangeInCapacity.
 	AdjustmentType *string `min:"1" type:"string"`
-
-	_ struct{} `type:"structure"`
 }
 
 // String returns the string representation
@@ -1704,13 +1704,13 @@ func (s AdjustmentType) GoString() string {
 
 // Describes an alarm.
 type Alarm struct {
+	_ struct{} `type:"structure"`
+
 	// The Amazon Resource Name (ARN) of the alarm.
 	AlarmARN *string `min:"1" type:"string"`
 
 	// The name of the alarm.
 	AlarmName *string `min:"1" type:"string"`
-
-	_ struct{} `type:"structure"`
 }
 
 // String returns the string representation
@@ -1724,13 +1724,13 @@ func (s Alarm) GoString() string {
 }
 
 type AttachInstancesInput struct {
+	_ struct{} `type:"structure"`
+
 	// The name of the group.
 	AutoScalingGroupName *string `min:"1" type:"string" required:"true"`
 
 	// One or more EC2 instance IDs.
 	InstanceIds []*string `type:"list"`
-
-	_ struct{} `type:"structure"`
 }
 
 // String returns the string representation
@@ -1758,13 +1758,13 @@ func (s AttachInstancesOutput) GoString() string {
 }
 
 type AttachLoadBalancersInput struct {
+	_ struct{} `type:"structure"`
+
 	// The name of the group.
 	AutoScalingGroupName *string `min:"1" type:"string"`
 
 	// One or more load balancer names.
 	LoadBalancerNames []*string `type:"list"`
-
-	_ struct{} `type:"structure"`
 }
 
 // String returns the string representation
@@ -1793,6 +1793,8 @@ func (s AttachLoadBalancersOutput) GoString() string {
 
 // Describes a block device mapping.
 type BlockDeviceMapping struct {
+	_ struct{} `type:"structure"`
+
 	// The device name exposed to the EC2 instance (for example, /dev/sdh or xvdh).
 	DeviceName *string `min:"1" type:"string" required:"true"`
 
@@ -1808,8 +1810,6 @@ type BlockDeviceMapping struct {
 
 	// The name of the virtual device (for example, ephemeral0).
 	VirtualName *string `min:"1" type:"string"`
-
-	_ struct{} `type:"structure"`
 }
 
 // String returns the string representation
@@ -1823,6 +1823,8 @@ func (s BlockDeviceMapping) GoString() string {
 }
 
 type CompleteLifecycleActionInput struct {
+	_ struct{} `type:"structure"`
+
 	// The name of the group for the lifecycle hook.
 	AutoScalingGroupName *string `min:"1" type:"string" required:"true"`
 
@@ -1837,8 +1839,6 @@ type CompleteLifecycleActionInput struct {
 
 	// The name of the lifecycle hook.
 	LifecycleHookName *string `min:"1" type:"string" required:"true"`
-
-	_ struct{} `type:"structure"`
 }
 
 // String returns the string representation
@@ -1866,6 +1866,8 @@ func (s CompleteLifecycleActionOutput) GoString() string {
 }
 
 type CreateAutoScalingGroupInput struct {
+	_ struct{} `type:"structure"`
+
 	// The name of the group. This name must be unique within the scope of your
 	// AWS account.
 	AutoScalingGroupName *string `min:"1" type:"string" required:"true"`
@@ -1969,8 +1971,6 @@ type CreateAutoScalingGroupInput struct {
 	// (http://docs.aws.amazon.com/AutoScaling/latest/DeveloperGuide/autoscalingsubnets.html)
 	// in the Auto Scaling Developer Guide.
 	VPCZoneIdentifier *string `min:"1" type:"string"`
-
-	_ struct{} `type:"structure"`
 }
 
 // String returns the string representation
@@ -1998,6 +1998,8 @@ func (s CreateAutoScalingGroupOutput) GoString() string {
 }
 
 type CreateLaunchConfigurationInput struct {
+	_ struct{} `type:"structure"`
+
 	// Used for groups that launch instances into a virtual private cloud (VPC).
 	// Specifies whether to assign a public IP address to each instance. For more
 	// information, see Auto Scaling and Amazon Virtual Private Cloud (http://docs.aws.amazon.com/AutoScaling/latest/DeveloperGuide/autoscalingsubnets.html)
@@ -2140,8 +2142,6 @@ type CreateLaunchConfigurationInput struct {
 	// At this time, launch configurations don't support compressed (zipped) user
 	// data files.
 	UserData *string `type:"string"`
-
-	_ struct{} `type:"structure"`
 }
 
 // String returns the string representation
@@ -2169,10 +2169,10 @@ func (s CreateLaunchConfigurationOutput) GoString() string {
 }
 
 type CreateOrUpdateTagsInput struct {
+	_ struct{} `type:"structure"`
+
 	// One or more tags.
 	Tags []*Tag `type:"list" required:"true"`
-
-	_ struct{} `type:"structure"`
 }
 
 // String returns the string representation
@@ -2200,6 +2200,8 @@ func (s CreateOrUpdateTagsOutput) GoString() string {
 }
 
 type DeleteAutoScalingGroupInput struct {
+	_ struct{} `type:"structure"`
+
 	// The name of the group to delete.
 	AutoScalingGroupName *string `min:"1" type:"string" required:"true"`
 
@@ -2207,8 +2209,6 @@ type DeleteAutoScalingGroupInput struct {
 	// with the group, without waiting for all instances to be terminated. This
 	// parameter also deletes any lifecycle actions associated with the group.
 	ForceDelete *bool `type:"boolean"`
-
-	_ struct{} `type:"structure"`
 }
 
 // String returns the string representation
@@ -2236,10 +2236,10 @@ func (s DeleteAutoScalingGroupOutput) GoString() string {
 }
 
 type DeleteLaunchConfigurationInput struct {
+	_ struct{} `type:"structure"`
+
 	// The name of the launch configuration.
 	LaunchConfigurationName *string `min:"1" type:"string" required:"true"`
-
-	_ struct{} `type:"structure"`
 }
 
 // String returns the string representation
@@ -2267,13 +2267,13 @@ func (s DeleteLaunchConfigurationOutput) GoString() string {
 }
 
 type DeleteLifecycleHookInput struct {
+	_ struct{} `type:"structure"`
+
 	// The name of the Auto Scaling group for the lifecycle hook.
 	AutoScalingGroupName *string `min:"1" type:"string" required:"true"`
 
 	// The name of the lifecycle hook.
 	LifecycleHookName *string `min:"1" type:"string" required:"true"`
-
-	_ struct{} `type:"structure"`
 }
 
 // String returns the string representation
@@ -2301,14 +2301,14 @@ func (s DeleteLifecycleHookOutput) GoString() string {
 }
 
 type DeleteNotificationConfigurationInput struct {
+	_ struct{} `type:"structure"`
+
 	// The name of the Auto Scaling group.
 	AutoScalingGroupName *string `min:"1" type:"string" required:"true"`
 
 	// The Amazon Resource Name (ARN) of the Amazon Simple Notification Service
 	// (SNS) topic.
 	TopicARN *string `min:"1" type:"string" required:"true"`
-
-	_ struct{} `type:"structure"`
 }
 
 // String returns the string representation
@@ -2336,13 +2336,13 @@ func (s DeleteNotificationConfigurationOutput) GoString() string {
 }
 
 type DeletePolicyInput struct {
+	_ struct{} `type:"structure"`
+
 	// The name of the Auto Scaling group.
 	AutoScalingGroupName *string `min:"1" type:"string"`
 
 	// The name or Amazon Resource Name (ARN) of the policy.
 	PolicyName *string `min:"1" type:"string" required:"true"`
-
-	_ struct{} `type:"structure"`
 }
 
 // String returns the string representation
@@ -2370,13 +2370,13 @@ func (s DeletePolicyOutput) GoString() string {
 }
 
 type DeleteScheduledActionInput struct {
+	_ struct{} `type:"structure"`
+
 	// The name of the Auto Scaling group.
 	AutoScalingGroupName *string `min:"1" type:"string"`
 
 	// The name of the action to delete.
 	ScheduledActionName *string `min:"1" type:"string" required:"true"`
-
-	_ struct{} `type:"structure"`
 }
 
 // String returns the string representation
@@ -2404,13 +2404,13 @@ func (s DeleteScheduledActionOutput) GoString() string {
 }
 
 type DeleteTagsInput struct {
+	_ struct{} `type:"structure"`
+
 	// Each tag should be defined by its resource type, resource ID, key, value,
 	// and a propagate flag. Valid values are: Resource type = auto-scaling-group,
 	// Resource ID = AutoScalingGroupName, key=value, value=value, propagate=true
 	// or false.
 	Tags []*Tag `type:"list" required:"true"`
-
-	_ struct{} `type:"structure"`
 }
 
 // String returns the string representation
@@ -2452,6 +2452,8 @@ func (s DescribeAccountLimitsInput) GoString() string {
 }
 
 type DescribeAccountLimitsOutput struct {
+	_ struct{} `type:"structure"`
+
 	// The maximum number of groups allowed for your AWS account. The default limit
 	// is 20 per region.
 	MaxNumberOfAutoScalingGroups *int64 `type:"integer"`
@@ -2459,8 +2461,6 @@ type DescribeAccountLimitsOutput struct {
 	// The maximum number of launch configurations allowed for your AWS account.
 	// The default limit is 100 per region.
 	MaxNumberOfLaunchConfigurations *int64 `type:"integer"`
-
-	_ struct{} `type:"structure"`
 }
 
 // String returns the string representation
@@ -2488,10 +2488,10 @@ func (s DescribeAdjustmentTypesInput) GoString() string {
 }
 
 type DescribeAdjustmentTypesOutput struct {
+	_ struct{} `type:"structure"`
+
 	// The policy adjustment types.
 	AdjustmentTypes []*AdjustmentType `type:"list"`
-
-	_ struct{} `type:"structure"`
 }
 
 // String returns the string representation
@@ -2505,6 +2505,8 @@ func (s DescribeAdjustmentTypesOutput) GoString() string {
 }
 
 type DescribeAutoScalingGroupsInput struct {
+	_ struct{} `type:"structure"`
+
 	// The group names.
 	AutoScalingGroupNames []*string `type:"list"`
 
@@ -2514,8 +2516,6 @@ type DescribeAutoScalingGroupsInput struct {
 	// The token for the next set of items to return. (You received this token from
 	// a previous call.)
 	NextToken *string `type:"string"`
-
-	_ struct{} `type:"structure"`
 }
 
 // String returns the string representation
@@ -2529,14 +2529,14 @@ func (s DescribeAutoScalingGroupsInput) GoString() string {
 }
 
 type DescribeAutoScalingGroupsOutput struct {
+	_ struct{} `type:"structure"`
+
 	// The groups.
 	AutoScalingGroups []*Group `type:"list" required:"true"`
 
 	// The token to use when requesting the next set of items. If there are no additional
 	// items to return, the string is empty.
 	NextToken *string `type:"string"`
-
-	_ struct{} `type:"structure"`
 }
 
 // String returns the string representation
@@ -2550,6 +2550,8 @@ func (s DescribeAutoScalingGroupsOutput) GoString() string {
 }
 
 type DescribeAutoScalingInstancesInput struct {
+	_ struct{} `type:"structure"`
+
 	// One or more Auto Scaling instances to describe, up to 50 instances. If you
 	// omit this parameter, all Auto Scaling instances are described. If you specify
 	// an ID that does not exist, it is ignored with no error.
@@ -2561,8 +2563,6 @@ type DescribeAutoScalingInstancesInput struct {
 	// The token for the next set of items to return. (You received this token from
 	// a previous call.)
 	NextToken *string `type:"string"`
-
-	_ struct{} `type:"structure"`
 }
 
 // String returns the string representation
@@ -2576,14 +2576,14 @@ func (s DescribeAutoScalingInstancesInput) GoString() string {
 }
 
 type DescribeAutoScalingInstancesOutput struct {
+	_ struct{} `type:"structure"`
+
 	// The instances.
 	AutoScalingInstances []*InstanceDetails `type:"list"`
 
 	// The token to use when requesting the next set of items. If there are no additional
 	// items to return, the string is empty.
 	NextToken *string `type:"string"`
-
-	_ struct{} `type:"structure"`
 }
 
 // String returns the string representation
@@ -2611,6 +2611,8 @@ func (s DescribeAutoScalingNotificationTypesInput) GoString() string {
 }
 
 type DescribeAutoScalingNotificationTypesOutput struct {
+	_ struct{} `type:"structure"`
+
 	// One or more of the following notification types:
 	//
 	//  autoscaling:EC2_INSTANCE_LAUNCH
@@ -2623,8 +2625,6 @@ type DescribeAutoScalingNotificationTypesOutput struct {
 	//
 	// autoscaling:TEST_NOTIFICATION
 	AutoScalingNotificationTypes []*string `type:"list"`
-
-	_ struct{} `type:"structure"`
 }
 
 // String returns the string representation
@@ -2638,6 +2638,8 @@ func (s DescribeAutoScalingNotificationTypesOutput) GoString() string {
 }
 
 type DescribeLaunchConfigurationsInput struct {
+	_ struct{} `type:"structure"`
+
 	// The launch configuration names.
 	LaunchConfigurationNames []*string `type:"list"`
 
@@ -2647,8 +2649,6 @@ type DescribeLaunchConfigurationsInput struct {
 	// The token for the next set of items to return. (You received this token from
 	// a previous call.)
 	NextToken *string `type:"string"`
-
-	_ struct{} `type:"structure"`
 }
 
 // String returns the string representation
@@ -2662,14 +2662,14 @@ func (s DescribeLaunchConfigurationsInput) GoString() string {
 }
 
 type DescribeLaunchConfigurationsOutput struct {
+	_ struct{} `type:"structure"`
+
 	// The launch configurations.
 	LaunchConfigurations []*LaunchConfiguration `type:"list" required:"true"`
 
 	// The token to use when requesting the next set of items. If there are no additional
 	// items to return, the string is empty.
 	NextToken *string `type:"string"`
-
-	_ struct{} `type:"structure"`
 }
 
 // String returns the string representation
@@ -2697,14 +2697,14 @@ func (s DescribeLifecycleHookTypesInput) GoString() string {
 }
 
 type DescribeLifecycleHookTypesOutput struct {
+	_ struct{} `type:"structure"`
+
 	// One or more of the following notification types:
 	//
 	//  autoscaling:EC2_INSTANCE_LAUNCHING
 	//
 	// autoscaling:EC2_INSTANCE_TERMINATING
 	LifecycleHookTypes []*string `type:"list"`
-
-	_ struct{} `type:"structure"`
 }
 
 // String returns the string representation
@@ -2718,13 +2718,13 @@ func (s DescribeLifecycleHookTypesOutput) GoString() string {
 }
 
 type DescribeLifecycleHooksInput struct {
+	_ struct{} `type:"structure"`
+
 	// The name of the group.
 	AutoScalingGroupName *string `min:"1" type:"string" required:"true"`
 
 	// The names of one or more lifecycle hooks.
 	LifecycleHookNames []*string `type:"list"`
-
-	_ struct{} `type:"structure"`
 }
 
 // String returns the string representation
@@ -2738,10 +2738,10 @@ func (s DescribeLifecycleHooksInput) GoString() string {
 }
 
 type DescribeLifecycleHooksOutput struct {
+	_ struct{} `type:"structure"`
+
 	// The lifecycle hooks for the specified group.
 	LifecycleHooks []*LifecycleHook `type:"list"`
-
-	_ struct{} `type:"structure"`
 }
 
 // String returns the string representation
@@ -2755,6 +2755,8 @@ func (s DescribeLifecycleHooksOutput) GoString() string {
 }
 
 type DescribeLoadBalancersInput struct {
+	_ struct{} `type:"structure"`
+
 	// The name of the group.
 	AutoScalingGroupName *string `min:"1" type:"string" required:"true"`
 
@@ -2764,8 +2766,6 @@ type DescribeLoadBalancersInput struct {
 	// The token for the next set of items to return. (You received this token from
 	// a previous call.)
 	NextToken *string `type:"string"`
-
-	_ struct{} `type:"structure"`
 }
 
 // String returns the string representation
@@ -2779,14 +2779,14 @@ func (s DescribeLoadBalancersInput) GoString() string {
 }
 
 type DescribeLoadBalancersOutput struct {
+	_ struct{} `type:"structure"`
+
 	// The load balancers.
 	LoadBalancers []*LoadBalancerState `type:"list"`
 
 	// The token to use when requesting the next set of items. If there are no additional
 	// items to return, the string is empty.
 	NextToken *string `type:"string"`
-
-	_ struct{} `type:"structure"`
 }
 
 // String returns the string representation
@@ -2814,13 +2814,13 @@ func (s DescribeMetricCollectionTypesInput) GoString() string {
 }
 
 type DescribeMetricCollectionTypesOutput struct {
+	_ struct{} `type:"structure"`
+
 	// The granularities for the metrics.
 	Granularities []*MetricGranularityType `type:"list"`
 
 	// One or more metrics.
 	Metrics []*MetricCollectionType `type:"list"`
-
-	_ struct{} `type:"structure"`
 }
 
 // String returns the string representation
@@ -2834,6 +2834,8 @@ func (s DescribeMetricCollectionTypesOutput) GoString() string {
 }
 
 type DescribeNotificationConfigurationsInput struct {
+	_ struct{} `type:"structure"`
+
 	// The name of the group.
 	AutoScalingGroupNames []*string `type:"list"`
 
@@ -2843,8 +2845,6 @@ type DescribeNotificationConfigurationsInput struct {
 	// The token for the next set of items to return. (You received this token from
 	// a previous call.)
 	NextToken *string `type:"string"`
-
-	_ struct{} `type:"structure"`
 }
 
 // String returns the string representation
@@ -2858,14 +2858,14 @@ func (s DescribeNotificationConfigurationsInput) GoString() string {
 }
 
 type DescribeNotificationConfigurationsOutput struct {
+	_ struct{} `type:"structure"`
+
 	// The token to use when requesting the next set of items. If there are no additional
 	// items to return, the string is empty.
 	NextToken *string `type:"string"`
 
 	// The notification configurations.
 	NotificationConfigurations []*NotificationConfiguration `type:"list" required:"true"`
-
-	_ struct{} `type:"structure"`
 }
 
 // String returns the string representation
@@ -2879,6 +2879,8 @@ func (s DescribeNotificationConfigurationsOutput) GoString() string {
 }
 
 type DescribePoliciesInput struct {
+	_ struct{} `type:"structure"`
+
 	// The name of the group.
 	AutoScalingGroupName *string `min:"1" type:"string"`
 
@@ -2897,8 +2899,6 @@ type DescribePoliciesInput struct {
 
 	// One or more policy types. Valid values are SimpleScaling and StepScaling.
 	PolicyTypes []*string `type:"list"`
-
-	_ struct{} `type:"structure"`
 }
 
 // String returns the string representation
@@ -2912,14 +2912,14 @@ func (s DescribePoliciesInput) GoString() string {
 }
 
 type DescribePoliciesOutput struct {
+	_ struct{} `type:"structure"`
+
 	// The token to use when requesting the next set of items. If there are no additional
 	// items to return, the string is empty.
 	NextToken *string `type:"string"`
 
 	// The scaling policies.
 	ScalingPolicies []*ScalingPolicy `type:"list"`
-
-	_ struct{} `type:"structure"`
 }
 
 // String returns the string representation
@@ -2933,6 +2933,8 @@ func (s DescribePoliciesOutput) GoString() string {
 }
 
 type DescribeScalingActivitiesInput struct {
+	_ struct{} `type:"structure"`
+
 	// The activity IDs of the desired scaling activities. If this list is omitted,
 	// all activities are described. If the AutoScalingGroupName parameter is provided,
 	// the results are limited to that group. The list of requested activities cannot
@@ -2949,8 +2951,6 @@ type DescribeScalingActivitiesInput struct {
 	// The token for the next set of items to return. (You received this token from
 	// a previous call.)
 	NextToken *string `type:"string"`
-
-	_ struct{} `type:"structure"`
 }
 
 // String returns the string representation
@@ -2964,14 +2964,14 @@ func (s DescribeScalingActivitiesInput) GoString() string {
 }
 
 type DescribeScalingActivitiesOutput struct {
+	_ struct{} `type:"structure"`
+
 	// The scaling activities.
 	Activities []*Activity `type:"list" required:"true"`
 
 	// The token to use when requesting the next set of items. If there are no additional
 	// items to return, the string is empty.
 	NextToken *string `type:"string"`
-
-	_ struct{} `type:"structure"`
 }
 
 // String returns the string representation
@@ -2999,10 +2999,10 @@ func (s DescribeScalingProcessTypesInput) GoString() string {
 }
 
 type DescribeScalingProcessTypesOutput struct {
+	_ struct{} `type:"structure"`
+
 	// The names of the process types.
 	Processes []*ProcessType `type:"list"`
-
-	_ struct{} `type:"structure"`
 }
 
 // String returns the string representation
@@ -3016,6 +3016,8 @@ func (s DescribeScalingProcessTypesOutput) GoString() string {
 }
 
 type DescribeScheduledActionsInput struct {
+	_ struct{} `type:"structure"`
+
 	// The name of the group.
 	AutoScalingGroupName *string `min:"1" type:"string"`
 
@@ -3042,8 +3044,6 @@ type DescribeScheduledActionsInput struct {
 	// The earliest scheduled start time to return. If scheduled action names are
 	// provided, this parameter is ignored.
 	StartTime *time.Time `type:"timestamp" timestampFormat:"iso8601"`
-
-	_ struct{} `type:"structure"`
 }
 
 // String returns the string representation
@@ -3057,14 +3057,14 @@ func (s DescribeScheduledActionsInput) GoString() string {
 }
 
 type DescribeScheduledActionsOutput struct {
+	_ struct{} `type:"structure"`
+
 	// The token to use when requesting the next set of items. If there are no additional
 	// items to return, the string is empty.
 	NextToken *string `type:"string"`
 
 	// The scheduled actions.
 	ScheduledUpdateGroupActions []*ScheduledUpdateGroupAction `type:"list"`
-
-	_ struct{} `type:"structure"`
 }
 
 // String returns the string representation
@@ -3078,6 +3078,8 @@ func (s DescribeScheduledActionsOutput) GoString() string {
 }
 
 type DescribeTagsInput struct {
+	_ struct{} `type:"structure"`
+
 	// A filter used to scope the tags to return.
 	Filters []*Filter `type:"list"`
 
@@ -3087,8 +3089,6 @@ type DescribeTagsInput struct {
 	// The token for the next set of items to return. (You received this token from
 	// a previous call.)
 	NextToken *string `type:"string"`
-
-	_ struct{} `type:"structure"`
 }
 
 // String returns the string representation
@@ -3102,14 +3102,14 @@ func (s DescribeTagsInput) GoString() string {
 }
 
 type DescribeTagsOutput struct {
+	_ struct{} `type:"structure"`
+
 	// The token to use when requesting the next set of items. If there are no additional
 	// items to return, the string is empty.
 	NextToken *string `type:"string"`
 
 	// The tags.
 	Tags []*TagDescription `type:"list"`
-
-	_ struct{} `type:"structure"`
 }
 
 // String returns the string representation
@@ -3137,11 +3137,11 @@ func (s DescribeTerminationPolicyTypesInput) GoString() string {
 }
 
 type DescribeTerminationPolicyTypesOutput struct {
+	_ struct{} `type:"structure"`
+
 	// The termination policies supported by Auto Scaling (OldestInstance, OldestLaunchConfiguration,
 	// NewestInstance, ClosestToNextInstanceHour, and Default).
 	TerminationPolicyTypes []*string `type:"list"`
-
-	_ struct{} `type:"structure"`
 }
 
 // String returns the string representation
@@ -3155,6 +3155,8 @@ func (s DescribeTerminationPolicyTypesOutput) GoString() string {
 }
 
 type DetachInstancesInput struct {
+	_ struct{} `type:"structure"`
+
 	// The name of the group.
 	AutoScalingGroupName *string `min:"1" type:"string" required:"true"`
 
@@ -3164,8 +3166,6 @@ type DetachInstancesInput struct {
 	// If True, the Auto Scaling group decrements the desired capacity value by
 	// the number of instances detached.
 	ShouldDecrementDesiredCapacity *bool `type:"boolean" required:"true"`
-
-	_ struct{} `type:"structure"`
 }
 
 // String returns the string representation
@@ -3179,10 +3179,10 @@ func (s DetachInstancesInput) GoString() string {
 }
 
 type DetachInstancesOutput struct {
+	_ struct{} `type:"structure"`
+
 	// The activities related to detaching the instances from the Auto Scaling group.
 	Activities []*Activity `type:"list"`
-
-	_ struct{} `type:"structure"`
 }
 
 // String returns the string representation
@@ -3196,13 +3196,13 @@ func (s DetachInstancesOutput) GoString() string {
 }
 
 type DetachLoadBalancersInput struct {
+	_ struct{} `type:"structure"`
+
 	// The name of the group.
 	AutoScalingGroupName *string `min:"1" type:"string"`
 
 	// One or more load balancer names.
 	LoadBalancerNames []*string `type:"list"`
-
-	_ struct{} `type:"structure"`
 }
 
 // String returns the string representation
@@ -3230,6 +3230,8 @@ func (s DetachLoadBalancersOutput) GoString() string {
 }
 
 type DisableMetricsCollectionInput struct {
+	_ struct{} `type:"structure"`
+
 	// The name or Amazon Resource Name (ARN) of the group.
 	AutoScalingGroupName *string `min:"1" type:"string" required:"true"`
 
@@ -3252,8 +3254,6 @@ type DisableMetricsCollectionInput struct {
 	//
 	// GroupTotalInstances
 	Metrics []*string `type:"list"`
-
-	_ struct{} `type:"structure"`
 }
 
 // String returns the string representation
@@ -3282,6 +3282,8 @@ func (s DisableMetricsCollectionOutput) GoString() string {
 
 // Describes an Amazon EBS volume.
 type Ebs struct {
+	_ struct{} `type:"structure"`
+
 	// Indicates whether to delete the volume on instance termination.
 	//
 	// Default: true
@@ -3323,8 +3325,6 @@ type Ebs struct {
 	//
 	// Default: standard
 	VolumeType *string `min:"1" type:"string"`
-
-	_ struct{} `type:"structure"`
 }
 
 // String returns the string representation
@@ -3338,6 +3338,8 @@ func (s Ebs) GoString() string {
 }
 
 type EnableMetricsCollectionInput struct {
+	_ struct{} `type:"structure"`
+
 	// The name or ARN of the Auto Scaling group.
 	AutoScalingGroupName *string `min:"1" type:"string" required:"true"`
 
@@ -3367,8 +3369,6 @@ type EnableMetricsCollectionInput struct {
 	//  Note that the GroupStandbyInstances metric is not enabled by default. You
 	// must explicitly request this metric.
 	Metrics []*string `type:"list"`
-
-	_ struct{} `type:"structure"`
 }
 
 // String returns the string representation
@@ -3397,6 +3397,8 @@ func (s EnableMetricsCollectionOutput) GoString() string {
 
 // Describes an enabled metric.
 type EnabledMetric struct {
+	_ struct{} `type:"structure"`
+
 	// The granularity of the metric. The only valid value is 1Minute.
 	Granularity *string `min:"1" type:"string"`
 
@@ -3418,8 +3420,6 @@ type EnabledMetric struct {
 	//
 	// GroupTotalInstances
 	Metric *string `min:"1" type:"string"`
-
-	_ struct{} `type:"structure"`
 }
 
 // String returns the string representation
@@ -3433,6 +3433,8 @@ func (s EnabledMetric) GoString() string {
 }
 
 type EnterStandbyInput struct {
+	_ struct{} `type:"structure"`
+
 	// The name of the Auto Scaling group.
 	AutoScalingGroupName *string `min:"1" type:"string" required:"true"`
 
@@ -3445,8 +3447,6 @@ type EnterStandbyInput struct {
 	// Auto Scaling group decrements by the number of instances moved to Standby
 	// mode.
 	ShouldDecrementDesiredCapacity *bool `type:"boolean" required:"true"`
-
-	_ struct{} `type:"structure"`
 }
 
 // String returns the string representation
@@ -3460,10 +3460,10 @@ func (s EnterStandbyInput) GoString() string {
 }
 
 type EnterStandbyOutput struct {
+	_ struct{} `type:"structure"`
+
 	// The activities related to moving instances into Standby mode.
 	Activities []*Activity `type:"list"`
-
-	_ struct{} `type:"structure"`
 }
 
 // String returns the string representation
@@ -3477,6 +3477,8 @@ func (s EnterStandbyOutput) GoString() string {
 }
 
 type ExecutePolicyInput struct {
+	_ struct{} `type:"structure"`
+
 	// The name or Amazon Resource Name (ARN) of the Auto Scaling group.
 	AutoScalingGroupName *string `min:"1" type:"string"`
 
@@ -3511,8 +3513,6 @@ type ExecutePolicyInput struct {
 
 	// The name or ARN of the policy.
 	PolicyName *string `min:"1" type:"string" required:"true"`
-
-	_ struct{} `type:"structure"`
 }
 
 // String returns the string representation
@@ -3540,13 +3540,13 @@ func (s ExecutePolicyOutput) GoString() string {
 }
 
 type ExitStandbyInput struct {
+	_ struct{} `type:"structure"`
+
 	// The name of the Auto Scaling group.
 	AutoScalingGroupName *string `min:"1" type:"string" required:"true"`
 
 	// One or more instance IDs. You must specify at least one instance ID.
 	InstanceIds []*string `type:"list"`
-
-	_ struct{} `type:"structure"`
 }
 
 // String returns the string representation
@@ -3560,10 +3560,10 @@ func (s ExitStandbyInput) GoString() string {
 }
 
 type ExitStandbyOutput struct {
+	_ struct{} `type:"structure"`
+
 	// The activities related to moving instances out of Standby mode.
 	Activities []*Activity `type:"list"`
-
-	_ struct{} `type:"structure"`
 }
 
 // String returns the string representation
@@ -3578,14 +3578,14 @@ func (s ExitStandbyOutput) GoString() string {
 
 // Describes a filter.
 type Filter struct {
+	_ struct{} `type:"structure"`
+
 	// The name of the filter. The valid values are: "auto-scaling-group", "key",
 	// "value", and "propagate-at-launch".
 	Name *string `type:"string"`
 
 	// The value of the filter.
 	Values []*string `type:"list"`
-
-	_ struct{} `type:"structure"`
 }
 
 // String returns the string representation
@@ -3600,6 +3600,8 @@ func (s Filter) GoString() string {
 
 // Describes an Auto Scaling group.
 type Group struct {
+	_ struct{} `type:"structure"`
+
 	// The Amazon Resource Name (ARN) of the group.
 	AutoScalingGroupARN *string `min:"1" type:"string"`
 
@@ -3667,8 +3669,6 @@ type Group struct {
 	// If you specify VPCZoneIdentifier and AvailabilityZones, ensure that the
 	// Availability Zones of the subnets match the values for AvailabilityZones.
 	VPCZoneIdentifier *string `min:"1" type:"string"`
-
-	_ struct{} `type:"structure"`
 }
 
 // String returns the string representation
@@ -3683,6 +3683,8 @@ func (s Group) GoString() string {
 
 // Describes an EC2 instance.
 type Instance struct {
+	_ struct{} `type:"structure"`
+
 	// The Availability Zone in which the instance is running.
 	AvailabilityZone *string `min:"1" type:"string" required:"true"`
 
@@ -3698,8 +3700,6 @@ type Instance struct {
 	// A description of the current lifecycle state. Note that the Quarantined state
 	// is not used.
 	LifecycleState *string `type:"string" required:"true" enum:"LifecycleState"`
-
-	_ struct{} `type:"structure"`
 }
 
 // String returns the string representation
@@ -3714,6 +3714,8 @@ func (s Instance) GoString() string {
 
 // Describes an EC2 instance associated with an Auto Scaling group.
 type InstanceDetails struct {
+	_ struct{} `type:"structure"`
+
 	// The name of the Auto Scaling group associated with the instance.
 	AutoScalingGroupName *string `min:"1" type:"string" required:"true"`
 
@@ -3735,8 +3737,6 @@ type InstanceDetails struct {
 	// Instance States (http://docs.aws.amazon.com/AutoScaling/latest/DeveloperGuide/AutoScalingGroupLifecycle.html#AutoScalingStates)
 	// in the Auto Scaling Developer Guide.
 	LifecycleState *string `min:"1" type:"string" required:"true"`
-
-	_ struct{} `type:"structure"`
 }
 
 // String returns the string representation
@@ -3751,10 +3751,10 @@ func (s InstanceDetails) GoString() string {
 
 // Describes whether instance monitoring is enabled.
 type InstanceMonitoring struct {
+	_ struct{} `type:"structure"`
+
 	// If True, instance monitoring is enabled.
 	Enabled *bool `type:"boolean"`
-
-	_ struct{} `type:"structure"`
 }
 
 // String returns the string representation
@@ -3769,6 +3769,8 @@ func (s InstanceMonitoring) GoString() string {
 
 // Describes a launch configuration.
 type LaunchConfiguration struct {
+	_ struct{} `type:"structure"`
+
 	// [EC2-VPC] Indicates whether to assign a public IP address to each instance.
 	AssociatePublicIpAddress *bool `type:"boolean"`
 
@@ -3834,8 +3836,6 @@ type LaunchConfiguration struct {
 
 	// The user data available to the instances.
 	UserData *string `type:"string"`
-
-	_ struct{} `type:"structure"`
 }
 
 // String returns the string representation
@@ -3858,6 +3858,8 @@ func (s LaunchConfiguration) GoString() string {
 // and Auto Scaling Terminating State (http://docs.aws.amazon.com/AutoScaling/latest/DeveloperGuide/AutoScalingTerminatingState.html)
 // in the Auto Scaling Developer Guide.
 type LifecycleHook struct {
+	_ struct{} `type:"structure"`
+
 	// The name of the Auto Scaling group for the lifecycle hook.
 	AutoScalingGroupName *string `min:"1" type:"string"`
 
@@ -3899,8 +3901,6 @@ type LifecycleHook struct {
 	// The ARN of the IAM role that allows the Auto Scaling group to publish to
 	// the specified notification target.
 	RoleARN *string `min:"1" type:"string"`
-
-	_ struct{} `type:"structure"`
 }
 
 // String returns the string representation
@@ -3915,6 +3915,8 @@ func (s LifecycleHook) GoString() string {
 
 // Describes the state of a load balancer.
 type LoadBalancerState struct {
+	_ struct{} `type:"structure"`
+
 	// The name of the load balancer.
 	LoadBalancerName *string `min:"1" type:"string"`
 
@@ -3931,8 +3933,6 @@ type LoadBalancerState struct {
 	// If connection draining is enabled, Elastic Load Balancing waits for in-flight
 	// requests to complete before deregistering the instances.
 	State *string `min:"1" type:"string"`
-
-	_ struct{} `type:"structure"`
 }
 
 // String returns the string representation
@@ -3947,6 +3947,8 @@ func (s LoadBalancerState) GoString() string {
 
 // Describes a metric.
 type MetricCollectionType struct {
+	_ struct{} `type:"structure"`
+
 	// One of the following metrics:
 	//
 	//  GroupMinSize
@@ -3965,8 +3967,6 @@ type MetricCollectionType struct {
 	//
 	// GroupTotalInstances
 	Metric *string `min:"1" type:"string"`
-
-	_ struct{} `type:"structure"`
 }
 
 // String returns the string representation
@@ -3981,10 +3981,10 @@ func (s MetricCollectionType) GoString() string {
 
 // Describes a granularity of a metric.
 type MetricGranularityType struct {
+	_ struct{} `type:"structure"`
+
 	// The granularity. The only valid value is 1Minute.
 	Granularity *string `min:"1" type:"string"`
-
-	_ struct{} `type:"structure"`
 }
 
 // String returns the string representation
@@ -3999,6 +3999,8 @@ func (s MetricGranularityType) GoString() string {
 
 // Describes a notification.
 type NotificationConfiguration struct {
+	_ struct{} `type:"structure"`
+
 	// The name of the group.
 	AutoScalingGroupName *string `min:"1" type:"string"`
 
@@ -4018,8 +4020,6 @@ type NotificationConfiguration struct {
 	// The Amazon Resource Name (ARN) of the Amazon Simple Notification Service
 	// (SNS) topic.
 	TopicARN *string `min:"1" type:"string"`
-
-	_ struct{} `type:"structure"`
 }
 
 // String returns the string representation
@@ -4037,6 +4037,8 @@ func (s NotificationConfiguration) GoString() string {
 // For more information, see Auto Scaling Processes (http://docs.aws.amazon.com/AutoScaling/latest/DeveloperGuide/US_SuspendResume.html#process-types)
 // in the Auto Scaling Developer Guide.
 type ProcessType struct {
+	_ struct{} `type:"structure"`
+
 	// One of the following processes:
 	//
 	//  Launch
@@ -4055,8 +4057,6 @@ type ProcessType struct {
 	//
 	// ScheduledActions
 	ProcessName *string `min:"1" type:"string" required:"true"`
-
-	_ struct{} `type:"structure"`
 }
 
 // String returns the string representation
@@ -4070,6 +4070,8 @@ func (s ProcessType) GoString() string {
 }
 
 type PutLifecycleHookInput struct {
+	_ struct{} `type:"structure"`
+
 	// The name of the Auto Scaling group to which you want to assign the lifecycle
 	// hook.
 	AutoScalingGroupName *string `min:"1" type:"string" required:"true"`
@@ -4128,8 +4130,6 @@ type PutLifecycleHookInput struct {
 	// This parameter is required for new lifecycle hooks, but optional when updating
 	// existing hooks.
 	RoleARN *string `min:"1" type:"string"`
-
-	_ struct{} `type:"structure"`
 }
 
 // String returns the string representation
@@ -4157,6 +4157,8 @@ func (s PutLifecycleHookOutput) GoString() string {
 }
 
 type PutNotificationConfigurationInput struct {
+	_ struct{} `type:"structure"`
+
 	// The name of the Auto Scaling group.
 	AutoScalingGroupName *string `min:"1" type:"string" required:"true"`
 
@@ -4167,8 +4169,6 @@ type PutNotificationConfigurationInput struct {
 	// The Amazon Resource Name (ARN) of the Amazon Simple Notification Service
 	// (SNS) topic.
 	TopicARN *string `min:"1" type:"string" required:"true"`
-
-	_ struct{} `type:"structure"`
 }
 
 // String returns the string representation
@@ -4196,6 +4196,8 @@ func (s PutNotificationConfigurationOutput) GoString() string {
 }
 
 type PutScalingPolicyInput struct {
+	_ struct{} `type:"structure"`
+
 	// The adjustment type. Valid values are ChangeInCapacity, ExactCapacity, and
 	// PercentChangeInCapacity.
 	//
@@ -4260,8 +4262,6 @@ type PutScalingPolicyInput struct {
 	// This parameter is required if the policy type is StepScaling and not supported
 	// otherwise.
 	StepAdjustments []*StepAdjustment `type:"list"`
-
-	_ struct{} `type:"structure"`
 }
 
 // String returns the string representation
@@ -4275,10 +4275,10 @@ func (s PutScalingPolicyInput) GoString() string {
 }
 
 type PutScalingPolicyOutput struct {
+	_ struct{} `type:"structure"`
+
 	// The Amazon Resource Name (ARN) of the policy.
 	PolicyARN *string `min:"1" type:"string"`
-
-	_ struct{} `type:"structure"`
 }
 
 // String returns the string representation
@@ -4292,6 +4292,8 @@ func (s PutScalingPolicyOutput) GoString() string {
 }
 
 type PutScheduledUpdateGroupActionInput struct {
+	_ struct{} `type:"structure"`
+
 	// The name or Amazon Resource Name (ARN) of the Auto Scaling group.
 	AutoScalingGroupName *string `min:"1" type:"string" required:"true"`
 
@@ -4333,8 +4335,6 @@ type PutScheduledUpdateGroupActionInput struct {
 	// The time for this action to start. If both Time and StartTime are specified,
 	// their values must be identical.
 	Time *time.Time `type:"timestamp" timestampFormat:"iso8601"`
-
-	_ struct{} `type:"structure"`
 }
 
 // String returns the string representation
@@ -4362,6 +4362,8 @@ func (s PutScheduledUpdateGroupActionOutput) GoString() string {
 }
 
 type RecordLifecycleActionHeartbeatInput struct {
+	_ struct{} `type:"structure"`
+
 	// The name of the Auto Scaling group for the hook.
 	AutoScalingGroupName *string `min:"1" type:"string" required:"true"`
 
@@ -4372,8 +4374,6 @@ type RecordLifecycleActionHeartbeatInput struct {
 
 	// The name of the lifecycle hook.
 	LifecycleHookName *string `min:"1" type:"string" required:"true"`
-
-	_ struct{} `type:"structure"`
 }
 
 // String returns the string representation
@@ -4416,6 +4416,8 @@ func (s ResumeProcessesOutput) GoString() string {
 
 // Describes a scaling policy.
 type ScalingPolicy struct {
+	_ struct{} `type:"structure"`
+
 	// The adjustment type, which specifies how ScalingAdjustment is interpreted.
 	// Valid values are ChangeInCapacity, ExactCapacity, and PercentChangeInCapacity.
 	AdjustmentType *string `min:"1" type:"string"`
@@ -4464,8 +4466,6 @@ type ScalingPolicy struct {
 	// A set of adjustments that enable you to scale based on the size of the alarm
 	// breach.
 	StepAdjustments []*StepAdjustment `type:"list"`
-
-	_ struct{} `type:"structure"`
 }
 
 // String returns the string representation
@@ -4479,6 +4479,8 @@ func (s ScalingPolicy) GoString() string {
 }
 
 type ScalingProcessQuery struct {
+	_ struct{} `type:"structure"`
+
 	// The name or Amazon Resource Name (ARN) of the Auto Scaling group.
 	AutoScalingGroupName *string `min:"1" type:"string" required:"true"`
 
@@ -4500,8 +4502,6 @@ type ScalingProcessQuery struct {
 	//
 	// AddToLoadBalancer
 	ScalingProcesses []*string `type:"list"`
-
-	_ struct{} `type:"structure"`
 }
 
 // String returns the string representation
@@ -4516,6 +4516,8 @@ func (s ScalingProcessQuery) GoString() string {
 
 // Describes a scheduled update to an Auto Scaling group.
 type ScheduledUpdateGroupAction struct {
+	_ struct{} `type:"structure"`
+
 	// The name of the group.
 	AutoScalingGroupName *string `min:"1" type:"string"`
 
@@ -4550,8 +4552,6 @@ type ScheduledUpdateGroupAction struct {
 
 	// This parameter is deprecated; use StartTime instead.
 	Time *time.Time `type:"timestamp" timestampFormat:"iso8601"`
-
-	_ struct{} `type:"structure"`
 }
 
 // String returns the string representation
@@ -4565,6 +4565,8 @@ func (s ScheduledUpdateGroupAction) GoString() string {
 }
 
 type SetDesiredCapacityInput struct {
+	_ struct{} `type:"structure"`
+
 	// The name of the Auto Scaling group.
 	AutoScalingGroupName *string `min:"1" type:"string" required:"true"`
 
@@ -4576,8 +4578,6 @@ type SetDesiredCapacityInput struct {
 	// cool-down period associated with the Auto Scaling group to complete before
 	// initiating a scaling activity to set your Auto Scaling group to its new capacity.
 	HonorCooldown *bool `type:"boolean"`
-
-	_ struct{} `type:"structure"`
 }
 
 // String returns the string representation
@@ -4605,6 +4605,8 @@ func (s SetDesiredCapacityOutput) GoString() string {
 }
 
 type SetInstanceHealthInput struct {
+	_ struct{} `type:"structure"`
+
 	// The health status of the instance. Set to Healthy if you want the instance
 	// to remain in service. Set to Unhealthy if you want the instance to be out
 	// of service. Auto Scaling will terminate and replace the unhealthy instance.
@@ -4621,8 +4623,6 @@ type SetInstanceHealthInput struct {
 	// For more information, see the HealthCheckGracePeriod parameter description
 	// for CreateAutoScalingGroup.
 	ShouldRespectGracePeriod *bool `type:"boolean"`
-
-	_ struct{} `type:"structure"`
 }
 
 // String returns the string representation
@@ -4678,6 +4678,8 @@ func (s SetInstanceHealthOutput) GoString() string {
 //
 //   The upper and lower bound can't be null in the same step adjustment.
 type StepAdjustment struct {
+	_ struct{} `type:"structure"`
+
 	// The lower bound for the difference between the alarm threshold and the CloudWatch
 	// metric. If the metric value is above the breach threshold, the lower bound
 	// is inclusive (the metric must be greater than or equal to the threshold plus
@@ -4699,8 +4701,6 @@ type StepAdjustment struct {
 	// value adds to the current capacity while a negative number removes from the
 	// current capacity.
 	ScalingAdjustment *int64 `type:"integer" required:"true"`
-
-	_ struct{} `type:"structure"`
 }
 
 // String returns the string representation
@@ -4730,13 +4730,13 @@ func (s SuspendProcessesOutput) GoString() string {
 // Describes an Auto Scaling process that has been suspended. For more information,
 // see ProcessType.
 type SuspendedProcess struct {
+	_ struct{} `type:"structure"`
+
 	// The name of the suspended process.
 	ProcessName *string `min:"1" type:"string"`
 
 	// The reason that the process was suspended.
 	SuspensionReason *string `min:"1" type:"string"`
-
-	_ struct{} `type:"structure"`
 }
 
 // String returns the string representation
@@ -4751,6 +4751,8 @@ func (s SuspendedProcess) GoString() string {
 
 // Describes a tag for an Auto Scaling group.
 type Tag struct {
+	_ struct{} `type:"structure"`
+
 	// The tag key.
 	Key *string `min:"1" type:"string" required:"true"`
 
@@ -4766,8 +4768,6 @@ type Tag struct {
 
 	// The tag value.
 	Value *string `type:"string"`
-
-	_ struct{} `type:"structure"`
 }
 
 // String returns the string representation
@@ -4782,6 +4782,8 @@ func (s Tag) GoString() string {
 
 // Describes a tag for an Auto Scaling group.
 type TagDescription struct {
+	_ struct{} `type:"structure"`
+
 	// The tag key.
 	Key *string `min:"1" type:"string"`
 
@@ -4797,8 +4799,6 @@ type TagDescription struct {
 
 	// The tag value.
 	Value *string `type:"string"`
-
-	_ struct{} `type:"structure"`
 }
 
 // String returns the string representation
@@ -4812,14 +4812,14 @@ func (s TagDescription) GoString() string {
 }
 
 type TerminateInstanceInAutoScalingGroupInput struct {
+	_ struct{} `type:"structure"`
+
 	// The ID of the EC2 instance.
 	InstanceId *string `min:"1" type:"string" required:"true"`
 
 	// If true, terminating the instance also decrements the size of the Auto Scaling
 	// group.
 	ShouldDecrementDesiredCapacity *bool `type:"boolean" required:"true"`
-
-	_ struct{} `type:"structure"`
 }
 
 // String returns the string representation
@@ -4833,10 +4833,10 @@ func (s TerminateInstanceInAutoScalingGroupInput) GoString() string {
 }
 
 type TerminateInstanceInAutoScalingGroupOutput struct {
+	_ struct{} `type:"structure"`
+
 	// A scaling activity.
 	Activity *Activity `type:"structure"`
-
-	_ struct{} `type:"structure"`
 }
 
 // String returns the string representation
@@ -4850,6 +4850,8 @@ func (s TerminateInstanceInAutoScalingGroupOutput) GoString() string {
 }
 
 type UpdateAutoScalingGroupInput struct {
+	_ struct{} `type:"structure"`
+
 	// The name of the Auto Scaling group.
 	AutoScalingGroupName *string `min:"1" type:"string" required:"true"`
 
@@ -4912,8 +4914,6 @@ type UpdateAutoScalingGroupInput struct {
 	// (http://docs.aws.amazon.com/AutoScaling/latest/DeveloperGuide/autoscalingsubnets.html)
 	// in the Auto Scaling Developer Guide.
 	VPCZoneIdentifier *string `min:"1" type:"string"`
-
-	_ struct{} `type:"structure"`
 }
 
 // String returns the string representation

--- a/service/cloudformation/api.go
+++ b/service/cloudformation/api.go
@@ -634,11 +634,7 @@ type AccountLimit struct {
 	// The value that is associated with the account limit name.
 	Value *int64 `type:"integer"`
 
-	metadataAccountLimit `json:"-" xml:"-"`
-}
-
-type metadataAccountLimit struct {
-	SDKShapeTraits bool `type:"structure"`
+	_ struct{} `type:"structure"`
 }
 
 // String returns the string representation
@@ -656,11 +652,7 @@ type CancelUpdateStackInput struct {
 	// The name or the unique stack ID that is associated with the stack.
 	StackName *string `type:"string" required:"true"`
 
-	metadataCancelUpdateStackInput `json:"-" xml:"-"`
-}
-
-type metadataCancelUpdateStackInput struct {
-	SDKShapeTraits bool `type:"structure"`
+	_ struct{} `type:"structure"`
 }
 
 // String returns the string representation
@@ -674,11 +666,7 @@ func (s CancelUpdateStackInput) GoString() string {
 }
 
 type CancelUpdateStackOutput struct {
-	metadataCancelUpdateStackOutput `json:"-" xml:"-"`
-}
-
-type metadataCancelUpdateStackOutput struct {
-	SDKShapeTraits bool `type:"structure"`
+	_ struct{} `type:"structure"`
 }
 
 // String returns the string representation
@@ -796,11 +784,7 @@ type CreateStackInput struct {
 	// back.
 	TimeoutInMinutes *int64 `min:"1" type:"integer"`
 
-	metadataCreateStackInput `json:"-" xml:"-"`
-}
-
-type metadataCreateStackInput struct {
-	SDKShapeTraits bool `type:"structure"`
+	_ struct{} `type:"structure"`
 }
 
 // String returns the string representation
@@ -818,11 +802,7 @@ type CreateStackOutput struct {
 	// Unique identifier of the stack.
 	StackId *string `type:"string"`
 
-	metadataCreateStackOutput `json:"-" xml:"-"`
-}
-
-type metadataCreateStackOutput struct {
-	SDKShapeTraits bool `type:"structure"`
+	_ struct{} `type:"structure"`
 }
 
 // String returns the string representation
@@ -840,11 +820,7 @@ type DeleteStackInput struct {
 	// The name or the unique stack ID that is associated with the stack.
 	StackName *string `type:"string" required:"true"`
 
-	metadataDeleteStackInput `json:"-" xml:"-"`
-}
-
-type metadataDeleteStackInput struct {
-	SDKShapeTraits bool `type:"structure"`
+	_ struct{} `type:"structure"`
 }
 
 // String returns the string representation
@@ -858,11 +834,7 @@ func (s DeleteStackInput) GoString() string {
 }
 
 type DeleteStackOutput struct {
-	metadataDeleteStackOutput `json:"-" xml:"-"`
-}
-
-type metadataDeleteStackOutput struct {
-	SDKShapeTraits bool `type:"structure"`
+	_ struct{} `type:"structure"`
 }
 
 // String returns the string representation
@@ -880,11 +852,7 @@ type DescribeAccountLimitsInput struct {
 	// A string that identifies the next page of limits that you want to retrieve.
 	NextToken *string `min:"1" type:"string"`
 
-	metadataDescribeAccountLimitsInput `json:"-" xml:"-"`
-}
-
-type metadataDescribeAccountLimitsInput struct {
-	SDKShapeTraits bool `type:"structure"`
+	_ struct{} `type:"structure"`
 }
 
 // String returns the string representation
@@ -907,11 +875,7 @@ type DescribeAccountLimitsOutput struct {
 	// this value is null.
 	NextToken *string `min:"1" type:"string"`
 
-	metadataDescribeAccountLimitsOutput `json:"-" xml:"-"`
-}
-
-type metadataDescribeAccountLimitsOutput struct {
-	SDKShapeTraits bool `type:"structure"`
+	_ struct{} `type:"structure"`
 }
 
 // String returns the string representation
@@ -940,11 +904,7 @@ type DescribeStackEventsInput struct {
 	// is no default value.
 	StackName *string `type:"string"`
 
-	metadataDescribeStackEventsInput `json:"-" xml:"-"`
-}
-
-type metadataDescribeStackEventsInput struct {
-	SDKShapeTraits bool `type:"structure"`
+	_ struct{} `type:"structure"`
 }
 
 // String returns the string representation
@@ -966,11 +926,7 @@ type DescribeStackEventsOutput struct {
 	// A list of StackEvents structures.
 	StackEvents []*StackEvent `type:"list"`
 
-	metadataDescribeStackEventsOutput `json:"-" xml:"-"`
-}
-
-type metadataDescribeStackEventsOutput struct {
-	SDKShapeTraits bool `type:"structure"`
+	_ struct{} `type:"structure"`
 }
 
 // String returns the string representation
@@ -998,11 +954,7 @@ type DescribeStackResourceInput struct {
 	// is no default value.
 	StackName *string `type:"string" required:"true"`
 
-	metadataDescribeStackResourceInput `json:"-" xml:"-"`
-}
-
-type metadataDescribeStackResourceInput struct {
-	SDKShapeTraits bool `type:"structure"`
+	_ struct{} `type:"structure"`
 }
 
 // String returns the string representation
@@ -1021,11 +973,7 @@ type DescribeStackResourceOutput struct {
 	// resource in the specified stack.
 	StackResourceDetail *StackResourceDetail `type:"structure"`
 
-	metadataDescribeStackResourceOutput `json:"-" xml:"-"`
-}
-
-type metadataDescribeStackResourceOutput struct {
-	SDKShapeTraits bool `type:"structure"`
+	_ struct{} `type:"structure"`
 }
 
 // String returns the string representation
@@ -1070,11 +1018,7 @@ type DescribeStackResourcesInput struct {
 	// PhysicalResourceId.
 	StackName *string `type:"string"`
 
-	metadataDescribeStackResourcesInput `json:"-" xml:"-"`
-}
-
-type metadataDescribeStackResourcesInput struct {
-	SDKShapeTraits bool `type:"structure"`
+	_ struct{} `type:"structure"`
 }
 
 // String returns the string representation
@@ -1092,11 +1036,7 @@ type DescribeStackResourcesOutput struct {
 	// A list of StackResource structures.
 	StackResources []*StackResource `type:"list"`
 
-	metadataDescribeStackResourcesOutput `json:"-" xml:"-"`
-}
-
-type metadataDescribeStackResourcesOutput struct {
-	SDKShapeTraits bool `type:"structure"`
+	_ struct{} `type:"structure"`
 }
 
 // String returns the string representation
@@ -1123,11 +1063,7 @@ type DescribeStacksInput struct {
 	// is no default value.
 	StackName *string `type:"string"`
 
-	metadataDescribeStacksInput `json:"-" xml:"-"`
-}
-
-type metadataDescribeStacksInput struct {
-	SDKShapeTraits bool `type:"structure"`
+	_ struct{} `type:"structure"`
 }
 
 // String returns the string representation
@@ -1149,11 +1085,7 @@ type DescribeStacksOutput struct {
 	// A list of stack structures.
 	Stacks []*Stack `type:"list"`
 
-	metadataDescribeStacksOutput `json:"-" xml:"-"`
-}
-
-type metadataDescribeStacksOutput struct {
-	SDKShapeTraits bool `type:"structure"`
+	_ struct{} `type:"structure"`
 }
 
 // String returns the string representation
@@ -1188,11 +1120,7 @@ type EstimateTemplateCostInput struct {
 	// only TemplateBody is used.
 	TemplateURL *string `min:"1" type:"string"`
 
-	metadataEstimateTemplateCostInput `json:"-" xml:"-"`
-}
-
-type metadataEstimateTemplateCostInput struct {
-	SDKShapeTraits bool `type:"structure"`
+	_ struct{} `type:"structure"`
 }
 
 // String returns the string representation
@@ -1211,11 +1139,7 @@ type EstimateTemplateCostOutput struct {
 	// resources required to run the template.
 	Url *string `type:"string"`
 
-	metadataEstimateTemplateCostOutput `json:"-" xml:"-"`
-}
-
-type metadataEstimateTemplateCostOutput struct {
-	SDKShapeTraits bool `type:"structure"`
+	_ struct{} `type:"structure"`
 }
 
 // String returns the string representation
@@ -1234,11 +1158,7 @@ type GetStackPolicyInput struct {
 	// you want to get.
 	StackName *string `type:"string" required:"true"`
 
-	metadataGetStackPolicyInput `json:"-" xml:"-"`
-}
-
-type metadataGetStackPolicyInput struct {
-	SDKShapeTraits bool `type:"structure"`
+	_ struct{} `type:"structure"`
 }
 
 // String returns the string representation
@@ -1258,11 +1178,7 @@ type GetStackPolicyOutput struct {
 	// in the AWS CloudFormation User Guide.)
 	StackPolicyBody *string `min:"1" type:"string"`
 
-	metadataGetStackPolicyOutput `json:"-" xml:"-"`
-}
-
-type metadataGetStackPolicyOutput struct {
-	SDKShapeTraits bool `type:"structure"`
+	_ struct{} `type:"structure"`
 }
 
 // String returns the string representation
@@ -1285,11 +1201,7 @@ type GetTemplateInput struct {
 	// is no default value.
 	StackName *string `type:"string" required:"true"`
 
-	metadataGetTemplateInput `json:"-" xml:"-"`
-}
-
-type metadataGetTemplateInput struct {
-	SDKShapeTraits bool `type:"structure"`
+	_ struct{} `type:"structure"`
 }
 
 // String returns the string representation
@@ -1309,11 +1221,7 @@ type GetTemplateOutput struct {
 	// in the AWS CloudFormation User Guide.)
 	TemplateBody *string `min:"1" type:"string"`
 
-	metadataGetTemplateOutput `json:"-" xml:"-"`
-}
-
-type metadataGetTemplateOutput struct {
-	SDKShapeTraits bool `type:"structure"`
+	_ struct{} `type:"structure"`
 }
 
 // String returns the string representation
@@ -1355,11 +1263,7 @@ type GetTemplateSummaryInput struct {
 	// TemplateBody, or TemplateURL.
 	TemplateURL *string `min:"1" type:"string"`
 
-	metadataGetTemplateSummaryInput `json:"-" xml:"-"`
-}
-
-type metadataGetTemplateSummaryInput struct {
-	SDKShapeTraits bool `type:"structure"`
+	_ struct{} `type:"structure"`
 }
 
 // String returns the string representation
@@ -1408,11 +1312,7 @@ type GetTemplateSummaryOutput struct {
 	// template.
 	Version *string `type:"string"`
 
-	metadataGetTemplateSummaryOutput `json:"-" xml:"-"`
-}
-
-type metadataGetTemplateSummaryOutput struct {
-	SDKShapeTraits bool `type:"structure"`
+	_ struct{} `type:"structure"`
 }
 
 // String returns the string representation
@@ -1441,11 +1341,7 @@ type ListStackResourcesInput struct {
 	// is no default value.
 	StackName *string `type:"string" required:"true"`
 
-	metadataListStackResourcesInput `json:"-" xml:"-"`
-}
-
-type metadataListStackResourcesInput struct {
-	SDKShapeTraits bool `type:"structure"`
+	_ struct{} `type:"structure"`
 }
 
 // String returns the string representation
@@ -1467,11 +1363,7 @@ type ListStackResourcesOutput struct {
 	// A list of StackResourceSummary structures.
 	StackResourceSummaries []*StackResourceSummary `type:"list"`
 
-	metadataListStackResourcesOutput `json:"-" xml:"-"`
-}
-
-type metadataListStackResourcesOutput struct {
-	SDKShapeTraits bool `type:"structure"`
+	_ struct{} `type:"structure"`
 }
 
 // String returns the string representation
@@ -1497,11 +1389,7 @@ type ListStacksInput struct {
 	// stack status codes, see the StackStatus parameter of the Stack data type.
 	StackStatusFilter []*string `type:"list"`
 
-	metadataListStacksInput `json:"-" xml:"-"`
-}
-
-type metadataListStacksInput struct {
-	SDKShapeTraits bool `type:"structure"`
+	_ struct{} `type:"structure"`
 }
 
 // String returns the string representation
@@ -1524,11 +1412,7 @@ type ListStacksOutput struct {
 	// stacks.
 	StackSummaries []*StackSummary `type:"list"`
 
-	metadataListStacksOutput `json:"-" xml:"-"`
-}
-
-type metadataListStacksOutput struct {
-	SDKShapeTraits bool `type:"structure"`
+	_ struct{} `type:"structure"`
 }
 
 // String returns the string representation
@@ -1552,11 +1436,7 @@ type Output struct {
 	// The value associated with the output.
 	OutputValue *string `type:"string"`
 
-	metadataOutput `json:"-" xml:"-"`
-}
-
-type metadataOutput struct {
-	SDKShapeTraits bool `type:"structure"`
+	_ struct{} `type:"structure"`
 }
 
 // String returns the string representation
@@ -1584,11 +1464,7 @@ type Parameter struct {
 	// value.
 	UsePreviousValue *bool `type:"boolean"`
 
-	metadataParameter `json:"-" xml:"-"`
-}
-
-type metadataParameter struct {
-	SDKShapeTraits bool `type:"structure"`
+	_ struct{} `type:"structure"`
 }
 
 // String returns the string representation
@@ -1608,11 +1484,7 @@ type ParameterConstraints struct {
 	// A list of values that are permitted for a parameter.
 	AllowedValues []*string `type:"list"`
 
-	metadataParameterConstraints `json:"-" xml:"-"`
-}
-
-type metadataParameterConstraints struct {
-	SDKShapeTraits bool `type:"structure"`
+	_ struct{} `type:"structure"`
 }
 
 // String returns the string representation
@@ -1646,11 +1518,7 @@ type ParameterDeclaration struct {
 	// The type of parameter.
 	ParameterType *string `type:"string"`
 
-	metadataParameterDeclaration `json:"-" xml:"-"`
-}
-
-type metadataParameterDeclaration struct {
-	SDKShapeTraits bool `type:"structure"`
+	_ struct{} `type:"structure"`
 }
 
 // String returns the string representation
@@ -1680,11 +1548,7 @@ type SetStackPolicyInput struct {
 	// but not both.
 	StackPolicyURL *string `min:"1" type:"string"`
 
-	metadataSetStackPolicyInput `json:"-" xml:"-"`
-}
-
-type metadataSetStackPolicyInput struct {
-	SDKShapeTraits bool `type:"structure"`
+	_ struct{} `type:"structure"`
 }
 
 // String returns the string representation
@@ -1698,11 +1562,7 @@ func (s SetStackPolicyInput) GoString() string {
 }
 
 type SetStackPolicyOutput struct {
-	metadataSetStackPolicyOutput `json:"-" xml:"-"`
-}
-
-type metadataSetStackPolicyOutput struct {
-	SDKShapeTraits bool `type:"structure"`
+	_ struct{} `type:"structure"`
 }
 
 // String returns the string representation
@@ -1735,11 +1595,7 @@ type SignalResourceInput struct {
 	// condition), each signal requires a different unique ID.
 	UniqueId *string `min:"1" type:"string" required:"true"`
 
-	metadataSignalResourceInput `json:"-" xml:"-"`
-}
-
-type metadataSignalResourceInput struct {
-	SDKShapeTraits bool `type:"structure"`
+	_ struct{} `type:"structure"`
 }
 
 // String returns the string representation
@@ -1753,11 +1609,7 @@ func (s SignalResourceInput) GoString() string {
 }
 
 type SignalResourceOutput struct {
-	metadataSignalResourceOutput `json:"-" xml:"-"`
-}
-
-type metadataSignalResourceOutput struct {
-	SDKShapeTraits bool `type:"structure"`
+	_ struct{} `type:"structure"`
 }
 
 // String returns the string representation
@@ -1817,11 +1669,7 @@ type Stack struct {
 	// The amount of time within which stack creation should complete.
 	TimeoutInMinutes *int64 `min:"1" type:"integer"`
 
-	metadataStack `json:"-" xml:"-"`
-}
-
-type metadataStack struct {
-	SDKShapeTraits bool `type:"structure"`
+	_ struct{} `type:"structure"`
 }
 
 // String returns the string representation
@@ -1869,11 +1717,7 @@ type StackEvent struct {
 	// Time the status was updated.
 	Timestamp *time.Time `type:"timestamp" timestampFormat:"iso8601" required:"true"`
 
-	metadataStackEvent `json:"-" xml:"-"`
-}
-
-type metadataStackEvent struct {
-	SDKShapeTraits bool `type:"structure"`
+	_ struct{} `type:"structure"`
 }
 
 // String returns the string representation
@@ -1918,11 +1762,7 @@ type StackResource struct {
 	// Time the status was updated.
 	Timestamp *time.Time `type:"timestamp" timestampFormat:"iso8601" required:"true"`
 
-	metadataStackResource `json:"-" xml:"-"`
-}
-
-type metadataStackResource struct {
-	SDKShapeTraits bool `type:"structure"`
+	_ struct{} `type:"structure"`
 }
 
 // String returns the string representation
@@ -1972,11 +1812,7 @@ type StackResourceDetail struct {
 	// The name associated with the stack.
 	StackName *string `type:"string"`
 
-	metadataStackResourceDetail `json:"-" xml:"-"`
-}
-
-type metadataStackResourceDetail struct {
-	SDKShapeTraits bool `type:"structure"`
+	_ struct{} `type:"structure"`
 }
 
 // String returns the string representation
@@ -2012,11 +1848,7 @@ type StackResourceSummary struct {
 	// in the AWS CloudFormation User Guide.)
 	ResourceType *string `type:"string" required:"true"`
 
-	metadataStackResourceSummary `json:"-" xml:"-"`
-}
-
-type metadataStackResourceSummary struct {
-	SDKShapeTraits bool `type:"structure"`
+	_ struct{} `type:"structure"`
 }
 
 // String returns the string representation
@@ -2056,11 +1888,7 @@ type StackSummary struct {
 	// The template description of the template used to create the stack.
 	TemplateDescription *string `type:"string"`
 
-	metadataStackSummary `json:"-" xml:"-"`
-}
-
-type metadataStackSummary struct {
-	SDKShapeTraits bool `type:"structure"`
+	_ struct{} `type:"structure"`
 }
 
 // String returns the string representation
@@ -2086,11 +1914,7 @@ type Tag struct {
 	// of 256 characters for a tag value.
 	Value *string `type:"string"`
 
-	metadataTag `json:"-" xml:"-"`
-}
-
-type metadataTag struct {
-	SDKShapeTraits bool `type:"structure"`
+	_ struct{} `type:"structure"`
 }
 
 // String returns the string representation
@@ -2118,11 +1942,7 @@ type TemplateParameter struct {
 	// The name associated with the parameter.
 	ParameterKey *string `type:"string"`
 
-	metadataTemplateParameter `json:"-" xml:"-"`
-}
-
-type metadataTemplateParameter struct {
-	SDKShapeTraits bool `type:"structure"`
+	_ struct{} `type:"structure"`
 }
 
 // String returns the string representation
@@ -2235,11 +2055,7 @@ type UpdateStackInput struct {
 	// updating.
 	UsePreviousTemplate *bool `type:"boolean"`
 
-	metadataUpdateStackInput `json:"-" xml:"-"`
-}
-
-type metadataUpdateStackInput struct {
-	SDKShapeTraits bool `type:"structure"`
+	_ struct{} `type:"structure"`
 }
 
 // String returns the string representation
@@ -2257,11 +2073,7 @@ type UpdateStackOutput struct {
 	// Unique identifier of the stack.
 	StackId *string `type:"string"`
 
-	metadataUpdateStackOutput `json:"-" xml:"-"`
-}
-
-type metadataUpdateStackOutput struct {
-	SDKShapeTraits bool `type:"structure"`
+	_ struct{} `type:"structure"`
 }
 
 // String returns the string representation
@@ -2294,11 +2106,7 @@ type ValidateTemplateInput struct {
 	// only TemplateBody is used.
 	TemplateURL *string `min:"1" type:"string"`
 
-	metadataValidateTemplateInput `json:"-" xml:"-"`
-}
-
-type metadataValidateTemplateInput struct {
-	SDKShapeTraits bool `type:"structure"`
+	_ struct{} `type:"structure"`
 }
 
 // String returns the string representation
@@ -2330,11 +2138,7 @@ type ValidateTemplateOutput struct {
 	// A list of TemplateParameter structures.
 	Parameters []*TemplateParameter `type:"list"`
 
-	metadataValidateTemplateOutput `json:"-" xml:"-"`
-}
-
-type metadataValidateTemplateOutput struct {
-	SDKShapeTraits bool `type:"structure"`
+	_ struct{} `type:"structure"`
 }
 
 // String returns the string representation

--- a/service/cloudformation/api.go
+++ b/service/cloudformation/api.go
@@ -628,13 +628,13 @@ func (c *CloudFormation) ValidateTemplate(input *ValidateTemplateInput) (*Valida
 
 // The AccountLimit data type.
 type AccountLimit struct {
+	_ struct{} `type:"structure"`
+
 	// The name of the account limit. Currently, the only account limit is StackLimit.
 	Name *string `type:"string"`
 
 	// The value that is associated with the account limit name.
 	Value *int64 `type:"integer"`
-
-	_ struct{} `type:"structure"`
 }
 
 // String returns the string representation
@@ -649,10 +649,10 @@ func (s AccountLimit) GoString() string {
 
 // The input for the CancelUpdateStack action.
 type CancelUpdateStackInput struct {
+	_ struct{} `type:"structure"`
+
 	// The name or the unique stack ID that is associated with the stack.
 	StackName *string `type:"string" required:"true"`
-
-	_ struct{} `type:"structure"`
 }
 
 // String returns the string representation
@@ -681,6 +681,8 @@ func (s CancelUpdateStackOutput) GoString() string {
 
 // The input for CreateStack action.
 type CreateStackInput struct {
+	_ struct{} `type:"structure"`
+
 	// A list of capabilities that you must specify before AWS CloudFormation can
 	// create or update certain stacks. Some stack templates might include resources
 	// that can affect permissions in your AWS account. For those stacks, you must
@@ -783,8 +785,6 @@ type CreateStackInput struct {
 	// if DisableRollback is not set or is set to false, the stack will be rolled
 	// back.
 	TimeoutInMinutes *int64 `min:"1" type:"integer"`
-
-	_ struct{} `type:"structure"`
 }
 
 // String returns the string representation
@@ -799,10 +799,10 @@ func (s CreateStackInput) GoString() string {
 
 // The output for a CreateStack action.
 type CreateStackOutput struct {
+	_ struct{} `type:"structure"`
+
 	// Unique identifier of the stack.
 	StackId *string `type:"string"`
-
-	_ struct{} `type:"structure"`
 }
 
 // String returns the string representation
@@ -817,10 +817,10 @@ func (s CreateStackOutput) GoString() string {
 
 // The input for DeleteStack action.
 type DeleteStackInput struct {
+	_ struct{} `type:"structure"`
+
 	// The name or the unique stack ID that is associated with the stack.
 	StackName *string `type:"string" required:"true"`
-
-	_ struct{} `type:"structure"`
 }
 
 // String returns the string representation
@@ -849,10 +849,10 @@ func (s DeleteStackOutput) GoString() string {
 
 // The input for the DescribeAccountLimits action.
 type DescribeAccountLimitsInput struct {
+	_ struct{} `type:"structure"`
+
 	// A string that identifies the next page of limits that you want to retrieve.
 	NextToken *string `min:"1" type:"string"`
-
-	_ struct{} `type:"structure"`
 }
 
 // String returns the string representation
@@ -867,6 +867,8 @@ func (s DescribeAccountLimitsInput) GoString() string {
 
 // The output for the DescribeAccountLimits action.
 type DescribeAccountLimitsOutput struct {
+	_ struct{} `type:"structure"`
+
 	// An account limit structure that contain a list of AWS CloudFormation account
 	// limits and their values.
 	AccountLimits []*AccountLimit `type:"list"`
@@ -874,8 +876,6 @@ type DescribeAccountLimitsOutput struct {
 	// A string that identifies the next page of limits. If no additional page exists,
 	// this value is null.
 	NextToken *string `min:"1" type:"string"`
-
-	_ struct{} `type:"structure"`
 }
 
 // String returns the string representation
@@ -890,6 +890,8 @@ func (s DescribeAccountLimitsOutput) GoString() string {
 
 // The input for DescribeStackEvents action.
 type DescribeStackEventsInput struct {
+	_ struct{} `type:"structure"`
+
 	// String that identifies the start of the next list of events, if there is
 	// one.
 	//
@@ -903,8 +905,6 @@ type DescribeStackEventsInput struct {
 	// ID. Deleted stacks: You must specify the unique stack ID.  Default: There
 	// is no default value.
 	StackName *string `type:"string"`
-
-	_ struct{} `type:"structure"`
 }
 
 // String returns the string representation
@@ -919,14 +919,14 @@ func (s DescribeStackEventsInput) GoString() string {
 
 // The output for a DescribeStackEvents action.
 type DescribeStackEventsOutput struct {
+	_ struct{} `type:"structure"`
+
 	// String that identifies the start of the next list of events, if there is
 	// one.
 	NextToken *string `min:"1" type:"string"`
 
 	// A list of StackEvents structures.
 	StackEvents []*StackEvent `type:"list"`
-
-	_ struct{} `type:"structure"`
 }
 
 // String returns the string representation
@@ -941,6 +941,8 @@ func (s DescribeStackEventsOutput) GoString() string {
 
 // The input for DescribeStackResource action.
 type DescribeStackResourceInput struct {
+	_ struct{} `type:"structure"`
+
 	// The logical name of the resource as specified in the template.
 	//
 	// Default: There is no default value.
@@ -953,8 +955,6 @@ type DescribeStackResourceInput struct {
 	// ID. Deleted stacks: You must specify the unique stack ID.  Default: There
 	// is no default value.
 	StackName *string `type:"string" required:"true"`
-
-	_ struct{} `type:"structure"`
 }
 
 // String returns the string representation
@@ -969,11 +969,11 @@ func (s DescribeStackResourceInput) GoString() string {
 
 // The output for a DescribeStackResource action.
 type DescribeStackResourceOutput struct {
+	_ struct{} `type:"structure"`
+
 	// A StackResourceDetail structure containing the description of the specified
 	// resource in the specified stack.
 	StackResourceDetail *StackResourceDetail `type:"structure"`
-
-	_ struct{} `type:"structure"`
 }
 
 // String returns the string representation
@@ -988,6 +988,8 @@ func (s DescribeStackResourceOutput) GoString() string {
 
 // The input for DescribeStackResources action.
 type DescribeStackResourcesInput struct {
+	_ struct{} `type:"structure"`
+
 	// The logical name of the resource as specified in the template.
 	//
 	// Default: There is no default value.
@@ -1017,8 +1019,6 @@ type DescribeStackResourcesInput struct {
 	// Required: Conditional. If you do not specify StackName, you must specify
 	// PhysicalResourceId.
 	StackName *string `type:"string"`
-
-	_ struct{} `type:"structure"`
 }
 
 // String returns the string representation
@@ -1033,10 +1033,10 @@ func (s DescribeStackResourcesInput) GoString() string {
 
 // The output for a DescribeStackResources action.
 type DescribeStackResourcesOutput struct {
+	_ struct{} `type:"structure"`
+
 	// A list of StackResource structures.
 	StackResources []*StackResource `type:"list"`
-
-	_ struct{} `type:"structure"`
 }
 
 // String returns the string representation
@@ -1051,6 +1051,8 @@ func (s DescribeStackResourcesOutput) GoString() string {
 
 // The input for DescribeStacks action.
 type DescribeStacksInput struct {
+	_ struct{} `type:"structure"`
+
 	// String that identifies the start of the next list of stacks, if there is
 	// one.
 	NextToken *string `min:"1" type:"string"`
@@ -1062,8 +1064,6 @@ type DescribeStacksInput struct {
 	// ID. Deleted stacks: You must specify the unique stack ID.  Default: There
 	// is no default value.
 	StackName *string `type:"string"`
-
-	_ struct{} `type:"structure"`
 }
 
 // String returns the string representation
@@ -1078,14 +1078,14 @@ func (s DescribeStacksInput) GoString() string {
 
 // The output for a DescribeStacks action.
 type DescribeStacksOutput struct {
+	_ struct{} `type:"structure"`
+
 	// String that identifies the start of the next list of stacks, if there is
 	// one.
 	NextToken *string `min:"1" type:"string"`
 
 	// A list of stack structures.
 	Stacks []*Stack `type:"list"`
-
-	_ struct{} `type:"structure"`
 }
 
 // String returns the string representation
@@ -1099,6 +1099,8 @@ func (s DescribeStacksOutput) GoString() string {
 }
 
 type EstimateTemplateCostInput struct {
+	_ struct{} `type:"structure"`
+
 	// A list of Parameter structures that specify input parameters.
 	Parameters []*Parameter `type:"list"`
 
@@ -1119,8 +1121,6 @@ type EstimateTemplateCostInput struct {
 	// Conditional: You must pass TemplateURL or TemplateBody. If both are passed,
 	// only TemplateBody is used.
 	TemplateURL *string `min:"1" type:"string"`
-
-	_ struct{} `type:"structure"`
 }
 
 // String returns the string representation
@@ -1135,11 +1135,11 @@ func (s EstimateTemplateCostInput) GoString() string {
 
 // The output for a EstimateTemplateCost action.
 type EstimateTemplateCostOutput struct {
+	_ struct{} `type:"structure"`
+
 	// An AWS Simple Monthly Calculator URL with a query string that describes the
 	// resources required to run the template.
 	Url *string `type:"string"`
-
-	_ struct{} `type:"structure"`
 }
 
 // String returns the string representation
@@ -1154,11 +1154,11 @@ func (s EstimateTemplateCostOutput) GoString() string {
 
 // The input for the GetStackPolicy action.
 type GetStackPolicyInput struct {
+	_ struct{} `type:"structure"`
+
 	// The name or unique stack ID that is associated with the stack whose policy
 	// you want to get.
 	StackName *string `type:"string" required:"true"`
-
-	_ struct{} `type:"structure"`
 }
 
 // String returns the string representation
@@ -1173,12 +1173,12 @@ func (s GetStackPolicyInput) GoString() string {
 
 // The output for the GetStackPolicy action.
 type GetStackPolicyOutput struct {
+	_ struct{} `type:"structure"`
+
 	// Structure containing the stack policy body. (For more information, go to
 	//  Prevent Updates to Stack Resources (http://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/protect-stack-resources.html)
 	// in the AWS CloudFormation User Guide.)
 	StackPolicyBody *string `min:"1" type:"string"`
-
-	_ struct{} `type:"structure"`
 }
 
 // String returns the string representation
@@ -1193,6 +1193,8 @@ func (s GetStackPolicyOutput) GoString() string {
 
 // The input for a GetTemplate action.
 type GetTemplateInput struct {
+	_ struct{} `type:"structure"`
+
 	// The name or the unique stack ID that is associated with the stack, which
 	// are not always interchangeable:
 	//
@@ -1200,8 +1202,6 @@ type GetTemplateInput struct {
 	// ID. Deleted stacks: You must specify the unique stack ID.  Default: There
 	// is no default value.
 	StackName *string `type:"string" required:"true"`
-
-	_ struct{} `type:"structure"`
 }
 
 // String returns the string representation
@@ -1216,12 +1216,12 @@ func (s GetTemplateInput) GoString() string {
 
 // The output for GetTemplate action.
 type GetTemplateOutput struct {
+	_ struct{} `type:"structure"`
+
 	// Structure containing the template body. (For more information, go to Template
 	// Anatomy (http://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/template-anatomy.html)
 	// in the AWS CloudFormation User Guide.)
 	TemplateBody *string `min:"1" type:"string"`
-
-	_ struct{} `type:"structure"`
 }
 
 // String returns the string representation
@@ -1236,6 +1236,8 @@ func (s GetTemplateOutput) GoString() string {
 
 // The input for the GetTemplateSummary action.
 type GetTemplateSummaryInput struct {
+	_ struct{} `type:"structure"`
+
 	// The name or the stack ID that is associated with the stack, which are not
 	// always interchangeable. For running stacks, you can specify either the stack's
 	// name or its unique stack ID. For deleted stack, you must specify the unique
@@ -1262,8 +1264,6 @@ type GetTemplateSummaryInput struct {
 	// Conditional: You must specify only one of the following parameters: StackName,
 	// TemplateBody, or TemplateURL.
 	TemplateURL *string `min:"1" type:"string"`
-
-	_ struct{} `type:"structure"`
 }
 
 // String returns the string representation
@@ -1278,6 +1278,8 @@ func (s GetTemplateSummaryInput) GoString() string {
 
 // The output for the GetTemplateSummary action.
 type GetTemplateSummaryOutput struct {
+	_ struct{} `type:"structure"`
+
 	// The capabilities found within the template. Currently, AWS CloudFormation
 	// supports only the CAPABILITY_IAM capability. If your template contains IAM
 	// resources, you must specify the CAPABILITY_IAM value for this parameter when
@@ -1311,8 +1313,6 @@ type GetTemplateSummaryOutput struct {
 	// The AWS template format version, which identifies the capabilities of the
 	// template.
 	Version *string `type:"string"`
-
-	_ struct{} `type:"structure"`
 }
 
 // String returns the string representation
@@ -1327,6 +1327,8 @@ func (s GetTemplateSummaryOutput) GoString() string {
 
 // The input for the ListStackResource action.
 type ListStackResourcesInput struct {
+	_ struct{} `type:"structure"`
+
 	// String that identifies the start of the next list of stack resource summaries,
 	// if there is one.
 	//
@@ -1340,8 +1342,6 @@ type ListStackResourcesInput struct {
 	// ID. Deleted stacks: You must specify the unique stack ID.  Default: There
 	// is no default value.
 	StackName *string `type:"string" required:"true"`
-
-	_ struct{} `type:"structure"`
 }
 
 // String returns the string representation
@@ -1356,14 +1356,14 @@ func (s ListStackResourcesInput) GoString() string {
 
 // The output for a ListStackResources action.
 type ListStackResourcesOutput struct {
+	_ struct{} `type:"structure"`
+
 	// String that identifies the start of the next list of stack resources, if
 	// there is one.
 	NextToken *string `min:"1" type:"string"`
 
 	// A list of StackResourceSummary structures.
 	StackResourceSummaries []*StackResourceSummary `type:"list"`
-
-	_ struct{} `type:"structure"`
 }
 
 // String returns the string representation
@@ -1378,6 +1378,8 @@ func (s ListStackResourcesOutput) GoString() string {
 
 // The input for ListStacks action.
 type ListStacksInput struct {
+	_ struct{} `type:"structure"`
+
 	// String that identifies the start of the next list of stacks, if there is
 	// one.
 	//
@@ -1388,8 +1390,6 @@ type ListStacksInput struct {
 	// list only stacks with the specified status codes. For a complete list of
 	// stack status codes, see the StackStatus parameter of the Stack data type.
 	StackStatusFilter []*string `type:"list"`
-
-	_ struct{} `type:"structure"`
 }
 
 // String returns the string representation
@@ -1404,6 +1404,8 @@ func (s ListStacksInput) GoString() string {
 
 // The output for ListStacks action.
 type ListStacksOutput struct {
+	_ struct{} `type:"structure"`
+
 	// String that identifies the start of the next list of stacks, if there is
 	// one.
 	NextToken *string `min:"1" type:"string"`
@@ -1411,8 +1413,6 @@ type ListStacksOutput struct {
 	// A list of StackSummary structures containing information about the specified
 	// stacks.
 	StackSummaries []*StackSummary `type:"list"`
-
-	_ struct{} `type:"structure"`
 }
 
 // String returns the string representation
@@ -1427,6 +1427,8 @@ func (s ListStacksOutput) GoString() string {
 
 // The Output data type.
 type Output struct {
+	_ struct{} `type:"structure"`
+
 	// User defined description associated with the output.
 	Description *string `type:"string"`
 
@@ -1435,8 +1437,6 @@ type Output struct {
 
 	// The value associated with the output.
 	OutputValue *string `type:"string"`
-
-	_ struct{} `type:"structure"`
 }
 
 // String returns the string representation
@@ -1451,6 +1451,8 @@ func (s Output) GoString() string {
 
 // The Parameter data type.
 type Parameter struct {
+	_ struct{} `type:"structure"`
+
 	// The key associated with the parameter. If you don't specify a key and value
 	// for a particular parameter, AWS CloudFormation uses the default value that
 	// is specified in your template.
@@ -1463,8 +1465,6 @@ type Parameter struct {
 	// using for a given parameter key. If you specify true, do not specify a parameter
 	// value.
 	UsePreviousValue *bool `type:"boolean"`
-
-	_ struct{} `type:"structure"`
 }
 
 // String returns the string representation
@@ -1481,10 +1481,10 @@ func (s Parameter) GoString() string {
 // Although other constraints might be defined in the stack template, AWS CloudFormation
 // returns only the AllowedValues property.
 type ParameterConstraints struct {
+	_ struct{} `type:"structure"`
+
 	// A list of values that are permitted for a parameter.
 	AllowedValues []*string `type:"list"`
-
-	_ struct{} `type:"structure"`
 }
 
 // String returns the string representation
@@ -1499,6 +1499,8 @@ func (s ParameterConstraints) GoString() string {
 
 // The ParameterDeclaration data type.
 type ParameterDeclaration struct {
+	_ struct{} `type:"structure"`
+
 	// The default value of the parameter.
 	DefaultValue *string `type:"string"`
 
@@ -1517,8 +1519,6 @@ type ParameterDeclaration struct {
 
 	// The type of parameter.
 	ParameterType *string `type:"string"`
-
-	_ struct{} `type:"structure"`
 }
 
 // String returns the string representation
@@ -1533,6 +1533,8 @@ func (s ParameterDeclaration) GoString() string {
 
 // The input for the SetStackPolicy action.
 type SetStackPolicyInput struct {
+	_ struct{} `type:"structure"`
+
 	// The name or unique stack ID that you want to associate a policy with.
 	StackName *string `type:"string" required:"true"`
 
@@ -1547,8 +1549,6 @@ type SetStackPolicyInput struct {
 	// You can specify either the StackPolicyBody or the StackPolicyURL parameter,
 	// but not both.
 	StackPolicyURL *string `min:"1" type:"string"`
-
-	_ struct{} `type:"structure"`
 }
 
 // String returns the string representation
@@ -1577,6 +1577,8 @@ func (s SetStackPolicyOutput) GoString() string {
 
 // The input for the SignalResource action.
 type SignalResourceInput struct {
+	_ struct{} `type:"structure"`
+
 	// The logical ID of the resource that you want to signal. The logical ID is
 	// the name of the resource that given in the template.
 	LogicalResourceId *string `type:"string" required:"true"`
@@ -1594,8 +1596,6 @@ type SignalResourceInput struct {
 	// If you send multiple signals to a single resource (such as signaling a wait
 	// condition), each signal requires a different unique ID.
 	UniqueId *string `min:"1" type:"string" required:"true"`
-
-	_ struct{} `type:"structure"`
 }
 
 // String returns the string representation
@@ -1624,6 +1624,8 @@ func (s SignalResourceOutput) GoString() string {
 
 // The Stack data type.
 type Stack struct {
+	_ struct{} `type:"structure"`
+
 	// The capabilities allowed in the stack.
 	Capabilities []*string `type:"list"`
 
@@ -1668,8 +1670,6 @@ type Stack struct {
 
 	// The amount of time within which stack creation should complete.
 	TimeoutInMinutes *int64 `min:"1" type:"integer"`
-
-	_ struct{} `type:"structure"`
 }
 
 // String returns the string representation
@@ -1684,6 +1684,8 @@ func (s Stack) GoString() string {
 
 // The StackEvent data type.
 type StackEvent struct {
+	_ struct{} `type:"structure"`
+
 	// The unique ID of this event.
 	EventId *string `type:"string" required:"true"`
 
@@ -1716,8 +1718,6 @@ type StackEvent struct {
 
 	// Time the status was updated.
 	Timestamp *time.Time `type:"timestamp" timestampFormat:"iso8601" required:"true"`
-
-	_ struct{} `type:"structure"`
 }
 
 // String returns the string representation
@@ -1732,6 +1732,8 @@ func (s StackEvent) GoString() string {
 
 // The StackResource data type.
 type StackResource struct {
+	_ struct{} `type:"structure"`
+
 	// User defined description associated with the resource.
 	Description *string `type:"string"`
 
@@ -1761,8 +1763,6 @@ type StackResource struct {
 
 	// Time the status was updated.
 	Timestamp *time.Time `type:"timestamp" timestampFormat:"iso8601" required:"true"`
-
-	_ struct{} `type:"structure"`
 }
 
 // String returns the string representation
@@ -1777,6 +1777,8 @@ func (s StackResource) GoString() string {
 
 // Contains detailed information about the specified stack resource.
 type StackResourceDetail struct {
+	_ struct{} `type:"structure"`
+
 	// User defined description associated with the resource.
 	Description *string `type:"string"`
 
@@ -1811,8 +1813,6 @@ type StackResourceDetail struct {
 
 	// The name associated with the stack.
 	StackName *string `type:"string"`
-
-	_ struct{} `type:"structure"`
 }
 
 // String returns the string representation
@@ -1827,6 +1827,8 @@ func (s StackResourceDetail) GoString() string {
 
 // Contains high-level information about the specified stack resource.
 type StackResourceSummary struct {
+	_ struct{} `type:"structure"`
+
 	// Time the status was updated.
 	LastUpdatedTimestamp *time.Time `type:"timestamp" timestampFormat:"iso8601" required:"true"`
 
@@ -1847,8 +1849,6 @@ type StackResourceSummary struct {
 	// (http://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-template-resource-type-ref.html)
 	// in the AWS CloudFormation User Guide.)
 	ResourceType *string `type:"string" required:"true"`
-
-	_ struct{} `type:"structure"`
 }
 
 // String returns the string representation
@@ -1863,6 +1863,8 @@ func (s StackResourceSummary) GoString() string {
 
 // The StackSummary Data Type
 type StackSummary struct {
+	_ struct{} `type:"structure"`
+
 	// The time the stack was created.
 	CreationTime *time.Time `type:"timestamp" timestampFormat:"iso8601" required:"true"`
 
@@ -1887,8 +1889,6 @@ type StackSummary struct {
 
 	// The template description of the template used to create the stack.
 	TemplateDescription *string `type:"string"`
-
-	_ struct{} `type:"structure"`
 }
 
 // String returns the string representation
@@ -1905,6 +1905,8 @@ func (s StackSummary) GoString() string {
 // to specify a key/value pair that can be used to store information related
 // to cost allocation for an AWS CloudFormation stack.
 type Tag struct {
+	_ struct{} `type:"structure"`
+
 	// Required. A string used to identify this tag. You can specify a maximum of
 	// 128 characters for a tag key. Tags owned by Amazon Web Services (AWS) have
 	// the reserved prefix: aws:.
@@ -1913,8 +1915,6 @@ type Tag struct {
 	// Required. A string containing the value for this tag. You can specify a maximum
 	// of 256 characters for a tag value.
 	Value *string `type:"string"`
-
-	_ struct{} `type:"structure"`
 }
 
 // String returns the string representation
@@ -1929,6 +1929,8 @@ func (s Tag) GoString() string {
 
 // The TemplateParameter data type.
 type TemplateParameter struct {
+	_ struct{} `type:"structure"`
+
 	// The default value associated with the parameter.
 	DefaultValue *string `type:"string"`
 
@@ -1941,8 +1943,6 @@ type TemplateParameter struct {
 
 	// The name associated with the parameter.
 	ParameterKey *string `type:"string"`
-
-	_ struct{} `type:"structure"`
 }
 
 // String returns the string representation
@@ -1957,6 +1957,8 @@ func (s TemplateParameter) GoString() string {
 
 // The input for UpdateStack action.
 type UpdateStackInput struct {
+	_ struct{} `type:"structure"`
+
 	// A list of capabilities that you must specify before AWS CloudFormation can
 	// create or update certain stacks. Some stack templates might include resources
 	// that can affect permissions in your AWS account. For those stacks, you must
@@ -2054,8 +2056,6 @@ type UpdateStackInput struct {
 	// Reuse the existing template that is associated with the stack that you are
 	// updating.
 	UsePreviousTemplate *bool `type:"boolean"`
-
-	_ struct{} `type:"structure"`
 }
 
 // String returns the string representation
@@ -2070,10 +2070,10 @@ func (s UpdateStackInput) GoString() string {
 
 // The output for a UpdateStack action.
 type UpdateStackOutput struct {
+	_ struct{} `type:"structure"`
+
 	// Unique identifier of the stack.
 	StackId *string `type:"string"`
-
-	_ struct{} `type:"structure"`
 }
 
 // String returns the string representation
@@ -2088,6 +2088,8 @@ func (s UpdateStackOutput) GoString() string {
 
 // The input for ValidateTemplate action.
 type ValidateTemplateInput struct {
+	_ struct{} `type:"structure"`
+
 	// Structure containing the template body with a minimum length of 1 byte and
 	// a maximum length of 51,200 bytes. For more information, go to Template Anatomy
 	// (http://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/template-anatomy.html)
@@ -2105,8 +2107,6 @@ type ValidateTemplateInput struct {
 	// Conditional: You must pass TemplateURL or TemplateBody. If both are passed,
 	// only TemplateBody is used.
 	TemplateURL *string `min:"1" type:"string"`
-
-	_ struct{} `type:"structure"`
 }
 
 // String returns the string representation
@@ -2121,6 +2121,8 @@ func (s ValidateTemplateInput) GoString() string {
 
 // The output for ValidateTemplate action.
 type ValidateTemplateOutput struct {
+	_ struct{} `type:"structure"`
+
 	// The capabilities found within the template. Currently, AWS CloudFormation
 	// supports only the CAPABILITY_IAM capability. If your template contains IAM
 	// resources, you must specify the CAPABILITY_IAM value for this parameter when
@@ -2137,8 +2139,6 @@ type ValidateTemplateOutput struct {
 
 	// A list of TemplateParameter structures.
 	Parameters []*TemplateParameter `type:"list"`
-
-	_ struct{} `type:"structure"`
 }
 
 // String returns the string representation

--- a/service/cloudfront/api.go
+++ b/service/cloudfront/api.go
@@ -665,6 +665,8 @@ func (c *CloudFront) UpdateStreamingDistribution(input *UpdateStreamingDistribut
 // of the other cache behaviors for this distribution. These are accounts that
 // you want to allow to create signed URLs for private content.
 type ActiveTrustedSigners struct {
+	_ struct{} `type:"structure"`
+
 	// Each active trusted signer.
 	Enabled *bool `type:"boolean" required:"true"`
 
@@ -677,8 +679,6 @@ type ActiveTrustedSigners struct {
 	// example, if three cache behaviors all list the same three AWS accounts, the
 	// value of Quantity for ActiveTrustedSigners will be 3.
 	Quantity *int64 `type:"integer" required:"true"`
-
-	_ struct{} `type:"structure"`
 }
 
 // String returns the string representation
@@ -694,14 +694,14 @@ func (s ActiveTrustedSigners) GoString() string {
 // A complex type that contains information about CNAMEs (alternate domain names),
 // if any, for this distribution.
 type Aliases struct {
+	_ struct{} `type:"structure"`
+
 	// Optional: A complex type that contains CNAME elements, if any, for this distribution.
 	// If Quantity is 0, you can omit Items.
 	Items []*string `locationNameList:"CNAME" type:"list"`
 
 	// The number of CNAMEs, if any, for this distribution.
 	Quantity *int64 `type:"integer" required:"true"`
-
-	_ struct{} `type:"structure"`
 }
 
 // String returns the string representation
@@ -723,6 +723,8 @@ func (s Aliases) GoString() string {
 // so users can't perform operations that you don't want them to. For example,
 // you may not want users to have permission to delete objects from your origin.
 type AllowedMethods struct {
+	_ struct{} `type:"structure"`
+
 	// A complex type that controls whether CloudFront caches the response to requests
 	// using the specified HTTP methods. There are two choices: - CloudFront caches
 	// responses to GET and HEAD requests. - CloudFront caches responses to GET,
@@ -739,8 +741,6 @@ type AllowedMethods struct {
 	// Valid values are 2 (for GET and HEAD requests), 3 (for GET, HEAD and OPTIONS
 	// requests) and 7 (for GET, HEAD, OPTIONS, PUT, PATCH, POST, and DELETE requests).
 	Quantity *int64 `type:"integer" required:"true"`
-
-	_ struct{} `type:"structure"`
 }
 
 // String returns the string representation
@@ -768,6 +768,8 @@ func (s AllowedMethods) GoString() string {
 // one or more cache behaviors, update the distribution configuration and specify
 // all of the cache behaviors that you want to include in the updated distribution.
 type CacheBehavior struct {
+	_ struct{} `type:"structure"`
+
 	// A complex type that controls which HTTP methods CloudFront processes and
 	// forwards to your Amazon S3 bucket or your custom origin. There are three
 	// choices: - CloudFront forwards only GET and HEAD requests. - CloudFront forwards
@@ -846,8 +848,6 @@ type CacheBehavior struct {
 	// URL, specify redirect-to-https. The viewer then resubmits the request using
 	// the HTTPS URL.
 	ViewerProtocolPolicy *string `type:"string" required:"true" enum:"ViewerProtocolPolicy"`
-
-	_ struct{} `type:"structure"`
 }
 
 // String returns the string representation
@@ -862,14 +862,14 @@ func (s CacheBehavior) GoString() string {
 
 // A complex type that contains zero or more CacheBehavior elements.
 type CacheBehaviors struct {
+	_ struct{} `type:"structure"`
+
 	// Optional: A complex type that contains cache behaviors for this distribution.
 	// If Quantity is 0, you can omit Items.
 	Items []*CacheBehavior `locationNameList:"CacheBehavior" type:"list"`
 
 	// The number of cache behaviors for this distribution.
 	Quantity *int64 `type:"integer" required:"true"`
-
-	_ struct{} `type:"structure"`
 }
 
 // String returns the string representation
@@ -889,6 +889,8 @@ func (s CacheBehaviors) GoString() string {
 // you may need to forward Access-Control-Request-Method, Access-Control-Request-Headers
 // and Origin headers for the responses to be cached correctly.
 type CachedMethods struct {
+	_ struct{} `type:"structure"`
+
 	// A complex type that contains the HTTP methods that you want CloudFront to
 	// cache responses to.
 	Items []*string `locationNameList:"Method" type:"list" required:"true"`
@@ -897,8 +899,6 @@ type CachedMethods struct {
 	// Valid values are 2 (for caching responses to GET and HEAD requests) and 3
 	// (for caching responses to GET, HEAD, and OPTIONS requests).
 	Quantity *int64 `type:"integer" required:"true"`
-
-	_ struct{} `type:"structure"`
 }
 
 // String returns the string representation
@@ -914,14 +914,14 @@ func (s CachedMethods) GoString() string {
 // A complex type that specifies the whitelisted cookies, if any, that you want
 // CloudFront to forward to your origin that is associated with this cache behavior.
 type CookieNames struct {
+	_ struct{} `type:"structure"`
+
 	// Optional: A complex type that contains whitelisted cookies for this cache
 	// behavior. If Quantity is 0, you can omit Items.
 	Items []*string `locationNameList:"Name" type:"list"`
 
 	// The number of whitelisted cookies for this cache behavior.
 	Quantity *int64 `type:"integer" required:"true"`
-
-	_ struct{} `type:"structure"`
 }
 
 // String returns the string representation
@@ -937,6 +937,8 @@ func (s CookieNames) GoString() string {
 // A complex type that specifies the cookie preferences associated with this
 // cache behavior.
 type CookiePreference struct {
+	_ struct{} `type:"structure"`
+
 	// Use this element to specify whether you want CloudFront to forward cookies
 	// to the origin that is associated with this cache behavior. You can specify
 	// all, none or whitelist. If you choose All, CloudFront forwards all cookies
@@ -946,8 +948,6 @@ type CookiePreference struct {
 	// A complex type that specifies the whitelisted cookies, if any, that you want
 	// CloudFront to forward to your origin that is associated with this cache behavior.
 	WhitelistedNames *CookieNames `type:"structure"`
-
-	_ struct{} `type:"structure"`
 }
 
 // String returns the string representation
@@ -962,10 +962,10 @@ func (s CookiePreference) GoString() string {
 
 // The request to create a new origin access identity.
 type CreateCloudFrontOriginAccessIdentityInput struct {
+	_ struct{} `type:"structure" payload:"CloudFrontOriginAccessIdentityConfig"`
+
 	// The origin access identity's configuration information.
 	CloudFrontOriginAccessIdentityConfig *OriginAccessIdentityConfig `locationName:"CloudFrontOriginAccessIdentityConfig" type:"structure" required:"true"`
-
-	_ struct{} `type:"structure" payload:"CloudFrontOriginAccessIdentityConfig"`
 }
 
 // String returns the string representation
@@ -980,6 +980,8 @@ func (s CreateCloudFrontOriginAccessIdentityInput) GoString() string {
 
 // The returned result of the corresponding request.
 type CreateCloudFrontOriginAccessIdentityOutput struct {
+	_ struct{} `type:"structure" payload:"CloudFrontOriginAccessIdentity"`
+
 	// The origin access identity's information.
 	CloudFrontOriginAccessIdentity *OriginAccessIdentity `type:"structure"`
 
@@ -989,8 +991,6 @@ type CreateCloudFrontOriginAccessIdentityOutput struct {
 	// The fully qualified URI of the new origin access identity just created. For
 	// example: https://cloudfront.amazonaws.com/2010-11-01/origin-access-identity/cloudfront/E74FTE3AJFJ256A.
 	Location *string `location:"header" locationName:"Location" type:"string"`
-
-	_ struct{} `type:"structure" payload:"CloudFrontOriginAccessIdentity"`
 }
 
 // String returns the string representation
@@ -1005,10 +1005,10 @@ func (s CreateCloudFrontOriginAccessIdentityOutput) GoString() string {
 
 // The request to create a new distribution.
 type CreateDistributionInput struct {
+	_ struct{} `type:"structure" payload:"DistributionConfig"`
+
 	// The distribution's configuration information.
 	DistributionConfig *DistributionConfig `locationName:"DistributionConfig" type:"structure" required:"true"`
-
-	_ struct{} `type:"structure" payload:"DistributionConfig"`
 }
 
 // String returns the string representation
@@ -1023,6 +1023,8 @@ func (s CreateDistributionInput) GoString() string {
 
 // The returned result of the corresponding request.
 type CreateDistributionOutput struct {
+	_ struct{} `type:"structure" payload:"Distribution"`
+
 	// The distribution's information.
 	Distribution *Distribution `type:"structure"`
 
@@ -1032,8 +1034,6 @@ type CreateDistributionOutput struct {
 	// The fully qualified URI of the new distribution resource just created. For
 	// example: https://cloudfront.amazonaws.com/2010-11-01/distribution/EDFDVBD632BHDS5.
 	Location *string `location:"header" locationName:"Location" type:"string"`
-
-	_ struct{} `type:"structure" payload:"Distribution"`
 }
 
 // String returns the string representation
@@ -1048,13 +1048,13 @@ func (s CreateDistributionOutput) GoString() string {
 
 // The request to create an invalidation.
 type CreateInvalidationInput struct {
+	_ struct{} `type:"structure" payload:"InvalidationBatch"`
+
 	// The distribution's id.
 	DistributionId *string `location:"uri" locationName:"DistributionId" type:"string" required:"true"`
 
 	// The batch information for the invalidation.
 	InvalidationBatch *InvalidationBatch `locationName:"InvalidationBatch" type:"structure" required:"true"`
-
-	_ struct{} `type:"structure" payload:"InvalidationBatch"`
 }
 
 // String returns the string representation
@@ -1069,14 +1069,14 @@ func (s CreateInvalidationInput) GoString() string {
 
 // The returned result of the corresponding request.
 type CreateInvalidationOutput struct {
+	_ struct{} `type:"structure" payload:"Invalidation"`
+
 	// The invalidation's information.
 	Invalidation *Invalidation `type:"structure"`
 
 	// The fully qualified URI of the distribution and invalidation batch request,
 	// including the Invalidation ID.
 	Location *string `location:"header" locationName:"Location" type:"string"`
-
-	_ struct{} `type:"structure" payload:"Invalidation"`
 }
 
 // String returns the string representation
@@ -1091,10 +1091,10 @@ func (s CreateInvalidationOutput) GoString() string {
 
 // The request to create a new streaming distribution.
 type CreateStreamingDistributionInput struct {
+	_ struct{} `type:"structure" payload:"StreamingDistributionConfig"`
+
 	// The streaming distribution's configuration information.
 	StreamingDistributionConfig *StreamingDistributionConfig `locationName:"StreamingDistributionConfig" type:"structure" required:"true"`
-
-	_ struct{} `type:"structure" payload:"StreamingDistributionConfig"`
 }
 
 // String returns the string representation
@@ -1109,6 +1109,8 @@ func (s CreateStreamingDistributionInput) GoString() string {
 
 // The returned result of the corresponding request.
 type CreateStreamingDistributionOutput struct {
+	_ struct{} `type:"structure" payload:"StreamingDistribution"`
+
 	// The current version of the streaming distribution created.
 	ETag *string `location:"header" locationName:"ETag" type:"string"`
 
@@ -1118,8 +1120,6 @@ type CreateStreamingDistributionOutput struct {
 
 	// The streaming distribution's information.
 	StreamingDistribution *StreamingDistribution `type:"structure"`
-
-	_ struct{} `type:"structure" payload:"StreamingDistribution"`
 }
 
 // String returns the string representation
@@ -1144,6 +1144,8 @@ func (s CreateStreamingDistributionOutput) GoString() string {
 // specify all of the custom error responses that you want to include in the
 // updated distribution.
 type CustomErrorResponse struct {
+	_ struct{} `type:"structure"`
+
 	// The minimum amount of time you want HTTP error codes to stay in CloudFront
 	// caches before CloudFront queries your origin to see whether the object has
 	// been updated. You can specify a value from 0 to 31,536,000.
@@ -1165,8 +1167,6 @@ type CustomErrorResponse struct {
 	// Do not URL encode any other characters in the path, or CloudFront will not
 	// return the custom error page to the viewer.
 	ResponsePagePath *string `type:"string"`
-
-	_ struct{} `type:"structure"`
 }
 
 // String returns the string representation
@@ -1181,14 +1181,14 @@ func (s CustomErrorResponse) GoString() string {
 
 // A complex type that contains zero or more CustomErrorResponse elements.
 type CustomErrorResponses struct {
+	_ struct{} `type:"structure"`
+
 	// Optional: A complex type that contains custom error responses for this distribution.
 	// If Quantity is 0, you can omit Items.
 	Items []*CustomErrorResponse `locationNameList:"CustomErrorResponse" type:"list"`
 
 	// The number of custom error responses for this distribution.
 	Quantity *int64 `type:"integer" required:"true"`
-
-	_ struct{} `type:"structure"`
 }
 
 // String returns the string representation
@@ -1203,6 +1203,8 @@ func (s CustomErrorResponses) GoString() string {
 
 // A customer origin.
 type CustomOriginConfig struct {
+	_ struct{} `type:"structure"`
+
 	// The HTTP port the custom origin listens on.
 	HTTPPort *int64 `type:"integer" required:"true"`
 
@@ -1211,8 +1213,6 @@ type CustomOriginConfig struct {
 
 	// The origin protocol policy to apply to your origin.
 	OriginProtocolPolicy *string `type:"string" required:"true" enum:"OriginProtocolPolicy"`
-
-	_ struct{} `type:"structure"`
 }
 
 // String returns the string representation
@@ -1229,6 +1229,8 @@ func (s CustomOriginConfig) GoString() string {
 // a CacheBehavior element or if files don't match any of the values of PathPattern
 // in CacheBehavior elements.You must create exactly one default cache behavior.
 type DefaultCacheBehavior struct {
+	_ struct{} `type:"structure"`
+
 	// A complex type that controls which HTTP methods CloudFront processes and
 	// forwards to your Amazon S3 bucket or your custom origin. There are three
 	// choices: - CloudFront forwards only GET and HEAD requests. - CloudFront forwards
@@ -1298,8 +1300,6 @@ type DefaultCacheBehavior struct {
 	// URL, specify redirect-to-https. The viewer then resubmits the request using
 	// the HTTPS URL.
 	ViewerProtocolPolicy *string `type:"string" required:"true" enum:"ViewerProtocolPolicy"`
-
-	_ struct{} `type:"structure"`
 }
 
 // String returns the string representation
@@ -1314,14 +1314,14 @@ func (s DefaultCacheBehavior) GoString() string {
 
 // The request to delete a origin access identity.
 type DeleteCloudFrontOriginAccessIdentityInput struct {
+	_ struct{} `type:"structure"`
+
 	// The origin access identity's id.
 	Id *string `location:"uri" locationName:"Id" type:"string" required:"true"`
 
 	// The value of the ETag header you received from a previous GET or PUT request.
 	// For example: E2QWRUHAPOMQZL.
 	IfMatch *string `location:"header" locationName:"If-Match" type:"string"`
-
-	_ struct{} `type:"structure"`
 }
 
 // String returns the string representation
@@ -1350,14 +1350,14 @@ func (s DeleteCloudFrontOriginAccessIdentityOutput) GoString() string {
 
 // The request to delete a distribution.
 type DeleteDistributionInput struct {
+	_ struct{} `type:"structure"`
+
 	// The distribution id.
 	Id *string `location:"uri" locationName:"Id" type:"string" required:"true"`
 
 	// The value of the ETag header you received when you disabled the distribution.
 	// For example: E2QWRUHAPOMQZL.
 	IfMatch *string `location:"header" locationName:"If-Match" type:"string"`
-
-	_ struct{} `type:"structure"`
 }
 
 // String returns the string representation
@@ -1386,14 +1386,14 @@ func (s DeleteDistributionOutput) GoString() string {
 
 // The request to delete a streaming distribution.
 type DeleteStreamingDistributionInput struct {
+	_ struct{} `type:"structure"`
+
 	// The distribution id.
 	Id *string `location:"uri" locationName:"Id" type:"string" required:"true"`
 
 	// The value of the ETag header you received when you disabled the streaming
 	// distribution. For example: E2QWRUHAPOMQZL.
 	IfMatch *string `location:"header" locationName:"If-Match" type:"string"`
-
-	_ struct{} `type:"structure"`
 }
 
 // String returns the string representation
@@ -1422,6 +1422,8 @@ func (s DeleteStreamingDistributionOutput) GoString() string {
 
 // A distribution.
 type Distribution struct {
+	_ struct{} `type:"structure"`
+
 	// CloudFront automatically adds this element to the response only if you've
 	// set up the distribution to serve private content with signed URLs. The element
 	// lists the key pair IDs that CloudFront is aware of for each trusted signer.
@@ -1451,8 +1453,6 @@ type Distribution struct {
 	// the status is Deployed, the distribution's information is fully propagated
 	// throughout the Amazon CloudFront system.
 	Status *string `type:"string" required:"true"`
-
-	_ struct{} `type:"structure"`
 }
 
 // String returns the string representation
@@ -1467,6 +1467,8 @@ func (s Distribution) GoString() string {
 
 // A distribution Configuration.
 type DistributionConfig struct {
+	_ struct{} `type:"structure"`
+
 	// A complex type that contains information about CNAMEs (alternate domain names),
 	// if any, for this distribution.
 	Aliases *Aliases `type:"structure"`
@@ -1530,8 +1532,6 @@ type DistributionConfig struct {
 	// (Optional) If you're using AWS WAF to filter CloudFront requests, the Id
 	// of the AWS WAF web ACL that is associated with the distribution.
 	WebACLId *string `type:"string"`
-
-	_ struct{} `type:"structure"`
 }
 
 // String returns the string representation
@@ -1546,6 +1546,8 @@ func (s DistributionConfig) GoString() string {
 
 // A distribution list.
 type DistributionList struct {
+	_ struct{} `type:"structure"`
+
 	// A flag that indicates whether more distributions remain to be listed. If
 	// your results were truncated, you can make a follow-up pagination request
 	// using the Marker request parameter to retrieve more distributions in the
@@ -1569,8 +1571,6 @@ type DistributionList struct {
 
 	// The number of distributions that were created by the current AWS account.
 	Quantity *int64 `type:"integer" required:"true"`
-
-	_ struct{} `type:"structure"`
 }
 
 // String returns the string representation
@@ -1585,6 +1585,8 @@ func (s DistributionList) GoString() string {
 
 // A summary of the information for an Amazon CloudFront distribution.
 type DistributionSummary struct {
+	_ struct{} `type:"structure"`
+
 	// A complex type that contains information about CNAMEs (alternate domain names),
 	// if any, for this distribution.
 	Aliases *Aliases `type:"structure" required:"true"`
@@ -1635,8 +1637,6 @@ type DistributionSummary struct {
 
 	// The Web ACL Id (if any) associated with the distribution.
 	WebACLId *string `type:"string" required:"true"`
-
-	_ struct{} `type:"structure"`
 }
 
 // String returns the string representation
@@ -1652,6 +1652,8 @@ func (s DistributionSummary) GoString() string {
 // A complex type that specifies how CloudFront handles query strings, cookies
 // and headers.
 type ForwardedValues struct {
+	_ struct{} `type:"structure"`
+
 	// A complex type that specifies how CloudFront handles cookies.
 	Cookies *CookiePreference `type:"structure" required:"true"`
 
@@ -1663,8 +1665,6 @@ type ForwardedValues struct {
 	// that is associated with this cache behavior. If so, specify true; if not,
 	// specify false.
 	QueryString *bool `type:"boolean" required:"true"`
-
-	_ struct{} `type:"structure"`
 }
 
 // String returns the string representation
@@ -1684,6 +1684,8 @@ func (s ForwardedValues) GoString() string {
 // of these databases, see How accurate are your GeoIP databases? on the MaxMind
 // website.
 type GeoRestriction struct {
+	_ struct{} `type:"structure"`
+
 	// A complex type that contains a Location element for each country in which
 	// you want CloudFront either to distribute your content (whitelist) or not
 	// distribute your content (blacklist). The Location element is a two-letter,
@@ -1707,8 +1709,6 @@ type GeoRestriction struct {
 	// content. - whitelist: The Location elements specify the countries in which
 	// you want CloudFront to distribute your content.
 	RestrictionType *string `type:"string" required:"true" enum:"GeoRestrictionType"`
-
-	_ struct{} `type:"structure"`
 }
 
 // String returns the string representation
@@ -1723,10 +1723,10 @@ func (s GeoRestriction) GoString() string {
 
 // The request to get an origin access identity's configuration.
 type GetCloudFrontOriginAccessIdentityConfigInput struct {
+	_ struct{} `type:"structure"`
+
 	// The identity's id.
 	Id *string `location:"uri" locationName:"Id" type:"string" required:"true"`
-
-	_ struct{} `type:"structure"`
 }
 
 // String returns the string representation
@@ -1741,13 +1741,13 @@ func (s GetCloudFrontOriginAccessIdentityConfigInput) GoString() string {
 
 // The returned result of the corresponding request.
 type GetCloudFrontOriginAccessIdentityConfigOutput struct {
+	_ struct{} `type:"structure" payload:"CloudFrontOriginAccessIdentityConfig"`
+
 	// The origin access identity's configuration information.
 	CloudFrontOriginAccessIdentityConfig *OriginAccessIdentityConfig `type:"structure"`
 
 	// The current version of the configuration. For example: E2QWRUHAPOMQZL.
 	ETag *string `location:"header" locationName:"ETag" type:"string"`
-
-	_ struct{} `type:"structure" payload:"CloudFrontOriginAccessIdentityConfig"`
 }
 
 // String returns the string representation
@@ -1762,10 +1762,10 @@ func (s GetCloudFrontOriginAccessIdentityConfigOutput) GoString() string {
 
 // The request to get an origin access identity's information.
 type GetCloudFrontOriginAccessIdentityInput struct {
+	_ struct{} `type:"structure"`
+
 	// The identity's id.
 	Id *string `location:"uri" locationName:"Id" type:"string" required:"true"`
-
-	_ struct{} `type:"structure"`
 }
 
 // String returns the string representation
@@ -1780,14 +1780,14 @@ func (s GetCloudFrontOriginAccessIdentityInput) GoString() string {
 
 // The returned result of the corresponding request.
 type GetCloudFrontOriginAccessIdentityOutput struct {
+	_ struct{} `type:"structure" payload:"CloudFrontOriginAccessIdentity"`
+
 	// The origin access identity's information.
 	CloudFrontOriginAccessIdentity *OriginAccessIdentity `type:"structure"`
 
 	// The current version of the origin access identity's information. For example:
 	// E2QWRUHAPOMQZL.
 	ETag *string `location:"header" locationName:"ETag" type:"string"`
-
-	_ struct{} `type:"structure" payload:"CloudFrontOriginAccessIdentity"`
 }
 
 // String returns the string representation
@@ -1802,10 +1802,10 @@ func (s GetCloudFrontOriginAccessIdentityOutput) GoString() string {
 
 // The request to get a distribution configuration.
 type GetDistributionConfigInput struct {
+	_ struct{} `type:"structure"`
+
 	// The distribution's id.
 	Id *string `location:"uri" locationName:"Id" type:"string" required:"true"`
-
-	_ struct{} `type:"structure"`
 }
 
 // String returns the string representation
@@ -1820,13 +1820,13 @@ func (s GetDistributionConfigInput) GoString() string {
 
 // The returned result of the corresponding request.
 type GetDistributionConfigOutput struct {
+	_ struct{} `type:"structure" payload:"DistributionConfig"`
+
 	// The distribution's configuration information.
 	DistributionConfig *DistributionConfig `type:"structure"`
 
 	// The current version of the configuration. For example: E2QWRUHAPOMQZL.
 	ETag *string `location:"header" locationName:"ETag" type:"string"`
-
-	_ struct{} `type:"structure" payload:"DistributionConfig"`
 }
 
 // String returns the string representation
@@ -1841,10 +1841,10 @@ func (s GetDistributionConfigOutput) GoString() string {
 
 // The request to get a distribution's information.
 type GetDistributionInput struct {
+	_ struct{} `type:"structure"`
+
 	// The distribution's id.
 	Id *string `location:"uri" locationName:"Id" type:"string" required:"true"`
-
-	_ struct{} `type:"structure"`
 }
 
 // String returns the string representation
@@ -1859,13 +1859,13 @@ func (s GetDistributionInput) GoString() string {
 
 // The returned result of the corresponding request.
 type GetDistributionOutput struct {
+	_ struct{} `type:"structure" payload:"Distribution"`
+
 	// The distribution's information.
 	Distribution *Distribution `type:"structure"`
 
 	// The current version of the distribution's information. For example: E2QWRUHAPOMQZL.
 	ETag *string `location:"header" locationName:"ETag" type:"string"`
-
-	_ struct{} `type:"structure" payload:"Distribution"`
 }
 
 // String returns the string representation
@@ -1880,13 +1880,13 @@ func (s GetDistributionOutput) GoString() string {
 
 // The request to get an invalidation's information.
 type GetInvalidationInput struct {
+	_ struct{} `type:"structure"`
+
 	// The distribution's id.
 	DistributionId *string `location:"uri" locationName:"DistributionId" type:"string" required:"true"`
 
 	// The invalidation's id.
 	Id *string `location:"uri" locationName:"Id" type:"string" required:"true"`
-
-	_ struct{} `type:"structure"`
 }
 
 // String returns the string representation
@@ -1901,10 +1901,10 @@ func (s GetInvalidationInput) GoString() string {
 
 // The returned result of the corresponding request.
 type GetInvalidationOutput struct {
+	_ struct{} `type:"structure" payload:"Invalidation"`
+
 	// The invalidation's information.
 	Invalidation *Invalidation `type:"structure"`
-
-	_ struct{} `type:"structure" payload:"Invalidation"`
 }
 
 // String returns the string representation
@@ -1919,10 +1919,10 @@ func (s GetInvalidationOutput) GoString() string {
 
 // To request to get a streaming distribution configuration.
 type GetStreamingDistributionConfigInput struct {
+	_ struct{} `type:"structure"`
+
 	// The streaming distribution's id.
 	Id *string `location:"uri" locationName:"Id" type:"string" required:"true"`
-
-	_ struct{} `type:"structure"`
 }
 
 // String returns the string representation
@@ -1937,13 +1937,13 @@ func (s GetStreamingDistributionConfigInput) GoString() string {
 
 // The returned result of the corresponding request.
 type GetStreamingDistributionConfigOutput struct {
+	_ struct{} `type:"structure" payload:"StreamingDistributionConfig"`
+
 	// The current version of the configuration. For example: E2QWRUHAPOMQZL.
 	ETag *string `location:"header" locationName:"ETag" type:"string"`
 
 	// The streaming distribution's configuration information.
 	StreamingDistributionConfig *StreamingDistributionConfig `type:"structure"`
-
-	_ struct{} `type:"structure" payload:"StreamingDistributionConfig"`
 }
 
 // String returns the string representation
@@ -1958,10 +1958,10 @@ func (s GetStreamingDistributionConfigOutput) GoString() string {
 
 // The request to get a streaming distribution's information.
 type GetStreamingDistributionInput struct {
+	_ struct{} `type:"structure"`
+
 	// The streaming distribution's id.
 	Id *string `location:"uri" locationName:"Id" type:"string" required:"true"`
-
-	_ struct{} `type:"structure"`
 }
 
 // String returns the string representation
@@ -1976,14 +1976,14 @@ func (s GetStreamingDistributionInput) GoString() string {
 
 // The returned result of the corresponding request.
 type GetStreamingDistributionOutput struct {
+	_ struct{} `type:"structure" payload:"StreamingDistribution"`
+
 	// The current version of the streaming distribution's information. For example:
 	// E2QWRUHAPOMQZL.
 	ETag *string `location:"header" locationName:"ETag" type:"string"`
 
 	// The streaming distribution's information.
 	StreamingDistribution *StreamingDistribution `type:"structure"`
-
-	_ struct{} `type:"structure" payload:"StreamingDistribution"`
 }
 
 // String returns the string representation
@@ -2005,6 +2005,8 @@ func (s GetStreamingDistributionOutput) GoString() string {
 // on the Product header. CloudFront forwards the Product header to the origin
 // and caches the response from the origin once for each header value.
 type Headers struct {
+	_ struct{} `type:"structure"`
+
 	// Optional: A complex type that contains a Name element for each header that
 	// you want CloudFront to forward to the origin and to vary on for this cache
 	// behavior. If Quantity is 0, omit Items.
@@ -2018,8 +2020,6 @@ type Headers struct {
 	// to the origin or to vary on any headers, specify 0 for Quantity and omit
 	// Items.
 	Quantity *int64 `type:"integer" required:"true"`
-
-	_ struct{} `type:"structure"`
 }
 
 // String returns the string representation
@@ -2034,6 +2034,8 @@ func (s Headers) GoString() string {
 
 // An invalidation.
 type Invalidation struct {
+	_ struct{} `type:"structure"`
+
 	// The date and time the invalidation request was first made.
 	CreateTime *time.Time `type:"timestamp" timestampFormat:"iso8601" required:"true"`
 
@@ -2046,8 +2048,6 @@ type Invalidation struct {
 	// The status of the invalidation request. When the invalidation batch is finished,
 	// the status is Completed.
 	Status *string `type:"string" required:"true"`
-
-	_ struct{} `type:"structure"`
 }
 
 // String returns the string representation
@@ -2062,6 +2062,8 @@ func (s Invalidation) GoString() string {
 
 // An invalidation batch.
 type InvalidationBatch struct {
+	_ struct{} `type:"structure"`
+
 	// A unique name that ensures the request can't be replayed. If the CallerReference
 	// is new (no matter the content of the Path object), a new distribution is
 	// created. If the CallerReference is a value you already sent in a previous
@@ -2080,8 +2082,6 @@ type InvalidationBatch struct {
 	// URL encode those characters. Do not URL encode any other characters in the
 	// path, or CloudFront will not invalidate the old version of the updated object.
 	Paths *Paths `type:"structure" required:"true"`
-
-	_ struct{} `type:"structure"`
 }
 
 // String returns the string representation
@@ -2096,6 +2096,8 @@ func (s InvalidationBatch) GoString() string {
 
 // An invalidation list.
 type InvalidationList struct {
+	_ struct{} `type:"structure"`
+
 	// A flag that indicates whether more invalidation batch requests remain to
 	// be listed. If your results were truncated, you can make a follow-up pagination
 	// request using the Marker request parameter to retrieve more invalidation
@@ -2119,8 +2121,6 @@ type InvalidationList struct {
 
 	// The number of invalidation batches that were created by the current AWS account.
 	Quantity *int64 `type:"integer" required:"true"`
-
-	_ struct{} `type:"structure"`
 }
 
 // String returns the string representation
@@ -2135,6 +2135,8 @@ func (s InvalidationList) GoString() string {
 
 // Summary of an invalidation request.
 type InvalidationSummary struct {
+	_ struct{} `type:"structure"`
+
 	CreateTime *time.Time `type:"timestamp" timestampFormat:"iso8601" required:"true"`
 
 	// The unique ID for an invalidation request.
@@ -2142,8 +2144,6 @@ type InvalidationSummary struct {
 
 	// The status of an invalidation request.
 	Status *string `type:"string" required:"true"`
-
-	_ struct{} `type:"structure"`
 }
 
 // String returns the string representation
@@ -2159,14 +2159,14 @@ func (s InvalidationSummary) GoString() string {
 // A complex type that lists the active CloudFront key pairs, if any, that are
 // associated with AwsAccountNumber.
 type KeyPairIds struct {
+	_ struct{} `type:"structure"`
+
 	// A complex type that lists the active CloudFront key pairs, if any, that are
 	// associated with AwsAccountNumber.
 	Items []*string `locationNameList:"KeyPairId" type:"list"`
 
 	// The number of active CloudFront key pairs for AwsAccountNumber.
 	Quantity *int64 `type:"integer" required:"true"`
-
-	_ struct{} `type:"structure"`
 }
 
 // String returns the string representation
@@ -2181,6 +2181,8 @@ func (s KeyPairIds) GoString() string {
 
 // The request to list origin access identities.
 type ListCloudFrontOriginAccessIdentitiesInput struct {
+	_ struct{} `type:"structure"`
+
 	// Use this when paginating results to indicate where to begin in your list
 	// of origin access identities. The results include identities in the list that
 	// occur after the marker. To get the next page of results, set the Marker to
@@ -2190,8 +2192,6 @@ type ListCloudFrontOriginAccessIdentitiesInput struct {
 
 	// The maximum number of origin access identities you want in the response body.
 	MaxItems *int64 `location:"querystring" locationName:"MaxItems" type:"integer"`
-
-	_ struct{} `type:"structure"`
 }
 
 // String returns the string representation
@@ -2206,10 +2206,10 @@ func (s ListCloudFrontOriginAccessIdentitiesInput) GoString() string {
 
 // The returned result of the corresponding request.
 type ListCloudFrontOriginAccessIdentitiesOutput struct {
+	_ struct{} `type:"structure" payload:"CloudFrontOriginAccessIdentityList"`
+
 	// The CloudFrontOriginAccessIdentityList type.
 	CloudFrontOriginAccessIdentityList *OriginAccessIdentityList `type:"structure"`
-
-	_ struct{} `type:"structure" payload:"CloudFrontOriginAccessIdentityList"`
 }
 
 // String returns the string representation
@@ -2225,6 +2225,8 @@ func (s ListCloudFrontOriginAccessIdentitiesOutput) GoString() string {
 // The request to list distributions that are associated with a specified AWS
 // WAF web ACL.
 type ListDistributionsByWebACLIdInput struct {
+	_ struct{} `type:"structure"`
+
 	// Use Marker and MaxItems to control pagination of results. If you have more
 	// than MaxItems distributions that satisfy the request, the response includes
 	// a NextMarker element. To get the next page of results, submit another request.
@@ -2240,8 +2242,6 @@ type ListDistributionsByWebACLIdInput struct {
 	// If you specify "null" for the Id, the request returns a list of the distributions
 	// that aren't associated with a web ACL.
 	WebACLId *string `location:"uri" locationName:"WebACLId" type:"string" required:"true"`
-
-	_ struct{} `type:"structure"`
 }
 
 // String returns the string representation
@@ -2257,10 +2257,10 @@ func (s ListDistributionsByWebACLIdInput) GoString() string {
 // The response to a request to list the distributions that are associated with
 // a specified AWS WAF web ACL.
 type ListDistributionsByWebACLIdOutput struct {
+	_ struct{} `type:"structure" payload:"DistributionList"`
+
 	// The DistributionList type.
 	DistributionList *DistributionList `type:"structure"`
-
-	_ struct{} `type:"structure" payload:"DistributionList"`
 }
 
 // String returns the string representation
@@ -2275,6 +2275,8 @@ func (s ListDistributionsByWebACLIdOutput) GoString() string {
 
 // The request to list your distributions.
 type ListDistributionsInput struct {
+	_ struct{} `type:"structure"`
+
 	// Use Marker and MaxItems to control pagination of results. If you have more
 	// than MaxItems distributions that satisfy the request, the response includes
 	// a NextMarker element. To get the next page of results, submit another request.
@@ -2285,8 +2287,6 @@ type ListDistributionsInput struct {
 	// The maximum number of distributions that you want CloudFront to return in
 	// the response body. The maximum and default values are both 100.
 	MaxItems *int64 `location:"querystring" locationName:"MaxItems" type:"integer"`
-
-	_ struct{} `type:"structure"`
 }
 
 // String returns the string representation
@@ -2301,10 +2301,10 @@ func (s ListDistributionsInput) GoString() string {
 
 // The returned result of the corresponding request.
 type ListDistributionsOutput struct {
+	_ struct{} `type:"structure" payload:"DistributionList"`
+
 	// The DistributionList type.
 	DistributionList *DistributionList `type:"structure"`
-
-	_ struct{} `type:"structure" payload:"DistributionList"`
 }
 
 // String returns the string representation
@@ -2319,6 +2319,8 @@ func (s ListDistributionsOutput) GoString() string {
 
 // The request to list invalidations.
 type ListInvalidationsInput struct {
+	_ struct{} `type:"structure"`
+
 	// The distribution's id.
 	DistributionId *string `location:"uri" locationName:"DistributionId" type:"string" required:"true"`
 
@@ -2333,8 +2335,6 @@ type ListInvalidationsInput struct {
 
 	// The maximum number of invalidation batches you want in the response body.
 	MaxItems *int64 `location:"querystring" locationName:"MaxItems" type:"integer"`
-
-	_ struct{} `type:"structure"`
 }
 
 // String returns the string representation
@@ -2349,10 +2349,10 @@ func (s ListInvalidationsInput) GoString() string {
 
 // The returned result of the corresponding request.
 type ListInvalidationsOutput struct {
+	_ struct{} `type:"structure" payload:"InvalidationList"`
+
 	// Information about invalidation batches.
 	InvalidationList *InvalidationList `type:"structure"`
-
-	_ struct{} `type:"structure" payload:"InvalidationList"`
 }
 
 // String returns the string representation
@@ -2367,6 +2367,8 @@ func (s ListInvalidationsOutput) GoString() string {
 
 // The request to list your streaming distributions.
 type ListStreamingDistributionsInput struct {
+	_ struct{} `type:"structure"`
+
 	// Use this when paginating results to indicate where to begin in your list
 	// of streaming distributions. The results include distributions in the list
 	// that occur after the marker. To get the next page of results, set the Marker
@@ -2376,8 +2378,6 @@ type ListStreamingDistributionsInput struct {
 
 	// The maximum number of streaming distributions you want in the response body.
 	MaxItems *int64 `location:"querystring" locationName:"MaxItems" type:"integer"`
-
-	_ struct{} `type:"structure"`
 }
 
 // String returns the string representation
@@ -2392,10 +2392,10 @@ func (s ListStreamingDistributionsInput) GoString() string {
 
 // The returned result of the corresponding request.
 type ListStreamingDistributionsOutput struct {
+	_ struct{} `type:"structure" payload:"StreamingDistributionList"`
+
 	// The StreamingDistributionList type.
 	StreamingDistributionList *StreamingDistributionList `type:"structure"`
-
-	_ struct{} `type:"structure" payload:"StreamingDistributionList"`
 }
 
 // String returns the string representation
@@ -2410,6 +2410,8 @@ func (s ListStreamingDistributionsOutput) GoString() string {
 
 // A complex type that controls whether access logs are written for the distribution.
 type LoggingConfig struct {
+	_ struct{} `type:"structure"`
+
 	// The Amazon S3 bucket to store the access logs in, for example, myawslogbucket.s3.amazonaws.com.
 	Bucket *string `type:"string" required:"true"`
 
@@ -2434,8 +2436,6 @@ type LoggingConfig struct {
 	// but you do not want to specify a prefix, you still must include an empty
 	// Prefix element in the Logging element.
 	Prefix *string `type:"string" required:"true"`
-
-	_ struct{} `type:"structure"`
 }
 
 // String returns the string representation
@@ -2452,6 +2452,8 @@ func (s LoggingConfig) GoString() string {
 // example, a web server) from which CloudFront gets your files.You must create
 // at least one origin.
 type Origin struct {
+	_ struct{} `type:"structure"`
+
 	// A complex type that contains information about a custom origin. If the origin
 	// is an Amazon S3 bucket, use the S3OriginConfig element instead.
 	CustomOriginConfig *CustomOriginConfig `type:"structure"`
@@ -2477,8 +2479,6 @@ type Origin struct {
 	// A complex type that contains information about the Amazon S3 origin. If the
 	// origin is a custom origin, use the CustomOriginConfig element instead.
 	S3OriginConfig *S3OriginConfig `type:"structure"`
-
-	_ struct{} `type:"structure"`
 }
 
 // String returns the string representation
@@ -2493,6 +2493,8 @@ func (s Origin) GoString() string {
 
 // CloudFront origin access identity.
 type OriginAccessIdentity struct {
+	_ struct{} `type:"structure"`
+
 	// The current configuration information for the identity.
 	CloudFrontOriginAccessIdentityConfig *OriginAccessIdentityConfig `type:"structure"`
 
@@ -2503,8 +2505,6 @@ type OriginAccessIdentity struct {
 	// use when giving the origin access identity read permission to an object in
 	// Amazon S3.
 	S3CanonicalUserId *string `type:"string" required:"true"`
-
-	_ struct{} `type:"structure"`
 }
 
 // String returns the string representation
@@ -2519,6 +2519,8 @@ func (s OriginAccessIdentity) GoString() string {
 
 // Origin access identity configuration.
 type OriginAccessIdentityConfig struct {
+	_ struct{} `type:"structure"`
+
 	// A unique number that ensures the request can't be replayed. If the CallerReference
 	// is new (no matter the content of the CloudFrontOriginAccessIdentityConfig
 	// object), a new origin access identity is created. If the CallerReference
@@ -2534,8 +2536,6 @@ type OriginAccessIdentityConfig struct {
 
 	// Any comments you want to include about the origin access identity.
 	Comment *string `type:"string" required:"true"`
-
-	_ struct{} `type:"structure"`
 }
 
 // String returns the string representation
@@ -2550,6 +2550,8 @@ func (s OriginAccessIdentityConfig) GoString() string {
 
 // The CloudFrontOriginAccessIdentityList type.
 type OriginAccessIdentityList struct {
+	_ struct{} `type:"structure"`
+
 	// A flag that indicates whether more origin access identities remain to be
 	// listed. If your results were truncated, you can make a follow-up pagination
 	// request using the Marker request parameter to retrieve more items in the
@@ -2574,8 +2576,6 @@ type OriginAccessIdentityList struct {
 	// The number of CloudFront origin access identities that were created by the
 	// current AWS account.
 	Quantity *int64 `type:"integer" required:"true"`
-
-	_ struct{} `type:"structure"`
 }
 
 // String returns the string representation
@@ -2590,6 +2590,8 @@ func (s OriginAccessIdentityList) GoString() string {
 
 // Summary of the information about a CloudFront origin access identity.
 type OriginAccessIdentitySummary struct {
+	_ struct{} `type:"structure"`
+
 	// The comment for this origin access identity, as originally specified when
 	// created.
 	Comment *string `type:"string" required:"true"`
@@ -2601,8 +2603,6 @@ type OriginAccessIdentitySummary struct {
 	// use when giving the origin access identity read permission to an object in
 	// Amazon S3.
 	S3CanonicalUserId *string `type:"string" required:"true"`
-
-	_ struct{} `type:"structure"`
 }
 
 // String returns the string representation
@@ -2617,13 +2617,13 @@ func (s OriginAccessIdentitySummary) GoString() string {
 
 // A complex type that contains information about origins for this distribution.
 type Origins struct {
+	_ struct{} `type:"structure"`
+
 	// A complex type that contains origins for this distribution.
 	Items []*Origin `locationNameList:"Origin" min:"1" type:"list"`
 
 	// The number of origins for this distribution.
 	Quantity *int64 `type:"integer" required:"true"`
-
-	_ struct{} `type:"structure"`
 }
 
 // String returns the string representation
@@ -2639,13 +2639,13 @@ func (s Origins) GoString() string {
 // A complex type that contains information about the objects that you want
 // to invalidate.
 type Paths struct {
+	_ struct{} `type:"structure"`
+
 	// A complex type that contains a list of the objects that you want to invalidate.
 	Items []*string `locationNameList:"Path" type:"list"`
 
 	// The number of objects that you want to invalidate.
 	Quantity *int64 `type:"integer" required:"true"`
-
-	_ struct{} `type:"structure"`
 }
 
 // String returns the string representation
@@ -2661,6 +2661,8 @@ func (s Paths) GoString() string {
 // A complex type that identifies ways in which you want to restrict distribution
 // of your content.
 type Restrictions struct {
+	_ struct{} `type:"structure"`
+
 	// A complex type that controls the countries in which your content is distributed.
 	// For more information about geo restriction, go to Customizing Error Responses
 	// in the Amazon CloudFront Developer Guide. CloudFront determines the location
@@ -2668,8 +2670,6 @@ type Restrictions struct {
 	// of these databases, see How accurate are your GeoIP databases? on the MaxMind
 	// website.
 	GeoRestriction *GeoRestriction `type:"structure" required:"true"`
-
-	_ struct{} `type:"structure"`
 }
 
 // String returns the string representation
@@ -2685,13 +2685,13 @@ func (s Restrictions) GoString() string {
 // A complex type that contains information about the Amazon S3 bucket from
 // which you want CloudFront to get your media files for distribution.
 type S3Origin struct {
+	_ struct{} `type:"structure"`
+
 	// The DNS name of the S3 origin.
 	DomainName *string `type:"string" required:"true"`
 
 	// Your S3 origin's origin access identity.
 	OriginAccessIdentity *string `type:"string" required:"true"`
-
-	_ struct{} `type:"structure"`
 }
 
 // String returns the string representation
@@ -2707,6 +2707,8 @@ func (s S3Origin) GoString() string {
 // A complex type that contains information about the Amazon S3 origin. If the
 // origin is a custom origin, use the CustomOriginConfig element instead.
 type S3OriginConfig struct {
+	_ struct{} `type:"structure"`
+
 	// The CloudFront origin access identity to associate with the origin. Use an
 	// origin access identity to configure the origin so that end users can only
 	// access objects in an Amazon S3 bucket through CloudFront. If you want end
@@ -2719,8 +2721,6 @@ type S3OriginConfig struct {
 	// where Id is the value that CloudFront returned in the Id element when you
 	// created the origin access identity.
 	OriginAccessIdentity *string `type:"string" required:"true"`
-
-	_ struct{} `type:"structure"`
 }
 
 // String returns the string representation
@@ -2736,6 +2736,8 @@ func (s S3OriginConfig) GoString() string {
 // A complex type that lists the AWS accounts that were included in the TrustedSigners
 // complex type, as well as their active CloudFront key pair IDs, if any.
 type Signer struct {
+	_ struct{} `type:"structure"`
+
 	// Specifies an AWS account that can create signed URLs. Values: self, which
 	// indicates that the AWS account that was used to create the distribution can
 	// created signed URLs, or an AWS account number. Omit the dashes in the account
@@ -2745,8 +2747,6 @@ type Signer struct {
 	// A complex type that lists the active CloudFront key pairs, if any, that are
 	// associated with AwsAccountNumber.
 	KeyPairIds *KeyPairIds `type:"structure"`
-
-	_ struct{} `type:"structure"`
 }
 
 // String returns the string representation
@@ -2761,6 +2761,8 @@ func (s Signer) GoString() string {
 
 // A streaming distribution.
 type StreamingDistribution struct {
+	_ struct{} `type:"structure"`
+
 	// CloudFront automatically adds this element to the response only if you've
 	// set up the distribution to serve private content with signed URLs. The element
 	// lists the key pair IDs that CloudFront is aware of for each trusted signer.
@@ -2788,8 +2790,6 @@ type StreamingDistribution struct {
 
 	// The current configuration information for the streaming distribution.
 	StreamingDistributionConfig *StreamingDistributionConfig `type:"structure" required:"true"`
-
-	_ struct{} `type:"structure"`
 }
 
 // String returns the string representation
@@ -2804,6 +2804,8 @@ func (s StreamingDistribution) GoString() string {
 
 // The configuration for the streaming distribution.
 type StreamingDistributionConfig struct {
+	_ struct{} `type:"structure"`
+
 	// A complex type that contains information about CNAMEs (alternate domain names),
 	// if any, for this streaming distribution.
 	Aliases *Aliases `type:"structure"`
@@ -2851,8 +2853,6 @@ type StreamingDistributionConfig struct {
 	// (if it's currently false), change Quantity as applicable, and specify all
 	// of the trusted signers that you want to include in the updated distribution.
 	TrustedSigners *TrustedSigners `type:"structure" required:"true"`
-
-	_ struct{} `type:"structure"`
 }
 
 // String returns the string representation
@@ -2867,6 +2867,8 @@ func (s StreamingDistributionConfig) GoString() string {
 
 // A streaming distribution list.
 type StreamingDistributionList struct {
+	_ struct{} `type:"structure"`
+
 	// A flag that indicates whether more streaming distributions remain to be listed.
 	// If your results were truncated, you can make a follow-up pagination request
 	// using the Marker request parameter to retrieve more distributions in the
@@ -2891,8 +2893,6 @@ type StreamingDistributionList struct {
 	// The number of streaming distributions that were created by the current AWS
 	// account.
 	Quantity *int64 `type:"integer" required:"true"`
-
-	_ struct{} `type:"structure"`
 }
 
 // String returns the string representation
@@ -2907,6 +2907,8 @@ func (s StreamingDistributionList) GoString() string {
 
 // A summary of the information for an Amazon CloudFront streaming distribution.
 type StreamingDistributionSummary struct {
+	_ struct{} `type:"structure"`
+
 	// A complex type that contains information about CNAMEs (alternate domain names),
 	// if any, for this streaming distribution.
 	Aliases *Aliases `type:"structure" required:"true"`
@@ -2949,8 +2951,6 @@ type StreamingDistributionSummary struct {
 	// (if it's currently false), change Quantity as applicable, and specify all
 	// of the trusted signers that you want to include in the updated distribution.
 	TrustedSigners *TrustedSigners `type:"structure" required:"true"`
-
-	_ struct{} `type:"structure"`
 }
 
 // String returns the string representation
@@ -2966,6 +2966,8 @@ func (s StreamingDistributionSummary) GoString() string {
 // A complex type that controls whether access logs are written for this streaming
 // distribution.
 type StreamingLoggingConfig struct {
+	_ struct{} `type:"structure"`
+
 	// The Amazon S3 bucket to store the access logs in, for example, myawslogbucket.s3.amazonaws.com.
 	Bucket *string `type:"string" required:"true"`
 
@@ -2982,8 +2984,6 @@ type StreamingLoggingConfig struct {
 	// logging, but you do not want to specify a prefix, you still must include
 	// an empty Prefix element in the Logging element.
 	Prefix *string `type:"string" required:"true"`
-
-	_ struct{} `type:"structure"`
 }
 
 // String returns the string representation
@@ -3008,6 +3008,8 @@ func (s StreamingLoggingConfig) GoString() string {
 // (if it's currently false), change Quantity as applicable, and specify all
 // of the trusted signers that you want to include in the updated distribution.
 type TrustedSigners struct {
+	_ struct{} `type:"structure"`
+
 	// Specifies whether you want to require end users to use signed URLs to access
 	// the files specified by PathPattern and TargetOriginId.
 	Enabled *bool `type:"boolean" required:"true"`
@@ -3018,8 +3020,6 @@ type TrustedSigners struct {
 
 	// The number of trusted signers for this cache behavior.
 	Quantity *int64 `type:"integer" required:"true"`
-
-	_ struct{} `type:"structure"`
 }
 
 // String returns the string representation
@@ -3034,6 +3034,8 @@ func (s TrustedSigners) GoString() string {
 
 // The request to update an origin access identity.
 type UpdateCloudFrontOriginAccessIdentityInput struct {
+	_ struct{} `type:"structure" payload:"CloudFrontOriginAccessIdentityConfig"`
+
 	// The identity's configuration information.
 	CloudFrontOriginAccessIdentityConfig *OriginAccessIdentityConfig `locationName:"CloudFrontOriginAccessIdentityConfig" type:"structure" required:"true"`
 
@@ -3043,8 +3045,6 @@ type UpdateCloudFrontOriginAccessIdentityInput struct {
 	// The value of the ETag header you received when retrieving the identity's
 	// configuration. For example: E2QWRUHAPOMQZL.
 	IfMatch *string `location:"header" locationName:"If-Match" type:"string"`
-
-	_ struct{} `type:"structure" payload:"CloudFrontOriginAccessIdentityConfig"`
 }
 
 // String returns the string representation
@@ -3059,13 +3059,13 @@ func (s UpdateCloudFrontOriginAccessIdentityInput) GoString() string {
 
 // The returned result of the corresponding request.
 type UpdateCloudFrontOriginAccessIdentityOutput struct {
+	_ struct{} `type:"structure" payload:"CloudFrontOriginAccessIdentity"`
+
 	// The origin access identity's information.
 	CloudFrontOriginAccessIdentity *OriginAccessIdentity `type:"structure"`
 
 	// The current version of the configuration. For example: E2QWRUHAPOMQZL.
 	ETag *string `location:"header" locationName:"ETag" type:"string"`
-
-	_ struct{} `type:"structure" payload:"CloudFrontOriginAccessIdentity"`
 }
 
 // String returns the string representation
@@ -3080,6 +3080,8 @@ func (s UpdateCloudFrontOriginAccessIdentityOutput) GoString() string {
 
 // The request to update a distribution.
 type UpdateDistributionInput struct {
+	_ struct{} `type:"structure" payload:"DistributionConfig"`
+
 	// The distribution's configuration information.
 	DistributionConfig *DistributionConfig `locationName:"DistributionConfig" type:"structure" required:"true"`
 
@@ -3089,8 +3091,6 @@ type UpdateDistributionInput struct {
 	// The value of the ETag header you received when retrieving the distribution's
 	// configuration. For example: E2QWRUHAPOMQZL.
 	IfMatch *string `location:"header" locationName:"If-Match" type:"string"`
-
-	_ struct{} `type:"structure" payload:"DistributionConfig"`
 }
 
 // String returns the string representation
@@ -3105,13 +3105,13 @@ func (s UpdateDistributionInput) GoString() string {
 
 // The returned result of the corresponding request.
 type UpdateDistributionOutput struct {
+	_ struct{} `type:"structure" payload:"Distribution"`
+
 	// The distribution's information.
 	Distribution *Distribution `type:"structure"`
 
 	// The current version of the configuration. For example: E2QWRUHAPOMQZL.
 	ETag *string `location:"header" locationName:"ETag" type:"string"`
-
-	_ struct{} `type:"structure" payload:"Distribution"`
 }
 
 // String returns the string representation
@@ -3126,6 +3126,8 @@ func (s UpdateDistributionOutput) GoString() string {
 
 // The request to update a streaming distribution.
 type UpdateStreamingDistributionInput struct {
+	_ struct{} `type:"structure" payload:"StreamingDistributionConfig"`
+
 	// The streaming distribution's id.
 	Id *string `location:"uri" locationName:"Id" type:"string" required:"true"`
 
@@ -3135,8 +3137,6 @@ type UpdateStreamingDistributionInput struct {
 
 	// The streaming distribution's configuration information.
 	StreamingDistributionConfig *StreamingDistributionConfig `locationName:"StreamingDistributionConfig" type:"structure" required:"true"`
-
-	_ struct{} `type:"structure" payload:"StreamingDistributionConfig"`
 }
 
 // String returns the string representation
@@ -3151,13 +3151,13 @@ func (s UpdateStreamingDistributionInput) GoString() string {
 
 // The returned result of the corresponding request.
 type UpdateStreamingDistributionOutput struct {
+	_ struct{} `type:"structure" payload:"StreamingDistribution"`
+
 	// The current version of the configuration. For example: E2QWRUHAPOMQZL.
 	ETag *string `location:"header" locationName:"ETag" type:"string"`
 
 	// The streaming distribution's information.
 	StreamingDistribution *StreamingDistribution `type:"structure"`
-
-	_ struct{} `type:"structure" payload:"StreamingDistribution"`
 }
 
 // String returns the string representation
@@ -3173,6 +3173,8 @@ func (s UpdateStreamingDistributionOutput) GoString() string {
 // A complex type that contains information about viewer certificates for this
 // distribution.
 type ViewerCertificate struct {
+	_ struct{} `type:"structure"`
+
 	// If you want viewers to use HTTPS to request your objects and you're using
 	// the CloudFront domain name of your distribution in your object URLs (for
 	// example, https://d111111abcdef8.cloudfront.net/logo.jpg), set to true. Omit
@@ -3208,8 +3210,6 @@ type ViewerCertificate struct {
 	// SNI, but some browsers still in use don't support SNI. Do not specify a value
 	// for SSLSupportMethod if you specified true for CloudFrontDefaultCertificate.
 	SSLSupportMethod *string `type:"string" enum:"SSLSupportMethod"`
-
-	_ struct{} `type:"structure"`
 }
 
 // String returns the string representation

--- a/service/cloudfront/api.go
+++ b/service/cloudfront/api.go
@@ -678,11 +678,7 @@ type ActiveTrustedSigners struct {
 	// value of Quantity for ActiveTrustedSigners will be 3.
 	Quantity *int64 `type:"integer" required:"true"`
 
-	metadataActiveTrustedSigners `json:"-" xml:"-"`
-}
-
-type metadataActiveTrustedSigners struct {
-	SDKShapeTraits bool `type:"structure"`
+	_ struct{} `type:"structure"`
 }
 
 // String returns the string representation
@@ -705,11 +701,7 @@ type Aliases struct {
 	// The number of CNAMEs, if any, for this distribution.
 	Quantity *int64 `type:"integer" required:"true"`
 
-	metadataAliases `json:"-" xml:"-"`
-}
-
-type metadataAliases struct {
-	SDKShapeTraits bool `type:"structure"`
+	_ struct{} `type:"structure"`
 }
 
 // String returns the string representation
@@ -748,11 +740,7 @@ type AllowedMethods struct {
 	// requests) and 7 (for GET, HEAD, OPTIONS, PUT, PATCH, POST, and DELETE requests).
 	Quantity *int64 `type:"integer" required:"true"`
 
-	metadataAllowedMethods `json:"-" xml:"-"`
-}
-
-type metadataAllowedMethods struct {
-	SDKShapeTraits bool `type:"structure"`
+	_ struct{} `type:"structure"`
 }
 
 // String returns the string representation
@@ -859,11 +847,7 @@ type CacheBehavior struct {
 	// the HTTPS URL.
 	ViewerProtocolPolicy *string `type:"string" required:"true" enum:"ViewerProtocolPolicy"`
 
-	metadataCacheBehavior `json:"-" xml:"-"`
-}
-
-type metadataCacheBehavior struct {
-	SDKShapeTraits bool `type:"structure"`
+	_ struct{} `type:"structure"`
 }
 
 // String returns the string representation
@@ -885,11 +869,7 @@ type CacheBehaviors struct {
 	// The number of cache behaviors for this distribution.
 	Quantity *int64 `type:"integer" required:"true"`
 
-	metadataCacheBehaviors `json:"-" xml:"-"`
-}
-
-type metadataCacheBehaviors struct {
-	SDKShapeTraits bool `type:"structure"`
+	_ struct{} `type:"structure"`
 }
 
 // String returns the string representation
@@ -918,11 +898,7 @@ type CachedMethods struct {
 	// (for caching responses to GET, HEAD, and OPTIONS requests).
 	Quantity *int64 `type:"integer" required:"true"`
 
-	metadataCachedMethods `json:"-" xml:"-"`
-}
-
-type metadataCachedMethods struct {
-	SDKShapeTraits bool `type:"structure"`
+	_ struct{} `type:"structure"`
 }
 
 // String returns the string representation
@@ -945,11 +921,7 @@ type CookieNames struct {
 	// The number of whitelisted cookies for this cache behavior.
 	Quantity *int64 `type:"integer" required:"true"`
 
-	metadataCookieNames `json:"-" xml:"-"`
-}
-
-type metadataCookieNames struct {
-	SDKShapeTraits bool `type:"structure"`
+	_ struct{} `type:"structure"`
 }
 
 // String returns the string representation
@@ -975,11 +947,7 @@ type CookiePreference struct {
 	// CloudFront to forward to your origin that is associated with this cache behavior.
 	WhitelistedNames *CookieNames `type:"structure"`
 
-	metadataCookiePreference `json:"-" xml:"-"`
-}
-
-type metadataCookiePreference struct {
-	SDKShapeTraits bool `type:"structure"`
+	_ struct{} `type:"structure"`
 }
 
 // String returns the string representation
@@ -997,11 +965,7 @@ type CreateCloudFrontOriginAccessIdentityInput struct {
 	// The origin access identity's configuration information.
 	CloudFrontOriginAccessIdentityConfig *OriginAccessIdentityConfig `locationName:"CloudFrontOriginAccessIdentityConfig" type:"structure" required:"true"`
 
-	metadataCreateCloudFrontOriginAccessIdentityInput `json:"-" xml:"-"`
-}
-
-type metadataCreateCloudFrontOriginAccessIdentityInput struct {
-	SDKShapeTraits bool `type:"structure" payload:"CloudFrontOriginAccessIdentityConfig"`
+	_ struct{} `type:"structure" payload:"CloudFrontOriginAccessIdentityConfig"`
 }
 
 // String returns the string representation
@@ -1026,11 +990,7 @@ type CreateCloudFrontOriginAccessIdentityOutput struct {
 	// example: https://cloudfront.amazonaws.com/2010-11-01/origin-access-identity/cloudfront/E74FTE3AJFJ256A.
 	Location *string `location:"header" locationName:"Location" type:"string"`
 
-	metadataCreateCloudFrontOriginAccessIdentityOutput `json:"-" xml:"-"`
-}
-
-type metadataCreateCloudFrontOriginAccessIdentityOutput struct {
-	SDKShapeTraits bool `type:"structure" payload:"CloudFrontOriginAccessIdentity"`
+	_ struct{} `type:"structure" payload:"CloudFrontOriginAccessIdentity"`
 }
 
 // String returns the string representation
@@ -1048,11 +1008,7 @@ type CreateDistributionInput struct {
 	// The distribution's configuration information.
 	DistributionConfig *DistributionConfig `locationName:"DistributionConfig" type:"structure" required:"true"`
 
-	metadataCreateDistributionInput `json:"-" xml:"-"`
-}
-
-type metadataCreateDistributionInput struct {
-	SDKShapeTraits bool `type:"structure" payload:"DistributionConfig"`
+	_ struct{} `type:"structure" payload:"DistributionConfig"`
 }
 
 // String returns the string representation
@@ -1077,11 +1033,7 @@ type CreateDistributionOutput struct {
 	// example: https://cloudfront.amazonaws.com/2010-11-01/distribution/EDFDVBD632BHDS5.
 	Location *string `location:"header" locationName:"Location" type:"string"`
 
-	metadataCreateDistributionOutput `json:"-" xml:"-"`
-}
-
-type metadataCreateDistributionOutput struct {
-	SDKShapeTraits bool `type:"structure" payload:"Distribution"`
+	_ struct{} `type:"structure" payload:"Distribution"`
 }
 
 // String returns the string representation
@@ -1102,11 +1054,7 @@ type CreateInvalidationInput struct {
 	// The batch information for the invalidation.
 	InvalidationBatch *InvalidationBatch `locationName:"InvalidationBatch" type:"structure" required:"true"`
 
-	metadataCreateInvalidationInput `json:"-" xml:"-"`
-}
-
-type metadataCreateInvalidationInput struct {
-	SDKShapeTraits bool `type:"structure" payload:"InvalidationBatch"`
+	_ struct{} `type:"structure" payload:"InvalidationBatch"`
 }
 
 // String returns the string representation
@@ -1128,11 +1076,7 @@ type CreateInvalidationOutput struct {
 	// including the Invalidation ID.
 	Location *string `location:"header" locationName:"Location" type:"string"`
 
-	metadataCreateInvalidationOutput `json:"-" xml:"-"`
-}
-
-type metadataCreateInvalidationOutput struct {
-	SDKShapeTraits bool `type:"structure" payload:"Invalidation"`
+	_ struct{} `type:"structure" payload:"Invalidation"`
 }
 
 // String returns the string representation
@@ -1150,11 +1094,7 @@ type CreateStreamingDistributionInput struct {
 	// The streaming distribution's configuration information.
 	StreamingDistributionConfig *StreamingDistributionConfig `locationName:"StreamingDistributionConfig" type:"structure" required:"true"`
 
-	metadataCreateStreamingDistributionInput `json:"-" xml:"-"`
-}
-
-type metadataCreateStreamingDistributionInput struct {
-	SDKShapeTraits bool `type:"structure" payload:"StreamingDistributionConfig"`
+	_ struct{} `type:"structure" payload:"StreamingDistributionConfig"`
 }
 
 // String returns the string representation
@@ -1179,11 +1119,7 @@ type CreateStreamingDistributionOutput struct {
 	// The streaming distribution's information.
 	StreamingDistribution *StreamingDistribution `type:"structure"`
 
-	metadataCreateStreamingDistributionOutput `json:"-" xml:"-"`
-}
-
-type metadataCreateStreamingDistributionOutput struct {
-	SDKShapeTraits bool `type:"structure" payload:"StreamingDistribution"`
+	_ struct{} `type:"structure" payload:"StreamingDistribution"`
 }
 
 // String returns the string representation
@@ -1230,11 +1166,7 @@ type CustomErrorResponse struct {
 	// return the custom error page to the viewer.
 	ResponsePagePath *string `type:"string"`
 
-	metadataCustomErrorResponse `json:"-" xml:"-"`
-}
-
-type metadataCustomErrorResponse struct {
-	SDKShapeTraits bool `type:"structure"`
+	_ struct{} `type:"structure"`
 }
 
 // String returns the string representation
@@ -1256,11 +1188,7 @@ type CustomErrorResponses struct {
 	// The number of custom error responses for this distribution.
 	Quantity *int64 `type:"integer" required:"true"`
 
-	metadataCustomErrorResponses `json:"-" xml:"-"`
-}
-
-type metadataCustomErrorResponses struct {
-	SDKShapeTraits bool `type:"structure"`
+	_ struct{} `type:"structure"`
 }
 
 // String returns the string representation
@@ -1284,11 +1212,7 @@ type CustomOriginConfig struct {
 	// The origin protocol policy to apply to your origin.
 	OriginProtocolPolicy *string `type:"string" required:"true" enum:"OriginProtocolPolicy"`
 
-	metadataCustomOriginConfig `json:"-" xml:"-"`
-}
-
-type metadataCustomOriginConfig struct {
-	SDKShapeTraits bool `type:"structure"`
+	_ struct{} `type:"structure"`
 }
 
 // String returns the string representation
@@ -1375,11 +1299,7 @@ type DefaultCacheBehavior struct {
 	// the HTTPS URL.
 	ViewerProtocolPolicy *string `type:"string" required:"true" enum:"ViewerProtocolPolicy"`
 
-	metadataDefaultCacheBehavior `json:"-" xml:"-"`
-}
-
-type metadataDefaultCacheBehavior struct {
-	SDKShapeTraits bool `type:"structure"`
+	_ struct{} `type:"structure"`
 }
 
 // String returns the string representation
@@ -1401,11 +1321,7 @@ type DeleteCloudFrontOriginAccessIdentityInput struct {
 	// For example: E2QWRUHAPOMQZL.
 	IfMatch *string `location:"header" locationName:"If-Match" type:"string"`
 
-	metadataDeleteCloudFrontOriginAccessIdentityInput `json:"-" xml:"-"`
-}
-
-type metadataDeleteCloudFrontOriginAccessIdentityInput struct {
-	SDKShapeTraits bool `type:"structure"`
+	_ struct{} `type:"structure"`
 }
 
 // String returns the string representation
@@ -1419,11 +1335,7 @@ func (s DeleteCloudFrontOriginAccessIdentityInput) GoString() string {
 }
 
 type DeleteCloudFrontOriginAccessIdentityOutput struct {
-	metadataDeleteCloudFrontOriginAccessIdentityOutput `json:"-" xml:"-"`
-}
-
-type metadataDeleteCloudFrontOriginAccessIdentityOutput struct {
-	SDKShapeTraits bool `type:"structure"`
+	_ struct{} `type:"structure"`
 }
 
 // String returns the string representation
@@ -1445,11 +1357,7 @@ type DeleteDistributionInput struct {
 	// For example: E2QWRUHAPOMQZL.
 	IfMatch *string `location:"header" locationName:"If-Match" type:"string"`
 
-	metadataDeleteDistributionInput `json:"-" xml:"-"`
-}
-
-type metadataDeleteDistributionInput struct {
-	SDKShapeTraits bool `type:"structure"`
+	_ struct{} `type:"structure"`
 }
 
 // String returns the string representation
@@ -1463,11 +1371,7 @@ func (s DeleteDistributionInput) GoString() string {
 }
 
 type DeleteDistributionOutput struct {
-	metadataDeleteDistributionOutput `json:"-" xml:"-"`
-}
-
-type metadataDeleteDistributionOutput struct {
-	SDKShapeTraits bool `type:"structure"`
+	_ struct{} `type:"structure"`
 }
 
 // String returns the string representation
@@ -1489,11 +1393,7 @@ type DeleteStreamingDistributionInput struct {
 	// distribution. For example: E2QWRUHAPOMQZL.
 	IfMatch *string `location:"header" locationName:"If-Match" type:"string"`
 
-	metadataDeleteStreamingDistributionInput `json:"-" xml:"-"`
-}
-
-type metadataDeleteStreamingDistributionInput struct {
-	SDKShapeTraits bool `type:"structure"`
+	_ struct{} `type:"structure"`
 }
 
 // String returns the string representation
@@ -1507,11 +1407,7 @@ func (s DeleteStreamingDistributionInput) GoString() string {
 }
 
 type DeleteStreamingDistributionOutput struct {
-	metadataDeleteStreamingDistributionOutput `json:"-" xml:"-"`
-}
-
-type metadataDeleteStreamingDistributionOutput struct {
-	SDKShapeTraits bool `type:"structure"`
+	_ struct{} `type:"structure"`
 }
 
 // String returns the string representation
@@ -1556,11 +1452,7 @@ type Distribution struct {
 	// throughout the Amazon CloudFront system.
 	Status *string `type:"string" required:"true"`
 
-	metadataDistribution `json:"-" xml:"-"`
-}
-
-type metadataDistribution struct {
-	SDKShapeTraits bool `type:"structure"`
+	_ struct{} `type:"structure"`
 }
 
 // String returns the string representation
@@ -1639,11 +1531,7 @@ type DistributionConfig struct {
 	// of the AWS WAF web ACL that is associated with the distribution.
 	WebACLId *string `type:"string"`
 
-	metadataDistributionConfig `json:"-" xml:"-"`
-}
-
-type metadataDistributionConfig struct {
-	SDKShapeTraits bool `type:"structure"`
+	_ struct{} `type:"structure"`
 }
 
 // String returns the string representation
@@ -1682,11 +1570,7 @@ type DistributionList struct {
 	// The number of distributions that were created by the current AWS account.
 	Quantity *int64 `type:"integer" required:"true"`
 
-	metadataDistributionList `json:"-" xml:"-"`
-}
-
-type metadataDistributionList struct {
-	SDKShapeTraits bool `type:"structure"`
+	_ struct{} `type:"structure"`
 }
 
 // String returns the string representation
@@ -1752,11 +1636,7 @@ type DistributionSummary struct {
 	// The Web ACL Id (if any) associated with the distribution.
 	WebACLId *string `type:"string" required:"true"`
 
-	metadataDistributionSummary `json:"-" xml:"-"`
-}
-
-type metadataDistributionSummary struct {
-	SDKShapeTraits bool `type:"structure"`
+	_ struct{} `type:"structure"`
 }
 
 // String returns the string representation
@@ -1784,11 +1664,7 @@ type ForwardedValues struct {
 	// specify false.
 	QueryString *bool `type:"boolean" required:"true"`
 
-	metadataForwardedValues `json:"-" xml:"-"`
-}
-
-type metadataForwardedValues struct {
-	SDKShapeTraits bool `type:"structure"`
+	_ struct{} `type:"structure"`
 }
 
 // String returns the string representation
@@ -1832,11 +1708,7 @@ type GeoRestriction struct {
 	// you want CloudFront to distribute your content.
 	RestrictionType *string `type:"string" required:"true" enum:"GeoRestrictionType"`
 
-	metadataGeoRestriction `json:"-" xml:"-"`
-}
-
-type metadataGeoRestriction struct {
-	SDKShapeTraits bool `type:"structure"`
+	_ struct{} `type:"structure"`
 }
 
 // String returns the string representation
@@ -1854,11 +1726,7 @@ type GetCloudFrontOriginAccessIdentityConfigInput struct {
 	// The identity's id.
 	Id *string `location:"uri" locationName:"Id" type:"string" required:"true"`
 
-	metadataGetCloudFrontOriginAccessIdentityConfigInput `json:"-" xml:"-"`
-}
-
-type metadataGetCloudFrontOriginAccessIdentityConfigInput struct {
-	SDKShapeTraits bool `type:"structure"`
+	_ struct{} `type:"structure"`
 }
 
 // String returns the string representation
@@ -1879,11 +1747,7 @@ type GetCloudFrontOriginAccessIdentityConfigOutput struct {
 	// The current version of the configuration. For example: E2QWRUHAPOMQZL.
 	ETag *string `location:"header" locationName:"ETag" type:"string"`
 
-	metadataGetCloudFrontOriginAccessIdentityConfigOutput `json:"-" xml:"-"`
-}
-
-type metadataGetCloudFrontOriginAccessIdentityConfigOutput struct {
-	SDKShapeTraits bool `type:"structure" payload:"CloudFrontOriginAccessIdentityConfig"`
+	_ struct{} `type:"structure" payload:"CloudFrontOriginAccessIdentityConfig"`
 }
 
 // String returns the string representation
@@ -1901,11 +1765,7 @@ type GetCloudFrontOriginAccessIdentityInput struct {
 	// The identity's id.
 	Id *string `location:"uri" locationName:"Id" type:"string" required:"true"`
 
-	metadataGetCloudFrontOriginAccessIdentityInput `json:"-" xml:"-"`
-}
-
-type metadataGetCloudFrontOriginAccessIdentityInput struct {
-	SDKShapeTraits bool `type:"structure"`
+	_ struct{} `type:"structure"`
 }
 
 // String returns the string representation
@@ -1927,11 +1787,7 @@ type GetCloudFrontOriginAccessIdentityOutput struct {
 	// E2QWRUHAPOMQZL.
 	ETag *string `location:"header" locationName:"ETag" type:"string"`
 
-	metadataGetCloudFrontOriginAccessIdentityOutput `json:"-" xml:"-"`
-}
-
-type metadataGetCloudFrontOriginAccessIdentityOutput struct {
-	SDKShapeTraits bool `type:"structure" payload:"CloudFrontOriginAccessIdentity"`
+	_ struct{} `type:"structure" payload:"CloudFrontOriginAccessIdentity"`
 }
 
 // String returns the string representation
@@ -1949,11 +1805,7 @@ type GetDistributionConfigInput struct {
 	// The distribution's id.
 	Id *string `location:"uri" locationName:"Id" type:"string" required:"true"`
 
-	metadataGetDistributionConfigInput `json:"-" xml:"-"`
-}
-
-type metadataGetDistributionConfigInput struct {
-	SDKShapeTraits bool `type:"structure"`
+	_ struct{} `type:"structure"`
 }
 
 // String returns the string representation
@@ -1974,11 +1826,7 @@ type GetDistributionConfigOutput struct {
 	// The current version of the configuration. For example: E2QWRUHAPOMQZL.
 	ETag *string `location:"header" locationName:"ETag" type:"string"`
 
-	metadataGetDistributionConfigOutput `json:"-" xml:"-"`
-}
-
-type metadataGetDistributionConfigOutput struct {
-	SDKShapeTraits bool `type:"structure" payload:"DistributionConfig"`
+	_ struct{} `type:"structure" payload:"DistributionConfig"`
 }
 
 // String returns the string representation
@@ -1996,11 +1844,7 @@ type GetDistributionInput struct {
 	// The distribution's id.
 	Id *string `location:"uri" locationName:"Id" type:"string" required:"true"`
 
-	metadataGetDistributionInput `json:"-" xml:"-"`
-}
-
-type metadataGetDistributionInput struct {
-	SDKShapeTraits bool `type:"structure"`
+	_ struct{} `type:"structure"`
 }
 
 // String returns the string representation
@@ -2021,11 +1865,7 @@ type GetDistributionOutput struct {
 	// The current version of the distribution's information. For example: E2QWRUHAPOMQZL.
 	ETag *string `location:"header" locationName:"ETag" type:"string"`
 
-	metadataGetDistributionOutput `json:"-" xml:"-"`
-}
-
-type metadataGetDistributionOutput struct {
-	SDKShapeTraits bool `type:"structure" payload:"Distribution"`
+	_ struct{} `type:"structure" payload:"Distribution"`
 }
 
 // String returns the string representation
@@ -2046,11 +1886,7 @@ type GetInvalidationInput struct {
 	// The invalidation's id.
 	Id *string `location:"uri" locationName:"Id" type:"string" required:"true"`
 
-	metadataGetInvalidationInput `json:"-" xml:"-"`
-}
-
-type metadataGetInvalidationInput struct {
-	SDKShapeTraits bool `type:"structure"`
+	_ struct{} `type:"structure"`
 }
 
 // String returns the string representation
@@ -2068,11 +1904,7 @@ type GetInvalidationOutput struct {
 	// The invalidation's information.
 	Invalidation *Invalidation `type:"structure"`
 
-	metadataGetInvalidationOutput `json:"-" xml:"-"`
-}
-
-type metadataGetInvalidationOutput struct {
-	SDKShapeTraits bool `type:"structure" payload:"Invalidation"`
+	_ struct{} `type:"structure" payload:"Invalidation"`
 }
 
 // String returns the string representation
@@ -2090,11 +1922,7 @@ type GetStreamingDistributionConfigInput struct {
 	// The streaming distribution's id.
 	Id *string `location:"uri" locationName:"Id" type:"string" required:"true"`
 
-	metadataGetStreamingDistributionConfigInput `json:"-" xml:"-"`
-}
-
-type metadataGetStreamingDistributionConfigInput struct {
-	SDKShapeTraits bool `type:"structure"`
+	_ struct{} `type:"structure"`
 }
 
 // String returns the string representation
@@ -2115,11 +1943,7 @@ type GetStreamingDistributionConfigOutput struct {
 	// The streaming distribution's configuration information.
 	StreamingDistributionConfig *StreamingDistributionConfig `type:"structure"`
 
-	metadataGetStreamingDistributionConfigOutput `json:"-" xml:"-"`
-}
-
-type metadataGetStreamingDistributionConfigOutput struct {
-	SDKShapeTraits bool `type:"structure" payload:"StreamingDistributionConfig"`
+	_ struct{} `type:"structure" payload:"StreamingDistributionConfig"`
 }
 
 // String returns the string representation
@@ -2137,11 +1961,7 @@ type GetStreamingDistributionInput struct {
 	// The streaming distribution's id.
 	Id *string `location:"uri" locationName:"Id" type:"string" required:"true"`
 
-	metadataGetStreamingDistributionInput `json:"-" xml:"-"`
-}
-
-type metadataGetStreamingDistributionInput struct {
-	SDKShapeTraits bool `type:"structure"`
+	_ struct{} `type:"structure"`
 }
 
 // String returns the string representation
@@ -2163,11 +1983,7 @@ type GetStreamingDistributionOutput struct {
 	// The streaming distribution's information.
 	StreamingDistribution *StreamingDistribution `type:"structure"`
 
-	metadataGetStreamingDistributionOutput `json:"-" xml:"-"`
-}
-
-type metadataGetStreamingDistributionOutput struct {
-	SDKShapeTraits bool `type:"structure" payload:"StreamingDistribution"`
+	_ struct{} `type:"structure" payload:"StreamingDistribution"`
 }
 
 // String returns the string representation
@@ -2203,11 +2019,7 @@ type Headers struct {
 	// Items.
 	Quantity *int64 `type:"integer" required:"true"`
 
-	metadataHeaders `json:"-" xml:"-"`
-}
-
-type metadataHeaders struct {
-	SDKShapeTraits bool `type:"structure"`
+	_ struct{} `type:"structure"`
 }
 
 // String returns the string representation
@@ -2235,11 +2047,7 @@ type Invalidation struct {
 	// the status is Completed.
 	Status *string `type:"string" required:"true"`
 
-	metadataInvalidation `json:"-" xml:"-"`
-}
-
-type metadataInvalidation struct {
-	SDKShapeTraits bool `type:"structure"`
+	_ struct{} `type:"structure"`
 }
 
 // String returns the string representation
@@ -2273,11 +2081,7 @@ type InvalidationBatch struct {
 	// path, or CloudFront will not invalidate the old version of the updated object.
 	Paths *Paths `type:"structure" required:"true"`
 
-	metadataInvalidationBatch `json:"-" xml:"-"`
-}
-
-type metadataInvalidationBatch struct {
-	SDKShapeTraits bool `type:"structure"`
+	_ struct{} `type:"structure"`
 }
 
 // String returns the string representation
@@ -2316,11 +2120,7 @@ type InvalidationList struct {
 	// The number of invalidation batches that were created by the current AWS account.
 	Quantity *int64 `type:"integer" required:"true"`
 
-	metadataInvalidationList `json:"-" xml:"-"`
-}
-
-type metadataInvalidationList struct {
-	SDKShapeTraits bool `type:"structure"`
+	_ struct{} `type:"structure"`
 }
 
 // String returns the string representation
@@ -2343,11 +2143,7 @@ type InvalidationSummary struct {
 	// The status of an invalidation request.
 	Status *string `type:"string" required:"true"`
 
-	metadataInvalidationSummary `json:"-" xml:"-"`
-}
-
-type metadataInvalidationSummary struct {
-	SDKShapeTraits bool `type:"structure"`
+	_ struct{} `type:"structure"`
 }
 
 // String returns the string representation
@@ -2370,11 +2166,7 @@ type KeyPairIds struct {
 	// The number of active CloudFront key pairs for AwsAccountNumber.
 	Quantity *int64 `type:"integer" required:"true"`
 
-	metadataKeyPairIds `json:"-" xml:"-"`
-}
-
-type metadataKeyPairIds struct {
-	SDKShapeTraits bool `type:"structure"`
+	_ struct{} `type:"structure"`
 }
 
 // String returns the string representation
@@ -2399,11 +2191,7 @@ type ListCloudFrontOriginAccessIdentitiesInput struct {
 	// The maximum number of origin access identities you want in the response body.
 	MaxItems *int64 `location:"querystring" locationName:"MaxItems" type:"integer"`
 
-	metadataListCloudFrontOriginAccessIdentitiesInput `json:"-" xml:"-"`
-}
-
-type metadataListCloudFrontOriginAccessIdentitiesInput struct {
-	SDKShapeTraits bool `type:"structure"`
+	_ struct{} `type:"structure"`
 }
 
 // String returns the string representation
@@ -2421,11 +2209,7 @@ type ListCloudFrontOriginAccessIdentitiesOutput struct {
 	// The CloudFrontOriginAccessIdentityList type.
 	CloudFrontOriginAccessIdentityList *OriginAccessIdentityList `type:"structure"`
 
-	metadataListCloudFrontOriginAccessIdentitiesOutput `json:"-" xml:"-"`
-}
-
-type metadataListCloudFrontOriginAccessIdentitiesOutput struct {
-	SDKShapeTraits bool `type:"structure" payload:"CloudFrontOriginAccessIdentityList"`
+	_ struct{} `type:"structure" payload:"CloudFrontOriginAccessIdentityList"`
 }
 
 // String returns the string representation
@@ -2457,11 +2241,7 @@ type ListDistributionsByWebACLIdInput struct {
 	// that aren't associated with a web ACL.
 	WebACLId *string `location:"uri" locationName:"WebACLId" type:"string" required:"true"`
 
-	metadataListDistributionsByWebACLIdInput `json:"-" xml:"-"`
-}
-
-type metadataListDistributionsByWebACLIdInput struct {
-	SDKShapeTraits bool `type:"structure"`
+	_ struct{} `type:"structure"`
 }
 
 // String returns the string representation
@@ -2480,11 +2260,7 @@ type ListDistributionsByWebACLIdOutput struct {
 	// The DistributionList type.
 	DistributionList *DistributionList `type:"structure"`
 
-	metadataListDistributionsByWebACLIdOutput `json:"-" xml:"-"`
-}
-
-type metadataListDistributionsByWebACLIdOutput struct {
-	SDKShapeTraits bool `type:"structure" payload:"DistributionList"`
+	_ struct{} `type:"structure" payload:"DistributionList"`
 }
 
 // String returns the string representation
@@ -2510,11 +2286,7 @@ type ListDistributionsInput struct {
 	// the response body. The maximum and default values are both 100.
 	MaxItems *int64 `location:"querystring" locationName:"MaxItems" type:"integer"`
 
-	metadataListDistributionsInput `json:"-" xml:"-"`
-}
-
-type metadataListDistributionsInput struct {
-	SDKShapeTraits bool `type:"structure"`
+	_ struct{} `type:"structure"`
 }
 
 // String returns the string representation
@@ -2532,11 +2304,7 @@ type ListDistributionsOutput struct {
 	// The DistributionList type.
 	DistributionList *DistributionList `type:"structure"`
 
-	metadataListDistributionsOutput `json:"-" xml:"-"`
-}
-
-type metadataListDistributionsOutput struct {
-	SDKShapeTraits bool `type:"structure" payload:"DistributionList"`
+	_ struct{} `type:"structure" payload:"DistributionList"`
 }
 
 // String returns the string representation
@@ -2566,11 +2334,7 @@ type ListInvalidationsInput struct {
 	// The maximum number of invalidation batches you want in the response body.
 	MaxItems *int64 `location:"querystring" locationName:"MaxItems" type:"integer"`
 
-	metadataListInvalidationsInput `json:"-" xml:"-"`
-}
-
-type metadataListInvalidationsInput struct {
-	SDKShapeTraits bool `type:"structure"`
+	_ struct{} `type:"structure"`
 }
 
 // String returns the string representation
@@ -2588,11 +2352,7 @@ type ListInvalidationsOutput struct {
 	// Information about invalidation batches.
 	InvalidationList *InvalidationList `type:"structure"`
 
-	metadataListInvalidationsOutput `json:"-" xml:"-"`
-}
-
-type metadataListInvalidationsOutput struct {
-	SDKShapeTraits bool `type:"structure" payload:"InvalidationList"`
+	_ struct{} `type:"structure" payload:"InvalidationList"`
 }
 
 // String returns the string representation
@@ -2617,11 +2377,7 @@ type ListStreamingDistributionsInput struct {
 	// The maximum number of streaming distributions you want in the response body.
 	MaxItems *int64 `location:"querystring" locationName:"MaxItems" type:"integer"`
 
-	metadataListStreamingDistributionsInput `json:"-" xml:"-"`
-}
-
-type metadataListStreamingDistributionsInput struct {
-	SDKShapeTraits bool `type:"structure"`
+	_ struct{} `type:"structure"`
 }
 
 // String returns the string representation
@@ -2639,11 +2395,7 @@ type ListStreamingDistributionsOutput struct {
 	// The StreamingDistributionList type.
 	StreamingDistributionList *StreamingDistributionList `type:"structure"`
 
-	metadataListStreamingDistributionsOutput `json:"-" xml:"-"`
-}
-
-type metadataListStreamingDistributionsOutput struct {
-	SDKShapeTraits bool `type:"structure" payload:"StreamingDistributionList"`
+	_ struct{} `type:"structure" payload:"StreamingDistributionList"`
 }
 
 // String returns the string representation
@@ -2683,11 +2435,7 @@ type LoggingConfig struct {
 	// Prefix element in the Logging element.
 	Prefix *string `type:"string" required:"true"`
 
-	metadataLoggingConfig `json:"-" xml:"-"`
-}
-
-type metadataLoggingConfig struct {
-	SDKShapeTraits bool `type:"structure"`
+	_ struct{} `type:"structure"`
 }
 
 // String returns the string representation
@@ -2730,11 +2478,7 @@ type Origin struct {
 	// origin is a custom origin, use the CustomOriginConfig element instead.
 	S3OriginConfig *S3OriginConfig `type:"structure"`
 
-	metadataOrigin `json:"-" xml:"-"`
-}
-
-type metadataOrigin struct {
-	SDKShapeTraits bool `type:"structure"`
+	_ struct{} `type:"structure"`
 }
 
 // String returns the string representation
@@ -2760,11 +2504,7 @@ type OriginAccessIdentity struct {
 	// Amazon S3.
 	S3CanonicalUserId *string `type:"string" required:"true"`
 
-	metadataOriginAccessIdentity `json:"-" xml:"-"`
-}
-
-type metadataOriginAccessIdentity struct {
-	SDKShapeTraits bool `type:"structure"`
+	_ struct{} `type:"structure"`
 }
 
 // String returns the string representation
@@ -2795,11 +2535,7 @@ type OriginAccessIdentityConfig struct {
 	// Any comments you want to include about the origin access identity.
 	Comment *string `type:"string" required:"true"`
 
-	metadataOriginAccessIdentityConfig `json:"-" xml:"-"`
-}
-
-type metadataOriginAccessIdentityConfig struct {
-	SDKShapeTraits bool `type:"structure"`
+	_ struct{} `type:"structure"`
 }
 
 // String returns the string representation
@@ -2839,11 +2575,7 @@ type OriginAccessIdentityList struct {
 	// current AWS account.
 	Quantity *int64 `type:"integer" required:"true"`
 
-	metadataOriginAccessIdentityList `json:"-" xml:"-"`
-}
-
-type metadataOriginAccessIdentityList struct {
-	SDKShapeTraits bool `type:"structure"`
+	_ struct{} `type:"structure"`
 }
 
 // String returns the string representation
@@ -2870,11 +2602,7 @@ type OriginAccessIdentitySummary struct {
 	// Amazon S3.
 	S3CanonicalUserId *string `type:"string" required:"true"`
 
-	metadataOriginAccessIdentitySummary `json:"-" xml:"-"`
-}
-
-type metadataOriginAccessIdentitySummary struct {
-	SDKShapeTraits bool `type:"structure"`
+	_ struct{} `type:"structure"`
 }
 
 // String returns the string representation
@@ -2895,11 +2623,7 @@ type Origins struct {
 	// The number of origins for this distribution.
 	Quantity *int64 `type:"integer" required:"true"`
 
-	metadataOrigins `json:"-" xml:"-"`
-}
-
-type metadataOrigins struct {
-	SDKShapeTraits bool `type:"structure"`
+	_ struct{} `type:"structure"`
 }
 
 // String returns the string representation
@@ -2921,11 +2645,7 @@ type Paths struct {
 	// The number of objects that you want to invalidate.
 	Quantity *int64 `type:"integer" required:"true"`
 
-	metadataPaths `json:"-" xml:"-"`
-}
-
-type metadataPaths struct {
-	SDKShapeTraits bool `type:"structure"`
+	_ struct{} `type:"structure"`
 }
 
 // String returns the string representation
@@ -2949,11 +2669,7 @@ type Restrictions struct {
 	// website.
 	GeoRestriction *GeoRestriction `type:"structure" required:"true"`
 
-	metadataRestrictions `json:"-" xml:"-"`
-}
-
-type metadataRestrictions struct {
-	SDKShapeTraits bool `type:"structure"`
+	_ struct{} `type:"structure"`
 }
 
 // String returns the string representation
@@ -2975,11 +2691,7 @@ type S3Origin struct {
 	// Your S3 origin's origin access identity.
 	OriginAccessIdentity *string `type:"string" required:"true"`
 
-	metadataS3Origin `json:"-" xml:"-"`
-}
-
-type metadataS3Origin struct {
-	SDKShapeTraits bool `type:"structure"`
+	_ struct{} `type:"structure"`
 }
 
 // String returns the string representation
@@ -3008,11 +2720,7 @@ type S3OriginConfig struct {
 	// created the origin access identity.
 	OriginAccessIdentity *string `type:"string" required:"true"`
 
-	metadataS3OriginConfig `json:"-" xml:"-"`
-}
-
-type metadataS3OriginConfig struct {
-	SDKShapeTraits bool `type:"structure"`
+	_ struct{} `type:"structure"`
 }
 
 // String returns the string representation
@@ -3038,11 +2746,7 @@ type Signer struct {
 	// associated with AwsAccountNumber.
 	KeyPairIds *KeyPairIds `type:"structure"`
 
-	metadataSigner `json:"-" xml:"-"`
-}
-
-type metadataSigner struct {
-	SDKShapeTraits bool `type:"structure"`
+	_ struct{} `type:"structure"`
 }
 
 // String returns the string representation
@@ -3085,11 +2789,7 @@ type StreamingDistribution struct {
 	// The current configuration information for the streaming distribution.
 	StreamingDistributionConfig *StreamingDistributionConfig `type:"structure" required:"true"`
 
-	metadataStreamingDistribution `json:"-" xml:"-"`
-}
-
-type metadataStreamingDistribution struct {
-	SDKShapeTraits bool `type:"structure"`
+	_ struct{} `type:"structure"`
 }
 
 // String returns the string representation
@@ -3152,11 +2852,7 @@ type StreamingDistributionConfig struct {
 	// of the trusted signers that you want to include in the updated distribution.
 	TrustedSigners *TrustedSigners `type:"structure" required:"true"`
 
-	metadataStreamingDistributionConfig `json:"-" xml:"-"`
-}
-
-type metadataStreamingDistributionConfig struct {
-	SDKShapeTraits bool `type:"structure"`
+	_ struct{} `type:"structure"`
 }
 
 // String returns the string representation
@@ -3196,11 +2892,7 @@ type StreamingDistributionList struct {
 	// account.
 	Quantity *int64 `type:"integer" required:"true"`
 
-	metadataStreamingDistributionList `json:"-" xml:"-"`
-}
-
-type metadataStreamingDistributionList struct {
-	SDKShapeTraits bool `type:"structure"`
+	_ struct{} `type:"structure"`
 }
 
 // String returns the string representation
@@ -3258,11 +2950,7 @@ type StreamingDistributionSummary struct {
 	// of the trusted signers that you want to include in the updated distribution.
 	TrustedSigners *TrustedSigners `type:"structure" required:"true"`
 
-	metadataStreamingDistributionSummary `json:"-" xml:"-"`
-}
-
-type metadataStreamingDistributionSummary struct {
-	SDKShapeTraits bool `type:"structure"`
+	_ struct{} `type:"structure"`
 }
 
 // String returns the string representation
@@ -3295,11 +2983,7 @@ type StreamingLoggingConfig struct {
 	// an empty Prefix element in the Logging element.
 	Prefix *string `type:"string" required:"true"`
 
-	metadataStreamingLoggingConfig `json:"-" xml:"-"`
-}
-
-type metadataStreamingLoggingConfig struct {
-	SDKShapeTraits bool `type:"structure"`
+	_ struct{} `type:"structure"`
 }
 
 // String returns the string representation
@@ -3335,11 +3019,7 @@ type TrustedSigners struct {
 	// The number of trusted signers for this cache behavior.
 	Quantity *int64 `type:"integer" required:"true"`
 
-	metadataTrustedSigners `json:"-" xml:"-"`
-}
-
-type metadataTrustedSigners struct {
-	SDKShapeTraits bool `type:"structure"`
+	_ struct{} `type:"structure"`
 }
 
 // String returns the string representation
@@ -3364,11 +3044,7 @@ type UpdateCloudFrontOriginAccessIdentityInput struct {
 	// configuration. For example: E2QWRUHAPOMQZL.
 	IfMatch *string `location:"header" locationName:"If-Match" type:"string"`
 
-	metadataUpdateCloudFrontOriginAccessIdentityInput `json:"-" xml:"-"`
-}
-
-type metadataUpdateCloudFrontOriginAccessIdentityInput struct {
-	SDKShapeTraits bool `type:"structure" payload:"CloudFrontOriginAccessIdentityConfig"`
+	_ struct{} `type:"structure" payload:"CloudFrontOriginAccessIdentityConfig"`
 }
 
 // String returns the string representation
@@ -3389,11 +3065,7 @@ type UpdateCloudFrontOriginAccessIdentityOutput struct {
 	// The current version of the configuration. For example: E2QWRUHAPOMQZL.
 	ETag *string `location:"header" locationName:"ETag" type:"string"`
 
-	metadataUpdateCloudFrontOriginAccessIdentityOutput `json:"-" xml:"-"`
-}
-
-type metadataUpdateCloudFrontOriginAccessIdentityOutput struct {
-	SDKShapeTraits bool `type:"structure" payload:"CloudFrontOriginAccessIdentity"`
+	_ struct{} `type:"structure" payload:"CloudFrontOriginAccessIdentity"`
 }
 
 // String returns the string representation
@@ -3418,11 +3090,7 @@ type UpdateDistributionInput struct {
 	// configuration. For example: E2QWRUHAPOMQZL.
 	IfMatch *string `location:"header" locationName:"If-Match" type:"string"`
 
-	metadataUpdateDistributionInput `json:"-" xml:"-"`
-}
-
-type metadataUpdateDistributionInput struct {
-	SDKShapeTraits bool `type:"structure" payload:"DistributionConfig"`
+	_ struct{} `type:"structure" payload:"DistributionConfig"`
 }
 
 // String returns the string representation
@@ -3443,11 +3111,7 @@ type UpdateDistributionOutput struct {
 	// The current version of the configuration. For example: E2QWRUHAPOMQZL.
 	ETag *string `location:"header" locationName:"ETag" type:"string"`
 
-	metadataUpdateDistributionOutput `json:"-" xml:"-"`
-}
-
-type metadataUpdateDistributionOutput struct {
-	SDKShapeTraits bool `type:"structure" payload:"Distribution"`
+	_ struct{} `type:"structure" payload:"Distribution"`
 }
 
 // String returns the string representation
@@ -3472,11 +3136,7 @@ type UpdateStreamingDistributionInput struct {
 	// The streaming distribution's configuration information.
 	StreamingDistributionConfig *StreamingDistributionConfig `locationName:"StreamingDistributionConfig" type:"structure" required:"true"`
 
-	metadataUpdateStreamingDistributionInput `json:"-" xml:"-"`
-}
-
-type metadataUpdateStreamingDistributionInput struct {
-	SDKShapeTraits bool `type:"structure" payload:"StreamingDistributionConfig"`
+	_ struct{} `type:"structure" payload:"StreamingDistributionConfig"`
 }
 
 // String returns the string representation
@@ -3497,11 +3157,7 @@ type UpdateStreamingDistributionOutput struct {
 	// The streaming distribution's information.
 	StreamingDistribution *StreamingDistribution `type:"structure"`
 
-	metadataUpdateStreamingDistributionOutput `json:"-" xml:"-"`
-}
-
-type metadataUpdateStreamingDistributionOutput struct {
-	SDKShapeTraits bool `type:"structure" payload:"StreamingDistribution"`
+	_ struct{} `type:"structure" payload:"StreamingDistribution"`
 }
 
 // String returns the string representation
@@ -3553,11 +3209,7 @@ type ViewerCertificate struct {
 	// for SSLSupportMethod if you specified true for CloudFrontDefaultCertificate.
 	SSLSupportMethod *string `type:"string" enum:"SSLSupportMethod"`
 
-	metadataViewerCertificate `json:"-" xml:"-"`
-}
-
-type metadataViewerCertificate struct {
-	SDKShapeTraits bool `type:"structure"`
+	_ struct{} `type:"structure"`
 }
 
 // String returns the string representation

--- a/service/cloudhsm/api.go
+++ b/service/cloudhsm/api.go
@@ -508,10 +508,10 @@ func (c *CloudHSM) ModifyLunaClient(input *ModifyLunaClientInput) (*ModifyLunaCl
 
 // Contains the inputs for the CreateHapgRequest action.
 type CreateHapgInput struct {
+	_ struct{} `type:"structure"`
+
 	// The label of the new high-availability partition group.
 	Label *string `type:"string" required:"true"`
-
-	_ struct{} `type:"structure"`
 }
 
 // String returns the string representation
@@ -526,10 +526,10 @@ func (s CreateHapgInput) GoString() string {
 
 // Contains the output of the CreateHAPartitionGroup action.
 type CreateHapgOutput struct {
+	_ struct{} `type:"structure"`
+
 	// The ARN of the high-availability partition group.
 	HapgArn *string `type:"string"`
-
-	_ struct{} `type:"structure"`
 }
 
 // String returns the string representation
@@ -544,6 +544,8 @@ func (s CreateHapgOutput) GoString() string {
 
 // Contains the inputs for the CreateHsm operation.
 type CreateHsmInput struct {
+	_ struct{} `locationName:"CreateHsmRequest" type:"structure"`
+
 	// A user-defined token to ensure idempotence. Subsequent calls to this operation
 	// with the same token will be ignored.
 	ClientToken *string `locationName:"ClientToken" type:"string"`
@@ -576,8 +578,6 @@ type CreateHsmInput struct {
 	// The IP address for the syslog monitoring server. The AWS CloudHSM service
 	// only supports one syslog monitoring server.
 	SyslogIp *string `locationName:"SyslogIp" type:"string"`
-
-	_ struct{} `locationName:"CreateHsmRequest" type:"structure"`
 }
 
 // String returns the string representation
@@ -592,10 +592,10 @@ func (s CreateHsmInput) GoString() string {
 
 // Contains the output of the CreateHsm operation.
 type CreateHsmOutput struct {
+	_ struct{} `type:"structure"`
+
 	// The ARN of the HSM.
 	HsmArn *string `type:"string"`
-
-	_ struct{} `type:"structure"`
 }
 
 // String returns the string representation
@@ -610,14 +610,14 @@ func (s CreateHsmOutput) GoString() string {
 
 // Contains the inputs for the CreateLunaClient action.
 type CreateLunaClientInput struct {
+	_ struct{} `type:"structure"`
+
 	// The contents of a Base64-Encoded X.509 v3 certificate to be installed on
 	// the HSMs used by this client.
 	Certificate *string `min:"600" type:"string" required:"true"`
 
 	// The label for the client.
 	Label *string `type:"string"`
-
-	_ struct{} `type:"structure"`
 }
 
 // String returns the string representation
@@ -632,10 +632,10 @@ func (s CreateLunaClientInput) GoString() string {
 
 // Contains the output of the CreateLunaClient action.
 type CreateLunaClientOutput struct {
+	_ struct{} `type:"structure"`
+
 	// The ARN of the client.
 	ClientArn *string `type:"string"`
-
-	_ struct{} `type:"structure"`
 }
 
 // String returns the string representation
@@ -650,10 +650,10 @@ func (s CreateLunaClientOutput) GoString() string {
 
 // Contains the inputs for the DeleteHapg action.
 type DeleteHapgInput struct {
+	_ struct{} `type:"structure"`
+
 	// The ARN of the high-availability partition group to delete.
 	HapgArn *string `type:"string" required:"true"`
-
-	_ struct{} `type:"structure"`
 }
 
 // String returns the string representation
@@ -668,10 +668,10 @@ func (s DeleteHapgInput) GoString() string {
 
 // Contains the output of the DeleteHapg action.
 type DeleteHapgOutput struct {
+	_ struct{} `type:"structure"`
+
 	// The status of the action.
 	Status *string `type:"string" required:"true"`
-
-	_ struct{} `type:"structure"`
 }
 
 // String returns the string representation
@@ -686,10 +686,10 @@ func (s DeleteHapgOutput) GoString() string {
 
 // Contains the inputs for the DeleteHsm operation.
 type DeleteHsmInput struct {
+	_ struct{} `locationName:"DeleteHsmRequest" type:"structure"`
+
 	// The ARN of the HSM to delete.
 	HsmArn *string `locationName:"HsmArn" type:"string" required:"true"`
-
-	_ struct{} `locationName:"DeleteHsmRequest" type:"structure"`
 }
 
 // String returns the string representation
@@ -704,10 +704,10 @@ func (s DeleteHsmInput) GoString() string {
 
 // Contains the output of the DeleteHsm operation.
 type DeleteHsmOutput struct {
+	_ struct{} `type:"structure"`
+
 	// The status of the operation.
 	Status *string `type:"string" required:"true"`
-
-	_ struct{} `type:"structure"`
 }
 
 // String returns the string representation
@@ -721,10 +721,10 @@ func (s DeleteHsmOutput) GoString() string {
 }
 
 type DeleteLunaClientInput struct {
+	_ struct{} `type:"structure"`
+
 	// The ARN of the client to delete.
 	ClientArn *string `type:"string" required:"true"`
-
-	_ struct{} `type:"structure"`
 }
 
 // String returns the string representation
@@ -738,10 +738,10 @@ func (s DeleteLunaClientInput) GoString() string {
 }
 
 type DeleteLunaClientOutput struct {
+	_ struct{} `type:"structure"`
+
 	// The status of the action.
 	Status *string `type:"string" required:"true"`
-
-	_ struct{} `type:"structure"`
 }
 
 // String returns the string representation
@@ -756,10 +756,10 @@ func (s DeleteLunaClientOutput) GoString() string {
 
 // Contains the inputs for the DescribeHapg action.
 type DescribeHapgInput struct {
+	_ struct{} `type:"structure"`
+
 	// The ARN of the high-availability partition group to describe.
 	HapgArn *string `type:"string" required:"true"`
-
-	_ struct{} `type:"structure"`
 }
 
 // String returns the string representation
@@ -774,6 +774,8 @@ func (s DescribeHapgInput) GoString() string {
 
 // Contains the output of the DescribeHapg action.
 type DescribeHapgOutput struct {
+	_ struct{} `type:"structure"`
+
 	// The ARN of the high-availability partition group.
 	HapgArn *string `type:"string"`
 
@@ -801,8 +803,6 @@ type DescribeHapgOutput struct {
 
 	// The state of the high-availability partition group.
 	State *string `type:"string" enum:"CloudHsmObjectState"`
-
-	_ struct{} `type:"structure"`
 }
 
 // String returns the string representation
@@ -817,6 +817,8 @@ func (s DescribeHapgOutput) GoString() string {
 
 // Contains the inputs for the DescribeHsm operation.
 type DescribeHsmInput struct {
+	_ struct{} `type:"structure"`
+
 	// The ARN of the HSM. Either the HsmArn or the SerialNumber parameter must
 	// be specified.
 	HsmArn *string `type:"string"`
@@ -824,8 +826,6 @@ type DescribeHsmInput struct {
 	// The serial number of the HSM. Either the HsmArn or the HsmSerialNumber parameter
 	// must be specified.
 	HsmSerialNumber *string `type:"string"`
-
-	_ struct{} `type:"structure"`
 }
 
 // String returns the string representation
@@ -840,6 +840,8 @@ func (s DescribeHsmInput) GoString() string {
 
 // Contains the output of the DescribeHsm operation.
 type DescribeHsmOutput struct {
+	_ struct{} `type:"structure"`
+
 	// The Availability Zone that the HSM is in.
 	AvailabilityZone *string `type:"string"`
 
@@ -905,8 +907,6 @@ type DescribeHsmOutput struct {
 
 	// The identifier of the VPC that the HSM is in.
 	VpcId *string `type:"string"`
-
-	_ struct{} `type:"structure"`
 }
 
 // String returns the string representation
@@ -920,13 +920,13 @@ func (s DescribeHsmOutput) GoString() string {
 }
 
 type DescribeLunaClientInput struct {
+	_ struct{} `type:"structure"`
+
 	// The certificate fingerprint.
 	CertificateFingerprint *string `type:"string"`
 
 	// The ARN of the client.
 	ClientArn *string `type:"string"`
-
-	_ struct{} `type:"structure"`
 }
 
 // String returns the string representation
@@ -940,6 +940,8 @@ func (s DescribeLunaClientInput) GoString() string {
 }
 
 type DescribeLunaClientOutput struct {
+	_ struct{} `type:"structure"`
+
 	// The certificate installed on the HSMs used by this client.
 	Certificate *string `min:"600" type:"string"`
 
@@ -954,8 +956,6 @@ type DescribeLunaClientOutput struct {
 
 	// The date and time the client was last modified.
 	LastModifiedTimestamp *string `type:"string"`
-
-	_ struct{} `type:"structure"`
 }
 
 // String returns the string representation
@@ -969,6 +969,8 @@ func (s DescribeLunaClientOutput) GoString() string {
 }
 
 type GetConfigInput struct {
+	_ struct{} `type:"structure"`
+
 	// The ARN of the client.
 	ClientArn *string `type:"string" required:"true"`
 
@@ -978,8 +980,6 @@ type GetConfigInput struct {
 	// A list of ARNs that identify the high-availability partition groups that
 	// are associated with the client.
 	HapgList []*string `type:"list" required:"true"`
-
-	_ struct{} `type:"structure"`
 }
 
 // String returns the string representation
@@ -993,6 +993,8 @@ func (s GetConfigInput) GoString() string {
 }
 
 type GetConfigOutput struct {
+	_ struct{} `type:"structure"`
+
 	// The certificate file containing the server.pem files of the HSMs.
 	ConfigCred *string `type:"string"`
 
@@ -1001,8 +1003,6 @@ type GetConfigOutput struct {
 
 	// The type of credentials.
 	ConfigType *string `type:"string"`
-
-	_ struct{} `type:"structure"`
 }
 
 // String returns the string representation
@@ -1031,10 +1031,10 @@ func (s ListAvailableZonesInput) GoString() string {
 }
 
 type ListAvailableZonesOutput struct {
+	_ struct{} `type:"structure"`
+
 	// The list of Availability Zones that have available AWS CloudHSM capacity.
 	AZList []*string `type:"list"`
-
-	_ struct{} `type:"structure"`
 }
 
 // String returns the string representation
@@ -1048,11 +1048,11 @@ func (s ListAvailableZonesOutput) GoString() string {
 }
 
 type ListHapgsInput struct {
+	_ struct{} `type:"structure"`
+
 	// The NextToken value from a previous call to ListHapgs. Pass null if this
 	// is the first call.
 	NextToken *string `type:"string"`
-
-	_ struct{} `type:"structure"`
 }
 
 // String returns the string representation
@@ -1066,14 +1066,14 @@ func (s ListHapgsInput) GoString() string {
 }
 
 type ListHapgsOutput struct {
+	_ struct{} `type:"structure"`
+
 	// The list of high-availability partition groups.
 	HapgList []*string `type:"list" required:"true"`
 
 	// If not null, more results are available. Pass this value to ListHapgs to
 	// retrieve the next set of items.
 	NextToken *string `type:"string"`
-
-	_ struct{} `type:"structure"`
 }
 
 // String returns the string representation
@@ -1087,11 +1087,11 @@ func (s ListHapgsOutput) GoString() string {
 }
 
 type ListHsmsInput struct {
+	_ struct{} `type:"structure"`
+
 	// The NextToken value from a previous call to ListHsms. Pass null if this is
 	// the first call.
 	NextToken *string `type:"string"`
-
-	_ struct{} `type:"structure"`
 }
 
 // String returns the string representation
@@ -1106,14 +1106,14 @@ func (s ListHsmsInput) GoString() string {
 
 // Contains the output of the ListHsms operation.
 type ListHsmsOutput struct {
+	_ struct{} `type:"structure"`
+
 	// The list of ARNs that identify the HSMs.
 	HsmList []*string `type:"list"`
 
 	// If not null, more results are available. Pass this value to ListHsms to retrieve
 	// the next set of items.
 	NextToken *string `type:"string"`
-
-	_ struct{} `type:"structure"`
 }
 
 // String returns the string representation
@@ -1127,11 +1127,11 @@ func (s ListHsmsOutput) GoString() string {
 }
 
 type ListLunaClientsInput struct {
+	_ struct{} `type:"structure"`
+
 	// The NextToken value from a previous call to ListLunaClients. Pass null if
 	// this is the first call.
 	NextToken *string `type:"string"`
-
-	_ struct{} `type:"structure"`
 }
 
 // String returns the string representation
@@ -1145,14 +1145,14 @@ func (s ListLunaClientsInput) GoString() string {
 }
 
 type ListLunaClientsOutput struct {
+	_ struct{} `type:"structure"`
+
 	// The list of clients.
 	ClientList []*string `type:"list" required:"true"`
 
 	// If not null, more results are available. Pass this to ListLunaClients to
 	// retrieve the next set of items.
 	NextToken *string `type:"string"`
-
-	_ struct{} `type:"structure"`
 }
 
 // String returns the string representation
@@ -1166,6 +1166,8 @@ func (s ListLunaClientsOutput) GoString() string {
 }
 
 type ModifyHapgInput struct {
+	_ struct{} `type:"structure"`
+
 	// The ARN of the high-availability partition group to modify.
 	HapgArn *string `type:"string" required:"true"`
 
@@ -1175,8 +1177,6 @@ type ModifyHapgInput struct {
 	// The list of partition serial numbers to make members of the high-availability
 	// partition group.
 	PartitionSerialList []*string `type:"list"`
-
-	_ struct{} `type:"structure"`
 }
 
 // String returns the string representation
@@ -1190,10 +1190,10 @@ func (s ModifyHapgInput) GoString() string {
 }
 
 type ModifyHapgOutput struct {
+	_ struct{} `type:"structure"`
+
 	// The ARN of the high-availability partition group.
 	HapgArn *string `type:"string"`
-
-	_ struct{} `type:"structure"`
 }
 
 // String returns the string representation
@@ -1208,6 +1208,8 @@ func (s ModifyHapgOutput) GoString() string {
 
 // Contains the inputs for the ModifyHsm operation.
 type ModifyHsmInput struct {
+	_ struct{} `locationName:"ModifyHsmRequest" type:"structure"`
+
 	// The new IP address for the elastic network interface (ENI) attached to the
 	// HSM.
 	//
@@ -1231,8 +1233,6 @@ type ModifyHsmInput struct {
 	// The new IP address for the syslog monitoring server. The AWS CloudHSM service
 	// only supports one syslog monitoring server.
 	SyslogIp *string `locationName:"SyslogIp" type:"string"`
-
-	_ struct{} `locationName:"ModifyHsmRequest" type:"structure"`
 }
 
 // String returns the string representation
@@ -1247,10 +1247,10 @@ func (s ModifyHsmInput) GoString() string {
 
 // Contains the output of the ModifyHsm operation.
 type ModifyHsmOutput struct {
+	_ struct{} `type:"structure"`
+
 	// The ARN of the HSM.
 	HsmArn *string `type:"string"`
-
-	_ struct{} `type:"structure"`
 }
 
 // String returns the string representation
@@ -1264,13 +1264,13 @@ func (s ModifyHsmOutput) GoString() string {
 }
 
 type ModifyLunaClientInput struct {
+	_ struct{} `type:"structure"`
+
 	// The new certificate for the client.
 	Certificate *string `min:"600" type:"string" required:"true"`
 
 	// The ARN of the client.
 	ClientArn *string `type:"string" required:"true"`
-
-	_ struct{} `type:"structure"`
 }
 
 // String returns the string representation
@@ -1284,10 +1284,10 @@ func (s ModifyLunaClientInput) GoString() string {
 }
 
 type ModifyLunaClientOutput struct {
+	_ struct{} `type:"structure"`
+
 	// The ARN of the client.
 	ClientArn *string `type:"string"`
-
-	_ struct{} `type:"structure"`
 }
 
 // String returns the string representation

--- a/service/cloudhsm/api.go
+++ b/service/cloudhsm/api.go
@@ -511,11 +511,7 @@ type CreateHapgInput struct {
 	// The label of the new high-availability partition group.
 	Label *string `type:"string" required:"true"`
 
-	metadataCreateHapgInput `json:"-" xml:"-"`
-}
-
-type metadataCreateHapgInput struct {
-	SDKShapeTraits bool `type:"structure"`
+	_ struct{} `type:"structure"`
 }
 
 // String returns the string representation
@@ -533,11 +529,7 @@ type CreateHapgOutput struct {
 	// The ARN of the high-availability partition group.
 	HapgArn *string `type:"string"`
 
-	metadataCreateHapgOutput `json:"-" xml:"-"`
-}
-
-type metadataCreateHapgOutput struct {
-	SDKShapeTraits bool `type:"structure"`
+	_ struct{} `type:"structure"`
 }
 
 // String returns the string representation
@@ -585,11 +577,7 @@ type CreateHsmInput struct {
 	// only supports one syslog monitoring server.
 	SyslogIp *string `locationName:"SyslogIp" type:"string"`
 
-	metadataCreateHsmInput `json:"-" xml:"-"`
-}
-
-type metadataCreateHsmInput struct {
-	SDKShapeTraits bool `locationName:"CreateHsmRequest" type:"structure"`
+	_ struct{} `locationName:"CreateHsmRequest" type:"structure"`
 }
 
 // String returns the string representation
@@ -607,11 +595,7 @@ type CreateHsmOutput struct {
 	// The ARN of the HSM.
 	HsmArn *string `type:"string"`
 
-	metadataCreateHsmOutput `json:"-" xml:"-"`
-}
-
-type metadataCreateHsmOutput struct {
-	SDKShapeTraits bool `type:"structure"`
+	_ struct{} `type:"structure"`
 }
 
 // String returns the string representation
@@ -633,11 +617,7 @@ type CreateLunaClientInput struct {
 	// The label for the client.
 	Label *string `type:"string"`
 
-	metadataCreateLunaClientInput `json:"-" xml:"-"`
-}
-
-type metadataCreateLunaClientInput struct {
-	SDKShapeTraits bool `type:"structure"`
+	_ struct{} `type:"structure"`
 }
 
 // String returns the string representation
@@ -655,11 +635,7 @@ type CreateLunaClientOutput struct {
 	// The ARN of the client.
 	ClientArn *string `type:"string"`
 
-	metadataCreateLunaClientOutput `json:"-" xml:"-"`
-}
-
-type metadataCreateLunaClientOutput struct {
-	SDKShapeTraits bool `type:"structure"`
+	_ struct{} `type:"structure"`
 }
 
 // String returns the string representation
@@ -677,11 +653,7 @@ type DeleteHapgInput struct {
 	// The ARN of the high-availability partition group to delete.
 	HapgArn *string `type:"string" required:"true"`
 
-	metadataDeleteHapgInput `json:"-" xml:"-"`
-}
-
-type metadataDeleteHapgInput struct {
-	SDKShapeTraits bool `type:"structure"`
+	_ struct{} `type:"structure"`
 }
 
 // String returns the string representation
@@ -699,11 +671,7 @@ type DeleteHapgOutput struct {
 	// The status of the action.
 	Status *string `type:"string" required:"true"`
 
-	metadataDeleteHapgOutput `json:"-" xml:"-"`
-}
-
-type metadataDeleteHapgOutput struct {
-	SDKShapeTraits bool `type:"structure"`
+	_ struct{} `type:"structure"`
 }
 
 // String returns the string representation
@@ -721,11 +689,7 @@ type DeleteHsmInput struct {
 	// The ARN of the HSM to delete.
 	HsmArn *string `locationName:"HsmArn" type:"string" required:"true"`
 
-	metadataDeleteHsmInput `json:"-" xml:"-"`
-}
-
-type metadataDeleteHsmInput struct {
-	SDKShapeTraits bool `locationName:"DeleteHsmRequest" type:"structure"`
+	_ struct{} `locationName:"DeleteHsmRequest" type:"structure"`
 }
 
 // String returns the string representation
@@ -743,11 +707,7 @@ type DeleteHsmOutput struct {
 	// The status of the operation.
 	Status *string `type:"string" required:"true"`
 
-	metadataDeleteHsmOutput `json:"-" xml:"-"`
-}
-
-type metadataDeleteHsmOutput struct {
-	SDKShapeTraits bool `type:"structure"`
+	_ struct{} `type:"structure"`
 }
 
 // String returns the string representation
@@ -764,11 +724,7 @@ type DeleteLunaClientInput struct {
 	// The ARN of the client to delete.
 	ClientArn *string `type:"string" required:"true"`
 
-	metadataDeleteLunaClientInput `json:"-" xml:"-"`
-}
-
-type metadataDeleteLunaClientInput struct {
-	SDKShapeTraits bool `type:"structure"`
+	_ struct{} `type:"structure"`
 }
 
 // String returns the string representation
@@ -785,11 +741,7 @@ type DeleteLunaClientOutput struct {
 	// The status of the action.
 	Status *string `type:"string" required:"true"`
 
-	metadataDeleteLunaClientOutput `json:"-" xml:"-"`
-}
-
-type metadataDeleteLunaClientOutput struct {
-	SDKShapeTraits bool `type:"structure"`
+	_ struct{} `type:"structure"`
 }
 
 // String returns the string representation
@@ -807,11 +759,7 @@ type DescribeHapgInput struct {
 	// The ARN of the high-availability partition group to describe.
 	HapgArn *string `type:"string" required:"true"`
 
-	metadataDescribeHapgInput `json:"-" xml:"-"`
-}
-
-type metadataDescribeHapgInput struct {
-	SDKShapeTraits bool `type:"structure"`
+	_ struct{} `type:"structure"`
 }
 
 // String returns the string representation
@@ -854,11 +802,7 @@ type DescribeHapgOutput struct {
 	// The state of the high-availability partition group.
 	State *string `type:"string" enum:"CloudHsmObjectState"`
 
-	metadataDescribeHapgOutput `json:"-" xml:"-"`
-}
-
-type metadataDescribeHapgOutput struct {
-	SDKShapeTraits bool `type:"structure"`
+	_ struct{} `type:"structure"`
 }
 
 // String returns the string representation
@@ -881,11 +825,7 @@ type DescribeHsmInput struct {
 	// must be specified.
 	HsmSerialNumber *string `type:"string"`
 
-	metadataDescribeHsmInput `json:"-" xml:"-"`
-}
-
-type metadataDescribeHsmInput struct {
-	SDKShapeTraits bool `type:"structure"`
+	_ struct{} `type:"structure"`
 }
 
 // String returns the string representation
@@ -966,11 +906,7 @@ type DescribeHsmOutput struct {
 	// The identifier of the VPC that the HSM is in.
 	VpcId *string `type:"string"`
 
-	metadataDescribeHsmOutput `json:"-" xml:"-"`
-}
-
-type metadataDescribeHsmOutput struct {
-	SDKShapeTraits bool `type:"structure"`
+	_ struct{} `type:"structure"`
 }
 
 // String returns the string representation
@@ -990,11 +926,7 @@ type DescribeLunaClientInput struct {
 	// The ARN of the client.
 	ClientArn *string `type:"string"`
 
-	metadataDescribeLunaClientInput `json:"-" xml:"-"`
-}
-
-type metadataDescribeLunaClientInput struct {
-	SDKShapeTraits bool `type:"structure"`
+	_ struct{} `type:"structure"`
 }
 
 // String returns the string representation
@@ -1023,11 +955,7 @@ type DescribeLunaClientOutput struct {
 	// The date and time the client was last modified.
 	LastModifiedTimestamp *string `type:"string"`
 
-	metadataDescribeLunaClientOutput `json:"-" xml:"-"`
-}
-
-type metadataDescribeLunaClientOutput struct {
-	SDKShapeTraits bool `type:"structure"`
+	_ struct{} `type:"structure"`
 }
 
 // String returns the string representation
@@ -1051,11 +979,7 @@ type GetConfigInput struct {
 	// are associated with the client.
 	HapgList []*string `type:"list" required:"true"`
 
-	metadataGetConfigInput `json:"-" xml:"-"`
-}
-
-type metadataGetConfigInput struct {
-	SDKShapeTraits bool `type:"structure"`
+	_ struct{} `type:"structure"`
 }
 
 // String returns the string representation
@@ -1078,11 +1002,7 @@ type GetConfigOutput struct {
 	// The type of credentials.
 	ConfigType *string `type:"string"`
 
-	metadataGetConfigOutput `json:"-" xml:"-"`
-}
-
-type metadataGetConfigOutput struct {
-	SDKShapeTraits bool `type:"structure"`
+	_ struct{} `type:"structure"`
 }
 
 // String returns the string representation
@@ -1097,11 +1017,7 @@ func (s GetConfigOutput) GoString() string {
 
 // Contains the inputs for the ListAvailableZones action.
 type ListAvailableZonesInput struct {
-	metadataListAvailableZonesInput `json:"-" xml:"-"`
-}
-
-type metadataListAvailableZonesInput struct {
-	SDKShapeTraits bool `type:"structure"`
+	_ struct{} `type:"structure"`
 }
 
 // String returns the string representation
@@ -1118,11 +1034,7 @@ type ListAvailableZonesOutput struct {
 	// The list of Availability Zones that have available AWS CloudHSM capacity.
 	AZList []*string `type:"list"`
 
-	metadataListAvailableZonesOutput `json:"-" xml:"-"`
-}
-
-type metadataListAvailableZonesOutput struct {
-	SDKShapeTraits bool `type:"structure"`
+	_ struct{} `type:"structure"`
 }
 
 // String returns the string representation
@@ -1140,11 +1052,7 @@ type ListHapgsInput struct {
 	// is the first call.
 	NextToken *string `type:"string"`
 
-	metadataListHapgsInput `json:"-" xml:"-"`
-}
-
-type metadataListHapgsInput struct {
-	SDKShapeTraits bool `type:"structure"`
+	_ struct{} `type:"structure"`
 }
 
 // String returns the string representation
@@ -1165,11 +1073,7 @@ type ListHapgsOutput struct {
 	// retrieve the next set of items.
 	NextToken *string `type:"string"`
 
-	metadataListHapgsOutput `json:"-" xml:"-"`
-}
-
-type metadataListHapgsOutput struct {
-	SDKShapeTraits bool `type:"structure"`
+	_ struct{} `type:"structure"`
 }
 
 // String returns the string representation
@@ -1187,11 +1091,7 @@ type ListHsmsInput struct {
 	// the first call.
 	NextToken *string `type:"string"`
 
-	metadataListHsmsInput `json:"-" xml:"-"`
-}
-
-type metadataListHsmsInput struct {
-	SDKShapeTraits bool `type:"structure"`
+	_ struct{} `type:"structure"`
 }
 
 // String returns the string representation
@@ -1213,11 +1113,7 @@ type ListHsmsOutput struct {
 	// the next set of items.
 	NextToken *string `type:"string"`
 
-	metadataListHsmsOutput `json:"-" xml:"-"`
-}
-
-type metadataListHsmsOutput struct {
-	SDKShapeTraits bool `type:"structure"`
+	_ struct{} `type:"structure"`
 }
 
 // String returns the string representation
@@ -1235,11 +1131,7 @@ type ListLunaClientsInput struct {
 	// this is the first call.
 	NextToken *string `type:"string"`
 
-	metadataListLunaClientsInput `json:"-" xml:"-"`
-}
-
-type metadataListLunaClientsInput struct {
-	SDKShapeTraits bool `type:"structure"`
+	_ struct{} `type:"structure"`
 }
 
 // String returns the string representation
@@ -1260,11 +1152,7 @@ type ListLunaClientsOutput struct {
 	// retrieve the next set of items.
 	NextToken *string `type:"string"`
 
-	metadataListLunaClientsOutput `json:"-" xml:"-"`
-}
-
-type metadataListLunaClientsOutput struct {
-	SDKShapeTraits bool `type:"structure"`
+	_ struct{} `type:"structure"`
 }
 
 // String returns the string representation
@@ -1288,11 +1176,7 @@ type ModifyHapgInput struct {
 	// partition group.
 	PartitionSerialList []*string `type:"list"`
 
-	metadataModifyHapgInput `json:"-" xml:"-"`
-}
-
-type metadataModifyHapgInput struct {
-	SDKShapeTraits bool `type:"structure"`
+	_ struct{} `type:"structure"`
 }
 
 // String returns the string representation
@@ -1309,11 +1193,7 @@ type ModifyHapgOutput struct {
 	// The ARN of the high-availability partition group.
 	HapgArn *string `type:"string"`
 
-	metadataModifyHapgOutput `json:"-" xml:"-"`
-}
-
-type metadataModifyHapgOutput struct {
-	SDKShapeTraits bool `type:"structure"`
+	_ struct{} `type:"structure"`
 }
 
 // String returns the string representation
@@ -1352,11 +1232,7 @@ type ModifyHsmInput struct {
 	// only supports one syslog monitoring server.
 	SyslogIp *string `locationName:"SyslogIp" type:"string"`
 
-	metadataModifyHsmInput `json:"-" xml:"-"`
-}
-
-type metadataModifyHsmInput struct {
-	SDKShapeTraits bool `locationName:"ModifyHsmRequest" type:"structure"`
+	_ struct{} `locationName:"ModifyHsmRequest" type:"structure"`
 }
 
 // String returns the string representation
@@ -1374,11 +1250,7 @@ type ModifyHsmOutput struct {
 	// The ARN of the HSM.
 	HsmArn *string `type:"string"`
 
-	metadataModifyHsmOutput `json:"-" xml:"-"`
-}
-
-type metadataModifyHsmOutput struct {
-	SDKShapeTraits bool `type:"structure"`
+	_ struct{} `type:"structure"`
 }
 
 // String returns the string representation
@@ -1398,11 +1270,7 @@ type ModifyLunaClientInput struct {
 	// The ARN of the client.
 	ClientArn *string `type:"string" required:"true"`
 
-	metadataModifyLunaClientInput `json:"-" xml:"-"`
-}
-
-type metadataModifyLunaClientInput struct {
-	SDKShapeTraits bool `type:"structure"`
+	_ struct{} `type:"structure"`
 }
 
 // String returns the string representation
@@ -1419,11 +1287,7 @@ type ModifyLunaClientOutput struct {
 	// The ARN of the client.
 	ClientArn *string `type:"string"`
 
-	metadataModifyLunaClientOutput `json:"-" xml:"-"`
-}
-
-type metadataModifyLunaClientOutput struct {
-	SDKShapeTraits bool `type:"structure"`
+	_ struct{} `type:"structure"`
 }
 
 // String returns the string representation

--- a/service/cloudsearch/api.go
+++ b/service/cloudsearch/api.go
@@ -759,11 +759,7 @@ type AccessPoliciesStatus struct {
 	// The status of domain configuration option.
 	Status *OptionStatus `type:"structure" required:"true"`
 
-	metadataAccessPoliciesStatus `json:"-" xml:"-"`
-}
-
-type metadataAccessPoliciesStatus struct {
-	SDKShapeTraits bool `type:"structure"`
+	_ struct{} `type:"structure"`
 }
 
 // String returns the string representation
@@ -815,11 +811,7 @@ type AnalysisOptions struct {
 	// in the Amazon CloudSearch Developer Guide.
 	Synonyms *string `type:"string"`
 
-	metadataAnalysisOptions `json:"-" xml:"-"`
-}
-
-type metadataAnalysisOptions struct {
-	SDKShapeTraits bool `type:"structure"`
+	_ struct{} `type:"structure"`
 }
 
 // String returns the string representation
@@ -849,11 +841,7 @@ type AnalysisScheme struct {
 	// a-z (lowercase), 0-9, and _ (underscore).
 	AnalysisSchemeName *string `min:"1" type:"string" required:"true"`
 
-	metadataAnalysisScheme `json:"-" xml:"-"`
-}
-
-type metadataAnalysisScheme struct {
-	SDKShapeTraits bool `type:"structure"`
+	_ struct{} `type:"structure"`
 }
 
 // String returns the string representation
@@ -877,11 +865,7 @@ type AnalysisSchemeStatus struct {
 	// The status of domain configuration option.
 	Status *OptionStatus `type:"structure" required:"true"`
 
-	metadataAnalysisSchemeStatus `json:"-" xml:"-"`
-}
-
-type metadataAnalysisSchemeStatus struct {
-	SDKShapeTraits bool `type:"structure"`
+	_ struct{} `type:"structure"`
 }
 
 // String returns the string representation
@@ -902,11 +886,7 @@ type AvailabilityOptionsStatus struct {
 	// The status of domain configuration option.
 	Status *OptionStatus `type:"structure" required:"true"`
 
-	metadataAvailabilityOptionsStatus `json:"-" xml:"-"`
-}
-
-type metadataAvailabilityOptionsStatus struct {
-	SDKShapeTraits bool `type:"structure"`
+	_ struct{} `type:"structure"`
 }
 
 // String returns the string representation
@@ -928,11 +908,7 @@ type BuildSuggestersInput struct {
 	// 0-9, and - (hyphen).
 	DomainName *string `min:"3" type:"string" required:"true"`
 
-	metadataBuildSuggestersInput `json:"-" xml:"-"`
-}
-
-type metadataBuildSuggestersInput struct {
-	SDKShapeTraits bool `type:"structure"`
+	_ struct{} `type:"structure"`
 }
 
 // String returns the string representation
@@ -951,11 +927,7 @@ type BuildSuggestersOutput struct {
 	// A list of field names.
 	FieldNames []*string `type:"list"`
 
-	metadataBuildSuggestersOutput `json:"-" xml:"-"`
-}
-
-type metadataBuildSuggestersOutput struct {
-	SDKShapeTraits bool `type:"structure"`
+	_ struct{} `type:"structure"`
 }
 
 // String returns the string representation
@@ -976,11 +948,7 @@ type CreateDomainInput struct {
 	// and be at least 3 and no more than 28 characters long.
 	DomainName *string `min:"3" type:"string" required:"true"`
 
-	metadataCreateDomainInput `json:"-" xml:"-"`
-}
-
-type metadataCreateDomainInput struct {
-	SDKShapeTraits bool `type:"structure"`
+	_ struct{} `type:"structure"`
 }
 
 // String returns the string representation
@@ -999,11 +967,7 @@ type CreateDomainOutput struct {
 	// The current status of the search domain.
 	DomainStatus *DomainStatus `type:"structure"`
 
-	metadataCreateDomainOutput `json:"-" xml:"-"`
-}
-
-type metadataCreateDomainOutput struct {
-	SDKShapeTraits bool `type:"structure"`
+	_ struct{} `type:"structure"`
 }
 
 // String returns the string representation
@@ -1034,11 +998,7 @@ type DateArrayOptions struct {
 	// A list of source fields to map to the field.
 	SourceFields *string `type:"string"`
 
-	metadataDateArrayOptions `json:"-" xml:"-"`
-}
-
-type metadataDateArrayOptions struct {
-	SDKShapeTraits bool `type:"structure"`
+	_ struct{} `type:"structure"`
 }
 
 // String returns the string representation
@@ -1087,11 +1047,7 @@ type DateOptions struct {
 	// a document's ID, you can use the name _id.
 	SourceField *string `min:"1" type:"string"`
 
-	metadataDateOptions `json:"-" xml:"-"`
-}
-
-type metadataDateOptions struct {
-	SDKShapeTraits bool `type:"structure"`
+	_ struct{} `type:"structure"`
 }
 
 // String returns the string representation
@@ -1119,11 +1075,7 @@ type DefineAnalysisSchemeInput struct {
 	// 0-9, and - (hyphen).
 	DomainName *string `min:"3" type:"string" required:"true"`
 
-	metadataDefineAnalysisSchemeInput `json:"-" xml:"-"`
-}
-
-type metadataDefineAnalysisSchemeInput struct {
-	SDKShapeTraits bool `type:"structure"`
+	_ struct{} `type:"structure"`
 }
 
 // String returns the string representation
@@ -1142,11 +1094,7 @@ type DefineAnalysisSchemeOutput struct {
 	// The status and configuration of an AnalysisScheme.
 	AnalysisScheme *AnalysisSchemeStatus `type:"structure" required:"true"`
 
-	metadataDefineAnalysisSchemeOutput `json:"-" xml:"-"`
-}
-
-type metadataDefineAnalysisSchemeOutput struct {
-	SDKShapeTraits bool `type:"structure"`
+	_ struct{} `type:"structure"`
 }
 
 // String returns the string representation
@@ -1174,11 +1122,7 @@ type DefineExpressionInput struct {
 	// in the search results.
 	Expression *Expression `type:"structure" required:"true"`
 
-	metadataDefineExpressionInput `json:"-" xml:"-"`
-}
-
-type metadataDefineExpressionInput struct {
-	SDKShapeTraits bool `type:"structure"`
+	_ struct{} `type:"structure"`
 }
 
 // String returns the string representation
@@ -1197,11 +1141,7 @@ type DefineExpressionOutput struct {
 	// The value of an Expression and its current status.
 	Expression *ExpressionStatus `type:"structure" required:"true"`
 
-	metadataDefineExpressionOutput `json:"-" xml:"-"`
-}
-
-type metadataDefineExpressionOutput struct {
-	SDKShapeTraits bool `type:"structure"`
+	_ struct{} `type:"structure"`
 }
 
 // String returns the string representation
@@ -1226,11 +1166,7 @@ type DefineIndexFieldInput struct {
 	// The index field and field options you want to configure.
 	IndexField *IndexField `type:"structure" required:"true"`
 
-	metadataDefineIndexFieldInput `json:"-" xml:"-"`
-}
-
-type metadataDefineIndexFieldInput struct {
-	SDKShapeTraits bool `type:"structure"`
+	_ struct{} `type:"structure"`
 }
 
 // String returns the string representation
@@ -1249,11 +1185,7 @@ type DefineIndexFieldOutput struct {
 	// The value of an IndexField and its current status.
 	IndexField *IndexFieldStatus `type:"structure" required:"true"`
 
-	metadataDefineIndexFieldOutput `json:"-" xml:"-"`
-}
-
-type metadataDefineIndexFieldOutput struct {
-	SDKShapeTraits bool `type:"structure"`
+	_ struct{} `type:"structure"`
 }
 
 // String returns the string representation
@@ -1280,11 +1212,7 @@ type DefineSuggesterInput struct {
 	// options can be configured for a suggester: FuzzyMatching, SortExpression.
 	Suggester *Suggester `type:"structure" required:"true"`
 
-	metadataDefineSuggesterInput `json:"-" xml:"-"`
-}
-
-type metadataDefineSuggesterInput struct {
-	SDKShapeTraits bool `type:"structure"`
+	_ struct{} `type:"structure"`
 }
 
 // String returns the string representation
@@ -1303,11 +1231,7 @@ type DefineSuggesterOutput struct {
 	// The value of a Suggester and its current status.
 	Suggester *SuggesterStatus `type:"structure" required:"true"`
 
-	metadataDefineSuggesterOutput `json:"-" xml:"-"`
-}
-
-type metadataDefineSuggesterOutput struct {
-	SDKShapeTraits bool `type:"structure"`
+	_ struct{} `type:"structure"`
 }
 
 // String returns the string representation
@@ -1333,11 +1257,7 @@ type DeleteAnalysisSchemeInput struct {
 	// 0-9, and - (hyphen).
 	DomainName *string `min:"3" type:"string" required:"true"`
 
-	metadataDeleteAnalysisSchemeInput `json:"-" xml:"-"`
-}
-
-type metadataDeleteAnalysisSchemeInput struct {
-	SDKShapeTraits bool `type:"structure"`
+	_ struct{} `type:"structure"`
 }
 
 // String returns the string representation
@@ -1356,11 +1276,7 @@ type DeleteAnalysisSchemeOutput struct {
 	// The status of the analysis scheme being deleted.
 	AnalysisScheme *AnalysisSchemeStatus `type:"structure" required:"true"`
 
-	metadataDeleteAnalysisSchemeOutput `json:"-" xml:"-"`
-}
-
-type metadataDeleteAnalysisSchemeOutput struct {
-	SDKShapeTraits bool `type:"structure"`
+	_ struct{} `type:"structure"`
 }
 
 // String returns the string representation
@@ -1379,11 +1295,7 @@ type DeleteDomainInput struct {
 	// The name of the domain you want to permanently delete.
 	DomainName *string `min:"3" type:"string" required:"true"`
 
-	metadataDeleteDomainInput `json:"-" xml:"-"`
-}
-
-type metadataDeleteDomainInput struct {
-	SDKShapeTraits bool `type:"structure"`
+	_ struct{} `type:"structure"`
 }
 
 // String returns the string representation
@@ -1402,11 +1314,7 @@ type DeleteDomainOutput struct {
 	// The current status of the search domain.
 	DomainStatus *DomainStatus `type:"structure"`
 
-	metadataDeleteDomainOutput `json:"-" xml:"-"`
-}
-
-type metadataDeleteDomainOutput struct {
-	SDKShapeTraits bool `type:"structure"`
+	_ struct{} `type:"structure"`
 }
 
 // String returns the string representation
@@ -1432,11 +1340,7 @@ type DeleteExpressionInput struct {
 	// The name of the Expression to delete.
 	ExpressionName *string `min:"1" type:"string" required:"true"`
 
-	metadataDeleteExpressionInput `json:"-" xml:"-"`
-}
-
-type metadataDeleteExpressionInput struct {
-	SDKShapeTraits bool `type:"structure"`
+	_ struct{} `type:"structure"`
 }
 
 // String returns the string representation
@@ -1455,11 +1359,7 @@ type DeleteExpressionOutput struct {
 	// The status of the expression being deleted.
 	Expression *ExpressionStatus `type:"structure" required:"true"`
 
-	metadataDeleteExpressionOutput `json:"-" xml:"-"`
-}
-
-type metadataDeleteExpressionOutput struct {
-	SDKShapeTraits bool `type:"structure"`
+	_ struct{} `type:"structure"`
 }
 
 // String returns the string representation
@@ -1486,11 +1386,7 @@ type DeleteIndexFieldInput struct {
 	// options.
 	IndexFieldName *string `min:"1" type:"string" required:"true"`
 
-	metadataDeleteIndexFieldInput `json:"-" xml:"-"`
-}
-
-type metadataDeleteIndexFieldInput struct {
-	SDKShapeTraits bool `type:"structure"`
+	_ struct{} `type:"structure"`
 }
 
 // String returns the string representation
@@ -1508,11 +1404,7 @@ type DeleteIndexFieldOutput struct {
 	// The status of the index field being deleted.
 	IndexField *IndexFieldStatus `type:"structure" required:"true"`
 
-	metadataDeleteIndexFieldOutput `json:"-" xml:"-"`
-}
-
-type metadataDeleteIndexFieldOutput struct {
-	SDKShapeTraits bool `type:"structure"`
+	_ struct{} `type:"structure"`
 }
 
 // String returns the string representation
@@ -1538,11 +1430,7 @@ type DeleteSuggesterInput struct {
 	// Specifies the name of the suggester you want to delete.
 	SuggesterName *string `min:"1" type:"string" required:"true"`
 
-	metadataDeleteSuggesterInput `json:"-" xml:"-"`
-}
-
-type metadataDeleteSuggesterInput struct {
-	SDKShapeTraits bool `type:"structure"`
+	_ struct{} `type:"structure"`
 }
 
 // String returns the string representation
@@ -1561,11 +1449,7 @@ type DeleteSuggesterOutput struct {
 	// The status of the suggester being deleted.
 	Suggester *SuggesterStatus `type:"structure" required:"true"`
 
-	metadataDeleteSuggesterOutput `json:"-" xml:"-"`
-}
-
-type metadataDeleteSuggesterOutput struct {
-	SDKShapeTraits bool `type:"structure"`
+	_ struct{} `type:"structure"`
 }
 
 // String returns the string representation
@@ -1594,11 +1478,7 @@ type DescribeAnalysisSchemesInput struct {
 	// The name of the domain you want to describe.
 	DomainName *string `min:"3" type:"string" required:"true"`
 
-	metadataDescribeAnalysisSchemesInput `json:"-" xml:"-"`
-}
-
-type metadataDescribeAnalysisSchemesInput struct {
-	SDKShapeTraits bool `type:"structure"`
+	_ struct{} `type:"structure"`
 }
 
 // String returns the string representation
@@ -1617,11 +1497,7 @@ type DescribeAnalysisSchemesOutput struct {
 	// The analysis scheme descriptions.
 	AnalysisSchemes []*AnalysisSchemeStatus `type:"list" required:"true"`
 
-	metadataDescribeAnalysisSchemesOutput `json:"-" xml:"-"`
-}
-
-type metadataDescribeAnalysisSchemesOutput struct {
-	SDKShapeTraits bool `type:"structure"`
+	_ struct{} `type:"structure"`
 }
 
 // String returns the string representation
@@ -1646,11 +1522,7 @@ type DescribeAvailabilityOptionsInput struct {
 	// The name of the domain you want to describe.
 	DomainName *string `min:"3" type:"string" required:"true"`
 
-	metadataDescribeAvailabilityOptionsInput `json:"-" xml:"-"`
-}
-
-type metadataDescribeAvailabilityOptionsInput struct {
-	SDKShapeTraits bool `type:"structure"`
+	_ struct{} `type:"structure"`
 }
 
 // String returns the string representation
@@ -1670,11 +1542,7 @@ type DescribeAvailabilityOptionsOutput struct {
 	// is enabled for the domain.
 	AvailabilityOptions *AvailabilityOptionsStatus `type:"structure"`
 
-	metadataDescribeAvailabilityOptionsOutput `json:"-" xml:"-"`
-}
-
-type metadataDescribeAvailabilityOptionsOutput struct {
-	SDKShapeTraits bool `type:"structure"`
+	_ struct{} `type:"structure"`
 }
 
 // String returns the string representation
@@ -1694,11 +1562,7 @@ type DescribeDomainsInput struct {
 	// The names of the domains you want to include in the response.
 	DomainNames []*string `type:"list"`
 
-	metadataDescribeDomainsInput `json:"-" xml:"-"`
-}
-
-type metadataDescribeDomainsInput struct {
-	SDKShapeTraits bool `type:"structure"`
+	_ struct{} `type:"structure"`
 }
 
 // String returns the string representation
@@ -1717,11 +1581,7 @@ type DescribeDomainsOutput struct {
 	// A list that contains the status of each requested domain.
 	DomainStatusList []*DomainStatus `type:"list" required:"true"`
 
-	metadataDescribeDomainsOutput `json:"-" xml:"-"`
-}
-
-type metadataDescribeDomainsOutput struct {
-	SDKShapeTraits bool `type:"structure"`
+	_ struct{} `type:"structure"`
 }
 
 // String returns the string representation
@@ -1751,11 +1611,7 @@ type DescribeExpressionsInput struct {
 	// not specified, all expressions are shown.
 	ExpressionNames []*string `type:"list"`
 
-	metadataDescribeExpressionsInput `json:"-" xml:"-"`
-}
-
-type metadataDescribeExpressionsInput struct {
-	SDKShapeTraits bool `type:"structure"`
+	_ struct{} `type:"structure"`
 }
 
 // String returns the string representation
@@ -1774,11 +1630,7 @@ type DescribeExpressionsOutput struct {
 	// The expressions configured for the domain.
 	Expressions []*ExpressionStatus `type:"list" required:"true"`
 
-	metadataDescribeExpressionsOutput `json:"-" xml:"-"`
-}
-
-type metadataDescribeExpressionsOutput struct {
-	SDKShapeTraits bool `type:"structure"`
+	_ struct{} `type:"structure"`
 }
 
 // String returns the string representation
@@ -1808,11 +1660,7 @@ type DescribeIndexFieldsInput struct {
 	// is returned for all configured index fields.
 	FieldNames []*string `type:"list"`
 
-	metadataDescribeIndexFieldsInput `json:"-" xml:"-"`
-}
-
-type metadataDescribeIndexFieldsInput struct {
-	SDKShapeTraits bool `type:"structure"`
+	_ struct{} `type:"structure"`
 }
 
 // String returns the string representation
@@ -1831,11 +1679,7 @@ type DescribeIndexFieldsOutput struct {
 	// The index fields configured for the domain.
 	IndexFields []*IndexFieldStatus `type:"list" required:"true"`
 
-	metadataDescribeIndexFieldsOutput `json:"-" xml:"-"`
-}
-
-type metadataDescribeIndexFieldsOutput struct {
-	SDKShapeTraits bool `type:"structure"`
+	_ struct{} `type:"structure"`
 }
 
 // String returns the string representation
@@ -1857,11 +1701,7 @@ type DescribeScalingParametersInput struct {
 	// 0-9, and - (hyphen).
 	DomainName *string `min:"3" type:"string" required:"true"`
 
-	metadataDescribeScalingParametersInput `json:"-" xml:"-"`
-}
-
-type metadataDescribeScalingParametersInput struct {
-	SDKShapeTraits bool `type:"structure"`
+	_ struct{} `type:"structure"`
 }
 
 // String returns the string representation
@@ -1880,11 +1720,7 @@ type DescribeScalingParametersOutput struct {
 	// The status and configuration of a search domain's scaling parameters.
 	ScalingParameters *ScalingParametersStatus `type:"structure" required:"true"`
 
-	metadataDescribeScalingParametersOutput `json:"-" xml:"-"`
-}
-
-type metadataDescribeScalingParametersOutput struct {
-	SDKShapeTraits bool `type:"structure"`
+	_ struct{} `type:"structure"`
 }
 
 // String returns the string representation
@@ -1909,11 +1745,7 @@ type DescribeServiceAccessPoliciesInput struct {
 	// The name of the domain you want to describe.
 	DomainName *string `min:"3" type:"string" required:"true"`
 
-	metadataDescribeServiceAccessPoliciesInput `json:"-" xml:"-"`
-}
-
-type metadataDescribeServiceAccessPoliciesInput struct {
-	SDKShapeTraits bool `type:"structure"`
+	_ struct{} `type:"structure"`
 }
 
 // String returns the string representation
@@ -1931,11 +1763,7 @@ type DescribeServiceAccessPoliciesOutput struct {
 	// The access rules configured for the domain specified in the request.
 	AccessPolicies *AccessPoliciesStatus `type:"structure" required:"true"`
 
-	metadataDescribeServiceAccessPoliciesOutput `json:"-" xml:"-"`
-}
-
-type metadataDescribeServiceAccessPoliciesOutput struct {
-	SDKShapeTraits bool `type:"structure"`
+	_ struct{} `type:"structure"`
 }
 
 // String returns the string representation
@@ -1964,11 +1792,7 @@ type DescribeSuggestersInput struct {
 	// The suggesters you want to describe.
 	SuggesterNames []*string `type:"list"`
 
-	metadataDescribeSuggestersInput `json:"-" xml:"-"`
-}
-
-type metadataDescribeSuggestersInput struct {
-	SDKShapeTraits bool `type:"structure"`
+	_ struct{} `type:"structure"`
 }
 
 // String returns the string representation
@@ -1986,11 +1810,7 @@ type DescribeSuggestersOutput struct {
 	// The suggesters configured for the domain specified in the request.
 	Suggesters []*SuggesterStatus `type:"list" required:"true"`
 
-	metadataDescribeSuggestersOutput `json:"-" xml:"-"`
-}
-
-type metadataDescribeSuggestersOutput struct {
-	SDKShapeTraits bool `type:"structure"`
+	_ struct{} `type:"structure"`
 }
 
 // String returns the string representation
@@ -2024,11 +1844,7 @@ type DocumentSuggesterOptions struct {
 	// The name of the index field you want to use for suggestions.
 	SourceField *string `min:"1" type:"string" required:"true"`
 
-	metadataDocumentSuggesterOptions `json:"-" xml:"-"`
-}
-
-type metadataDocumentSuggesterOptions struct {
-	SDKShapeTraits bool `type:"structure"`
+	_ struct{} `type:"structure"`
 }
 
 // String returns the string representation
@@ -2093,11 +1909,7 @@ type DomainStatus struct {
 	// The service endpoint for requesting search results from a search domain.
 	SearchService *ServiceEndpoint `type:"structure"`
 
-	metadataDomainStatus `json:"-" xml:"-"`
-}
-
-type metadataDomainStatus struct {
-	SDKShapeTraits bool `type:"structure"`
+	_ struct{} `type:"structure"`
 }
 
 // String returns the string representation
@@ -2129,11 +1941,7 @@ type DoubleArrayOptions struct {
 	// A list of source fields to map to the field.
 	SourceFields *string `type:"string"`
 
-	metadataDoubleArrayOptions `json:"-" xml:"-"`
-}
-
-type metadataDoubleArrayOptions struct {
-	SDKShapeTraits bool `type:"structure"`
+	_ struct{} `type:"structure"`
 }
 
 // String returns the string representation
@@ -2169,11 +1977,7 @@ type DoubleOptions struct {
 	// The name of the source field to map to the field.
 	SourceField *string `min:"1" type:"string"`
 
-	metadataDoubleOptions `json:"-" xml:"-"`
-}
-
-type metadataDoubleOptions struct {
-	SDKShapeTraits bool `type:"structure"`
+	_ struct{} `type:"structure"`
 }
 
 // String returns the string representation
@@ -2200,11 +2004,7 @@ type Expression struct {
 	// target="_blank) in the Amazon CloudSearch Developer Guide.
 	ExpressionValue *string `min:"1" type:"string" required:"true"`
 
-	metadataExpression `json:"-" xml:"-"`
-}
-
-type metadataExpression struct {
-	SDKShapeTraits bool `type:"structure"`
+	_ struct{} `type:"structure"`
 }
 
 // String returns the string representation
@@ -2225,11 +2025,7 @@ type ExpressionStatus struct {
 	// The status of domain configuration option.
 	Status *OptionStatus `type:"structure" required:"true"`
 
-	metadataExpressionStatus `json:"-" xml:"-"`
-}
-
-type metadataExpressionStatus struct {
-	SDKShapeTraits bool `type:"structure"`
+	_ struct{} `type:"structure"`
 }
 
 // String returns the string representation
@@ -2251,11 +2047,7 @@ type IndexDocumentsInput struct {
 	// 0-9, and - (hyphen).
 	DomainName *string `min:"3" type:"string" required:"true"`
 
-	metadataIndexDocumentsInput `json:"-" xml:"-"`
-}
-
-type metadataIndexDocumentsInput struct {
-	SDKShapeTraits bool `type:"structure"`
+	_ struct{} `type:"structure"`
 }
 
 // String returns the string representation
@@ -2274,11 +2066,7 @@ type IndexDocumentsOutput struct {
 	// The names of the fields that are currently being indexed.
 	FieldNames []*string `type:"list"`
 
-	metadataIndexDocumentsOutput `json:"-" xml:"-"`
-}
-
-type metadataIndexDocumentsOutput struct {
-	SDKShapeTraits bool `type:"structure"`
+	_ struct{} `type:"structure"`
 }
 
 // String returns the string representation
@@ -2368,11 +2156,7 @@ type IndexField struct {
 	// by default.
 	TextOptions *TextOptions `type:"structure"`
 
-	metadataIndexField `json:"-" xml:"-"`
-}
-
-type metadataIndexField struct {
-	SDKShapeTraits bool `type:"structure"`
+	_ struct{} `type:"structure"`
 }
 
 // String returns the string representation
@@ -2394,11 +2178,7 @@ type IndexFieldStatus struct {
 	// The status of domain configuration option.
 	Status *OptionStatus `type:"structure" required:"true"`
 
-	metadataIndexFieldStatus `json:"-" xml:"-"`
-}
-
-type metadataIndexFieldStatus struct {
-	SDKShapeTraits bool `type:"structure"`
+	_ struct{} `type:"structure"`
 }
 
 // String returns the string representation
@@ -2430,11 +2210,7 @@ type IntArrayOptions struct {
 	// A list of source fields to map to the field.
 	SourceFields *string `type:"string"`
 
-	metadataIntArrayOptions `json:"-" xml:"-"`
-}
-
-type metadataIntArrayOptions struct {
-	SDKShapeTraits bool `type:"structure"`
+	_ struct{} `type:"structure"`
 }
 
 // String returns the string representation
@@ -2470,11 +2246,7 @@ type IntOptions struct {
 	// The name of the source field to map to the field.
 	SourceField *string `min:"1" type:"string"`
 
-	metadataIntOptions `json:"-" xml:"-"`
-}
-
-type metadataIntOptions struct {
-	SDKShapeTraits bool `type:"structure"`
+	_ struct{} `type:"structure"`
 }
 
 // String returns the string representation
@@ -2522,11 +2294,7 @@ type LatLonOptions struct {
 	// a document's ID, you can use the name _id.
 	SourceField *string `min:"1" type:"string"`
 
-	metadataLatLonOptions `json:"-" xml:"-"`
-}
-
-type metadataLatLonOptions struct {
-	SDKShapeTraits bool `type:"structure"`
+	_ struct{} `type:"structure"`
 }
 
 // String returns the string representation
@@ -2544,11 +2312,7 @@ type Limits struct {
 
 	MaximumReplicationCount *int64 `min:"1" type:"integer" required:"true"`
 
-	metadataLimits `json:"-" xml:"-"`
-}
-
-type metadataLimits struct {
-	SDKShapeTraits bool `type:"structure"`
+	_ struct{} `type:"structure"`
 }
 
 // String returns the string representation
@@ -2562,11 +2326,7 @@ func (s Limits) GoString() string {
 }
 
 type ListDomainNamesInput struct {
-	metadataListDomainNamesInput `json:"-" xml:"-"`
-}
-
-type metadataListDomainNamesInput struct {
-	SDKShapeTraits bool `type:"structure"`
+	_ struct{} `type:"structure"`
 }
 
 // String returns the string representation
@@ -2585,11 +2345,7 @@ type ListDomainNamesOutput struct {
 	// The names of the search domains owned by an account.
 	DomainNames map[string]*string `type:"map"`
 
-	metadataListDomainNamesOutput `json:"-" xml:"-"`
-}
-
-type metadataListDomainNamesOutput struct {
-	SDKShapeTraits bool `type:"structure"`
+	_ struct{} `type:"structure"`
 }
 
 // String returns the string representation
@@ -2621,11 +2377,7 @@ type LiteralArrayOptions struct {
 	// A list of source fields to map to the field.
 	SourceFields *string `type:"string"`
 
-	metadataLiteralArrayOptions `json:"-" xml:"-"`
-}
-
-type metadataLiteralArrayOptions struct {
-	SDKShapeTraits bool `type:"structure"`
+	_ struct{} `type:"structure"`
 }
 
 // String returns the string representation
@@ -2672,11 +2424,7 @@ type LiteralOptions struct {
 	// a document's ID, you can use the name _id.
 	SourceField *string `min:"1" type:"string"`
 
-	metadataLiteralOptions `json:"-" xml:"-"`
-}
-
-type metadataLiteralOptions struct {
-	SDKShapeTraits bool `type:"structure"`
+	_ struct{} `type:"structure"`
 }
 
 // String returns the string representation
@@ -2714,11 +2462,7 @@ type OptionStatus struct {
 	// A unique integer that indicates when this option was last updated.
 	UpdateVersion *int64 `type:"integer"`
 
-	metadataOptionStatus `json:"-" xml:"-"`
-}
-
-type metadataOptionStatus struct {
-	SDKShapeTraits bool `type:"structure"`
+	_ struct{} `type:"structure"`
 }
 
 // String returns the string representation
@@ -2744,11 +2488,7 @@ type ScalingParameters struct {
 	// The number of replicas you want to preconfigure for each index partition.
 	DesiredReplicationCount *int64 `type:"integer"`
 
-	metadataScalingParameters `json:"-" xml:"-"`
-}
-
-type metadataScalingParameters struct {
-	SDKShapeTraits bool `type:"structure"`
+	_ struct{} `type:"structure"`
 }
 
 // String returns the string representation
@@ -2769,11 +2509,7 @@ type ScalingParametersStatus struct {
 	// The status of domain configuration option.
 	Status *OptionStatus `type:"structure" required:"true"`
 
-	metadataScalingParametersStatus `json:"-" xml:"-"`
-}
-
-type metadataScalingParametersStatus struct {
-	SDKShapeTraits bool `type:"structure"`
+	_ struct{} `type:"structure"`
 }
 
 // String returns the string representation
@@ -2792,11 +2528,7 @@ type ServiceEndpoint struct {
 	// or doc-imdb-movies-oopcnjfn6ugofer3zx5iadxxca.eu-west-1.cloudsearch.amazonaws.com.
 	Endpoint *string `type:"string"`
 
-	metadataServiceEndpoint `json:"-" xml:"-"`
-}
-
-type metadataServiceEndpoint struct {
-	SDKShapeTraits bool `type:"structure"`
+	_ struct{} `type:"structure"`
 }
 
 // String returns the string representation
@@ -2820,11 +2552,7 @@ type Suggester struct {
 	// a-z (lowercase), 0-9, and _ (underscore).
 	SuggesterName *string `min:"1" type:"string" required:"true"`
 
-	metadataSuggester `json:"-" xml:"-"`
-}
-
-type metadataSuggester struct {
-	SDKShapeTraits bool `type:"structure"`
+	_ struct{} `type:"structure"`
 }
 
 // String returns the string representation
@@ -2847,11 +2575,7 @@ type SuggesterStatus struct {
 	// The status of domain configuration option.
 	Status *OptionStatus `type:"structure" required:"true"`
 
-	metadataSuggesterStatus `json:"-" xml:"-"`
-}
-
-type metadataSuggesterStatus struct {
-	SDKShapeTraits bool `type:"structure"`
+	_ struct{} `type:"structure"`
 }
 
 // String returns the string representation
@@ -2883,11 +2607,7 @@ type TextArrayOptions struct {
 	// A list of source fields to map to the field.
 	SourceFields *string `type:"string"`
 
-	metadataTextArrayOptions `json:"-" xml:"-"`
-}
-
-type metadataTextArrayOptions struct {
-	SDKShapeTraits bool `type:"structure"`
+	_ struct{} `type:"structure"`
 }
 
 // String returns the string representation
@@ -2935,11 +2655,7 @@ type TextOptions struct {
 	// a document's ID, you can use the name _id.
 	SourceField *string `min:"1" type:"string"`
 
-	metadataTextOptions `json:"-" xml:"-"`
-}
-
-type metadataTextOptions struct {
-	SDKShapeTraits bool `type:"structure"`
+	_ struct{} `type:"structure"`
 }
 
 // String returns the string representation
@@ -2968,11 +2684,7 @@ type UpdateAvailabilityOptionsInput struct {
 	// option to false.
 	MultiAZ *bool `type:"boolean" required:"true"`
 
-	metadataUpdateAvailabilityOptionsInput `json:"-" xml:"-"`
-}
-
-type metadataUpdateAvailabilityOptionsInput struct {
-	SDKShapeTraits bool `type:"structure"`
+	_ struct{} `type:"structure"`
 }
 
 // String returns the string representation
@@ -2992,11 +2704,7 @@ type UpdateAvailabilityOptionsOutput struct {
 	// enabled for the domain.
 	AvailabilityOptions *AvailabilityOptionsStatus `type:"structure"`
 
-	metadataUpdateAvailabilityOptionsOutput `json:"-" xml:"-"`
-}
-
-type metadataUpdateAvailabilityOptionsOutput struct {
-	SDKShapeTraits bool `type:"structure"`
+	_ struct{} `type:"structure"`
 }
 
 // String returns the string representation
@@ -3022,11 +2730,7 @@ type UpdateScalingParametersInput struct {
 	// The desired instance type and desired number of replicas of each index partition.
 	ScalingParameters *ScalingParameters `type:"structure" required:"true"`
 
-	metadataUpdateScalingParametersInput `json:"-" xml:"-"`
-}
-
-type metadataUpdateScalingParametersInput struct {
-	SDKShapeTraits bool `type:"structure"`
+	_ struct{} `type:"structure"`
 }
 
 // String returns the string representation
@@ -3045,11 +2749,7 @@ type UpdateScalingParametersOutput struct {
 	// The status and configuration of a search domain's scaling parameters.
 	ScalingParameters *ScalingParametersStatus `type:"structure" required:"true"`
 
-	metadataUpdateScalingParametersOutput `json:"-" xml:"-"`
-}
-
-type metadataUpdateScalingParametersOutput struct {
-	SDKShapeTraits bool `type:"structure"`
+	_ struct{} `type:"structure"`
 }
 
 // String returns the string representation
@@ -3076,11 +2776,7 @@ type UpdateServiceAccessPoliciesInput struct {
 	// 0-9, and - (hyphen).
 	DomainName *string `min:"3" type:"string" required:"true"`
 
-	metadataUpdateServiceAccessPoliciesInput `json:"-" xml:"-"`
-}
-
-type metadataUpdateServiceAccessPoliciesInput struct {
-	SDKShapeTraits bool `type:"structure"`
+	_ struct{} `type:"structure"`
 }
 
 // String returns the string representation
@@ -3099,11 +2795,7 @@ type UpdateServiceAccessPoliciesOutput struct {
 	// The access rules configured for the domain.
 	AccessPolicies *AccessPoliciesStatus `type:"structure" required:"true"`
 
-	metadataUpdateServiceAccessPoliciesOutput `json:"-" xml:"-"`
-}
-
-type metadataUpdateServiceAccessPoliciesOutput struct {
-	SDKShapeTraits bool `type:"structure"`
+	_ struct{} `type:"structure"`
 }
 
 // String returns the string representation

--- a/service/cloudsearch/api.go
+++ b/service/cloudsearch/api.go
@@ -750,6 +750,8 @@ func (c *CloudSearch) UpdateServiceAccessPolicies(input *UpdateServiceAccessPoli
 // The configured access rules for the domain's document and search endpoints,
 // and the current status of those rules.
 type AccessPoliciesStatus struct {
+	_ struct{} `type:"structure"`
+
 	// Access rules for a domain's document or search service endpoints. For more
 	// information, see Configuring Access for a Search Domain (http://docs.aws.amazon.com/cloudsearch/latest/developerguide/configuring-access.html"
 	// target="_blank) in the Amazon CloudSearch Developer Guide. The maximum size
@@ -758,8 +760,6 @@ type AccessPoliciesStatus struct {
 
 	// The status of domain configuration option.
 	Status *OptionStatus `type:"structure" required:"true"`
-
-	_ struct{} `type:"structure"`
 }
 
 // String returns the string representation
@@ -775,6 +775,8 @@ func (s AccessPoliciesStatus) GoString() string {
 // Synonyms, stopwords, and stemming options for an analysis scheme. Includes
 // tokenization dictionary for Japanese.
 type AnalysisOptions struct {
+	_ struct{} `type:"structure"`
+
 	// The level of algorithmic stemming to perform: none, minimal, light, or full.
 	// The available levels vary depending on the language. For more information,
 	// see Language Specific Text Processing Settings (http://docs.aws.amazon.com/cloudsearch/latest/developerguide/text-processing.html#text-processing-settings"
@@ -810,8 +812,6 @@ type AnalysisOptions struct {
 	// about specifying synonyms, see Synonyms (http://docs.aws.amazon.com/cloudsearch/latest/developerguide/configuring-analysis-schemes.html#synonyms)
 	// in the Amazon CloudSearch Developer Guide.
 	Synonyms *string `type:"string"`
-
-	_ struct{} `type:"structure"`
 }
 
 // String returns the string representation
@@ -829,6 +829,8 @@ func (s AnalysisOptions) GoString() string {
 // following options can be configured for an analysis scheme: Synonyms, Stopwords,
 // StemmingDictionary, JapaneseTokenizationDictionary and AlgorithmicStemming.
 type AnalysisScheme struct {
+	_ struct{} `type:"structure"`
+
 	// Synonyms, stopwords, and stemming options for an analysis scheme. Includes
 	// tokenization dictionary for Japanese.
 	AnalysisOptions *AnalysisOptions `type:"structure"`
@@ -840,8 +842,6 @@ type AnalysisScheme struct {
 	// Names must begin with a letter and can contain the following characters:
 	// a-z (lowercase), 0-9, and _ (underscore).
 	AnalysisSchemeName *string `min:"1" type:"string" required:"true"`
-
-	_ struct{} `type:"structure"`
 }
 
 // String returns the string representation
@@ -856,6 +856,8 @@ func (s AnalysisScheme) GoString() string {
 
 // The status and configuration of an AnalysisScheme.
 type AnalysisSchemeStatus struct {
+	_ struct{} `type:"structure"`
+
 	// Configuration information for an analysis scheme. Each analysis scheme has
 	// a unique name and specifies the language of the text to be processed. The
 	// following options can be configured for an analysis scheme: Synonyms, Stopwords,
@@ -864,8 +866,6 @@ type AnalysisSchemeStatus struct {
 
 	// The status of domain configuration option.
 	Status *OptionStatus `type:"structure" required:"true"`
-
-	_ struct{} `type:"structure"`
 }
 
 // String returns the string representation
@@ -880,13 +880,13 @@ func (s AnalysisSchemeStatus) GoString() string {
 
 // The status and configuration of the domain's availability options.
 type AvailabilityOptionsStatus struct {
+	_ struct{} `type:"structure"`
+
 	// The availability options configured for the domain.
 	Options *bool `type:"boolean" required:"true"`
 
 	// The status of domain configuration option.
 	Status *OptionStatus `type:"structure" required:"true"`
-
-	_ struct{} `type:"structure"`
 }
 
 // String returns the string representation
@@ -902,13 +902,13 @@ func (s AvailabilityOptionsStatus) GoString() string {
 // Container for the parameters to the BuildSuggester operation. Specifies the
 // name of the domain you want to update.
 type BuildSuggestersInput struct {
+	_ struct{} `type:"structure"`
+
 	// A string that represents the name of a domain. Domain names are unique across
 	// the domains owned by an account within an AWS region. Domain names start
 	// with a letter or number and can contain the following characters: a-z (lowercase),
 	// 0-9, and - (hyphen).
 	DomainName *string `min:"3" type:"string" required:"true"`
-
-	_ struct{} `type:"structure"`
 }
 
 // String returns the string representation
@@ -924,10 +924,10 @@ func (s BuildSuggestersInput) GoString() string {
 // The result of a BuildSuggester request. Contains a list of the fields used
 // for suggestions.
 type BuildSuggestersOutput struct {
+	_ struct{} `type:"structure"`
+
 	// A list of field names.
 	FieldNames []*string `type:"list"`
-
-	_ struct{} `type:"structure"`
 }
 
 // String returns the string representation
@@ -943,12 +943,12 @@ func (s BuildSuggestersOutput) GoString() string {
 // Container for the parameters to the CreateDomain operation. Specifies a name
 // for the new search domain.
 type CreateDomainInput struct {
+	_ struct{} `type:"structure"`
+
 	// A name for the domain you are creating. Allowed characters are a-z (lower-case
 	// letters), 0-9, and hyphen (-). Domain names must start with a letter or number
 	// and be at least 3 and no more than 28 characters long.
 	DomainName *string `min:"3" type:"string" required:"true"`
-
-	_ struct{} `type:"structure"`
 }
 
 // String returns the string representation
@@ -964,10 +964,10 @@ func (s CreateDomainInput) GoString() string {
 // The result of a CreateDomainRequest. Contains the status of a newly created
 // domain.
 type CreateDomainOutput struct {
+	_ struct{} `type:"structure"`
+
 	// The current status of the search domain.
 	DomainStatus *DomainStatus `type:"structure"`
-
-	_ struct{} `type:"structure"`
 }
 
 // String returns the string representation
@@ -983,6 +983,8 @@ func (s CreateDomainOutput) GoString() string {
 // Options for a field that contains an array of dates. Present if IndexFieldType
 // specifies the field is of type date-array. All options are enabled by default.
 type DateArrayOptions struct {
+	_ struct{} `type:"structure"`
+
 	// A value to use for the field if the field isn't specified for a document.
 	DefaultValue *string `type:"string"`
 
@@ -997,8 +999,6 @@ type DateArrayOptions struct {
 
 	// A list of source fields to map to the field.
 	SourceFields *string `type:"string"`
-
-	_ struct{} `type:"structure"`
 }
 
 // String returns the string representation
@@ -1016,6 +1016,8 @@ func (s DateArrayOptions) GoString() string {
 // if IndexFieldType specifies the field is of type date. All options are enabled
 // by default.
 type DateOptions struct {
+	_ struct{} `type:"structure"`
+
 	// A value to use for the field if the field isn't specified for a document.
 	DefaultValue *string `type:"string"`
 
@@ -1046,8 +1048,6 @@ type DateOptions struct {
 	// The name score is reserved and cannot be used as a field name. To reference
 	// a document's ID, you can use the name _id.
 	SourceField *string `min:"1" type:"string"`
-
-	_ struct{} `type:"structure"`
 }
 
 // String returns the string representation
@@ -1063,6 +1063,8 @@ func (s DateOptions) GoString() string {
 // Container for the parameters to the DefineAnalysisScheme operation. Specifies
 // the name of the domain you want to update and the analysis scheme configuration.
 type DefineAnalysisSchemeInput struct {
+	_ struct{} `type:"structure"`
+
 	// Configuration information for an analysis scheme. Each analysis scheme has
 	// a unique name and specifies the language of the text to be processed. The
 	// following options can be configured for an analysis scheme: Synonyms, Stopwords,
@@ -1074,8 +1076,6 @@ type DefineAnalysisSchemeInput struct {
 	// with a letter or number and can contain the following characters: a-z (lowercase),
 	// 0-9, and - (hyphen).
 	DomainName *string `min:"3" type:"string" required:"true"`
-
-	_ struct{} `type:"structure"`
 }
 
 // String returns the string representation
@@ -1091,10 +1091,10 @@ func (s DefineAnalysisSchemeInput) GoString() string {
 // The result of a DefineAnalysisScheme request. Contains the status of the
 // newly-configured analysis scheme.
 type DefineAnalysisSchemeOutput struct {
+	_ struct{} `type:"structure"`
+
 	// The status and configuration of an AnalysisScheme.
 	AnalysisScheme *AnalysisSchemeStatus `type:"structure" required:"true"`
-
-	_ struct{} `type:"structure"`
 }
 
 // String returns the string representation
@@ -1111,6 +1111,8 @@ func (s DefineAnalysisSchemeOutput) GoString() string {
 // the name of the domain you want to update and the expression you want to
 // configure.
 type DefineExpressionInput struct {
+	_ struct{} `type:"structure"`
+
 	// A string that represents the name of a domain. Domain names are unique across
 	// the domains owned by an account within an AWS region. Domain names start
 	// with a letter or number and can contain the following characters: a-z (lowercase),
@@ -1121,8 +1123,6 @@ type DefineExpressionInput struct {
 	// the search results, define other expressions, or return computed information
 	// in the search results.
 	Expression *Expression `type:"structure" required:"true"`
-
-	_ struct{} `type:"structure"`
 }
 
 // String returns the string representation
@@ -1138,10 +1138,10 @@ func (s DefineExpressionInput) GoString() string {
 // The result of a DefineExpression request. Contains the status of the newly-configured
 // expression.
 type DefineExpressionOutput struct {
+	_ struct{} `type:"structure"`
+
 	// The value of an Expression and its current status.
 	Expression *ExpressionStatus `type:"structure" required:"true"`
-
-	_ struct{} `type:"structure"`
 }
 
 // String returns the string representation
@@ -1157,6 +1157,8 @@ func (s DefineExpressionOutput) GoString() string {
 // Container for the parameters to the DefineIndexField operation. Specifies
 // the name of the domain you want to update and the index field configuration.
 type DefineIndexFieldInput struct {
+	_ struct{} `type:"structure"`
+
 	// A string that represents the name of a domain. Domain names are unique across
 	// the domains owned by an account within an AWS region. Domain names start
 	// with a letter or number and can contain the following characters: a-z (lowercase),
@@ -1165,8 +1167,6 @@ type DefineIndexFieldInput struct {
 
 	// The index field and field options you want to configure.
 	IndexField *IndexField `type:"structure" required:"true"`
-
-	_ struct{} `type:"structure"`
 }
 
 // String returns the string representation
@@ -1182,10 +1182,10 @@ func (s DefineIndexFieldInput) GoString() string {
 // The result of a DefineIndexField request. Contains the status of the newly-configured
 // index field.
 type DefineIndexFieldOutput struct {
+	_ struct{} `type:"structure"`
+
 	// The value of an IndexField and its current status.
 	IndexField *IndexFieldStatus `type:"structure" required:"true"`
-
-	_ struct{} `type:"structure"`
 }
 
 // String returns the string representation
@@ -1201,6 +1201,8 @@ func (s DefineIndexFieldOutput) GoString() string {
 // Container for the parameters to the DefineSuggester operation. Specifies
 // the name of the domain you want to update and the suggester configuration.
 type DefineSuggesterInput struct {
+	_ struct{} `type:"structure"`
+
 	// A string that represents the name of a domain. Domain names are unique across
 	// the domains owned by an account within an AWS region. Domain names start
 	// with a letter or number and can contain the following characters: a-z (lowercase),
@@ -1211,8 +1213,6 @@ type DefineSuggesterInput struct {
 	// name and specifies the text field you want to use for suggestions. The following
 	// options can be configured for a suggester: FuzzyMatching, SortExpression.
 	Suggester *Suggester `type:"structure" required:"true"`
-
-	_ struct{} `type:"structure"`
 }
 
 // String returns the string representation
@@ -1228,10 +1228,10 @@ func (s DefineSuggesterInput) GoString() string {
 // The result of a DefineSuggester request. Contains the status of the newly-configured
 // suggester.
 type DefineSuggesterOutput struct {
+	_ struct{} `type:"structure"`
+
 	// The value of a Suggester and its current status.
 	Suggester *SuggesterStatus `type:"structure" required:"true"`
-
-	_ struct{} `type:"structure"`
 }
 
 // String returns the string representation
@@ -1248,6 +1248,8 @@ func (s DefineSuggesterOutput) GoString() string {
 // the name of the domain you want to update and the analysis scheme you want
 // to delete.
 type DeleteAnalysisSchemeInput struct {
+	_ struct{} `type:"structure"`
+
 	// The name of the analysis scheme you want to delete.
 	AnalysisSchemeName *string `min:"1" type:"string" required:"true"`
 
@@ -1256,8 +1258,6 @@ type DeleteAnalysisSchemeInput struct {
 	// with a letter or number and can contain the following characters: a-z (lowercase),
 	// 0-9, and - (hyphen).
 	DomainName *string `min:"3" type:"string" required:"true"`
-
-	_ struct{} `type:"structure"`
 }
 
 // String returns the string representation
@@ -1273,10 +1273,10 @@ func (s DeleteAnalysisSchemeInput) GoString() string {
 // The result of a DeleteAnalysisScheme request. Contains the status of the
 // deleted analysis scheme.
 type DeleteAnalysisSchemeOutput struct {
+	_ struct{} `type:"structure"`
+
 	// The status of the analysis scheme being deleted.
 	AnalysisScheme *AnalysisSchemeStatus `type:"structure" required:"true"`
-
-	_ struct{} `type:"structure"`
 }
 
 // String returns the string representation
@@ -1292,10 +1292,10 @@ func (s DeleteAnalysisSchemeOutput) GoString() string {
 // Container for the parameters to the DeleteDomain operation. Specifies the
 // name of the domain you want to delete.
 type DeleteDomainInput struct {
+	_ struct{} `type:"structure"`
+
 	// The name of the domain you want to permanently delete.
 	DomainName *string `min:"3" type:"string" required:"true"`
-
-	_ struct{} `type:"structure"`
 }
 
 // String returns the string representation
@@ -1311,10 +1311,10 @@ func (s DeleteDomainInput) GoString() string {
 // The result of a DeleteDomain request. Contains the status of a newly deleted
 // domain, or no status if the domain has already been completely deleted.
 type DeleteDomainOutput struct {
+	_ struct{} `type:"structure"`
+
 	// The current status of the search domain.
 	DomainStatus *DomainStatus `type:"structure"`
-
-	_ struct{} `type:"structure"`
 }
 
 // String returns the string representation
@@ -1331,6 +1331,8 @@ func (s DeleteDomainOutput) GoString() string {
 // the name of the domain you want to update and the name of the expression
 // you want to delete.
 type DeleteExpressionInput struct {
+	_ struct{} `type:"structure"`
+
 	// A string that represents the name of a domain. Domain names are unique across
 	// the domains owned by an account within an AWS region. Domain names start
 	// with a letter or number and can contain the following characters: a-z (lowercase),
@@ -1339,8 +1341,6 @@ type DeleteExpressionInput struct {
 
 	// The name of the Expression to delete.
 	ExpressionName *string `min:"1" type:"string" required:"true"`
-
-	_ struct{} `type:"structure"`
 }
 
 // String returns the string representation
@@ -1356,10 +1356,10 @@ func (s DeleteExpressionInput) GoString() string {
 // The result of a DeleteExpression request. Specifies the expression being
 // deleted.
 type DeleteExpressionOutput struct {
+	_ struct{} `type:"structure"`
+
 	// The status of the expression being deleted.
 	Expression *ExpressionStatus `type:"structure" required:"true"`
-
-	_ struct{} `type:"structure"`
 }
 
 // String returns the string representation
@@ -1376,6 +1376,8 @@ func (s DeleteExpressionOutput) GoString() string {
 // the name of the domain you want to update and the name of the index field
 // you want to delete.
 type DeleteIndexFieldInput struct {
+	_ struct{} `type:"structure"`
+
 	// A string that represents the name of a domain. Domain names are unique across
 	// the domains owned by an account within an AWS region. Domain names start
 	// with a letter or number and can contain the following characters: a-z (lowercase),
@@ -1385,8 +1387,6 @@ type DeleteIndexFieldInput struct {
 	// The name of the index field your want to remove from the domain's indexing
 	// options.
 	IndexFieldName *string `min:"1" type:"string" required:"true"`
-
-	_ struct{} `type:"structure"`
 }
 
 // String returns the string representation
@@ -1401,10 +1401,10 @@ func (s DeleteIndexFieldInput) GoString() string {
 
 // The result of a DeleteIndexField request.
 type DeleteIndexFieldOutput struct {
+	_ struct{} `type:"structure"`
+
 	// The status of the index field being deleted.
 	IndexField *IndexFieldStatus `type:"structure" required:"true"`
-
-	_ struct{} `type:"structure"`
 }
 
 // String returns the string representation
@@ -1421,6 +1421,8 @@ func (s DeleteIndexFieldOutput) GoString() string {
 // the name of the domain you want to update and name of the suggester you want
 // to delete.
 type DeleteSuggesterInput struct {
+	_ struct{} `type:"structure"`
+
 	// A string that represents the name of a domain. Domain names are unique across
 	// the domains owned by an account within an AWS region. Domain names start
 	// with a letter or number and can contain the following characters: a-z (lowercase),
@@ -1429,8 +1431,6 @@ type DeleteSuggesterInput struct {
 
 	// Specifies the name of the suggester you want to delete.
 	SuggesterName *string `min:"1" type:"string" required:"true"`
-
-	_ struct{} `type:"structure"`
 }
 
 // String returns the string representation
@@ -1446,10 +1446,10 @@ func (s DeleteSuggesterInput) GoString() string {
 // The result of a DeleteSuggester request. Contains the status of the deleted
 // suggester.
 type DeleteSuggesterOutput struct {
+	_ struct{} `type:"structure"`
+
 	// The status of the suggester being deleted.
 	Suggester *SuggesterStatus `type:"structure" required:"true"`
-
-	_ struct{} `type:"structure"`
 }
 
 // String returns the string representation
@@ -1468,6 +1468,8 @@ func (s DeleteSuggesterOutput) GoString() string {
 // To show the active configuration and exclude any pending changes, set the
 // Deployed option to true.
 type DescribeAnalysisSchemesInput struct {
+	_ struct{} `type:"structure"`
+
 	// The analysis schemes you want to describe.
 	AnalysisSchemeNames []*string `type:"list"`
 
@@ -1477,8 +1479,6 @@ type DescribeAnalysisSchemesInput struct {
 
 	// The name of the domain you want to describe.
 	DomainName *string `min:"3" type:"string" required:"true"`
-
-	_ struct{} `type:"structure"`
 }
 
 // String returns the string representation
@@ -1494,10 +1494,10 @@ func (s DescribeAnalysisSchemesInput) GoString() string {
 // The result of a DescribeAnalysisSchemes request. Contains the analysis schemes
 // configured for the domain specified in the request.
 type DescribeAnalysisSchemesOutput struct {
+	_ struct{} `type:"structure"`
+
 	// The analysis scheme descriptions.
 	AnalysisSchemes []*AnalysisSchemeStatus `type:"list" required:"true"`
-
-	_ struct{} `type:"structure"`
 }
 
 // String returns the string representation
@@ -1515,14 +1515,14 @@ func (s DescribeAnalysisSchemesOutput) GoString() string {
 // configuration and exclude any pending changes, set the Deployed option to
 // true.
 type DescribeAvailabilityOptionsInput struct {
+	_ struct{} `type:"structure"`
+
 	// Whether to display the deployed configuration (true) or include any pending
 	// changes (false). Defaults to false.
 	Deployed *bool `type:"boolean"`
 
 	// The name of the domain you want to describe.
 	DomainName *string `min:"3" type:"string" required:"true"`
-
-	_ struct{} `type:"structure"`
 }
 
 // String returns the string representation
@@ -1538,11 +1538,11 @@ func (s DescribeAvailabilityOptionsInput) GoString() string {
 // The result of a DescribeAvailabilityOptions request. Indicates whether or
 // not the Multi-AZ option is enabled for the domain specified in the request.
 type DescribeAvailabilityOptionsOutput struct {
+	_ struct{} `type:"structure"`
+
 	// The availability options configured for the domain. Indicates whether Multi-AZ
 	// is enabled for the domain.
 	AvailabilityOptions *AvailabilityOptionsStatus `type:"structure"`
-
-	_ struct{} `type:"structure"`
 }
 
 // String returns the string representation
@@ -1559,10 +1559,10 @@ func (s DescribeAvailabilityOptionsOutput) GoString() string {
 // shows the status of all domains. To restrict the response to particular domains,
 // specify the names of the domains you want to describe.
 type DescribeDomainsInput struct {
+	_ struct{} `type:"structure"`
+
 	// The names of the domains you want to include in the response.
 	DomainNames []*string `type:"list"`
-
-	_ struct{} `type:"structure"`
 }
 
 // String returns the string representation
@@ -1578,10 +1578,10 @@ func (s DescribeDomainsInput) GoString() string {
 // The result of a DescribeDomains request. Contains the status of the domains
 // specified in the request or all domains owned by the account.
 type DescribeDomainsOutput struct {
+	_ struct{} `type:"structure"`
+
 	// A list that contains the status of each requested domain.
 	DomainStatusList []*DomainStatus `type:"list" required:"true"`
-
-	_ struct{} `type:"structure"`
 }
 
 // String returns the string representation
@@ -1600,6 +1600,8 @@ func (s DescribeDomainsOutput) GoString() string {
 // describe. To show the active configuration and exclude any pending changes,
 // set the Deployed option to true.
 type DescribeExpressionsInput struct {
+	_ struct{} `type:"structure"`
+
 	// Whether to display the deployed configuration (true) or include any pending
 	// changes (false). Defaults to false.
 	Deployed *bool `type:"boolean"`
@@ -1610,8 +1612,6 @@ type DescribeExpressionsInput struct {
 	// Limits the DescribeExpressions response to the specified expressions. If
 	// not specified, all expressions are shown.
 	ExpressionNames []*string `type:"list"`
-
-	_ struct{} `type:"structure"`
 }
 
 // String returns the string representation
@@ -1627,10 +1627,10 @@ func (s DescribeExpressionsInput) GoString() string {
 // The result of a DescribeExpressions request. Contains the expressions configured
 // for the domain specified in the request.
 type DescribeExpressionsOutput struct {
+	_ struct{} `type:"structure"`
+
 	// The expressions configured for the domain.
 	Expressions []*ExpressionStatus `type:"list" required:"true"`
-
-	_ struct{} `type:"structure"`
 }
 
 // String returns the string representation
@@ -1649,6 +1649,8 @@ func (s DescribeExpressionsOutput) GoString() string {
 // describe. To show the active configuration and exclude any pending changes,
 // set the Deployed option to true.
 type DescribeIndexFieldsInput struct {
+	_ struct{} `type:"structure"`
+
 	// Whether to display the deployed configuration (true) or include any pending
 	// changes (false). Defaults to false.
 	Deployed *bool `type:"boolean"`
@@ -1659,8 +1661,6 @@ type DescribeIndexFieldsInput struct {
 	// A list of the index fields you want to describe. If not specified, information
 	// is returned for all configured index fields.
 	FieldNames []*string `type:"list"`
-
-	_ struct{} `type:"structure"`
 }
 
 // String returns the string representation
@@ -1676,10 +1676,10 @@ func (s DescribeIndexFieldsInput) GoString() string {
 // The result of a DescribeIndexFields request. Contains the index fields configured
 // for the domain specified in the request.
 type DescribeIndexFieldsOutput struct {
+	_ struct{} `type:"structure"`
+
 	// The index fields configured for the domain.
 	IndexFields []*IndexFieldStatus `type:"list" required:"true"`
-
-	_ struct{} `type:"structure"`
 }
 
 // String returns the string representation
@@ -1695,13 +1695,13 @@ func (s DescribeIndexFieldsOutput) GoString() string {
 // Container for the parameters to the DescribeScalingParameters operation.
 // Specifies the name of the domain you want to describe.
 type DescribeScalingParametersInput struct {
+	_ struct{} `type:"structure"`
+
 	// A string that represents the name of a domain. Domain names are unique across
 	// the domains owned by an account within an AWS region. Domain names start
 	// with a letter or number and can contain the following characters: a-z (lowercase),
 	// 0-9, and - (hyphen).
 	DomainName *string `min:"3" type:"string" required:"true"`
-
-	_ struct{} `type:"structure"`
 }
 
 // String returns the string representation
@@ -1717,10 +1717,10 @@ func (s DescribeScalingParametersInput) GoString() string {
 // The result of a DescribeScalingParameters request. Contains the scaling parameters
 // configured for the domain specified in the request.
 type DescribeScalingParametersOutput struct {
+	_ struct{} `type:"structure"`
+
 	// The status and configuration of a search domain's scaling parameters.
 	ScalingParameters *ScalingParametersStatus `type:"structure" required:"true"`
-
-	_ struct{} `type:"structure"`
 }
 
 // String returns the string representation
@@ -1738,14 +1738,14 @@ func (s DescribeScalingParametersOutput) GoString() string {
 // configuration and exclude any pending changes, set the Deployed option to
 // true.
 type DescribeServiceAccessPoliciesInput struct {
+	_ struct{} `type:"structure"`
+
 	// Whether to display the deployed configuration (true) or include any pending
 	// changes (false). Defaults to false.
 	Deployed *bool `type:"boolean"`
 
 	// The name of the domain you want to describe.
 	DomainName *string `min:"3" type:"string" required:"true"`
-
-	_ struct{} `type:"structure"`
 }
 
 // String returns the string representation
@@ -1760,10 +1760,10 @@ func (s DescribeServiceAccessPoliciesInput) GoString() string {
 
 // The result of a DescribeServiceAccessPolicies request.
 type DescribeServiceAccessPoliciesOutput struct {
+	_ struct{} `type:"structure"`
+
 	// The access rules configured for the domain specified in the request.
 	AccessPolicies *AccessPoliciesStatus `type:"structure" required:"true"`
-
-	_ struct{} `type:"structure"`
 }
 
 // String returns the string representation
@@ -1782,6 +1782,8 @@ func (s DescribeServiceAccessPoliciesOutput) GoString() string {
 // To show the active configuration and exclude any pending changes, set the
 // Deployed option to true.
 type DescribeSuggestersInput struct {
+	_ struct{} `type:"structure"`
+
 	// Whether to display the deployed configuration (true) or include any pending
 	// changes (false). Defaults to false.
 	Deployed *bool `type:"boolean"`
@@ -1791,8 +1793,6 @@ type DescribeSuggestersInput struct {
 
 	// The suggesters you want to describe.
 	SuggesterNames []*string `type:"list"`
-
-	_ struct{} `type:"structure"`
 }
 
 // String returns the string representation
@@ -1807,10 +1807,10 @@ func (s DescribeSuggestersInput) GoString() string {
 
 // The result of a DescribeSuggesters request.
 type DescribeSuggestersOutput struct {
+	_ struct{} `type:"structure"`
+
 	// The suggesters configured for the domain specified in the request.
 	Suggesters []*SuggesterStatus `type:"list" required:"true"`
-
-	_ struct{} `type:"structure"`
 }
 
 // String returns the string representation
@@ -1825,6 +1825,8 @@ func (s DescribeSuggestersOutput) GoString() string {
 
 // Options for a search suggester.
 type DocumentSuggesterOptions struct {
+	_ struct{} `type:"structure"`
+
 	// The level of fuzziness allowed when suggesting matches for a string: none,
 	// low, or high. With none, the specified string is treated as an exact prefix.
 	// With low, suggestions must differ from the specified string by no more than
@@ -1843,8 +1845,6 @@ type DocumentSuggesterOptions struct {
 
 	// The name of the index field you want to use for suggestions.
 	SourceField *string `min:"1" type:"string" required:"true"`
-
-	_ struct{} `type:"structure"`
 }
 
 // String returns the string representation
@@ -1859,6 +1859,8 @@ func (s DocumentSuggesterOptions) GoString() string {
 
 // The current status of the search domain.
 type DomainStatus struct {
+	_ struct{} `type:"structure"`
+
 	// The Amazon Resource Name (ARN) of the search domain. See Identifiers for
 	// IAM Entities (http://docs.aws.amazon.com/IAM/latest/UserGuide/index.html?Using_Identifiers.html"
 	// target="_blank) in Using AWS Identity and Access Management for more information.
@@ -1908,8 +1910,6 @@ type DomainStatus struct {
 
 	// The service endpoint for requesting search results from a search domain.
 	SearchService *ServiceEndpoint `type:"structure"`
-
-	_ struct{} `type:"structure"`
 }
 
 // String returns the string representation
@@ -1926,6 +1926,8 @@ func (s DomainStatus) GoString() string {
 // point values. Present if IndexFieldType specifies the field is of type double-array.
 // All options are enabled by default.
 type DoubleArrayOptions struct {
+	_ struct{} `type:"structure"`
+
 	// A value to use for the field if the field isn't specified for a document.
 	DefaultValue *float64 `type:"double"`
 
@@ -1940,8 +1942,6 @@ type DoubleArrayOptions struct {
 
 	// A list of source fields to map to the field.
 	SourceFields *string `type:"string"`
-
-	_ struct{} `type:"structure"`
 }
 
 // String returns the string representation
@@ -1957,6 +1957,8 @@ func (s DoubleArrayOptions) GoString() string {
 // Options for a double-precision 64-bit floating point field. Present if IndexFieldType
 // specifies the field is of type double. All options are enabled by default.
 type DoubleOptions struct {
+	_ struct{} `type:"structure"`
+
 	// A value to use for the field if the field isn't specified for a document.
 	// This can be important if you are using the field in an expression and that
 	// field is not present in every document.
@@ -1976,8 +1978,6 @@ type DoubleOptions struct {
 
 	// The name of the source field to map to the field.
 	SourceField *string `min:"1" type:"string"`
-
-	_ struct{} `type:"structure"`
 }
 
 // String returns the string representation
@@ -1994,6 +1994,8 @@ func (s DoubleOptions) GoString() string {
 // the search results, define other expressions, or return computed information
 // in the search results.
 type Expression struct {
+	_ struct{} `type:"structure"`
+
 	// Names must begin with a letter and can contain the following characters:
 	// a-z (lowercase), 0-9, and _ (underscore).
 	ExpressionName *string `min:"1" type:"string" required:"true"`
@@ -2003,8 +2005,6 @@ type Expression struct {
 	// see Configuring Expressions (http://docs.aws.amazon.com/cloudsearch/latest/developerguide/configuring-expressions.html"
 	// target="_blank) in the Amazon CloudSearch Developer Guide.
 	ExpressionValue *string `min:"1" type:"string" required:"true"`
-
-	_ struct{} `type:"structure"`
 }
 
 // String returns the string representation
@@ -2019,13 +2019,13 @@ func (s Expression) GoString() string {
 
 // The value of an Expression and its current status.
 type ExpressionStatus struct {
+	_ struct{} `type:"structure"`
+
 	// The expression that is evaluated for sorting while processing a search request.
 	Options *Expression `type:"structure" required:"true"`
 
 	// The status of domain configuration option.
 	Status *OptionStatus `type:"structure" required:"true"`
-
-	_ struct{} `type:"structure"`
 }
 
 // String returns the string representation
@@ -2041,13 +2041,13 @@ func (s ExpressionStatus) GoString() string {
 // Container for the parameters to the IndexDocuments operation. Specifies the
 // name of the domain you want to re-index.
 type IndexDocumentsInput struct {
+	_ struct{} `type:"structure"`
+
 	// A string that represents the name of a domain. Domain names are unique across
 	// the domains owned by an account within an AWS region. Domain names start
 	// with a letter or number and can contain the following characters: a-z (lowercase),
 	// 0-9, and - (hyphen).
 	DomainName *string `min:"3" type:"string" required:"true"`
-
-	_ struct{} `type:"structure"`
 }
 
 // String returns the string representation
@@ -2063,10 +2063,10 @@ func (s IndexDocumentsInput) GoString() string {
 // The result of an IndexDocuments request. Contains the status of the indexing
 // operation, including the fields being indexed.
 type IndexDocumentsOutput struct {
+	_ struct{} `type:"structure"`
+
 	// The names of the fields that are currently being indexed.
 	FieldNames []*string `type:"list"`
-
-	_ struct{} `type:"structure"`
 }
 
 // String returns the string representation
@@ -2082,6 +2082,8 @@ func (s IndexDocumentsOutput) GoString() string {
 // Configuration information for a field in the index, including its name, type,
 // and options. The supported options depend on the IndexFieldType.
 type IndexField struct {
+	_ struct{} `type:"structure"`
+
 	// Options for a field that contains an array of dates. Present if IndexFieldType
 	// specifies the field is of type date-array. All options are enabled by default.
 	DateArrayOptions *DateArrayOptions `type:"structure"`
@@ -2155,8 +2157,6 @@ type IndexField struct {
 	// of type text. A text field is always searchable. All options are enabled
 	// by default.
 	TextOptions *TextOptions `type:"structure"`
-
-	_ struct{} `type:"structure"`
 }
 
 // String returns the string representation
@@ -2171,14 +2171,14 @@ func (s IndexField) GoString() string {
 
 // The value of an IndexField and its current status.
 type IndexFieldStatus struct {
+	_ struct{} `type:"structure"`
+
 	// Configuration information for a field in the index, including its name, type,
 	// and options. The supported options depend on the IndexFieldType.
 	Options *IndexField `type:"structure" required:"true"`
 
 	// The status of domain configuration option.
 	Status *OptionStatus `type:"structure" required:"true"`
-
-	_ struct{} `type:"structure"`
 }
 
 // String returns the string representation
@@ -2195,6 +2195,8 @@ func (s IndexFieldStatus) GoString() string {
 // if IndexFieldType specifies the field is of type int-array. All options are
 // enabled by default.
 type IntArrayOptions struct {
+	_ struct{} `type:"structure"`
+
 	// A value to use for the field if the field isn't specified for a document.
 	DefaultValue *int64 `type:"long"`
 
@@ -2209,8 +2211,6 @@ type IntArrayOptions struct {
 
 	// A list of source fields to map to the field.
 	SourceFields *string `type:"string"`
-
-	_ struct{} `type:"structure"`
 }
 
 // String returns the string representation
@@ -2226,6 +2226,8 @@ func (s IntArrayOptions) GoString() string {
 // Options for a 64-bit signed integer field. Present if IndexFieldType specifies
 // the field is of type int. All options are enabled by default.
 type IntOptions struct {
+	_ struct{} `type:"structure"`
+
 	// A value to use for the field if the field isn't specified for a document.
 	// This can be important if you are using the field in an expression and that
 	// field is not present in every document.
@@ -2245,8 +2247,6 @@ type IntOptions struct {
 
 	// The name of the source field to map to the field.
 	SourceField *string `min:"1" type:"string"`
-
-	_ struct{} `type:"structure"`
 }
 
 // String returns the string representation
@@ -2263,6 +2263,8 @@ func (s IntOptions) GoString() string {
 // a latitude and longitude value pair. Present if IndexFieldType specifies
 // the field is of type latlon. All options are enabled by default.
 type LatLonOptions struct {
+	_ struct{} `type:"structure"`
+
 	// A value to use for the field if the field isn't specified for a document.
 	DefaultValue *string `type:"string"`
 
@@ -2293,8 +2295,6 @@ type LatLonOptions struct {
 	// The name score is reserved and cannot be used as a field name. To reference
 	// a document's ID, you can use the name _id.
 	SourceField *string `min:"1" type:"string"`
-
-	_ struct{} `type:"structure"`
 }
 
 // String returns the string representation
@@ -2308,11 +2308,11 @@ func (s LatLonOptions) GoString() string {
 }
 
 type Limits struct {
+	_ struct{} `type:"structure"`
+
 	MaximumPartitionCount *int64 `min:"1" type:"integer" required:"true"`
 
 	MaximumReplicationCount *int64 `min:"1" type:"integer" required:"true"`
-
-	_ struct{} `type:"structure"`
 }
 
 // String returns the string representation
@@ -2342,10 +2342,10 @@ func (s ListDomainNamesInput) GoString() string {
 // The result of a ListDomainNames request. Contains a list of the domains owned
 // by an account.
 type ListDomainNamesOutput struct {
+	_ struct{} `type:"structure"`
+
 	// The names of the search domains owned by an account.
 	DomainNames map[string]*string `type:"map"`
-
-	_ struct{} `type:"structure"`
 }
 
 // String returns the string representation
@@ -2362,6 +2362,8 @@ func (s ListDomainNamesOutput) GoString() string {
 // IndexFieldType specifies the field is of type literal-array. All options
 // are enabled by default.
 type LiteralArrayOptions struct {
+	_ struct{} `type:"structure"`
+
 	// A value to use for the field if the field isn't specified for a document.
 	DefaultValue *string `type:"string"`
 
@@ -2376,8 +2378,6 @@ type LiteralArrayOptions struct {
 
 	// A list of source fields to map to the field.
 	SourceFields *string `type:"string"`
-
-	_ struct{} `type:"structure"`
 }
 
 // String returns the string representation
@@ -2393,6 +2393,8 @@ func (s LiteralArrayOptions) GoString() string {
 // Options for literal field. Present if IndexFieldType specifies the field
 // is of type literal. All options are enabled by default.
 type LiteralOptions struct {
+	_ struct{} `type:"structure"`
+
 	// A value to use for the field if the field isn't specified for a document.
 	DefaultValue *string `type:"string"`
 
@@ -2423,8 +2425,6 @@ type LiteralOptions struct {
 	// The name score is reserved and cannot be used as a field name. To reference
 	// a document's ID, you can use the name _id.
 	SourceField *string `min:"1" type:"string"`
-
-	_ struct{} `type:"structure"`
 }
 
 // String returns the string representation
@@ -2439,6 +2439,8 @@ func (s LiteralOptions) GoString() string {
 
 // The status of domain configuration option.
 type OptionStatus struct {
+	_ struct{} `type:"structure"`
+
 	// A timestamp for when this option was created.
 	CreationDate *time.Time `type:"timestamp" timestampFormat:"iso8601" required:"true"`
 
@@ -2461,8 +2463,6 @@ type OptionStatus struct {
 
 	// A unique integer that indicates when this option was last updated.
 	UpdateVersion *int64 `type:"integer"`
-
-	_ struct{} `type:"structure"`
 }
 
 // String returns the string representation
@@ -2477,6 +2477,8 @@ func (s OptionStatus) GoString() string {
 
 // The desired instance type and desired number of replicas of each index partition.
 type ScalingParameters struct {
+	_ struct{} `type:"structure"`
+
 	// The instance type that you want to preconfigure for your domain. For example,
 	// search.m1.small.
 	DesiredInstanceType *string `type:"string" enum:"PartitionInstanceType"`
@@ -2487,8 +2489,6 @@ type ScalingParameters struct {
 
 	// The number of replicas you want to preconfigure for each index partition.
 	DesiredReplicationCount *int64 `type:"integer"`
-
-	_ struct{} `type:"structure"`
 }
 
 // String returns the string representation
@@ -2503,13 +2503,13 @@ func (s ScalingParameters) GoString() string {
 
 // The status and configuration of a search domain's scaling parameters.
 type ScalingParametersStatus struct {
+	_ struct{} `type:"structure"`
+
 	// The desired instance type and desired number of replicas of each index partition.
 	Options *ScalingParameters `type:"structure" required:"true"`
 
 	// The status of domain configuration option.
 	Status *OptionStatus `type:"structure" required:"true"`
-
-	_ struct{} `type:"structure"`
 }
 
 // String returns the string representation
@@ -2524,11 +2524,11 @@ func (s ScalingParametersStatus) GoString() string {
 
 // The endpoint to which service requests can be submitted.
 type ServiceEndpoint struct {
+	_ struct{} `type:"structure"`
+
 	// The endpoint to which service requests can be submitted. For example, search-imdb-movies-oopcnjfn6ugofer3zx5iadxxca.eu-west-1.cloudsearch.amazonaws.com
 	// or doc-imdb-movies-oopcnjfn6ugofer3zx5iadxxca.eu-west-1.cloudsearch.amazonaws.com.
 	Endpoint *string `type:"string"`
-
-	_ struct{} `type:"structure"`
 }
 
 // String returns the string representation
@@ -2545,14 +2545,14 @@ func (s ServiceEndpoint) GoString() string {
 // name and specifies the text field you want to use for suggestions. The following
 // options can be configured for a suggester: FuzzyMatching, SortExpression.
 type Suggester struct {
+	_ struct{} `type:"structure"`
+
 	// Options for a search suggester.
 	DocumentSuggesterOptions *DocumentSuggesterOptions `type:"structure" required:"true"`
 
 	// Names must begin with a letter and can contain the following characters:
 	// a-z (lowercase), 0-9, and _ (underscore).
 	SuggesterName *string `min:"1" type:"string" required:"true"`
-
-	_ struct{} `type:"structure"`
 }
 
 // String returns the string representation
@@ -2567,6 +2567,8 @@ func (s Suggester) GoString() string {
 
 // The value of a Suggester and its current status.
 type SuggesterStatus struct {
+	_ struct{} `type:"structure"`
+
 	// Configuration information for a search suggester. Each suggester has a unique
 	// name and specifies the text field you want to use for suggestions. The following
 	// options can be configured for a suggester: FuzzyMatching, SortExpression.
@@ -2574,8 +2576,6 @@ type SuggesterStatus struct {
 
 	// The status of domain configuration option.
 	Status *OptionStatus `type:"structure" required:"true"`
-
-	_ struct{} `type:"structure"`
 }
 
 // String returns the string representation
@@ -2592,6 +2592,8 @@ func (s SuggesterStatus) GoString() string {
 // specifies the field is of type text-array. A text-array field is always searchable.
 // All options are enabled by default.
 type TextArrayOptions struct {
+	_ struct{} `type:"structure"`
+
 	// The name of an analysis scheme for a text-array field.
 	AnalysisScheme *string `type:"string"`
 
@@ -2606,8 +2608,6 @@ type TextArrayOptions struct {
 
 	// A list of source fields to map to the field.
 	SourceFields *string `type:"string"`
-
-	_ struct{} `type:"structure"`
 }
 
 // String returns the string representation
@@ -2624,6 +2624,8 @@ func (s TextArrayOptions) GoString() string {
 // of type text. A text field is always searchable. All options are enabled
 // by default.
 type TextOptions struct {
+	_ struct{} `type:"structure"`
+
 	// The name of an analysis scheme for a text field.
 	AnalysisScheme *string `type:"string"`
 
@@ -2654,8 +2656,6 @@ type TextOptions struct {
 	// The name score is reserved and cannot be used as a field name. To reference
 	// a document's ID, you can use the name _id.
 	SourceField *string `min:"1" type:"string"`
-
-	_ struct{} `type:"structure"`
 }
 
 // String returns the string representation
@@ -2672,6 +2672,8 @@ func (s TextOptions) GoString() string {
 // Specifies the name of the domain you want to update and the Multi-AZ availability
 // option.
 type UpdateAvailabilityOptionsInput struct {
+	_ struct{} `type:"structure"`
+
 	// A string that represents the name of a domain. Domain names are unique across
 	// the domains owned by an account within an AWS region. Domain names start
 	// with a letter or number and can contain the following characters: a-z (lowercase),
@@ -2683,8 +2685,6 @@ type UpdateAvailabilityOptionsInput struct {
 	// to downgrade the domain to a single Availability Zone by setting the Multi-AZ
 	// option to false.
 	MultiAZ *bool `type:"boolean" required:"true"`
-
-	_ struct{} `type:"structure"`
 }
 
 // String returns the string representation
@@ -2700,11 +2700,11 @@ func (s UpdateAvailabilityOptionsInput) GoString() string {
 // The result of a UpdateAvailabilityOptions request. Contains the status of
 // the domain's availability options.
 type UpdateAvailabilityOptionsOutput struct {
+	_ struct{} `type:"structure"`
+
 	// The newly-configured availability options. Indicates whether Multi-AZ is
 	// enabled for the domain.
 	AvailabilityOptions *AvailabilityOptionsStatus `type:"structure"`
-
-	_ struct{} `type:"structure"`
 }
 
 // String returns the string representation
@@ -2721,6 +2721,8 @@ func (s UpdateAvailabilityOptionsOutput) GoString() string {
 // the name of the domain you want to update and the scaling parameters you
 // want to configure.
 type UpdateScalingParametersInput struct {
+	_ struct{} `type:"structure"`
+
 	// A string that represents the name of a domain. Domain names are unique across
 	// the domains owned by an account within an AWS region. Domain names start
 	// with a letter or number and can contain the following characters: a-z (lowercase),
@@ -2729,8 +2731,6 @@ type UpdateScalingParametersInput struct {
 
 	// The desired instance type and desired number of replicas of each index partition.
 	ScalingParameters *ScalingParameters `type:"structure" required:"true"`
-
-	_ struct{} `type:"structure"`
 }
 
 // String returns the string representation
@@ -2746,10 +2746,10 @@ func (s UpdateScalingParametersInput) GoString() string {
 // The result of a UpdateScalingParameters request. Contains the status of the
 // newly-configured scaling parameters.
 type UpdateScalingParametersOutput struct {
+	_ struct{} `type:"structure"`
+
 	// The status and configuration of a search domain's scaling parameters.
 	ScalingParameters *ScalingParametersStatus `type:"structure" required:"true"`
-
-	_ struct{} `type:"structure"`
 }
 
 // String returns the string representation
@@ -2766,6 +2766,8 @@ func (s UpdateScalingParametersOutput) GoString() string {
 // Specifies the name of the domain you want to update and the access rules
 // you want to configure.
 type UpdateServiceAccessPoliciesInput struct {
+	_ struct{} `type:"structure"`
+
 	// The access rules you want to configure. These rules replace any existing
 	// rules.
 	AccessPolicies *string `type:"string" required:"true"`
@@ -2775,8 +2777,6 @@ type UpdateServiceAccessPoliciesInput struct {
 	// with a letter or number and can contain the following characters: a-z (lowercase),
 	// 0-9, and - (hyphen).
 	DomainName *string `min:"3" type:"string" required:"true"`
-
-	_ struct{} `type:"structure"`
 }
 
 // String returns the string representation
@@ -2792,10 +2792,10 @@ func (s UpdateServiceAccessPoliciesInput) GoString() string {
 // The result of an UpdateServiceAccessPolicies request. Contains the new access
 // policies.
 type UpdateServiceAccessPoliciesOutput struct {
+	_ struct{} `type:"structure"`
+
 	// The access rules configured for the domain.
 	AccessPolicies *AccessPoliciesStatus `type:"structure" required:"true"`
-
-	_ struct{} `type:"structure"`
 }
 
 // String returns the string representation

--- a/service/cloudsearchdomain/api.go
+++ b/service/cloudsearchdomain/api.go
@@ -154,11 +154,7 @@ type Bucket struct {
 	// The facet value being counted.
 	Value *string `locationName:"value" type:"string"`
 
-	metadataBucket `json:"-" xml:"-"`
-}
-
-type metadataBucket struct {
-	SDKShapeTraits bool `type:"structure"`
+	_ struct{} `type:"structure"`
 }
 
 // String returns the string representation
@@ -176,11 +172,7 @@ type BucketInfo struct {
 	// A list of the calculated facet values and counts.
 	Buckets []*Bucket `locationName:"buckets" type:"list"`
 
-	metadataBucketInfo `json:"-" xml:"-"`
-}
-
-type metadataBucketInfo struct {
-	SDKShapeTraits bool `type:"structure"`
+	_ struct{} `type:"structure"`
 }
 
 // String returns the string representation
@@ -199,11 +191,7 @@ type DocumentServiceWarning struct {
 	// The description for a warning returned by the document service.
 	Message *string `locationName:"message" type:"string"`
 
-	metadataDocumentServiceWarning `json:"-" xml:"-"`
-}
-
-type metadataDocumentServiceWarning struct {
-	SDKShapeTraits bool `type:"structure"`
+	_ struct{} `type:"structure"`
 }
 
 // String returns the string representation
@@ -230,11 +218,7 @@ type Hit struct {
 	// The document ID of a document that matches the search request.
 	Id *string `locationName:"id" type:"string"`
 
-	metadataHit `json:"-" xml:"-"`
-}
-
-type metadataHit struct {
-	SDKShapeTraits bool `type:"structure"`
+	_ struct{} `type:"structure"`
 }
 
 // String returns the string representation
@@ -262,11 +246,7 @@ type Hits struct {
 	// The index of the first matching document.
 	Start *int64 `locationName:"start" type:"long"`
 
-	metadataHits `json:"-" xml:"-"`
-}
-
-type metadataHits struct {
-	SDKShapeTraits bool `type:"structure"`
+	_ struct{} `type:"structure"`
 }
 
 // String returns the string representation
@@ -558,11 +538,7 @@ type SearchInput struct {
 	// in the Amazon CloudSearch Developer Guide.
 	Start *int64 `location:"querystring" locationName:"start" type:"long"`
 
-	metadataSearchInput `json:"-" xml:"-"`
-}
-
-type metadataSearchInput struct {
-	SDKShapeTraits bool `type:"structure"`
+	_ struct{} `type:"structure"`
 }
 
 // String returns the string representation
@@ -587,11 +563,7 @@ type SearchOutput struct {
 	// The status information returned for the search request.
 	Status *SearchStatus `locationName:"status" type:"structure"`
 
-	metadataSearchOutput `json:"-" xml:"-"`
-}
-
-type metadataSearchOutput struct {
-	SDKShapeTraits bool `type:"structure"`
+	_ struct{} `type:"structure"`
 }
 
 // String returns the string representation
@@ -613,11 +585,7 @@ type SearchStatus struct {
 	// How long it took to process the request, in milliseconds.
 	Timems *int64 `locationName:"timems" type:"long"`
 
-	metadataSearchStatus `json:"-" xml:"-"`
-}
-
-type metadataSearchStatus struct {
-	SDKShapeTraits bool `type:"structure"`
+	_ struct{} `type:"structure"`
 }
 
 // String returns the string representation
@@ -641,11 +609,7 @@ type SuggestInput struct {
 	// Specifies the name of the suggester to use to find suggested matches.
 	Suggester *string `location:"querystring" locationName:"suggester" type:"string" required:"true"`
 
-	metadataSuggestInput `json:"-" xml:"-"`
-}
-
-type metadataSuggestInput struct {
-	SDKShapeTraits bool `type:"structure"`
+	_ struct{} `type:"structure"`
 }
 
 // String returns the string representation
@@ -669,11 +633,7 @@ type SuggestModel struct {
 	// The documents that match the query string.
 	Suggestions []*SuggestionMatch `locationName:"suggestions" type:"list"`
 
-	metadataSuggestModel `json:"-" xml:"-"`
-}
-
-type metadataSuggestModel struct {
-	SDKShapeTraits bool `type:"structure"`
+	_ struct{} `type:"structure"`
 }
 
 // String returns the string representation
@@ -695,11 +655,7 @@ type SuggestOutput struct {
 	// Container for the matching search suggestion information.
 	Suggest *SuggestModel `locationName:"suggest" type:"structure"`
 
-	metadataSuggestOutput `json:"-" xml:"-"`
-}
-
-type metadataSuggestOutput struct {
-	SDKShapeTraits bool `type:"structure"`
+	_ struct{} `type:"structure"`
 }
 
 // String returns the string representation
@@ -721,11 +677,7 @@ type SuggestStatus struct {
 	// How long it took to process the request, in milliseconds.
 	Timems *int64 `locationName:"timems" type:"long"`
 
-	metadataSuggestStatus `json:"-" xml:"-"`
-}
-
-type metadataSuggestStatus struct {
-	SDKShapeTraits bool `type:"structure"`
+	_ struct{} `type:"structure"`
 }
 
 // String returns the string representation
@@ -749,11 +701,7 @@ type SuggestionMatch struct {
 	// The string that matches the query string specified in the SuggestRequest.
 	Suggestion *string `locationName:"suggestion" type:"string"`
 
-	metadataSuggestionMatch `json:"-" xml:"-"`
-}
-
-type metadataSuggestionMatch struct {
-	SDKShapeTraits bool `type:"structure"`
+	_ struct{} `type:"structure"`
 }
 
 // String returns the string representation
@@ -777,11 +725,7 @@ type UploadDocumentsInput struct {
 	// A batch of documents formatted in JSON or HTML.
 	Documents io.ReadSeeker `locationName:"documents" type:"blob" required:"true"`
 
-	metadataUploadDocumentsInput `json:"-" xml:"-"`
-}
-
-type metadataUploadDocumentsInput struct {
-	SDKShapeTraits bool `type:"structure" payload:"Documents"`
+	_ struct{} `type:"structure" payload:"Documents"`
 }
 
 // String returns the string representation
@@ -808,11 +752,7 @@ type UploadDocumentsOutput struct {
 	// Any warnings returned by the document service about the documents being uploaded.
 	Warnings []*DocumentServiceWarning `locationName:"warnings" type:"list"`
 
-	metadataUploadDocumentsOutput `json:"-" xml:"-"`
-}
-
-type metadataUploadDocumentsOutput struct {
-	SDKShapeTraits bool `type:"structure"`
+	_ struct{} `type:"structure"`
 }
 
 // String returns the string representation

--- a/service/cloudsearchdomain/api.go
+++ b/service/cloudsearchdomain/api.go
@@ -148,13 +148,13 @@ func (c *CloudSearchDomain) UploadDocuments(input *UploadDocumentsInput) (*Uploa
 
 // A container for facet information.
 type Bucket struct {
+	_ struct{} `type:"structure"`
+
 	// The number of hits that contain the facet value in the specified facet field.
 	Count *int64 `locationName:"count" type:"long"`
 
 	// The facet value being counted.
 	Value *string `locationName:"value" type:"string"`
-
-	_ struct{} `type:"structure"`
 }
 
 // String returns the string representation
@@ -169,10 +169,10 @@ func (s Bucket) GoString() string {
 
 // A container for the calculated facet values and counts.
 type BucketInfo struct {
+	_ struct{} `type:"structure"`
+
 	// A list of the calculated facet values and counts.
 	Buckets []*Bucket `locationName:"buckets" type:"list"`
-
-	_ struct{} `type:"structure"`
 }
 
 // String returns the string representation
@@ -188,10 +188,10 @@ func (s BucketInfo) GoString() string {
 // A warning returned by the document service when an issue is discovered while
 // processing an upload request.
 type DocumentServiceWarning struct {
+	_ struct{} `type:"structure"`
+
 	// The description for a warning returned by the document service.
 	Message *string `locationName:"message" type:"string"`
-
-	_ struct{} `type:"structure"`
 }
 
 // String returns the string representation
@@ -206,6 +206,8 @@ func (s DocumentServiceWarning) GoString() string {
 
 // Information about a document that matches the search request.
 type Hit struct {
+	_ struct{} `type:"structure"`
+
 	// The expressions returned from a document that matches the search request.
 	Exprs map[string]*string `locationName:"exprs" type:"map"`
 
@@ -217,8 +219,6 @@ type Hit struct {
 
 	// The document ID of a document that matches the search request.
 	Id *string `locationName:"id" type:"string"`
-
-	_ struct{} `type:"structure"`
 }
 
 // String returns the string representation
@@ -233,6 +233,8 @@ func (s Hit) GoString() string {
 
 // The collection of documents that match the search request.
 type Hits struct {
+	_ struct{} `type:"structure"`
+
 	// A cursor that can be used to retrieve the next set of matching documents
 	// when you want to page through a large result set.
 	Cursor *string `locationName:"cursor" type:"string"`
@@ -245,8 +247,6 @@ type Hits struct {
 
 	// The index of the first matching document.
 	Start *int64 `locationName:"start" type:"long"`
-
-	_ struct{} `type:"structure"`
 }
 
 // String returns the string representation
@@ -261,6 +261,8 @@ func (s Hits) GoString() string {
 
 // Container for the parameters to the Search request.
 type SearchInput struct {
+	_ struct{} `type:"structure"`
+
 	// Retrieves a cursor value you can use to page through large result sets. Use
 	// the size parameter to control the number of hits to include in each response.
 	// You can specify either the cursor or start parameter in a request; they are
@@ -537,8 +539,6 @@ type SearchInput struct {
 	// For more information, see Paginating Results (http://docs.aws.amazon.com/cloudsearch/latest/developerguide/paginating-results.html)
 	// in the Amazon CloudSearch Developer Guide.
 	Start *int64 `location:"querystring" locationName:"start" type:"long"`
-
-	_ struct{} `type:"structure"`
 }
 
 // String returns the string representation
@@ -554,6 +554,8 @@ func (s SearchInput) GoString() string {
 // The result of a Search request. Contains the documents that match the specified
 // search criteria and any requested fields, highlights, and facet information.
 type SearchOutput struct {
+	_ struct{} `type:"structure"`
+
 	// The requested facet information.
 	Facets map[string]*BucketInfo `locationName:"facets" type:"map"`
 
@@ -562,8 +564,6 @@ type SearchOutput struct {
 
 	// The status information returned for the search request.
 	Status *SearchStatus `locationName:"status" type:"structure"`
-
-	_ struct{} `type:"structure"`
 }
 
 // String returns the string representation
@@ -579,13 +579,13 @@ func (s SearchOutput) GoString() string {
 // Contains the resource id (rid) and the time it took to process the request
 // (timems).
 type SearchStatus struct {
+	_ struct{} `type:"structure"`
+
 	// The encrypted resource ID for the request.
 	Rid *string `locationName:"rid" type:"string"`
 
 	// How long it took to process the request, in milliseconds.
 	Timems *int64 `locationName:"timems" type:"long"`
-
-	_ struct{} `type:"structure"`
 }
 
 // String returns the string representation
@@ -600,6 +600,8 @@ func (s SearchStatus) GoString() string {
 
 // Container for the parameters to the Suggest request.
 type SuggestInput struct {
+	_ struct{} `type:"structure"`
+
 	// Specifies the string for which you want to get suggestions.
 	Query *string `location:"querystring" locationName:"q" type:"string" required:"true"`
 
@@ -608,8 +610,6 @@ type SuggestInput struct {
 
 	// Specifies the name of the suggester to use to find suggested matches.
 	Suggester *string `location:"querystring" locationName:"suggester" type:"string" required:"true"`
-
-	_ struct{} `type:"structure"`
 }
 
 // String returns the string representation
@@ -624,6 +624,8 @@ func (s SuggestInput) GoString() string {
 
 // Container for the suggestion information returned in a SuggestResponse.
 type SuggestModel struct {
+	_ struct{} `type:"structure"`
+
 	// The number of documents that were found to match the query string.
 	Found *int64 `locationName:"found" type:"long"`
 
@@ -632,8 +634,6 @@ type SuggestModel struct {
 
 	// The documents that match the query string.
 	Suggestions []*SuggestionMatch `locationName:"suggestions" type:"list"`
-
-	_ struct{} `type:"structure"`
 }
 
 // String returns the string representation
@@ -648,14 +648,14 @@ func (s SuggestModel) GoString() string {
 
 // Contains the response to a Suggest request.
 type SuggestOutput struct {
+	_ struct{} `type:"structure"`
+
 	// The status of a SuggestRequest. Contains the resource ID (rid) and how long
 	// it took to process the request (timems).
 	Status *SuggestStatus `locationName:"status" type:"structure"`
 
 	// Container for the matching search suggestion information.
 	Suggest *SuggestModel `locationName:"suggest" type:"structure"`
-
-	_ struct{} `type:"structure"`
 }
 
 // String returns the string representation
@@ -671,13 +671,13 @@ func (s SuggestOutput) GoString() string {
 // Contains the resource id (rid) and the time it took to process the request
 // (timems).
 type SuggestStatus struct {
+	_ struct{} `type:"structure"`
+
 	// The encrypted resource ID for the request.
 	Rid *string `locationName:"rid" type:"string"`
 
 	// How long it took to process the request, in milliseconds.
 	Timems *int64 `locationName:"timems" type:"long"`
-
-	_ struct{} `type:"structure"`
 }
 
 // String returns the string representation
@@ -692,6 +692,8 @@ func (s SuggestStatus) GoString() string {
 
 // An autocomplete suggestion that matches the query string specified in a SuggestRequest.
 type SuggestionMatch struct {
+	_ struct{} `type:"structure"`
+
 	// The document ID of the suggested document.
 	Id *string `locationName:"id" type:"string"`
 
@@ -700,8 +702,6 @@ type SuggestionMatch struct {
 
 	// The string that matches the query string specified in the SuggestRequest.
 	Suggestion *string `locationName:"suggestion" type:"string"`
-
-	_ struct{} `type:"structure"`
 }
 
 // String returns the string representation
@@ -716,6 +716,8 @@ func (s SuggestionMatch) GoString() string {
 
 // Container for the parameters to the UploadDocuments request.
 type UploadDocumentsInput struct {
+	_ struct{} `type:"structure" payload:"Documents"`
+
 	// The format of the batch you are uploading. Amazon CloudSearch supports two
 	// document batch formats:
 	//
@@ -724,8 +726,6 @@ type UploadDocumentsInput struct {
 
 	// A batch of documents formatted in JSON or HTML.
 	Documents io.ReadSeeker `locationName:"documents" type:"blob" required:"true"`
-
-	_ struct{} `type:"structure" payload:"Documents"`
 }
 
 // String returns the string representation
@@ -740,6 +740,8 @@ func (s UploadDocumentsInput) GoString() string {
 
 // Contains the response to an UploadDocuments request.
 type UploadDocumentsOutput struct {
+	_ struct{} `type:"structure"`
+
 	// The number of documents that were added to the search domain.
 	Adds *int64 `locationName:"adds" type:"long"`
 
@@ -751,8 +753,6 @@ type UploadDocumentsOutput struct {
 
 	// Any warnings returned by the document service about the documents being uploaded.
 	Warnings []*DocumentServiceWarning `locationName:"warnings" type:"list"`
-
-	_ struct{} `type:"structure"`
 }
 
 // String returns the string representation

--- a/service/cloudtrail/api.go
+++ b/service/cloudtrail/api.go
@@ -380,11 +380,7 @@ type AddTagsInput struct {
 	// Contains a list of CloudTrail tags, up to a limit of 10.
 	TagsList []*Tag `type:"list"`
 
-	metadataAddTagsInput `json:"-" xml:"-"`
-}
-
-type metadataAddTagsInput struct {
-	SDKShapeTraits bool `type:"structure"`
+	_ struct{} `type:"structure"`
 }
 
 // String returns the string representation
@@ -400,11 +396,7 @@ func (s AddTagsInput) GoString() string {
 // Returns the objects or data listed below if successful. Otherwise, returns
 // an error.
 type AddTagsOutput struct {
-	metadataAddTagsOutput `json:"-" xml:"-"`
-}
-
-type metadataAddTagsOutput struct {
-	SDKShapeTraits bool `type:"structure"`
+	_ struct{} `type:"structure"`
 }
 
 // String returns the string representation
@@ -479,11 +471,7 @@ type CreateTrailInput struct {
 	// file delivery. The maximum length is 256 characters.
 	SnsTopicName *string `type:"string"`
 
-	metadataCreateTrailInput `json:"-" xml:"-"`
-}
-
-type metadataCreateTrailInput struct {
-	SDKShapeTraits bool `type:"structure"`
+	_ struct{} `type:"structure"`
 }
 
 // String returns the string representation
@@ -539,11 +527,7 @@ type CreateTrailOutput struct {
 	// Specifies the ARN of the trail that was created.
 	TrailARN *string `type:"string"`
 
-	metadataCreateTrailOutput `json:"-" xml:"-"`
-}
-
-type metadataCreateTrailOutput struct {
-	SDKShapeTraits bool `type:"structure"`
+	_ struct{} `type:"structure"`
 }
 
 // String returns the string representation
@@ -562,11 +546,7 @@ type DeleteTrailInput struct {
 	// format of a trail ARN is arn:aws:cloudtrail:us-east-1:123456789012:trail/MyTrail.
 	Name *string `type:"string" required:"true"`
 
-	metadataDeleteTrailInput `json:"-" xml:"-"`
-}
-
-type metadataDeleteTrailInput struct {
-	SDKShapeTraits bool `type:"structure"`
+	_ struct{} `type:"structure"`
 }
 
 // String returns the string representation
@@ -582,11 +562,7 @@ func (s DeleteTrailInput) GoString() string {
 // Returns the objects or data listed below if successful. Otherwise, returns
 // an error.
 type DeleteTrailOutput struct {
-	metadataDeleteTrailOutput `json:"-" xml:"-"`
-}
-
-type metadataDeleteTrailOutput struct {
-	SDKShapeTraits bool `type:"structure"`
+	_ struct{} `type:"structure"`
 }
 
 // String returns the string representation
@@ -607,11 +583,7 @@ type DescribeTrailsInput struct {
 	// is returned.
 	TrailNameList []*string `locationName:"trailNameList" type:"list"`
 
-	metadataDescribeTrailsInput `json:"-" xml:"-"`
-}
-
-type metadataDescribeTrailsInput struct {
-	SDKShapeTraits bool `type:"structure"`
+	_ struct{} `type:"structure"`
 }
 
 // String returns the string representation
@@ -630,11 +602,7 @@ type DescribeTrailsOutput struct {
 	// The list of trail objects.
 	TrailList []*Trail `locationName:"trailList" type:"list"`
 
-	metadataDescribeTrailsOutput `json:"-" xml:"-"`
-}
-
-type metadataDescribeTrailsOutput struct {
-	SDKShapeTraits bool `type:"structure"`
+	_ struct{} `type:"structure"`
 }
 
 // String returns the string representation
@@ -669,11 +637,7 @@ type Event struct {
 	// returned.
 	Username *string `type:"string"`
 
-	metadataEvent `json:"-" xml:"-"`
-}
-
-type metadataEvent struct {
-	SDKShapeTraits bool `type:"structure"`
+	_ struct{} `type:"structure"`
 }
 
 // String returns the string representation
@@ -692,11 +656,7 @@ type GetTrailStatusInput struct {
 	// status. The format of a trail ARN is arn:aws:cloudtrail:us-east-1:123456789012:trail/MyTrail.
 	Name *string `type:"string" required:"true"`
 
-	metadataGetTrailStatusInput `json:"-" xml:"-"`
-}
-
-type metadataGetTrailStatusInput struct {
-	SDKShapeTraits bool `type:"structure"`
+	_ struct{} `type:"structure"`
 }
 
 // String returns the string representation
@@ -788,11 +748,7 @@ type GetTrailStatusOutput struct {
 	// This field is deprecated.
 	TimeLoggingStopped *string `type:"string"`
 
-	metadataGetTrailStatusOutput `json:"-" xml:"-"`
-}
-
-type metadataGetTrailStatusOutput struct {
-	SDKShapeTraits bool `type:"structure"`
+	_ struct{} `type:"structure"`
 }
 
 // String returns the string representation
@@ -819,11 +775,7 @@ type ListPublicKeysInput struct {
 	// and the current public key is returned.
 	StartTime *time.Time `type:"timestamp" timestampFormat:"unix"`
 
-	metadataListPublicKeysInput `json:"-" xml:"-"`
-}
-
-type metadataListPublicKeysInput struct {
-	SDKShapeTraits bool `type:"structure"`
+	_ struct{} `type:"structure"`
 }
 
 // String returns the string representation
@@ -847,11 +799,7 @@ type ListPublicKeysOutput struct {
 	// The returned public keys may have validity time ranges that overlap.
 	PublicKeyList []*PublicKey `type:"list"`
 
-	metadataListPublicKeysOutput `json:"-" xml:"-"`
-}
-
-type metadataListPublicKeysOutput struct {
-	SDKShapeTraits bool `type:"structure"`
+	_ struct{} `type:"structure"`
 }
 
 // String returns the string representation
@@ -873,11 +821,7 @@ type ListTagsInput struct {
 	// limit of 20 ARNs. The format of a trail ARN is arn:aws:cloudtrail:us-east-1:123456789012:trail/MyTrail.
 	ResourceIdList []*string `type:"list" required:"true"`
 
-	metadataListTagsInput `json:"-" xml:"-"`
-}
-
-type metadataListTagsInput struct {
-	SDKShapeTraits bool `type:"structure"`
+	_ struct{} `type:"structure"`
 }
 
 // String returns the string representation
@@ -899,11 +843,7 @@ type ListTagsOutput struct {
 	// A list of resource tags.
 	ResourceTagList []*ResourceTag `type:"list"`
 
-	metadataListTagsOutput `json:"-" xml:"-"`
-}
-
-type metadataListTagsOutput struct {
-	SDKShapeTraits bool `type:"structure"`
+	_ struct{} `type:"structure"`
 }
 
 // String returns the string representation
@@ -924,11 +864,7 @@ type LookupAttribute struct {
 	// Specifies a value for the specified AttributeKey.
 	AttributeValue *string `type:"string" required:"true"`
 
-	metadataLookupAttribute `json:"-" xml:"-"`
-}
-
-type metadataLookupAttribute struct {
-	SDKShapeTraits bool `type:"structure"`
+	_ struct{} `type:"structure"`
 }
 
 // String returns the string representation
@@ -968,11 +904,7 @@ type LookupEventsInput struct {
 	// error is returned.
 	StartTime *time.Time `type:"timestamp" timestampFormat:"unix"`
 
-	metadataLookupEventsInput `json:"-" xml:"-"`
-}
-
-type metadataLookupEventsInput struct {
-	SDKShapeTraits bool `type:"structure"`
+	_ struct{} `type:"structure"`
 }
 
 // String returns the string representation
@@ -999,11 +931,7 @@ type LookupEventsOutput struct {
 	// of 'root', the call with NextToken should include those same parameters.
 	NextToken *string `type:"string"`
 
-	metadataLookupEventsOutput `json:"-" xml:"-"`
-}
-
-type metadataLookupEventsOutput struct {
-	SDKShapeTraits bool `type:"structure"`
+	_ struct{} `type:"structure"`
 }
 
 // String returns the string representation
@@ -1030,11 +958,7 @@ type PublicKey struct {
 	// The DER encoded public key value in PKCS#1 format.
 	Value []byte `type:"blob"`
 
-	metadataPublicKey `json:"-" xml:"-"`
-}
-
-type metadataPublicKey struct {
-	SDKShapeTraits bool `type:"structure"`
+	_ struct{} `type:"structure"`
 }
 
 // String returns the string representation
@@ -1056,11 +980,7 @@ type RemoveTagsInput struct {
 	// Specifies a list of tags to be removed.
 	TagsList []*Tag `type:"list"`
 
-	metadataRemoveTagsInput `json:"-" xml:"-"`
-}
-
-type metadataRemoveTagsInput struct {
-	SDKShapeTraits bool `type:"structure"`
+	_ struct{} `type:"structure"`
 }
 
 // String returns the string representation
@@ -1076,11 +996,7 @@ func (s RemoveTagsInput) GoString() string {
 // Returns the objects or data listed below if successful. Otherwise, returns
 // an error.
 type RemoveTagsOutput struct {
-	metadataRemoveTagsOutput `json:"-" xml:"-"`
-}
-
-type metadataRemoveTagsOutput struct {
-	SDKShapeTraits bool `type:"structure"`
+	_ struct{} `type:"structure"`
 }
 
 // String returns the string representation
@@ -1108,11 +1024,7 @@ type Resource struct {
 	// Types Supported for Event Lookup (http://docs.aws.amazon.com/awscloudtrail/latest/userguide/lookup_supported_resourcetypes.html).
 	ResourceType *string `type:"string"`
 
-	metadataResource `json:"-" xml:"-"`
-}
-
-type metadataResource struct {
-	SDKShapeTraits bool `type:"structure"`
+	_ struct{} `type:"structure"`
 }
 
 // String returns the string representation
@@ -1133,11 +1045,7 @@ type ResourceTag struct {
 	// A list of tags.
 	TagsList []*Tag `type:"list"`
 
-	metadataResourceTag `json:"-" xml:"-"`
-}
-
-type metadataResourceTag struct {
-	SDKShapeTraits bool `type:"structure"`
+	_ struct{} `type:"structure"`
 }
 
 // String returns the string representation
@@ -1156,11 +1064,7 @@ type StartLoggingInput struct {
 	// logs AWS API calls. The format of a trail ARN is arn:aws:cloudtrail:us-east-1:123456789012:trail/MyTrail.
 	Name *string `type:"string" required:"true"`
 
-	metadataStartLoggingInput `json:"-" xml:"-"`
-}
-
-type metadataStartLoggingInput struct {
-	SDKShapeTraits bool `type:"structure"`
+	_ struct{} `type:"structure"`
 }
 
 // String returns the string representation
@@ -1176,11 +1080,7 @@ func (s StartLoggingInput) GoString() string {
 // Returns the objects or data listed below if successful. Otherwise, returns
 // an error.
 type StartLoggingOutput struct {
-	metadataStartLoggingOutput `json:"-" xml:"-"`
-}
-
-type metadataStartLoggingOutput struct {
-	SDKShapeTraits bool `type:"structure"`
+	_ struct{} `type:"structure"`
 }
 
 // String returns the string representation
@@ -1200,11 +1100,7 @@ type StopLoggingInput struct {
 	// will stop logging AWS API calls. The format of a trail ARN is arn:aws:cloudtrail:us-east-1:123456789012:trail/MyTrail.
 	Name *string `type:"string" required:"true"`
 
-	metadataStopLoggingInput `json:"-" xml:"-"`
-}
-
-type metadataStopLoggingInput struct {
-	SDKShapeTraits bool `type:"structure"`
+	_ struct{} `type:"structure"`
 }
 
 // String returns the string representation
@@ -1220,11 +1116,7 @@ func (s StopLoggingInput) GoString() string {
 // Returns the objects or data listed below if successful. Otherwise, returns
 // an error.
 type StopLoggingOutput struct {
-	metadataStopLoggingOutput `json:"-" xml:"-"`
-}
-
-type metadataStopLoggingOutput struct {
-	SDKShapeTraits bool `type:"structure"`
+	_ struct{} `type:"structure"`
 }
 
 // String returns the string representation
@@ -1247,11 +1139,7 @@ type Tag struct {
 	// 256 Unicode characters.
 	Value *string `type:"string"`
 
-	metadataTag `json:"-" xml:"-"`
-}
-
-type metadataTag struct {
-	SDKShapeTraits bool `type:"structure"`
+	_ struct{} `type:"structure"`
 }
 
 // String returns the string representation
@@ -1308,11 +1196,7 @@ type Trail struct {
 	// The Amazon Resource Name of the trail. The TrailARN format is arn:aws:cloudtrail:us-east-1:123456789012:trail/MyTrail.
 	TrailARN *string `type:"string"`
 
-	metadataTrail `json:"-" xml:"-"`
-}
-
-type metadataTrail struct {
-	SDKShapeTraits bool `type:"structure"`
+	_ struct{} `type:"structure"`
 }
 
 // String returns the string representation
@@ -1388,11 +1272,7 @@ type UpdateTrailInput struct {
 	// file delivery. The maximum length is 256 characters.
 	SnsTopicName *string `type:"string"`
 
-	metadataUpdateTrailInput `json:"-" xml:"-"`
-}
-
-type metadataUpdateTrailInput struct {
-	SDKShapeTraits bool `type:"structure"`
+	_ struct{} `type:"structure"`
 }
 
 // String returns the string representation
@@ -1448,11 +1328,7 @@ type UpdateTrailOutput struct {
 	// Specifies the ARN of the trail that was updated.
 	TrailARN *string `type:"string"`
 
-	metadataUpdateTrailOutput `json:"-" xml:"-"`
-}
-
-type metadataUpdateTrailOutput struct {
-	SDKShapeTraits bool `type:"structure"`
+	_ struct{} `type:"structure"`
 }
 
 // String returns the string representation

--- a/service/cloudtrail/api.go
+++ b/service/cloudtrail/api.go
@@ -373,14 +373,14 @@ func (c *CloudTrail) UpdateTrail(input *UpdateTrailInput) (*UpdateTrailOutput, e
 
 // Specifies the tags to add to a trail.
 type AddTagsInput struct {
+	_ struct{} `type:"structure"`
+
 	// Specifies the ARN of the trail to which one or more tags will be added. The
 	// format of a trail ARN is arn:aws:cloudtrail:us-east-1:123456789012:trail/MyTrail.
 	ResourceId *string `type:"string" required:"true"`
 
 	// Contains a list of CloudTrail tags, up to a limit of 10.
 	TagsList []*Tag `type:"list"`
-
-	_ struct{} `type:"structure"`
 }
 
 // String returns the string representation
@@ -411,6 +411,8 @@ func (s AddTagsOutput) GoString() string {
 
 // Specifies the settings for each trail.
 type CreateTrailInput struct {
+	_ struct{} `type:"structure"`
+
 	// Specifies a log group name using an Amazon Resource Name (ARN), a unique
 	// identifier that represents the log group to which CloudTrail logs will be
 	// delivered. Not required unless you specify CloudWatchLogsRoleArn.
@@ -470,8 +472,6 @@ type CreateTrailInput struct {
 	// Specifies the name of the Amazon SNS topic defined for notification of log
 	// file delivery. The maximum length is 256 characters.
 	SnsTopicName *string `type:"string"`
-
-	_ struct{} `type:"structure"`
 }
 
 // String returns the string representation
@@ -487,6 +487,8 @@ func (s CreateTrailInput) GoString() string {
 // Returns the objects or data listed below if successful. Otherwise, returns
 // an error.
 type CreateTrailOutput struct {
+	_ struct{} `type:"structure"`
+
 	// Specifies the Amazon Resource Name (ARN) of the log group to which CloudTrail
 	// logs will be delivered.
 	CloudWatchLogsLogGroupArn *string `type:"string"`
@@ -526,8 +528,6 @@ type CreateTrailOutput struct {
 
 	// Specifies the ARN of the trail that was created.
 	TrailARN *string `type:"string"`
-
-	_ struct{} `type:"structure"`
 }
 
 // String returns the string representation
@@ -542,11 +542,11 @@ func (s CreateTrailOutput) GoString() string {
 
 // The request that specifies the name of a trail to delete.
 type DeleteTrailInput struct {
+	_ struct{} `type:"structure"`
+
 	// Specifies the name or the CloudTrail ARN of the trail to be deleted. The
 	// format of a trail ARN is arn:aws:cloudtrail:us-east-1:123456789012:trail/MyTrail.
 	Name *string `type:"string" required:"true"`
-
-	_ struct{} `type:"structure"`
 }
 
 // String returns the string representation
@@ -577,13 +577,13 @@ func (s DeleteTrailOutput) GoString() string {
 
 // Returns information about the trail.
 type DescribeTrailsInput struct {
+	_ struct{} `type:"structure"`
+
 	// Specifies a list of trail names, trail ARNs, or both, of the trails to describe.
 	// The format of a trail ARN is arn:aws:cloudtrail:us-east-1:123456789012:trail/MyTrail.
 	// If an empty list is specified, information for the trail in the current region
 	// is returned.
 	TrailNameList []*string `locationName:"trailNameList" type:"list"`
-
-	_ struct{} `type:"structure"`
 }
 
 // String returns the string representation
@@ -599,10 +599,10 @@ func (s DescribeTrailsInput) GoString() string {
 // Returns the objects or data listed below if successful. Otherwise, returns
 // an error.
 type DescribeTrailsOutput struct {
+	_ struct{} `type:"structure"`
+
 	// The list of trail objects.
 	TrailList []*Trail `locationName:"trailList" type:"list"`
-
-	_ struct{} `type:"structure"`
 }
 
 // String returns the string representation
@@ -618,6 +618,8 @@ func (s DescribeTrailsOutput) GoString() string {
 // Contains information about an event that was returned by a lookup request.
 // The result includes a representation of a CloudTrail event.
 type Event struct {
+	_ struct{} `type:"structure"`
+
 	// A JSON string that contains a representation of the event returned.
 	CloudTrailEvent *string `type:"string"`
 
@@ -636,8 +638,6 @@ type Event struct {
 	// A user name or role name of the requester that called the API in the event
 	// returned.
 	Username *string `type:"string"`
-
-	_ struct{} `type:"structure"`
 }
 
 // String returns the string representation
@@ -652,11 +652,11 @@ func (s Event) GoString() string {
 
 // The name of a trail about which you want the current status.
 type GetTrailStatusInput struct {
+	_ struct{} `type:"structure"`
+
 	// Specifies the name or the CloudTrail ARN of the trail for which you are requesting
 	// status. The format of a trail ARN is arn:aws:cloudtrail:us-east-1:123456789012:trail/MyTrail.
 	Name *string `type:"string" required:"true"`
-
-	_ struct{} `type:"structure"`
 }
 
 // String returns the string representation
@@ -672,6 +672,8 @@ func (s GetTrailStatusInput) GoString() string {
 // Returns the objects or data listed below if successful. Otherwise, returns
 // an error.
 type GetTrailStatusOutput struct {
+	_ struct{} `type:"structure"`
+
 	// Whether the CloudTrail is currently logging AWS API calls.
 	IsLogging *bool `type:"boolean"`
 
@@ -747,8 +749,6 @@ type GetTrailStatusOutput struct {
 
 	// This field is deprecated.
 	TimeLoggingStopped *string `type:"string"`
-
-	_ struct{} `type:"structure"`
 }
 
 // String returns the string representation
@@ -763,6 +763,8 @@ func (s GetTrailStatusOutput) GoString() string {
 
 // Requests the public keys for a specified time range.
 type ListPublicKeysInput struct {
+	_ struct{} `type:"structure"`
+
 	// Optionally specifies, in UTC, the end of the time range to look up public
 	// keys for CloudTrail digest files. If not specified, the current time is used.
 	EndTime *time.Time `type:"timestamp" timestampFormat:"unix"`
@@ -774,8 +776,6 @@ type ListPublicKeysInput struct {
 	// keys for CloudTrail digest files. If not specified, the current time is used,
 	// and the current public key is returned.
 	StartTime *time.Time `type:"timestamp" timestampFormat:"unix"`
-
-	_ struct{} `type:"structure"`
 }
 
 // String returns the string representation
@@ -791,6 +791,8 @@ func (s ListPublicKeysInput) GoString() string {
 // Returns the objects or data listed below if successful. Otherwise, returns
 // an error.
 type ListPublicKeysOutput struct {
+	_ struct{} `type:"structure"`
+
 	// Reserved for future use.
 	NextToken *string `type:"string"`
 
@@ -798,8 +800,6 @@ type ListPublicKeysOutput struct {
 	//
 	// The returned public keys may have validity time ranges that overlap.
 	PublicKeyList []*PublicKey `type:"list"`
-
-	_ struct{} `type:"structure"`
 }
 
 // String returns the string representation
@@ -814,14 +814,14 @@ func (s ListPublicKeysOutput) GoString() string {
 
 // Specifies a list of trail tags to return.
 type ListTagsInput struct {
+	_ struct{} `type:"structure"`
+
 	// Reserved for future use.
 	NextToken *string `type:"string"`
 
 	// Specifies a list of trail ARNs whose tags will be listed. The list has a
 	// limit of 20 ARNs. The format of a trail ARN is arn:aws:cloudtrail:us-east-1:123456789012:trail/MyTrail.
 	ResourceIdList []*string `type:"list" required:"true"`
-
-	_ struct{} `type:"structure"`
 }
 
 // String returns the string representation
@@ -837,13 +837,13 @@ func (s ListTagsInput) GoString() string {
 // Returns the objects or data listed below if successful. Otherwise, returns
 // an error.
 type ListTagsOutput struct {
+	_ struct{} `type:"structure"`
+
 	// Reserved for future use.
 	NextToken *string `type:"string"`
 
 	// A list of resource tags.
 	ResourceTagList []*ResourceTag `type:"list"`
-
-	_ struct{} `type:"structure"`
 }
 
 // String returns the string representation
@@ -858,13 +858,13 @@ func (s ListTagsOutput) GoString() string {
 
 // Specifies an attribute and value that filter the events returned.
 type LookupAttribute struct {
+	_ struct{} `type:"structure"`
+
 	// Specifies an attribute on which to filter the events returned.
 	AttributeKey *string `type:"string" required:"true" enum:"LookupAttributeKey"`
 
 	// Specifies a value for the specified AttributeKey.
 	AttributeValue *string `type:"string" required:"true"`
-
-	_ struct{} `type:"structure"`
 }
 
 // String returns the string representation
@@ -879,6 +879,8 @@ func (s LookupAttribute) GoString() string {
 
 // Contains a request for LookupEvents.
 type LookupEventsInput struct {
+	_ struct{} `type:"structure"`
+
 	// Specifies that only events that occur before or at the specified time are
 	// returned. If the specified end time is before the specified start time, an
 	// error is returned.
@@ -903,8 +905,6 @@ type LookupEventsInput struct {
 	// returned. If the specified start time is after the specified end time, an
 	// error is returned.
 	StartTime *time.Time `type:"timestamp" timestampFormat:"unix"`
-
-	_ struct{} `type:"structure"`
 }
 
 // String returns the string representation
@@ -919,6 +919,8 @@ func (s LookupEventsInput) GoString() string {
 
 // Contains a response to a LookupEvents action.
 type LookupEventsOutput struct {
+	_ struct{} `type:"structure"`
+
 	// A list of events returned based on the lookup attributes specified and the
 	// CloudTrail event. The events list is sorted by time. The most recent event
 	// is listed first.
@@ -930,8 +932,6 @@ type LookupEventsOutput struct {
 	// if the original call specified an AttributeKey of 'Username' with a value
 	// of 'root', the call with NextToken should include those same parameters.
 	NextToken *string `type:"string"`
-
-	_ struct{} `type:"structure"`
 }
 
 // String returns the string representation
@@ -946,6 +946,8 @@ func (s LookupEventsOutput) GoString() string {
 
 // Contains information about a returned public key.
 type PublicKey struct {
+	_ struct{} `type:"structure"`
+
 	// The fingerprint of the public key.
 	Fingerprint *string `type:"string"`
 
@@ -957,8 +959,6 @@ type PublicKey struct {
 
 	// The DER encoded public key value in PKCS#1 format.
 	Value []byte `type:"blob"`
-
-	_ struct{} `type:"structure"`
 }
 
 // String returns the string representation
@@ -973,14 +973,14 @@ func (s PublicKey) GoString() string {
 
 // Specifies the tags to remove from a trail.
 type RemoveTagsInput struct {
+	_ struct{} `type:"structure"`
+
 	// Specifies the ARN of the trail from which tags should be removed. The format
 	// of a trail ARN is arn:aws:cloudtrail:us-east-1:123456789012:trail/MyTrail.
 	ResourceId *string `type:"string" required:"true"`
 
 	// Specifies a list of tags to be removed.
 	TagsList []*Tag `type:"list"`
-
-	_ struct{} `type:"structure"`
 }
 
 // String returns the string representation
@@ -1011,6 +1011,8 @@ func (s RemoveTagsOutput) GoString() string {
 
 // Specifies the type and name of a resource referenced by an event.
 type Resource struct {
+	_ struct{} `type:"structure"`
+
 	// The name of the resource referenced by the event returned. These are user-created
 	// names whose values will depend on the environment. For example, the resource
 	// name might be "auto-scaling-test-group" for an Auto Scaling Group or "i-1234567"
@@ -1023,8 +1025,6 @@ type Resource struct {
 	// for IAM. For a list of resource types supported for event lookup, see Resource
 	// Types Supported for Event Lookup (http://docs.aws.amazon.com/awscloudtrail/latest/userguide/lookup_supported_resourcetypes.html).
 	ResourceType *string `type:"string"`
-
-	_ struct{} `type:"structure"`
 }
 
 // String returns the string representation
@@ -1039,13 +1039,13 @@ func (s Resource) GoString() string {
 
 // A resource tag.
 type ResourceTag struct {
+	_ struct{} `type:"structure"`
+
 	// Specifies the ARN of the resource.
 	ResourceId *string `type:"string"`
 
 	// A list of tags.
 	TagsList []*Tag `type:"list"`
-
-	_ struct{} `type:"structure"`
 }
 
 // String returns the string representation
@@ -1060,11 +1060,11 @@ func (s ResourceTag) GoString() string {
 
 // The request to CloudTrail to start logging AWS API calls for an account.
 type StartLoggingInput struct {
+	_ struct{} `type:"structure"`
+
 	// Specifies the name or the CloudTrail ARN of the trail for which CloudTrail
 	// logs AWS API calls. The format of a trail ARN is arn:aws:cloudtrail:us-east-1:123456789012:trail/MyTrail.
 	Name *string `type:"string" required:"true"`
-
-	_ struct{} `type:"structure"`
 }
 
 // String returns the string representation
@@ -1096,11 +1096,11 @@ func (s StartLoggingOutput) GoString() string {
 // Passes the request to CloudTrail to stop logging AWS API calls for the specified
 // account.
 type StopLoggingInput struct {
+	_ struct{} `type:"structure"`
+
 	// Specifies the name or the CloudTrail ARN of the trail for which CloudTrail
 	// will stop logging AWS API calls. The format of a trail ARN is arn:aws:cloudtrail:us-east-1:123456789012:trail/MyTrail.
 	Name *string `type:"string" required:"true"`
-
-	_ struct{} `type:"structure"`
 }
 
 // String returns the string representation
@@ -1131,6 +1131,8 @@ func (s StopLoggingOutput) GoString() string {
 
 // A custom key-value pair associated with a resource such as a CloudTrail trail.
 type Tag struct {
+	_ struct{} `type:"structure"`
+
 	// The key in a key-value pair. The key must be must be no longer than 128 Unicode
 	// characters. The key must be unique for the resource to which it applies.
 	Key *string `type:"string" required:"true"`
@@ -1138,8 +1140,6 @@ type Tag struct {
 	// The value in a key-value pair of a tag. The value must be no longer than
 	// 256 Unicode characters.
 	Value *string `type:"string"`
-
-	_ struct{} `type:"structure"`
 }
 
 // String returns the string representation
@@ -1154,6 +1154,8 @@ func (s Tag) GoString() string {
 
 // The settings for a trail.
 type Trail struct {
+	_ struct{} `type:"structure"`
+
 	// Specifies an Amazon Resource Name (ARN), a unique identifier that represents
 	// the log group to which CloudTrail logs will be delivered.
 	CloudWatchLogsLogGroupArn *string `type:"string"`
@@ -1195,8 +1197,6 @@ type Trail struct {
 
 	// The Amazon Resource Name of the trail. The TrailARN format is arn:aws:cloudtrail:us-east-1:123456789012:trail/MyTrail.
 	TrailARN *string `type:"string"`
-
-	_ struct{} `type:"structure"`
 }
 
 // String returns the string representation
@@ -1211,6 +1211,8 @@ func (s Trail) GoString() string {
 
 // Specifies settings to update for the trail.
 type UpdateTrailInput struct {
+	_ struct{} `type:"structure"`
+
 	// Specifies a log group name using an Amazon Resource Name (ARN), a unique
 	// identifier that represents the log group to which CloudTrail logs will be
 	// delivered. Not required unless you specify CloudWatchLogsRoleArn.
@@ -1271,8 +1273,6 @@ type UpdateTrailInput struct {
 	// Specifies the name of the Amazon SNS topic defined for notification of log
 	// file delivery. The maximum length is 256 characters.
 	SnsTopicName *string `type:"string"`
-
-	_ struct{} `type:"structure"`
 }
 
 // String returns the string representation
@@ -1288,6 +1288,8 @@ func (s UpdateTrailInput) GoString() string {
 // Returns the objects or data listed below if successful. Otherwise, returns
 // an error.
 type UpdateTrailOutput struct {
+	_ struct{} `type:"structure"`
+
 	// Specifies the Amazon Resource Name (ARN) of the log group to which CloudTrail
 	// logs will be delivered.
 	CloudWatchLogsLogGroupArn *string `type:"string"`
@@ -1327,8 +1329,6 @@ type UpdateTrailOutput struct {
 
 	// Specifies the ARN of the trail that was updated.
 	TrailARN *string `type:"string"`
-
-	_ struct{} `type:"structure"`
 }
 
 // String returns the string representation

--- a/service/cloudwatch/api.go
+++ b/service/cloudwatch/api.go
@@ -408,6 +408,8 @@ func (c *CloudWatch) SetAlarmState(input *SetAlarmStateInput) (*SetAlarmStateOut
 // history of a specific alarm. If you call DescribeAlarmHistory, Amazon CloudWatch
 // returns this data type as part of the DescribeAlarmHistoryResult data type.
 type AlarmHistoryItem struct {
+	_ struct{} `type:"structure"`
+
 	// The descriptive name for the alarm.
 	AlarmName *string `min:"1" type:"string"`
 
@@ -426,8 +428,6 @@ type AlarmHistoryItem struct {
 	// see Time stamps (http://docs.aws.amazon.com/AmazonCloudWatch/latest/DeveloperGuide/cloudwatch_concepts.html#about_timestamp)
 	// in the Amazon CloudWatch Developer Guide.
 	Timestamp *time.Time `type:"timestamp" timestampFormat:"iso8601"`
-
-	_ struct{} `type:"structure"`
 }
 
 // String returns the string representation
@@ -443,6 +443,8 @@ func (s AlarmHistoryItem) GoString() string {
 // The Datapoint data type encapsulates the statistical data that Amazon CloudWatch
 // computes from metric data.
 type Datapoint struct {
+	_ struct{} `type:"structure"`
+
 	// The average of metric values that correspond to the datapoint.
 	Average *float64 `type:"double"`
 
@@ -468,8 +470,6 @@ type Datapoint struct {
 
 	// The standard unit used for the datapoint.
 	Unit *string `type:"string" enum:"StandardUnit"`
-
-	_ struct{} `type:"structure"`
 }
 
 // String returns the string representation
@@ -483,10 +483,10 @@ func (s Datapoint) GoString() string {
 }
 
 type DeleteAlarmsInput struct {
+	_ struct{} `type:"structure"`
+
 	// A list of alarms to be deleted.
 	AlarmNames []*string `type:"list" required:"true"`
-
-	_ struct{} `type:"structure"`
 }
 
 // String returns the string representation
@@ -514,6 +514,8 @@ func (s DeleteAlarmsOutput) GoString() string {
 }
 
 type DescribeAlarmHistoryInput struct {
+	_ struct{} `type:"structure"`
+
 	// The name of the alarm.
 	AlarmName *string `min:"1" type:"string"`
 
@@ -532,8 +534,6 @@ type DescribeAlarmHistoryInput struct {
 
 	// The starting date to retrieve alarm history.
 	StartDate *time.Time `type:"timestamp" timestampFormat:"iso8601"`
-
-	_ struct{} `type:"structure"`
 }
 
 // String returns the string representation
@@ -548,13 +548,13 @@ func (s DescribeAlarmHistoryInput) GoString() string {
 
 // The output for the DescribeAlarmHistory action.
 type DescribeAlarmHistoryOutput struct {
+	_ struct{} `type:"structure"`
+
 	// A list of alarm histories in JSON format.
 	AlarmHistoryItems []*AlarmHistoryItem `type:"list"`
 
 	// A string that marks the start of the next batch of returned results.
 	NextToken *string `type:"string"`
-
-	_ struct{} `type:"structure"`
 }
 
 // String returns the string representation
@@ -568,6 +568,8 @@ func (s DescribeAlarmHistoryOutput) GoString() string {
 }
 
 type DescribeAlarmsForMetricInput struct {
+	_ struct{} `type:"structure"`
+
 	// The list of dimensions associated with the metric.
 	Dimensions []*Dimension `type:"list"`
 
@@ -585,8 +587,6 @@ type DescribeAlarmsForMetricInput struct {
 
 	// The unit for the metric.
 	Unit *string `type:"string" enum:"StandardUnit"`
-
-	_ struct{} `type:"structure"`
 }
 
 // String returns the string representation
@@ -601,10 +601,10 @@ func (s DescribeAlarmsForMetricInput) GoString() string {
 
 // The output for the DescribeAlarmsForMetric action.
 type DescribeAlarmsForMetricOutput struct {
+	_ struct{} `type:"structure"`
+
 	// A list of information for each alarm with the specified metric.
 	MetricAlarms []*MetricAlarm `type:"list"`
-
-	_ struct{} `type:"structure"`
 }
 
 // String returns the string representation
@@ -618,6 +618,8 @@ func (s DescribeAlarmsForMetricOutput) GoString() string {
 }
 
 type DescribeAlarmsInput struct {
+	_ struct{} `type:"structure"`
+
 	// The action name prefix.
 	ActionPrefix *string `min:"1" type:"string"`
 
@@ -637,8 +639,6 @@ type DescribeAlarmsInput struct {
 
 	// The state value to be used in matching alarms.
 	StateValue *string `type:"string" enum:"StateValue"`
-
-	_ struct{} `type:"structure"`
 }
 
 // String returns the string representation
@@ -653,13 +653,13 @@ func (s DescribeAlarmsInput) GoString() string {
 
 // The output for the DescribeAlarms action.
 type DescribeAlarmsOutput struct {
+	_ struct{} `type:"structure"`
+
 	// A list of information for the specified alarms.
 	MetricAlarms []*MetricAlarm `type:"list"`
 
 	// A string that marks the start of the next batch of returned results.
 	NextToken *string `type:"string"`
-
-	_ struct{} `type:"structure"`
 }
 
 // String returns the string representation
@@ -677,13 +677,13 @@ func (s DescribeAlarmsOutput) GoString() string {
 //
 // For examples that use one or more dimensions, see PutMetricData.
 type Dimension struct {
+	_ struct{} `type:"structure"`
+
 	// The name of the dimension.
 	Name *string `min:"1" type:"string" required:"true"`
 
 	// The value representing the dimension measurement
 	Value *string `min:"1" type:"string" required:"true"`
-
-	_ struct{} `type:"structure"`
 }
 
 // String returns the string representation
@@ -698,13 +698,13 @@ func (s Dimension) GoString() string {
 
 // The DimensionFilter data type is used to filter ListMetrics results.
 type DimensionFilter struct {
+	_ struct{} `type:"structure"`
+
 	// The dimension name to be matched.
 	Name *string `min:"1" type:"string" required:"true"`
 
 	// The value of the dimension to be matched.
 	Value *string `min:"1" type:"string"`
-
-	_ struct{} `type:"structure"`
 }
 
 // String returns the string representation
@@ -718,10 +718,10 @@ func (s DimensionFilter) GoString() string {
 }
 
 type DisableAlarmActionsInput struct {
+	_ struct{} `type:"structure"`
+
 	// The names of the alarms to disable actions for.
 	AlarmNames []*string `type:"list" required:"true"`
-
-	_ struct{} `type:"structure"`
 }
 
 // String returns the string representation
@@ -749,10 +749,10 @@ func (s DisableAlarmActionsOutput) GoString() string {
 }
 
 type EnableAlarmActionsInput struct {
+	_ struct{} `type:"structure"`
+
 	// The names of the alarms to enable actions for.
 	AlarmNames []*string `type:"list" required:"true"`
-
-	_ struct{} `type:"structure"`
 }
 
 // String returns the string representation
@@ -780,6 +780,8 @@ func (s EnableAlarmActionsOutput) GoString() string {
 }
 
 type GetMetricStatisticsInput struct {
+	_ struct{} `type:"structure"`
+
 	// A list of dimensions describing qualities of the metric.
 	Dimensions []*Dimension `type:"list"`
 
@@ -812,8 +814,6 @@ type GetMetricStatisticsInput struct {
 
 	// The unit for the metric.
 	Unit *string `type:"string" enum:"StandardUnit"`
-
-	_ struct{} `type:"structure"`
 }
 
 // String returns the string representation
@@ -828,13 +828,13 @@ func (s GetMetricStatisticsInput) GoString() string {
 
 // The output for the GetMetricStatistics action.
 type GetMetricStatisticsOutput struct {
+	_ struct{} `type:"structure"`
+
 	// The datapoints for the specified metric.
 	Datapoints []*Datapoint `type:"list"`
 
 	// A label describing the specified metric.
 	Label *string `type:"string"`
-
-	_ struct{} `type:"structure"`
 }
 
 // String returns the string representation
@@ -848,6 +848,8 @@ func (s GetMetricStatisticsOutput) GoString() string {
 }
 
 type ListMetricsInput struct {
+	_ struct{} `type:"structure"`
+
 	// A list of dimensions to filter against.
 	Dimensions []*DimensionFilter `type:"list"`
 
@@ -860,8 +862,6 @@ type ListMetricsInput struct {
 	// The token returned by a previous call to indicate that there is more data
 	// available.
 	NextToken *string `type:"string"`
-
-	_ struct{} `type:"structure"`
 }
 
 // String returns the string representation
@@ -876,13 +876,13 @@ func (s ListMetricsInput) GoString() string {
 
 // The output for the ListMetrics action.
 type ListMetricsOutput struct {
+	_ struct{} `type:"structure"`
+
 	// A list of metrics used to generate statistics for an AWS account.
 	Metrics []*Metric `type:"list"`
 
 	// A string that marks the start of the next batch of returned results.
 	NextToken *string `type:"string"`
-
-	_ struct{} `type:"structure"`
 }
 
 // String returns the string representation
@@ -903,6 +903,8 @@ func (s ListMetricsOutput) GoString() string {
 // and latency. Both metrics are in the examples namespace. Both metrics have
 // two dimensions, InstanceID and InstanceType.
 type Metric struct {
+	_ struct{} `type:"structure"`
+
 	// A list of dimensions associated with the metric.
 	Dimensions []*Dimension `type:"list"`
 
@@ -911,8 +913,6 @@ type Metric struct {
 
 	// The namespace of the metric.
 	Namespace *string `min:"1" type:"string"`
-
-	_ struct{} `type:"structure"`
 }
 
 // String returns the string representation
@@ -928,6 +928,8 @@ func (s Metric) GoString() string {
 // The MetricAlarm data type represents an alarm. You can use PutMetricAlarm
 // to create or update an alarm.
 type MetricAlarm struct {
+	_ struct{} `type:"structure"`
+
 	// Indicates whether actions should be executed during any changes to the alarm's
 	// state.
 	ActionsEnabled *bool `type:"boolean"`
@@ -1011,8 +1013,6 @@ type MetricAlarm struct {
 
 	// The unit of the alarm's associated metric.
 	Unit *string `type:"string" enum:"StandardUnit"`
-
-	_ struct{} `type:"structure"`
 }
 
 // String returns the string representation
@@ -1029,6 +1029,8 @@ func (s MetricAlarm) GoString() string {
 // to either create a new metric or add new values to be aggregated into an
 // existing metric.
 type MetricDatum struct {
+	_ struct{} `type:"structure"`
+
 	// A list of dimensions associated with the metric. Note, when using the Dimensions
 	// value in a query, you need to append .member.N to it (e.g., Dimensions.member.N).
 	Dimensions []*Dimension `type:"list"`
@@ -1057,8 +1059,6 @@ type MetricDatum struct {
 	// greater than 126 (1 x 10^126) are truncated. Likewise, values with base-10
 	// exponents less than -130 (1 x 10^-130) are also truncated.
 	Value *float64 `type:"double"`
-
-	_ struct{} `type:"structure"`
 }
 
 // String returns the string representation
@@ -1072,6 +1072,8 @@ func (s MetricDatum) GoString() string {
 }
 
 type PutMetricAlarmInput struct {
+	_ struct{} `type:"structure"`
+
 	// Indicates whether or not actions should be executed during any changes to
 	// the alarm's state.
 	ActionsEnabled *bool `type:"boolean"`
@@ -1128,8 +1130,6 @@ type PutMetricAlarmInput struct {
 
 	// The unit for the alarm's associated metric.
 	Unit *string `type:"string" enum:"StandardUnit"`
-
-	_ struct{} `type:"structure"`
 }
 
 // String returns the string representation
@@ -1157,13 +1157,13 @@ func (s PutMetricAlarmOutput) GoString() string {
 }
 
 type PutMetricDataInput struct {
+	_ struct{} `type:"structure"`
+
 	// A list of data describing the metric.
 	MetricData []*MetricDatum `type:"list" required:"true"`
 
 	// The namespace for the metric data.
 	Namespace *string `min:"1" type:"string" required:"true"`
-
-	_ struct{} `type:"structure"`
 }
 
 // String returns the string representation
@@ -1191,6 +1191,8 @@ func (s PutMetricDataOutput) GoString() string {
 }
 
 type SetAlarmStateInput struct {
+	_ struct{} `type:"structure"`
+
 	// The descriptive name for the alarm. This name must be unique within the user's
 	// AWS account. The maximum length is 255 characters.
 	AlarmName *string `min:"1" type:"string" required:"true"`
@@ -1205,8 +1207,6 @@ type SetAlarmStateInput struct {
 
 	// The value of the state.
 	StateValue *string `type:"string" required:"true" enum:"StateValue"`
-
-	_ struct{} `type:"structure"`
 }
 
 // String returns the string representation
@@ -1236,6 +1236,8 @@ func (s SetAlarmStateOutput) GoString() string {
 // The StatisticSet data type describes the StatisticValues component of MetricDatum,
 // and represents a set of statistics that describes a specific metric.
 type StatisticSet struct {
+	_ struct{} `type:"structure"`
+
 	// The maximum value of the sample set.
 	Maximum *float64 `type:"double" required:"true"`
 
@@ -1247,8 +1249,6 @@ type StatisticSet struct {
 
 	// The sum of values for the sample set.
 	Sum *float64 `type:"double" required:"true"`
-
-	_ struct{} `type:"structure"`
 }
 
 // String returns the string representation

--- a/service/cloudwatch/api.go
+++ b/service/cloudwatch/api.go
@@ -427,11 +427,7 @@ type AlarmHistoryItem struct {
 	// in the Amazon CloudWatch Developer Guide.
 	Timestamp *time.Time `type:"timestamp" timestampFormat:"iso8601"`
 
-	metadataAlarmHistoryItem `json:"-" xml:"-"`
-}
-
-type metadataAlarmHistoryItem struct {
-	SDKShapeTraits bool `type:"structure"`
+	_ struct{} `type:"structure"`
 }
 
 // String returns the string representation
@@ -473,11 +469,7 @@ type Datapoint struct {
 	// The standard unit used for the datapoint.
 	Unit *string `type:"string" enum:"StandardUnit"`
 
-	metadataDatapoint `json:"-" xml:"-"`
-}
-
-type metadataDatapoint struct {
-	SDKShapeTraits bool `type:"structure"`
+	_ struct{} `type:"structure"`
 }
 
 // String returns the string representation
@@ -494,11 +486,7 @@ type DeleteAlarmsInput struct {
 	// A list of alarms to be deleted.
 	AlarmNames []*string `type:"list" required:"true"`
 
-	metadataDeleteAlarmsInput `json:"-" xml:"-"`
-}
-
-type metadataDeleteAlarmsInput struct {
-	SDKShapeTraits bool `type:"structure"`
+	_ struct{} `type:"structure"`
 }
 
 // String returns the string representation
@@ -512,11 +500,7 @@ func (s DeleteAlarmsInput) GoString() string {
 }
 
 type DeleteAlarmsOutput struct {
-	metadataDeleteAlarmsOutput `json:"-" xml:"-"`
-}
-
-type metadataDeleteAlarmsOutput struct {
-	SDKShapeTraits bool `type:"structure"`
+	_ struct{} `type:"structure"`
 }
 
 // String returns the string representation
@@ -549,11 +533,7 @@ type DescribeAlarmHistoryInput struct {
 	// The starting date to retrieve alarm history.
 	StartDate *time.Time `type:"timestamp" timestampFormat:"iso8601"`
 
-	metadataDescribeAlarmHistoryInput `json:"-" xml:"-"`
-}
-
-type metadataDescribeAlarmHistoryInput struct {
-	SDKShapeTraits bool `type:"structure"`
+	_ struct{} `type:"structure"`
 }
 
 // String returns the string representation
@@ -574,11 +554,7 @@ type DescribeAlarmHistoryOutput struct {
 	// A string that marks the start of the next batch of returned results.
 	NextToken *string `type:"string"`
 
-	metadataDescribeAlarmHistoryOutput `json:"-" xml:"-"`
-}
-
-type metadataDescribeAlarmHistoryOutput struct {
-	SDKShapeTraits bool `type:"structure"`
+	_ struct{} `type:"structure"`
 }
 
 // String returns the string representation
@@ -610,11 +586,7 @@ type DescribeAlarmsForMetricInput struct {
 	// The unit for the metric.
 	Unit *string `type:"string" enum:"StandardUnit"`
 
-	metadataDescribeAlarmsForMetricInput `json:"-" xml:"-"`
-}
-
-type metadataDescribeAlarmsForMetricInput struct {
-	SDKShapeTraits bool `type:"structure"`
+	_ struct{} `type:"structure"`
 }
 
 // String returns the string representation
@@ -632,11 +604,7 @@ type DescribeAlarmsForMetricOutput struct {
 	// A list of information for each alarm with the specified metric.
 	MetricAlarms []*MetricAlarm `type:"list"`
 
-	metadataDescribeAlarmsForMetricOutput `json:"-" xml:"-"`
-}
-
-type metadataDescribeAlarmsForMetricOutput struct {
-	SDKShapeTraits bool `type:"structure"`
+	_ struct{} `type:"structure"`
 }
 
 // String returns the string representation
@@ -670,11 +638,7 @@ type DescribeAlarmsInput struct {
 	// The state value to be used in matching alarms.
 	StateValue *string `type:"string" enum:"StateValue"`
 
-	metadataDescribeAlarmsInput `json:"-" xml:"-"`
-}
-
-type metadataDescribeAlarmsInput struct {
-	SDKShapeTraits bool `type:"structure"`
+	_ struct{} `type:"structure"`
 }
 
 // String returns the string representation
@@ -695,11 +659,7 @@ type DescribeAlarmsOutput struct {
 	// A string that marks the start of the next batch of returned results.
 	NextToken *string `type:"string"`
 
-	metadataDescribeAlarmsOutput `json:"-" xml:"-"`
-}
-
-type metadataDescribeAlarmsOutput struct {
-	SDKShapeTraits bool `type:"structure"`
+	_ struct{} `type:"structure"`
 }
 
 // String returns the string representation
@@ -723,11 +683,7 @@ type Dimension struct {
 	// The value representing the dimension measurement
 	Value *string `min:"1" type:"string" required:"true"`
 
-	metadataDimension `json:"-" xml:"-"`
-}
-
-type metadataDimension struct {
-	SDKShapeTraits bool `type:"structure"`
+	_ struct{} `type:"structure"`
 }
 
 // String returns the string representation
@@ -748,11 +704,7 @@ type DimensionFilter struct {
 	// The value of the dimension to be matched.
 	Value *string `min:"1" type:"string"`
 
-	metadataDimensionFilter `json:"-" xml:"-"`
-}
-
-type metadataDimensionFilter struct {
-	SDKShapeTraits bool `type:"structure"`
+	_ struct{} `type:"structure"`
 }
 
 // String returns the string representation
@@ -769,11 +721,7 @@ type DisableAlarmActionsInput struct {
 	// The names of the alarms to disable actions for.
 	AlarmNames []*string `type:"list" required:"true"`
 
-	metadataDisableAlarmActionsInput `json:"-" xml:"-"`
-}
-
-type metadataDisableAlarmActionsInput struct {
-	SDKShapeTraits bool `type:"structure"`
+	_ struct{} `type:"structure"`
 }
 
 // String returns the string representation
@@ -787,11 +735,7 @@ func (s DisableAlarmActionsInput) GoString() string {
 }
 
 type DisableAlarmActionsOutput struct {
-	metadataDisableAlarmActionsOutput `json:"-" xml:"-"`
-}
-
-type metadataDisableAlarmActionsOutput struct {
-	SDKShapeTraits bool `type:"structure"`
+	_ struct{} `type:"structure"`
 }
 
 // String returns the string representation
@@ -808,11 +752,7 @@ type EnableAlarmActionsInput struct {
 	// The names of the alarms to enable actions for.
 	AlarmNames []*string `type:"list" required:"true"`
 
-	metadataEnableAlarmActionsInput `json:"-" xml:"-"`
-}
-
-type metadataEnableAlarmActionsInput struct {
-	SDKShapeTraits bool `type:"structure"`
+	_ struct{} `type:"structure"`
 }
 
 // String returns the string representation
@@ -826,11 +766,7 @@ func (s EnableAlarmActionsInput) GoString() string {
 }
 
 type EnableAlarmActionsOutput struct {
-	metadataEnableAlarmActionsOutput `json:"-" xml:"-"`
-}
-
-type metadataEnableAlarmActionsOutput struct {
-	SDKShapeTraits bool `type:"structure"`
+	_ struct{} `type:"structure"`
 }
 
 // String returns the string representation
@@ -877,11 +813,7 @@ type GetMetricStatisticsInput struct {
 	// The unit for the metric.
 	Unit *string `type:"string" enum:"StandardUnit"`
 
-	metadataGetMetricStatisticsInput `json:"-" xml:"-"`
-}
-
-type metadataGetMetricStatisticsInput struct {
-	SDKShapeTraits bool `type:"structure"`
+	_ struct{} `type:"structure"`
 }
 
 // String returns the string representation
@@ -902,11 +834,7 @@ type GetMetricStatisticsOutput struct {
 	// A label describing the specified metric.
 	Label *string `type:"string"`
 
-	metadataGetMetricStatisticsOutput `json:"-" xml:"-"`
-}
-
-type metadataGetMetricStatisticsOutput struct {
-	SDKShapeTraits bool `type:"structure"`
+	_ struct{} `type:"structure"`
 }
 
 // String returns the string representation
@@ -933,11 +861,7 @@ type ListMetricsInput struct {
 	// available.
 	NextToken *string `type:"string"`
 
-	metadataListMetricsInput `json:"-" xml:"-"`
-}
-
-type metadataListMetricsInput struct {
-	SDKShapeTraits bool `type:"structure"`
+	_ struct{} `type:"structure"`
 }
 
 // String returns the string representation
@@ -958,11 +882,7 @@ type ListMetricsOutput struct {
 	// A string that marks the start of the next batch of returned results.
 	NextToken *string `type:"string"`
 
-	metadataListMetricsOutput `json:"-" xml:"-"`
-}
-
-type metadataListMetricsOutput struct {
-	SDKShapeTraits bool `type:"structure"`
+	_ struct{} `type:"structure"`
 }
 
 // String returns the string representation
@@ -992,11 +912,7 @@ type Metric struct {
 	// The namespace of the metric.
 	Namespace *string `min:"1" type:"string"`
 
-	metadataMetric `json:"-" xml:"-"`
-}
-
-type metadataMetric struct {
-	SDKShapeTraits bool `type:"structure"`
+	_ struct{} `type:"structure"`
 }
 
 // String returns the string representation
@@ -1096,11 +1012,7 @@ type MetricAlarm struct {
 	// The unit of the alarm's associated metric.
 	Unit *string `type:"string" enum:"StandardUnit"`
 
-	metadataMetricAlarm `json:"-" xml:"-"`
-}
-
-type metadataMetricAlarm struct {
-	SDKShapeTraits bool `type:"structure"`
+	_ struct{} `type:"structure"`
 }
 
 // String returns the string representation
@@ -1146,11 +1058,7 @@ type MetricDatum struct {
 	// exponents less than -130 (1 x 10^-130) are also truncated.
 	Value *float64 `type:"double"`
 
-	metadataMetricDatum `json:"-" xml:"-"`
-}
-
-type metadataMetricDatum struct {
-	SDKShapeTraits bool `type:"structure"`
+	_ struct{} `type:"structure"`
 }
 
 // String returns the string representation
@@ -1221,11 +1129,7 @@ type PutMetricAlarmInput struct {
 	// The unit for the alarm's associated metric.
 	Unit *string `type:"string" enum:"StandardUnit"`
 
-	metadataPutMetricAlarmInput `json:"-" xml:"-"`
-}
-
-type metadataPutMetricAlarmInput struct {
-	SDKShapeTraits bool `type:"structure"`
+	_ struct{} `type:"structure"`
 }
 
 // String returns the string representation
@@ -1239,11 +1143,7 @@ func (s PutMetricAlarmInput) GoString() string {
 }
 
 type PutMetricAlarmOutput struct {
-	metadataPutMetricAlarmOutput `json:"-" xml:"-"`
-}
-
-type metadataPutMetricAlarmOutput struct {
-	SDKShapeTraits bool `type:"structure"`
+	_ struct{} `type:"structure"`
 }
 
 // String returns the string representation
@@ -1263,11 +1163,7 @@ type PutMetricDataInput struct {
 	// The namespace for the metric data.
 	Namespace *string `min:"1" type:"string" required:"true"`
 
-	metadataPutMetricDataInput `json:"-" xml:"-"`
-}
-
-type metadataPutMetricDataInput struct {
-	SDKShapeTraits bool `type:"structure"`
+	_ struct{} `type:"structure"`
 }
 
 // String returns the string representation
@@ -1281,11 +1177,7 @@ func (s PutMetricDataInput) GoString() string {
 }
 
 type PutMetricDataOutput struct {
-	metadataPutMetricDataOutput `json:"-" xml:"-"`
-}
-
-type metadataPutMetricDataOutput struct {
-	SDKShapeTraits bool `type:"structure"`
+	_ struct{} `type:"structure"`
 }
 
 // String returns the string representation
@@ -1314,11 +1206,7 @@ type SetAlarmStateInput struct {
 	// The value of the state.
 	StateValue *string `type:"string" required:"true" enum:"StateValue"`
 
-	metadataSetAlarmStateInput `json:"-" xml:"-"`
-}
-
-type metadataSetAlarmStateInput struct {
-	SDKShapeTraits bool `type:"structure"`
+	_ struct{} `type:"structure"`
 }
 
 // String returns the string representation
@@ -1332,11 +1220,7 @@ func (s SetAlarmStateInput) GoString() string {
 }
 
 type SetAlarmStateOutput struct {
-	metadataSetAlarmStateOutput `json:"-" xml:"-"`
-}
-
-type metadataSetAlarmStateOutput struct {
-	SDKShapeTraits bool `type:"structure"`
+	_ struct{} `type:"structure"`
 }
 
 // String returns the string representation
@@ -1364,11 +1248,7 @@ type StatisticSet struct {
 	// The sum of values for the sample set.
 	Sum *float64 `type:"double" required:"true"`
 
-	metadataStatisticSet `json:"-" xml:"-"`
-}
-
-type metadataStatisticSet struct {
-	SDKShapeTraits bool `type:"structure"`
+	_ struct{} `type:"structure"`
 }
 
 // String returns the string representation

--- a/service/cloudwatchlogs/api.go
+++ b/service/cloudwatchlogs/api.go
@@ -911,10 +911,10 @@ func (c *CloudWatchLogs) TestMetricFilter(input *TestMetricFilterInput) (*TestMe
 }
 
 type CancelExportTaskInput struct {
+	_ struct{} `type:"structure"`
+
 	// Id of the export task to cancel.
 	TaskId *string `locationName:"taskId" min:"1" type:"string" required:"true"`
-
-	_ struct{} `type:"structure"`
 }
 
 // String returns the string representation
@@ -942,6 +942,8 @@ func (s CancelExportTaskOutput) GoString() string {
 }
 
 type CreateExportTaskInput struct {
+	_ struct{} `type:"structure"`
+
 	// Name of Amazon S3 bucket to which the log data will be exported. NOTE: Only
 	// buckets in the same AWS region are supported
 	Destination *string `locationName:"destination" min:"1" type:"string" required:"true"`
@@ -967,8 +969,6 @@ type CreateExportTaskInput struct {
 	// A unix timestamp indicating the end time of the range for the request. Events
 	// with a timestamp later than this time will not be exported.
 	To *int64 `locationName:"to" type:"long" required:"true"`
-
-	_ struct{} `type:"structure"`
 }
 
 // String returns the string representation
@@ -982,10 +982,10 @@ func (s CreateExportTaskInput) GoString() string {
 }
 
 type CreateExportTaskOutput struct {
+	_ struct{} `type:"structure"`
+
 	// Id of the export task that got created.
 	TaskId *string `locationName:"taskId" min:"1" type:"string"`
-
-	_ struct{} `type:"structure"`
 }
 
 // String returns the string representation
@@ -999,10 +999,10 @@ func (s CreateExportTaskOutput) GoString() string {
 }
 
 type CreateLogGroupInput struct {
+	_ struct{} `type:"structure"`
+
 	// The name of the log group to create.
 	LogGroupName *string `locationName:"logGroupName" min:"1" type:"string" required:"true"`
-
-	_ struct{} `type:"structure"`
 }
 
 // String returns the string representation
@@ -1030,13 +1030,13 @@ func (s CreateLogGroupOutput) GoString() string {
 }
 
 type CreateLogStreamInput struct {
+	_ struct{} `type:"structure"`
+
 	// The name of the log group under which the log stream is to be created.
 	LogGroupName *string `locationName:"logGroupName" min:"1" type:"string" required:"true"`
 
 	// The name of the log stream to create.
 	LogStreamName *string `locationName:"logStreamName" min:"1" type:"string" required:"true"`
-
-	_ struct{} `type:"structure"`
 }
 
 // String returns the string representation
@@ -1064,10 +1064,10 @@ func (s CreateLogStreamOutput) GoString() string {
 }
 
 type DeleteDestinationInput struct {
+	_ struct{} `type:"structure"`
+
 	// The name of destination to delete.
 	DestinationName *string `locationName:"destinationName" min:"1" type:"string" required:"true"`
-
-	_ struct{} `type:"structure"`
 }
 
 // String returns the string representation
@@ -1095,10 +1095,10 @@ func (s DeleteDestinationOutput) GoString() string {
 }
 
 type DeleteLogGroupInput struct {
+	_ struct{} `type:"structure"`
+
 	// The name of the log group to delete.
 	LogGroupName *string `locationName:"logGroupName" min:"1" type:"string" required:"true"`
-
-	_ struct{} `type:"structure"`
 }
 
 // String returns the string representation
@@ -1126,13 +1126,13 @@ func (s DeleteLogGroupOutput) GoString() string {
 }
 
 type DeleteLogStreamInput struct {
+	_ struct{} `type:"structure"`
+
 	// The name of the log group under which the log stream to delete belongs.
 	LogGroupName *string `locationName:"logGroupName" min:"1" type:"string" required:"true"`
 
 	// The name of the log stream to delete.
 	LogStreamName *string `locationName:"logStreamName" min:"1" type:"string" required:"true"`
-
-	_ struct{} `type:"structure"`
 }
 
 // String returns the string representation
@@ -1160,13 +1160,13 @@ func (s DeleteLogStreamOutput) GoString() string {
 }
 
 type DeleteMetricFilterInput struct {
+	_ struct{} `type:"structure"`
+
 	// The name of the metric filter to delete.
 	FilterName *string `locationName:"filterName" min:"1" type:"string" required:"true"`
 
 	// The name of the log group that is associated with the metric filter to delete.
 	LogGroupName *string `locationName:"logGroupName" min:"1" type:"string" required:"true"`
-
-	_ struct{} `type:"structure"`
 }
 
 // String returns the string representation
@@ -1194,11 +1194,11 @@ func (s DeleteMetricFilterOutput) GoString() string {
 }
 
 type DeleteRetentionPolicyInput struct {
+	_ struct{} `type:"structure"`
+
 	// The name of the log group that is associated with the retention policy to
 	// delete.
 	LogGroupName *string `locationName:"logGroupName" min:"1" type:"string" required:"true"`
-
-	_ struct{} `type:"structure"`
 }
 
 // String returns the string representation
@@ -1226,14 +1226,14 @@ func (s DeleteRetentionPolicyOutput) GoString() string {
 }
 
 type DeleteSubscriptionFilterInput struct {
+	_ struct{} `type:"structure"`
+
 	// The name of the subscription filter to delete.
 	FilterName *string `locationName:"filterName" min:"1" type:"string" required:"true"`
 
 	// The name of the log group that is associated with the subscription filter
 	// to delete.
 	LogGroupName *string `locationName:"logGroupName" min:"1" type:"string" required:"true"`
-
-	_ struct{} `type:"structure"`
 }
 
 // String returns the string representation
@@ -1261,6 +1261,8 @@ func (s DeleteSubscriptionFilterOutput) GoString() string {
 }
 
 type DescribeDestinationsInput struct {
+	_ struct{} `type:"structure"`
+
 	// Will only return destinations that match the provided destinationNamePrefix.
 	// If you don't specify a value, no prefix is applied.
 	DestinationNamePrefix *string `min:"1" type:"string"`
@@ -1272,8 +1274,6 @@ type DescribeDestinationsInput struct {
 	// It must be a value obtained from the response of the previous request. The
 	// token expires after 24 hours.
 	NextToken *string `locationName:"nextToken" min:"1" type:"string"`
-
-	_ struct{} `type:"structure"`
 }
 
 // String returns the string representation
@@ -1287,14 +1287,14 @@ func (s DescribeDestinationsInput) GoString() string {
 }
 
 type DescribeDestinationsOutput struct {
+	_ struct{} `type:"structure"`
+
 	Destinations []*Destination `locationName:"destinations" type:"list"`
 
 	// A string token used for pagination that points to the next page of results.
 	// It must be a value obtained from the response of the previous request. The
 	// token expires after 24 hours.
 	NextToken *string `locationName:"nextToken" min:"1" type:"string"`
-
-	_ struct{} `type:"structure"`
 }
 
 // String returns the string representation
@@ -1308,6 +1308,8 @@ func (s DescribeDestinationsOutput) GoString() string {
 }
 
 type DescribeExportTasksInput struct {
+	_ struct{} `type:"structure"`
+
 	// The maximum number of items returned in the response. If you don't specify
 	// a value, the request would return up to 50 items.
 	Limit *int64 `locationName:"limit" min:"1" type:"integer"`
@@ -1324,8 +1326,6 @@ type DescribeExportTasksInput struct {
 	// Export task that matches the specified task Id will be returned. This can
 	// result in zero or one export task.
 	TaskId *string `locationName:"taskId" min:"1" type:"string"`
-
-	_ struct{} `type:"structure"`
 }
 
 // String returns the string representation
@@ -1339,6 +1339,8 @@ func (s DescribeExportTasksInput) GoString() string {
 }
 
 type DescribeExportTasksOutput struct {
+	_ struct{} `type:"structure"`
+
 	// A list of export tasks.
 	ExportTasks []*ExportTask `locationName:"exportTasks" type:"list"`
 
@@ -1346,8 +1348,6 @@ type DescribeExportTasksOutput struct {
 	// It must be a value obtained from the response of the previous request. The
 	// token expires after 24 hours.
 	NextToken *string `locationName:"nextToken" min:"1" type:"string"`
-
-	_ struct{} `type:"structure"`
 }
 
 // String returns the string representation
@@ -1361,6 +1361,8 @@ func (s DescribeExportTasksOutput) GoString() string {
 }
 
 type DescribeLogGroupsInput struct {
+	_ struct{} `type:"structure"`
+
 	// The maximum number of items returned in the response. If you don't specify
 	// a value, the request would return up to 50 items.
 	Limit *int64 `locationName:"limit" min:"1" type:"integer"`
@@ -1373,8 +1375,6 @@ type DescribeLogGroupsInput struct {
 	// It must be a value obtained from the response of the previous DescribeLogGroups
 	// request.
 	NextToken *string `locationName:"nextToken" min:"1" type:"string"`
-
-	_ struct{} `type:"structure"`
 }
 
 // String returns the string representation
@@ -1388,6 +1388,8 @@ func (s DescribeLogGroupsInput) GoString() string {
 }
 
 type DescribeLogGroupsOutput struct {
+	_ struct{} `type:"structure"`
+
 	// A list of log groups.
 	LogGroups []*LogGroup `locationName:"logGroups" type:"list"`
 
@@ -1395,8 +1397,6 @@ type DescribeLogGroupsOutput struct {
 	// It must be a value obtained from the response of the previous request. The
 	// token expires after 24 hours.
 	NextToken *string `locationName:"nextToken" min:"1" type:"string"`
-
-	_ struct{} `type:"structure"`
 }
 
 // String returns the string representation
@@ -1410,6 +1410,8 @@ func (s DescribeLogGroupsOutput) GoString() string {
 }
 
 type DescribeLogStreamsInput struct {
+	_ struct{} `type:"structure"`
+
 	// If set to true, results are returned in descending order. If you don't specify
 	// a value or set it to false, results are returned in ascending order.
 	Descending *bool `locationName:"descending" type:"boolean"`
@@ -1435,8 +1437,6 @@ type DescribeLogStreamsInput struct {
 	// are ordered by LogStreamName. If 'LastEventTime' is chosen, the request cannot
 	// also contain a logStreamNamePrefix.
 	OrderBy *string `locationName:"orderBy" type:"string" enum:"OrderBy"`
-
-	_ struct{} `type:"structure"`
 }
 
 // String returns the string representation
@@ -1450,6 +1450,8 @@ func (s DescribeLogStreamsInput) GoString() string {
 }
 
 type DescribeLogStreamsOutput struct {
+	_ struct{} `type:"structure"`
+
 	// A list of log streams.
 	LogStreams []*LogStream `locationName:"logStreams" type:"list"`
 
@@ -1457,8 +1459,6 @@ type DescribeLogStreamsOutput struct {
 	// It must be a value obtained from the response of the previous request. The
 	// token expires after 24 hours.
 	NextToken *string `locationName:"nextToken" min:"1" type:"string"`
-
-	_ struct{} `type:"structure"`
 }
 
 // String returns the string representation
@@ -1472,6 +1472,8 @@ func (s DescribeLogStreamsOutput) GoString() string {
 }
 
 type DescribeMetricFiltersInput struct {
+	_ struct{} `type:"structure"`
+
 	// Will only return metric filters that match the provided filterNamePrefix.
 	// If you don't specify a value, no prefix filter is applied.
 	FilterNamePrefix *string `locationName:"filterNamePrefix" min:"1" type:"string"`
@@ -1487,8 +1489,6 @@ type DescribeMetricFiltersInput struct {
 	// It must be a value obtained from the response of the previous DescribeMetricFilters
 	// request.
 	NextToken *string `locationName:"nextToken" min:"1" type:"string"`
-
-	_ struct{} `type:"structure"`
 }
 
 // String returns the string representation
@@ -1502,14 +1502,14 @@ func (s DescribeMetricFiltersInput) GoString() string {
 }
 
 type DescribeMetricFiltersOutput struct {
+	_ struct{} `type:"structure"`
+
 	MetricFilters []*MetricFilter `locationName:"metricFilters" type:"list"`
 
 	// A string token used for pagination that points to the next page of results.
 	// It must be a value obtained from the response of the previous request. The
 	// token expires after 24 hours.
 	NextToken *string `locationName:"nextToken" min:"1" type:"string"`
-
-	_ struct{} `type:"structure"`
 }
 
 // String returns the string representation
@@ -1523,6 +1523,8 @@ func (s DescribeMetricFiltersOutput) GoString() string {
 }
 
 type DescribeSubscriptionFiltersInput struct {
+	_ struct{} `type:"structure"`
+
 	// Will only return subscription filters that match the provided filterNamePrefix.
 	// If you don't specify a value, no prefix filter is applied.
 	FilterNamePrefix *string `locationName:"filterNamePrefix" min:"1" type:"string"`
@@ -1537,8 +1539,6 @@ type DescribeSubscriptionFiltersInput struct {
 	// It must be a value obtained from the response of the previous request. The
 	// token expires after 24 hours.
 	NextToken *string `locationName:"nextToken" min:"1" type:"string"`
-
-	_ struct{} `type:"structure"`
 }
 
 // String returns the string representation
@@ -1552,14 +1552,14 @@ func (s DescribeSubscriptionFiltersInput) GoString() string {
 }
 
 type DescribeSubscriptionFiltersOutput struct {
+	_ struct{} `type:"structure"`
+
 	// A string token used for pagination that points to the next page of results.
 	// It must be a value obtained from the response of the previous request. The
 	// token expires after 24 hours.
 	NextToken *string `locationName:"nextToken" min:"1" type:"string"`
 
 	SubscriptionFilters []*SubscriptionFilter `locationName:"subscriptionFilters" type:"list"`
-
-	_ struct{} `type:"structure"`
 }
 
 // String returns the string representation
@@ -1574,6 +1574,8 @@ func (s DescribeSubscriptionFiltersOutput) GoString() string {
 
 // A cross account destination that is the recipient of subscription log events.
 type Destination struct {
+	_ struct{} `type:"structure"`
+
 	// An IAM policy document that governs which AWS accounts can create subscription
 	// filters against this destination.
 	AccessPolicy *string `locationName:"accessPolicy" min:"1" type:"string"`
@@ -1594,8 +1596,6 @@ type Destination struct {
 	// ARN of the physical target where the log events will be delivered (eg. ARN
 	// of a Kinesis stream).
 	TargetArn *string `locationName:"targetArn" min:"1" type:"string"`
-
-	_ struct{} `type:"structure"`
 }
 
 // String returns the string representation
@@ -1610,6 +1610,8 @@ func (s Destination) GoString() string {
 
 // Represents an export task.
 type ExportTask struct {
+	_ struct{} `type:"structure"`
+
 	// Name of Amazon S3 bucket to which the log data was exported.
 	Destination *string `locationName:"destination" min:"1" type:"string"`
 
@@ -1638,8 +1640,6 @@ type ExportTask struct {
 	// A unix timestamp indicating the end time of the range for the request. Events
 	// with a timestamp later than this time were not exported.
 	To *int64 `locationName:"to" type:"long"`
-
-	_ struct{} `type:"structure"`
 }
 
 // String returns the string representation
@@ -1654,13 +1654,13 @@ func (s ExportTask) GoString() string {
 
 // Represents the status of an export task.
 type ExportTaskExecutionInfo struct {
+	_ struct{} `type:"structure"`
+
 	// A point in time when the export task got completed.
 	CompletionTime *int64 `locationName:"completionTime" type:"long"`
 
 	// A point in time when the export task got created.
 	CreationTime *int64 `locationName:"creationTime" type:"long"`
-
-	_ struct{} `type:"structure"`
 }
 
 // String returns the string representation
@@ -1675,13 +1675,13 @@ func (s ExportTaskExecutionInfo) GoString() string {
 
 // Represents the status of an export task.
 type ExportTaskStatus struct {
+	_ struct{} `type:"structure"`
+
 	// Status code of the export task.
 	Code *string `locationName:"code" type:"string" enum:"ExportTaskStatusCode"`
 
 	// Status message related to the code.
 	Message *string `locationName:"message" type:"string"`
-
-	_ struct{} `type:"structure"`
 }
 
 // String returns the string representation
@@ -1695,6 +1695,8 @@ func (s ExportTaskStatus) GoString() string {
 }
 
 type FilterLogEventsInput struct {
+	_ struct{} `type:"structure"`
+
 	// A unix timestamp indicating the end time of the range for the request. If
 	// provided, events with a timestamp later than this time will not be returned.
 	EndTime *int64 `locationName:"endTime" type:"long"`
@@ -1727,8 +1729,6 @@ type FilterLogEventsInput struct {
 	// A unix timestamp indicating the start time of the range for the request.
 	// If provided, events with a timestamp prior to this time will not be returned.
 	StartTime *int64 `locationName:"startTime" type:"long"`
-
-	_ struct{} `type:"structure"`
 }
 
 // String returns the string representation
@@ -1742,6 +1742,8 @@ func (s FilterLogEventsInput) GoString() string {
 }
 
 type FilterLogEventsOutput struct {
+	_ struct{} `type:"structure"`
+
 	// A list of FilteredLogEvent objects representing the matched events from the
 	// request.
 	Events []*FilteredLogEvent `locationName:"events" type:"list"`
@@ -1754,8 +1756,6 @@ type FilterLogEventsOutput struct {
 	// searched in this request and whether each has been searched completely or
 	// still has more to be paginated.
 	SearchedLogStreams []*SearchedLogStream `locationName:"searchedLogStreams" type:"list"`
-
-	_ struct{} `type:"structure"`
 }
 
 // String returns the string representation
@@ -1770,6 +1770,8 @@ func (s FilterLogEventsOutput) GoString() string {
 
 // Represents a matched event from a FilterLogEvents request.
 type FilteredLogEvent struct {
+	_ struct{} `type:"structure"`
+
 	// A unique identifier for this event.
 	EventId *string `locationName:"eventId" type:"string"`
 
@@ -1786,8 +1788,6 @@ type FilteredLogEvent struct {
 	// A point in time expressed as the number of milliseconds since Jan 1, 1970
 	// 00:00:00 UTC.
 	Timestamp *int64 `locationName:"timestamp" type:"long"`
-
-	_ struct{} `type:"structure"`
 }
 
 // String returns the string representation
@@ -1801,6 +1801,8 @@ func (s FilteredLogEvent) GoString() string {
 }
 
 type GetLogEventsInput struct {
+	_ struct{} `type:"structure"`
+
 	// A point in time expressed as the number of milliseconds since Jan 1, 1970
 	// 00:00:00 UTC.
 	EndTime *int64 `locationName:"endTime" type:"long"`
@@ -1828,8 +1830,6 @@ type GetLogEventsInput struct {
 	// A point in time expressed as the number of milliseconds since Jan 1, 1970
 	// 00:00:00 UTC.
 	StartTime *int64 `locationName:"startTime" type:"long"`
-
-	_ struct{} `type:"structure"`
 }
 
 // String returns the string representation
@@ -1843,6 +1843,8 @@ func (s GetLogEventsInput) GoString() string {
 }
 
 type GetLogEventsOutput struct {
+	_ struct{} `type:"structure"`
+
 	Events []*OutputLogEvent `locationName:"events" type:"list"`
 
 	// A string token used for pagination that points to the next page of results.
@@ -1854,8 +1856,6 @@ type GetLogEventsOutput struct {
 	// It must be a value obtained from the response of the previous request. The
 	// token expires after 24 hours.
 	NextForwardToken *string `locationName:"nextForwardToken" min:"1" type:"string"`
-
-	_ struct{} `type:"structure"`
 }
 
 // String returns the string representation
@@ -1873,13 +1873,13 @@ func (s GetLogEventsOutput) GoString() string {
 // Logs understands contains two properties: the timestamp of when the event
 // occurred, and the raw event message.
 type InputLogEvent struct {
+	_ struct{} `type:"structure"`
+
 	Message *string `locationName:"message" min:"1" type:"string" required:"true"`
 
 	// A point in time expressed as the number of milliseconds since Jan 1, 1970
 	// 00:00:00 UTC.
 	Timestamp *int64 `locationName:"timestamp" type:"long" required:"true"`
-
-	_ struct{} `type:"structure"`
 }
 
 // String returns the string representation
@@ -1893,6 +1893,8 @@ func (s InputLogEvent) GoString() string {
 }
 
 type LogGroup struct {
+	_ struct{} `type:"structure"`
+
 	Arn *string `locationName:"arn" type:"string"`
 
 	// A point in time expressed as the number of milliseconds since Jan 1, 1970
@@ -1910,8 +1912,6 @@ type LogGroup struct {
 	RetentionInDays *int64 `locationName:"retentionInDays" type:"integer"`
 
 	StoredBytes *int64 `locationName:"storedBytes" type:"long"`
-
-	_ struct{} `type:"structure"`
 }
 
 // String returns the string representation
@@ -1926,6 +1926,8 @@ func (s LogGroup) GoString() string {
 
 // A log stream is sequence of log events from a single emitter of logs.
 type LogStream struct {
+	_ struct{} `type:"structure"`
+
 	Arn *string `locationName:"arn" type:"string"`
 
 	// A point in time expressed as the number of milliseconds since Jan 1, 1970
@@ -1952,8 +1954,6 @@ type LogStream struct {
 	// only be used once, and PutLogEvents requests must include the sequenceToken
 	// obtained from the response of the previous request.
 	UploadSequenceToken *string `locationName:"uploadSequenceToken" min:"1" type:"string"`
-
-	_ struct{} `type:"structure"`
 }
 
 // String returns the string representation
@@ -1970,6 +1970,8 @@ func (s LogStream) GoString() string {
 // metric observations from ingested log events and transform them to metric
 // data in a CloudWatch metric.
 type MetricFilter struct {
+	_ struct{} `type:"structure"`
+
 	// A point in time expressed as the number of milliseconds since Jan 1, 1970
 	// 00:00:00 UTC.
 	CreationTime *int64 `locationName:"creationTime" type:"long"`
@@ -1984,8 +1986,6 @@ type MetricFilter struct {
 	FilterPattern *string `locationName:"filterPattern" type:"string"`
 
 	MetricTransformations []*MetricTransformation `locationName:"metricTransformations" min:"1" type:"list"`
-
-	_ struct{} `type:"structure"`
 }
 
 // String returns the string representation
@@ -1999,13 +1999,13 @@ func (s MetricFilter) GoString() string {
 }
 
 type MetricFilterMatchRecord struct {
+	_ struct{} `type:"structure"`
+
 	EventMessage *string `locationName:"eventMessage" min:"1" type:"string"`
 
 	EventNumber *int64 `locationName:"eventNumber" type:"long"`
 
 	ExtractedValues map[string]*string `locationName:"extractedValues" type:"map"`
-
-	_ struct{} `type:"structure"`
 }
 
 // String returns the string representation
@@ -2019,6 +2019,8 @@ func (s MetricFilterMatchRecord) GoString() string {
 }
 
 type MetricTransformation struct {
+	_ struct{} `type:"structure"`
+
 	// The name of the CloudWatch metric to which the monitored log information
 	// should be published. For example, you may publish to a metric called ErrorCount.
 	MetricName *string `locationName:"metricName" type:"string" required:"true"`
@@ -2031,8 +2033,6 @@ type MetricTransformation struct {
 	// If you're counting the bytes transferred the published value will be the
 	// value in the log event.
 	MetricValue *string `locationName:"metricValue" type:"string" required:"true"`
-
-	_ struct{} `type:"structure"`
 }
 
 // String returns the string representation
@@ -2046,6 +2046,8 @@ func (s MetricTransformation) GoString() string {
 }
 
 type OutputLogEvent struct {
+	_ struct{} `type:"structure"`
+
 	// A point in time expressed as the number of milliseconds since Jan 1, 1970
 	// 00:00:00 UTC.
 	IngestionTime *int64 `locationName:"ingestionTime" type:"long"`
@@ -2055,8 +2057,6 @@ type OutputLogEvent struct {
 	// A point in time expressed as the number of milliseconds since Jan 1, 1970
 	// 00:00:00 UTC.
 	Timestamp *int64 `locationName:"timestamp" type:"long"`
-
-	_ struct{} `type:"structure"`
 }
 
 // String returns the string representation
@@ -2070,6 +2070,8 @@ func (s OutputLogEvent) GoString() string {
 }
 
 type PutDestinationInput struct {
+	_ struct{} `type:"structure"`
+
 	// A name for the destination.
 	DestinationName *string `locationName:"destinationName" min:"1" type:"string" required:"true"`
 
@@ -2079,8 +2081,6 @@ type PutDestinationInput struct {
 
 	// The ARN of an Amazon Kinesis stream to deliver matching log events to.
 	TargetArn *string `locationName:"targetArn" min:"1" type:"string" required:"true"`
-
-	_ struct{} `type:"structure"`
 }
 
 // String returns the string representation
@@ -2094,10 +2094,10 @@ func (s PutDestinationInput) GoString() string {
 }
 
 type PutDestinationOutput struct {
+	_ struct{} `type:"structure"`
+
 	// A cross account destination that is the recipient of subscription log events.
 	Destination *Destination `locationName:"destination" type:"structure"`
-
-	_ struct{} `type:"structure"`
 }
 
 // String returns the string representation
@@ -2111,14 +2111,14 @@ func (s PutDestinationOutput) GoString() string {
 }
 
 type PutDestinationPolicyInput struct {
+	_ struct{} `type:"structure"`
+
 	// An IAM policy document that authorizes cross-account users to deliver their
 	// log events to associated destination.
 	AccessPolicy *string `locationName:"accessPolicy" min:"1" type:"string" required:"true"`
 
 	// A name for an existing destination.
 	DestinationName *string `locationName:"destinationName" min:"1" type:"string" required:"true"`
-
-	_ struct{} `type:"structure"`
 }
 
 // String returns the string representation
@@ -2146,6 +2146,8 @@ func (s PutDestinationPolicyOutput) GoString() string {
 }
 
 type PutLogEventsInput struct {
+	_ struct{} `type:"structure"`
+
 	// A list of log events belonging to a log stream.
 	LogEvents []*InputLogEvent `locationName:"logEvents" min:"1" type:"list" required:"true"`
 
@@ -2158,8 +2160,6 @@ type PutLogEventsInput struct {
 	// A string token that must be obtained from the response of the previous PutLogEvents
 	// request.
 	SequenceToken *string `locationName:"sequenceToken" min:"1" type:"string"`
-
-	_ struct{} `type:"structure"`
 }
 
 // String returns the string representation
@@ -2173,14 +2173,14 @@ func (s PutLogEventsInput) GoString() string {
 }
 
 type PutLogEventsOutput struct {
+	_ struct{} `type:"structure"`
+
 	// A string token used for making PutLogEvents requests. A sequenceToken can
 	// only be used once, and PutLogEvents requests must include the sequenceToken
 	// obtained from the response of the previous request.
 	NextSequenceToken *string `locationName:"nextSequenceToken" min:"1" type:"string"`
 
 	RejectedLogEventsInfo *RejectedLogEventsInfo `locationName:"rejectedLogEventsInfo" type:"structure"`
-
-	_ struct{} `type:"structure"`
 }
 
 // String returns the string representation
@@ -2194,6 +2194,8 @@ func (s PutLogEventsOutput) GoString() string {
 }
 
 type PutMetricFilterInput struct {
+	_ struct{} `type:"structure"`
+
 	// A name for the metric filter.
 	FilterName *string `locationName:"filterName" min:"1" type:"string" required:"true"`
 
@@ -2206,8 +2208,6 @@ type PutMetricFilterInput struct {
 
 	// A collection of information needed to define how metric data gets emitted.
 	MetricTransformations []*MetricTransformation `locationName:"metricTransformations" min:"1" type:"list" required:"true"`
-
-	_ struct{} `type:"structure"`
 }
 
 // String returns the string representation
@@ -2235,6 +2235,8 @@ func (s PutMetricFilterOutput) GoString() string {
 }
 
 type PutRetentionPolicyInput struct {
+	_ struct{} `type:"structure"`
+
 	// The name of the log group to associate the retention policy with.
 	LogGroupName *string `locationName:"logGroupName" min:"1" type:"string" required:"true"`
 
@@ -2242,8 +2244,6 @@ type PutRetentionPolicyInput struct {
 	// log group. Possible values are: 1, 3, 5, 7, 14, 30, 60, 90, 120, 150, 180,
 	// 365, 400, 545, 731, 1827, 3653.
 	RetentionInDays *int64 `locationName:"retentionInDays" type:"integer" required:"true"`
-
-	_ struct{} `type:"structure"`
 }
 
 // String returns the string representation
@@ -2271,6 +2271,8 @@ func (s PutRetentionPolicyOutput) GoString() string {
 }
 
 type PutSubscriptionFilterInput struct {
+	_ struct{} `type:"structure"`
+
 	// The ARN of the destination to deliver matching log events to. Currently,
 	// the supported destinations are:   A Amazon Kinesis stream belonging to the
 	// same account as the subscription filter, for same-account delivery.   A logical
@@ -2293,8 +2295,6 @@ type PutSubscriptionFilterInput struct {
 	// provide the ARN when you are working with a logical destination (used via
 	// an ARN of Destination) for cross-account delivery.
 	RoleArn *string `locationName:"roleArn" min:"1" type:"string"`
-
-	_ struct{} `type:"structure"`
 }
 
 // String returns the string representation
@@ -2322,13 +2322,13 @@ func (s PutSubscriptionFilterOutput) GoString() string {
 }
 
 type RejectedLogEventsInfo struct {
+	_ struct{} `type:"structure"`
+
 	ExpiredLogEventEndIndex *int64 `locationName:"expiredLogEventEndIndex" type:"integer"`
 
 	TooNewLogEventStartIndex *int64 `locationName:"tooNewLogEventStartIndex" type:"integer"`
 
 	TooOldLogEventEndIndex *int64 `locationName:"tooOldLogEventEndIndex" type:"integer"`
-
-	_ struct{} `type:"structure"`
 }
 
 // String returns the string representation
@@ -2344,14 +2344,14 @@ func (s RejectedLogEventsInfo) GoString() string {
 // An object indicating the search status of a log stream in a FilterLogEvents
 // request.
 type SearchedLogStream struct {
+	_ struct{} `type:"structure"`
+
 	// The name of the log stream.
 	LogStreamName *string `locationName:"logStreamName" min:"1" type:"string"`
 
 	// Indicates whether all the events in this log stream were searched or more
 	// data exists to search by paginating further.
 	SearchedCompletely *bool `locationName:"searchedCompletely" type:"boolean"`
-
-	_ struct{} `type:"structure"`
 }
 
 // String returns the string representation
@@ -2365,6 +2365,8 @@ func (s SearchedLogStream) GoString() string {
 }
 
 type SubscriptionFilter struct {
+	_ struct{} `type:"structure"`
+
 	// A point in time expressed as the number of milliseconds since Jan 1, 1970
 	// 00:00:00 UTC.
 	CreationTime *int64 `locationName:"creationTime" type:"long"`
@@ -2383,8 +2385,6 @@ type SubscriptionFilter struct {
 	LogGroupName *string `locationName:"logGroupName" min:"1" type:"string"`
 
 	RoleArn *string `locationName:"roleArn" min:"1" type:"string"`
-
-	_ struct{} `type:"structure"`
 }
 
 // String returns the string representation
@@ -2398,6 +2398,8 @@ func (s SubscriptionFilter) GoString() string {
 }
 
 type TestMetricFilterInput struct {
+	_ struct{} `type:"structure"`
+
 	// A symbolic description of how Amazon CloudWatch Logs should interpret the
 	// data in each log event. For example, a log event may contain timestamps,
 	// IP addresses, strings, and so on. You use the filter pattern to specify what
@@ -2406,8 +2408,6 @@ type TestMetricFilterInput struct {
 
 	// A list of log event messages to test.
 	LogEventMessages []*string `locationName:"logEventMessages" min:"1" type:"list" required:"true"`
-
-	_ struct{} `type:"structure"`
 }
 
 // String returns the string representation
@@ -2421,9 +2421,9 @@ func (s TestMetricFilterInput) GoString() string {
 }
 
 type TestMetricFilterOutput struct {
-	Matches []*MetricFilterMatchRecord `locationName:"matches" type:"list"`
-
 	_ struct{} `type:"structure"`
+
+	Matches []*MetricFilterMatchRecord `locationName:"matches" type:"list"`
 }
 
 // String returns the string representation

--- a/service/cloudwatchlogs/api.go
+++ b/service/cloudwatchlogs/api.go
@@ -914,11 +914,7 @@ type CancelExportTaskInput struct {
 	// Id of the export task to cancel.
 	TaskId *string `locationName:"taskId" min:"1" type:"string" required:"true"`
 
-	metadataCancelExportTaskInput `json:"-" xml:"-"`
-}
-
-type metadataCancelExportTaskInput struct {
-	SDKShapeTraits bool `type:"structure"`
+	_ struct{} `type:"structure"`
 }
 
 // String returns the string representation
@@ -932,11 +928,7 @@ func (s CancelExportTaskInput) GoString() string {
 }
 
 type CancelExportTaskOutput struct {
-	metadataCancelExportTaskOutput `json:"-" xml:"-"`
-}
-
-type metadataCancelExportTaskOutput struct {
-	SDKShapeTraits bool `type:"structure"`
+	_ struct{} `type:"structure"`
 }
 
 // String returns the string representation
@@ -976,11 +968,7 @@ type CreateExportTaskInput struct {
 	// with a timestamp later than this time will not be exported.
 	To *int64 `locationName:"to" type:"long" required:"true"`
 
-	metadataCreateExportTaskInput `json:"-" xml:"-"`
-}
-
-type metadataCreateExportTaskInput struct {
-	SDKShapeTraits bool `type:"structure"`
+	_ struct{} `type:"structure"`
 }
 
 // String returns the string representation
@@ -997,11 +985,7 @@ type CreateExportTaskOutput struct {
 	// Id of the export task that got created.
 	TaskId *string `locationName:"taskId" min:"1" type:"string"`
 
-	metadataCreateExportTaskOutput `json:"-" xml:"-"`
-}
-
-type metadataCreateExportTaskOutput struct {
-	SDKShapeTraits bool `type:"structure"`
+	_ struct{} `type:"structure"`
 }
 
 // String returns the string representation
@@ -1018,11 +1002,7 @@ type CreateLogGroupInput struct {
 	// The name of the log group to create.
 	LogGroupName *string `locationName:"logGroupName" min:"1" type:"string" required:"true"`
 
-	metadataCreateLogGroupInput `json:"-" xml:"-"`
-}
-
-type metadataCreateLogGroupInput struct {
-	SDKShapeTraits bool `type:"structure"`
+	_ struct{} `type:"structure"`
 }
 
 // String returns the string representation
@@ -1036,11 +1016,7 @@ func (s CreateLogGroupInput) GoString() string {
 }
 
 type CreateLogGroupOutput struct {
-	metadataCreateLogGroupOutput `json:"-" xml:"-"`
-}
-
-type metadataCreateLogGroupOutput struct {
-	SDKShapeTraits bool `type:"structure"`
+	_ struct{} `type:"structure"`
 }
 
 // String returns the string representation
@@ -1060,11 +1036,7 @@ type CreateLogStreamInput struct {
 	// The name of the log stream to create.
 	LogStreamName *string `locationName:"logStreamName" min:"1" type:"string" required:"true"`
 
-	metadataCreateLogStreamInput `json:"-" xml:"-"`
-}
-
-type metadataCreateLogStreamInput struct {
-	SDKShapeTraits bool `type:"structure"`
+	_ struct{} `type:"structure"`
 }
 
 // String returns the string representation
@@ -1078,11 +1050,7 @@ func (s CreateLogStreamInput) GoString() string {
 }
 
 type CreateLogStreamOutput struct {
-	metadataCreateLogStreamOutput `json:"-" xml:"-"`
-}
-
-type metadataCreateLogStreamOutput struct {
-	SDKShapeTraits bool `type:"structure"`
+	_ struct{} `type:"structure"`
 }
 
 // String returns the string representation
@@ -1099,11 +1067,7 @@ type DeleteDestinationInput struct {
 	// The name of destination to delete.
 	DestinationName *string `locationName:"destinationName" min:"1" type:"string" required:"true"`
 
-	metadataDeleteDestinationInput `json:"-" xml:"-"`
-}
-
-type metadataDeleteDestinationInput struct {
-	SDKShapeTraits bool `type:"structure"`
+	_ struct{} `type:"structure"`
 }
 
 // String returns the string representation
@@ -1117,11 +1081,7 @@ func (s DeleteDestinationInput) GoString() string {
 }
 
 type DeleteDestinationOutput struct {
-	metadataDeleteDestinationOutput `json:"-" xml:"-"`
-}
-
-type metadataDeleteDestinationOutput struct {
-	SDKShapeTraits bool `type:"structure"`
+	_ struct{} `type:"structure"`
 }
 
 // String returns the string representation
@@ -1138,11 +1098,7 @@ type DeleteLogGroupInput struct {
 	// The name of the log group to delete.
 	LogGroupName *string `locationName:"logGroupName" min:"1" type:"string" required:"true"`
 
-	metadataDeleteLogGroupInput `json:"-" xml:"-"`
-}
-
-type metadataDeleteLogGroupInput struct {
-	SDKShapeTraits bool `type:"structure"`
+	_ struct{} `type:"structure"`
 }
 
 // String returns the string representation
@@ -1156,11 +1112,7 @@ func (s DeleteLogGroupInput) GoString() string {
 }
 
 type DeleteLogGroupOutput struct {
-	metadataDeleteLogGroupOutput `json:"-" xml:"-"`
-}
-
-type metadataDeleteLogGroupOutput struct {
-	SDKShapeTraits bool `type:"structure"`
+	_ struct{} `type:"structure"`
 }
 
 // String returns the string representation
@@ -1180,11 +1132,7 @@ type DeleteLogStreamInput struct {
 	// The name of the log stream to delete.
 	LogStreamName *string `locationName:"logStreamName" min:"1" type:"string" required:"true"`
 
-	metadataDeleteLogStreamInput `json:"-" xml:"-"`
-}
-
-type metadataDeleteLogStreamInput struct {
-	SDKShapeTraits bool `type:"structure"`
+	_ struct{} `type:"structure"`
 }
 
 // String returns the string representation
@@ -1198,11 +1146,7 @@ func (s DeleteLogStreamInput) GoString() string {
 }
 
 type DeleteLogStreamOutput struct {
-	metadataDeleteLogStreamOutput `json:"-" xml:"-"`
-}
-
-type metadataDeleteLogStreamOutput struct {
-	SDKShapeTraits bool `type:"structure"`
+	_ struct{} `type:"structure"`
 }
 
 // String returns the string representation
@@ -1222,11 +1166,7 @@ type DeleteMetricFilterInput struct {
 	// The name of the log group that is associated with the metric filter to delete.
 	LogGroupName *string `locationName:"logGroupName" min:"1" type:"string" required:"true"`
 
-	metadataDeleteMetricFilterInput `json:"-" xml:"-"`
-}
-
-type metadataDeleteMetricFilterInput struct {
-	SDKShapeTraits bool `type:"structure"`
+	_ struct{} `type:"structure"`
 }
 
 // String returns the string representation
@@ -1240,11 +1180,7 @@ func (s DeleteMetricFilterInput) GoString() string {
 }
 
 type DeleteMetricFilterOutput struct {
-	metadataDeleteMetricFilterOutput `json:"-" xml:"-"`
-}
-
-type metadataDeleteMetricFilterOutput struct {
-	SDKShapeTraits bool `type:"structure"`
+	_ struct{} `type:"structure"`
 }
 
 // String returns the string representation
@@ -1262,11 +1198,7 @@ type DeleteRetentionPolicyInput struct {
 	// delete.
 	LogGroupName *string `locationName:"logGroupName" min:"1" type:"string" required:"true"`
 
-	metadataDeleteRetentionPolicyInput `json:"-" xml:"-"`
-}
-
-type metadataDeleteRetentionPolicyInput struct {
-	SDKShapeTraits bool `type:"structure"`
+	_ struct{} `type:"structure"`
 }
 
 // String returns the string representation
@@ -1280,11 +1212,7 @@ func (s DeleteRetentionPolicyInput) GoString() string {
 }
 
 type DeleteRetentionPolicyOutput struct {
-	metadataDeleteRetentionPolicyOutput `json:"-" xml:"-"`
-}
-
-type metadataDeleteRetentionPolicyOutput struct {
-	SDKShapeTraits bool `type:"structure"`
+	_ struct{} `type:"structure"`
 }
 
 // String returns the string representation
@@ -1305,11 +1233,7 @@ type DeleteSubscriptionFilterInput struct {
 	// to delete.
 	LogGroupName *string `locationName:"logGroupName" min:"1" type:"string" required:"true"`
 
-	metadataDeleteSubscriptionFilterInput `json:"-" xml:"-"`
-}
-
-type metadataDeleteSubscriptionFilterInput struct {
-	SDKShapeTraits bool `type:"structure"`
+	_ struct{} `type:"structure"`
 }
 
 // String returns the string representation
@@ -1323,11 +1247,7 @@ func (s DeleteSubscriptionFilterInput) GoString() string {
 }
 
 type DeleteSubscriptionFilterOutput struct {
-	metadataDeleteSubscriptionFilterOutput `json:"-" xml:"-"`
-}
-
-type metadataDeleteSubscriptionFilterOutput struct {
-	SDKShapeTraits bool `type:"structure"`
+	_ struct{} `type:"structure"`
 }
 
 // String returns the string representation
@@ -1353,11 +1273,7 @@ type DescribeDestinationsInput struct {
 	// token expires after 24 hours.
 	NextToken *string `locationName:"nextToken" min:"1" type:"string"`
 
-	metadataDescribeDestinationsInput `json:"-" xml:"-"`
-}
-
-type metadataDescribeDestinationsInput struct {
-	SDKShapeTraits bool `type:"structure"`
+	_ struct{} `type:"structure"`
 }
 
 // String returns the string representation
@@ -1378,11 +1294,7 @@ type DescribeDestinationsOutput struct {
 	// token expires after 24 hours.
 	NextToken *string `locationName:"nextToken" min:"1" type:"string"`
 
-	metadataDescribeDestinationsOutput `json:"-" xml:"-"`
-}
-
-type metadataDescribeDestinationsOutput struct {
-	SDKShapeTraits bool `type:"structure"`
+	_ struct{} `type:"structure"`
 }
 
 // String returns the string representation
@@ -1413,11 +1325,7 @@ type DescribeExportTasksInput struct {
 	// result in zero or one export task.
 	TaskId *string `locationName:"taskId" min:"1" type:"string"`
 
-	metadataDescribeExportTasksInput `json:"-" xml:"-"`
-}
-
-type metadataDescribeExportTasksInput struct {
-	SDKShapeTraits bool `type:"structure"`
+	_ struct{} `type:"structure"`
 }
 
 // String returns the string representation
@@ -1439,11 +1347,7 @@ type DescribeExportTasksOutput struct {
 	// token expires after 24 hours.
 	NextToken *string `locationName:"nextToken" min:"1" type:"string"`
 
-	metadataDescribeExportTasksOutput `json:"-" xml:"-"`
-}
-
-type metadataDescribeExportTasksOutput struct {
-	SDKShapeTraits bool `type:"structure"`
+	_ struct{} `type:"structure"`
 }
 
 // String returns the string representation
@@ -1470,11 +1374,7 @@ type DescribeLogGroupsInput struct {
 	// request.
 	NextToken *string `locationName:"nextToken" min:"1" type:"string"`
 
-	metadataDescribeLogGroupsInput `json:"-" xml:"-"`
-}
-
-type metadataDescribeLogGroupsInput struct {
-	SDKShapeTraits bool `type:"structure"`
+	_ struct{} `type:"structure"`
 }
 
 // String returns the string representation
@@ -1496,11 +1396,7 @@ type DescribeLogGroupsOutput struct {
 	// token expires after 24 hours.
 	NextToken *string `locationName:"nextToken" min:"1" type:"string"`
 
-	metadataDescribeLogGroupsOutput `json:"-" xml:"-"`
-}
-
-type metadataDescribeLogGroupsOutput struct {
-	SDKShapeTraits bool `type:"structure"`
+	_ struct{} `type:"structure"`
 }
 
 // String returns the string representation
@@ -1540,11 +1436,7 @@ type DescribeLogStreamsInput struct {
 	// also contain a logStreamNamePrefix.
 	OrderBy *string `locationName:"orderBy" type:"string" enum:"OrderBy"`
 
-	metadataDescribeLogStreamsInput `json:"-" xml:"-"`
-}
-
-type metadataDescribeLogStreamsInput struct {
-	SDKShapeTraits bool `type:"structure"`
+	_ struct{} `type:"structure"`
 }
 
 // String returns the string representation
@@ -1566,11 +1458,7 @@ type DescribeLogStreamsOutput struct {
 	// token expires after 24 hours.
 	NextToken *string `locationName:"nextToken" min:"1" type:"string"`
 
-	metadataDescribeLogStreamsOutput `json:"-" xml:"-"`
-}
-
-type metadataDescribeLogStreamsOutput struct {
-	SDKShapeTraits bool `type:"structure"`
+	_ struct{} `type:"structure"`
 }
 
 // String returns the string representation
@@ -1600,11 +1488,7 @@ type DescribeMetricFiltersInput struct {
 	// request.
 	NextToken *string `locationName:"nextToken" min:"1" type:"string"`
 
-	metadataDescribeMetricFiltersInput `json:"-" xml:"-"`
-}
-
-type metadataDescribeMetricFiltersInput struct {
-	SDKShapeTraits bool `type:"structure"`
+	_ struct{} `type:"structure"`
 }
 
 // String returns the string representation
@@ -1625,11 +1509,7 @@ type DescribeMetricFiltersOutput struct {
 	// token expires after 24 hours.
 	NextToken *string `locationName:"nextToken" min:"1" type:"string"`
 
-	metadataDescribeMetricFiltersOutput `json:"-" xml:"-"`
-}
-
-type metadataDescribeMetricFiltersOutput struct {
-	SDKShapeTraits bool `type:"structure"`
+	_ struct{} `type:"structure"`
 }
 
 // String returns the string representation
@@ -1658,11 +1538,7 @@ type DescribeSubscriptionFiltersInput struct {
 	// token expires after 24 hours.
 	NextToken *string `locationName:"nextToken" min:"1" type:"string"`
 
-	metadataDescribeSubscriptionFiltersInput `json:"-" xml:"-"`
-}
-
-type metadataDescribeSubscriptionFiltersInput struct {
-	SDKShapeTraits bool `type:"structure"`
+	_ struct{} `type:"structure"`
 }
 
 // String returns the string representation
@@ -1683,11 +1559,7 @@ type DescribeSubscriptionFiltersOutput struct {
 
 	SubscriptionFilters []*SubscriptionFilter `locationName:"subscriptionFilters" type:"list"`
 
-	metadataDescribeSubscriptionFiltersOutput `json:"-" xml:"-"`
-}
-
-type metadataDescribeSubscriptionFiltersOutput struct {
-	SDKShapeTraits bool `type:"structure"`
+	_ struct{} `type:"structure"`
 }
 
 // String returns the string representation
@@ -1723,11 +1595,7 @@ type Destination struct {
 	// of a Kinesis stream).
 	TargetArn *string `locationName:"targetArn" min:"1" type:"string"`
 
-	metadataDestination `json:"-" xml:"-"`
-}
-
-type metadataDestination struct {
-	SDKShapeTraits bool `type:"structure"`
+	_ struct{} `type:"structure"`
 }
 
 // String returns the string representation
@@ -1771,11 +1639,7 @@ type ExportTask struct {
 	// with a timestamp later than this time were not exported.
 	To *int64 `locationName:"to" type:"long"`
 
-	metadataExportTask `json:"-" xml:"-"`
-}
-
-type metadataExportTask struct {
-	SDKShapeTraits bool `type:"structure"`
+	_ struct{} `type:"structure"`
 }
 
 // String returns the string representation
@@ -1796,11 +1660,7 @@ type ExportTaskExecutionInfo struct {
 	// A point in time when the export task got created.
 	CreationTime *int64 `locationName:"creationTime" type:"long"`
 
-	metadataExportTaskExecutionInfo `json:"-" xml:"-"`
-}
-
-type metadataExportTaskExecutionInfo struct {
-	SDKShapeTraits bool `type:"structure"`
+	_ struct{} `type:"structure"`
 }
 
 // String returns the string representation
@@ -1821,11 +1681,7 @@ type ExportTaskStatus struct {
 	// Status message related to the code.
 	Message *string `locationName:"message" type:"string"`
 
-	metadataExportTaskStatus `json:"-" xml:"-"`
-}
-
-type metadataExportTaskStatus struct {
-	SDKShapeTraits bool `type:"structure"`
+	_ struct{} `type:"structure"`
 }
 
 // String returns the string representation
@@ -1872,11 +1728,7 @@ type FilterLogEventsInput struct {
 	// If provided, events with a timestamp prior to this time will not be returned.
 	StartTime *int64 `locationName:"startTime" type:"long"`
 
-	metadataFilterLogEventsInput `json:"-" xml:"-"`
-}
-
-type metadataFilterLogEventsInput struct {
-	SDKShapeTraits bool `type:"structure"`
+	_ struct{} `type:"structure"`
 }
 
 // String returns the string representation
@@ -1903,11 +1755,7 @@ type FilterLogEventsOutput struct {
 	// still has more to be paginated.
 	SearchedLogStreams []*SearchedLogStream `locationName:"searchedLogStreams" type:"list"`
 
-	metadataFilterLogEventsOutput `json:"-" xml:"-"`
-}
-
-type metadataFilterLogEventsOutput struct {
-	SDKShapeTraits bool `type:"structure"`
+	_ struct{} `type:"structure"`
 }
 
 // String returns the string representation
@@ -1939,11 +1787,7 @@ type FilteredLogEvent struct {
 	// 00:00:00 UTC.
 	Timestamp *int64 `locationName:"timestamp" type:"long"`
 
-	metadataFilteredLogEvent `json:"-" xml:"-"`
-}
-
-type metadataFilteredLogEvent struct {
-	SDKShapeTraits bool `type:"structure"`
+	_ struct{} `type:"structure"`
 }
 
 // String returns the string representation
@@ -1985,11 +1829,7 @@ type GetLogEventsInput struct {
 	// 00:00:00 UTC.
 	StartTime *int64 `locationName:"startTime" type:"long"`
 
-	metadataGetLogEventsInput `json:"-" xml:"-"`
-}
-
-type metadataGetLogEventsInput struct {
-	SDKShapeTraits bool `type:"structure"`
+	_ struct{} `type:"structure"`
 }
 
 // String returns the string representation
@@ -2015,11 +1855,7 @@ type GetLogEventsOutput struct {
 	// token expires after 24 hours.
 	NextForwardToken *string `locationName:"nextForwardToken" min:"1" type:"string"`
 
-	metadataGetLogEventsOutput `json:"-" xml:"-"`
-}
-
-type metadataGetLogEventsOutput struct {
-	SDKShapeTraits bool `type:"structure"`
+	_ struct{} `type:"structure"`
 }
 
 // String returns the string representation
@@ -2043,11 +1879,7 @@ type InputLogEvent struct {
 	// 00:00:00 UTC.
 	Timestamp *int64 `locationName:"timestamp" type:"long" required:"true"`
 
-	metadataInputLogEvent `json:"-" xml:"-"`
-}
-
-type metadataInputLogEvent struct {
-	SDKShapeTraits bool `type:"structure"`
+	_ struct{} `type:"structure"`
 }
 
 // String returns the string representation
@@ -2079,11 +1911,7 @@ type LogGroup struct {
 
 	StoredBytes *int64 `locationName:"storedBytes" type:"long"`
 
-	metadataLogGroup `json:"-" xml:"-"`
-}
-
-type metadataLogGroup struct {
-	SDKShapeTraits bool `type:"structure"`
+	_ struct{} `type:"structure"`
 }
 
 // String returns the string representation
@@ -2125,11 +1953,7 @@ type LogStream struct {
 	// obtained from the response of the previous request.
 	UploadSequenceToken *string `locationName:"uploadSequenceToken" min:"1" type:"string"`
 
-	metadataLogStream `json:"-" xml:"-"`
-}
-
-type metadataLogStream struct {
-	SDKShapeTraits bool `type:"structure"`
+	_ struct{} `type:"structure"`
 }
 
 // String returns the string representation
@@ -2161,11 +1985,7 @@ type MetricFilter struct {
 
 	MetricTransformations []*MetricTransformation `locationName:"metricTransformations" min:"1" type:"list"`
 
-	metadataMetricFilter `json:"-" xml:"-"`
-}
-
-type metadataMetricFilter struct {
-	SDKShapeTraits bool `type:"structure"`
+	_ struct{} `type:"structure"`
 }
 
 // String returns the string representation
@@ -2185,11 +2005,7 @@ type MetricFilterMatchRecord struct {
 
 	ExtractedValues map[string]*string `locationName:"extractedValues" type:"map"`
 
-	metadataMetricFilterMatchRecord `json:"-" xml:"-"`
-}
-
-type metadataMetricFilterMatchRecord struct {
-	SDKShapeTraits bool `type:"structure"`
+	_ struct{} `type:"structure"`
 }
 
 // String returns the string representation
@@ -2216,11 +2032,7 @@ type MetricTransformation struct {
 	// value in the log event.
 	MetricValue *string `locationName:"metricValue" type:"string" required:"true"`
 
-	metadataMetricTransformation `json:"-" xml:"-"`
-}
-
-type metadataMetricTransformation struct {
-	SDKShapeTraits bool `type:"structure"`
+	_ struct{} `type:"structure"`
 }
 
 // String returns the string representation
@@ -2244,11 +2056,7 @@ type OutputLogEvent struct {
 	// 00:00:00 UTC.
 	Timestamp *int64 `locationName:"timestamp" type:"long"`
 
-	metadataOutputLogEvent `json:"-" xml:"-"`
-}
-
-type metadataOutputLogEvent struct {
-	SDKShapeTraits bool `type:"structure"`
+	_ struct{} `type:"structure"`
 }
 
 // String returns the string representation
@@ -2272,11 +2080,7 @@ type PutDestinationInput struct {
 	// The ARN of an Amazon Kinesis stream to deliver matching log events to.
 	TargetArn *string `locationName:"targetArn" min:"1" type:"string" required:"true"`
 
-	metadataPutDestinationInput `json:"-" xml:"-"`
-}
-
-type metadataPutDestinationInput struct {
-	SDKShapeTraits bool `type:"structure"`
+	_ struct{} `type:"structure"`
 }
 
 // String returns the string representation
@@ -2293,11 +2097,7 @@ type PutDestinationOutput struct {
 	// A cross account destination that is the recipient of subscription log events.
 	Destination *Destination `locationName:"destination" type:"structure"`
 
-	metadataPutDestinationOutput `json:"-" xml:"-"`
-}
-
-type metadataPutDestinationOutput struct {
-	SDKShapeTraits bool `type:"structure"`
+	_ struct{} `type:"structure"`
 }
 
 // String returns the string representation
@@ -2318,11 +2118,7 @@ type PutDestinationPolicyInput struct {
 	// A name for an existing destination.
 	DestinationName *string `locationName:"destinationName" min:"1" type:"string" required:"true"`
 
-	metadataPutDestinationPolicyInput `json:"-" xml:"-"`
-}
-
-type metadataPutDestinationPolicyInput struct {
-	SDKShapeTraits bool `type:"structure"`
+	_ struct{} `type:"structure"`
 }
 
 // String returns the string representation
@@ -2336,11 +2132,7 @@ func (s PutDestinationPolicyInput) GoString() string {
 }
 
 type PutDestinationPolicyOutput struct {
-	metadataPutDestinationPolicyOutput `json:"-" xml:"-"`
-}
-
-type metadataPutDestinationPolicyOutput struct {
-	SDKShapeTraits bool `type:"structure"`
+	_ struct{} `type:"structure"`
 }
 
 // String returns the string representation
@@ -2367,11 +2159,7 @@ type PutLogEventsInput struct {
 	// request.
 	SequenceToken *string `locationName:"sequenceToken" min:"1" type:"string"`
 
-	metadataPutLogEventsInput `json:"-" xml:"-"`
-}
-
-type metadataPutLogEventsInput struct {
-	SDKShapeTraits bool `type:"structure"`
+	_ struct{} `type:"structure"`
 }
 
 // String returns the string representation
@@ -2392,11 +2180,7 @@ type PutLogEventsOutput struct {
 
 	RejectedLogEventsInfo *RejectedLogEventsInfo `locationName:"rejectedLogEventsInfo" type:"structure"`
 
-	metadataPutLogEventsOutput `json:"-" xml:"-"`
-}
-
-type metadataPutLogEventsOutput struct {
-	SDKShapeTraits bool `type:"structure"`
+	_ struct{} `type:"structure"`
 }
 
 // String returns the string representation
@@ -2423,11 +2207,7 @@ type PutMetricFilterInput struct {
 	// A collection of information needed to define how metric data gets emitted.
 	MetricTransformations []*MetricTransformation `locationName:"metricTransformations" min:"1" type:"list" required:"true"`
 
-	metadataPutMetricFilterInput `json:"-" xml:"-"`
-}
-
-type metadataPutMetricFilterInput struct {
-	SDKShapeTraits bool `type:"structure"`
+	_ struct{} `type:"structure"`
 }
 
 // String returns the string representation
@@ -2441,11 +2221,7 @@ func (s PutMetricFilterInput) GoString() string {
 }
 
 type PutMetricFilterOutput struct {
-	metadataPutMetricFilterOutput `json:"-" xml:"-"`
-}
-
-type metadataPutMetricFilterOutput struct {
-	SDKShapeTraits bool `type:"structure"`
+	_ struct{} `type:"structure"`
 }
 
 // String returns the string representation
@@ -2467,11 +2243,7 @@ type PutRetentionPolicyInput struct {
 	// 365, 400, 545, 731, 1827, 3653.
 	RetentionInDays *int64 `locationName:"retentionInDays" type:"integer" required:"true"`
 
-	metadataPutRetentionPolicyInput `json:"-" xml:"-"`
-}
-
-type metadataPutRetentionPolicyInput struct {
-	SDKShapeTraits bool `type:"structure"`
+	_ struct{} `type:"structure"`
 }
 
 // String returns the string representation
@@ -2485,11 +2257,7 @@ func (s PutRetentionPolicyInput) GoString() string {
 }
 
 type PutRetentionPolicyOutput struct {
-	metadataPutRetentionPolicyOutput `json:"-" xml:"-"`
-}
-
-type metadataPutRetentionPolicyOutput struct {
-	SDKShapeTraits bool `type:"structure"`
+	_ struct{} `type:"structure"`
 }
 
 // String returns the string representation
@@ -2526,11 +2294,7 @@ type PutSubscriptionFilterInput struct {
 	// an ARN of Destination) for cross-account delivery.
 	RoleArn *string `locationName:"roleArn" min:"1" type:"string"`
 
-	metadataPutSubscriptionFilterInput `json:"-" xml:"-"`
-}
-
-type metadataPutSubscriptionFilterInput struct {
-	SDKShapeTraits bool `type:"structure"`
+	_ struct{} `type:"structure"`
 }
 
 // String returns the string representation
@@ -2544,11 +2308,7 @@ func (s PutSubscriptionFilterInput) GoString() string {
 }
 
 type PutSubscriptionFilterOutput struct {
-	metadataPutSubscriptionFilterOutput `json:"-" xml:"-"`
-}
-
-type metadataPutSubscriptionFilterOutput struct {
-	SDKShapeTraits bool `type:"structure"`
+	_ struct{} `type:"structure"`
 }
 
 // String returns the string representation
@@ -2568,11 +2328,7 @@ type RejectedLogEventsInfo struct {
 
 	TooOldLogEventEndIndex *int64 `locationName:"tooOldLogEventEndIndex" type:"integer"`
 
-	metadataRejectedLogEventsInfo `json:"-" xml:"-"`
-}
-
-type metadataRejectedLogEventsInfo struct {
-	SDKShapeTraits bool `type:"structure"`
+	_ struct{} `type:"structure"`
 }
 
 // String returns the string representation
@@ -2595,11 +2351,7 @@ type SearchedLogStream struct {
 	// data exists to search by paginating further.
 	SearchedCompletely *bool `locationName:"searchedCompletely" type:"boolean"`
 
-	metadataSearchedLogStream `json:"-" xml:"-"`
-}
-
-type metadataSearchedLogStream struct {
-	SDKShapeTraits bool `type:"structure"`
+	_ struct{} `type:"structure"`
 }
 
 // String returns the string representation
@@ -2632,11 +2384,7 @@ type SubscriptionFilter struct {
 
 	RoleArn *string `locationName:"roleArn" min:"1" type:"string"`
 
-	metadataSubscriptionFilter `json:"-" xml:"-"`
-}
-
-type metadataSubscriptionFilter struct {
-	SDKShapeTraits bool `type:"structure"`
+	_ struct{} `type:"structure"`
 }
 
 // String returns the string representation
@@ -2659,11 +2407,7 @@ type TestMetricFilterInput struct {
 	// A list of log event messages to test.
 	LogEventMessages []*string `locationName:"logEventMessages" min:"1" type:"list" required:"true"`
 
-	metadataTestMetricFilterInput `json:"-" xml:"-"`
-}
-
-type metadataTestMetricFilterInput struct {
-	SDKShapeTraits bool `type:"structure"`
+	_ struct{} `type:"structure"`
 }
 
 // String returns the string representation
@@ -2679,11 +2423,7 @@ func (s TestMetricFilterInput) GoString() string {
 type TestMetricFilterOutput struct {
 	Matches []*MetricFilterMatchRecord `locationName:"matches" type:"list"`
 
-	metadataTestMetricFilterOutput `json:"-" xml:"-"`
-}
-
-type metadataTestMetricFilterOutput struct {
-	SDKShapeTraits bool `type:"structure"`
+	_ struct{} `type:"structure"`
 }
 
 // String returns the string representation

--- a/service/codecommit/api.go
+++ b/service/codecommit/api.go
@@ -340,10 +340,10 @@ func (c *CodeCommit) UpdateRepositoryName(input *UpdateRepositoryNameInput) (*Up
 
 // Represents the input of a batch get repositories operation.
 type BatchGetRepositoriesInput struct {
+	_ struct{} `type:"structure"`
+
 	// The names of the repositories to get information about.
 	RepositoryNames []*string `locationName:"repositoryNames" type:"list" required:"true"`
-
-	_ struct{} `type:"structure"`
 }
 
 // String returns the string representation
@@ -358,13 +358,13 @@ func (s BatchGetRepositoriesInput) GoString() string {
 
 // Represents the output of a batch get repositories operation.
 type BatchGetRepositoriesOutput struct {
+	_ struct{} `type:"structure"`
+
 	// A list of repositories returned by the batch get repositories operation.
 	Repositories []*RepositoryMetadata `locationName:"repositories" type:"list"`
 
 	// Returns a list of repository names for which information could not be found.
 	RepositoriesNotFound []*string `locationName:"repositoriesNotFound" type:"list"`
-
-	_ struct{} `type:"structure"`
 }
 
 // String returns the string representation
@@ -379,13 +379,13 @@ func (s BatchGetRepositoriesOutput) GoString() string {
 
 // Returns information about a branch.
 type BranchInfo struct {
+	_ struct{} `type:"structure"`
+
 	// The name of the branch.
 	BranchName *string `locationName:"branchName" min:"1" type:"string"`
 
 	// The ID of the last commit made to the branch.
 	CommitId *string `locationName:"commitId" type:"string"`
-
-	_ struct{} `type:"structure"`
 }
 
 // String returns the string representation
@@ -400,6 +400,8 @@ func (s BranchInfo) GoString() string {
 
 // Represents the input of a create branch operation.
 type CreateBranchInput struct {
+	_ struct{} `type:"structure"`
+
 	// The name of the new branch to create.
 	BranchName *string `locationName:"branchName" min:"1" type:"string" required:"true"`
 
@@ -411,8 +413,6 @@ type CreateBranchInput struct {
 
 	// The name of the repository in which you want to create the new branch.
 	RepositoryName *string `locationName:"repositoryName" min:"1" type:"string" required:"true"`
-
-	_ struct{} `type:"structure"`
 }
 
 // String returns the string representation
@@ -441,6 +441,8 @@ func (s CreateBranchOutput) GoString() string {
 
 // Represents the input of a create repository operation.
 type CreateRepositoryInput struct {
+	_ struct{} `type:"structure"`
+
 	// A comment or description about the new repository.
 	RepositoryDescription *string `locationName:"repositoryDescription" type:"string"`
 
@@ -450,8 +452,6 @@ type CreateRepositoryInput struct {
 	// repository names are restricted to alphanumeric characters. The suffix ".git"
 	// is prohibited.
 	RepositoryName *string `locationName:"repositoryName" min:"1" type:"string" required:"true"`
-
-	_ struct{} `type:"structure"`
 }
 
 // String returns the string representation
@@ -466,10 +466,10 @@ func (s CreateRepositoryInput) GoString() string {
 
 // Represents the output of a create repository operation.
 type CreateRepositoryOutput struct {
+	_ struct{} `type:"structure"`
+
 	// Information about the newly created repository.
 	RepositoryMetadata *RepositoryMetadata `locationName:"repositoryMetadata" type:"structure"`
-
-	_ struct{} `type:"structure"`
 }
 
 // String returns the string representation
@@ -484,10 +484,10 @@ func (s CreateRepositoryOutput) GoString() string {
 
 // Represents the input of a delete repository operation.
 type DeleteRepositoryInput struct {
+	_ struct{} `type:"structure"`
+
 	// The name of the repository to delete.
 	RepositoryName *string `locationName:"repositoryName" min:"1" type:"string" required:"true"`
-
-	_ struct{} `type:"structure"`
 }
 
 // String returns the string representation
@@ -502,10 +502,10 @@ func (s DeleteRepositoryInput) GoString() string {
 
 // Represents the output of a delete repository operation.
 type DeleteRepositoryOutput struct {
+	_ struct{} `type:"structure"`
+
 	// The ID of the repository that was deleted.
 	RepositoryId *string `locationName:"repositoryId" type:"string"`
-
-	_ struct{} `type:"structure"`
 }
 
 // String returns the string representation
@@ -520,6 +520,8 @@ func (s DeleteRepositoryOutput) GoString() string {
 
 // Represents the input of a get branch operation.
 type GetBranchInput struct {
+	_ struct{} `type:"structure"`
+
 	// The name of the branch for which you want to retrieve information.
 	BranchName *string `locationName:"branchName" min:"1" type:"string"`
 
@@ -527,8 +529,6 @@ type GetBranchInput struct {
 	// ".", "_", and "-". Additionally, the suffix ".git" is prohibited in a repository
 	// name.
 	RepositoryName *string `locationName:"repositoryName" min:"1" type:"string"`
-
-	_ struct{} `type:"structure"`
 }
 
 // String returns the string representation
@@ -543,10 +543,10 @@ func (s GetBranchInput) GoString() string {
 
 // Represents the output of a get branch operation.
 type GetBranchOutput struct {
+	_ struct{} `type:"structure"`
+
 	// The name of the branch.
 	Branch *BranchInfo `locationName:"branch" type:"structure"`
-
-	_ struct{} `type:"structure"`
 }
 
 // String returns the string representation
@@ -561,10 +561,10 @@ func (s GetBranchOutput) GoString() string {
 
 // Represents the input of a get repository operation.
 type GetRepositoryInput struct {
+	_ struct{} `type:"structure"`
+
 	// The name of the repository to get information about.
 	RepositoryName *string `locationName:"repositoryName" min:"1" type:"string" required:"true"`
-
-	_ struct{} `type:"structure"`
 }
 
 // String returns the string representation
@@ -579,10 +579,10 @@ func (s GetRepositoryInput) GoString() string {
 
 // Represents the output of a get repository operation.
 type GetRepositoryOutput struct {
+	_ struct{} `type:"structure"`
+
 	// Information about the repository.
 	RepositoryMetadata *RepositoryMetadata `locationName:"repositoryMetadata" type:"structure"`
-
-	_ struct{} `type:"structure"`
 }
 
 // String returns the string representation
@@ -597,13 +597,13 @@ func (s GetRepositoryOutput) GoString() string {
 
 // Represents the input of a list branches operation.
 type ListBranchesInput struct {
+	_ struct{} `type:"structure"`
+
 	// An enumeration token that allows the operation to batch the results.
 	NextToken *string `locationName:"nextToken" type:"string"`
 
 	// The name of the repository that contains the branches.
 	RepositoryName *string `locationName:"repositoryName" min:"1" type:"string" required:"true"`
-
-	_ struct{} `type:"structure"`
 }
 
 // String returns the string representation
@@ -618,13 +618,13 @@ func (s ListBranchesInput) GoString() string {
 
 // Represents the output of a list branches operation.
 type ListBranchesOutput struct {
+	_ struct{} `type:"structure"`
+
 	// The list of branch names.
 	Branches []*string `locationName:"branches" type:"list"`
 
 	// An enumeration token that returns the batch of the results.
 	NextToken *string `locationName:"nextToken" type:"string"`
-
-	_ struct{} `type:"structure"`
 }
 
 // String returns the string representation
@@ -639,6 +639,8 @@ func (s ListBranchesOutput) GoString() string {
 
 // Represents the input of a list repositories operation.
 type ListRepositoriesInput struct {
+	_ struct{} `type:"structure"`
+
 	// An enumeration token that allows the operation to batch the results of the
 	// operation. Batch sizes are 1,000 for list repository operations. When the
 	// client sends the token back to AWS CodeCommit, another page of 1,000 records
@@ -650,8 +652,6 @@ type ListRepositoriesInput struct {
 
 	// The criteria used to sort the results of a list repositories operation.
 	SortBy *string `locationName:"sortBy" type:"string" enum:"SortByEnum"`
-
-	_ struct{} `type:"structure"`
 }
 
 // String returns the string representation
@@ -666,6 +666,8 @@ func (s ListRepositoriesInput) GoString() string {
 
 // Represents the output of a list repositories operation.
 type ListRepositoriesOutput struct {
+	_ struct{} `type:"structure"`
+
 	// An enumeration token that allows the operation to batch the results of the
 	// operation. Batch sizes are 1,000 for list repository operations. When the
 	// client sends the token back to AWS CodeCommit, another page of 1,000 records
@@ -674,8 +676,6 @@ type ListRepositoriesOutput struct {
 
 	// Lists the repositories called by the list repositories operation.
 	Repositories []*RepositoryNameIdPair `locationName:"repositories" type:"list"`
-
-	_ struct{} `type:"structure"`
 }
 
 // String returns the string representation
@@ -690,6 +690,8 @@ func (s ListRepositoriesOutput) GoString() string {
 
 // Information about a repository.
 type RepositoryMetadata struct {
+	_ struct{} `type:"structure"`
+
 	// The ID of the AWS account associated with the repository.
 	AccountId *string `locationName:"accountId" type:"string"`
 
@@ -719,8 +721,6 @@ type RepositoryMetadata struct {
 
 	// The repository's name.
 	RepositoryName *string `locationName:"repositoryName" min:"1" type:"string"`
-
-	_ struct{} `type:"structure"`
 }
 
 // String returns the string representation
@@ -735,6 +735,8 @@ func (s RepositoryMetadata) GoString() string {
 
 // Information about a repository name and ID.
 type RepositoryNameIdPair struct {
+	_ struct{} `type:"structure"`
+
 	// The ID associated with the repository name.
 	RepositoryId *string `locationName:"repositoryId" type:"string"`
 
@@ -742,8 +744,6 @@ type RepositoryNameIdPair struct {
 	// ".", "_", and "-". Additionally, the suffix ".git" is prohibited in a repository
 	// name.
 	RepositoryName *string `locationName:"repositoryName" min:"1" type:"string"`
-
-	_ struct{} `type:"structure"`
 }
 
 // String returns the string representation
@@ -758,13 +758,13 @@ func (s RepositoryNameIdPair) GoString() string {
 
 // Represents the input of an update default branch operation.
 type UpdateDefaultBranchInput struct {
+	_ struct{} `type:"structure"`
+
 	// The name of the branch to set as the default.
 	DefaultBranchName *string `locationName:"defaultBranchName" min:"1" type:"string" required:"true"`
 
 	// The name of the repository to set or change the default branch for.
 	RepositoryName *string `locationName:"repositoryName" min:"1" type:"string" required:"true"`
-
-	_ struct{} `type:"structure"`
 }
 
 // String returns the string representation
@@ -793,13 +793,13 @@ func (s UpdateDefaultBranchOutput) GoString() string {
 
 // Represents the input of an update repository description operation.
 type UpdateRepositoryDescriptionInput struct {
+	_ struct{} `type:"structure"`
+
 	// The new comment or description for the specified repository.
 	RepositoryDescription *string `locationName:"repositoryDescription" type:"string"`
 
 	// The name of the repository to set or change the comment or description for.
 	RepositoryName *string `locationName:"repositoryName" min:"1" type:"string" required:"true"`
-
-	_ struct{} `type:"structure"`
 }
 
 // String returns the string representation
@@ -828,6 +828,8 @@ func (s UpdateRepositoryDescriptionOutput) GoString() string {
 
 // Represents the input of an update repository description operation.
 type UpdateRepositoryNameInput struct {
+	_ struct{} `type:"structure"`
+
 	// Repository name is restricted to alphanumeric characters (a-z, A-Z, 0-9),
 	// ".", "_", and "-". Additionally, the suffix ".git" is prohibited in a repository
 	// name.
@@ -837,8 +839,6 @@ type UpdateRepositoryNameInput struct {
 	// ".", "_", and "-". Additionally, the suffix ".git" is prohibited in a repository
 	// name.
 	OldName *string `locationName:"oldName" min:"1" type:"string" required:"true"`
-
-	_ struct{} `type:"structure"`
 }
 
 // String returns the string representation

--- a/service/codecommit/api.go
+++ b/service/codecommit/api.go
@@ -343,11 +343,7 @@ type BatchGetRepositoriesInput struct {
 	// The names of the repositories to get information about.
 	RepositoryNames []*string `locationName:"repositoryNames" type:"list" required:"true"`
 
-	metadataBatchGetRepositoriesInput `json:"-" xml:"-"`
-}
-
-type metadataBatchGetRepositoriesInput struct {
-	SDKShapeTraits bool `type:"structure"`
+	_ struct{} `type:"structure"`
 }
 
 // String returns the string representation
@@ -368,11 +364,7 @@ type BatchGetRepositoriesOutput struct {
 	// Returns a list of repository names for which information could not be found.
 	RepositoriesNotFound []*string `locationName:"repositoriesNotFound" type:"list"`
 
-	metadataBatchGetRepositoriesOutput `json:"-" xml:"-"`
-}
-
-type metadataBatchGetRepositoriesOutput struct {
-	SDKShapeTraits bool `type:"structure"`
+	_ struct{} `type:"structure"`
 }
 
 // String returns the string representation
@@ -393,11 +385,7 @@ type BranchInfo struct {
 	// The ID of the last commit made to the branch.
 	CommitId *string `locationName:"commitId" type:"string"`
 
-	metadataBranchInfo `json:"-" xml:"-"`
-}
-
-type metadataBranchInfo struct {
-	SDKShapeTraits bool `type:"structure"`
+	_ struct{} `type:"structure"`
 }
 
 // String returns the string representation
@@ -424,11 +412,7 @@ type CreateBranchInput struct {
 	// The name of the repository in which you want to create the new branch.
 	RepositoryName *string `locationName:"repositoryName" min:"1" type:"string" required:"true"`
 
-	metadataCreateBranchInput `json:"-" xml:"-"`
-}
-
-type metadataCreateBranchInput struct {
-	SDKShapeTraits bool `type:"structure"`
+	_ struct{} `type:"structure"`
 }
 
 // String returns the string representation
@@ -442,11 +426,7 @@ func (s CreateBranchInput) GoString() string {
 }
 
 type CreateBranchOutput struct {
-	metadataCreateBranchOutput `json:"-" xml:"-"`
-}
-
-type metadataCreateBranchOutput struct {
-	SDKShapeTraits bool `type:"structure"`
+	_ struct{} `type:"structure"`
 }
 
 // String returns the string representation
@@ -471,11 +451,7 @@ type CreateRepositoryInput struct {
 	// is prohibited.
 	RepositoryName *string `locationName:"repositoryName" min:"1" type:"string" required:"true"`
 
-	metadataCreateRepositoryInput `json:"-" xml:"-"`
-}
-
-type metadataCreateRepositoryInput struct {
-	SDKShapeTraits bool `type:"structure"`
+	_ struct{} `type:"structure"`
 }
 
 // String returns the string representation
@@ -493,11 +469,7 @@ type CreateRepositoryOutput struct {
 	// Information about the newly created repository.
 	RepositoryMetadata *RepositoryMetadata `locationName:"repositoryMetadata" type:"structure"`
 
-	metadataCreateRepositoryOutput `json:"-" xml:"-"`
-}
-
-type metadataCreateRepositoryOutput struct {
-	SDKShapeTraits bool `type:"structure"`
+	_ struct{} `type:"structure"`
 }
 
 // String returns the string representation
@@ -515,11 +487,7 @@ type DeleteRepositoryInput struct {
 	// The name of the repository to delete.
 	RepositoryName *string `locationName:"repositoryName" min:"1" type:"string" required:"true"`
 
-	metadataDeleteRepositoryInput `json:"-" xml:"-"`
-}
-
-type metadataDeleteRepositoryInput struct {
-	SDKShapeTraits bool `type:"structure"`
+	_ struct{} `type:"structure"`
 }
 
 // String returns the string representation
@@ -537,11 +505,7 @@ type DeleteRepositoryOutput struct {
 	// The ID of the repository that was deleted.
 	RepositoryId *string `locationName:"repositoryId" type:"string"`
 
-	metadataDeleteRepositoryOutput `json:"-" xml:"-"`
-}
-
-type metadataDeleteRepositoryOutput struct {
-	SDKShapeTraits bool `type:"structure"`
+	_ struct{} `type:"structure"`
 }
 
 // String returns the string representation
@@ -564,11 +528,7 @@ type GetBranchInput struct {
 	// name.
 	RepositoryName *string `locationName:"repositoryName" min:"1" type:"string"`
 
-	metadataGetBranchInput `json:"-" xml:"-"`
-}
-
-type metadataGetBranchInput struct {
-	SDKShapeTraits bool `type:"structure"`
+	_ struct{} `type:"structure"`
 }
 
 // String returns the string representation
@@ -586,11 +546,7 @@ type GetBranchOutput struct {
 	// The name of the branch.
 	Branch *BranchInfo `locationName:"branch" type:"structure"`
 
-	metadataGetBranchOutput `json:"-" xml:"-"`
-}
-
-type metadataGetBranchOutput struct {
-	SDKShapeTraits bool `type:"structure"`
+	_ struct{} `type:"structure"`
 }
 
 // String returns the string representation
@@ -608,11 +564,7 @@ type GetRepositoryInput struct {
 	// The name of the repository to get information about.
 	RepositoryName *string `locationName:"repositoryName" min:"1" type:"string" required:"true"`
 
-	metadataGetRepositoryInput `json:"-" xml:"-"`
-}
-
-type metadataGetRepositoryInput struct {
-	SDKShapeTraits bool `type:"structure"`
+	_ struct{} `type:"structure"`
 }
 
 // String returns the string representation
@@ -630,11 +582,7 @@ type GetRepositoryOutput struct {
 	// Information about the repository.
 	RepositoryMetadata *RepositoryMetadata `locationName:"repositoryMetadata" type:"structure"`
 
-	metadataGetRepositoryOutput `json:"-" xml:"-"`
-}
-
-type metadataGetRepositoryOutput struct {
-	SDKShapeTraits bool `type:"structure"`
+	_ struct{} `type:"structure"`
 }
 
 // String returns the string representation
@@ -655,11 +603,7 @@ type ListBranchesInput struct {
 	// The name of the repository that contains the branches.
 	RepositoryName *string `locationName:"repositoryName" min:"1" type:"string" required:"true"`
 
-	metadataListBranchesInput `json:"-" xml:"-"`
-}
-
-type metadataListBranchesInput struct {
-	SDKShapeTraits bool `type:"structure"`
+	_ struct{} `type:"structure"`
 }
 
 // String returns the string representation
@@ -680,11 +624,7 @@ type ListBranchesOutput struct {
 	// An enumeration token that returns the batch of the results.
 	NextToken *string `locationName:"nextToken" type:"string"`
 
-	metadataListBranchesOutput `json:"-" xml:"-"`
-}
-
-type metadataListBranchesOutput struct {
-	SDKShapeTraits bool `type:"structure"`
+	_ struct{} `type:"structure"`
 }
 
 // String returns the string representation
@@ -711,11 +651,7 @@ type ListRepositoriesInput struct {
 	// The criteria used to sort the results of a list repositories operation.
 	SortBy *string `locationName:"sortBy" type:"string" enum:"SortByEnum"`
 
-	metadataListRepositoriesInput `json:"-" xml:"-"`
-}
-
-type metadataListRepositoriesInput struct {
-	SDKShapeTraits bool `type:"structure"`
+	_ struct{} `type:"structure"`
 }
 
 // String returns the string representation
@@ -739,11 +675,7 @@ type ListRepositoriesOutput struct {
 	// Lists the repositories called by the list repositories operation.
 	Repositories []*RepositoryNameIdPair `locationName:"repositories" type:"list"`
 
-	metadataListRepositoriesOutput `json:"-" xml:"-"`
-}
-
-type metadataListRepositoriesOutput struct {
-	SDKShapeTraits bool `type:"structure"`
+	_ struct{} `type:"structure"`
 }
 
 // String returns the string representation
@@ -788,11 +720,7 @@ type RepositoryMetadata struct {
 	// The repository's name.
 	RepositoryName *string `locationName:"repositoryName" min:"1" type:"string"`
 
-	metadataRepositoryMetadata `json:"-" xml:"-"`
-}
-
-type metadataRepositoryMetadata struct {
-	SDKShapeTraits bool `type:"structure"`
+	_ struct{} `type:"structure"`
 }
 
 // String returns the string representation
@@ -815,11 +743,7 @@ type RepositoryNameIdPair struct {
 	// name.
 	RepositoryName *string `locationName:"repositoryName" min:"1" type:"string"`
 
-	metadataRepositoryNameIdPair `json:"-" xml:"-"`
-}
-
-type metadataRepositoryNameIdPair struct {
-	SDKShapeTraits bool `type:"structure"`
+	_ struct{} `type:"structure"`
 }
 
 // String returns the string representation
@@ -840,11 +764,7 @@ type UpdateDefaultBranchInput struct {
 	// The name of the repository to set or change the default branch for.
 	RepositoryName *string `locationName:"repositoryName" min:"1" type:"string" required:"true"`
 
-	metadataUpdateDefaultBranchInput `json:"-" xml:"-"`
-}
-
-type metadataUpdateDefaultBranchInput struct {
-	SDKShapeTraits bool `type:"structure"`
+	_ struct{} `type:"structure"`
 }
 
 // String returns the string representation
@@ -858,11 +778,7 @@ func (s UpdateDefaultBranchInput) GoString() string {
 }
 
 type UpdateDefaultBranchOutput struct {
-	metadataUpdateDefaultBranchOutput `json:"-" xml:"-"`
-}
-
-type metadataUpdateDefaultBranchOutput struct {
-	SDKShapeTraits bool `type:"structure"`
+	_ struct{} `type:"structure"`
 }
 
 // String returns the string representation
@@ -883,11 +799,7 @@ type UpdateRepositoryDescriptionInput struct {
 	// The name of the repository to set or change the comment or description for.
 	RepositoryName *string `locationName:"repositoryName" min:"1" type:"string" required:"true"`
 
-	metadataUpdateRepositoryDescriptionInput `json:"-" xml:"-"`
-}
-
-type metadataUpdateRepositoryDescriptionInput struct {
-	SDKShapeTraits bool `type:"structure"`
+	_ struct{} `type:"structure"`
 }
 
 // String returns the string representation
@@ -901,11 +813,7 @@ func (s UpdateRepositoryDescriptionInput) GoString() string {
 }
 
 type UpdateRepositoryDescriptionOutput struct {
-	metadataUpdateRepositoryDescriptionOutput `json:"-" xml:"-"`
-}
-
-type metadataUpdateRepositoryDescriptionOutput struct {
-	SDKShapeTraits bool `type:"structure"`
+	_ struct{} `type:"structure"`
 }
 
 // String returns the string representation
@@ -930,11 +838,7 @@ type UpdateRepositoryNameInput struct {
 	// name.
 	OldName *string `locationName:"oldName" min:"1" type:"string" required:"true"`
 
-	metadataUpdateRepositoryNameInput `json:"-" xml:"-"`
-}
-
-type metadataUpdateRepositoryNameInput struct {
-	SDKShapeTraits bool `type:"structure"`
+	_ struct{} `type:"structure"`
 }
 
 // String returns the string representation
@@ -948,11 +852,7 @@ func (s UpdateRepositoryNameInput) GoString() string {
 }
 
 type UpdateRepositoryNameOutput struct {
-	metadataUpdateRepositoryNameOutput `json:"-" xml:"-"`
-}
-
-type metadataUpdateRepositoryNameOutput struct {
-	SDKShapeTraits bool `type:"structure"`
+	_ struct{} `type:"structure"`
 }
 
 // String returns the string representation

--- a/service/codedeploy/api.go
+++ b/service/codedeploy/api.go
@@ -970,6 +970,8 @@ func (c *CodeDeploy) UpdateDeploymentGroup(input *UpdateDeploymentGroupInput) (*
 
 // Represents the input of an adds tags to on-premises instance operation.
 type AddTagsToOnPremisesInstancesInput struct {
+	_ struct{} `type:"structure"`
+
 	// The names of the on-premises instances to add tags to.
 	InstanceNames []*string `locationName:"instanceNames" type:"list" required:"true"`
 
@@ -978,8 +980,6 @@ type AddTagsToOnPremisesInstancesInput struct {
 	// Keys and values are both required. Keys cannot be nulls or empty strings.
 	// Value-only tags are not allowed.
 	Tags []*Tag `locationName:"tags" type:"list" required:"true"`
-
-	_ struct{} `type:"structure"`
 }
 
 // String returns the string representation
@@ -1008,6 +1008,8 @@ func (s AddTagsToOnPremisesInstancesOutput) GoString() string {
 
 // Information about an application.
 type ApplicationInfo struct {
+	_ struct{} `type:"structure"`
+
 	// The application ID.
 	ApplicationId *string `locationName:"applicationId" type:"string"`
 
@@ -1020,8 +1022,6 @@ type ApplicationInfo struct {
 	// True if the user has authenticated with GitHub for the specified application;
 	// otherwise, false.
 	LinkedToGitHub *bool `locationName:"linkedToGitHub" type:"boolean"`
-
-	_ struct{} `type:"structure"`
 }
 
 // String returns the string representation
@@ -1036,13 +1036,13 @@ func (s ApplicationInfo) GoString() string {
 
 // Information about an Auto Scaling group.
 type AutoScalingGroup struct {
+	_ struct{} `type:"structure"`
+
 	// An Auto Scaling lifecycle event hook name.
 	Hook *string `locationName:"hook" type:"string"`
 
 	// The Auto Scaling group name.
 	Name *string `locationName:"name" type:"string"`
-
-	_ struct{} `type:"structure"`
 }
 
 // String returns the string representation
@@ -1057,11 +1057,11 @@ func (s AutoScalingGroup) GoString() string {
 
 // Represents the input of a batch get applications operation.
 type BatchGetApplicationsInput struct {
+	_ struct{} `type:"structure"`
+
 	// A list of application names, with multiple application names separated by
 	// spaces.
 	ApplicationNames []*string `locationName:"applicationNames" type:"list"`
-
-	_ struct{} `type:"structure"`
 }
 
 // String returns the string representation
@@ -1076,10 +1076,10 @@ func (s BatchGetApplicationsInput) GoString() string {
 
 // Represents the output of a batch get applications operation.
 type BatchGetApplicationsOutput struct {
+	_ struct{} `type:"structure"`
+
 	// Information about the applications.
 	ApplicationsInfo []*ApplicationInfo `locationName:"applicationsInfo" type:"list"`
-
-	_ struct{} `type:"structure"`
 }
 
 // String returns the string representation
@@ -1094,10 +1094,10 @@ func (s BatchGetApplicationsOutput) GoString() string {
 
 // Represents the input of a batch get deployments operation.
 type BatchGetDeploymentsInput struct {
+	_ struct{} `type:"structure"`
+
 	// A list of deployment IDs, with multiple deployment IDs separated by spaces.
 	DeploymentIds []*string `locationName:"deploymentIds" type:"list"`
-
-	_ struct{} `type:"structure"`
 }
 
 // String returns the string representation
@@ -1112,10 +1112,10 @@ func (s BatchGetDeploymentsInput) GoString() string {
 
 // Represents the output of a batch get deployments operation.
 type BatchGetDeploymentsOutput struct {
+	_ struct{} `type:"structure"`
+
 	// Information about the deployments.
 	DeploymentsInfo []*DeploymentInfo `locationName:"deploymentsInfo" type:"list"`
-
-	_ struct{} `type:"structure"`
 }
 
 // String returns the string representation
@@ -1130,10 +1130,10 @@ func (s BatchGetDeploymentsOutput) GoString() string {
 
 // Represents the input of a batch get on-premises instances operation.
 type BatchGetOnPremisesInstancesInput struct {
+	_ struct{} `type:"structure"`
+
 	// The names of the on-premises instances to get information about.
 	InstanceNames []*string `locationName:"instanceNames" type:"list"`
-
-	_ struct{} `type:"structure"`
 }
 
 // String returns the string representation
@@ -1148,10 +1148,10 @@ func (s BatchGetOnPremisesInstancesInput) GoString() string {
 
 // Represents the output of a batch get on-premises instances operation.
 type BatchGetOnPremisesInstancesOutput struct {
+	_ struct{} `type:"structure"`
+
 	// Information about the on-premises instances.
 	InstanceInfos []*InstanceInfo `locationName:"instanceInfos" type:"list"`
-
-	_ struct{} `type:"structure"`
 }
 
 // String returns the string representation
@@ -1166,11 +1166,11 @@ func (s BatchGetOnPremisesInstancesOutput) GoString() string {
 
 // Represents the input of a create application operation.
 type CreateApplicationInput struct {
+	_ struct{} `type:"structure"`
+
 	// The name of the application. This name must be unique with the applicable
 	// IAM user or AWS account.
 	ApplicationName *string `locationName:"applicationName" min:"1" type:"string" required:"true"`
-
-	_ struct{} `type:"structure"`
 }
 
 // String returns the string representation
@@ -1185,10 +1185,10 @@ func (s CreateApplicationInput) GoString() string {
 
 // Represents the output of a create application operation.
 type CreateApplicationOutput struct {
+	_ struct{} `type:"structure"`
+
 	// A unique application ID.
 	ApplicationId *string `locationName:"applicationId" type:"string"`
-
-	_ struct{} `type:"structure"`
 }
 
 // String returns the string representation
@@ -1203,6 +1203,8 @@ func (s CreateApplicationOutput) GoString() string {
 
 // Represents the input of a create deployment configuration operation.
 type CreateDeploymentConfigInput struct {
+	_ struct{} `type:"structure"`
+
 	// The name of the deployment configuration to create.
 	DeploymentConfigName *string `locationName:"deploymentConfigName" min:"1" type:"string" required:"true"`
 
@@ -1223,8 +1225,6 @@ type CreateDeploymentConfigInput struct {
 	// For example, to set a minimum of 95% healthy instances, specify a type of
 	// FLEET_PERCENT and a value of 95.
 	MinimumHealthyHosts *MinimumHealthyHosts `locationName:"minimumHealthyHosts" type:"structure"`
-
-	_ struct{} `type:"structure"`
 }
 
 // String returns the string representation
@@ -1239,10 +1239,10 @@ func (s CreateDeploymentConfigInput) GoString() string {
 
 // Represents the output of a create deployment configuration operation.
 type CreateDeploymentConfigOutput struct {
+	_ struct{} `type:"structure"`
+
 	// A unique deployment configuration ID.
 	DeploymentConfigId *string `locationName:"deploymentConfigId" type:"string"`
-
-	_ struct{} `type:"structure"`
 }
 
 // String returns the string representation
@@ -1257,6 +1257,8 @@ func (s CreateDeploymentConfigOutput) GoString() string {
 
 // Represents the input of a create deployment group operation.
 type CreateDeploymentGroupInput struct {
+	_ struct{} `type:"structure"`
+
 	// The name of an existing AWS CodeDeploy application associated with the applicable
 	// IAM user or AWS account.
 	ApplicationName *string `locationName:"applicationName" min:"1" type:"string" required:"true"`
@@ -1307,8 +1309,6 @@ type CreateDeploymentGroupInput struct {
 	// A service role ARN that allows AWS CodeDeploy to act on the user's behalf
 	// when interacting with AWS services.
 	ServiceRoleArn *string `locationName:"serviceRoleArn" type:"string" required:"true"`
-
-	_ struct{} `type:"structure"`
 }
 
 // String returns the string representation
@@ -1323,10 +1323,10 @@ func (s CreateDeploymentGroupInput) GoString() string {
 
 // Represents the output of a create deployment group operation.
 type CreateDeploymentGroupOutput struct {
+	_ struct{} `type:"structure"`
+
 	// A unique deployment group ID.
 	DeploymentGroupId *string `locationName:"deploymentGroupId" type:"string"`
-
-	_ struct{} `type:"structure"`
 }
 
 // String returns the string representation
@@ -1341,6 +1341,8 @@ func (s CreateDeploymentGroupOutput) GoString() string {
 
 // Represents the input of a create deployment operation.
 type CreateDeploymentInput struct {
+	_ struct{} `type:"structure"`
+
 	// The name of an existing AWS CodeDeploy application associated with the applicable
 	// IAM user or AWS account.
 	ApplicationName *string `locationName:"applicationName" min:"1" type:"string" required:"true"`
@@ -1373,8 +1375,6 @@ type CreateDeploymentInput struct {
 	// The type of revision to deploy, along with information about the revision's
 	// location.
 	Revision *RevisionLocation `locationName:"revision" type:"structure"`
-
-	_ struct{} `type:"structure"`
 }
 
 // String returns the string representation
@@ -1389,10 +1389,10 @@ func (s CreateDeploymentInput) GoString() string {
 
 // Represents the output of a create deployment operation.
 type CreateDeploymentOutput struct {
+	_ struct{} `type:"structure"`
+
 	// A unique deployment ID.
 	DeploymentId *string `locationName:"deploymentId" type:"string"`
-
-	_ struct{} `type:"structure"`
 }
 
 // String returns the string representation
@@ -1407,11 +1407,11 @@ func (s CreateDeploymentOutput) GoString() string {
 
 // Represents the input of a delete application operation.
 type DeleteApplicationInput struct {
+	_ struct{} `type:"structure"`
+
 	// The name of an existing AWS CodeDeploy application associated with the applicable
 	// IAM user or AWS account.
 	ApplicationName *string `locationName:"applicationName" min:"1" type:"string" required:"true"`
-
-	_ struct{} `type:"structure"`
 }
 
 // String returns the string representation
@@ -1440,11 +1440,11 @@ func (s DeleteApplicationOutput) GoString() string {
 
 // Represents the input of a delete deployment configuration operation.
 type DeleteDeploymentConfigInput struct {
+	_ struct{} `type:"structure"`
+
 	// The name of an existing deployment configuration associated with the applicable
 	// IAM user or AWS account.
 	DeploymentConfigName *string `locationName:"deploymentConfigName" min:"1" type:"string" required:"true"`
-
-	_ struct{} `type:"structure"`
 }
 
 // String returns the string representation
@@ -1473,14 +1473,14 @@ func (s DeleteDeploymentConfigOutput) GoString() string {
 
 // Represents the input of a delete deployment group operation.
 type DeleteDeploymentGroupInput struct {
+	_ struct{} `type:"structure"`
+
 	// The name of an existing AWS CodeDeploy application associated with the applicable
 	// IAM user or AWS account.
 	ApplicationName *string `locationName:"applicationName" min:"1" type:"string" required:"true"`
 
 	// The name of an existing deployment group for the specified application.
 	DeploymentGroupName *string `locationName:"deploymentGroupName" min:"1" type:"string" required:"true"`
-
-	_ struct{} `type:"structure"`
 }
 
 // String returns the string representation
@@ -1495,6 +1495,8 @@ func (s DeleteDeploymentGroupInput) GoString() string {
 
 // Represents the output of a delete deployment group operation.
 type DeleteDeploymentGroupOutput struct {
+	_ struct{} `type:"structure"`
+
 	// If the output contains no data, and the corresponding deployment group contained
 	// at least one Auto Scaling group, AWS CodeDeploy successfully removed all
 	// corresponding Auto Scaling lifecycle event hooks from the Amazon EC2 instances
@@ -1502,8 +1504,6 @@ type DeleteDeploymentGroupOutput struct {
 	// not remove some Auto Scaling lifecycle event hooks from the Amazon EC2 instances
 	// in the Auto Scaling group.
 	HooksNotCleanedUp []*AutoScalingGroup `locationName:"hooksNotCleanedUp" type:"list"`
-
-	_ struct{} `type:"structure"`
 }
 
 // String returns the string representation
@@ -1518,6 +1518,8 @@ func (s DeleteDeploymentGroupOutput) GoString() string {
 
 // Information about a deployment configuration.
 type DeploymentConfigInfo struct {
+	_ struct{} `type:"structure"`
+
 	// The time that the deployment configuration was created.
 	CreateTime *time.Time `locationName:"createTime" type:"timestamp" timestampFormat:"unix"`
 
@@ -1529,8 +1531,6 @@ type DeploymentConfigInfo struct {
 
 	// Information about the number or percentage of minimum healthy instances.
 	MinimumHealthyHosts *MinimumHealthyHosts `locationName:"minimumHealthyHosts" type:"structure"`
-
-	_ struct{} `type:"structure"`
 }
 
 // String returns the string representation
@@ -1545,6 +1545,8 @@ func (s DeploymentConfigInfo) GoString() string {
 
 // Information about a deployment group.
 type DeploymentGroupInfo struct {
+	_ struct{} `type:"structure"`
+
 	// The application name.
 	ApplicationName *string `locationName:"applicationName" min:"1" type:"string"`
 
@@ -1572,8 +1574,6 @@ type DeploymentGroupInfo struct {
 	// Information about the deployment group's target revision, including the revision's
 	// type and its location.
 	TargetRevision *RevisionLocation `locationName:"targetRevision" type:"structure"`
-
-	_ struct{} `type:"structure"`
 }
 
 // String returns the string representation
@@ -1588,6 +1588,8 @@ func (s DeploymentGroupInfo) GoString() string {
 
 // Information about a deployment.
 type DeploymentInfo struct {
+	_ struct{} `type:"structure"`
+
 	// The application name.
 	ApplicationName *string `locationName:"applicationName" min:"1" type:"string"`
 
@@ -1646,8 +1648,6 @@ type DeploymentInfo struct {
 
 	// The current state of the deployment as a whole.
 	Status *string `locationName:"status" type:"string" enum:"DeploymentStatus"`
-
-	_ struct{} `type:"structure"`
 }
 
 // String returns the string representation
@@ -1662,6 +1662,8 @@ func (s DeploymentInfo) GoString() string {
 
 // Information about the deployment status of the instances in the deployment.
 type DeploymentOverview struct {
+	_ struct{} `type:"structure"`
+
 	// The number of instances that have failed in the deployment.
 	Failed *int64 `type:"long"`
 
@@ -1676,8 +1678,6 @@ type DeploymentOverview struct {
 
 	// The number of instances that have succeeded in the deployment.
 	Succeeded *int64 `type:"long"`
-
-	_ struct{} `type:"structure"`
 }
 
 // String returns the string representation
@@ -1692,10 +1692,10 @@ func (s DeploymentOverview) GoString() string {
 
 // Represents the input of a deregister on-premises instance operation.
 type DeregisterOnPremisesInstanceInput struct {
+	_ struct{} `type:"structure"`
+
 	// The name of the on-premises instance to deregister.
 	InstanceName *string `locationName:"instanceName" type:"string" required:"true"`
-
-	_ struct{} `type:"structure"`
 }
 
 // String returns the string representation
@@ -1724,6 +1724,8 @@ func (s DeregisterOnPremisesInstanceOutput) GoString() string {
 
 // Diagnostic information about executable scripts that are part of a deployment.
 type Diagnostics struct {
+	_ struct{} `type:"structure"`
+
 	// The associated error code:
 	//
 	//  Success: The specified script ran. ScriptMissing: The specified script
@@ -1742,8 +1744,6 @@ type Diagnostics struct {
 
 	// The name of the script.
 	ScriptName *string `locationName:"scriptName" type:"string"`
-
-	_ struct{} `type:"structure"`
 }
 
 // String returns the string representation
@@ -1758,6 +1758,8 @@ func (s Diagnostics) GoString() string {
 
 // Information about a tag filter.
 type EC2TagFilter struct {
+	_ struct{} `type:"structure"`
+
 	// The tag filter key.
 	Key *string `type:"string"`
 
@@ -1768,8 +1770,6 @@ type EC2TagFilter struct {
 
 	// The tag filter value.
 	Value *string `type:"string"`
-
-	_ struct{} `type:"structure"`
 }
 
 // String returns the string representation
@@ -1784,6 +1784,8 @@ func (s EC2TagFilter) GoString() string {
 
 // Information about a deployment error.
 type ErrorInformation struct {
+	_ struct{} `type:"structure"`
+
 	// The error code:
 	//
 	//  APPLICATION_MISSING: The application was missing. Note that this error
@@ -1809,8 +1811,6 @@ type ErrorInformation struct {
 
 	// An accompanying error message.
 	Message *string `locationName:"message" type:"string"`
-
-	_ struct{} `type:"structure"`
 }
 
 // String returns the string representation
@@ -1825,6 +1825,8 @@ func (s ErrorInformation) GoString() string {
 
 // Information about an application revision.
 type GenericRevisionInfo struct {
+	_ struct{} `type:"structure"`
+
 	// A list of deployment groups that use this revision.
 	DeploymentGroups []*string `locationName:"deploymentGroups" type:"list"`
 
@@ -1839,8 +1841,6 @@ type GenericRevisionInfo struct {
 
 	// When the revision was registered with AWS CodeDeploy.
 	RegisterTime *time.Time `locationName:"registerTime" type:"timestamp" timestampFormat:"unix"`
-
-	_ struct{} `type:"structure"`
 }
 
 // String returns the string representation
@@ -1855,11 +1855,11 @@ func (s GenericRevisionInfo) GoString() string {
 
 // Represents the input of a get application operation.
 type GetApplicationInput struct {
+	_ struct{} `type:"structure"`
+
 	// The name of an existing AWS CodeDeploy application associated with the applicable
 	// IAM user or AWS account.
 	ApplicationName *string `locationName:"applicationName" min:"1" type:"string" required:"true"`
-
-	_ struct{} `type:"structure"`
 }
 
 // String returns the string representation
@@ -1874,10 +1874,10 @@ func (s GetApplicationInput) GoString() string {
 
 // Represents the output of a get application operation.
 type GetApplicationOutput struct {
+	_ struct{} `type:"structure"`
+
 	// Information about the application.
 	Application *ApplicationInfo `locationName:"application" type:"structure"`
-
-	_ struct{} `type:"structure"`
 }
 
 // String returns the string representation
@@ -1892,14 +1892,14 @@ func (s GetApplicationOutput) GoString() string {
 
 // Represents the input of a get application revision operation.
 type GetApplicationRevisionInput struct {
+	_ struct{} `type:"structure"`
+
 	// The name of the application that corresponds to the revision.
 	ApplicationName *string `locationName:"applicationName" min:"1" type:"string" required:"true"`
 
 	// Information about the application revision to get, including the revision's
 	// type and its location.
 	Revision *RevisionLocation `locationName:"revision" type:"structure" required:"true"`
-
-	_ struct{} `type:"structure"`
 }
 
 // String returns the string representation
@@ -1914,6 +1914,8 @@ func (s GetApplicationRevisionInput) GoString() string {
 
 // Represents the output of a get application revision operation.
 type GetApplicationRevisionOutput struct {
+	_ struct{} `type:"structure"`
+
 	// The name of the application that corresponds to the revision.
 	ApplicationName *string `locationName:"applicationName" min:"1" type:"string"`
 
@@ -1923,8 +1925,6 @@ type GetApplicationRevisionOutput struct {
 
 	// General information about the revision.
 	RevisionInfo *GenericRevisionInfo `locationName:"revisionInfo" type:"structure"`
-
-	_ struct{} `type:"structure"`
 }
 
 // String returns the string representation
@@ -1939,11 +1939,11 @@ func (s GetApplicationRevisionOutput) GoString() string {
 
 // Represents the input of a get deployment configuration operation.
 type GetDeploymentConfigInput struct {
+	_ struct{} `type:"structure"`
+
 	// The name of an existing deployment configuration associated with the applicable
 	// IAM user or AWS account.
 	DeploymentConfigName *string `locationName:"deploymentConfigName" min:"1" type:"string" required:"true"`
-
-	_ struct{} `type:"structure"`
 }
 
 // String returns the string representation
@@ -1958,10 +1958,10 @@ func (s GetDeploymentConfigInput) GoString() string {
 
 // Represents the output of a get deployment configuration operation.
 type GetDeploymentConfigOutput struct {
+	_ struct{} `type:"structure"`
+
 	// Information about the deployment configuration.
 	DeploymentConfigInfo *DeploymentConfigInfo `locationName:"deploymentConfigInfo" type:"structure"`
-
-	_ struct{} `type:"structure"`
 }
 
 // String returns the string representation
@@ -1976,14 +1976,14 @@ func (s GetDeploymentConfigOutput) GoString() string {
 
 // Represents the input of a get deployment group operation.
 type GetDeploymentGroupInput struct {
+	_ struct{} `type:"structure"`
+
 	// The name of an existing AWS CodeDeploy application associated with the applicable
 	// IAM user or AWS account.
 	ApplicationName *string `locationName:"applicationName" min:"1" type:"string" required:"true"`
 
 	// The name of an existing deployment group for the specified application.
 	DeploymentGroupName *string `locationName:"deploymentGroupName" min:"1" type:"string" required:"true"`
-
-	_ struct{} `type:"structure"`
 }
 
 // String returns the string representation
@@ -1998,10 +1998,10 @@ func (s GetDeploymentGroupInput) GoString() string {
 
 // Represents the output of a get deployment group operation.
 type GetDeploymentGroupOutput struct {
+	_ struct{} `type:"structure"`
+
 	// Information about the deployment group.
 	DeploymentGroupInfo *DeploymentGroupInfo `locationName:"deploymentGroupInfo" type:"structure"`
-
-	_ struct{} `type:"structure"`
 }
 
 // String returns the string representation
@@ -2016,11 +2016,11 @@ func (s GetDeploymentGroupOutput) GoString() string {
 
 // Represents the input of a get deployment operation.
 type GetDeploymentInput struct {
+	_ struct{} `type:"structure"`
+
 	// An existing deployment ID associated with the applicable IAM user or AWS
 	// account.
 	DeploymentId *string `locationName:"deploymentId" type:"string" required:"true"`
-
-	_ struct{} `type:"structure"`
 }
 
 // String returns the string representation
@@ -2035,13 +2035,13 @@ func (s GetDeploymentInput) GoString() string {
 
 // Represents the input of a get deployment instance operation.
 type GetDeploymentInstanceInput struct {
+	_ struct{} `type:"structure"`
+
 	// The unique ID of a deployment.
 	DeploymentId *string `locationName:"deploymentId" type:"string" required:"true"`
 
 	// The unique ID of an instance in the deployment's deployment group.
 	InstanceId *string `locationName:"instanceId" type:"string" required:"true"`
-
-	_ struct{} `type:"structure"`
 }
 
 // String returns the string representation
@@ -2056,10 +2056,10 @@ func (s GetDeploymentInstanceInput) GoString() string {
 
 // Represents the output of a get deployment instance operation.
 type GetDeploymentInstanceOutput struct {
+	_ struct{} `type:"structure"`
+
 	// Information about the instance.
 	InstanceSummary *InstanceSummary `locationName:"instanceSummary" type:"structure"`
-
-	_ struct{} `type:"structure"`
 }
 
 // String returns the string representation
@@ -2074,10 +2074,10 @@ func (s GetDeploymentInstanceOutput) GoString() string {
 
 // Represents the output of a get deployment operation.
 type GetDeploymentOutput struct {
+	_ struct{} `type:"structure"`
+
 	// Information about the deployment.
 	DeploymentInfo *DeploymentInfo `locationName:"deploymentInfo" type:"structure"`
-
-	_ struct{} `type:"structure"`
 }
 
 // String returns the string representation
@@ -2092,10 +2092,10 @@ func (s GetDeploymentOutput) GoString() string {
 
 // Represents the input of a get on-premises instance operation.
 type GetOnPremisesInstanceInput struct {
+	_ struct{} `type:"structure"`
+
 	// The name of the on-premises instance to get information about
 	InstanceName *string `locationName:"instanceName" type:"string" required:"true"`
-
-	_ struct{} `type:"structure"`
 }
 
 // String returns the string representation
@@ -2110,10 +2110,10 @@ func (s GetOnPremisesInstanceInput) GoString() string {
 
 // Represents the output of a get on-premises instance operation.
 type GetOnPremisesInstanceOutput struct {
+	_ struct{} `type:"structure"`
+
 	// Information about the on-premises instance.
 	InstanceInfo *InstanceInfo `locationName:"instanceInfo" type:"structure"`
-
-	_ struct{} `type:"structure"`
 }
 
 // String returns the string representation
@@ -2129,6 +2129,8 @@ func (s GetOnPremisesInstanceOutput) GoString() string {
 // Information about the location of application artifacts that are stored in
 // GitHub.
 type GitHubLocation struct {
+	_ struct{} `type:"structure"`
+
 	// The SHA1 commit ID of the GitHub commit that references the that represents
 	// the bundled artifacts for the application revision.
 	CommitId *string `locationName:"commitId" type:"string"`
@@ -2138,8 +2140,6 @@ type GitHubLocation struct {
 	//
 	// Specified as account/repository.
 	Repository *string `locationName:"repository" type:"string"`
-
-	_ struct{} `type:"structure"`
 }
 
 // String returns the string representation
@@ -2154,6 +2154,8 @@ func (s GitHubLocation) GoString() string {
 
 // Information about an on-premises instance.
 type InstanceInfo struct {
+	_ struct{} `type:"structure"`
+
 	// If the on-premises instance was deregistered, the time that the on-premises
 	// instance was deregistered.
 	DeregisterTime *time.Time `locationName:"deregisterTime" type:"timestamp" timestampFormat:"unix"`
@@ -2172,8 +2174,6 @@ type InstanceInfo struct {
 
 	// The tags that are currently associated with the on-premises instance.
 	Tags []*Tag `locationName:"tags" type:"list"`
-
-	_ struct{} `type:"structure"`
 }
 
 // String returns the string representation
@@ -2188,6 +2188,8 @@ func (s InstanceInfo) GoString() string {
 
 // Information about an instance in a deployment.
 type InstanceSummary struct {
+	_ struct{} `type:"structure"`
+
 	// The deployment ID.
 	DeploymentId *string `locationName:"deploymentId" type:"string"`
 
@@ -2208,8 +2210,6 @@ type InstanceSummary struct {
 	// Skipped: The deployment has been skipped for this instance. Unknown: The
 	// deployment status is unknown for this instance.
 	Status *string `locationName:"status" type:"string" enum:"InstanceStatus"`
-
-	_ struct{} `type:"structure"`
 }
 
 // String returns the string representation
@@ -2224,6 +2224,8 @@ func (s InstanceSummary) GoString() string {
 
 // Information about a deployment lifecycle event.
 type LifecycleEvent struct {
+	_ struct{} `type:"structure"`
+
 	// Diagnostic information about the deployment lifecycle event.
 	Diagnostics *Diagnostics `locationName:"diagnostics" type:"structure"`
 
@@ -2245,8 +2247,6 @@ type LifecycleEvent struct {
 	// The deployment lifecycle event has been skipped. Unknown: The deployment
 	// lifecycle event is unknown.
 	Status *string `locationName:"status" type:"string" enum:"LifecycleEventStatus"`
-
-	_ struct{} `type:"structure"`
 }
 
 // String returns the string representation
@@ -2261,6 +2261,8 @@ func (s LifecycleEvent) GoString() string {
 
 // Represents the input of a list application revisions operation.
 type ListApplicationRevisionsInput struct {
+	_ struct{} `type:"structure"`
+
 	// The name of an existing AWS CodeDeploy application associated with the applicable
 	// IAM user or AWS account.
 	ApplicationName *string `locationName:"applicationName" min:"1" type:"string" required:"true"`
@@ -2304,8 +2306,6 @@ type ListApplicationRevisionsInput struct {
 	//
 	// If set to null, the results will be sorted in an arbitrary order.
 	SortOrder *string `locationName:"sortOrder" type:"string" enum:"SortOrder"`
-
-	_ struct{} `type:"structure"`
 }
 
 // String returns the string representation
@@ -2320,6 +2320,8 @@ func (s ListApplicationRevisionsInput) GoString() string {
 
 // Represents the output of a list application revisions operation.
 type ListApplicationRevisionsOutput struct {
+	_ struct{} `type:"structure"`
+
 	// If the amount of information that is returned is significantly large, an
 	// identifier will also be returned, which can be used in a subsequent list
 	// application revisions call to return the next set of application revisions
@@ -2328,8 +2330,6 @@ type ListApplicationRevisionsOutput struct {
 
 	// A list of revision locations that contain the matching revisions.
 	Revisions []*RevisionLocation `locationName:"revisions" type:"list"`
-
-	_ struct{} `type:"structure"`
 }
 
 // String returns the string representation
@@ -2344,11 +2344,11 @@ func (s ListApplicationRevisionsOutput) GoString() string {
 
 // Represents the input of a list applications operation.
 type ListApplicationsInput struct {
+	_ struct{} `type:"structure"`
+
 	// An identifier that was returned from the previous list applications call,
 	// which can be used to return the next set of applications in the list.
 	NextToken *string `locationName:"nextToken" type:"string"`
-
-	_ struct{} `type:"structure"`
 }
 
 // String returns the string representation
@@ -2363,6 +2363,8 @@ func (s ListApplicationsInput) GoString() string {
 
 // Represents the output of a list applications operation.
 type ListApplicationsOutput struct {
+	_ struct{} `type:"structure"`
+
 	// A list of application names.
 	Applications []*string `locationName:"applications" type:"list"`
 
@@ -2370,8 +2372,6 @@ type ListApplicationsOutput struct {
 	// identifier will also be returned, which can be used in a subsequent list
 	// applications call to return the next set of applications in the list.
 	NextToken *string `locationName:"nextToken" type:"string"`
-
-	_ struct{} `type:"structure"`
 }
 
 // String returns the string representation
@@ -2386,12 +2386,12 @@ func (s ListApplicationsOutput) GoString() string {
 
 // Represents the input of a list deployment configurations operation.
 type ListDeploymentConfigsInput struct {
+	_ struct{} `type:"structure"`
+
 	// An identifier that was returned from the previous list deployment configurations
 	// call, which can be used to return the next set of deployment configurations
 	// in the list.
 	NextToken *string `locationName:"nextToken" type:"string"`
-
-	_ struct{} `type:"structure"`
 }
 
 // String returns the string representation
@@ -2406,6 +2406,8 @@ func (s ListDeploymentConfigsInput) GoString() string {
 
 // Represents the output of a list deployment configurations operation.
 type ListDeploymentConfigsOutput struct {
+	_ struct{} `type:"structure"`
+
 	// A list of deployment configurations, including the built-in configurations
 	// such as CodeDeployDefault.OneAtATime.
 	DeploymentConfigsList []*string `locationName:"deploymentConfigsList" type:"list"`
@@ -2415,8 +2417,6 @@ type ListDeploymentConfigsOutput struct {
 	// deployment configurations call to return the next set of deployment configurations
 	// in the list.
 	NextToken *string `locationName:"nextToken" type:"string"`
-
-	_ struct{} `type:"structure"`
 }
 
 // String returns the string representation
@@ -2431,6 +2431,8 @@ func (s ListDeploymentConfigsOutput) GoString() string {
 
 // Represents the input of a list deployment groups operation.
 type ListDeploymentGroupsInput struct {
+	_ struct{} `type:"structure"`
+
 	// The name of an existing AWS CodeDeploy application associated with the applicable
 	// IAM user or AWS account.
 	ApplicationName *string `locationName:"applicationName" min:"1" type:"string" required:"true"`
@@ -2439,8 +2441,6 @@ type ListDeploymentGroupsInput struct {
 	// call, which can be used to return the next set of deployment groups in the
 	// list.
 	NextToken *string `locationName:"nextToken" type:"string"`
-
-	_ struct{} `type:"structure"`
 }
 
 // String returns the string representation
@@ -2455,6 +2455,8 @@ func (s ListDeploymentGroupsInput) GoString() string {
 
 // Represents the output of a list deployment groups operation.
 type ListDeploymentGroupsOutput struct {
+	_ struct{} `type:"structure"`
+
 	// The application name.
 	ApplicationName *string `locationName:"applicationName" min:"1" type:"string"`
 
@@ -2466,8 +2468,6 @@ type ListDeploymentGroupsOutput struct {
 	// deployment groups call to return the next set of deployment groups in the
 	// list.
 	NextToken *string `locationName:"nextToken" type:"string"`
-
-	_ struct{} `type:"structure"`
 }
 
 // String returns the string representation
@@ -2482,6 +2482,8 @@ func (s ListDeploymentGroupsOutput) GoString() string {
 
 // Represents the input of a list deployment instances operation.
 type ListDeploymentInstancesInput struct {
+	_ struct{} `type:"structure"`
+
 	// The unique ID of a deployment.
 	DeploymentId *string `locationName:"deploymentId" type:"string" required:"true"`
 
@@ -2500,8 +2502,6 @@ type ListDeploymentInstancesInput struct {
 	// call, which can be used to return the next set of deployment instances in
 	// the list.
 	NextToken *string `locationName:"nextToken" type:"string"`
-
-	_ struct{} `type:"structure"`
 }
 
 // String returns the string representation
@@ -2516,6 +2516,8 @@ func (s ListDeploymentInstancesInput) GoString() string {
 
 // Represents the output of a list deployment instances operation.
 type ListDeploymentInstancesOutput struct {
+	_ struct{} `type:"structure"`
+
 	// A list of instances IDs.
 	InstancesList []*string `locationName:"instancesList" type:"list"`
 
@@ -2524,8 +2526,6 @@ type ListDeploymentInstancesOutput struct {
 	// deployment instances call to return the next set of deployment instances
 	// in the list.
 	NextToken *string `locationName:"nextToken" type:"string"`
-
-	_ struct{} `type:"structure"`
 }
 
 // String returns the string representation
@@ -2540,6 +2540,8 @@ func (s ListDeploymentInstancesOutput) GoString() string {
 
 // Represents the input of a list deployments operation.
 type ListDeploymentsInput struct {
+	_ struct{} `type:"structure"`
+
 	// The name of an existing AWS CodeDeploy application associated with the applicable
 	// IAM user or AWS account.
 	ApplicationName *string `locationName:"applicationName" min:"1" type:"string"`
@@ -2563,8 +2565,6 @@ type ListDeploymentsInput struct {
 	// An identifier that was returned from the previous list deployments call,
 	// which can be used to return the next set of deployments in the list.
 	NextToken *string `locationName:"nextToken" type:"string"`
-
-	_ struct{} `type:"structure"`
 }
 
 // String returns the string representation
@@ -2579,6 +2579,8 @@ func (s ListDeploymentsInput) GoString() string {
 
 // Represents the output of a list deployments operation.
 type ListDeploymentsOutput struct {
+	_ struct{} `type:"structure"`
+
 	// A list of deployment IDs.
 	Deployments []*string `locationName:"deployments" type:"list"`
 
@@ -2586,8 +2588,6 @@ type ListDeploymentsOutput struct {
 	// identifier will also be returned, which can be used in a subsequent list
 	// deployments call to return the next set of deployments in the list.
 	NextToken *string `locationName:"nextToken" type:"string"`
-
-	_ struct{} `type:"structure"`
 }
 
 // String returns the string representation
@@ -2604,6 +2604,8 @@ func (s ListDeploymentsOutput) GoString() string {
 //
 // .
 type ListOnPremisesInstancesInput struct {
+	_ struct{} `type:"structure"`
+
 	// An identifier that was returned from the previous list on-premises instances
 	// call, which can be used to return the next set of on-premises instances in
 	// the list.
@@ -2618,8 +2620,6 @@ type ListOnPremisesInstancesInput struct {
 	// The on-premises instance tags that will be used to restrict the corresponding
 	// on-premises instance names that are returned.
 	TagFilters []*TagFilter `locationName:"tagFilters" type:"list"`
-
-	_ struct{} `type:"structure"`
 }
 
 // String returns the string representation
@@ -2634,6 +2634,8 @@ func (s ListOnPremisesInstancesInput) GoString() string {
 
 // Represents the output of list on-premises instances operation.
 type ListOnPremisesInstancesOutput struct {
+	_ struct{} `type:"structure"`
+
 	// The list of matching on-premises instance names.
 	InstanceNames []*string `locationName:"instanceNames" type:"list"`
 
@@ -2642,8 +2644,6 @@ type ListOnPremisesInstancesOutput struct {
 	// on-premises instances call to return the next set of on-premises instances
 	// in the list.
 	NextToken *string `locationName:"nextToken" type:"string"`
-
-	_ struct{} `type:"structure"`
 }
 
 // String returns the string representation
@@ -2658,6 +2658,8 @@ func (s ListOnPremisesInstancesOutput) GoString() string {
 
 // Information about minimum healthy instances.
 type MinimumHealthyHosts struct {
+	_ struct{} `type:"structure"`
+
 	// The minimum healthy instances type:
 	//
 	//  HOST_COUNT: The minimum number of healthy instances, as an absolute value.
@@ -2677,8 +2679,6 @@ type MinimumHealthyHosts struct {
 
 	// The minimum healthy instances value.
 	Value *int64 `locationName:"value" type:"integer"`
-
-	_ struct{} `type:"structure"`
 }
 
 // String returns the string representation
@@ -2693,6 +2693,8 @@ func (s MinimumHealthyHosts) GoString() string {
 
 // Represents the input of a register application revision operation.
 type RegisterApplicationRevisionInput struct {
+	_ struct{} `type:"structure"`
+
 	// The name of an existing AWS CodeDeploy application associated with the applicable
 	// IAM user or AWS account.
 	ApplicationName *string `locationName:"applicationName" min:"1" type:"string" required:"true"`
@@ -2703,8 +2705,6 @@ type RegisterApplicationRevisionInput struct {
 	// Information about the application revision to register, including the revision's
 	// type and its location.
 	Revision *RevisionLocation `locationName:"revision" type:"structure" required:"true"`
-
-	_ struct{} `type:"structure"`
 }
 
 // String returns the string representation
@@ -2733,13 +2733,13 @@ func (s RegisterApplicationRevisionOutput) GoString() string {
 
 // Represents the input of register on-premises instance operation.
 type RegisterOnPremisesInstanceInput struct {
+	_ struct{} `type:"structure"`
+
 	// The ARN of the IAM user to associate with the on-premises instance.
 	IamUserArn *string `locationName:"iamUserArn" type:"string" required:"true"`
 
 	// The name of the on-premises instance to register.
 	InstanceName *string `locationName:"instanceName" type:"string" required:"true"`
-
-	_ struct{} `type:"structure"`
 }
 
 // String returns the string representation
@@ -2768,13 +2768,13 @@ func (s RegisterOnPremisesInstanceOutput) GoString() string {
 
 // Represents the input of a remove tags from on-premises instances operation.
 type RemoveTagsFromOnPremisesInstancesInput struct {
+	_ struct{} `type:"structure"`
+
 	// The names of the on-premises instances to remove tags from.
 	InstanceNames []*string `locationName:"instanceNames" type:"list" required:"true"`
 
 	// The tag key-value pairs to remove from the on-premises instances.
 	Tags []*Tag `locationName:"tags" type:"list" required:"true"`
-
-	_ struct{} `type:"structure"`
 }
 
 // String returns the string representation
@@ -2803,6 +2803,8 @@ func (s RemoveTagsFromOnPremisesInstancesOutput) GoString() string {
 
 // Information about an application revision's location.
 type RevisionLocation struct {
+	_ struct{} `type:"structure"`
+
 	// Information about the location of application artifacts that are stored in
 	// GitHub.
 	GitHubLocation *GitHubLocation `locationName:"gitHubLocation" type:"structure"`
@@ -2816,8 +2818,6 @@ type RevisionLocation struct {
 	// Information about the location of application artifacts that are stored in
 	// Amazon S3.
 	S3Location *S3Location `locationName:"s3Location" type:"structure"`
-
-	_ struct{} `type:"structure"`
 }
 
 // String returns the string representation
@@ -2833,6 +2833,8 @@ func (s RevisionLocation) GoString() string {
 // Information about the location of application artifacts that are stored in
 // Amazon S3.
 type S3Location struct {
+	_ struct{} `type:"structure"`
+
 	// The name of the Amazon S3 bucket where the application revision is stored.
 	Bucket *string `locationName:"bucket" type:"string"`
 
@@ -2859,8 +2861,6 @@ type S3Location struct {
 	// If the version is not specified, the system will use the most recent version
 	// by default.
 	Version *string `locationName:"version" type:"string"`
-
-	_ struct{} `type:"structure"`
 }
 
 // String returns the string representation
@@ -2875,10 +2875,10 @@ func (s S3Location) GoString() string {
 
 // Represents the input of a stop deployment operation.
 type StopDeploymentInput struct {
+	_ struct{} `type:"structure"`
+
 	// The unique ID of a deployment.
 	DeploymentId *string `locationName:"deploymentId" type:"string" required:"true"`
-
-	_ struct{} `type:"structure"`
 }
 
 // String returns the string representation
@@ -2893,6 +2893,8 @@ func (s StopDeploymentInput) GoString() string {
 
 // Represents the output of a stop deployment operation.
 type StopDeploymentOutput struct {
+	_ struct{} `type:"structure"`
+
 	// The status of the stop deployment operation:
 	//
 	//  Pending: The stop operation is pending. Succeeded: The stop operation succeeded.
@@ -2900,8 +2902,6 @@ type StopDeploymentOutput struct {
 
 	// An accompanying status message.
 	StatusMessage *string `locationName:"statusMessage" type:"string"`
-
-	_ struct{} `type:"structure"`
 }
 
 // String returns the string representation
@@ -2916,13 +2916,13 @@ func (s StopDeploymentOutput) GoString() string {
 
 // Information about a tag.
 type Tag struct {
+	_ struct{} `type:"structure"`
+
 	// The tag's key.
 	Key *string `type:"string"`
 
 	// The tag's value.
 	Value *string `type:"string"`
-
-	_ struct{} `type:"structure"`
 }
 
 // String returns the string representation
@@ -2937,6 +2937,8 @@ func (s Tag) GoString() string {
 
 // Information about an on-premises instance tag filter.
 type TagFilter struct {
+	_ struct{} `type:"structure"`
+
 	// The on-premises instance tag filter key.
 	Key *string `type:"string"`
 
@@ -2947,8 +2949,6 @@ type TagFilter struct {
 
 	// The on-premises instance tag filter value.
 	Value *string `type:"string"`
-
-	_ struct{} `type:"structure"`
 }
 
 // String returns the string representation
@@ -2963,6 +2963,8 @@ func (s TagFilter) GoString() string {
 
 // Information about a time range.
 type TimeRange struct {
+	_ struct{} `type:"structure"`
+
 	// The time range's end time.
 	//
 	// Specify null to leave the time range's end time open-ended.
@@ -2972,8 +2974,6 @@ type TimeRange struct {
 	//
 	// Specify null to leave the time range's start time open-ended.
 	Start *time.Time `locationName:"start" type:"timestamp" timestampFormat:"unix"`
-
-	_ struct{} `type:"structure"`
 }
 
 // String returns the string representation
@@ -2988,13 +2988,13 @@ func (s TimeRange) GoString() string {
 
 // Represents the input of an update application operation.
 type UpdateApplicationInput struct {
+	_ struct{} `type:"structure"`
+
 	// The current name of the application that you want to change.
 	ApplicationName *string `locationName:"applicationName" min:"1" type:"string"`
 
 	// The new name that you want to change the application to.
 	NewApplicationName *string `locationName:"newApplicationName" min:"1" type:"string"`
-
-	_ struct{} `type:"structure"`
 }
 
 // String returns the string representation
@@ -3023,6 +3023,8 @@ func (s UpdateApplicationOutput) GoString() string {
 
 // Represents the input of an update deployment group operation.
 type UpdateDeploymentGroupInput struct {
+	_ struct{} `type:"structure"`
+
 	// The application name corresponding to the deployment group to update.
 	ApplicationName *string `locationName:"applicationName" min:"1" type:"string" required:"true"`
 
@@ -3050,8 +3052,6 @@ type UpdateDeploymentGroupInput struct {
 
 	// A replacement service role's ARN, if you want to change it.
 	ServiceRoleArn *string `locationName:"serviceRoleArn" type:"string"`
-
-	_ struct{} `type:"structure"`
 }
 
 // String returns the string representation
@@ -3066,14 +3066,14 @@ func (s UpdateDeploymentGroupInput) GoString() string {
 
 // Represents the output of an update deployment group operation.
 type UpdateDeploymentGroupOutput struct {
+	_ struct{} `type:"structure"`
+
 	// If the output contains no data, and the corresponding deployment group contained
 	// at least one Auto Scaling group, AWS CodeDeploy successfully removed all
 	// corresponding Auto Scaling lifecycle event hooks from the AWS account. If
 	// the output does contain data, AWS CodeDeploy could not remove some Auto Scaling
 	// lifecycle event hooks from the AWS account.
 	HooksNotCleanedUp []*AutoScalingGroup `locationName:"hooksNotCleanedUp" type:"list"`
-
-	_ struct{} `type:"structure"`
 }
 
 // String returns the string representation

--- a/service/codedeploy/api.go
+++ b/service/codedeploy/api.go
@@ -979,11 +979,7 @@ type AddTagsToOnPremisesInstancesInput struct {
 	// Value-only tags are not allowed.
 	Tags []*Tag `locationName:"tags" type:"list" required:"true"`
 
-	metadataAddTagsToOnPremisesInstancesInput `json:"-" xml:"-"`
-}
-
-type metadataAddTagsToOnPremisesInstancesInput struct {
-	SDKShapeTraits bool `type:"structure"`
+	_ struct{} `type:"structure"`
 }
 
 // String returns the string representation
@@ -997,11 +993,7 @@ func (s AddTagsToOnPremisesInstancesInput) GoString() string {
 }
 
 type AddTagsToOnPremisesInstancesOutput struct {
-	metadataAddTagsToOnPremisesInstancesOutput `json:"-" xml:"-"`
-}
-
-type metadataAddTagsToOnPremisesInstancesOutput struct {
-	SDKShapeTraits bool `type:"structure"`
+	_ struct{} `type:"structure"`
 }
 
 // String returns the string representation
@@ -1029,11 +1021,7 @@ type ApplicationInfo struct {
 	// otherwise, false.
 	LinkedToGitHub *bool `locationName:"linkedToGitHub" type:"boolean"`
 
-	metadataApplicationInfo `json:"-" xml:"-"`
-}
-
-type metadataApplicationInfo struct {
-	SDKShapeTraits bool `type:"structure"`
+	_ struct{} `type:"structure"`
 }
 
 // String returns the string representation
@@ -1054,11 +1042,7 @@ type AutoScalingGroup struct {
 	// The Auto Scaling group name.
 	Name *string `locationName:"name" type:"string"`
 
-	metadataAutoScalingGroup `json:"-" xml:"-"`
-}
-
-type metadataAutoScalingGroup struct {
-	SDKShapeTraits bool `type:"structure"`
+	_ struct{} `type:"structure"`
 }
 
 // String returns the string representation
@@ -1077,11 +1061,7 @@ type BatchGetApplicationsInput struct {
 	// spaces.
 	ApplicationNames []*string `locationName:"applicationNames" type:"list"`
 
-	metadataBatchGetApplicationsInput `json:"-" xml:"-"`
-}
-
-type metadataBatchGetApplicationsInput struct {
-	SDKShapeTraits bool `type:"structure"`
+	_ struct{} `type:"structure"`
 }
 
 // String returns the string representation
@@ -1099,11 +1079,7 @@ type BatchGetApplicationsOutput struct {
 	// Information about the applications.
 	ApplicationsInfo []*ApplicationInfo `locationName:"applicationsInfo" type:"list"`
 
-	metadataBatchGetApplicationsOutput `json:"-" xml:"-"`
-}
-
-type metadataBatchGetApplicationsOutput struct {
-	SDKShapeTraits bool `type:"structure"`
+	_ struct{} `type:"structure"`
 }
 
 // String returns the string representation
@@ -1121,11 +1097,7 @@ type BatchGetDeploymentsInput struct {
 	// A list of deployment IDs, with multiple deployment IDs separated by spaces.
 	DeploymentIds []*string `locationName:"deploymentIds" type:"list"`
 
-	metadataBatchGetDeploymentsInput `json:"-" xml:"-"`
-}
-
-type metadataBatchGetDeploymentsInput struct {
-	SDKShapeTraits bool `type:"structure"`
+	_ struct{} `type:"structure"`
 }
 
 // String returns the string representation
@@ -1143,11 +1115,7 @@ type BatchGetDeploymentsOutput struct {
 	// Information about the deployments.
 	DeploymentsInfo []*DeploymentInfo `locationName:"deploymentsInfo" type:"list"`
 
-	metadataBatchGetDeploymentsOutput `json:"-" xml:"-"`
-}
-
-type metadataBatchGetDeploymentsOutput struct {
-	SDKShapeTraits bool `type:"structure"`
+	_ struct{} `type:"structure"`
 }
 
 // String returns the string representation
@@ -1165,11 +1133,7 @@ type BatchGetOnPremisesInstancesInput struct {
 	// The names of the on-premises instances to get information about.
 	InstanceNames []*string `locationName:"instanceNames" type:"list"`
 
-	metadataBatchGetOnPremisesInstancesInput `json:"-" xml:"-"`
-}
-
-type metadataBatchGetOnPremisesInstancesInput struct {
-	SDKShapeTraits bool `type:"structure"`
+	_ struct{} `type:"structure"`
 }
 
 // String returns the string representation
@@ -1187,11 +1151,7 @@ type BatchGetOnPremisesInstancesOutput struct {
 	// Information about the on-premises instances.
 	InstanceInfos []*InstanceInfo `locationName:"instanceInfos" type:"list"`
 
-	metadataBatchGetOnPremisesInstancesOutput `json:"-" xml:"-"`
-}
-
-type metadataBatchGetOnPremisesInstancesOutput struct {
-	SDKShapeTraits bool `type:"structure"`
+	_ struct{} `type:"structure"`
 }
 
 // String returns the string representation
@@ -1210,11 +1170,7 @@ type CreateApplicationInput struct {
 	// IAM user or AWS account.
 	ApplicationName *string `locationName:"applicationName" min:"1" type:"string" required:"true"`
 
-	metadataCreateApplicationInput `json:"-" xml:"-"`
-}
-
-type metadataCreateApplicationInput struct {
-	SDKShapeTraits bool `type:"structure"`
+	_ struct{} `type:"structure"`
 }
 
 // String returns the string representation
@@ -1232,11 +1188,7 @@ type CreateApplicationOutput struct {
 	// A unique application ID.
 	ApplicationId *string `locationName:"applicationId" type:"string"`
 
-	metadataCreateApplicationOutput `json:"-" xml:"-"`
-}
-
-type metadataCreateApplicationOutput struct {
-	SDKShapeTraits bool `type:"structure"`
+	_ struct{} `type:"structure"`
 }
 
 // String returns the string representation
@@ -1272,11 +1224,7 @@ type CreateDeploymentConfigInput struct {
 	// FLEET_PERCENT and a value of 95.
 	MinimumHealthyHosts *MinimumHealthyHosts `locationName:"minimumHealthyHosts" type:"structure"`
 
-	metadataCreateDeploymentConfigInput `json:"-" xml:"-"`
-}
-
-type metadataCreateDeploymentConfigInput struct {
-	SDKShapeTraits bool `type:"structure"`
+	_ struct{} `type:"structure"`
 }
 
 // String returns the string representation
@@ -1294,11 +1242,7 @@ type CreateDeploymentConfigOutput struct {
 	// A unique deployment configuration ID.
 	DeploymentConfigId *string `locationName:"deploymentConfigId" type:"string"`
 
-	metadataCreateDeploymentConfigOutput `json:"-" xml:"-"`
-}
-
-type metadataCreateDeploymentConfigOutput struct {
-	SDKShapeTraits bool `type:"structure"`
+	_ struct{} `type:"structure"`
 }
 
 // String returns the string representation
@@ -1364,11 +1308,7 @@ type CreateDeploymentGroupInput struct {
 	// when interacting with AWS services.
 	ServiceRoleArn *string `locationName:"serviceRoleArn" type:"string" required:"true"`
 
-	metadataCreateDeploymentGroupInput `json:"-" xml:"-"`
-}
-
-type metadataCreateDeploymentGroupInput struct {
-	SDKShapeTraits bool `type:"structure"`
+	_ struct{} `type:"structure"`
 }
 
 // String returns the string representation
@@ -1386,11 +1326,7 @@ type CreateDeploymentGroupOutput struct {
 	// A unique deployment group ID.
 	DeploymentGroupId *string `locationName:"deploymentGroupId" type:"string"`
 
-	metadataCreateDeploymentGroupOutput `json:"-" xml:"-"`
-}
-
-type metadataCreateDeploymentGroupOutput struct {
-	SDKShapeTraits bool `type:"structure"`
+	_ struct{} `type:"structure"`
 }
 
 // String returns the string representation
@@ -1438,11 +1374,7 @@ type CreateDeploymentInput struct {
 	// location.
 	Revision *RevisionLocation `locationName:"revision" type:"structure"`
 
-	metadataCreateDeploymentInput `json:"-" xml:"-"`
-}
-
-type metadataCreateDeploymentInput struct {
-	SDKShapeTraits bool `type:"structure"`
+	_ struct{} `type:"structure"`
 }
 
 // String returns the string representation
@@ -1460,11 +1392,7 @@ type CreateDeploymentOutput struct {
 	// A unique deployment ID.
 	DeploymentId *string `locationName:"deploymentId" type:"string"`
 
-	metadataCreateDeploymentOutput `json:"-" xml:"-"`
-}
-
-type metadataCreateDeploymentOutput struct {
-	SDKShapeTraits bool `type:"structure"`
+	_ struct{} `type:"structure"`
 }
 
 // String returns the string representation
@@ -1483,11 +1411,7 @@ type DeleteApplicationInput struct {
 	// IAM user or AWS account.
 	ApplicationName *string `locationName:"applicationName" min:"1" type:"string" required:"true"`
 
-	metadataDeleteApplicationInput `json:"-" xml:"-"`
-}
-
-type metadataDeleteApplicationInput struct {
-	SDKShapeTraits bool `type:"structure"`
+	_ struct{} `type:"structure"`
 }
 
 // String returns the string representation
@@ -1501,11 +1425,7 @@ func (s DeleteApplicationInput) GoString() string {
 }
 
 type DeleteApplicationOutput struct {
-	metadataDeleteApplicationOutput `json:"-" xml:"-"`
-}
-
-type metadataDeleteApplicationOutput struct {
-	SDKShapeTraits bool `type:"structure"`
+	_ struct{} `type:"structure"`
 }
 
 // String returns the string representation
@@ -1524,11 +1444,7 @@ type DeleteDeploymentConfigInput struct {
 	// IAM user or AWS account.
 	DeploymentConfigName *string `locationName:"deploymentConfigName" min:"1" type:"string" required:"true"`
 
-	metadataDeleteDeploymentConfigInput `json:"-" xml:"-"`
-}
-
-type metadataDeleteDeploymentConfigInput struct {
-	SDKShapeTraits bool `type:"structure"`
+	_ struct{} `type:"structure"`
 }
 
 // String returns the string representation
@@ -1542,11 +1458,7 @@ func (s DeleteDeploymentConfigInput) GoString() string {
 }
 
 type DeleteDeploymentConfigOutput struct {
-	metadataDeleteDeploymentConfigOutput `json:"-" xml:"-"`
-}
-
-type metadataDeleteDeploymentConfigOutput struct {
-	SDKShapeTraits bool `type:"structure"`
+	_ struct{} `type:"structure"`
 }
 
 // String returns the string representation
@@ -1568,11 +1480,7 @@ type DeleteDeploymentGroupInput struct {
 	// The name of an existing deployment group for the specified application.
 	DeploymentGroupName *string `locationName:"deploymentGroupName" min:"1" type:"string" required:"true"`
 
-	metadataDeleteDeploymentGroupInput `json:"-" xml:"-"`
-}
-
-type metadataDeleteDeploymentGroupInput struct {
-	SDKShapeTraits bool `type:"structure"`
+	_ struct{} `type:"structure"`
 }
 
 // String returns the string representation
@@ -1595,11 +1503,7 @@ type DeleteDeploymentGroupOutput struct {
 	// in the Auto Scaling group.
 	HooksNotCleanedUp []*AutoScalingGroup `locationName:"hooksNotCleanedUp" type:"list"`
 
-	metadataDeleteDeploymentGroupOutput `json:"-" xml:"-"`
-}
-
-type metadataDeleteDeploymentGroupOutput struct {
-	SDKShapeTraits bool `type:"structure"`
+	_ struct{} `type:"structure"`
 }
 
 // String returns the string representation
@@ -1626,11 +1530,7 @@ type DeploymentConfigInfo struct {
 	// Information about the number or percentage of minimum healthy instances.
 	MinimumHealthyHosts *MinimumHealthyHosts `locationName:"minimumHealthyHosts" type:"structure"`
 
-	metadataDeploymentConfigInfo `json:"-" xml:"-"`
-}
-
-type metadataDeploymentConfigInfo struct {
-	SDKShapeTraits bool `type:"structure"`
+	_ struct{} `type:"structure"`
 }
 
 // String returns the string representation
@@ -1673,11 +1573,7 @@ type DeploymentGroupInfo struct {
 	// type and its location.
 	TargetRevision *RevisionLocation `locationName:"targetRevision" type:"structure"`
 
-	metadataDeploymentGroupInfo `json:"-" xml:"-"`
-}
-
-type metadataDeploymentGroupInfo struct {
-	SDKShapeTraits bool `type:"structure"`
+	_ struct{} `type:"structure"`
 }
 
 // String returns the string representation
@@ -1751,11 +1647,7 @@ type DeploymentInfo struct {
 	// The current state of the deployment as a whole.
 	Status *string `locationName:"status" type:"string" enum:"DeploymentStatus"`
 
-	metadataDeploymentInfo `json:"-" xml:"-"`
-}
-
-type metadataDeploymentInfo struct {
-	SDKShapeTraits bool `type:"structure"`
+	_ struct{} `type:"structure"`
 }
 
 // String returns the string representation
@@ -1785,11 +1677,7 @@ type DeploymentOverview struct {
 	// The number of instances that have succeeded in the deployment.
 	Succeeded *int64 `type:"long"`
 
-	metadataDeploymentOverview `json:"-" xml:"-"`
-}
-
-type metadataDeploymentOverview struct {
-	SDKShapeTraits bool `type:"structure"`
+	_ struct{} `type:"structure"`
 }
 
 // String returns the string representation
@@ -1807,11 +1695,7 @@ type DeregisterOnPremisesInstanceInput struct {
 	// The name of the on-premises instance to deregister.
 	InstanceName *string `locationName:"instanceName" type:"string" required:"true"`
 
-	metadataDeregisterOnPremisesInstanceInput `json:"-" xml:"-"`
-}
-
-type metadataDeregisterOnPremisesInstanceInput struct {
-	SDKShapeTraits bool `type:"structure"`
+	_ struct{} `type:"structure"`
 }
 
 // String returns the string representation
@@ -1825,11 +1709,7 @@ func (s DeregisterOnPremisesInstanceInput) GoString() string {
 }
 
 type DeregisterOnPremisesInstanceOutput struct {
-	metadataDeregisterOnPremisesInstanceOutput `json:"-" xml:"-"`
-}
-
-type metadataDeregisterOnPremisesInstanceOutput struct {
-	SDKShapeTraits bool `type:"structure"`
+	_ struct{} `type:"structure"`
 }
 
 // String returns the string representation
@@ -1863,11 +1743,7 @@ type Diagnostics struct {
 	// The name of the script.
 	ScriptName *string `locationName:"scriptName" type:"string"`
 
-	metadataDiagnostics `json:"-" xml:"-"`
-}
-
-type metadataDiagnostics struct {
-	SDKShapeTraits bool `type:"structure"`
+	_ struct{} `type:"structure"`
 }
 
 // String returns the string representation
@@ -1893,11 +1769,7 @@ type EC2TagFilter struct {
 	// The tag filter value.
 	Value *string `type:"string"`
 
-	metadataEC2TagFilter `json:"-" xml:"-"`
-}
-
-type metadataEC2TagFilter struct {
-	SDKShapeTraits bool `type:"structure"`
+	_ struct{} `type:"structure"`
 }
 
 // String returns the string representation
@@ -1938,11 +1810,7 @@ type ErrorInformation struct {
 	// An accompanying error message.
 	Message *string `locationName:"message" type:"string"`
 
-	metadataErrorInformation `json:"-" xml:"-"`
-}
-
-type metadataErrorInformation struct {
-	SDKShapeTraits bool `type:"structure"`
+	_ struct{} `type:"structure"`
 }
 
 // String returns the string representation
@@ -1972,11 +1840,7 @@ type GenericRevisionInfo struct {
 	// When the revision was registered with AWS CodeDeploy.
 	RegisterTime *time.Time `locationName:"registerTime" type:"timestamp" timestampFormat:"unix"`
 
-	metadataGenericRevisionInfo `json:"-" xml:"-"`
-}
-
-type metadataGenericRevisionInfo struct {
-	SDKShapeTraits bool `type:"structure"`
+	_ struct{} `type:"structure"`
 }
 
 // String returns the string representation
@@ -1995,11 +1859,7 @@ type GetApplicationInput struct {
 	// IAM user or AWS account.
 	ApplicationName *string `locationName:"applicationName" min:"1" type:"string" required:"true"`
 
-	metadataGetApplicationInput `json:"-" xml:"-"`
-}
-
-type metadataGetApplicationInput struct {
-	SDKShapeTraits bool `type:"structure"`
+	_ struct{} `type:"structure"`
 }
 
 // String returns the string representation
@@ -2017,11 +1877,7 @@ type GetApplicationOutput struct {
 	// Information about the application.
 	Application *ApplicationInfo `locationName:"application" type:"structure"`
 
-	metadataGetApplicationOutput `json:"-" xml:"-"`
-}
-
-type metadataGetApplicationOutput struct {
-	SDKShapeTraits bool `type:"structure"`
+	_ struct{} `type:"structure"`
 }
 
 // String returns the string representation
@@ -2043,11 +1899,7 @@ type GetApplicationRevisionInput struct {
 	// type and its location.
 	Revision *RevisionLocation `locationName:"revision" type:"structure" required:"true"`
 
-	metadataGetApplicationRevisionInput `json:"-" xml:"-"`
-}
-
-type metadataGetApplicationRevisionInput struct {
-	SDKShapeTraits bool `type:"structure"`
+	_ struct{} `type:"structure"`
 }
 
 // String returns the string representation
@@ -2072,11 +1924,7 @@ type GetApplicationRevisionOutput struct {
 	// General information about the revision.
 	RevisionInfo *GenericRevisionInfo `locationName:"revisionInfo" type:"structure"`
 
-	metadataGetApplicationRevisionOutput `json:"-" xml:"-"`
-}
-
-type metadataGetApplicationRevisionOutput struct {
-	SDKShapeTraits bool `type:"structure"`
+	_ struct{} `type:"structure"`
 }
 
 // String returns the string representation
@@ -2095,11 +1943,7 @@ type GetDeploymentConfigInput struct {
 	// IAM user or AWS account.
 	DeploymentConfigName *string `locationName:"deploymentConfigName" min:"1" type:"string" required:"true"`
 
-	metadataGetDeploymentConfigInput `json:"-" xml:"-"`
-}
-
-type metadataGetDeploymentConfigInput struct {
-	SDKShapeTraits bool `type:"structure"`
+	_ struct{} `type:"structure"`
 }
 
 // String returns the string representation
@@ -2117,11 +1961,7 @@ type GetDeploymentConfigOutput struct {
 	// Information about the deployment configuration.
 	DeploymentConfigInfo *DeploymentConfigInfo `locationName:"deploymentConfigInfo" type:"structure"`
 
-	metadataGetDeploymentConfigOutput `json:"-" xml:"-"`
-}
-
-type metadataGetDeploymentConfigOutput struct {
-	SDKShapeTraits bool `type:"structure"`
+	_ struct{} `type:"structure"`
 }
 
 // String returns the string representation
@@ -2143,11 +1983,7 @@ type GetDeploymentGroupInput struct {
 	// The name of an existing deployment group for the specified application.
 	DeploymentGroupName *string `locationName:"deploymentGroupName" min:"1" type:"string" required:"true"`
 
-	metadataGetDeploymentGroupInput `json:"-" xml:"-"`
-}
-
-type metadataGetDeploymentGroupInput struct {
-	SDKShapeTraits bool `type:"structure"`
+	_ struct{} `type:"structure"`
 }
 
 // String returns the string representation
@@ -2165,11 +2001,7 @@ type GetDeploymentGroupOutput struct {
 	// Information about the deployment group.
 	DeploymentGroupInfo *DeploymentGroupInfo `locationName:"deploymentGroupInfo" type:"structure"`
 
-	metadataGetDeploymentGroupOutput `json:"-" xml:"-"`
-}
-
-type metadataGetDeploymentGroupOutput struct {
-	SDKShapeTraits bool `type:"structure"`
+	_ struct{} `type:"structure"`
 }
 
 // String returns the string representation
@@ -2188,11 +2020,7 @@ type GetDeploymentInput struct {
 	// account.
 	DeploymentId *string `locationName:"deploymentId" type:"string" required:"true"`
 
-	metadataGetDeploymentInput `json:"-" xml:"-"`
-}
-
-type metadataGetDeploymentInput struct {
-	SDKShapeTraits bool `type:"structure"`
+	_ struct{} `type:"structure"`
 }
 
 // String returns the string representation
@@ -2213,11 +2041,7 @@ type GetDeploymentInstanceInput struct {
 	// The unique ID of an instance in the deployment's deployment group.
 	InstanceId *string `locationName:"instanceId" type:"string" required:"true"`
 
-	metadataGetDeploymentInstanceInput `json:"-" xml:"-"`
-}
-
-type metadataGetDeploymentInstanceInput struct {
-	SDKShapeTraits bool `type:"structure"`
+	_ struct{} `type:"structure"`
 }
 
 // String returns the string representation
@@ -2235,11 +2059,7 @@ type GetDeploymentInstanceOutput struct {
 	// Information about the instance.
 	InstanceSummary *InstanceSummary `locationName:"instanceSummary" type:"structure"`
 
-	metadataGetDeploymentInstanceOutput `json:"-" xml:"-"`
-}
-
-type metadataGetDeploymentInstanceOutput struct {
-	SDKShapeTraits bool `type:"structure"`
+	_ struct{} `type:"structure"`
 }
 
 // String returns the string representation
@@ -2257,11 +2077,7 @@ type GetDeploymentOutput struct {
 	// Information about the deployment.
 	DeploymentInfo *DeploymentInfo `locationName:"deploymentInfo" type:"structure"`
 
-	metadataGetDeploymentOutput `json:"-" xml:"-"`
-}
-
-type metadataGetDeploymentOutput struct {
-	SDKShapeTraits bool `type:"structure"`
+	_ struct{} `type:"structure"`
 }
 
 // String returns the string representation
@@ -2279,11 +2095,7 @@ type GetOnPremisesInstanceInput struct {
 	// The name of the on-premises instance to get information about
 	InstanceName *string `locationName:"instanceName" type:"string" required:"true"`
 
-	metadataGetOnPremisesInstanceInput `json:"-" xml:"-"`
-}
-
-type metadataGetOnPremisesInstanceInput struct {
-	SDKShapeTraits bool `type:"structure"`
+	_ struct{} `type:"structure"`
 }
 
 // String returns the string representation
@@ -2301,11 +2113,7 @@ type GetOnPremisesInstanceOutput struct {
 	// Information about the on-premises instance.
 	InstanceInfo *InstanceInfo `locationName:"instanceInfo" type:"structure"`
 
-	metadataGetOnPremisesInstanceOutput `json:"-" xml:"-"`
-}
-
-type metadataGetOnPremisesInstanceOutput struct {
-	SDKShapeTraits bool `type:"structure"`
+	_ struct{} `type:"structure"`
 }
 
 // String returns the string representation
@@ -2331,11 +2139,7 @@ type GitHubLocation struct {
 	// Specified as account/repository.
 	Repository *string `locationName:"repository" type:"string"`
 
-	metadataGitHubLocation `json:"-" xml:"-"`
-}
-
-type metadataGitHubLocation struct {
-	SDKShapeTraits bool `type:"structure"`
+	_ struct{} `type:"structure"`
 }
 
 // String returns the string representation
@@ -2369,11 +2173,7 @@ type InstanceInfo struct {
 	// The tags that are currently associated with the on-premises instance.
 	Tags []*Tag `locationName:"tags" type:"list"`
 
-	metadataInstanceInfo `json:"-" xml:"-"`
-}
-
-type metadataInstanceInfo struct {
-	SDKShapeTraits bool `type:"structure"`
+	_ struct{} `type:"structure"`
 }
 
 // String returns the string representation
@@ -2409,11 +2209,7 @@ type InstanceSummary struct {
 	// deployment status is unknown for this instance.
 	Status *string `locationName:"status" type:"string" enum:"InstanceStatus"`
 
-	metadataInstanceSummary `json:"-" xml:"-"`
-}
-
-type metadataInstanceSummary struct {
-	SDKShapeTraits bool `type:"structure"`
+	_ struct{} `type:"structure"`
 }
 
 // String returns the string representation
@@ -2450,11 +2246,7 @@ type LifecycleEvent struct {
 	// lifecycle event is unknown.
 	Status *string `locationName:"status" type:"string" enum:"LifecycleEventStatus"`
 
-	metadataLifecycleEvent `json:"-" xml:"-"`
-}
-
-type metadataLifecycleEvent struct {
-	SDKShapeTraits bool `type:"structure"`
+	_ struct{} `type:"structure"`
 }
 
 // String returns the string representation
@@ -2513,11 +2305,7 @@ type ListApplicationRevisionsInput struct {
 	// If set to null, the results will be sorted in an arbitrary order.
 	SortOrder *string `locationName:"sortOrder" type:"string" enum:"SortOrder"`
 
-	metadataListApplicationRevisionsInput `json:"-" xml:"-"`
-}
-
-type metadataListApplicationRevisionsInput struct {
-	SDKShapeTraits bool `type:"structure"`
+	_ struct{} `type:"structure"`
 }
 
 // String returns the string representation
@@ -2541,11 +2329,7 @@ type ListApplicationRevisionsOutput struct {
 	// A list of revision locations that contain the matching revisions.
 	Revisions []*RevisionLocation `locationName:"revisions" type:"list"`
 
-	metadataListApplicationRevisionsOutput `json:"-" xml:"-"`
-}
-
-type metadataListApplicationRevisionsOutput struct {
-	SDKShapeTraits bool `type:"structure"`
+	_ struct{} `type:"structure"`
 }
 
 // String returns the string representation
@@ -2564,11 +2348,7 @@ type ListApplicationsInput struct {
 	// which can be used to return the next set of applications in the list.
 	NextToken *string `locationName:"nextToken" type:"string"`
 
-	metadataListApplicationsInput `json:"-" xml:"-"`
-}
-
-type metadataListApplicationsInput struct {
-	SDKShapeTraits bool `type:"structure"`
+	_ struct{} `type:"structure"`
 }
 
 // String returns the string representation
@@ -2591,11 +2371,7 @@ type ListApplicationsOutput struct {
 	// applications call to return the next set of applications in the list.
 	NextToken *string `locationName:"nextToken" type:"string"`
 
-	metadataListApplicationsOutput `json:"-" xml:"-"`
-}
-
-type metadataListApplicationsOutput struct {
-	SDKShapeTraits bool `type:"structure"`
+	_ struct{} `type:"structure"`
 }
 
 // String returns the string representation
@@ -2615,11 +2391,7 @@ type ListDeploymentConfigsInput struct {
 	// in the list.
 	NextToken *string `locationName:"nextToken" type:"string"`
 
-	metadataListDeploymentConfigsInput `json:"-" xml:"-"`
-}
-
-type metadataListDeploymentConfigsInput struct {
-	SDKShapeTraits bool `type:"structure"`
+	_ struct{} `type:"structure"`
 }
 
 // String returns the string representation
@@ -2644,11 +2416,7 @@ type ListDeploymentConfigsOutput struct {
 	// in the list.
 	NextToken *string `locationName:"nextToken" type:"string"`
 
-	metadataListDeploymentConfigsOutput `json:"-" xml:"-"`
-}
-
-type metadataListDeploymentConfigsOutput struct {
-	SDKShapeTraits bool `type:"structure"`
+	_ struct{} `type:"structure"`
 }
 
 // String returns the string representation
@@ -2672,11 +2440,7 @@ type ListDeploymentGroupsInput struct {
 	// list.
 	NextToken *string `locationName:"nextToken" type:"string"`
 
-	metadataListDeploymentGroupsInput `json:"-" xml:"-"`
-}
-
-type metadataListDeploymentGroupsInput struct {
-	SDKShapeTraits bool `type:"structure"`
+	_ struct{} `type:"structure"`
 }
 
 // String returns the string representation
@@ -2703,11 +2467,7 @@ type ListDeploymentGroupsOutput struct {
 	// list.
 	NextToken *string `locationName:"nextToken" type:"string"`
 
-	metadataListDeploymentGroupsOutput `json:"-" xml:"-"`
-}
-
-type metadataListDeploymentGroupsOutput struct {
-	SDKShapeTraits bool `type:"structure"`
+	_ struct{} `type:"structure"`
 }
 
 // String returns the string representation
@@ -2741,11 +2501,7 @@ type ListDeploymentInstancesInput struct {
 	// the list.
 	NextToken *string `locationName:"nextToken" type:"string"`
 
-	metadataListDeploymentInstancesInput `json:"-" xml:"-"`
-}
-
-type metadataListDeploymentInstancesInput struct {
-	SDKShapeTraits bool `type:"structure"`
+	_ struct{} `type:"structure"`
 }
 
 // String returns the string representation
@@ -2769,11 +2525,7 @@ type ListDeploymentInstancesOutput struct {
 	// in the list.
 	NextToken *string `locationName:"nextToken" type:"string"`
 
-	metadataListDeploymentInstancesOutput `json:"-" xml:"-"`
-}
-
-type metadataListDeploymentInstancesOutput struct {
-	SDKShapeTraits bool `type:"structure"`
+	_ struct{} `type:"structure"`
 }
 
 // String returns the string representation
@@ -2812,11 +2564,7 @@ type ListDeploymentsInput struct {
 	// which can be used to return the next set of deployments in the list.
 	NextToken *string `locationName:"nextToken" type:"string"`
 
-	metadataListDeploymentsInput `json:"-" xml:"-"`
-}
-
-type metadataListDeploymentsInput struct {
-	SDKShapeTraits bool `type:"structure"`
+	_ struct{} `type:"structure"`
 }
 
 // String returns the string representation
@@ -2839,11 +2587,7 @@ type ListDeploymentsOutput struct {
 	// deployments call to return the next set of deployments in the list.
 	NextToken *string `locationName:"nextToken" type:"string"`
 
-	metadataListDeploymentsOutput `json:"-" xml:"-"`
-}
-
-type metadataListDeploymentsOutput struct {
-	SDKShapeTraits bool `type:"structure"`
+	_ struct{} `type:"structure"`
 }
 
 // String returns the string representation
@@ -2875,11 +2619,7 @@ type ListOnPremisesInstancesInput struct {
 	// on-premises instance names that are returned.
 	TagFilters []*TagFilter `locationName:"tagFilters" type:"list"`
 
-	metadataListOnPremisesInstancesInput `json:"-" xml:"-"`
-}
-
-type metadataListOnPremisesInstancesInput struct {
-	SDKShapeTraits bool `type:"structure"`
+	_ struct{} `type:"structure"`
 }
 
 // String returns the string representation
@@ -2903,11 +2643,7 @@ type ListOnPremisesInstancesOutput struct {
 	// in the list.
 	NextToken *string `locationName:"nextToken" type:"string"`
 
-	metadataListOnPremisesInstancesOutput `json:"-" xml:"-"`
-}
-
-type metadataListOnPremisesInstancesOutput struct {
-	SDKShapeTraits bool `type:"structure"`
+	_ struct{} `type:"structure"`
 }
 
 // String returns the string representation
@@ -2942,11 +2678,7 @@ type MinimumHealthyHosts struct {
 	// The minimum healthy instances value.
 	Value *int64 `locationName:"value" type:"integer"`
 
-	metadataMinimumHealthyHosts `json:"-" xml:"-"`
-}
-
-type metadataMinimumHealthyHosts struct {
-	SDKShapeTraits bool `type:"structure"`
+	_ struct{} `type:"structure"`
 }
 
 // String returns the string representation
@@ -2972,11 +2704,7 @@ type RegisterApplicationRevisionInput struct {
 	// type and its location.
 	Revision *RevisionLocation `locationName:"revision" type:"structure" required:"true"`
 
-	metadataRegisterApplicationRevisionInput `json:"-" xml:"-"`
-}
-
-type metadataRegisterApplicationRevisionInput struct {
-	SDKShapeTraits bool `type:"structure"`
+	_ struct{} `type:"structure"`
 }
 
 // String returns the string representation
@@ -2990,11 +2718,7 @@ func (s RegisterApplicationRevisionInput) GoString() string {
 }
 
 type RegisterApplicationRevisionOutput struct {
-	metadataRegisterApplicationRevisionOutput `json:"-" xml:"-"`
-}
-
-type metadataRegisterApplicationRevisionOutput struct {
-	SDKShapeTraits bool `type:"structure"`
+	_ struct{} `type:"structure"`
 }
 
 // String returns the string representation
@@ -3015,11 +2739,7 @@ type RegisterOnPremisesInstanceInput struct {
 	// The name of the on-premises instance to register.
 	InstanceName *string `locationName:"instanceName" type:"string" required:"true"`
 
-	metadataRegisterOnPremisesInstanceInput `json:"-" xml:"-"`
-}
-
-type metadataRegisterOnPremisesInstanceInput struct {
-	SDKShapeTraits bool `type:"structure"`
+	_ struct{} `type:"structure"`
 }
 
 // String returns the string representation
@@ -3033,11 +2753,7 @@ func (s RegisterOnPremisesInstanceInput) GoString() string {
 }
 
 type RegisterOnPremisesInstanceOutput struct {
-	metadataRegisterOnPremisesInstanceOutput `json:"-" xml:"-"`
-}
-
-type metadataRegisterOnPremisesInstanceOutput struct {
-	SDKShapeTraits bool `type:"structure"`
+	_ struct{} `type:"structure"`
 }
 
 // String returns the string representation
@@ -3058,11 +2774,7 @@ type RemoveTagsFromOnPremisesInstancesInput struct {
 	// The tag key-value pairs to remove from the on-premises instances.
 	Tags []*Tag `locationName:"tags" type:"list" required:"true"`
 
-	metadataRemoveTagsFromOnPremisesInstancesInput `json:"-" xml:"-"`
-}
-
-type metadataRemoveTagsFromOnPremisesInstancesInput struct {
-	SDKShapeTraits bool `type:"structure"`
+	_ struct{} `type:"structure"`
 }
 
 // String returns the string representation
@@ -3076,11 +2788,7 @@ func (s RemoveTagsFromOnPremisesInstancesInput) GoString() string {
 }
 
 type RemoveTagsFromOnPremisesInstancesOutput struct {
-	metadataRemoveTagsFromOnPremisesInstancesOutput `json:"-" xml:"-"`
-}
-
-type metadataRemoveTagsFromOnPremisesInstancesOutput struct {
-	SDKShapeTraits bool `type:"structure"`
+	_ struct{} `type:"structure"`
 }
 
 // String returns the string representation
@@ -3109,11 +2817,7 @@ type RevisionLocation struct {
 	// Amazon S3.
 	S3Location *S3Location `locationName:"s3Location" type:"structure"`
 
-	metadataRevisionLocation `json:"-" xml:"-"`
-}
-
-type metadataRevisionLocation struct {
-	SDKShapeTraits bool `type:"structure"`
+	_ struct{} `type:"structure"`
 }
 
 // String returns the string representation
@@ -3156,11 +2860,7 @@ type S3Location struct {
 	// by default.
 	Version *string `locationName:"version" type:"string"`
 
-	metadataS3Location `json:"-" xml:"-"`
-}
-
-type metadataS3Location struct {
-	SDKShapeTraits bool `type:"structure"`
+	_ struct{} `type:"structure"`
 }
 
 // String returns the string representation
@@ -3178,11 +2878,7 @@ type StopDeploymentInput struct {
 	// The unique ID of a deployment.
 	DeploymentId *string `locationName:"deploymentId" type:"string" required:"true"`
 
-	metadataStopDeploymentInput `json:"-" xml:"-"`
-}
-
-type metadataStopDeploymentInput struct {
-	SDKShapeTraits bool `type:"structure"`
+	_ struct{} `type:"structure"`
 }
 
 // String returns the string representation
@@ -3205,11 +2901,7 @@ type StopDeploymentOutput struct {
 	// An accompanying status message.
 	StatusMessage *string `locationName:"statusMessage" type:"string"`
 
-	metadataStopDeploymentOutput `json:"-" xml:"-"`
-}
-
-type metadataStopDeploymentOutput struct {
-	SDKShapeTraits bool `type:"structure"`
+	_ struct{} `type:"structure"`
 }
 
 // String returns the string representation
@@ -3230,11 +2922,7 @@ type Tag struct {
 	// The tag's value.
 	Value *string `type:"string"`
 
-	metadataTag `json:"-" xml:"-"`
-}
-
-type metadataTag struct {
-	SDKShapeTraits bool `type:"structure"`
+	_ struct{} `type:"structure"`
 }
 
 // String returns the string representation
@@ -3260,11 +2948,7 @@ type TagFilter struct {
 	// The on-premises instance tag filter value.
 	Value *string `type:"string"`
 
-	metadataTagFilter `json:"-" xml:"-"`
-}
-
-type metadataTagFilter struct {
-	SDKShapeTraits bool `type:"structure"`
+	_ struct{} `type:"structure"`
 }
 
 // String returns the string representation
@@ -3289,11 +2973,7 @@ type TimeRange struct {
 	// Specify null to leave the time range's start time open-ended.
 	Start *time.Time `locationName:"start" type:"timestamp" timestampFormat:"unix"`
 
-	metadataTimeRange `json:"-" xml:"-"`
-}
-
-type metadataTimeRange struct {
-	SDKShapeTraits bool `type:"structure"`
+	_ struct{} `type:"structure"`
 }
 
 // String returns the string representation
@@ -3314,11 +2994,7 @@ type UpdateApplicationInput struct {
 	// The new name that you want to change the application to.
 	NewApplicationName *string `locationName:"newApplicationName" min:"1" type:"string"`
 
-	metadataUpdateApplicationInput `json:"-" xml:"-"`
-}
-
-type metadataUpdateApplicationInput struct {
-	SDKShapeTraits bool `type:"structure"`
+	_ struct{} `type:"structure"`
 }
 
 // String returns the string representation
@@ -3332,11 +3008,7 @@ func (s UpdateApplicationInput) GoString() string {
 }
 
 type UpdateApplicationOutput struct {
-	metadataUpdateApplicationOutput `json:"-" xml:"-"`
-}
-
-type metadataUpdateApplicationOutput struct {
-	SDKShapeTraits bool `type:"structure"`
+	_ struct{} `type:"structure"`
 }
 
 // String returns the string representation
@@ -3379,11 +3051,7 @@ type UpdateDeploymentGroupInput struct {
 	// A replacement service role's ARN, if you want to change it.
 	ServiceRoleArn *string `locationName:"serviceRoleArn" type:"string"`
 
-	metadataUpdateDeploymentGroupInput `json:"-" xml:"-"`
-}
-
-type metadataUpdateDeploymentGroupInput struct {
-	SDKShapeTraits bool `type:"structure"`
+	_ struct{} `type:"structure"`
 }
 
 // String returns the string representation
@@ -3405,11 +3073,7 @@ type UpdateDeploymentGroupOutput struct {
 	// lifecycle event hooks from the AWS account.
 	HooksNotCleanedUp []*AutoScalingGroup `locationName:"hooksNotCleanedUp" type:"list"`
 
-	metadataUpdateDeploymentGroupOutput `json:"-" xml:"-"`
-}
-
-type metadataUpdateDeploymentGroupOutput struct {
-	SDKShapeTraits bool `type:"structure"`
+	_ struct{} `type:"structure"`
 }
 
 // String returns the string representation

--- a/service/codepipeline/api.go
+++ b/service/codepipeline/api.go
@@ -677,6 +677,8 @@ func (c *CodePipeline) UpdatePipeline(input *UpdatePipelineInput) (*UpdatePipeli
 // used to access input and output artifacts in the Amazon S3 bucket used to
 // store artifact for the pipeline in AWS CodePipeline.
 type AWSSessionCredentials struct {
+	_ struct{} `type:"structure"`
+
 	// The access key for the session.
 	AccessKeyId *string `locationName:"accessKeyId" type:"string" required:"true"`
 
@@ -685,8 +687,6 @@ type AWSSessionCredentials struct {
 
 	// The token for the session.
 	SessionToken *string `locationName:"sessionToken" type:"string" required:"true"`
-
-	_ struct{} `type:"structure"`
 }
 
 // String returns the string representation
@@ -701,6 +701,8 @@ func (s AWSSessionCredentials) GoString() string {
 
 // Represents the input of an acknowledge job action.
 type AcknowledgeJobInput struct {
+	_ struct{} `type:"structure"`
+
 	// The unique system-generated ID of the job for which you want to confirm receipt.
 	JobId *string `locationName:"jobId" type:"string" required:"true"`
 
@@ -708,8 +710,6 @@ type AcknowledgeJobInput struct {
 	// the job is being worked on by only one job worker. This number must be returned
 	// in the response.
 	Nonce *string `locationName:"nonce" type:"string" required:"true"`
-
-	_ struct{} `type:"structure"`
 }
 
 // String returns the string representation
@@ -724,10 +724,10 @@ func (s AcknowledgeJobInput) GoString() string {
 
 // Represents the output of an acknowledge job action.
 type AcknowledgeJobOutput struct {
+	_ struct{} `type:"structure"`
+
 	// Whether the job worker has received the specified job.
 	Status *string `locationName:"status" type:"string" enum:"JobStatus"`
-
-	_ struct{} `type:"structure"`
 }
 
 // String returns the string representation
@@ -742,6 +742,8 @@ func (s AcknowledgeJobOutput) GoString() string {
 
 // Represents the input of an acknowledge third party job action.
 type AcknowledgeThirdPartyJobInput struct {
+	_ struct{} `type:"structure"`
+
 	// The clientToken portion of the clientId and clientToken pair used to verify
 	// that the calling entity is allowed access to the job and its details.
 	ClientToken *string `locationName:"clientToken" type:"string" required:"true"`
@@ -753,8 +755,6 @@ type AcknowledgeThirdPartyJobInput struct {
 	// the job is being worked on by only one job worker. This number must be returned
 	// in the response.
 	Nonce *string `locationName:"nonce" type:"string" required:"true"`
-
-	_ struct{} `type:"structure"`
 }
 
 // String returns the string representation
@@ -769,10 +769,10 @@ func (s AcknowledgeThirdPartyJobInput) GoString() string {
 
 // Represents the output of an acknowledge third party job action.
 type AcknowledgeThirdPartyJobOutput struct {
+	_ struct{} `type:"structure"`
+
 	// The status information for the third party job, if any.
 	Status *string `locationName:"status" type:"string" enum:"JobStatus"`
-
-	_ struct{} `type:"structure"`
 }
 
 // String returns the string representation
@@ -787,10 +787,10 @@ func (s AcknowledgeThirdPartyJobOutput) GoString() string {
 
 // Represents information about an action configuration.
 type ActionConfiguration struct {
+	_ struct{} `type:"structure"`
+
 	// The configuration data for the action.
 	Configuration map[string]*string `locationName:"configuration" type:"map"`
-
-	_ struct{} `type:"structure"`
 }
 
 // String returns the string representation
@@ -805,6 +805,8 @@ func (s ActionConfiguration) GoString() string {
 
 // Represents information about an action configuration property.
 type ActionConfigurationProperty struct {
+	_ struct{} `type:"structure"`
+
 	// The description of the action configuration property that will be displayed
 	// to users.
 	Description *string `locationName:"description" min:"1" type:"string"`
@@ -839,8 +841,6 @@ type ActionConfigurationProperty struct {
 
 	// The type of the configuration property.
 	Type *string `locationName:"type" type:"string" enum:"ActionConfigurationPropertyType"`
-
-	_ struct{} `type:"structure"`
 }
 
 // String returns the string representation
@@ -856,10 +856,10 @@ func (s ActionConfigurationProperty) GoString() string {
 // Represents the context of an action within the stage of a pipeline to a job
 // worker.
 type ActionContext struct {
+	_ struct{} `type:"structure"`
+
 	// The name of the action within the context of a job.
 	Name *string `locationName:"name" min:"1" type:"string"`
-
-	_ struct{} `type:"structure"`
 }
 
 // String returns the string representation
@@ -874,6 +874,8 @@ func (s ActionContext) GoString() string {
 
 // Represents information about an action declaration.
 type ActionDeclaration struct {
+	_ struct{} `type:"structure"`
+
 	// The configuration information for the action type.
 	ActionTypeId *ActionTypeId `locationName:"actionTypeId" type:"structure" required:"true"`
 
@@ -897,8 +899,6 @@ type ActionDeclaration struct {
 
 	// The order in which actions are run.
 	RunOrder *int64 `locationName:"runOrder" min:"1" type:"integer"`
-
-	_ struct{} `type:"structure"`
 }
 
 // String returns the string representation
@@ -913,6 +913,8 @@ func (s ActionDeclaration) GoString() string {
 
 // Represents information about how an action runs.
 type ActionExecution struct {
+	_ struct{} `type:"structure"`
+
 	// The details of an error returned by a URL external to AWS.
 	ErrorDetails *ErrorDetails `locationName:"errorDetails" type:"structure"`
 
@@ -935,8 +937,6 @@ type ActionExecution struct {
 
 	// A summary of the run of the action.
 	Summary *string `locationName:"summary" type:"string"`
-
-	_ struct{} `type:"structure"`
 }
 
 // String returns the string representation
@@ -951,6 +951,8 @@ func (s ActionExecution) GoString() string {
 
 // Represents information about the version (or revision) of an action.
 type ActionRevision struct {
+	_ struct{} `type:"structure"`
+
 	// The date and time when the most recent version of the action was created,
 	// in timestamp format.
 	Created *time.Time `locationName:"created" type:"timestamp" timestampFormat:"unix" required:"true"`
@@ -962,8 +964,6 @@ type ActionRevision struct {
 	// The system-generated unique ID that identifies the revision number of the
 	// action.
 	RevisionId *string `locationName:"revisionId" type:"string" required:"true"`
-
-	_ struct{} `type:"structure"`
 }
 
 // String returns the string representation
@@ -978,6 +978,8 @@ func (s ActionRevision) GoString() string {
 
 // Represents information about the state of an action.
 type ActionState struct {
+	_ struct{} `type:"structure"`
+
 	// The name of the action.
 	ActionName *string `locationName:"actionName" min:"1" type:"string"`
 
@@ -994,8 +996,6 @@ type ActionState struct {
 	// A URL link for more information about the revision, such as a commit details
 	// page.
 	RevisionUrl *string `locationName:"revisionUrl" min:"1" type:"string"`
-
-	_ struct{} `type:"structure"`
 }
 
 // String returns the string representation
@@ -1010,6 +1010,8 @@ func (s ActionState) GoString() string {
 
 // Returns information about the details of an action type.
 type ActionType struct {
+	_ struct{} `type:"structure"`
+
 	// The configuration properties for the action type.
 	ActionConfigurationProperties []*ActionConfigurationProperty `locationName:"actionConfigurationProperties" type:"list"`
 
@@ -1024,8 +1026,6 @@ type ActionType struct {
 
 	// The settings for the action type.
 	Settings *ActionTypeSettings `locationName:"settings" type:"structure"`
-
-	_ struct{} `type:"structure"`
 }
 
 // String returns the string representation
@@ -1040,6 +1040,8 @@ func (s ActionType) GoString() string {
 
 // Represents information about an action type.
 type ActionTypeId struct {
+	_ struct{} `type:"structure"`
+
 	// A category defines what kind of action can be taken in the stage, and constrains
 	// the provider type for the action. Valid categories are limited to one of
 	// the values below.
@@ -1056,8 +1058,6 @@ type ActionTypeId struct {
 
 	// A string that identifies the action type.
 	Version *string `locationName:"version" min:"1" type:"string" required:"true"`
-
-	_ struct{} `type:"structure"`
 }
 
 // String returns the string representation
@@ -1072,6 +1072,8 @@ func (s ActionTypeId) GoString() string {
 
 // Returns information about the settings for an action type.
 type ActionTypeSettings struct {
+	_ struct{} `type:"structure"`
+
 	// The URL returned to the AWS CodePipeline console that provides a deep link
 	// to the resources of the external system, such as the configuration page for
 	// an AWS CodeDeploy deployment group. This link is provided as part of the
@@ -1093,8 +1095,6 @@ type ActionTypeSettings struct {
 	// The URL of a sign-up page where users can sign up for an external service
 	// and perform initial configuration of the action provided by that service.
 	ThirdPartyConfigurationUrl *string `locationName:"thirdPartyConfigurationUrl" min:"1" type:"string"`
-
-	_ struct{} `type:"structure"`
 }
 
 // String returns the string representation
@@ -1110,6 +1110,8 @@ func (s ActionTypeSettings) GoString() string {
 // Represents information about an artifact that will be worked upon by actions
 // in the pipeline.
 type Artifact struct {
+	_ struct{} `type:"structure"`
+
 	// The location of an artifact.
 	Location *ArtifactLocation `locationName:"location" type:"structure"`
 
@@ -1119,8 +1121,6 @@ type Artifact struct {
 	// The artifact's revision ID. Depending on the type of object, this could be
 	// a commit ID (GitHub) or a revision ID (Amazon S3).
 	Revision *string `locationName:"revision" type:"string"`
-
-	_ struct{} `type:"structure"`
 }
 
 // String returns the string representation
@@ -1135,13 +1135,13 @@ func (s Artifact) GoString() string {
 
 // Returns information about the details of an artifact.
 type ArtifactDetails struct {
+	_ struct{} `type:"structure"`
+
 	// The maximum number of artifacts allowed for the action type.
 	MaximumCount *int64 `locationName:"maximumCount" type:"integer" required:"true"`
 
 	// The minimum number of artifacts allowed for the action type.
 	MinimumCount *int64 `locationName:"minimumCount" type:"integer" required:"true"`
-
-	_ struct{} `type:"structure"`
 }
 
 // String returns the string representation
@@ -1156,13 +1156,13 @@ func (s ArtifactDetails) GoString() string {
 
 // Represents information about the location of an artifact.
 type ArtifactLocation struct {
+	_ struct{} `type:"structure"`
+
 	// The Amazon S3 bucket that contains the artifact.
 	S3Location *S3ArtifactLocation `locationName:"s3Location" type:"structure"`
 
 	// The type of artifact in the location.
 	Type *string `locationName:"type" type:"string" enum:"ArtifactLocationType"`
-
-	_ struct{} `type:"structure"`
 }
 
 // String returns the string representation
@@ -1179,6 +1179,8 @@ func (s ArtifactLocation) GoString() string {
 // Amazon S3 bucket is created manually, it must meet the requirements for AWS
 // CodePipeline. For more information, see the Concepts.
 type ArtifactStore struct {
+	_ struct{} `type:"structure"`
+
 	// The AWS Key Management Service (AWS KMS) key used to encrypt the data in
 	// the artifact store. If this is undefined, the default key for Amazon S3 is
 	// used.
@@ -1190,8 +1192,6 @@ type ArtifactStore struct {
 
 	// The type of the artifact store, such as S3.
 	Type *string `locationName:"type" type:"string" required:"true" enum:"ArtifactStoreType"`
-
-	_ struct{} `type:"structure"`
 }
 
 // String returns the string representation
@@ -1206,13 +1206,13 @@ func (s ArtifactStore) GoString() string {
 
 // Represents information about a gate declaration.
 type BlockerDeclaration struct {
+	_ struct{} `type:"structure"`
+
 	// The name of the gate declaration.
 	Name *string `locationName:"name" min:"1" type:"string" required:"true"`
 
 	// The type of the gate declaration.
 	Type *string `locationName:"type" type:"string" required:"true" enum:"BlockerType"`
-
-	_ struct{} `type:"structure"`
 }
 
 // String returns the string representation
@@ -1227,6 +1227,8 @@ func (s BlockerDeclaration) GoString() string {
 
 // Represents the input of a create custom action operation.
 type CreateCustomActionTypeInput struct {
+	_ struct{} `type:"structure"`
+
 	// The category of the custom action, such as a source action or a build action.
 	Category *string `locationName:"category" type:"string" required:"true" enum:"ActionCategory"`
 
@@ -1250,8 +1252,6 @@ type CreateCustomActionTypeInput struct {
 	// A newly-created custom action is always assigned a version number of 1.
 	// This is required.
 	Version *string `locationName:"version" min:"1" type:"string" required:"true"`
-
-	_ struct{} `type:"structure"`
 }
 
 // String returns the string representation
@@ -1266,10 +1266,10 @@ func (s CreateCustomActionTypeInput) GoString() string {
 
 // Represents the output of a create custom action operation.
 type CreateCustomActionTypeOutput struct {
+	_ struct{} `type:"structure"`
+
 	// Returns information about the details of an action type.
 	ActionType *ActionType `locationName:"actionType" type:"structure" required:"true"`
-
-	_ struct{} `type:"structure"`
 }
 
 // String returns the string representation
@@ -1284,10 +1284,10 @@ func (s CreateCustomActionTypeOutput) GoString() string {
 
 // Represents the input of a create pipeline action.
 type CreatePipelineInput struct {
+	_ struct{} `type:"structure"`
+
 	// Represents the structure of actions and stages to be performed in the pipeline.
 	Pipeline *PipelineDeclaration `locationName:"pipeline" type:"structure" required:"true"`
-
-	_ struct{} `type:"structure"`
 }
 
 // String returns the string representation
@@ -1302,10 +1302,10 @@ func (s CreatePipelineInput) GoString() string {
 
 // Represents the output of a create pipeline action.
 type CreatePipelineOutput struct {
+	_ struct{} `type:"structure"`
+
 	// Represents the structure of actions and stages to be performed in the pipeline.
 	Pipeline *PipelineDeclaration `locationName:"pipeline" type:"structure"`
-
-	_ struct{} `type:"structure"`
 }
 
 // String returns the string representation
@@ -1320,13 +1320,13 @@ func (s CreatePipelineOutput) GoString() string {
 
 // Represents information about a current revision.
 type CurrentRevision struct {
+	_ struct{} `type:"structure"`
+
 	// The change identifier for the current revision.
 	ChangeIdentifier *string `locationName:"changeIdentifier" type:"string" required:"true"`
 
 	// The revision ID of the current version of an artifact.
 	Revision *string `locationName:"revision" type:"string" required:"true"`
-
-	_ struct{} `type:"structure"`
 }
 
 // String returns the string representation
@@ -1342,6 +1342,8 @@ func (s CurrentRevision) GoString() string {
 // Represents the input of a delete custom action operation. The custom action
 // will be marked as deleted.
 type DeleteCustomActionTypeInput struct {
+	_ struct{} `type:"structure"`
+
 	// The category of the custom action that you want to delete, such as source
 	// or deploy.
 	Category *string `locationName:"category" type:"string" required:"true" enum:"ActionCategory"`
@@ -1351,8 +1353,6 @@ type DeleteCustomActionTypeInput struct {
 
 	// The version of the custom action to delete.
 	Version *string `locationName:"version" min:"1" type:"string" required:"true"`
-
-	_ struct{} `type:"structure"`
 }
 
 // String returns the string representation
@@ -1381,10 +1381,10 @@ func (s DeleteCustomActionTypeOutput) GoString() string {
 
 // Represents the input of a delete pipeline action.
 type DeletePipelineInput struct {
+	_ struct{} `type:"structure"`
+
 	// The name of the pipeline to be deleted.
 	Name *string `locationName:"name" min:"1" type:"string" required:"true"`
-
-	_ struct{} `type:"structure"`
 }
 
 // String returns the string representation
@@ -1413,6 +1413,8 @@ func (s DeletePipelineOutput) GoString() string {
 
 // Represents the input of a disable stage transition input action.
 type DisableStageTransitionInput struct {
+	_ struct{} `type:"structure"`
+
 	// The name of the pipeline in which you want to disable the flow of artifacts
 	// from one stage to another.
 	PipelineName *string `locationName:"pipelineName" min:"1" type:"string" required:"true"`
@@ -1431,8 +1433,6 @@ type DisableStageTransitionInput struct {
 	// from transitioning from the stage after they have been processed by the actions
 	// in that stage (outbound).
 	TransitionType *string `locationName:"transitionType" type:"string" required:"true" enum:"StageTransitionType"`
-
-	_ struct{} `type:"structure"`
 }
 
 // String returns the string representation
@@ -1461,6 +1461,8 @@ func (s DisableStageTransitionOutput) GoString() string {
 
 // Represents the input of an enable stage transition action.
 type EnableStageTransitionInput struct {
+	_ struct{} `type:"structure"`
+
 	// The name of the pipeline in which you want to enable the flow of artifacts
 	// from one stage to another.
 	PipelineName *string `locationName:"pipelineName" min:"1" type:"string" required:"true"`
@@ -1473,8 +1475,6 @@ type EnableStageTransitionInput struct {
 	// by the actions in that stage (inbound) or whether already-processed artifacts
 	// will be allowed to transition to the next stage (outbound).
 	TransitionType *string `locationName:"transitionType" type:"string" required:"true" enum:"StageTransitionType"`
-
-	_ struct{} `type:"structure"`
 }
 
 // String returns the string representation
@@ -1504,13 +1504,13 @@ func (s EnableStageTransitionOutput) GoString() string {
 // Represents information about the AWS Key Management Service (AWS KMS) key
 // used to encrypt data in the artifact store.
 type EncryptionKey struct {
+	_ struct{} `type:"structure"`
+
 	// The ID of the AWS KMS key.
 	Id *string `locationName:"id" min:"1" type:"string" required:"true"`
 
 	// The type of AWS KMS key, such as a customer master key.
 	Type *string `locationName:"type" type:"string" required:"true" enum:"EncryptionKeyType"`
-
-	_ struct{} `type:"structure"`
 }
 
 // String returns the string representation
@@ -1525,13 +1525,13 @@ func (s EncryptionKey) GoString() string {
 
 // Represents information about an error in AWS CodePipeline.
 type ErrorDetails struct {
+	_ struct{} `type:"structure"`
+
 	// The system ID or error number code of the error.
 	Code *string `locationName:"code" type:"string"`
 
 	// The text of the error message.
 	Message *string `locationName:"message" type:"string"`
-
-	_ struct{} `type:"structure"`
 }
 
 // String returns the string representation
@@ -1547,6 +1547,8 @@ func (s ErrorDetails) GoString() string {
 // The details of the actions taken and results produced on an artifact as it
 // passes through stages in the pipeline.
 type ExecutionDetails struct {
+	_ struct{} `type:"structure"`
+
 	// The system-generated unique ID of this action used to identify this job worker
 	// in any external systems, such as AWS CodeDeploy.
 	ExternalExecutionId *string `locationName:"externalExecutionId" type:"string"`
@@ -1557,8 +1559,6 @@ type ExecutionDetails struct {
 
 	// The summary of the current status of the actions.
 	Summary *string `locationName:"summary" type:"string"`
-
-	_ struct{} `type:"structure"`
 }
 
 // String returns the string representation
@@ -1573,6 +1573,8 @@ func (s ExecutionDetails) GoString() string {
 
 // Represents information about failure details.
 type FailureDetails struct {
+	_ struct{} `type:"structure"`
+
 	// The external ID of the run of the action that failed.
 	ExternalExecutionId *string `locationName:"externalExecutionId" type:"string"`
 
@@ -1581,8 +1583,6 @@ type FailureDetails struct {
 
 	// The type of the failure.
 	Type *string `locationName:"type" type:"string" required:"true" enum:"FailureType"`
-
-	_ struct{} `type:"structure"`
 }
 
 // String returns the string representation
@@ -1597,10 +1597,10 @@ func (s FailureDetails) GoString() string {
 
 // Represents the input of a get job details action.
 type GetJobDetailsInput struct {
+	_ struct{} `type:"structure"`
+
 	// The unique system-generated ID for the job.
 	JobId *string `locationName:"jobId" type:"string" required:"true"`
-
-	_ struct{} `type:"structure"`
 }
 
 // String returns the string representation
@@ -1615,13 +1615,13 @@ func (s GetJobDetailsInput) GoString() string {
 
 // Represents the output of a get job details action.
 type GetJobDetailsOutput struct {
+	_ struct{} `type:"structure"`
+
 	// The details of the job.
 	//
 	//  If AWSSessionCredentials is used, a long-running job can call GetJobDetails
 	// again to obtain new credentials.
 	JobDetails *JobDetails `locationName:"jobDetails" type:"structure"`
-
-	_ struct{} `type:"structure"`
 }
 
 // String returns the string representation
@@ -1636,6 +1636,8 @@ func (s GetJobDetailsOutput) GoString() string {
 
 // Represents the input of a get pipeline action.
 type GetPipelineInput struct {
+	_ struct{} `type:"structure"`
+
 	// The name of the pipeline for which you want to get information. Pipeline
 	// names must be unique under an Amazon Web Services (AWS) user account.
 	Name *string `locationName:"name" min:"1" type:"string" required:"true"`
@@ -1643,8 +1645,6 @@ type GetPipelineInput struct {
 	// The version number of the pipeline. If you do not specify a version, defaults
 	// to the most current version.
 	Version *int64 `locationName:"version" min:"1" type:"integer"`
-
-	_ struct{} `type:"structure"`
 }
 
 // String returns the string representation
@@ -1659,10 +1659,10 @@ func (s GetPipelineInput) GoString() string {
 
 // Represents the output of a get pipeline action.
 type GetPipelineOutput struct {
+	_ struct{} `type:"structure"`
+
 	// Represents the structure of actions and stages to be performed in the pipeline.
 	Pipeline *PipelineDeclaration `locationName:"pipeline" type:"structure"`
-
-	_ struct{} `type:"structure"`
 }
 
 // String returns the string representation
@@ -1677,10 +1677,10 @@ func (s GetPipelineOutput) GoString() string {
 
 // Represents the input of a get pipeline state action.
 type GetPipelineStateInput struct {
+	_ struct{} `type:"structure"`
+
 	// The name of the pipeline about which you want to get information.
 	Name *string `locationName:"name" min:"1" type:"string" required:"true"`
-
-	_ struct{} `type:"structure"`
 }
 
 // String returns the string representation
@@ -1695,6 +1695,8 @@ func (s GetPipelineStateInput) GoString() string {
 
 // Represents the output of a get pipeline state action.
 type GetPipelineStateOutput struct {
+	_ struct{} `type:"structure"`
+
 	// The date and time the pipeline was created, in timestamp format.
 	Created *time.Time `locationName:"created" type:"timestamp" timestampFormat:"unix"`
 
@@ -1712,8 +1714,6 @@ type GetPipelineStateOutput struct {
 
 	// The date and time the pipeline was last updated, in timestamp format.
 	Updated *time.Time `locationName:"updated" type:"timestamp" timestampFormat:"unix"`
-
-	_ struct{} `type:"structure"`
 }
 
 // String returns the string representation
@@ -1728,14 +1728,14 @@ func (s GetPipelineStateOutput) GoString() string {
 
 // Represents the input of a get third party job details action.
 type GetThirdPartyJobDetailsInput struct {
+	_ struct{} `type:"structure"`
+
 	// The clientToken portion of the clientId and clientToken pair used to verify
 	// that the calling entity is allowed access to the job and its details.
 	ClientToken *string `locationName:"clientToken" type:"string" required:"true"`
 
 	// The unique system-generated ID used for identifying the job.
 	JobId *string `locationName:"jobId" min:"1" type:"string" required:"true"`
-
-	_ struct{} `type:"structure"`
 }
 
 // String returns the string representation
@@ -1750,10 +1750,10 @@ func (s GetThirdPartyJobDetailsInput) GoString() string {
 
 // Represents the output of a get third party job details action.
 type GetThirdPartyJobDetailsOutput struct {
+	_ struct{} `type:"structure"`
+
 	// The details of the job, including any protected values defined for the job.
 	JobDetails *ThirdPartyJobDetails `locationName:"jobDetails" type:"structure"`
-
-	_ struct{} `type:"structure"`
 }
 
 // String returns the string representation
@@ -1769,6 +1769,8 @@ func (s GetThirdPartyJobDetailsOutput) GoString() string {
 // Represents information about an artifact to be worked on, such as a test
 // or build artifact.
 type InputArtifact struct {
+	_ struct{} `type:"structure"`
+
 	// The name of the artifact to be worked on, for example, "My App".
 	//
 	// The input artifact of an action must exactly match the output artifact declared
@@ -1777,8 +1779,6 @@ type InputArtifact struct {
 	// Actions in parallel can declare different output artifacts, which are in
 	// turn consumed by different following actions.
 	Name *string `locationName:"name" min:"1" type:"string" required:"true"`
-
-	_ struct{} `type:"structure"`
 }
 
 // String returns the string representation
@@ -1793,6 +1793,8 @@ func (s InputArtifact) GoString() string {
 
 // Represents information about a job.
 type Job struct {
+	_ struct{} `type:"structure"`
+
 	// The ID of the AWS account to use when performing the job.
 	AccountId *string `locationName:"accountId" type:"string"`
 
@@ -1806,8 +1808,6 @@ type Job struct {
 	// the job is being worked on by only one job worker. This number must be returned
 	// in the response.
 	Nonce *string `locationName:"nonce" type:"string"`
-
-	_ struct{} `type:"structure"`
 }
 
 // String returns the string representation
@@ -1823,6 +1823,8 @@ func (s Job) GoString() string {
 // Represents additional information about a job required for a job worker to
 // complete the job.
 type JobData struct {
+	_ struct{} `type:"structure"`
+
 	// Represents information about an action configuration.
 	ActionConfiguration *ActionConfiguration `locationName:"actionConfiguration" type:"structure"`
 
@@ -1851,8 +1853,6 @@ type JobData struct {
 
 	// Represents information about a pipeline to a job worker.
 	PipelineContext *PipelineContext `locationName:"pipelineContext" type:"structure"`
-
-	_ struct{} `type:"structure"`
 }
 
 // String returns the string representation
@@ -1867,6 +1867,8 @@ func (s JobData) GoString() string {
 
 // Represents information about the details of a job.
 type JobDetails struct {
+	_ struct{} `type:"structure"`
+
 	// The AWS account ID associated with the job.
 	AccountId *string `locationName:"accountId" type:"string"`
 
@@ -1876,8 +1878,6 @@ type JobDetails struct {
 
 	// The unique system-generated ID of the job.
 	Id *string `locationName:"id" type:"string"`
-
-	_ struct{} `type:"structure"`
 }
 
 // String returns the string representation
@@ -1892,14 +1892,14 @@ func (s JobDetails) GoString() string {
 
 // Represents the input of a list action types action.
 type ListActionTypesInput struct {
+	_ struct{} `type:"structure"`
+
 	// Filters the list of action types to those created by a specified entity.
 	ActionOwnerFilter *string `locationName:"actionOwnerFilter" type:"string" enum:"ActionOwner"`
 
 	// An identifier that was returned from the previous list action types call,
 	// which can be used to return the next set of action types in the list.
 	NextToken *string `locationName:"nextToken" type:"string"`
-
-	_ struct{} `type:"structure"`
 }
 
 // String returns the string representation
@@ -1914,6 +1914,8 @@ func (s ListActionTypesInput) GoString() string {
 
 // Represents the output of a list action types action.
 type ListActionTypesOutput struct {
+	_ struct{} `type:"structure"`
+
 	// Provides details of the action types.
 	ActionTypes []*ActionType `locationName:"actionTypes" type:"list" required:"true"`
 
@@ -1921,8 +1923,6 @@ type ListActionTypesOutput struct {
 	// is also returned which can be used in a subsequent list action types call
 	// to return the next set of action types in the list.
 	NextToken *string `locationName:"nextToken" type:"string"`
-
-	_ struct{} `type:"structure"`
 }
 
 // String returns the string representation
@@ -1937,11 +1937,11 @@ func (s ListActionTypesOutput) GoString() string {
 
 // Represents the input of a list pipelines action.
 type ListPipelinesInput struct {
+	_ struct{} `type:"structure"`
+
 	// An identifier that was returned from the previous list pipelines call, which
 	// can be used to return the next set of pipelines in the list.
 	NextToken *string `locationName:"nextToken" type:"string"`
-
-	_ struct{} `type:"structure"`
 }
 
 // String returns the string representation
@@ -1956,6 +1956,8 @@ func (s ListPipelinesInput) GoString() string {
 
 // Represents the output of a list pipelines action.
 type ListPipelinesOutput struct {
+	_ struct{} `type:"structure"`
+
 	// If the amount of returned information is significantly large, an identifier
 	// is also returned which can be used in a subsequent list pipelines call to
 	// return the next set of pipelines in the list.
@@ -1963,8 +1965,6 @@ type ListPipelinesOutput struct {
 
 	// The list of pipelines.
 	Pipelines []*PipelineSummary `locationName:"pipelines" type:"list"`
-
-	_ struct{} `type:"structure"`
 }
 
 // String returns the string representation
@@ -1979,6 +1979,8 @@ func (s ListPipelinesOutput) GoString() string {
 
 // Represents information about the output of an action.
 type OutputArtifact struct {
+	_ struct{} `type:"structure"`
+
 	// The name of the output of an artifact, such as "My App".
 	//
 	// The input artifact of an action must exactly match the output artifact declared
@@ -1989,8 +1991,6 @@ type OutputArtifact struct {
 	//
 	// Output artifact names must be unique within a pipeline.
 	Name *string `locationName:"name" min:"1" type:"string" required:"true"`
-
-	_ struct{} `type:"structure"`
 }
 
 // String returns the string representation
@@ -2005,6 +2005,8 @@ func (s OutputArtifact) GoString() string {
 
 // Represents information about a pipeline to a job worker.
 type PipelineContext struct {
+	_ struct{} `type:"structure"`
+
 	// Represents the context of an action within the stage of a pipeline to a job
 	// worker.
 	Action *ActionContext `locationName:"action" type:"structure"`
@@ -2015,8 +2017,6 @@ type PipelineContext struct {
 
 	// The stage of the pipeline.
 	Stage *StageContext `locationName:"stage" type:"structure"`
-
-	_ struct{} `type:"structure"`
 }
 
 // String returns the string representation
@@ -2031,6 +2031,8 @@ func (s PipelineContext) GoString() string {
 
 // Represents the structure of actions and stages to be performed in the pipeline.
 type PipelineDeclaration struct {
+	_ struct{} `type:"structure"`
+
 	// The Amazon S3 location where artifacts are stored for the pipeline. If this
 	// Amazon S3 bucket is created manually, it must meet the requirements for AWS
 	// CodePipeline. For more information, see the Concepts.
@@ -2050,8 +2052,6 @@ type PipelineDeclaration struct {
 	// The version number of the pipeline. A new pipeline always has a version number
 	// of 1. This number is automatically incremented when a pipeline is updated.
 	Version *int64 `locationName:"version" min:"1" type:"integer"`
-
-	_ struct{} `type:"structure"`
 }
 
 // String returns the string representation
@@ -2066,6 +2066,8 @@ func (s PipelineDeclaration) GoString() string {
 
 // Returns a summary of a pipeline.
 type PipelineSummary struct {
+	_ struct{} `type:"structure"`
+
 	// The date and time the pipeline was created, in timestamp format.
 	Created *time.Time `locationName:"created" type:"timestamp" timestampFormat:"unix"`
 
@@ -2077,8 +2079,6 @@ type PipelineSummary struct {
 
 	// The version number of the pipeline.
 	Version *int64 `locationName:"version" min:"1" type:"integer"`
-
-	_ struct{} `type:"structure"`
 }
 
 // String returns the string representation
@@ -2093,6 +2093,8 @@ func (s PipelineSummary) GoString() string {
 
 // Represents the input of a poll for jobs action.
 type PollForJobsInput struct {
+	_ struct{} `type:"structure"`
+
 	// Represents information about an action type.
 	ActionTypeId *ActionTypeId `locationName:"actionTypeId" type:"structure" required:"true"`
 
@@ -2104,8 +2106,6 @@ type PollForJobsInput struct {
 	// a queryable property, you must supply that property as a key in the map.
 	// Only jobs whose action configuration matches the mapped value will be returned.
 	QueryParam map[string]*string `locationName:"queryParam" type:"map"`
-
-	_ struct{} `type:"structure"`
 }
 
 // String returns the string representation
@@ -2120,10 +2120,10 @@ func (s PollForJobsInput) GoString() string {
 
 // Represents the output of a poll for jobs action.
 type PollForJobsOutput struct {
+	_ struct{} `type:"structure"`
+
 	// Information about the jobs to take action on.
 	Jobs []*Job `locationName:"jobs" type:"list"`
-
-	_ struct{} `type:"structure"`
 }
 
 // String returns the string representation
@@ -2138,13 +2138,13 @@ func (s PollForJobsOutput) GoString() string {
 
 // Represents the input of a poll for third party jobs action.
 type PollForThirdPartyJobsInput struct {
+	_ struct{} `type:"structure"`
+
 	// Represents information about an action type.
 	ActionTypeId *ActionTypeId `locationName:"actionTypeId" type:"structure" required:"true"`
 
 	// The maximum number of jobs to return in a poll for jobs call.
 	MaxBatchSize *int64 `locationName:"maxBatchSize" min:"1" type:"integer"`
-
-	_ struct{} `type:"structure"`
 }
 
 // String returns the string representation
@@ -2159,10 +2159,10 @@ func (s PollForThirdPartyJobsInput) GoString() string {
 
 // Represents the output of a poll for third party jobs action.
 type PollForThirdPartyJobsOutput struct {
+	_ struct{} `type:"structure"`
+
 	// Information about the jobs to take action on.
 	Jobs []*ThirdPartyJob `locationName:"jobs" type:"list"`
-
-	_ struct{} `type:"structure"`
 }
 
 // String returns the string representation
@@ -2177,6 +2177,8 @@ func (s PollForThirdPartyJobsOutput) GoString() string {
 
 // Represents the input of a put action revision action.
 type PutActionRevisionInput struct {
+	_ struct{} `type:"structure"`
+
 	// The name of the action that will process the revision.
 	ActionName *string `locationName:"actionName" min:"1" type:"string" required:"true"`
 
@@ -2188,8 +2190,6 @@ type PutActionRevisionInput struct {
 
 	// The name of the stage that contains the action that will act upon the revision.
 	StageName *string `locationName:"stageName" min:"1" type:"string" required:"true"`
-
-	_ struct{} `type:"structure"`
 }
 
 // String returns the string representation
@@ -2204,13 +2204,13 @@ func (s PutActionRevisionInput) GoString() string {
 
 // Represents the output of a put action revision action.
 type PutActionRevisionOutput struct {
+	_ struct{} `type:"structure"`
+
 	// The new revision number or ID for the revision after the action completes.
 	NewRevision *bool `locationName:"newRevision" type:"boolean"`
 
 	// The ID of the current workflow state of the pipeline.
 	PipelineExecutionId *string `locationName:"pipelineExecutionId" type:"string"`
-
-	_ struct{} `type:"structure"`
 }
 
 // String returns the string representation
@@ -2225,14 +2225,14 @@ func (s PutActionRevisionOutput) GoString() string {
 
 // Represents the input of a put job failure result action.
 type PutJobFailureResultInput struct {
+	_ struct{} `type:"structure"`
+
 	// The details about the failure of a job.
 	FailureDetails *FailureDetails `locationName:"failureDetails" type:"structure" required:"true"`
 
 	// The unique system-generated ID of the job that failed. This is the same ID
 	// returned from PollForJobs.
 	JobId *string `locationName:"jobId" type:"string" required:"true"`
-
-	_ struct{} `type:"structure"`
 }
 
 // String returns the string representation
@@ -2261,6 +2261,8 @@ func (s PutJobFailureResultOutput) GoString() string {
 
 // Represents the input of a put job success result action.
 type PutJobSuccessResultInput struct {
+	_ struct{} `type:"structure"`
+
 	// A system-generated token, such as a AWS CodeDeploy deployment ID, that the
 	// successful job used to complete a job asynchronously.
 	ContinuationToken *string `locationName:"continuationToken" type:"string"`
@@ -2276,8 +2278,6 @@ type PutJobSuccessResultInput struct {
 	// The unique system-generated ID of the job that succeeded. This is the same
 	// ID returned from PollForJobs.
 	JobId *string `locationName:"jobId" type:"string" required:"true"`
-
-	_ struct{} `type:"structure"`
 }
 
 // String returns the string representation
@@ -2306,6 +2306,8 @@ func (s PutJobSuccessResultOutput) GoString() string {
 
 // Represents the input of a third party job failure result action.
 type PutThirdPartyJobFailureResultInput struct {
+	_ struct{} `type:"structure"`
+
 	// The clientToken portion of the clientId and clientToken pair used to verify
 	// that the calling entity is allowed access to the job and its details.
 	ClientToken *string `locationName:"clientToken" type:"string" required:"true"`
@@ -2315,8 +2317,6 @@ type PutThirdPartyJobFailureResultInput struct {
 
 	// The ID of the job that failed. This is the same ID returned from PollForThirdPartyJobs.
 	JobId *string `locationName:"jobId" min:"1" type:"string" required:"true"`
-
-	_ struct{} `type:"structure"`
 }
 
 // String returns the string representation
@@ -2345,6 +2345,8 @@ func (s PutThirdPartyJobFailureResultOutput) GoString() string {
 
 // Represents the input of a put third party job success result action.
 type PutThirdPartyJobSuccessResultInput struct {
+	_ struct{} `type:"structure"`
+
 	// The clientToken portion of the clientId and clientToken pair used to verify
 	// that the calling entity is allowed access to the job and its details.
 	ClientToken *string `locationName:"clientToken" type:"string" required:"true"`
@@ -2363,8 +2365,6 @@ type PutThirdPartyJobSuccessResultInput struct {
 	// The ID of the job that successfully completed. This is the same ID returned
 	// from PollForThirdPartyJobs.
 	JobId *string `locationName:"jobId" min:"1" type:"string" required:"true"`
-
-	_ struct{} `type:"structure"`
 }
 
 // String returns the string representation
@@ -2393,14 +2393,14 @@ func (s PutThirdPartyJobSuccessResultOutput) GoString() string {
 
 // The location of the Amazon S3 bucket that contains a revision.
 type S3ArtifactLocation struct {
+	_ struct{} `type:"structure"`
+
 	// The name of the Amazon S3 bucket.
 	BucketName *string `locationName:"bucketName" type:"string" required:"true"`
 
 	// The key of the object in the Amazon S3 bucket, which uniquely identifies
 	// the object in the bucket.
 	ObjectKey *string `locationName:"objectKey" type:"string" required:"true"`
-
-	_ struct{} `type:"structure"`
 }
 
 // String returns the string representation
@@ -2415,10 +2415,10 @@ func (s S3ArtifactLocation) GoString() string {
 
 // Represents information about a stage to a job worker.
 type StageContext struct {
+	_ struct{} `type:"structure"`
+
 	// The name of the stage.
 	Name *string `locationName:"name" min:"1" type:"string"`
-
-	_ struct{} `type:"structure"`
 }
 
 // String returns the string representation
@@ -2433,6 +2433,8 @@ func (s StageContext) GoString() string {
 
 // Represents information about a stage and its definition.
 type StageDeclaration struct {
+	_ struct{} `type:"structure"`
+
 	// The actions included in a stage.
 	Actions []*ActionDeclaration `locationName:"actions" type:"list" required:"true"`
 
@@ -2441,8 +2443,6 @@ type StageDeclaration struct {
 
 	// The name of the stage.
 	Name *string `locationName:"name" min:"1" type:"string" required:"true"`
-
-	_ struct{} `type:"structure"`
 }
 
 // String returns the string representation
@@ -2457,6 +2457,8 @@ func (s StageDeclaration) GoString() string {
 
 // Represents information about the state of the stage.
 type StageState struct {
+	_ struct{} `type:"structure"`
+
 	// The state of the stage.
 	ActionStates []*ActionState `locationName:"actionStates" type:"list"`
 
@@ -2465,8 +2467,6 @@ type StageState struct {
 
 	// The name of the stage.
 	StageName *string `locationName:"stageName" min:"1" type:"string"`
-
-	_ struct{} `type:"structure"`
 }
 
 // String returns the string representation
@@ -2481,10 +2481,10 @@ func (s StageState) GoString() string {
 
 // Represents the input of a start pipeline execution action.
 type StartPipelineExecutionInput struct {
+	_ struct{} `type:"structure"`
+
 	// The name of the pipeline to start.
 	Name *string `locationName:"name" min:"1" type:"string" required:"true"`
-
-	_ struct{} `type:"structure"`
 }
 
 // String returns the string representation
@@ -2499,10 +2499,10 @@ func (s StartPipelineExecutionInput) GoString() string {
 
 // Represents the output of a start pipeline execution action.
 type StartPipelineExecutionOutput struct {
+	_ struct{} `type:"structure"`
+
 	// The unique system-generated ID of the pipeline that was started.
 	PipelineExecutionId *string `locationName:"pipelineExecutionId" type:"string"`
-
-	_ struct{} `type:"structure"`
 }
 
 // String returns the string representation
@@ -2518,14 +2518,14 @@ func (s StartPipelineExecutionOutput) GoString() string {
 // A response to a PollForThirdPartyJobs request returned by AWS CodePipeline
 // when there is a job to be worked upon by a partner action.
 type ThirdPartyJob struct {
+	_ struct{} `type:"structure"`
+
 	// The clientToken portion of the clientId and clientToken pair used to verify
 	// that the calling entity is allowed access to the job and its details.
 	ClientId *string `locationName:"clientId" type:"string"`
 
 	// The identifier used to identify the job in AWS CodePipeline.
 	JobId *string `locationName:"jobId" type:"string"`
-
-	_ struct{} `type:"structure"`
 }
 
 // String returns the string representation
@@ -2540,6 +2540,8 @@ func (s ThirdPartyJob) GoString() string {
 
 // Represents information about the job data for a partner action.
 type ThirdPartyJobData struct {
+	_ struct{} `type:"structure"`
+
 	// Represents information about an action configuration.
 	ActionConfiguration *ActionConfiguration `locationName:"actionConfiguration" type:"structure"`
 
@@ -2574,8 +2576,6 @@ type ThirdPartyJobData struct {
 
 	// Represents information about a pipeline to a job worker.
 	PipelineContext *PipelineContext `locationName:"pipelineContext" type:"structure"`
-
-	_ struct{} `type:"structure"`
 }
 
 // String returns the string representation
@@ -2590,6 +2590,8 @@ func (s ThirdPartyJobData) GoString() string {
 
 // The details of a job sent in response to a GetThirdPartyJobDetails request.
 type ThirdPartyJobDetails struct {
+	_ struct{} `type:"structure"`
+
 	// The data to be returned by the third party job worker.
 	Data *ThirdPartyJobData `locationName:"data" type:"structure"`
 
@@ -2600,8 +2602,6 @@ type ThirdPartyJobDetails struct {
 	// the job is being worked on by only one job worker. This number must be returned
 	// in the response.
 	Nonce *string `locationName:"nonce" type:"string"`
-
-	_ struct{} `type:"structure"`
 }
 
 // String returns the string representation
@@ -2617,6 +2617,8 @@ func (s ThirdPartyJobDetails) GoString() string {
 // Represents information about the state of transitions between one stage and
 // another stage.
 type TransitionState struct {
+	_ struct{} `type:"structure"`
+
 	// The user-specified reason why the transition between two stages of a pipeline
 	// was disabled.
 	DisabledReason *string `locationName:"disabledReason" min:"1" type:"string"`
@@ -2629,8 +2631,6 @@ type TransitionState struct {
 
 	// The ID of the user who last changed the transition state.
 	LastChangedBy *string `locationName:"lastChangedBy" type:"string"`
-
-	_ struct{} `type:"structure"`
 }
 
 // String returns the string representation
@@ -2645,10 +2645,10 @@ func (s TransitionState) GoString() string {
 
 // Represents the input of an update pipeline action.
 type UpdatePipelineInput struct {
+	_ struct{} `type:"structure"`
+
 	// The name of the pipeline to be updated.
 	Pipeline *PipelineDeclaration `locationName:"pipeline" type:"structure" required:"true"`
-
-	_ struct{} `type:"structure"`
 }
 
 // String returns the string representation
@@ -2663,10 +2663,10 @@ func (s UpdatePipelineInput) GoString() string {
 
 // Represents the output of an update pipeline action.
 type UpdatePipelineOutput struct {
+	_ struct{} `type:"structure"`
+
 	// The structure of the updated pipeline.
 	Pipeline *PipelineDeclaration `locationName:"pipeline" type:"structure"`
-
-	_ struct{} `type:"structure"`
 }
 
 // String returns the string representation

--- a/service/codepipeline/api.go
+++ b/service/codepipeline/api.go
@@ -686,11 +686,7 @@ type AWSSessionCredentials struct {
 	// The token for the session.
 	SessionToken *string `locationName:"sessionToken" type:"string" required:"true"`
 
-	metadataAWSSessionCredentials `json:"-" xml:"-"`
-}
-
-type metadataAWSSessionCredentials struct {
-	SDKShapeTraits bool `type:"structure"`
+	_ struct{} `type:"structure"`
 }
 
 // String returns the string representation
@@ -713,11 +709,7 @@ type AcknowledgeJobInput struct {
 	// in the response.
 	Nonce *string `locationName:"nonce" type:"string" required:"true"`
 
-	metadataAcknowledgeJobInput `json:"-" xml:"-"`
-}
-
-type metadataAcknowledgeJobInput struct {
-	SDKShapeTraits bool `type:"structure"`
+	_ struct{} `type:"structure"`
 }
 
 // String returns the string representation
@@ -735,11 +727,7 @@ type AcknowledgeJobOutput struct {
 	// Whether the job worker has received the specified job.
 	Status *string `locationName:"status" type:"string" enum:"JobStatus"`
 
-	metadataAcknowledgeJobOutput `json:"-" xml:"-"`
-}
-
-type metadataAcknowledgeJobOutput struct {
-	SDKShapeTraits bool `type:"structure"`
+	_ struct{} `type:"structure"`
 }
 
 // String returns the string representation
@@ -766,11 +754,7 @@ type AcknowledgeThirdPartyJobInput struct {
 	// in the response.
 	Nonce *string `locationName:"nonce" type:"string" required:"true"`
 
-	metadataAcknowledgeThirdPartyJobInput `json:"-" xml:"-"`
-}
-
-type metadataAcknowledgeThirdPartyJobInput struct {
-	SDKShapeTraits bool `type:"structure"`
+	_ struct{} `type:"structure"`
 }
 
 // String returns the string representation
@@ -788,11 +772,7 @@ type AcknowledgeThirdPartyJobOutput struct {
 	// The status information for the third party job, if any.
 	Status *string `locationName:"status" type:"string" enum:"JobStatus"`
 
-	metadataAcknowledgeThirdPartyJobOutput `json:"-" xml:"-"`
-}
-
-type metadataAcknowledgeThirdPartyJobOutput struct {
-	SDKShapeTraits bool `type:"structure"`
+	_ struct{} `type:"structure"`
 }
 
 // String returns the string representation
@@ -810,11 +790,7 @@ type ActionConfiguration struct {
 	// The configuration data for the action.
 	Configuration map[string]*string `locationName:"configuration" type:"map"`
 
-	metadataActionConfiguration `json:"-" xml:"-"`
-}
-
-type metadataActionConfiguration struct {
-	SDKShapeTraits bool `type:"structure"`
+	_ struct{} `type:"structure"`
 }
 
 // String returns the string representation
@@ -864,11 +840,7 @@ type ActionConfigurationProperty struct {
 	// The type of the configuration property.
 	Type *string `locationName:"type" type:"string" enum:"ActionConfigurationPropertyType"`
 
-	metadataActionConfigurationProperty `json:"-" xml:"-"`
-}
-
-type metadataActionConfigurationProperty struct {
-	SDKShapeTraits bool `type:"structure"`
+	_ struct{} `type:"structure"`
 }
 
 // String returns the string representation
@@ -887,11 +859,7 @@ type ActionContext struct {
 	// The name of the action within the context of a job.
 	Name *string `locationName:"name" min:"1" type:"string"`
 
-	metadataActionContext `json:"-" xml:"-"`
-}
-
-type metadataActionContext struct {
-	SDKShapeTraits bool `type:"structure"`
+	_ struct{} `type:"structure"`
 }
 
 // String returns the string representation
@@ -930,11 +898,7 @@ type ActionDeclaration struct {
 	// The order in which actions are run.
 	RunOrder *int64 `locationName:"runOrder" min:"1" type:"integer"`
 
-	metadataActionDeclaration `json:"-" xml:"-"`
-}
-
-type metadataActionDeclaration struct {
-	SDKShapeTraits bool `type:"structure"`
+	_ struct{} `type:"structure"`
 }
 
 // String returns the string representation
@@ -972,11 +936,7 @@ type ActionExecution struct {
 	// A summary of the run of the action.
 	Summary *string `locationName:"summary" type:"string"`
 
-	metadataActionExecution `json:"-" xml:"-"`
-}
-
-type metadataActionExecution struct {
-	SDKShapeTraits bool `type:"structure"`
+	_ struct{} `type:"structure"`
 }
 
 // String returns the string representation
@@ -1003,11 +963,7 @@ type ActionRevision struct {
 	// action.
 	RevisionId *string `locationName:"revisionId" type:"string" required:"true"`
 
-	metadataActionRevision `json:"-" xml:"-"`
-}
-
-type metadataActionRevision struct {
-	SDKShapeTraits bool `type:"structure"`
+	_ struct{} `type:"structure"`
 }
 
 // String returns the string representation
@@ -1039,11 +995,7 @@ type ActionState struct {
 	// page.
 	RevisionUrl *string `locationName:"revisionUrl" min:"1" type:"string"`
 
-	metadataActionState `json:"-" xml:"-"`
-}
-
-type metadataActionState struct {
-	SDKShapeTraits bool `type:"structure"`
+	_ struct{} `type:"structure"`
 }
 
 // String returns the string representation
@@ -1073,11 +1025,7 @@ type ActionType struct {
 	// The settings for the action type.
 	Settings *ActionTypeSettings `locationName:"settings" type:"structure"`
 
-	metadataActionType `json:"-" xml:"-"`
-}
-
-type metadataActionType struct {
-	SDKShapeTraits bool `type:"structure"`
+	_ struct{} `type:"structure"`
 }
 
 // String returns the string representation
@@ -1109,11 +1057,7 @@ type ActionTypeId struct {
 	// A string that identifies the action type.
 	Version *string `locationName:"version" min:"1" type:"string" required:"true"`
 
-	metadataActionTypeId `json:"-" xml:"-"`
-}
-
-type metadataActionTypeId struct {
-	SDKShapeTraits bool `type:"structure"`
+	_ struct{} `type:"structure"`
 }
 
 // String returns the string representation
@@ -1150,11 +1094,7 @@ type ActionTypeSettings struct {
 	// and perform initial configuration of the action provided by that service.
 	ThirdPartyConfigurationUrl *string `locationName:"thirdPartyConfigurationUrl" min:"1" type:"string"`
 
-	metadataActionTypeSettings `json:"-" xml:"-"`
-}
-
-type metadataActionTypeSettings struct {
-	SDKShapeTraits bool `type:"structure"`
+	_ struct{} `type:"structure"`
 }
 
 // String returns the string representation
@@ -1180,11 +1120,7 @@ type Artifact struct {
 	// a commit ID (GitHub) or a revision ID (Amazon S3).
 	Revision *string `locationName:"revision" type:"string"`
 
-	metadataArtifact `json:"-" xml:"-"`
-}
-
-type metadataArtifact struct {
-	SDKShapeTraits bool `type:"structure"`
+	_ struct{} `type:"structure"`
 }
 
 // String returns the string representation
@@ -1205,11 +1141,7 @@ type ArtifactDetails struct {
 	// The minimum number of artifacts allowed for the action type.
 	MinimumCount *int64 `locationName:"minimumCount" type:"integer" required:"true"`
 
-	metadataArtifactDetails `json:"-" xml:"-"`
-}
-
-type metadataArtifactDetails struct {
-	SDKShapeTraits bool `type:"structure"`
+	_ struct{} `type:"structure"`
 }
 
 // String returns the string representation
@@ -1230,11 +1162,7 @@ type ArtifactLocation struct {
 	// The type of artifact in the location.
 	Type *string `locationName:"type" type:"string" enum:"ArtifactLocationType"`
 
-	metadataArtifactLocation `json:"-" xml:"-"`
-}
-
-type metadataArtifactLocation struct {
-	SDKShapeTraits bool `type:"structure"`
+	_ struct{} `type:"structure"`
 }
 
 // String returns the string representation
@@ -1263,11 +1191,7 @@ type ArtifactStore struct {
 	// The type of the artifact store, such as S3.
 	Type *string `locationName:"type" type:"string" required:"true" enum:"ArtifactStoreType"`
 
-	metadataArtifactStore `json:"-" xml:"-"`
-}
-
-type metadataArtifactStore struct {
-	SDKShapeTraits bool `type:"structure"`
+	_ struct{} `type:"structure"`
 }
 
 // String returns the string representation
@@ -1288,11 +1212,7 @@ type BlockerDeclaration struct {
 	// The type of the gate declaration.
 	Type *string `locationName:"type" type:"string" required:"true" enum:"BlockerType"`
 
-	metadataBlockerDeclaration `json:"-" xml:"-"`
-}
-
-type metadataBlockerDeclaration struct {
-	SDKShapeTraits bool `type:"structure"`
+	_ struct{} `type:"structure"`
 }
 
 // String returns the string representation
@@ -1331,11 +1251,7 @@ type CreateCustomActionTypeInput struct {
 	// This is required.
 	Version *string `locationName:"version" min:"1" type:"string" required:"true"`
 
-	metadataCreateCustomActionTypeInput `json:"-" xml:"-"`
-}
-
-type metadataCreateCustomActionTypeInput struct {
-	SDKShapeTraits bool `type:"structure"`
+	_ struct{} `type:"structure"`
 }
 
 // String returns the string representation
@@ -1353,11 +1269,7 @@ type CreateCustomActionTypeOutput struct {
 	// Returns information about the details of an action type.
 	ActionType *ActionType `locationName:"actionType" type:"structure" required:"true"`
 
-	metadataCreateCustomActionTypeOutput `json:"-" xml:"-"`
-}
-
-type metadataCreateCustomActionTypeOutput struct {
-	SDKShapeTraits bool `type:"structure"`
+	_ struct{} `type:"structure"`
 }
 
 // String returns the string representation
@@ -1375,11 +1287,7 @@ type CreatePipelineInput struct {
 	// Represents the structure of actions and stages to be performed in the pipeline.
 	Pipeline *PipelineDeclaration `locationName:"pipeline" type:"structure" required:"true"`
 
-	metadataCreatePipelineInput `json:"-" xml:"-"`
-}
-
-type metadataCreatePipelineInput struct {
-	SDKShapeTraits bool `type:"structure"`
+	_ struct{} `type:"structure"`
 }
 
 // String returns the string representation
@@ -1397,11 +1305,7 @@ type CreatePipelineOutput struct {
 	// Represents the structure of actions and stages to be performed in the pipeline.
 	Pipeline *PipelineDeclaration `locationName:"pipeline" type:"structure"`
 
-	metadataCreatePipelineOutput `json:"-" xml:"-"`
-}
-
-type metadataCreatePipelineOutput struct {
-	SDKShapeTraits bool `type:"structure"`
+	_ struct{} `type:"structure"`
 }
 
 // String returns the string representation
@@ -1422,11 +1326,7 @@ type CurrentRevision struct {
 	// The revision ID of the current version of an artifact.
 	Revision *string `locationName:"revision" type:"string" required:"true"`
 
-	metadataCurrentRevision `json:"-" xml:"-"`
-}
-
-type metadataCurrentRevision struct {
-	SDKShapeTraits bool `type:"structure"`
+	_ struct{} `type:"structure"`
 }
 
 // String returns the string representation
@@ -1452,11 +1352,7 @@ type DeleteCustomActionTypeInput struct {
 	// The version of the custom action to delete.
 	Version *string `locationName:"version" min:"1" type:"string" required:"true"`
 
-	metadataDeleteCustomActionTypeInput `json:"-" xml:"-"`
-}
-
-type metadataDeleteCustomActionTypeInput struct {
-	SDKShapeTraits bool `type:"structure"`
+	_ struct{} `type:"structure"`
 }
 
 // String returns the string representation
@@ -1470,11 +1366,7 @@ func (s DeleteCustomActionTypeInput) GoString() string {
 }
 
 type DeleteCustomActionTypeOutput struct {
-	metadataDeleteCustomActionTypeOutput `json:"-" xml:"-"`
-}
-
-type metadataDeleteCustomActionTypeOutput struct {
-	SDKShapeTraits bool `type:"structure"`
+	_ struct{} `type:"structure"`
 }
 
 // String returns the string representation
@@ -1492,11 +1384,7 @@ type DeletePipelineInput struct {
 	// The name of the pipeline to be deleted.
 	Name *string `locationName:"name" min:"1" type:"string" required:"true"`
 
-	metadataDeletePipelineInput `json:"-" xml:"-"`
-}
-
-type metadataDeletePipelineInput struct {
-	SDKShapeTraits bool `type:"structure"`
+	_ struct{} `type:"structure"`
 }
 
 // String returns the string representation
@@ -1510,11 +1398,7 @@ func (s DeletePipelineInput) GoString() string {
 }
 
 type DeletePipelineOutput struct {
-	metadataDeletePipelineOutput `json:"-" xml:"-"`
-}
-
-type metadataDeletePipelineOutput struct {
-	SDKShapeTraits bool `type:"structure"`
+	_ struct{} `type:"structure"`
 }
 
 // String returns the string representation
@@ -1548,11 +1432,7 @@ type DisableStageTransitionInput struct {
 	// in that stage (outbound).
 	TransitionType *string `locationName:"transitionType" type:"string" required:"true" enum:"StageTransitionType"`
 
-	metadataDisableStageTransitionInput `json:"-" xml:"-"`
-}
-
-type metadataDisableStageTransitionInput struct {
-	SDKShapeTraits bool `type:"structure"`
+	_ struct{} `type:"structure"`
 }
 
 // String returns the string representation
@@ -1566,11 +1446,7 @@ func (s DisableStageTransitionInput) GoString() string {
 }
 
 type DisableStageTransitionOutput struct {
-	metadataDisableStageTransitionOutput `json:"-" xml:"-"`
-}
-
-type metadataDisableStageTransitionOutput struct {
-	SDKShapeTraits bool `type:"structure"`
+	_ struct{} `type:"structure"`
 }
 
 // String returns the string representation
@@ -1598,11 +1474,7 @@ type EnableStageTransitionInput struct {
 	// will be allowed to transition to the next stage (outbound).
 	TransitionType *string `locationName:"transitionType" type:"string" required:"true" enum:"StageTransitionType"`
 
-	metadataEnableStageTransitionInput `json:"-" xml:"-"`
-}
-
-type metadataEnableStageTransitionInput struct {
-	SDKShapeTraits bool `type:"structure"`
+	_ struct{} `type:"structure"`
 }
 
 // String returns the string representation
@@ -1616,11 +1488,7 @@ func (s EnableStageTransitionInput) GoString() string {
 }
 
 type EnableStageTransitionOutput struct {
-	metadataEnableStageTransitionOutput `json:"-" xml:"-"`
-}
-
-type metadataEnableStageTransitionOutput struct {
-	SDKShapeTraits bool `type:"structure"`
+	_ struct{} `type:"structure"`
 }
 
 // String returns the string representation
@@ -1642,11 +1510,7 @@ type EncryptionKey struct {
 	// The type of AWS KMS key, such as a customer master key.
 	Type *string `locationName:"type" type:"string" required:"true" enum:"EncryptionKeyType"`
 
-	metadataEncryptionKey `json:"-" xml:"-"`
-}
-
-type metadataEncryptionKey struct {
-	SDKShapeTraits bool `type:"structure"`
+	_ struct{} `type:"structure"`
 }
 
 // String returns the string representation
@@ -1667,11 +1531,7 @@ type ErrorDetails struct {
 	// The text of the error message.
 	Message *string `locationName:"message" type:"string"`
 
-	metadataErrorDetails `json:"-" xml:"-"`
-}
-
-type metadataErrorDetails struct {
-	SDKShapeTraits bool `type:"structure"`
+	_ struct{} `type:"structure"`
 }
 
 // String returns the string representation
@@ -1698,11 +1558,7 @@ type ExecutionDetails struct {
 	// The summary of the current status of the actions.
 	Summary *string `locationName:"summary" type:"string"`
 
-	metadataExecutionDetails `json:"-" xml:"-"`
-}
-
-type metadataExecutionDetails struct {
-	SDKShapeTraits bool `type:"structure"`
+	_ struct{} `type:"structure"`
 }
 
 // String returns the string representation
@@ -1726,11 +1582,7 @@ type FailureDetails struct {
 	// The type of the failure.
 	Type *string `locationName:"type" type:"string" required:"true" enum:"FailureType"`
 
-	metadataFailureDetails `json:"-" xml:"-"`
-}
-
-type metadataFailureDetails struct {
-	SDKShapeTraits bool `type:"structure"`
+	_ struct{} `type:"structure"`
 }
 
 // String returns the string representation
@@ -1748,11 +1600,7 @@ type GetJobDetailsInput struct {
 	// The unique system-generated ID for the job.
 	JobId *string `locationName:"jobId" type:"string" required:"true"`
 
-	metadataGetJobDetailsInput `json:"-" xml:"-"`
-}
-
-type metadataGetJobDetailsInput struct {
-	SDKShapeTraits bool `type:"structure"`
+	_ struct{} `type:"structure"`
 }
 
 // String returns the string representation
@@ -1773,11 +1621,7 @@ type GetJobDetailsOutput struct {
 	// again to obtain new credentials.
 	JobDetails *JobDetails `locationName:"jobDetails" type:"structure"`
 
-	metadataGetJobDetailsOutput `json:"-" xml:"-"`
-}
-
-type metadataGetJobDetailsOutput struct {
-	SDKShapeTraits bool `type:"structure"`
+	_ struct{} `type:"structure"`
 }
 
 // String returns the string representation
@@ -1800,11 +1644,7 @@ type GetPipelineInput struct {
 	// to the most current version.
 	Version *int64 `locationName:"version" min:"1" type:"integer"`
 
-	metadataGetPipelineInput `json:"-" xml:"-"`
-}
-
-type metadataGetPipelineInput struct {
-	SDKShapeTraits bool `type:"structure"`
+	_ struct{} `type:"structure"`
 }
 
 // String returns the string representation
@@ -1822,11 +1662,7 @@ type GetPipelineOutput struct {
 	// Represents the structure of actions and stages to be performed in the pipeline.
 	Pipeline *PipelineDeclaration `locationName:"pipeline" type:"structure"`
 
-	metadataGetPipelineOutput `json:"-" xml:"-"`
-}
-
-type metadataGetPipelineOutput struct {
-	SDKShapeTraits bool `type:"structure"`
+	_ struct{} `type:"structure"`
 }
 
 // String returns the string representation
@@ -1844,11 +1680,7 @@ type GetPipelineStateInput struct {
 	// The name of the pipeline about which you want to get information.
 	Name *string `locationName:"name" min:"1" type:"string" required:"true"`
 
-	metadataGetPipelineStateInput `json:"-" xml:"-"`
-}
-
-type metadataGetPipelineStateInput struct {
-	SDKShapeTraits bool `type:"structure"`
+	_ struct{} `type:"structure"`
 }
 
 // String returns the string representation
@@ -1881,11 +1713,7 @@ type GetPipelineStateOutput struct {
 	// The date and time the pipeline was last updated, in timestamp format.
 	Updated *time.Time `locationName:"updated" type:"timestamp" timestampFormat:"unix"`
 
-	metadataGetPipelineStateOutput `json:"-" xml:"-"`
-}
-
-type metadataGetPipelineStateOutput struct {
-	SDKShapeTraits bool `type:"structure"`
+	_ struct{} `type:"structure"`
 }
 
 // String returns the string representation
@@ -1907,11 +1735,7 @@ type GetThirdPartyJobDetailsInput struct {
 	// The unique system-generated ID used for identifying the job.
 	JobId *string `locationName:"jobId" min:"1" type:"string" required:"true"`
 
-	metadataGetThirdPartyJobDetailsInput `json:"-" xml:"-"`
-}
-
-type metadataGetThirdPartyJobDetailsInput struct {
-	SDKShapeTraits bool `type:"structure"`
+	_ struct{} `type:"structure"`
 }
 
 // String returns the string representation
@@ -1929,11 +1753,7 @@ type GetThirdPartyJobDetailsOutput struct {
 	// The details of the job, including any protected values defined for the job.
 	JobDetails *ThirdPartyJobDetails `locationName:"jobDetails" type:"structure"`
 
-	metadataGetThirdPartyJobDetailsOutput `json:"-" xml:"-"`
-}
-
-type metadataGetThirdPartyJobDetailsOutput struct {
-	SDKShapeTraits bool `type:"structure"`
+	_ struct{} `type:"structure"`
 }
 
 // String returns the string representation
@@ -1958,11 +1778,7 @@ type InputArtifact struct {
 	// turn consumed by different following actions.
 	Name *string `locationName:"name" min:"1" type:"string" required:"true"`
 
-	metadataInputArtifact `json:"-" xml:"-"`
-}
-
-type metadataInputArtifact struct {
-	SDKShapeTraits bool `type:"structure"`
+	_ struct{} `type:"structure"`
 }
 
 // String returns the string representation
@@ -1991,11 +1807,7 @@ type Job struct {
 	// in the response.
 	Nonce *string `locationName:"nonce" type:"string"`
 
-	metadataJob `json:"-" xml:"-"`
-}
-
-type metadataJob struct {
-	SDKShapeTraits bool `type:"structure"`
+	_ struct{} `type:"structure"`
 }
 
 // String returns the string representation
@@ -2040,11 +1852,7 @@ type JobData struct {
 	// Represents information about a pipeline to a job worker.
 	PipelineContext *PipelineContext `locationName:"pipelineContext" type:"structure"`
 
-	metadataJobData `json:"-" xml:"-"`
-}
-
-type metadataJobData struct {
-	SDKShapeTraits bool `type:"structure"`
+	_ struct{} `type:"structure"`
 }
 
 // String returns the string representation
@@ -2069,11 +1877,7 @@ type JobDetails struct {
 	// The unique system-generated ID of the job.
 	Id *string `locationName:"id" type:"string"`
 
-	metadataJobDetails `json:"-" xml:"-"`
-}
-
-type metadataJobDetails struct {
-	SDKShapeTraits bool `type:"structure"`
+	_ struct{} `type:"structure"`
 }
 
 // String returns the string representation
@@ -2095,11 +1899,7 @@ type ListActionTypesInput struct {
 	// which can be used to return the next set of action types in the list.
 	NextToken *string `locationName:"nextToken" type:"string"`
 
-	metadataListActionTypesInput `json:"-" xml:"-"`
-}
-
-type metadataListActionTypesInput struct {
-	SDKShapeTraits bool `type:"structure"`
+	_ struct{} `type:"structure"`
 }
 
 // String returns the string representation
@@ -2122,11 +1922,7 @@ type ListActionTypesOutput struct {
 	// to return the next set of action types in the list.
 	NextToken *string `locationName:"nextToken" type:"string"`
 
-	metadataListActionTypesOutput `json:"-" xml:"-"`
-}
-
-type metadataListActionTypesOutput struct {
-	SDKShapeTraits bool `type:"structure"`
+	_ struct{} `type:"structure"`
 }
 
 // String returns the string representation
@@ -2145,11 +1941,7 @@ type ListPipelinesInput struct {
 	// can be used to return the next set of pipelines in the list.
 	NextToken *string `locationName:"nextToken" type:"string"`
 
-	metadataListPipelinesInput `json:"-" xml:"-"`
-}
-
-type metadataListPipelinesInput struct {
-	SDKShapeTraits bool `type:"structure"`
+	_ struct{} `type:"structure"`
 }
 
 // String returns the string representation
@@ -2172,11 +1964,7 @@ type ListPipelinesOutput struct {
 	// The list of pipelines.
 	Pipelines []*PipelineSummary `locationName:"pipelines" type:"list"`
 
-	metadataListPipelinesOutput `json:"-" xml:"-"`
-}
-
-type metadataListPipelinesOutput struct {
-	SDKShapeTraits bool `type:"structure"`
+	_ struct{} `type:"structure"`
 }
 
 // String returns the string representation
@@ -2202,11 +1990,7 @@ type OutputArtifact struct {
 	// Output artifact names must be unique within a pipeline.
 	Name *string `locationName:"name" min:"1" type:"string" required:"true"`
 
-	metadataOutputArtifact `json:"-" xml:"-"`
-}
-
-type metadataOutputArtifact struct {
-	SDKShapeTraits bool `type:"structure"`
+	_ struct{} `type:"structure"`
 }
 
 // String returns the string representation
@@ -2232,11 +2016,7 @@ type PipelineContext struct {
 	// The stage of the pipeline.
 	Stage *StageContext `locationName:"stage" type:"structure"`
 
-	metadataPipelineContext `json:"-" xml:"-"`
-}
-
-type metadataPipelineContext struct {
-	SDKShapeTraits bool `type:"structure"`
+	_ struct{} `type:"structure"`
 }
 
 // String returns the string representation
@@ -2271,11 +2051,7 @@ type PipelineDeclaration struct {
 	// of 1. This number is automatically incremented when a pipeline is updated.
 	Version *int64 `locationName:"version" min:"1" type:"integer"`
 
-	metadataPipelineDeclaration `json:"-" xml:"-"`
-}
-
-type metadataPipelineDeclaration struct {
-	SDKShapeTraits bool `type:"structure"`
+	_ struct{} `type:"structure"`
 }
 
 // String returns the string representation
@@ -2302,11 +2078,7 @@ type PipelineSummary struct {
 	// The version number of the pipeline.
 	Version *int64 `locationName:"version" min:"1" type:"integer"`
 
-	metadataPipelineSummary `json:"-" xml:"-"`
-}
-
-type metadataPipelineSummary struct {
-	SDKShapeTraits bool `type:"structure"`
+	_ struct{} `type:"structure"`
 }
 
 // String returns the string representation
@@ -2333,11 +2105,7 @@ type PollForJobsInput struct {
 	// Only jobs whose action configuration matches the mapped value will be returned.
 	QueryParam map[string]*string `locationName:"queryParam" type:"map"`
 
-	metadataPollForJobsInput `json:"-" xml:"-"`
-}
-
-type metadataPollForJobsInput struct {
-	SDKShapeTraits bool `type:"structure"`
+	_ struct{} `type:"structure"`
 }
 
 // String returns the string representation
@@ -2355,11 +2123,7 @@ type PollForJobsOutput struct {
 	// Information about the jobs to take action on.
 	Jobs []*Job `locationName:"jobs" type:"list"`
 
-	metadataPollForJobsOutput `json:"-" xml:"-"`
-}
-
-type metadataPollForJobsOutput struct {
-	SDKShapeTraits bool `type:"structure"`
+	_ struct{} `type:"structure"`
 }
 
 // String returns the string representation
@@ -2380,11 +2144,7 @@ type PollForThirdPartyJobsInput struct {
 	// The maximum number of jobs to return in a poll for jobs call.
 	MaxBatchSize *int64 `locationName:"maxBatchSize" min:"1" type:"integer"`
 
-	metadataPollForThirdPartyJobsInput `json:"-" xml:"-"`
-}
-
-type metadataPollForThirdPartyJobsInput struct {
-	SDKShapeTraits bool `type:"structure"`
+	_ struct{} `type:"structure"`
 }
 
 // String returns the string representation
@@ -2402,11 +2162,7 @@ type PollForThirdPartyJobsOutput struct {
 	// Information about the jobs to take action on.
 	Jobs []*ThirdPartyJob `locationName:"jobs" type:"list"`
 
-	metadataPollForThirdPartyJobsOutput `json:"-" xml:"-"`
-}
-
-type metadataPollForThirdPartyJobsOutput struct {
-	SDKShapeTraits bool `type:"structure"`
+	_ struct{} `type:"structure"`
 }
 
 // String returns the string representation
@@ -2433,11 +2189,7 @@ type PutActionRevisionInput struct {
 	// The name of the stage that contains the action that will act upon the revision.
 	StageName *string `locationName:"stageName" min:"1" type:"string" required:"true"`
 
-	metadataPutActionRevisionInput `json:"-" xml:"-"`
-}
-
-type metadataPutActionRevisionInput struct {
-	SDKShapeTraits bool `type:"structure"`
+	_ struct{} `type:"structure"`
 }
 
 // String returns the string representation
@@ -2458,11 +2210,7 @@ type PutActionRevisionOutput struct {
 	// The ID of the current workflow state of the pipeline.
 	PipelineExecutionId *string `locationName:"pipelineExecutionId" type:"string"`
 
-	metadataPutActionRevisionOutput `json:"-" xml:"-"`
-}
-
-type metadataPutActionRevisionOutput struct {
-	SDKShapeTraits bool `type:"structure"`
+	_ struct{} `type:"structure"`
 }
 
 // String returns the string representation
@@ -2484,11 +2232,7 @@ type PutJobFailureResultInput struct {
 	// returned from PollForJobs.
 	JobId *string `locationName:"jobId" type:"string" required:"true"`
 
-	metadataPutJobFailureResultInput `json:"-" xml:"-"`
-}
-
-type metadataPutJobFailureResultInput struct {
-	SDKShapeTraits bool `type:"structure"`
+	_ struct{} `type:"structure"`
 }
 
 // String returns the string representation
@@ -2502,11 +2246,7 @@ func (s PutJobFailureResultInput) GoString() string {
 }
 
 type PutJobFailureResultOutput struct {
-	metadataPutJobFailureResultOutput `json:"-" xml:"-"`
-}
-
-type metadataPutJobFailureResultOutput struct {
-	SDKShapeTraits bool `type:"structure"`
+	_ struct{} `type:"structure"`
 }
 
 // String returns the string representation
@@ -2537,11 +2277,7 @@ type PutJobSuccessResultInput struct {
 	// ID returned from PollForJobs.
 	JobId *string `locationName:"jobId" type:"string" required:"true"`
 
-	metadataPutJobSuccessResultInput `json:"-" xml:"-"`
-}
-
-type metadataPutJobSuccessResultInput struct {
-	SDKShapeTraits bool `type:"structure"`
+	_ struct{} `type:"structure"`
 }
 
 // String returns the string representation
@@ -2555,11 +2291,7 @@ func (s PutJobSuccessResultInput) GoString() string {
 }
 
 type PutJobSuccessResultOutput struct {
-	metadataPutJobSuccessResultOutput `json:"-" xml:"-"`
-}
-
-type metadataPutJobSuccessResultOutput struct {
-	SDKShapeTraits bool `type:"structure"`
+	_ struct{} `type:"structure"`
 }
 
 // String returns the string representation
@@ -2584,11 +2316,7 @@ type PutThirdPartyJobFailureResultInput struct {
 	// The ID of the job that failed. This is the same ID returned from PollForThirdPartyJobs.
 	JobId *string `locationName:"jobId" min:"1" type:"string" required:"true"`
 
-	metadataPutThirdPartyJobFailureResultInput `json:"-" xml:"-"`
-}
-
-type metadataPutThirdPartyJobFailureResultInput struct {
-	SDKShapeTraits bool `type:"structure"`
+	_ struct{} `type:"structure"`
 }
 
 // String returns the string representation
@@ -2602,11 +2330,7 @@ func (s PutThirdPartyJobFailureResultInput) GoString() string {
 }
 
 type PutThirdPartyJobFailureResultOutput struct {
-	metadataPutThirdPartyJobFailureResultOutput `json:"-" xml:"-"`
-}
-
-type metadataPutThirdPartyJobFailureResultOutput struct {
-	SDKShapeTraits bool `type:"structure"`
+	_ struct{} `type:"structure"`
 }
 
 // String returns the string representation
@@ -2640,11 +2364,7 @@ type PutThirdPartyJobSuccessResultInput struct {
 	// from PollForThirdPartyJobs.
 	JobId *string `locationName:"jobId" min:"1" type:"string" required:"true"`
 
-	metadataPutThirdPartyJobSuccessResultInput `json:"-" xml:"-"`
-}
-
-type metadataPutThirdPartyJobSuccessResultInput struct {
-	SDKShapeTraits bool `type:"structure"`
+	_ struct{} `type:"structure"`
 }
 
 // String returns the string representation
@@ -2658,11 +2378,7 @@ func (s PutThirdPartyJobSuccessResultInput) GoString() string {
 }
 
 type PutThirdPartyJobSuccessResultOutput struct {
-	metadataPutThirdPartyJobSuccessResultOutput `json:"-" xml:"-"`
-}
-
-type metadataPutThirdPartyJobSuccessResultOutput struct {
-	SDKShapeTraits bool `type:"structure"`
+	_ struct{} `type:"structure"`
 }
 
 // String returns the string representation
@@ -2684,11 +2400,7 @@ type S3ArtifactLocation struct {
 	// the object in the bucket.
 	ObjectKey *string `locationName:"objectKey" type:"string" required:"true"`
 
-	metadataS3ArtifactLocation `json:"-" xml:"-"`
-}
-
-type metadataS3ArtifactLocation struct {
-	SDKShapeTraits bool `type:"structure"`
+	_ struct{} `type:"structure"`
 }
 
 // String returns the string representation
@@ -2706,11 +2418,7 @@ type StageContext struct {
 	// The name of the stage.
 	Name *string `locationName:"name" min:"1" type:"string"`
 
-	metadataStageContext `json:"-" xml:"-"`
-}
-
-type metadataStageContext struct {
-	SDKShapeTraits bool `type:"structure"`
+	_ struct{} `type:"structure"`
 }
 
 // String returns the string representation
@@ -2734,11 +2442,7 @@ type StageDeclaration struct {
 	// The name of the stage.
 	Name *string `locationName:"name" min:"1" type:"string" required:"true"`
 
-	metadataStageDeclaration `json:"-" xml:"-"`
-}
-
-type metadataStageDeclaration struct {
-	SDKShapeTraits bool `type:"structure"`
+	_ struct{} `type:"structure"`
 }
 
 // String returns the string representation
@@ -2762,11 +2466,7 @@ type StageState struct {
 	// The name of the stage.
 	StageName *string `locationName:"stageName" min:"1" type:"string"`
 
-	metadataStageState `json:"-" xml:"-"`
-}
-
-type metadataStageState struct {
-	SDKShapeTraits bool `type:"structure"`
+	_ struct{} `type:"structure"`
 }
 
 // String returns the string representation
@@ -2784,11 +2484,7 @@ type StartPipelineExecutionInput struct {
 	// The name of the pipeline to start.
 	Name *string `locationName:"name" min:"1" type:"string" required:"true"`
 
-	metadataStartPipelineExecutionInput `json:"-" xml:"-"`
-}
-
-type metadataStartPipelineExecutionInput struct {
-	SDKShapeTraits bool `type:"structure"`
+	_ struct{} `type:"structure"`
 }
 
 // String returns the string representation
@@ -2806,11 +2502,7 @@ type StartPipelineExecutionOutput struct {
 	// The unique system-generated ID of the pipeline that was started.
 	PipelineExecutionId *string `locationName:"pipelineExecutionId" type:"string"`
 
-	metadataStartPipelineExecutionOutput `json:"-" xml:"-"`
-}
-
-type metadataStartPipelineExecutionOutput struct {
-	SDKShapeTraits bool `type:"structure"`
+	_ struct{} `type:"structure"`
 }
 
 // String returns the string representation
@@ -2833,11 +2525,7 @@ type ThirdPartyJob struct {
 	// The identifier used to identify the job in AWS CodePipeline.
 	JobId *string `locationName:"jobId" type:"string"`
 
-	metadataThirdPartyJob `json:"-" xml:"-"`
-}
-
-type metadataThirdPartyJob struct {
-	SDKShapeTraits bool `type:"structure"`
+	_ struct{} `type:"structure"`
 }
 
 // String returns the string representation
@@ -2887,11 +2575,7 @@ type ThirdPartyJobData struct {
 	// Represents information about a pipeline to a job worker.
 	PipelineContext *PipelineContext `locationName:"pipelineContext" type:"structure"`
 
-	metadataThirdPartyJobData `json:"-" xml:"-"`
-}
-
-type metadataThirdPartyJobData struct {
-	SDKShapeTraits bool `type:"structure"`
+	_ struct{} `type:"structure"`
 }
 
 // String returns the string representation
@@ -2917,11 +2601,7 @@ type ThirdPartyJobDetails struct {
 	// in the response.
 	Nonce *string `locationName:"nonce" type:"string"`
 
-	metadataThirdPartyJobDetails `json:"-" xml:"-"`
-}
-
-type metadataThirdPartyJobDetails struct {
-	SDKShapeTraits bool `type:"structure"`
+	_ struct{} `type:"structure"`
 }
 
 // String returns the string representation
@@ -2950,11 +2630,7 @@ type TransitionState struct {
 	// The ID of the user who last changed the transition state.
 	LastChangedBy *string `locationName:"lastChangedBy" type:"string"`
 
-	metadataTransitionState `json:"-" xml:"-"`
-}
-
-type metadataTransitionState struct {
-	SDKShapeTraits bool `type:"structure"`
+	_ struct{} `type:"structure"`
 }
 
 // String returns the string representation
@@ -2972,11 +2648,7 @@ type UpdatePipelineInput struct {
 	// The name of the pipeline to be updated.
 	Pipeline *PipelineDeclaration `locationName:"pipeline" type:"structure" required:"true"`
 
-	metadataUpdatePipelineInput `json:"-" xml:"-"`
-}
-
-type metadataUpdatePipelineInput struct {
-	SDKShapeTraits bool `type:"structure"`
+	_ struct{} `type:"structure"`
 }
 
 // String returns the string representation
@@ -2994,11 +2666,7 @@ type UpdatePipelineOutput struct {
 	// The structure of the updated pipeline.
 	Pipeline *PipelineDeclaration `locationName:"pipeline" type:"structure"`
 
-	metadataUpdatePipelineOutput `json:"-" xml:"-"`
-}
-
-type metadataUpdatePipelineOutput struct {
-	SDKShapeTraits bool `type:"structure"`
+	_ struct{} `type:"structure"`
 }
 
 // String returns the string representation

--- a/service/cognitoidentity/api.go
+++ b/service/cognitoidentity/api.go
@@ -580,6 +580,8 @@ func (c *CognitoIdentity) UpdateIdentityPool(input *IdentityPool) (*IdentityPool
 
 // Input to the CreateIdentityPool action.
 type CreateIdentityPoolInput struct {
+	_ struct{} `type:"structure"`
+
 	// TRUE if the identity pool supports unauthenticated logins.
 	AllowUnauthenticatedIdentities *bool `type:"boolean" required:"true"`
 
@@ -600,8 +602,6 @@ type CreateIdentityPoolInput struct {
 
 	// Optional key:value pairs mapping provider names to provider app IDs.
 	SupportedLoginProviders map[string]*string `type:"map"`
-
-	_ struct{} `type:"structure"`
 }
 
 // String returns the string representation
@@ -616,6 +616,8 @@ func (s CreateIdentityPoolInput) GoString() string {
 
 // Credentials for the the provided identity ID.
 type Credentials struct {
+	_ struct{} `type:"structure"`
+
 	// The Access Key portion of the credentials.
 	AccessKeyId *string `type:"string"`
 
@@ -627,8 +629,6 @@ type Credentials struct {
 
 	// The Session Token portion of the credentials
 	SessionToken *string `type:"string"`
-
-	_ struct{} `type:"structure"`
 }
 
 // String returns the string representation
@@ -643,10 +643,10 @@ func (s Credentials) GoString() string {
 
 // Input to the DeleteIdentities action.
 type DeleteIdentitiesInput struct {
+	_ struct{} `type:"structure"`
+
 	// A list of 1-60 identities that you want to delete.
 	IdentityIdsToDelete []*string `min:"1" type:"list" required:"true"`
-
-	_ struct{} `type:"structure"`
 }
 
 // String returns the string representation
@@ -661,11 +661,11 @@ func (s DeleteIdentitiesInput) GoString() string {
 
 // Returned in response to a successful DeleteIdentities operation.
 type DeleteIdentitiesOutput struct {
+	_ struct{} `type:"structure"`
+
 	// An array of UnprocessedIdentityId objects, each of which contains an ErrorCode
 	// and IdentityId.
 	UnprocessedIdentityIds []*UnprocessedIdentityId `type:"list"`
-
-	_ struct{} `type:"structure"`
 }
 
 // String returns the string representation
@@ -680,10 +680,10 @@ func (s DeleteIdentitiesOutput) GoString() string {
 
 // Input to the DeleteIdentityPool action.
 type DeleteIdentityPoolInput struct {
+	_ struct{} `type:"structure"`
+
 	// An identity pool ID in the format REGION:GUID.
 	IdentityPoolId *string `min:"1" type:"string" required:"true"`
-
-	_ struct{} `type:"structure"`
 }
 
 // String returns the string representation
@@ -712,10 +712,10 @@ func (s DeleteIdentityPoolOutput) GoString() string {
 
 // Input to the DescribeIdentity action.
 type DescribeIdentityInput struct {
+	_ struct{} `type:"structure"`
+
 	// A unique identifier in the format REGION:GUID.
 	IdentityId *string `min:"1" type:"string" required:"true"`
-
-	_ struct{} `type:"structure"`
 }
 
 // String returns the string representation
@@ -730,10 +730,10 @@ func (s DescribeIdentityInput) GoString() string {
 
 // Input to the DescribeIdentityPool action.
 type DescribeIdentityPoolInput struct {
+	_ struct{} `type:"structure"`
+
 	// An identity pool ID in the format REGION:GUID.
 	IdentityPoolId *string `min:"1" type:"string" required:"true"`
-
-	_ struct{} `type:"structure"`
 }
 
 // String returns the string representation
@@ -748,13 +748,13 @@ func (s DescribeIdentityPoolInput) GoString() string {
 
 // Input to the GetCredentialsForIdentity action.
 type GetCredentialsForIdentityInput struct {
+	_ struct{} `type:"structure"`
+
 	// A unique identifier in the format REGION:GUID.
 	IdentityId *string `min:"1" type:"string" required:"true"`
 
 	// A set of optional name-value pairs that map provider names to provider tokens.
 	Logins map[string]*string `type:"map"`
-
-	_ struct{} `type:"structure"`
 }
 
 // String returns the string representation
@@ -769,13 +769,13 @@ func (s GetCredentialsForIdentityInput) GoString() string {
 
 // Returned in response to a successful GetCredentialsForIdentity operation.
 type GetCredentialsForIdentityOutput struct {
+	_ struct{} `type:"structure"`
+
 	// Credentials for the the provided identity ID.
 	Credentials *Credentials `type:"structure"`
 
 	// A unique identifier in the format REGION:GUID.
 	IdentityId *string `min:"1" type:"string"`
-
-	_ struct{} `type:"structure"`
 }
 
 // String returns the string representation
@@ -790,6 +790,8 @@ func (s GetCredentialsForIdentityOutput) GoString() string {
 
 // Input to the GetId action.
 type GetIdInput struct {
+	_ struct{} `type:"structure"`
+
 	// A standard AWS account ID (9+ digits).
 	AccountId *string `min:"1" type:"string"`
 
@@ -802,8 +804,6 @@ type GetIdInput struct {
 	//  Google: accounts.google.com  Amazon: www.amazon.com  Twitter: www.twitter.com
 	//  Digits: www.digits.com
 	Logins map[string]*string `type:"map"`
-
-	_ struct{} `type:"structure"`
 }
 
 // String returns the string representation
@@ -818,10 +818,10 @@ func (s GetIdInput) GoString() string {
 
 // Returned in response to a GetId request.
 type GetIdOutput struct {
+	_ struct{} `type:"structure"`
+
 	// A unique identifier in the format REGION:GUID.
 	IdentityId *string `min:"1" type:"string"`
-
-	_ struct{} `type:"structure"`
 }
 
 // String returns the string representation
@@ -836,10 +836,10 @@ func (s GetIdOutput) GoString() string {
 
 // Input to the GetIdentityPoolRoles action.
 type GetIdentityPoolRolesInput struct {
+	_ struct{} `type:"structure"`
+
 	// An identity pool ID in the format REGION:GUID.
 	IdentityPoolId *string `min:"1" type:"string" required:"true"`
-
-	_ struct{} `type:"structure"`
 }
 
 // String returns the string representation
@@ -854,14 +854,14 @@ func (s GetIdentityPoolRolesInput) GoString() string {
 
 // Returned in response to a successful GetIdentityPoolRoles operation.
 type GetIdentityPoolRolesOutput struct {
+	_ struct{} `type:"structure"`
+
 	// An identity pool ID in the format REGION:GUID.
 	IdentityPoolId *string `min:"1" type:"string"`
 
 	// The map of roles associated with this pool. Currently only authenticated
 	// and unauthenticated roles are supported.
 	Roles map[string]*string `type:"map"`
-
-	_ struct{} `type:"structure"`
 }
 
 // String returns the string representation
@@ -876,6 +876,8 @@ func (s GetIdentityPoolRolesOutput) GoString() string {
 
 // Input to the GetOpenIdTokenForDeveloperIdentity action.
 type GetOpenIdTokenForDeveloperIdentityInput struct {
+	_ struct{} `type:"structure"`
+
 	// A unique identifier in the format REGION:GUID.
 	IdentityId *string `min:"1" type:"string"`
 
@@ -902,8 +904,6 @@ type GetOpenIdTokenForDeveloperIdentityInput struct {
 	// security implications: an attacker could use a leaked token to access your
 	// AWS resources for the token's duration.
 	TokenDuration *int64 `min:"1" type:"long"`
-
-	_ struct{} `type:"structure"`
 }
 
 // String returns the string representation
@@ -918,13 +918,13 @@ func (s GetOpenIdTokenForDeveloperIdentityInput) GoString() string {
 
 // Returned in response to a successful GetOpenIdTokenForDeveloperIdentity request.
 type GetOpenIdTokenForDeveloperIdentityOutput struct {
+	_ struct{} `type:"structure"`
+
 	// A unique identifier in the format REGION:GUID.
 	IdentityId *string `min:"1" type:"string"`
 
 	// An OpenID token.
 	Token *string `type:"string"`
-
-	_ struct{} `type:"structure"`
 }
 
 // String returns the string representation
@@ -939,6 +939,8 @@ func (s GetOpenIdTokenForDeveloperIdentityOutput) GoString() string {
 
 // Input to the GetOpenIdToken action.
 type GetOpenIdTokenInput struct {
+	_ struct{} `type:"structure"`
+
 	// A unique identifier in the format REGION:GUID.
 	IdentityId *string `min:"1" type:"string" required:"true"`
 
@@ -947,8 +949,6 @@ type GetOpenIdTokenInput struct {
 	// returned from the provider's authflow. For accounts.google.com or any other
 	// OpenId Connect provider, always include the id_token.
 	Logins map[string]*string `type:"map"`
-
-	_ struct{} `type:"structure"`
 }
 
 // String returns the string representation
@@ -963,14 +963,14 @@ func (s GetOpenIdTokenInput) GoString() string {
 
 // Returned in response to a successful GetOpenIdToken request.
 type GetOpenIdTokenOutput struct {
+	_ struct{} `type:"structure"`
+
 	// A unique identifier in the format REGION:GUID. Note that the IdentityId returned
 	// may not match the one passed on input.
 	IdentityId *string `min:"1" type:"string"`
 
 	// An OpenID token, valid for 15 minutes.
 	Token *string `type:"string"`
-
-	_ struct{} `type:"structure"`
 }
 
 // String returns the string representation
@@ -985,6 +985,8 @@ func (s GetOpenIdTokenOutput) GoString() string {
 
 // A description of the identity.
 type IdentityDescription struct {
+	_ struct{} `type:"structure"`
+
 	// Date on which the identity was created.
 	CreationDate *time.Time `type:"timestamp" timestampFormat:"unix"`
 
@@ -996,8 +998,6 @@ type IdentityDescription struct {
 
 	// A set of optional name-value pairs that map provider names to provider tokens.
 	Logins []*string `type:"list"`
-
-	_ struct{} `type:"structure"`
 }
 
 // String returns the string representation
@@ -1012,6 +1012,8 @@ func (s IdentityDescription) GoString() string {
 
 // An object representing a Cognito identity pool.
 type IdentityPool struct {
+	_ struct{} `type:"structure"`
+
 	// TRUE if the identity pool supports unauthenticated logins.
 	AllowUnauthenticatedIdentities *bool `type:"boolean" required:"true"`
 
@@ -1029,8 +1031,6 @@ type IdentityPool struct {
 
 	// Optional key:value pairs mapping provider names to provider app IDs.
 	SupportedLoginProviders map[string]*string `type:"map"`
-
-	_ struct{} `type:"structure"`
 }
 
 // String returns the string representation
@@ -1045,13 +1045,13 @@ func (s IdentityPool) GoString() string {
 
 // A description of the identity pool.
 type IdentityPoolShortDescription struct {
+	_ struct{} `type:"structure"`
+
 	// An identity pool ID in the format REGION:GUID.
 	IdentityPoolId *string `min:"1" type:"string"`
 
 	// A string that you provide.
 	IdentityPoolName *string `min:"1" type:"string"`
-
-	_ struct{} `type:"structure"`
 }
 
 // String returns the string representation
@@ -1066,6 +1066,8 @@ func (s IdentityPoolShortDescription) GoString() string {
 
 // Input to the ListIdentities action.
 type ListIdentitiesInput struct {
+	_ struct{} `type:"structure"`
+
 	// An optional boolean parameter that allows you to hide disabled identities.
 	// If omitted, the ListIdentities API will include disabled identities in the
 	// response.
@@ -1079,8 +1081,6 @@ type ListIdentitiesInput struct {
 
 	// A pagination token.
 	NextToken *string `min:"1" type:"string"`
-
-	_ struct{} `type:"structure"`
 }
 
 // String returns the string representation
@@ -1095,6 +1095,8 @@ func (s ListIdentitiesInput) GoString() string {
 
 // The response to a ListIdentities request.
 type ListIdentitiesOutput struct {
+	_ struct{} `type:"structure"`
+
 	// An object containing a set of identities and associated mappings.
 	Identities []*IdentityDescription `type:"list"`
 
@@ -1103,8 +1105,6 @@ type ListIdentitiesOutput struct {
 
 	// A pagination token.
 	NextToken *string `min:"1" type:"string"`
-
-	_ struct{} `type:"structure"`
 }
 
 // String returns the string representation
@@ -1119,13 +1119,13 @@ func (s ListIdentitiesOutput) GoString() string {
 
 // Input to the ListIdentityPools action.
 type ListIdentityPoolsInput struct {
+	_ struct{} `type:"structure"`
+
 	// The maximum number of identities to return.
 	MaxResults *int64 `min:"1" type:"integer" required:"true"`
 
 	// A pagination token.
 	NextToken *string `min:"1" type:"string"`
-
-	_ struct{} `type:"structure"`
 }
 
 // String returns the string representation
@@ -1140,13 +1140,13 @@ func (s ListIdentityPoolsInput) GoString() string {
 
 // The result of a successful ListIdentityPools action.
 type ListIdentityPoolsOutput struct {
+	_ struct{} `type:"structure"`
+
 	// The identity pools returned by the ListIdentityPools action.
 	IdentityPools []*IdentityPoolShortDescription `type:"list"`
 
 	// A pagination token.
 	NextToken *string `min:"1" type:"string"`
-
-	_ struct{} `type:"structure"`
 }
 
 // String returns the string representation
@@ -1161,6 +1161,8 @@ func (s ListIdentityPoolsOutput) GoString() string {
 
 // Input to the LookupDeveloperIdentityInput action.
 type LookupDeveloperIdentityInput struct {
+	_ struct{} `type:"structure"`
+
 	// A unique ID used by your backend authentication process to identify a user.
 	// Typically, a developer identity provider would issue many developer user
 	// identifiers, in keeping with the number of users.
@@ -1182,8 +1184,6 @@ type LookupDeveloperIdentityInput struct {
 	// part of the response. This token can be used to call the API again and get
 	// results starting from the 11th match.
 	NextToken *string `min:"1" type:"string"`
-
-	_ struct{} `type:"structure"`
 }
 
 // String returns the string representation
@@ -1198,6 +1198,8 @@ func (s LookupDeveloperIdentityInput) GoString() string {
 
 // Returned in response to a successful LookupDeveloperIdentity action.
 type LookupDeveloperIdentityOutput struct {
+	_ struct{} `type:"structure"`
+
 	// This is the list of developer user identifiers associated with an identity
 	// ID. Cognito supports the association of multiple developer user identifiers
 	// with an identity ID.
@@ -1213,8 +1215,6 @@ type LookupDeveloperIdentityOutput struct {
 	// part of the response. This token can be used to call the API again and get
 	// results starting from the 11th match.
 	NextToken *string `min:"1" type:"string"`
-
-	_ struct{} `type:"structure"`
 }
 
 // String returns the string representation
@@ -1229,6 +1229,8 @@ func (s LookupDeveloperIdentityOutput) GoString() string {
 
 // Input to the MergeDeveloperIdentities action.
 type MergeDeveloperIdentitiesInput struct {
+	_ struct{} `type:"structure"`
+
 	// User identifier for the destination user. The value should be a DeveloperUserIdentifier.
 	DestinationUserIdentifier *string `min:"1" type:"string" required:"true"`
 
@@ -1244,8 +1246,6 @@ type MergeDeveloperIdentitiesInput struct {
 
 	// User identifier for the source user. The value should be a DeveloperUserIdentifier.
 	SourceUserIdentifier *string `min:"1" type:"string" required:"true"`
-
-	_ struct{} `type:"structure"`
 }
 
 // String returns the string representation
@@ -1260,10 +1260,10 @@ func (s MergeDeveloperIdentitiesInput) GoString() string {
 
 // Returned in response to a successful MergeDeveloperIdentities action.
 type MergeDeveloperIdentitiesOutput struct {
+	_ struct{} `type:"structure"`
+
 	// A unique identifier in the format REGION:GUID.
 	IdentityId *string `min:"1" type:"string"`
-
-	_ struct{} `type:"structure"`
 }
 
 // String returns the string representation
@@ -1278,6 +1278,8 @@ func (s MergeDeveloperIdentitiesOutput) GoString() string {
 
 // Input to the SetIdentityPoolRoles action.
 type SetIdentityPoolRolesInput struct {
+	_ struct{} `type:"structure"`
+
 	// An identity pool ID in the format REGION:GUID.
 	IdentityPoolId *string `min:"1" type:"string" required:"true"`
 
@@ -1285,8 +1287,6 @@ type SetIdentityPoolRolesInput struct {
 	// be either "authenticated" or "unauthenticated" and the value will be the
 	// Role ARN.
 	Roles map[string]*string `type:"map" required:"true"`
-
-	_ struct{} `type:"structure"`
 }
 
 // String returns the string representation
@@ -1315,6 +1315,8 @@ func (s SetIdentityPoolRolesOutput) GoString() string {
 
 // Input to the UnlinkDeveloperIdentity action.
 type UnlinkDeveloperIdentityInput struct {
+	_ struct{} `type:"structure"`
+
 	// The "domain" by which Cognito will refer to your users.
 	DeveloperProviderName *string `min:"1" type:"string" required:"true"`
 
@@ -1326,8 +1328,6 @@ type UnlinkDeveloperIdentityInput struct {
 
 	// An identity pool ID in the format REGION:GUID.
 	IdentityPoolId *string `min:"1" type:"string" required:"true"`
-
-	_ struct{} `type:"structure"`
 }
 
 // String returns the string representation
@@ -1356,6 +1356,8 @@ func (s UnlinkDeveloperIdentityOutput) GoString() string {
 
 // Input to the UnlinkIdentity action.
 type UnlinkIdentityInput struct {
+	_ struct{} `type:"structure"`
+
 	// A unique identifier in the format REGION:GUID.
 	IdentityId *string `min:"1" type:"string" required:"true"`
 
@@ -1364,8 +1366,6 @@ type UnlinkIdentityInput struct {
 
 	// Provider names to unlink from this identity.
 	LoginsToRemove []*string `type:"list" required:"true"`
-
-	_ struct{} `type:"structure"`
 }
 
 // String returns the string representation
@@ -1395,13 +1395,13 @@ func (s UnlinkIdentityOutput) GoString() string {
 // An array of UnprocessedIdentityId objects, each of which contains an ErrorCode
 // and IdentityId.
 type UnprocessedIdentityId struct {
+	_ struct{} `type:"structure"`
+
 	// The error code indicating the type of error that occurred.
 	ErrorCode *string `type:"string" enum:"ErrorCode"`
 
 	// A unique identifier in the format REGION:GUID.
 	IdentityId *string `min:"1" type:"string"`
-
-	_ struct{} `type:"structure"`
 }
 
 // String returns the string representation

--- a/service/cognitoidentity/api.go
+++ b/service/cognitoidentity/api.go
@@ -601,11 +601,7 @@ type CreateIdentityPoolInput struct {
 	// Optional key:value pairs mapping provider names to provider app IDs.
 	SupportedLoginProviders map[string]*string `type:"map"`
 
-	metadataCreateIdentityPoolInput `json:"-" xml:"-"`
-}
-
-type metadataCreateIdentityPoolInput struct {
-	SDKShapeTraits bool `type:"structure"`
+	_ struct{} `type:"structure"`
 }
 
 // String returns the string representation
@@ -632,11 +628,7 @@ type Credentials struct {
 	// The Session Token portion of the credentials
 	SessionToken *string `type:"string"`
 
-	metadataCredentials `json:"-" xml:"-"`
-}
-
-type metadataCredentials struct {
-	SDKShapeTraits bool `type:"structure"`
+	_ struct{} `type:"structure"`
 }
 
 // String returns the string representation
@@ -654,11 +646,7 @@ type DeleteIdentitiesInput struct {
 	// A list of 1-60 identities that you want to delete.
 	IdentityIdsToDelete []*string `min:"1" type:"list" required:"true"`
 
-	metadataDeleteIdentitiesInput `json:"-" xml:"-"`
-}
-
-type metadataDeleteIdentitiesInput struct {
-	SDKShapeTraits bool `type:"structure"`
+	_ struct{} `type:"structure"`
 }
 
 // String returns the string representation
@@ -677,11 +665,7 @@ type DeleteIdentitiesOutput struct {
 	// and IdentityId.
 	UnprocessedIdentityIds []*UnprocessedIdentityId `type:"list"`
 
-	metadataDeleteIdentitiesOutput `json:"-" xml:"-"`
-}
-
-type metadataDeleteIdentitiesOutput struct {
-	SDKShapeTraits bool `type:"structure"`
+	_ struct{} `type:"structure"`
 }
 
 // String returns the string representation
@@ -699,11 +683,7 @@ type DeleteIdentityPoolInput struct {
 	// An identity pool ID in the format REGION:GUID.
 	IdentityPoolId *string `min:"1" type:"string" required:"true"`
 
-	metadataDeleteIdentityPoolInput `json:"-" xml:"-"`
-}
-
-type metadataDeleteIdentityPoolInput struct {
-	SDKShapeTraits bool `type:"structure"`
+	_ struct{} `type:"structure"`
 }
 
 // String returns the string representation
@@ -717,11 +697,7 @@ func (s DeleteIdentityPoolInput) GoString() string {
 }
 
 type DeleteIdentityPoolOutput struct {
-	metadataDeleteIdentityPoolOutput `json:"-" xml:"-"`
-}
-
-type metadataDeleteIdentityPoolOutput struct {
-	SDKShapeTraits bool `type:"structure"`
+	_ struct{} `type:"structure"`
 }
 
 // String returns the string representation
@@ -739,11 +715,7 @@ type DescribeIdentityInput struct {
 	// A unique identifier in the format REGION:GUID.
 	IdentityId *string `min:"1" type:"string" required:"true"`
 
-	metadataDescribeIdentityInput `json:"-" xml:"-"`
-}
-
-type metadataDescribeIdentityInput struct {
-	SDKShapeTraits bool `type:"structure"`
+	_ struct{} `type:"structure"`
 }
 
 // String returns the string representation
@@ -761,11 +733,7 @@ type DescribeIdentityPoolInput struct {
 	// An identity pool ID in the format REGION:GUID.
 	IdentityPoolId *string `min:"1" type:"string" required:"true"`
 
-	metadataDescribeIdentityPoolInput `json:"-" xml:"-"`
-}
-
-type metadataDescribeIdentityPoolInput struct {
-	SDKShapeTraits bool `type:"structure"`
+	_ struct{} `type:"structure"`
 }
 
 // String returns the string representation
@@ -786,11 +754,7 @@ type GetCredentialsForIdentityInput struct {
 	// A set of optional name-value pairs that map provider names to provider tokens.
 	Logins map[string]*string `type:"map"`
 
-	metadataGetCredentialsForIdentityInput `json:"-" xml:"-"`
-}
-
-type metadataGetCredentialsForIdentityInput struct {
-	SDKShapeTraits bool `type:"structure"`
+	_ struct{} `type:"structure"`
 }
 
 // String returns the string representation
@@ -811,11 +775,7 @@ type GetCredentialsForIdentityOutput struct {
 	// A unique identifier in the format REGION:GUID.
 	IdentityId *string `min:"1" type:"string"`
 
-	metadataGetCredentialsForIdentityOutput `json:"-" xml:"-"`
-}
-
-type metadataGetCredentialsForIdentityOutput struct {
-	SDKShapeTraits bool `type:"structure"`
+	_ struct{} `type:"structure"`
 }
 
 // String returns the string representation
@@ -843,11 +803,7 @@ type GetIdInput struct {
 	//  Digits: www.digits.com
 	Logins map[string]*string `type:"map"`
 
-	metadataGetIdInput `json:"-" xml:"-"`
-}
-
-type metadataGetIdInput struct {
-	SDKShapeTraits bool `type:"structure"`
+	_ struct{} `type:"structure"`
 }
 
 // String returns the string representation
@@ -865,11 +821,7 @@ type GetIdOutput struct {
 	// A unique identifier in the format REGION:GUID.
 	IdentityId *string `min:"1" type:"string"`
 
-	metadataGetIdOutput `json:"-" xml:"-"`
-}
-
-type metadataGetIdOutput struct {
-	SDKShapeTraits bool `type:"structure"`
+	_ struct{} `type:"structure"`
 }
 
 // String returns the string representation
@@ -887,11 +839,7 @@ type GetIdentityPoolRolesInput struct {
 	// An identity pool ID in the format REGION:GUID.
 	IdentityPoolId *string `min:"1" type:"string" required:"true"`
 
-	metadataGetIdentityPoolRolesInput `json:"-" xml:"-"`
-}
-
-type metadataGetIdentityPoolRolesInput struct {
-	SDKShapeTraits bool `type:"structure"`
+	_ struct{} `type:"structure"`
 }
 
 // String returns the string representation
@@ -913,11 +861,7 @@ type GetIdentityPoolRolesOutput struct {
 	// and unauthenticated roles are supported.
 	Roles map[string]*string `type:"map"`
 
-	metadataGetIdentityPoolRolesOutput `json:"-" xml:"-"`
-}
-
-type metadataGetIdentityPoolRolesOutput struct {
-	SDKShapeTraits bool `type:"structure"`
+	_ struct{} `type:"structure"`
 }
 
 // String returns the string representation
@@ -959,11 +903,7 @@ type GetOpenIdTokenForDeveloperIdentityInput struct {
 	// AWS resources for the token's duration.
 	TokenDuration *int64 `min:"1" type:"long"`
 
-	metadataGetOpenIdTokenForDeveloperIdentityInput `json:"-" xml:"-"`
-}
-
-type metadataGetOpenIdTokenForDeveloperIdentityInput struct {
-	SDKShapeTraits bool `type:"structure"`
+	_ struct{} `type:"structure"`
 }
 
 // String returns the string representation
@@ -984,11 +924,7 @@ type GetOpenIdTokenForDeveloperIdentityOutput struct {
 	// An OpenID token.
 	Token *string `type:"string"`
 
-	metadataGetOpenIdTokenForDeveloperIdentityOutput `json:"-" xml:"-"`
-}
-
-type metadataGetOpenIdTokenForDeveloperIdentityOutput struct {
-	SDKShapeTraits bool `type:"structure"`
+	_ struct{} `type:"structure"`
 }
 
 // String returns the string representation
@@ -1012,11 +948,7 @@ type GetOpenIdTokenInput struct {
 	// OpenId Connect provider, always include the id_token.
 	Logins map[string]*string `type:"map"`
 
-	metadataGetOpenIdTokenInput `json:"-" xml:"-"`
-}
-
-type metadataGetOpenIdTokenInput struct {
-	SDKShapeTraits bool `type:"structure"`
+	_ struct{} `type:"structure"`
 }
 
 // String returns the string representation
@@ -1038,11 +970,7 @@ type GetOpenIdTokenOutput struct {
 	// An OpenID token, valid for 15 minutes.
 	Token *string `type:"string"`
 
-	metadataGetOpenIdTokenOutput `json:"-" xml:"-"`
-}
-
-type metadataGetOpenIdTokenOutput struct {
-	SDKShapeTraits bool `type:"structure"`
+	_ struct{} `type:"structure"`
 }
 
 // String returns the string representation
@@ -1069,11 +997,7 @@ type IdentityDescription struct {
 	// A set of optional name-value pairs that map provider names to provider tokens.
 	Logins []*string `type:"list"`
 
-	metadataIdentityDescription `json:"-" xml:"-"`
-}
-
-type metadataIdentityDescription struct {
-	SDKShapeTraits bool `type:"structure"`
+	_ struct{} `type:"structure"`
 }
 
 // String returns the string representation
@@ -1106,11 +1030,7 @@ type IdentityPool struct {
 	// Optional key:value pairs mapping provider names to provider app IDs.
 	SupportedLoginProviders map[string]*string `type:"map"`
 
-	metadataIdentityPool `json:"-" xml:"-"`
-}
-
-type metadataIdentityPool struct {
-	SDKShapeTraits bool `type:"structure"`
+	_ struct{} `type:"structure"`
 }
 
 // String returns the string representation
@@ -1131,11 +1051,7 @@ type IdentityPoolShortDescription struct {
 	// A string that you provide.
 	IdentityPoolName *string `min:"1" type:"string"`
 
-	metadataIdentityPoolShortDescription `json:"-" xml:"-"`
-}
-
-type metadataIdentityPoolShortDescription struct {
-	SDKShapeTraits bool `type:"structure"`
+	_ struct{} `type:"structure"`
 }
 
 // String returns the string representation
@@ -1164,11 +1080,7 @@ type ListIdentitiesInput struct {
 	// A pagination token.
 	NextToken *string `min:"1" type:"string"`
 
-	metadataListIdentitiesInput `json:"-" xml:"-"`
-}
-
-type metadataListIdentitiesInput struct {
-	SDKShapeTraits bool `type:"structure"`
+	_ struct{} `type:"structure"`
 }
 
 // String returns the string representation
@@ -1192,11 +1104,7 @@ type ListIdentitiesOutput struct {
 	// A pagination token.
 	NextToken *string `min:"1" type:"string"`
 
-	metadataListIdentitiesOutput `json:"-" xml:"-"`
-}
-
-type metadataListIdentitiesOutput struct {
-	SDKShapeTraits bool `type:"structure"`
+	_ struct{} `type:"structure"`
 }
 
 // String returns the string representation
@@ -1217,11 +1125,7 @@ type ListIdentityPoolsInput struct {
 	// A pagination token.
 	NextToken *string `min:"1" type:"string"`
 
-	metadataListIdentityPoolsInput `json:"-" xml:"-"`
-}
-
-type metadataListIdentityPoolsInput struct {
-	SDKShapeTraits bool `type:"structure"`
+	_ struct{} `type:"structure"`
 }
 
 // String returns the string representation
@@ -1242,11 +1146,7 @@ type ListIdentityPoolsOutput struct {
 	// A pagination token.
 	NextToken *string `min:"1" type:"string"`
 
-	metadataListIdentityPoolsOutput `json:"-" xml:"-"`
-}
-
-type metadataListIdentityPoolsOutput struct {
-	SDKShapeTraits bool `type:"structure"`
+	_ struct{} `type:"structure"`
 }
 
 // String returns the string representation
@@ -1283,11 +1183,7 @@ type LookupDeveloperIdentityInput struct {
 	// results starting from the 11th match.
 	NextToken *string `min:"1" type:"string"`
 
-	metadataLookupDeveloperIdentityInput `json:"-" xml:"-"`
-}
-
-type metadataLookupDeveloperIdentityInput struct {
-	SDKShapeTraits bool `type:"structure"`
+	_ struct{} `type:"structure"`
 }
 
 // String returns the string representation
@@ -1318,11 +1214,7 @@ type LookupDeveloperIdentityOutput struct {
 	// results starting from the 11th match.
 	NextToken *string `min:"1" type:"string"`
 
-	metadataLookupDeveloperIdentityOutput `json:"-" xml:"-"`
-}
-
-type metadataLookupDeveloperIdentityOutput struct {
-	SDKShapeTraits bool `type:"structure"`
+	_ struct{} `type:"structure"`
 }
 
 // String returns the string representation
@@ -1353,11 +1245,7 @@ type MergeDeveloperIdentitiesInput struct {
 	// User identifier for the source user. The value should be a DeveloperUserIdentifier.
 	SourceUserIdentifier *string `min:"1" type:"string" required:"true"`
 
-	metadataMergeDeveloperIdentitiesInput `json:"-" xml:"-"`
-}
-
-type metadataMergeDeveloperIdentitiesInput struct {
-	SDKShapeTraits bool `type:"structure"`
+	_ struct{} `type:"structure"`
 }
 
 // String returns the string representation
@@ -1375,11 +1263,7 @@ type MergeDeveloperIdentitiesOutput struct {
 	// A unique identifier in the format REGION:GUID.
 	IdentityId *string `min:"1" type:"string"`
 
-	metadataMergeDeveloperIdentitiesOutput `json:"-" xml:"-"`
-}
-
-type metadataMergeDeveloperIdentitiesOutput struct {
-	SDKShapeTraits bool `type:"structure"`
+	_ struct{} `type:"structure"`
 }
 
 // String returns the string representation
@@ -1402,11 +1286,7 @@ type SetIdentityPoolRolesInput struct {
 	// Role ARN.
 	Roles map[string]*string `type:"map" required:"true"`
 
-	metadataSetIdentityPoolRolesInput `json:"-" xml:"-"`
-}
-
-type metadataSetIdentityPoolRolesInput struct {
-	SDKShapeTraits bool `type:"structure"`
+	_ struct{} `type:"structure"`
 }
 
 // String returns the string representation
@@ -1420,11 +1300,7 @@ func (s SetIdentityPoolRolesInput) GoString() string {
 }
 
 type SetIdentityPoolRolesOutput struct {
-	metadataSetIdentityPoolRolesOutput `json:"-" xml:"-"`
-}
-
-type metadataSetIdentityPoolRolesOutput struct {
-	SDKShapeTraits bool `type:"structure"`
+	_ struct{} `type:"structure"`
 }
 
 // String returns the string representation
@@ -1451,11 +1327,7 @@ type UnlinkDeveloperIdentityInput struct {
 	// An identity pool ID in the format REGION:GUID.
 	IdentityPoolId *string `min:"1" type:"string" required:"true"`
 
-	metadataUnlinkDeveloperIdentityInput `json:"-" xml:"-"`
-}
-
-type metadataUnlinkDeveloperIdentityInput struct {
-	SDKShapeTraits bool `type:"structure"`
+	_ struct{} `type:"structure"`
 }
 
 // String returns the string representation
@@ -1469,11 +1341,7 @@ func (s UnlinkDeveloperIdentityInput) GoString() string {
 }
 
 type UnlinkDeveloperIdentityOutput struct {
-	metadataUnlinkDeveloperIdentityOutput `json:"-" xml:"-"`
-}
-
-type metadataUnlinkDeveloperIdentityOutput struct {
-	SDKShapeTraits bool `type:"structure"`
+	_ struct{} `type:"structure"`
 }
 
 // String returns the string representation
@@ -1497,11 +1365,7 @@ type UnlinkIdentityInput struct {
 	// Provider names to unlink from this identity.
 	LoginsToRemove []*string `type:"list" required:"true"`
 
-	metadataUnlinkIdentityInput `json:"-" xml:"-"`
-}
-
-type metadataUnlinkIdentityInput struct {
-	SDKShapeTraits bool `type:"structure"`
+	_ struct{} `type:"structure"`
 }
 
 // String returns the string representation
@@ -1515,11 +1379,7 @@ func (s UnlinkIdentityInput) GoString() string {
 }
 
 type UnlinkIdentityOutput struct {
-	metadataUnlinkIdentityOutput `json:"-" xml:"-"`
-}
-
-type metadataUnlinkIdentityOutput struct {
-	SDKShapeTraits bool `type:"structure"`
+	_ struct{} `type:"structure"`
 }
 
 // String returns the string representation
@@ -1541,11 +1401,7 @@ type UnprocessedIdentityId struct {
 	// A unique identifier in the format REGION:GUID.
 	IdentityId *string `min:"1" type:"string"`
 
-	metadataUnprocessedIdentityId `json:"-" xml:"-"`
-}
-
-type metadataUnprocessedIdentityId struct {
-	SDKShapeTraits bool `type:"structure"`
+	_ struct{} `type:"structure"`
 }
 
 // String returns the string representation

--- a/service/cognitosync/api.go
+++ b/service/cognitosync/api.go
@@ -563,11 +563,7 @@ type BulkPublishInput struct {
 	// created by Amazon Cognito. GUID generation is unique within a region.
 	IdentityPoolId *string `location:"uri" locationName:"IdentityPoolId" min:"1" type:"string" required:"true"`
 
-	metadataBulkPublishInput `json:"-" xml:"-"`
-}
-
-type metadataBulkPublishInput struct {
-	SDKShapeTraits bool `type:"structure"`
+	_ struct{} `type:"structure"`
 }
 
 // String returns the string representation
@@ -586,11 +582,7 @@ type BulkPublishOutput struct {
 	// created by Amazon Cognito. GUID generation is unique within a region.
 	IdentityPoolId *string `min:"1" type:"string"`
 
-	metadataBulkPublishOutput `json:"-" xml:"-"`
-}
-
-type metadataBulkPublishOutput struct {
-	SDKShapeTraits bool `type:"structure"`
+	_ struct{} `type:"structure"`
 }
 
 // String returns the string representation
@@ -621,11 +613,7 @@ type CognitoStreams struct {
 	// will also fail if StreamingStatus is DISABLED.
 	StreamingStatus *string `type:"string" enum:"StreamingStatus"`
 
-	metadataCognitoStreams `json:"-" xml:"-"`
-}
-
-type metadataCognitoStreams struct {
-	SDKShapeTraits bool `type:"structure"`
+	_ struct{} `type:"structure"`
 }
 
 // String returns the string representation
@@ -667,11 +655,7 @@ type Dataset struct {
 	// Number of records in this dataset.
 	NumRecords *int64 `type:"long"`
 
-	metadataDataset `json:"-" xml:"-"`
-}
-
-type metadataDataset struct {
-	SDKShapeTraits bool `type:"structure"`
+	_ struct{} `type:"structure"`
 }
 
 // String returns the string representation
@@ -698,11 +682,7 @@ type DeleteDatasetInput struct {
 	// created by Amazon Cognito. GUID generation is unique within a region.
 	IdentityPoolId *string `location:"uri" locationName:"IdentityPoolId" min:"1" type:"string" required:"true"`
 
-	metadataDeleteDatasetInput `json:"-" xml:"-"`
-}
-
-type metadataDeleteDatasetInput struct {
-	SDKShapeTraits bool `type:"structure"`
+	_ struct{} `type:"structure"`
 }
 
 // String returns the string representation
@@ -724,11 +704,7 @@ type DeleteDatasetOutput struct {
 	// hold up to 1MB of key-value pairs.
 	Dataset *Dataset `type:"structure"`
 
-	metadataDeleteDatasetOutput `json:"-" xml:"-"`
-}
-
-type metadataDeleteDatasetOutput struct {
-	SDKShapeTraits bool `type:"structure"`
+	_ struct{} `type:"structure"`
 }
 
 // String returns the string representation
@@ -756,11 +732,7 @@ type DescribeDatasetInput struct {
 	// created by Amazon Cognito. GUID generation is unique within a region.
 	IdentityPoolId *string `location:"uri" locationName:"IdentityPoolId" min:"1" type:"string" required:"true"`
 
-	metadataDescribeDatasetInput `json:"-" xml:"-"`
-}
-
-type metadataDescribeDatasetInput struct {
-	SDKShapeTraits bool `type:"structure"`
+	_ struct{} `type:"structure"`
 }
 
 // String returns the string representation
@@ -782,11 +754,7 @@ type DescribeDatasetOutput struct {
 	// hold up to 1MB of key-value pairs.
 	Dataset *Dataset `type:"structure"`
 
-	metadataDescribeDatasetOutput `json:"-" xml:"-"`
-}
-
-type metadataDescribeDatasetOutput struct {
-	SDKShapeTraits bool `type:"structure"`
+	_ struct{} `type:"structure"`
 }
 
 // String returns the string representation
@@ -805,11 +773,7 @@ type DescribeIdentityPoolUsageInput struct {
 	// created by Amazon Cognito. GUID generation is unique within a region.
 	IdentityPoolId *string `location:"uri" locationName:"IdentityPoolId" min:"1" type:"string" required:"true"`
 
-	metadataDescribeIdentityPoolUsageInput `json:"-" xml:"-"`
-}
-
-type metadataDescribeIdentityPoolUsageInput struct {
-	SDKShapeTraits bool `type:"structure"`
+	_ struct{} `type:"structure"`
 }
 
 // String returns the string representation
@@ -827,11 +791,7 @@ type DescribeIdentityPoolUsageOutput struct {
 	// Information about the usage of the identity pool.
 	IdentityPoolUsage *IdentityPoolUsage `type:"structure"`
 
-	metadataDescribeIdentityPoolUsageOutput `json:"-" xml:"-"`
-}
-
-type metadataDescribeIdentityPoolUsageOutput struct {
-	SDKShapeTraits bool `type:"structure"`
+	_ struct{} `type:"structure"`
 }
 
 // String returns the string representation
@@ -854,11 +814,7 @@ type DescribeIdentityUsageInput struct {
 	// created by Amazon Cognito. GUID generation is unique within a region.
 	IdentityPoolId *string `location:"uri" locationName:"IdentityPoolId" min:"1" type:"string" required:"true"`
 
-	metadataDescribeIdentityUsageInput `json:"-" xml:"-"`
-}
-
-type metadataDescribeIdentityUsageInput struct {
-	SDKShapeTraits bool `type:"structure"`
+	_ struct{} `type:"structure"`
 }
 
 // String returns the string representation
@@ -876,11 +832,7 @@ type DescribeIdentityUsageOutput struct {
 	// Usage information for the identity.
 	IdentityUsage *IdentityUsage `type:"structure"`
 
-	metadataDescribeIdentityUsageOutput `json:"-" xml:"-"`
-}
-
-type metadataDescribeIdentityUsageOutput struct {
-	SDKShapeTraits bool `type:"structure"`
+	_ struct{} `type:"structure"`
 }
 
 // String returns the string representation
@@ -899,11 +851,7 @@ type GetBulkPublishDetailsInput struct {
 	// created by Amazon Cognito. GUID generation is unique within a region.
 	IdentityPoolId *string `location:"uri" locationName:"IdentityPoolId" min:"1" type:"string" required:"true"`
 
-	metadataGetBulkPublishDetailsInput `json:"-" xml:"-"`
-}
-
-type metadataGetBulkPublishDetailsInput struct {
-	SDKShapeTraits bool `type:"structure"`
+	_ struct{} `type:"structure"`
 }
 
 // String returns the string representation
@@ -945,11 +893,7 @@ type GetBulkPublishDetailsOutput struct {
 	// created by Amazon Cognito. GUID generation is unique within a region.
 	IdentityPoolId *string `min:"1" type:"string"`
 
-	metadataGetBulkPublishDetailsOutput `json:"-" xml:"-"`
-}
-
-type metadataGetBulkPublishDetailsOutput struct {
-	SDKShapeTraits bool `type:"structure"`
+	_ struct{} `type:"structure"`
 }
 
 // String returns the string representation
@@ -967,11 +911,7 @@ type GetCognitoEventsInput struct {
 	// The Cognito Identity Pool ID for the request
 	IdentityPoolId *string `location:"uri" locationName:"IdentityPoolId" min:"1" type:"string" required:"true"`
 
-	metadataGetCognitoEventsInput `json:"-" xml:"-"`
-}
-
-type metadataGetCognitoEventsInput struct {
-	SDKShapeTraits bool `type:"structure"`
+	_ struct{} `type:"structure"`
 }
 
 // String returns the string representation
@@ -989,11 +929,7 @@ type GetCognitoEventsOutput struct {
 	// The Cognito Events returned from the GetCognitoEvents request
 	Events map[string]*string `type:"map"`
 
-	metadataGetCognitoEventsOutput `json:"-" xml:"-"`
-}
-
-type metadataGetCognitoEventsOutput struct {
-	SDKShapeTraits bool `type:"structure"`
+	_ struct{} `type:"structure"`
 }
 
 // String returns the string representation
@@ -1013,11 +949,7 @@ type GetIdentityPoolConfigurationInput struct {
 	// a configuration.
 	IdentityPoolId *string `location:"uri" locationName:"IdentityPoolId" min:"1" type:"string" required:"true"`
 
-	metadataGetIdentityPoolConfigurationInput `json:"-" xml:"-"`
-}
-
-type metadataGetIdentityPoolConfigurationInput struct {
-	SDKShapeTraits bool `type:"structure"`
+	_ struct{} `type:"structure"`
 }
 
 // String returns the string representation
@@ -1042,11 +974,7 @@ type GetIdentityPoolConfigurationOutput struct {
 	// Options to apply to this identity pool for push synchronization.
 	PushSync *PushSync `type:"structure"`
 
-	metadataGetIdentityPoolConfigurationOutput `json:"-" xml:"-"`
-}
-
-type metadataGetIdentityPoolConfigurationOutput struct {
-	SDKShapeTraits bool `type:"structure"`
+	_ struct{} `type:"structure"`
 }
 
 // String returns the string representation
@@ -1074,11 +1002,7 @@ type IdentityPoolUsage struct {
 	// Number of sync sessions for the identity pool.
 	SyncSessionsCount *int64 `type:"long"`
 
-	metadataIdentityPoolUsage `json:"-" xml:"-"`
-}
-
-type metadataIdentityPoolUsage struct {
-	SDKShapeTraits bool `type:"structure"`
+	_ struct{} `type:"structure"`
 }
 
 // String returns the string representation
@@ -1110,11 +1034,7 @@ type IdentityUsage struct {
 	// Date on which the identity was last modified.
 	LastModifiedDate *time.Time `type:"timestamp" timestampFormat:"unix"`
 
-	metadataIdentityUsage `json:"-" xml:"-"`
-}
-
-type metadataIdentityUsage struct {
-	SDKShapeTraits bool `type:"structure"`
+	_ struct{} `type:"structure"`
 }
 
 // String returns the string representation
@@ -1143,11 +1063,7 @@ type ListDatasetsInput struct {
 	// A pagination token for obtaining the next page of results.
 	NextToken *string `location:"querystring" locationName:"nextToken" type:"string"`
 
-	metadataListDatasetsInput `json:"-" xml:"-"`
-}
-
-type metadataListDatasetsInput struct {
-	SDKShapeTraits bool `type:"structure"`
+	_ struct{} `type:"structure"`
 }
 
 // String returns the string representation
@@ -1171,11 +1087,7 @@ type ListDatasetsOutput struct {
 	// A pagination token for obtaining the next page of results.
 	NextToken *string `type:"string"`
 
-	metadataListDatasetsOutput `json:"-" xml:"-"`
-}
-
-type metadataListDatasetsOutput struct {
-	SDKShapeTraits bool `type:"structure"`
+	_ struct{} `type:"structure"`
 }
 
 // String returns the string representation
@@ -1196,11 +1108,7 @@ type ListIdentityPoolUsageInput struct {
 	// A pagination token for obtaining the next page of results.
 	NextToken *string `location:"querystring" locationName:"nextToken" type:"string"`
 
-	metadataListIdentityPoolUsageInput `json:"-" xml:"-"`
-}
-
-type metadataListIdentityPoolUsageInput struct {
-	SDKShapeTraits bool `type:"structure"`
+	_ struct{} `type:"structure"`
 }
 
 // String returns the string representation
@@ -1227,11 +1135,7 @@ type ListIdentityPoolUsageOutput struct {
 	// A pagination token for obtaining the next page of results.
 	NextToken *string `type:"string"`
 
-	metadataListIdentityPoolUsageOutput `json:"-" xml:"-"`
-}
-
-type metadataListIdentityPoolUsageOutput struct {
-	SDKShapeTraits bool `type:"structure"`
+	_ struct{} `type:"structure"`
 }
 
 // String returns the string representation
@@ -1270,11 +1174,7 @@ type ListRecordsInput struct {
 	// A token containing a session ID, identity ID, and expiration.
 	SyncSessionToken *string `location:"querystring" locationName:"syncSessionToken" type:"string"`
 
-	metadataListRecordsInput `json:"-" xml:"-"`
-}
-
-type metadataListRecordsInput struct {
-	SDKShapeTraits bool `type:"structure"`
+	_ struct{} `type:"structure"`
 }
 
 // String returns the string representation
@@ -1316,11 +1216,7 @@ type ListRecordsOutput struct {
 	// A token containing a session ID, identity ID, and expiration.
 	SyncSessionToken *string `type:"string"`
 
-	metadataListRecordsOutput `json:"-" xml:"-"`
-}
-
-type metadataListRecordsOutput struct {
-	SDKShapeTraits bool `type:"structure"`
+	_ struct{} `type:"structure"`
 }
 
 // String returns the string representation
@@ -1341,11 +1237,7 @@ type PushSync struct {
 	// A role configured to allow Cognito to call SNS on behalf of the developer.
 	RoleArn *string `min:"20" type:"string"`
 
-	metadataPushSync `json:"-" xml:"-"`
-}
-
-type metadataPushSync struct {
-	SDKShapeTraits bool `type:"structure"`
+	_ struct{} `type:"structure"`
 }
 
 // String returns the string representation
@@ -1378,11 +1270,7 @@ type Record struct {
 	// The value for the record.
 	Value *string `type:"string"`
 
-	metadataRecord `json:"-" xml:"-"`
-}
-
-type metadataRecord struct {
-	SDKShapeTraits bool `type:"structure"`
+	_ struct{} `type:"structure"`
 }
 
 // String returns the string representation
@@ -1412,11 +1300,7 @@ type RecordPatch struct {
 	// The value associated with the record patch.
 	Value *string `type:"string"`
 
-	metadataRecordPatch `json:"-" xml:"-"`
-}
-
-type metadataRecordPatch struct {
-	SDKShapeTraits bool `type:"structure"`
+	_ struct{} `type:"structure"`
 }
 
 // String returns the string representation
@@ -1445,11 +1329,7 @@ type RegisterDeviceInput struct {
 	// The push token.
 	Token *string `type:"string" required:"true"`
 
-	metadataRegisterDeviceInput `json:"-" xml:"-"`
-}
-
-type metadataRegisterDeviceInput struct {
-	SDKShapeTraits bool `type:"structure"`
+	_ struct{} `type:"structure"`
 }
 
 // String returns the string representation
@@ -1467,11 +1347,7 @@ type RegisterDeviceOutput struct {
 	// The unique ID generated for this device by Cognito.
 	DeviceId *string `min:"1" type:"string"`
 
-	metadataRegisterDeviceOutput `json:"-" xml:"-"`
-}
-
-type metadataRegisterDeviceOutput struct {
-	SDKShapeTraits bool `type:"structure"`
+	_ struct{} `type:"structure"`
 }
 
 // String returns the string representation
@@ -1494,11 +1370,7 @@ type SetCognitoEventsInput struct {
 	// The Cognito Identity Pool to use when configuring Cognito Events
 	IdentityPoolId *string `location:"uri" locationName:"IdentityPoolId" min:"1" type:"string" required:"true"`
 
-	metadataSetCognitoEventsInput `json:"-" xml:"-"`
-}
-
-type metadataSetCognitoEventsInput struct {
-	SDKShapeTraits bool `type:"structure"`
+	_ struct{} `type:"structure"`
 }
 
 // String returns the string representation
@@ -1512,11 +1384,7 @@ func (s SetCognitoEventsInput) GoString() string {
 }
 
 type SetCognitoEventsOutput struct {
-	metadataSetCognitoEventsOutput `json:"-" xml:"-"`
-}
-
-type metadataSetCognitoEventsOutput struct {
-	SDKShapeTraits bool `type:"structure"`
+	_ struct{} `type:"structure"`
 }
 
 // String returns the string representation
@@ -1541,11 +1409,7 @@ type SetIdentityPoolConfigurationInput struct {
 	// Options to apply to this identity pool for push synchronization.
 	PushSync *PushSync `type:"structure"`
 
-	metadataSetIdentityPoolConfigurationInput `json:"-" xml:"-"`
-}
-
-type metadataSetIdentityPoolConfigurationInput struct {
-	SDKShapeTraits bool `type:"structure"`
+	_ struct{} `type:"structure"`
 }
 
 // String returns the string representation
@@ -1570,11 +1434,7 @@ type SetIdentityPoolConfigurationOutput struct {
 	// Options to apply to this identity pool for push synchronization.
 	PushSync *PushSync `type:"structure"`
 
-	metadataSetIdentityPoolConfigurationOutput `json:"-" xml:"-"`
-}
-
-type metadataSetIdentityPoolConfigurationOutput struct {
-	SDKShapeTraits bool `type:"structure"`
+	_ struct{} `type:"structure"`
 }
 
 // String returns the string representation
@@ -1602,11 +1462,7 @@ type SubscribeToDatasetInput struct {
 	// created by Amazon Cognito. The ID of the pool to which the identity belongs.
 	IdentityPoolId *string `location:"uri" locationName:"IdentityPoolId" min:"1" type:"string" required:"true"`
 
-	metadataSubscribeToDatasetInput `json:"-" xml:"-"`
-}
-
-type metadataSubscribeToDatasetInput struct {
-	SDKShapeTraits bool `type:"structure"`
+	_ struct{} `type:"structure"`
 }
 
 // String returns the string representation
@@ -1621,11 +1477,7 @@ func (s SubscribeToDatasetInput) GoString() string {
 
 // Response to a SubscribeToDataset request.
 type SubscribeToDatasetOutput struct {
-	metadataSubscribeToDatasetOutput `json:"-" xml:"-"`
-}
-
-type metadataSubscribeToDatasetOutput struct {
-	SDKShapeTraits bool `type:"structure"`
+	_ struct{} `type:"structure"`
 }
 
 // String returns the string representation
@@ -1653,11 +1505,7 @@ type UnsubscribeFromDatasetInput struct {
 	// created by Amazon Cognito. The ID of the pool to which this identity belongs.
 	IdentityPoolId *string `location:"uri" locationName:"IdentityPoolId" min:"1" type:"string" required:"true"`
 
-	metadataUnsubscribeFromDatasetInput `json:"-" xml:"-"`
-}
-
-type metadataUnsubscribeFromDatasetInput struct {
-	SDKShapeTraits bool `type:"structure"`
+	_ struct{} `type:"structure"`
 }
 
 // String returns the string representation
@@ -1672,11 +1520,7 @@ func (s UnsubscribeFromDatasetInput) GoString() string {
 
 // Response to an UnsubscribeFromDataset request.
 type UnsubscribeFromDatasetOutput struct {
-	metadataUnsubscribeFromDatasetOutput `json:"-" xml:"-"`
-}
-
-type metadataUnsubscribeFromDatasetOutput struct {
-	SDKShapeTraits bool `type:"structure"`
+	_ struct{} `type:"structure"`
 }
 
 // String returns the string representation
@@ -1718,11 +1562,7 @@ type UpdateRecordsInput struct {
 	// dataset and identity.
 	SyncSessionToken *string `type:"string" required:"true"`
 
-	metadataUpdateRecordsInput `json:"-" xml:"-"`
-}
-
-type metadataUpdateRecordsInput struct {
-	SDKShapeTraits bool `type:"structure"`
+	_ struct{} `type:"structure"`
 }
 
 // String returns the string representation
@@ -1740,11 +1580,7 @@ type UpdateRecordsOutput struct {
 	// A list of records that have been updated.
 	Records []*Record `type:"list"`
 
-	metadataUpdateRecordsOutput `json:"-" xml:"-"`
-}
-
-type metadataUpdateRecordsOutput struct {
-	SDKShapeTraits bool `type:"structure"`
+	_ struct{} `type:"structure"`
 }
 
 // String returns the string representation

--- a/service/cognitosync/api.go
+++ b/service/cognitosync/api.go
@@ -559,11 +559,11 @@ func (c *CognitoSync) UpdateRecords(input *UpdateRecordsInput) (*UpdateRecordsOu
 
 // The input for the BulkPublish operation.
 type BulkPublishInput struct {
+	_ struct{} `type:"structure"`
+
 	// A name-spaced GUID (for example, us-east-1:23EC4050-6AEA-7089-A2DD-08002EXAMPLE)
 	// created by Amazon Cognito. GUID generation is unique within a region.
 	IdentityPoolId *string `location:"uri" locationName:"IdentityPoolId" min:"1" type:"string" required:"true"`
-
-	_ struct{} `type:"structure"`
 }
 
 // String returns the string representation
@@ -578,11 +578,11 @@ func (s BulkPublishInput) GoString() string {
 
 // The output for the BulkPublish operation.
 type BulkPublishOutput struct {
+	_ struct{} `type:"structure"`
+
 	// A name-spaced GUID (for example, us-east-1:23EC4050-6AEA-7089-A2DD-08002EXAMPLE)
 	// created by Amazon Cognito. GUID generation is unique within a region.
 	IdentityPoolId *string `min:"1" type:"string"`
-
-	_ struct{} `type:"structure"`
 }
 
 // String returns the string representation
@@ -597,6 +597,8 @@ func (s BulkPublishOutput) GoString() string {
 
 // Configuration options for configure Cognito streams.
 type CognitoStreams struct {
+	_ struct{} `type:"structure"`
+
 	// The ARN of the role Amazon Cognito can assume in order to publish to the
 	// stream. This role must grant access to Amazon Cognito (cognito-sync) to invoke
 	// PutRecord on your Cognito stream.
@@ -612,8 +614,6 @@ type CognitoStreams struct {
 	// DISABLED - Streaming of updates to identity pool is disabled. Bulk publish
 	// will also fail if StreamingStatus is DISABLED.
 	StreamingStatus *string `type:"string" enum:"StreamingStatus"`
-
-	_ struct{} `type:"structure"`
 }
 
 // String returns the string representation
@@ -632,6 +632,8 @@ func (s CognitoStreams) GoString() string {
 // created if they don't exist. Data is synced by dataset, and a dataset can
 // hold up to 1MB of key-value pairs.
 type Dataset struct {
+	_ struct{} `type:"structure"`
+
 	// Date on which the dataset was created.
 	CreationDate *time.Time `type:"timestamp" timestampFormat:"unix"`
 
@@ -654,8 +656,6 @@ type Dataset struct {
 
 	// Number of records in this dataset.
 	NumRecords *int64 `type:"long"`
-
-	_ struct{} `type:"structure"`
 }
 
 // String returns the string representation
@@ -670,6 +670,8 @@ func (s Dataset) GoString() string {
 
 // A request to delete the specific dataset.
 type DeleteDatasetInput struct {
+	_ struct{} `type:"structure"`
+
 	// A string of up to 128 characters. Allowed characters are a-z, A-Z, 0-9, '_'
 	// (underscore), '-' (dash), and '.' (dot).
 	DatasetName *string `location:"uri" locationName:"DatasetName" min:"1" type:"string" required:"true"`
@@ -681,8 +683,6 @@ type DeleteDatasetInput struct {
 	// A name-spaced GUID (for example, us-east-1:23EC4050-6AEA-7089-A2DD-08002EXAMPLE)
 	// created by Amazon Cognito. GUID generation is unique within a region.
 	IdentityPoolId *string `location:"uri" locationName:"IdentityPoolId" min:"1" type:"string" required:"true"`
-
-	_ struct{} `type:"structure"`
 }
 
 // String returns the string representation
@@ -697,14 +697,14 @@ func (s DeleteDatasetInput) GoString() string {
 
 // Response to a successful DeleteDataset request.
 type DeleteDatasetOutput struct {
+	_ struct{} `type:"structure"`
+
 	// A collection of data for an identity pool. An identity pool can have multiple
 	// datasets. A dataset is per identity and can be general or associated with
 	// a particular entity in an application (like a saved game). Datasets are automatically
 	// created if they don't exist. Data is synced by dataset, and a dataset can
 	// hold up to 1MB of key-value pairs.
 	Dataset *Dataset `type:"structure"`
-
-	_ struct{} `type:"structure"`
 }
 
 // String returns the string representation
@@ -720,6 +720,8 @@ func (s DeleteDatasetOutput) GoString() string {
 // A request for meta data about a dataset (creation date, number of records,
 // size) by owner and dataset name.
 type DescribeDatasetInput struct {
+	_ struct{} `type:"structure"`
+
 	// A string of up to 128 characters. Allowed characters are a-z, A-Z, 0-9, '_'
 	// (underscore), '-' (dash), and '.' (dot).
 	DatasetName *string `location:"uri" locationName:"DatasetName" min:"1" type:"string" required:"true"`
@@ -731,8 +733,6 @@ type DescribeDatasetInput struct {
 	// A name-spaced GUID (for example, us-east-1:23EC4050-6AEA-7089-A2DD-08002EXAMPLE)
 	// created by Amazon Cognito. GUID generation is unique within a region.
 	IdentityPoolId *string `location:"uri" locationName:"IdentityPoolId" min:"1" type:"string" required:"true"`
-
-	_ struct{} `type:"structure"`
 }
 
 // String returns the string representation
@@ -747,14 +747,14 @@ func (s DescribeDatasetInput) GoString() string {
 
 // Response to a successful DescribeDataset request.
 type DescribeDatasetOutput struct {
+	_ struct{} `type:"structure"`
+
 	// Meta data for a collection of data for an identity. An identity can have
 	// multiple datasets. A dataset can be general or associated with a particular
 	// entity in an application (like a saved game). Datasets are automatically
 	// created if they don't exist. Data is synced by dataset, and a dataset can
 	// hold up to 1MB of key-value pairs.
 	Dataset *Dataset `type:"structure"`
-
-	_ struct{} `type:"structure"`
 }
 
 // String returns the string representation
@@ -769,11 +769,11 @@ func (s DescribeDatasetOutput) GoString() string {
 
 // A request for usage information about the identity pool.
 type DescribeIdentityPoolUsageInput struct {
+	_ struct{} `type:"structure"`
+
 	// A name-spaced GUID (for example, us-east-1:23EC4050-6AEA-7089-A2DD-08002EXAMPLE)
 	// created by Amazon Cognito. GUID generation is unique within a region.
 	IdentityPoolId *string `location:"uri" locationName:"IdentityPoolId" min:"1" type:"string" required:"true"`
-
-	_ struct{} `type:"structure"`
 }
 
 // String returns the string representation
@@ -788,10 +788,10 @@ func (s DescribeIdentityPoolUsageInput) GoString() string {
 
 // Response to a successful DescribeIdentityPoolUsage request.
 type DescribeIdentityPoolUsageOutput struct {
+	_ struct{} `type:"structure"`
+
 	// Information about the usage of the identity pool.
 	IdentityPoolUsage *IdentityPoolUsage `type:"structure"`
-
-	_ struct{} `type:"structure"`
 }
 
 // String returns the string representation
@@ -806,6 +806,8 @@ func (s DescribeIdentityPoolUsageOutput) GoString() string {
 
 // A request for information about the usage of an identity pool.
 type DescribeIdentityUsageInput struct {
+	_ struct{} `type:"structure"`
+
 	// A name-spaced GUID (for example, us-east-1:23EC4050-6AEA-7089-A2DD-08002EXAMPLE)
 	// created by Amazon Cognito. GUID generation is unique within a region.
 	IdentityId *string `location:"uri" locationName:"IdentityId" min:"1" type:"string" required:"true"`
@@ -813,8 +815,6 @@ type DescribeIdentityUsageInput struct {
 	// A name-spaced GUID (for example, us-east-1:23EC4050-6AEA-7089-A2DD-08002EXAMPLE)
 	// created by Amazon Cognito. GUID generation is unique within a region.
 	IdentityPoolId *string `location:"uri" locationName:"IdentityPoolId" min:"1" type:"string" required:"true"`
-
-	_ struct{} `type:"structure"`
 }
 
 // String returns the string representation
@@ -829,10 +829,10 @@ func (s DescribeIdentityUsageInput) GoString() string {
 
 // The response to a successful DescribeIdentityUsage request.
 type DescribeIdentityUsageOutput struct {
+	_ struct{} `type:"structure"`
+
 	// Usage information for the identity.
 	IdentityUsage *IdentityUsage `type:"structure"`
-
-	_ struct{} `type:"structure"`
 }
 
 // String returns the string representation
@@ -847,11 +847,11 @@ func (s DescribeIdentityUsageOutput) GoString() string {
 
 // The input for the GetBulkPublishDetails operation.
 type GetBulkPublishDetailsInput struct {
+	_ struct{} `type:"structure"`
+
 	// A name-spaced GUID (for example, us-east-1:23EC4050-6AEA-7089-A2DD-08002EXAMPLE)
 	// created by Amazon Cognito. GUID generation is unique within a region.
 	IdentityPoolId *string `location:"uri" locationName:"IdentityPoolId" min:"1" type:"string" required:"true"`
-
-	_ struct{} `type:"structure"`
 }
 
 // String returns the string representation
@@ -866,6 +866,8 @@ func (s GetBulkPublishDetailsInput) GoString() string {
 
 // The output for the GetBulkPublishDetails operation.
 type GetBulkPublishDetailsOutput struct {
+	_ struct{} `type:"structure"`
+
 	// If BulkPublishStatus is SUCCEEDED, the time the last bulk publish operation
 	// completed.
 	BulkPublishCompleteTime *time.Time `type:"timestamp" timestampFormat:"unix"`
@@ -892,8 +894,6 @@ type GetBulkPublishDetailsOutput struct {
 	// A name-spaced GUID (for example, us-east-1:23EC4050-6AEA-7089-A2DD-08002EXAMPLE)
 	// created by Amazon Cognito. GUID generation is unique within a region.
 	IdentityPoolId *string `min:"1" type:"string"`
-
-	_ struct{} `type:"structure"`
 }
 
 // String returns the string representation
@@ -908,10 +908,10 @@ func (s GetBulkPublishDetailsOutput) GoString() string {
 
 // A request for a list of the configured Cognito Events
 type GetCognitoEventsInput struct {
+	_ struct{} `type:"structure"`
+
 	// The Cognito Identity Pool ID for the request
 	IdentityPoolId *string `location:"uri" locationName:"IdentityPoolId" min:"1" type:"string" required:"true"`
-
-	_ struct{} `type:"structure"`
 }
 
 // String returns the string representation
@@ -926,10 +926,10 @@ func (s GetCognitoEventsInput) GoString() string {
 
 // The response from the GetCognitoEvents request
 type GetCognitoEventsOutput struct {
+	_ struct{} `type:"structure"`
+
 	// The Cognito Events returned from the GetCognitoEvents request
 	Events map[string]*string `type:"map"`
-
-	_ struct{} `type:"structure"`
 }
 
 // String returns the string representation
@@ -944,12 +944,12 @@ func (s GetCognitoEventsOutput) GoString() string {
 
 // The input for the GetIdentityPoolConfiguration operation.
 type GetIdentityPoolConfigurationInput struct {
+	_ struct{} `type:"structure"`
+
 	// A name-spaced GUID (for example, us-east-1:23EC4050-6AEA-7089-A2DD-08002EXAMPLE)
 	// created by Amazon Cognito. This is the ID of the pool for which to return
 	// a configuration.
 	IdentityPoolId *string `location:"uri" locationName:"IdentityPoolId" min:"1" type:"string" required:"true"`
-
-	_ struct{} `type:"structure"`
 }
 
 // String returns the string representation
@@ -964,6 +964,8 @@ func (s GetIdentityPoolConfigurationInput) GoString() string {
 
 // The output for the GetIdentityPoolConfiguration operation.
 type GetIdentityPoolConfigurationOutput struct {
+	_ struct{} `type:"structure"`
+
 	// Options to apply to this identity pool for Amazon Cognito streams.
 	CognitoStreams *CognitoStreams `type:"structure"`
 
@@ -973,8 +975,6 @@ type GetIdentityPoolConfigurationOutput struct {
 
 	// Options to apply to this identity pool for push synchronization.
 	PushSync *PushSync `type:"structure"`
-
-	_ struct{} `type:"structure"`
 }
 
 // String returns the string representation
@@ -989,6 +989,8 @@ func (s GetIdentityPoolConfigurationOutput) GoString() string {
 
 // Usage information for the identity pool.
 type IdentityPoolUsage struct {
+	_ struct{} `type:"structure"`
+
 	// Data storage information for the identity pool.
 	DataStorage *int64 `type:"long"`
 
@@ -1001,8 +1003,6 @@ type IdentityPoolUsage struct {
 
 	// Number of sync sessions for the identity pool.
 	SyncSessionsCount *int64 `type:"long"`
-
-	_ struct{} `type:"structure"`
 }
 
 // String returns the string representation
@@ -1017,6 +1017,8 @@ func (s IdentityPoolUsage) GoString() string {
 
 // Usage information for the identity.
 type IdentityUsage struct {
+	_ struct{} `type:"structure"`
+
 	// Total data storage for this identity.
 	DataStorage *int64 `type:"long"`
 
@@ -1033,8 +1035,6 @@ type IdentityUsage struct {
 
 	// Date on which the identity was last modified.
 	LastModifiedDate *time.Time `type:"timestamp" timestampFormat:"unix"`
-
-	_ struct{} `type:"structure"`
 }
 
 // String returns the string representation
@@ -1049,6 +1049,8 @@ func (s IdentityUsage) GoString() string {
 
 // Request for a list of datasets for an identity.
 type ListDatasetsInput struct {
+	_ struct{} `type:"structure"`
+
 	// A name-spaced GUID (for example, us-east-1:23EC4050-6AEA-7089-A2DD-08002EXAMPLE)
 	// created by Amazon Cognito. GUID generation is unique within a region.
 	IdentityId *string `location:"uri" locationName:"IdentityId" min:"1" type:"string" required:"true"`
@@ -1062,8 +1064,6 @@ type ListDatasetsInput struct {
 
 	// A pagination token for obtaining the next page of results.
 	NextToken *string `location:"querystring" locationName:"nextToken" type:"string"`
-
-	_ struct{} `type:"structure"`
 }
 
 // String returns the string representation
@@ -1078,6 +1078,8 @@ func (s ListDatasetsInput) GoString() string {
 
 // Returned for a successful ListDatasets request.
 type ListDatasetsOutput struct {
+	_ struct{} `type:"structure"`
+
 	// Number of datasets returned.
 	Count *int64 `type:"integer"`
 
@@ -1086,8 +1088,6 @@ type ListDatasetsOutput struct {
 
 	// A pagination token for obtaining the next page of results.
 	NextToken *string `type:"string"`
-
-	_ struct{} `type:"structure"`
 }
 
 // String returns the string representation
@@ -1102,13 +1102,13 @@ func (s ListDatasetsOutput) GoString() string {
 
 // A request for usage information on an identity pool.
 type ListIdentityPoolUsageInput struct {
+	_ struct{} `type:"structure"`
+
 	// The maximum number of results to be returned.
 	MaxResults *int64 `location:"querystring" locationName:"maxResults" type:"integer"`
 
 	// A pagination token for obtaining the next page of results.
 	NextToken *string `location:"querystring" locationName:"nextToken" type:"string"`
-
-	_ struct{} `type:"structure"`
 }
 
 // String returns the string representation
@@ -1123,6 +1123,8 @@ func (s ListIdentityPoolUsageInput) GoString() string {
 
 // Returned for a successful ListIdentityPoolUsage request.
 type ListIdentityPoolUsageOutput struct {
+	_ struct{} `type:"structure"`
+
 	// Total number of identities for the identity pool.
 	Count *int64 `type:"integer"`
 
@@ -1134,8 +1136,6 @@ type ListIdentityPoolUsageOutput struct {
 
 	// A pagination token for obtaining the next page of results.
 	NextToken *string `type:"string"`
-
-	_ struct{} `type:"structure"`
 }
 
 // String returns the string representation
@@ -1150,6 +1150,8 @@ func (s ListIdentityPoolUsageOutput) GoString() string {
 
 // A request for a list of records.
 type ListRecordsInput struct {
+	_ struct{} `type:"structure"`
+
 	// A string of up to 128 characters. Allowed characters are a-z, A-Z, 0-9, '_'
 	// (underscore), '-' (dash), and '.' (dot).
 	DatasetName *string `location:"uri" locationName:"DatasetName" min:"1" type:"string" required:"true"`
@@ -1173,8 +1175,6 @@ type ListRecordsInput struct {
 
 	// A token containing a session ID, identity ID, and expiration.
 	SyncSessionToken *string `location:"querystring" locationName:"syncSessionToken" type:"string"`
-
-	_ struct{} `type:"structure"`
 }
 
 // String returns the string representation
@@ -1189,6 +1189,8 @@ func (s ListRecordsInput) GoString() string {
 
 // Returned for a successful ListRecordsRequest.
 type ListRecordsOutput struct {
+	_ struct{} `type:"structure"`
+
 	// Total number of records.
 	Count *int64 `type:"integer"`
 
@@ -1215,8 +1217,6 @@ type ListRecordsOutput struct {
 
 	// A token containing a session ID, identity ID, and expiration.
 	SyncSessionToken *string `type:"string"`
-
-	_ struct{} `type:"structure"`
 }
 
 // String returns the string representation
@@ -1231,13 +1231,13 @@ func (s ListRecordsOutput) GoString() string {
 
 // Configuration options to be applied to the identity pool.
 type PushSync struct {
+	_ struct{} `type:"structure"`
+
 	// List of SNS platform application ARNs that could be used by clients.
 	ApplicationArns []*string `type:"list"`
 
 	// A role configured to allow Cognito to call SNS on behalf of the developer.
 	RoleArn *string `min:"20" type:"string"`
-
-	_ struct{} `type:"structure"`
 }
 
 // String returns the string representation
@@ -1252,6 +1252,8 @@ func (s PushSync) GoString() string {
 
 // The basic data structure of a dataset.
 type Record struct {
+	_ struct{} `type:"structure"`
+
 	// The last modified date of the client device.
 	DeviceLastModifiedDate *time.Time `type:"timestamp" timestampFormat:"unix"`
 
@@ -1269,8 +1271,6 @@ type Record struct {
 
 	// The value for the record.
 	Value *string `type:"string"`
-
-	_ struct{} `type:"structure"`
 }
 
 // String returns the string representation
@@ -1285,6 +1285,8 @@ func (s Record) GoString() string {
 
 // An update operation for a record.
 type RecordPatch struct {
+	_ struct{} `type:"structure"`
+
 	// The last modified date of the client device.
 	DeviceLastModifiedDate *time.Time `type:"timestamp" timestampFormat:"unix"`
 
@@ -1299,8 +1301,6 @@ type RecordPatch struct {
 
 	// The value associated with the record patch.
 	Value *string `type:"string"`
-
-	_ struct{} `type:"structure"`
 }
 
 // String returns the string representation
@@ -1315,6 +1315,8 @@ func (s RecordPatch) GoString() string {
 
 // A request to RegisterDevice.
 type RegisterDeviceInput struct {
+	_ struct{} `type:"structure"`
+
 	// The unique ID for this identity.
 	IdentityId *string `location:"uri" locationName:"IdentityId" min:"1" type:"string" required:"true"`
 
@@ -1328,8 +1330,6 @@ type RegisterDeviceInput struct {
 
 	// The push token.
 	Token *string `type:"string" required:"true"`
-
-	_ struct{} `type:"structure"`
 }
 
 // String returns the string representation
@@ -1344,10 +1344,10 @@ func (s RegisterDeviceInput) GoString() string {
 
 // Response to a RegisterDevice request.
 type RegisterDeviceOutput struct {
+	_ struct{} `type:"structure"`
+
 	// The unique ID generated for this device by Cognito.
 	DeviceId *string `min:"1" type:"string"`
-
-	_ struct{} `type:"structure"`
 }
 
 // String returns the string representation
@@ -1364,13 +1364,13 @@ func (s RegisterDeviceOutput) GoString() string {
 //
 // "
 type SetCognitoEventsInput struct {
+	_ struct{} `type:"structure"`
+
 	// The events to configure
 	Events map[string]*string `type:"map" required:"true"`
 
 	// The Cognito Identity Pool to use when configuring Cognito Events
 	IdentityPoolId *string `location:"uri" locationName:"IdentityPoolId" min:"1" type:"string" required:"true"`
-
-	_ struct{} `type:"structure"`
 }
 
 // String returns the string representation
@@ -1399,6 +1399,8 @@ func (s SetCognitoEventsOutput) GoString() string {
 
 // The input for the SetIdentityPoolConfiguration operation.
 type SetIdentityPoolConfigurationInput struct {
+	_ struct{} `type:"structure"`
+
 	// Options to apply to this identity pool for Amazon Cognito streams.
 	CognitoStreams *CognitoStreams `type:"structure"`
 
@@ -1408,8 +1410,6 @@ type SetIdentityPoolConfigurationInput struct {
 
 	// Options to apply to this identity pool for push synchronization.
 	PushSync *PushSync `type:"structure"`
-
-	_ struct{} `type:"structure"`
 }
 
 // String returns the string representation
@@ -1424,6 +1424,8 @@ func (s SetIdentityPoolConfigurationInput) GoString() string {
 
 // The output for the SetIdentityPoolConfiguration operation
 type SetIdentityPoolConfigurationOutput struct {
+	_ struct{} `type:"structure"`
+
 	// Options to apply to this identity pool for Amazon Cognito streams.
 	CognitoStreams *CognitoStreams `type:"structure"`
 
@@ -1433,8 +1435,6 @@ type SetIdentityPoolConfigurationOutput struct {
 
 	// Options to apply to this identity pool for push synchronization.
 	PushSync *PushSync `type:"structure"`
-
-	_ struct{} `type:"structure"`
 }
 
 // String returns the string representation
@@ -1449,6 +1449,8 @@ func (s SetIdentityPoolConfigurationOutput) GoString() string {
 
 // A request to SubscribeToDatasetRequest.
 type SubscribeToDatasetInput struct {
+	_ struct{} `type:"structure"`
+
 	// The name of the dataset to subcribe to.
 	DatasetName *string `location:"uri" locationName:"DatasetName" min:"1" type:"string" required:"true"`
 
@@ -1461,8 +1463,6 @@ type SubscribeToDatasetInput struct {
 	// A name-spaced GUID (for example, us-east-1:23EC4050-6AEA-7089-A2DD-08002EXAMPLE)
 	// created by Amazon Cognito. The ID of the pool to which the identity belongs.
 	IdentityPoolId *string `location:"uri" locationName:"IdentityPoolId" min:"1" type:"string" required:"true"`
-
-	_ struct{} `type:"structure"`
 }
 
 // String returns the string representation
@@ -1492,6 +1492,8 @@ func (s SubscribeToDatasetOutput) GoString() string {
 
 // A request to UnsubscribeFromDataset.
 type UnsubscribeFromDatasetInput struct {
+	_ struct{} `type:"structure"`
+
 	// The name of the dataset from which to unsubcribe.
 	DatasetName *string `location:"uri" locationName:"DatasetName" min:"1" type:"string" required:"true"`
 
@@ -1504,8 +1506,6 @@ type UnsubscribeFromDatasetInput struct {
 	// A name-spaced GUID (for example, us-east-1:23EC4050-6AEA-7089-A2DD-08002EXAMPLE)
 	// created by Amazon Cognito. The ID of the pool to which this identity belongs.
 	IdentityPoolId *string `location:"uri" locationName:"IdentityPoolId" min:"1" type:"string" required:"true"`
-
-	_ struct{} `type:"structure"`
 }
 
 // String returns the string representation
@@ -1536,6 +1536,8 @@ func (s UnsubscribeFromDatasetOutput) GoString() string {
 // A request to post updates to records or add and delete records for a dataset
 // and user.
 type UpdateRecordsInput struct {
+	_ struct{} `type:"structure"`
+
 	// Intended to supply a device ID that will populate the lastModifiedBy field
 	// referenced in other methods. The ClientContext field is not yet implemented.
 	ClientContext *string `location:"header" locationName:"x-amz-Client-Context" type:"string"`
@@ -1561,8 +1563,6 @@ type UpdateRecordsInput struct {
 	// The SyncSessionToken returned by a previous call to ListRecords for this
 	// dataset and identity.
 	SyncSessionToken *string `type:"string" required:"true"`
-
-	_ struct{} `type:"structure"`
 }
 
 // String returns the string representation
@@ -1577,10 +1577,10 @@ func (s UpdateRecordsInput) GoString() string {
 
 // Returned for a successful UpdateRecordsRequest.
 type UpdateRecordsOutput struct {
+	_ struct{} `type:"structure"`
+
 	// A list of records that have been updated.
 	Records []*Record `type:"list"`
-
-	_ struct{} `type:"structure"`
 }
 
 // String returns the string representation

--- a/service/configservice/api.go
+++ b/service/configservice/api.go
@@ -808,6 +808,8 @@ func (c *ConfigService) StopConfigurationRecorder(input *StopConfigurationRecord
 // Indicates whether an AWS resource or AWS Config rule is compliant and provides
 // the number of contributors that affect the compliance.
 type Compliance struct {
+	_ struct{} `type:"structure"`
+
 	// The number of AWS resources or AWS Config rules that cause a result of NON_COMPLIANT,
 	// up to a maximum of 25.
 	ComplianceContributorCount *ComplianceContributorCount `type:"structure"`
@@ -821,8 +823,6 @@ type Compliance struct {
 	// A rule is compliant if all of the resources that the rule evaluates comply
 	// with it, and it is noncompliant if any of these resources do not comply.
 	ComplianceType *string `type:"string" enum:"ComplianceType"`
-
-	_ struct{} `type:"structure"`
 }
 
 // String returns the string representation
@@ -839,13 +839,13 @@ func (s Compliance) GoString() string {
 // all of the resources that the rule evaluated comply with it, and it is noncompliant
 // if any of these resources do not comply.
 type ComplianceByConfigRule struct {
+	_ struct{} `type:"structure"`
+
 	// Indicates whether the AWS Config rule is compliant.
 	Compliance *Compliance `type:"structure"`
 
 	// The name of the AWS Config rule.
 	ConfigRuleName *string `min:"1" type:"string"`
-
-	_ struct{} `type:"structure"`
 }
 
 // String returns the string representation
@@ -863,6 +863,8 @@ func (s ComplianceByConfigRule) GoString() string {
 // all of the rules that evaluate it, and it is noncompliant if it does not
 // comply with one or more of these rules.
 type ComplianceByResource struct {
+	_ struct{} `type:"structure"`
+
 	// Indicates whether the AWS resource complies with all of the AWS Config rules
 	// that evaluated it.
 	Compliance *Compliance `type:"structure"`
@@ -872,8 +874,6 @@ type ComplianceByResource struct {
 
 	// The type of the AWS resource that was evaluated.
 	ResourceType *string `min:"1" type:"string"`
-
-	_ struct{} `type:"structure"`
 }
 
 // String returns the string representation
@@ -889,14 +889,14 @@ func (s ComplianceByResource) GoString() string {
 // The number of AWS resources or AWS Config rules responsible for the current
 // compliance of the item, up to a maximum number.
 type ComplianceContributorCount struct {
+	_ struct{} `type:"structure"`
+
 	// Indicates whether the maximum count is reached.
 	CapExceeded *bool `type:"boolean"`
 
 	// The number of AWS resources or AWS Config rules responsible for the current
 	// compliance of the item.
 	CappedCount *int64 `type:"integer"`
-
-	_ struct{} `type:"structure"`
 }
 
 // String returns the string representation
@@ -912,6 +912,8 @@ func (s ComplianceContributorCount) GoString() string {
 // The number of AWS Config rules or AWS resources that are compliant and noncompliant,
 // up to a maximum.
 type ComplianceSummary struct {
+	_ struct{} `type:"structure"`
+
 	// The time that AWS Config created the compliance summary.
 	ComplianceSummaryTimestamp *time.Time `type:"timestamp" timestampFormat:"unix"`
 
@@ -922,8 +924,6 @@ type ComplianceSummary struct {
 	// The number of AWS Config rules or AWS resources that are noncompliant, up
 	// to a maximum of 25 for rules and 100 for resources.
 	NonCompliantResourceCount *ComplianceContributorCount `type:"structure"`
-
-	_ struct{} `type:"structure"`
 }
 
 // String returns the string representation
@@ -939,14 +939,14 @@ func (s ComplianceSummary) GoString() string {
 // The number of AWS resources of a specific type that are compliant or noncompliant,
 // up to a maximum of 100 for each compliance.
 type ComplianceSummaryByResourceType struct {
+	_ struct{} `type:"structure"`
+
 	// The number of AWS resources that are compliant or noncompliant, up to a maximum
 	// of 100 for each compliance.
 	ComplianceSummary *ComplianceSummary `type:"structure"`
 
 	// The type of AWS resource.
 	ResourceType *string `min:"1" type:"string"`
-
-	_ struct{} `type:"structure"`
 }
 
 // String returns the string representation
@@ -962,6 +962,8 @@ func (s ComplianceSummaryByResourceType) GoString() string {
 // A list that contains the status of the delivery of either the snapshot or
 // the configuration history to the specified Amazon S3 bucket.
 type ConfigExportDeliveryInfo struct {
+	_ struct{} `type:"structure"`
+
 	// The time of the last attempted delivery.
 	LastAttemptTime *time.Time `locationName:"lastAttemptTime" type:"timestamp" timestampFormat:"unix"`
 
@@ -979,8 +981,6 @@ type ConfigExportDeliveryInfo struct {
 
 	// The time that the next delivery occurs.
 	NextDeliveryTime *time.Time `locationName:"nextDeliveryTime" type:"timestamp" timestampFormat:"unix"`
-
-	_ struct{} `type:"structure"`
 }
 
 // String returns the string representation
@@ -1003,6 +1003,8 @@ func (s ConfigExportDeliveryInfo) GoString() string {
 // AWS Resource Configurations with AWS Config (http://docs.aws.amazon.com/config/latest/developerguide/evaluate-config.html)
 // in the AWS Config Developer Guide.
 type ConfigRule struct {
+	_ struct{} `type:"structure"`
+
 	// The Amazon Resource Name (ARN) of the AWS Config rule.
 	ConfigRuleArn *string `type:"string"`
 
@@ -1052,8 +1054,6 @@ type ConfigRule struct {
 	// Provides the rule owner (AWS or customer), the rule identifier, and the events
 	// that cause the function to evaluate your AWS resources.
 	Source *Source `type:"structure" required:"true"`
-
-	_ struct{} `type:"structure"`
 }
 
 // String returns the string representation
@@ -1073,6 +1073,8 @@ func (s ConfigRule) GoString() string {
 // This action does not return status information about customer managed Config
 // rules.
 type ConfigRuleEvaluationStatus struct {
+	_ struct{} `type:"structure"`
+
 	// The Amazon Resource Name (ARN) of the AWS Config rule.
 	ConfigRuleArn *string `type:"string"`
 
@@ -1098,8 +1100,6 @@ type ConfigRuleEvaluationStatus struct {
 	// The time that AWS Config last successfully invoked the AWS Config rule to
 	// evaluate your AWS resources.
 	LastSuccessfulInvocationTime *time.Time `type:"timestamp" timestampFormat:"unix"`
-
-	_ struct{} `type:"structure"`
 }
 
 // String returns the string representation
@@ -1115,11 +1115,11 @@ func (s ConfigRuleEvaluationStatus) GoString() string {
 // Options for how AWS Config delivers configuration snapshots to the Amazon
 // S3 bucket in your delivery channel.
 type ConfigSnapshotDeliveryProperties struct {
+	_ struct{} `type:"structure"`
+
 	// The frequency with which a AWS Config recurringly delivers configuration
 	// snapshots.
 	DeliveryFrequency *string `locationName:"deliveryFrequency" type:"string" enum:"MaximumExecutionFrequency"`
-
-	_ struct{} `type:"structure"`
 }
 
 // String returns the string representation
@@ -1135,6 +1135,8 @@ func (s ConfigSnapshotDeliveryProperties) GoString() string {
 // A list that contains the status of the delivery of the configuration stream
 // notification to the Amazon SNS topic.
 type ConfigStreamDeliveryInfo struct {
+	_ struct{} `type:"structure"`
+
 	// The error code from the last attempted delivery.
 	LastErrorCode *string `locationName:"lastErrorCode" type:"string"`
 
@@ -1150,8 +1152,6 @@ type ConfigStreamDeliveryInfo struct {
 
 	// The time from the last status change.
 	LastStatusChangeTime *time.Time `locationName:"lastStatusChangeTime" type:"timestamp" timestampFormat:"unix"`
-
-	_ struct{} `type:"structure"`
 }
 
 // String returns the string representation
@@ -1169,6 +1169,8 @@ func (s ConfigStreamDeliveryInfo) GoString() string {
 //  Currently, the list does not contain information about non-AWS components
 // (for example, applications on your Amazon EC2 instances).
 type ConfigurationItem struct {
+	_ struct{} `type:"structure"`
+
 	// The 12 digit AWS account ID associated with the resource.
 	AccountId *string `locationName:"accountId" type:"string"`
 
@@ -1230,8 +1232,6 @@ type ConfigurationItem struct {
 
 	// The version number of the resource configuration.
 	Version *string `locationName:"version" type:"string"`
-
-	_ struct{} `type:"structure"`
 }
 
 // String returns the string representation
@@ -1247,6 +1247,8 @@ func (s ConfigurationItem) GoString() string {
 // An object that represents the recording of configuration changes of an AWS
 // resource.
 type ConfigurationRecorder struct {
+	_ struct{} `type:"structure"`
+
 	// The name of the recorder. By default, AWS Config automatically assigns the
 	// name "default" when creating the configuration recorder. You cannot change
 	// the assigned name.
@@ -1260,8 +1262,6 @@ type ConfigurationRecorder struct {
 	// Amazon Resource Name (ARN) of the IAM role used to describe the AWS resources
 	// associated with the account.
 	RoleARN *string `locationName:"roleARN" type:"string"`
-
-	_ struct{} `type:"structure"`
 }
 
 // String returns the string representation
@@ -1276,6 +1276,8 @@ func (s ConfigurationRecorder) GoString() string {
 
 // The current status of the configuration recorder.
 type ConfigurationRecorderStatus struct {
+	_ struct{} `type:"structure"`
+
 	// The error code indicating that the recording failed.
 	LastErrorCode *string `locationName:"lastErrorCode" type:"string"`
 
@@ -1299,8 +1301,6 @@ type ConfigurationRecorderStatus struct {
 
 	// Specifies whether the recorder is currently recording or not.
 	Recording *bool `locationName:"recording" type:"boolean"`
-
-	_ struct{} `type:"structure"`
 }
 
 // String returns the string representation
@@ -1314,10 +1314,10 @@ func (s ConfigurationRecorderStatus) GoString() string {
 }
 
 type DeleteConfigRuleInput struct {
+	_ struct{} `type:"structure"`
+
 	// The name of the AWS Config rule that you want to delete.
 	ConfigRuleName *string `min:"1" type:"string" required:"true"`
-
-	_ struct{} `type:"structure"`
 }
 
 // String returns the string representation
@@ -1347,10 +1347,10 @@ func (s DeleteConfigRuleOutput) GoString() string {
 // The input for the DeleteDeliveryChannel action. The action accepts the following
 // data in JSON format.
 type DeleteDeliveryChannelInput struct {
+	_ struct{} `type:"structure"`
+
 	// The name of the delivery channel to delete.
 	DeliveryChannelName *string `min:"1" type:"string" required:"true"`
-
-	_ struct{} `type:"structure"`
 }
 
 // String returns the string representation
@@ -1379,10 +1379,10 @@ func (s DeleteDeliveryChannelOutput) GoString() string {
 
 // The input for the DeliverConfigSnapshot action.
 type DeliverConfigSnapshotInput struct {
+	_ struct{} `type:"structure"`
+
 	// The name of the delivery channel through which the snapshot is delivered.
 	DeliveryChannelName *string `locationName:"deliveryChannelName" min:"1" type:"string" required:"true"`
-
-	_ struct{} `type:"structure"`
 }
 
 // String returns the string representation
@@ -1397,10 +1397,10 @@ func (s DeliverConfigSnapshotInput) GoString() string {
 
 // The output for the DeliverConfigSnapshot action in JSON format.
 type DeliverConfigSnapshotOutput struct {
+	_ struct{} `type:"structure"`
+
 	// The ID of the snapshot that is being created.
 	ConfigSnapshotId *string `locationName:"configSnapshotId" type:"string"`
-
-	_ struct{} `type:"structure"`
 }
 
 // String returns the string representation
@@ -1416,6 +1416,8 @@ func (s DeliverConfigSnapshotOutput) GoString() string {
 // A logical container used for storing the configuration changes of an AWS
 // resource.
 type DeliveryChannel struct {
+	_ struct{} `type:"structure"`
+
 	// Options for how AWS Config delivers configuration snapshots to the Amazon
 	// S3 bucket in your delivery channel.
 	ConfigSnapshotDeliveryProperties *ConfigSnapshotDeliveryProperties `locationName:"configSnapshotDeliveryProperties" type:"structure"`
@@ -1435,8 +1437,6 @@ type DeliveryChannel struct {
 	// The Amazon Resource Name (ARN) of the SNS topic that AWS Config delivers
 	// notifications to.
 	SnsTopicARN *string `locationName:"snsTopicARN" type:"string"`
-
-	_ struct{} `type:"structure"`
 }
 
 // String returns the string representation
@@ -1453,6 +1453,8 @@ func (s DeliveryChannel) GoString() string {
 //
 // Valid values: Success | Failure
 type DeliveryChannelStatus struct {
+	_ struct{} `type:"structure"`
+
 	// A list that contains the status of the delivery of the configuration history
 	// to the specified Amazon S3 bucket.
 	ConfigHistoryDeliveryInfo *ConfigExportDeliveryInfo `locationName:"configHistoryDeliveryInfo" type:"structure"`
@@ -1467,8 +1469,6 @@ type DeliveryChannelStatus struct {
 
 	// The name of the delivery channel.
 	Name *string `locationName:"name" type:"string"`
-
-	_ struct{} `type:"structure"`
 }
 
 // String returns the string representation
@@ -1482,6 +1482,8 @@ func (s DeliveryChannelStatus) GoString() string {
 }
 
 type DescribeComplianceByConfigRuleInput struct {
+	_ struct{} `type:"structure"`
+
 	// Filters the results by compliance. The valid values are Compliant and NonCompliant.
 	ComplianceTypes []*string `type:"list"`
 
@@ -1491,8 +1493,6 @@ type DescribeComplianceByConfigRuleInput struct {
 	// The nextToken string returned on a previous page that you use to get the
 	// next page of results in a paginated response.
 	NextToken *string `type:"string"`
-
-	_ struct{} `type:"structure"`
 }
 
 // String returns the string representation
@@ -1506,14 +1506,14 @@ func (s DescribeComplianceByConfigRuleInput) GoString() string {
 }
 
 type DescribeComplianceByConfigRuleOutput struct {
+	_ struct{} `type:"structure"`
+
 	// Indicates whether each of the specified AWS Config rules is compliant.
 	ComplianceByConfigRules []*ComplianceByConfigRule `type:"list"`
 
 	// The string that you use in a subsequent request to get the next page of results
 	// in a paginated response.
 	NextToken *string `type:"string"`
-
-	_ struct{} `type:"structure"`
 }
 
 // String returns the string representation
@@ -1527,6 +1527,8 @@ func (s DescribeComplianceByConfigRuleOutput) GoString() string {
 }
 
 type DescribeComplianceByResourceInput struct {
+	_ struct{} `type:"structure"`
+
 	// Filters the results by compliance. The valid values are Compliant and NonCompliant.
 	ComplianceTypes []*string `type:"list"`
 
@@ -1548,8 +1550,6 @@ type DescribeComplianceByResourceInput struct {
 	// example, AWS::EC2::Instance. For this action, you can specify that the resource
 	// type is an AWS account by specifying AWS::::Account.
 	ResourceType *string `min:"1" type:"string"`
-
-	_ struct{} `type:"structure"`
 }
 
 // String returns the string representation
@@ -1563,6 +1563,8 @@ func (s DescribeComplianceByResourceInput) GoString() string {
 }
 
 type DescribeComplianceByResourceOutput struct {
+	_ struct{} `type:"structure"`
+
 	// Indicates whether the specified AWS resource complies with all of the AWS
 	// Config rules that evaluate it.
 	ComplianceByResources []*ComplianceByResource `type:"list"`
@@ -1570,8 +1572,6 @@ type DescribeComplianceByResourceOutput struct {
 	// The string that you use in a subsequent request to get the next page of results
 	// in a paginated response.
 	NextToken *string `type:"string"`
-
-	_ struct{} `type:"structure"`
 }
 
 // String returns the string representation
@@ -1585,12 +1585,12 @@ func (s DescribeComplianceByResourceOutput) GoString() string {
 }
 
 type DescribeConfigRuleEvaluationStatusInput struct {
+	_ struct{} `type:"structure"`
+
 	// The name of the AWS managed Config rules for which you want status information.
 	// If you do not specify any names, AWS Config returns status information for
 	// all AWS managed Config rules that you use.
 	ConfigRuleNames []*string `type:"list"`
-
-	_ struct{} `type:"structure"`
 }
 
 // String returns the string representation
@@ -1604,10 +1604,10 @@ func (s DescribeConfigRuleEvaluationStatusInput) GoString() string {
 }
 
 type DescribeConfigRuleEvaluationStatusOutput struct {
+	_ struct{} `type:"structure"`
+
 	// Status information about your AWS managed Config rules.
 	ConfigRulesEvaluationStatus []*ConfigRuleEvaluationStatus `type:"list"`
-
-	_ struct{} `type:"structure"`
 }
 
 // String returns the string representation
@@ -1621,6 +1621,8 @@ func (s DescribeConfigRuleEvaluationStatusOutput) GoString() string {
 }
 
 type DescribeConfigRulesInput struct {
+	_ struct{} `type:"structure"`
+
 	// The names of the AWS Config rules for which you want details. If you do not
 	// specify any names, AWS Config returns details for all your rules.
 	ConfigRuleNames []*string `type:"list"`
@@ -1628,8 +1630,6 @@ type DescribeConfigRulesInput struct {
 	// The nextToken string returned on a previous page that you use to get the
 	// next page of results in a paginated response.
 	NextToken *string `type:"string"`
-
-	_ struct{} `type:"structure"`
 }
 
 // String returns the string representation
@@ -1643,14 +1643,14 @@ func (s DescribeConfigRulesInput) GoString() string {
 }
 
 type DescribeConfigRulesOutput struct {
+	_ struct{} `type:"structure"`
+
 	// The details about your AWS Config rules.
 	ConfigRules []*ConfigRule `type:"list"`
 
 	// The string that you use in a subsequent request to get the next page of results
 	// in a paginated response.
 	NextToken *string `type:"string"`
-
-	_ struct{} `type:"structure"`
 }
 
 // String returns the string representation
@@ -1665,12 +1665,12 @@ func (s DescribeConfigRulesOutput) GoString() string {
 
 // The input for the DescribeConfigurationRecorderStatus action.
 type DescribeConfigurationRecorderStatusInput struct {
+	_ struct{} `type:"structure"`
+
 	// The name(s) of the configuration recorder. If the name is not specified,
 	// the action returns the current status of all the configuration recorders
 	// associated with the account.
 	ConfigurationRecorderNames []*string `type:"list"`
-
-	_ struct{} `type:"structure"`
 }
 
 // String returns the string representation
@@ -1685,10 +1685,10 @@ func (s DescribeConfigurationRecorderStatusInput) GoString() string {
 
 // The output for the DescribeConfigurationRecorderStatus action in JSON format.
 type DescribeConfigurationRecorderStatusOutput struct {
+	_ struct{} `type:"structure"`
+
 	// A list that contains status of the specified recorders.
 	ConfigurationRecordersStatus []*ConfigurationRecorderStatus `type:"list"`
-
-	_ struct{} `type:"structure"`
 }
 
 // String returns the string representation
@@ -1703,10 +1703,10 @@ func (s DescribeConfigurationRecorderStatusOutput) GoString() string {
 
 // The input for the DescribeConfigurationRecorders action.
 type DescribeConfigurationRecordersInput struct {
+	_ struct{} `type:"structure"`
+
 	// A list of configuration recorder names.
 	ConfigurationRecorderNames []*string `type:"list"`
-
-	_ struct{} `type:"structure"`
 }
 
 // String returns the string representation
@@ -1721,10 +1721,10 @@ func (s DescribeConfigurationRecordersInput) GoString() string {
 
 // The output for the DescribeConfigurationRecorders action.
 type DescribeConfigurationRecordersOutput struct {
+	_ struct{} `type:"structure"`
+
 	// A list that contains the descriptions of the specified configuration recorders.
 	ConfigurationRecorders []*ConfigurationRecorder `type:"list"`
-
-	_ struct{} `type:"structure"`
 }
 
 // String returns the string representation
@@ -1739,10 +1739,10 @@ func (s DescribeConfigurationRecordersOutput) GoString() string {
 
 // The input for the DeliveryChannelStatus action.
 type DescribeDeliveryChannelStatusInput struct {
+	_ struct{} `type:"structure"`
+
 	// A list of delivery channel names.
 	DeliveryChannelNames []*string `type:"list"`
-
-	_ struct{} `type:"structure"`
 }
 
 // String returns the string representation
@@ -1757,10 +1757,10 @@ func (s DescribeDeliveryChannelStatusInput) GoString() string {
 
 // The output for the DescribeDeliveryChannelStatus action.
 type DescribeDeliveryChannelStatusOutput struct {
+	_ struct{} `type:"structure"`
+
 	// A list that contains the status of a specified delivery channel.
 	DeliveryChannelsStatus []*DeliveryChannelStatus `type:"list"`
-
-	_ struct{} `type:"structure"`
 }
 
 // String returns the string representation
@@ -1775,10 +1775,10 @@ func (s DescribeDeliveryChannelStatusOutput) GoString() string {
 
 // The input for the DescribeDeliveryChannels action.
 type DescribeDeliveryChannelsInput struct {
+	_ struct{} `type:"structure"`
+
 	// A list of delivery channel names.
 	DeliveryChannelNames []*string `type:"list"`
-
-	_ struct{} `type:"structure"`
 }
 
 // String returns the string representation
@@ -1793,10 +1793,10 @@ func (s DescribeDeliveryChannelsInput) GoString() string {
 
 // The output for the DescribeDeliveryChannels action.
 type DescribeDeliveryChannelsOutput struct {
+	_ struct{} `type:"structure"`
+
 	// A list that contains the descriptions of the specified delivery channel.
 	DeliveryChannels []*DeliveryChannel `type:"list"`
-
-	_ struct{} `type:"structure"`
 }
 
 // String returns the string representation
@@ -1812,6 +1812,8 @@ func (s DescribeDeliveryChannelsOutput) GoString() string {
 // Identifies an AWS resource and indicates whether it complies with the AWS
 // Config rule that it was evaluated against.
 type Evaluation struct {
+	_ struct{} `type:"structure"`
+
 	// Supplementary information about how the evaluation determined the compliance.
 	Annotation *string `min:"1" type:"string"`
 
@@ -1830,8 +1832,6 @@ type Evaluation struct {
 	// item that triggered the evaluation. For periodic evaluations, the time indicates
 	// when AWS Config delivered the configuration snapshot that triggered the evaluation.
 	OrderingTimestamp *time.Time `type:"timestamp" timestampFormat:"unix" required:"true"`
-
-	_ struct{} `type:"structure"`
 }
 
 // String returns the string representation
@@ -1848,6 +1848,8 @@ func (s Evaluation) GoString() string {
 // evaluated, the compliance of the resource, related timestamps, and supplementary
 // information.
 type EvaluationResult struct {
+	_ struct{} `type:"structure"`
+
 	// Supplementary information about how the evaluation determined the compliance.
 	Annotation *string `min:"1" type:"string"`
 
@@ -1868,8 +1870,6 @@ type EvaluationResult struct {
 	// The token identifies the rule, the AWS resource being evaluated, and the
 	// event that triggered the evaluation.
 	ResultToken *string `type:"string"`
-
-	_ struct{} `type:"structure"`
 }
 
 // String returns the string representation
@@ -1884,6 +1884,8 @@ func (s EvaluationResult) GoString() string {
 
 // Uniquely identifies an evaluation result.
 type EvaluationResultIdentifier struct {
+	_ struct{} `type:"structure"`
+
 	// Identifies an AWS Config rule used to evaluate an AWS resource, and provides
 	// the type and ID of the evaluated resource.
 	EvaluationResultQualifier *EvaluationResultQualifier `type:"structure"`
@@ -1893,8 +1895,6 @@ type EvaluationResultIdentifier struct {
 	// notification, or it can indicate when AWS Config delivered the configuration
 	// snapshot, depending on which event triggered the evaluation.
 	OrderingTimestamp *time.Time `type:"timestamp" timestampFormat:"unix"`
-
-	_ struct{} `type:"structure"`
 }
 
 // String returns the string representation
@@ -1910,6 +1910,8 @@ func (s EvaluationResultIdentifier) GoString() string {
 // Identifies an AWS Config rule that evaluated an AWS resource, and provides
 // the type and ID of the resource that the rule evaluated.
 type EvaluationResultQualifier struct {
+	_ struct{} `type:"structure"`
+
 	// The name of the AWS Config rule that was used in the evaluation.
 	ConfigRuleName *string `min:"1" type:"string"`
 
@@ -1918,8 +1920,6 @@ type EvaluationResultQualifier struct {
 
 	// The type of AWS resource that was evaluated.
 	ResourceType *string `min:"1" type:"string"`
-
-	_ struct{} `type:"structure"`
 }
 
 // String returns the string representation
@@ -1933,6 +1933,8 @@ func (s EvaluationResultQualifier) GoString() string {
 }
 
 type GetComplianceDetailsByConfigRuleInput struct {
+	_ struct{} `type:"structure"`
+
 	// Specify to filter the results by compliance. The valid values are Compliant,
 	// NonCompliant, and NotApplicable.
 	ComplianceTypes []*string `type:"list"`
@@ -1948,8 +1950,6 @@ type GetComplianceDetailsByConfigRuleInput struct {
 	// The nextToken string returned on a previous page that you use to get the
 	// next page of results in a paginated response.
 	NextToken *string `type:"string"`
-
-	_ struct{} `type:"structure"`
 }
 
 // String returns the string representation
@@ -1963,6 +1963,8 @@ func (s GetComplianceDetailsByConfigRuleInput) GoString() string {
 }
 
 type GetComplianceDetailsByConfigRuleOutput struct {
+	_ struct{} `type:"structure"`
+
 	// Indicates whether the AWS resource complies with the specified AWS Config
 	// rule.
 	EvaluationResults []*EvaluationResult `type:"list"`
@@ -1970,8 +1972,6 @@ type GetComplianceDetailsByConfigRuleOutput struct {
 	// The string that you use in a subsequent request to get the next page of results
 	// in a paginated response.
 	NextToken *string `type:"string"`
-
-	_ struct{} `type:"structure"`
 }
 
 // String returns the string representation
@@ -1985,6 +1985,8 @@ func (s GetComplianceDetailsByConfigRuleOutput) GoString() string {
 }
 
 type GetComplianceDetailsByResourceInput struct {
+	_ struct{} `type:"structure"`
+
 	// Specify to filter the results by compliance. The valid values are Compliant,
 	// NonCompliant, and NotApplicable.
 	ComplianceTypes []*string `type:"list"`
@@ -1998,8 +2000,6 @@ type GetComplianceDetailsByResourceInput struct {
 
 	// The type of the AWS resource for which you want compliance information.
 	ResourceType *string `min:"1" type:"string" required:"true"`
-
-	_ struct{} `type:"structure"`
 }
 
 // String returns the string representation
@@ -2013,14 +2013,14 @@ func (s GetComplianceDetailsByResourceInput) GoString() string {
 }
 
 type GetComplianceDetailsByResourceOutput struct {
+	_ struct{} `type:"structure"`
+
 	// Indicates whether the specified AWS resource complies each AWS Config rule.
 	EvaluationResults []*EvaluationResult `type:"list"`
 
 	// The string that you use in a subsequent request to get the next page of results
 	// in a paginated response.
 	NextToken *string `type:"string"`
-
-	_ struct{} `type:"structure"`
 }
 
 // String returns the string representation
@@ -2048,11 +2048,11 @@ func (s GetComplianceSummaryByConfigRuleInput) GoString() string {
 }
 
 type GetComplianceSummaryByConfigRuleOutput struct {
+	_ struct{} `type:"structure"`
+
 	// The number of AWS Config rules that are compliant and the number that are
 	// noncompliant, up to a maximum of 25 for each.
 	ComplianceSummary *ComplianceSummary `type:"structure"`
-
-	_ struct{} `type:"structure"`
 }
 
 // String returns the string representation
@@ -2066,6 +2066,8 @@ func (s GetComplianceSummaryByConfigRuleOutput) GoString() string {
 }
 
 type GetComplianceSummaryByResourceTypeInput struct {
+	_ struct{} `type:"structure"`
+
 	// Specify one or more resource types to get the number of resources that are
 	// compliant and the number that are noncompliant for each resource type.
 	//
@@ -2073,8 +2075,6 @@ type GetComplianceSummaryByResourceTypeInput struct {
 	// and you can specify that the resource type is an AWS account by specifying
 	// AWS::::Account.
 	ResourceTypes []*string `type:"list"`
-
-	_ struct{} `type:"structure"`
 }
 
 // String returns the string representation
@@ -2088,12 +2088,12 @@ func (s GetComplianceSummaryByResourceTypeInput) GoString() string {
 }
 
 type GetComplianceSummaryByResourceTypeOutput struct {
+	_ struct{} `type:"structure"`
+
 	// The number of resources that are compliant and the number that are noncompliant.
 	// If one or more resource types were provided with the request, the numbers
 	// are returned for each resource type. The maximum number returned is 100.
 	ComplianceSummariesByResourceType []*ComplianceSummaryByResourceType `type:"list"`
-
-	_ struct{} `type:"structure"`
 }
 
 // String returns the string representation
@@ -2108,6 +2108,8 @@ func (s GetComplianceSummaryByResourceTypeOutput) GoString() string {
 
 // The input for the GetResourceConfigHistory action.
 type GetResourceConfigHistoryInput struct {
+	_ struct{} `type:"structure"`
+
 	// The chronological order for configuration items listed. By default the results
 	// are listed in reverse chronological order.
 	ChronologicalOrder *string `locationName:"chronologicalOrder" type:"string" enum:"ChronologicalOrder"`
@@ -2135,8 +2137,6 @@ type GetResourceConfigHistoryInput struct {
 
 	// The resource type.
 	ResourceType *string `locationName:"resourceType" type:"string" required:"true" enum:"ResourceType"`
-
-	_ struct{} `type:"structure"`
 }
 
 // String returns the string representation
@@ -2151,14 +2151,14 @@ func (s GetResourceConfigHistoryInput) GoString() string {
 
 // The output for the GetResourceConfigHistory action.
 type GetResourceConfigHistoryOutput struct {
+	_ struct{} `type:"structure"`
+
 	// A list that contains the configuration history of one or more resources.
 	ConfigurationItems []*ConfigurationItem `locationName:"configurationItems" type:"list"`
 
 	// The string that you use in a subsequent request to get the next page of results
 	// in a paginated response.
 	NextToken *string `locationName:"nextToken" type:"string"`
-
-	_ struct{} `type:"structure"`
 }
 
 // String returns the string representation
@@ -2172,6 +2172,8 @@ func (s GetResourceConfigHistoryOutput) GoString() string {
 }
 
 type ListDiscoveredResourcesInput struct {
+	_ struct{} `type:"structure"`
+
 	// Specifies whether AWS Config includes deleted resources in the results. By
 	// default, deleted resources are not included.
 	IncludeDeletedResources *bool `locationName:"includeDeletedResources" type:"boolean"`
@@ -2197,8 +2199,6 @@ type ListDiscoveredResourcesInput struct {
 
 	// The type of resources that you want AWS Config to list in the response.
 	ResourceType *string `locationName:"resourceType" type:"string" required:"true" enum:"ResourceType"`
-
-	_ struct{} `type:"structure"`
 }
 
 // String returns the string representation
@@ -2212,6 +2212,8 @@ func (s ListDiscoveredResourcesInput) GoString() string {
 }
 
 type ListDiscoveredResourcesOutput struct {
+	_ struct{} `type:"structure"`
+
 	// The string that you use in a subsequent request to get the next page of results
 	// in a paginated response.
 	NextToken *string `locationName:"nextToken" type:"string"`
@@ -2219,8 +2221,6 @@ type ListDiscoveredResourcesOutput struct {
 	// The details that identify a resource that is discovered by AWS Config, including
 	// the resource type, ID, and (if available) the custom resource name.
 	ResourceIdentifiers []*ResourceIdentifier `locationName:"resourceIdentifiers" type:"list"`
-
-	_ struct{} `type:"structure"`
 }
 
 // String returns the string representation
@@ -2234,6 +2234,8 @@ func (s ListDiscoveredResourcesOutput) GoString() string {
 }
 
 type PutConfigRuleInput struct {
+	_ struct{} `type:"structure"`
+
 	// An AWS Lambda function that evaluates configuration items to assess whether
 	// your AWS resources comply with your desired configurations. This function
 	// can run when AWS Config detects a configuration change or delivers a configuration
@@ -2244,8 +2246,6 @@ type PutConfigRuleInput struct {
 	// AWS Resource Configurations with AWS Config (http://docs.aws.amazon.com/config/latest/developerguide/evaluate-config.html)
 	// in the AWS Config Developer Guide.
 	ConfigRule *ConfigRule `type:"structure" required:"true"`
-
-	_ struct{} `type:"structure"`
 }
 
 // String returns the string representation
@@ -2274,11 +2274,11 @@ func (s PutConfigRuleOutput) GoString() string {
 
 // The input for the PutConfigurationRecorder action.
 type PutConfigurationRecorderInput struct {
+	_ struct{} `type:"structure"`
+
 	// The configuration recorder object that records each configuration change
 	// made to the resources.
 	ConfigurationRecorder *ConfigurationRecorder `type:"structure" required:"true"`
-
-	_ struct{} `type:"structure"`
 }
 
 // String returns the string representation
@@ -2307,11 +2307,11 @@ func (s PutConfigurationRecorderOutput) GoString() string {
 
 // The input for the PutDeliveryChannel action.
 type PutDeliveryChannelInput struct {
+	_ struct{} `type:"structure"`
+
 	// The configuration delivery channel object that delivers the configuration
 	// information to an Amazon S3 bucket, and to an Amazon SNS topic.
 	DeliveryChannel *DeliveryChannel `type:"structure" required:"true"`
-
-	_ struct{} `type:"structure"`
 }
 
 // String returns the string representation
@@ -2339,6 +2339,8 @@ func (s PutDeliveryChannelOutput) GoString() string {
 }
 
 type PutEvaluationsInput struct {
+	_ struct{} `type:"structure"`
+
 	// The assessments that the AWS Lambda function performs. Each evaluation identifies
 	// an AWS resource and indicates whether it complies with the AWS Config rule
 	// that invokes the AWS Lambda function.
@@ -2347,8 +2349,6 @@ type PutEvaluationsInput struct {
 	// An encrypted token that associates an evaluation with an AWS Config rule.
 	// Identifies the rule and the event that triggered the evaluation
 	ResultToken *string `type:"string" required:"true"`
-
-	_ struct{} `type:"structure"`
 }
 
 // String returns the string representation
@@ -2362,10 +2362,10 @@ func (s PutEvaluationsInput) GoString() string {
 }
 
 type PutEvaluationsOutput struct {
+	_ struct{} `type:"structure"`
+
 	// Requests that failed because of a client or server error.
 	FailedEvaluations []*Evaluation `type:"list"`
-
-	_ struct{} `type:"structure"`
 }
 
 // String returns the string representation
@@ -2384,6 +2384,8 @@ func (s PutEvaluationsOutput) GoString() string {
 // recordingGroup can have one and only one parameter. Choose either allSupported
 // or resourceTypes.
 type RecordingGroup struct {
+	_ struct{} `type:"structure"`
+
 	// Records all supported resource types in the recording group. For a list of
 	// supported resource types, see Supported resource types (http://docs.aws.amazon.com/config/latest/developerguide/resource-config-reference.html#supported-resources).
 	// If you specify allSupported, you cannot enumerate a list of resourceTypes.
@@ -2395,8 +2397,6 @@ type RecordingGroup struct {
 	// resourceTypes values, see the resourceType Value column in the following
 	// topic: Supported AWS Resource Types (http://docs.aws.amazon.com/config/latest/developerguide/resource-config-reference.html#supported-resources).
 	ResourceTypes []*string `locationName:"resourceTypes" type:"list"`
-
-	_ struct{} `type:"structure"`
 }
 
 // String returns the string representation
@@ -2411,6 +2411,8 @@ func (s RecordingGroup) GoString() string {
 
 // The relationship of the related resource to the main resource.
 type Relationship struct {
+	_ struct{} `type:"structure"`
+
 	// The type of relationship with the related resource.
 	RelationshipName *string `locationName:"relationshipName" type:"string"`
 
@@ -2422,8 +2424,6 @@ type Relationship struct {
 
 	// The resource type of the related resource.
 	ResourceType *string `locationName:"resourceType" type:"string" enum:"ResourceType"`
-
-	_ struct{} `type:"structure"`
 }
 
 // String returns the string representation
@@ -2439,6 +2439,8 @@ func (s Relationship) GoString() string {
 // The details that identify a resource that is discovered by AWS Config, including
 // the resource type, ID, and (if available) the custom resource name.
 type ResourceIdentifier struct {
+	_ struct{} `type:"structure"`
+
 	// The time that the resource was deleted.
 	ResourceDeletionTime *time.Time `locationName:"resourceDeletionTime" type:"timestamp" timestampFormat:"unix"`
 
@@ -2450,8 +2452,6 @@ type ResourceIdentifier struct {
 
 	// The type of resource.
 	ResourceType *string `locationName:"resourceType" type:"string" enum:"ResourceType"`
-
-	_ struct{} `type:"structure"`
 }
 
 // String returns the string representation
@@ -2471,6 +2471,8 @@ func (s ResourceIdentifier) GoString() string {
 // a scope, all resources in your recording group are evaluated against the
 // rule.
 type Scope struct {
+	_ struct{} `type:"structure"`
+
 	// The IDs of only those AWS resources that you want AWS Config to evaluate
 	// against the rule. If you specify a resource ID, you must specify one resource
 	// type for ComplianceResourceTypes.
@@ -2489,8 +2491,6 @@ type Scope struct {
 	// to evaluate against the rule. If you specify a value for TagValue, you must
 	// also specify a value for TagKey.
 	TagValue *string `min:"1" type:"string"`
-
-	_ struct{} `type:"structure"`
 }
 
 // String returns the string representation
@@ -2506,6 +2506,8 @@ func (s Scope) GoString() string {
 // Provides the AWS Config rule owner (AWS or customer), the rule identifier,
 // and the events that trigger the evaluation of your AWS resources.
 type Source struct {
+	_ struct{} `type:"structure"`
+
 	// Indicates whether AWS or the customer owns and manages the AWS Config rule.
 	Owner *string `type:"string" enum:"Owner"`
 
@@ -2519,8 +2521,6 @@ type Source struct {
 	// For customer managed Config rules, the identifier is the Amazon Resource
 	// Name (ARN) of the rule's AWS Lambda function.
 	SourceIdentifier *string `min:"1" type:"string"`
-
-	_ struct{} `type:"structure"`
 }
 
 // String returns the string representation
@@ -2536,6 +2536,8 @@ func (s Source) GoString() string {
 // Provides the source and type of the event that triggers AWS Config to evaluate
 // your AWS resources against a rule.
 type SourceDetail struct {
+	_ struct{} `type:"structure"`
+
 	// The source of the event, such as an AWS service, that triggers AWS Config
 	// to evaluate your AWS resources.
 	EventSource *string `type:"string" enum:"EventSource"`
@@ -2546,8 +2548,6 @@ type SourceDetail struct {
 	// evaluations that are initiated when AWS Config delivers a configuration snapshot,
 	// you must use ConfigurationSnapshotDeliveryCompleted.
 	MessageType *string `type:"string" enum:"MessageType"`
-
-	_ struct{} `type:"structure"`
 }
 
 // String returns the string representation
@@ -2562,11 +2562,11 @@ func (s SourceDetail) GoString() string {
 
 // The input for the StartConfigurationRecorder action.
 type StartConfigurationRecorderInput struct {
+	_ struct{} `type:"structure"`
+
 	// The name of the recorder object that records each configuration change made
 	// to the resources.
 	ConfigurationRecorderName *string `min:"1" type:"string" required:"true"`
-
-	_ struct{} `type:"structure"`
 }
 
 // String returns the string representation
@@ -2595,11 +2595,11 @@ func (s StartConfigurationRecorderOutput) GoString() string {
 
 // The input for the StopConfigurationRecorder action.
 type StopConfigurationRecorderInput struct {
+	_ struct{} `type:"structure"`
+
 	// The name of the recorder object that records each configuration change made
 	// to the resources.
 	ConfigurationRecorderName *string `min:"1" type:"string" required:"true"`
-
-	_ struct{} `type:"structure"`
 }
 
 // String returns the string representation

--- a/service/configservice/api.go
+++ b/service/configservice/api.go
@@ -822,11 +822,7 @@ type Compliance struct {
 	// with it, and it is noncompliant if any of these resources do not comply.
 	ComplianceType *string `type:"string" enum:"ComplianceType"`
 
-	metadataCompliance `json:"-" xml:"-"`
-}
-
-type metadataCompliance struct {
-	SDKShapeTraits bool `type:"structure"`
+	_ struct{} `type:"structure"`
 }
 
 // String returns the string representation
@@ -849,11 +845,7 @@ type ComplianceByConfigRule struct {
 	// The name of the AWS Config rule.
 	ConfigRuleName *string `min:"1" type:"string"`
 
-	metadataComplianceByConfigRule `json:"-" xml:"-"`
-}
-
-type metadataComplianceByConfigRule struct {
-	SDKShapeTraits bool `type:"structure"`
+	_ struct{} `type:"structure"`
 }
 
 // String returns the string representation
@@ -881,11 +873,7 @@ type ComplianceByResource struct {
 	// The type of the AWS resource that was evaluated.
 	ResourceType *string `min:"1" type:"string"`
 
-	metadataComplianceByResource `json:"-" xml:"-"`
-}
-
-type metadataComplianceByResource struct {
-	SDKShapeTraits bool `type:"structure"`
+	_ struct{} `type:"structure"`
 }
 
 // String returns the string representation
@@ -908,11 +896,7 @@ type ComplianceContributorCount struct {
 	// compliance of the item.
 	CappedCount *int64 `type:"integer"`
 
-	metadataComplianceContributorCount `json:"-" xml:"-"`
-}
-
-type metadataComplianceContributorCount struct {
-	SDKShapeTraits bool `type:"structure"`
+	_ struct{} `type:"structure"`
 }
 
 // String returns the string representation
@@ -939,11 +923,7 @@ type ComplianceSummary struct {
 	// to a maximum of 25 for rules and 100 for resources.
 	NonCompliantResourceCount *ComplianceContributorCount `type:"structure"`
 
-	metadataComplianceSummary `json:"-" xml:"-"`
-}
-
-type metadataComplianceSummary struct {
-	SDKShapeTraits bool `type:"structure"`
+	_ struct{} `type:"structure"`
 }
 
 // String returns the string representation
@@ -966,11 +946,7 @@ type ComplianceSummaryByResourceType struct {
 	// The type of AWS resource.
 	ResourceType *string `min:"1" type:"string"`
 
-	metadataComplianceSummaryByResourceType `json:"-" xml:"-"`
-}
-
-type metadataComplianceSummaryByResourceType struct {
-	SDKShapeTraits bool `type:"structure"`
+	_ struct{} `type:"structure"`
 }
 
 // String returns the string representation
@@ -1004,11 +980,7 @@ type ConfigExportDeliveryInfo struct {
 	// The time that the next delivery occurs.
 	NextDeliveryTime *time.Time `locationName:"nextDeliveryTime" type:"timestamp" timestampFormat:"unix"`
 
-	metadataConfigExportDeliveryInfo `json:"-" xml:"-"`
-}
-
-type metadataConfigExportDeliveryInfo struct {
-	SDKShapeTraits bool `type:"structure"`
+	_ struct{} `type:"structure"`
 }
 
 // String returns the string representation
@@ -1081,11 +1053,7 @@ type ConfigRule struct {
 	// that cause the function to evaluate your AWS resources.
 	Source *Source `type:"structure" required:"true"`
 
-	metadataConfigRule `json:"-" xml:"-"`
-}
-
-type metadataConfigRule struct {
-	SDKShapeTraits bool `type:"structure"`
+	_ struct{} `type:"structure"`
 }
 
 // String returns the string representation
@@ -1131,11 +1099,7 @@ type ConfigRuleEvaluationStatus struct {
 	// evaluate your AWS resources.
 	LastSuccessfulInvocationTime *time.Time `type:"timestamp" timestampFormat:"unix"`
 
-	metadataConfigRuleEvaluationStatus `json:"-" xml:"-"`
-}
-
-type metadataConfigRuleEvaluationStatus struct {
-	SDKShapeTraits bool `type:"structure"`
+	_ struct{} `type:"structure"`
 }
 
 // String returns the string representation
@@ -1155,11 +1119,7 @@ type ConfigSnapshotDeliveryProperties struct {
 	// snapshots.
 	DeliveryFrequency *string `locationName:"deliveryFrequency" type:"string" enum:"MaximumExecutionFrequency"`
 
-	metadataConfigSnapshotDeliveryProperties `json:"-" xml:"-"`
-}
-
-type metadataConfigSnapshotDeliveryProperties struct {
-	SDKShapeTraits bool `type:"structure"`
+	_ struct{} `type:"structure"`
 }
 
 // String returns the string representation
@@ -1191,11 +1151,7 @@ type ConfigStreamDeliveryInfo struct {
 	// The time from the last status change.
 	LastStatusChangeTime *time.Time `locationName:"lastStatusChangeTime" type:"timestamp" timestampFormat:"unix"`
 
-	metadataConfigStreamDeliveryInfo `json:"-" xml:"-"`
-}
-
-type metadataConfigStreamDeliveryInfo struct {
-	SDKShapeTraits bool `type:"structure"`
+	_ struct{} `type:"structure"`
 }
 
 // String returns the string representation
@@ -1275,11 +1231,7 @@ type ConfigurationItem struct {
 	// The version number of the resource configuration.
 	Version *string `locationName:"version" type:"string"`
 
-	metadataConfigurationItem `json:"-" xml:"-"`
-}
-
-type metadataConfigurationItem struct {
-	SDKShapeTraits bool `type:"structure"`
+	_ struct{} `type:"structure"`
 }
 
 // String returns the string representation
@@ -1309,11 +1261,7 @@ type ConfigurationRecorder struct {
 	// associated with the account.
 	RoleARN *string `locationName:"roleARN" type:"string"`
 
-	metadataConfigurationRecorder `json:"-" xml:"-"`
-}
-
-type metadataConfigurationRecorder struct {
-	SDKShapeTraits bool `type:"structure"`
+	_ struct{} `type:"structure"`
 }
 
 // String returns the string representation
@@ -1352,11 +1300,7 @@ type ConfigurationRecorderStatus struct {
 	// Specifies whether the recorder is currently recording or not.
 	Recording *bool `locationName:"recording" type:"boolean"`
 
-	metadataConfigurationRecorderStatus `json:"-" xml:"-"`
-}
-
-type metadataConfigurationRecorderStatus struct {
-	SDKShapeTraits bool `type:"structure"`
+	_ struct{} `type:"structure"`
 }
 
 // String returns the string representation
@@ -1373,11 +1317,7 @@ type DeleteConfigRuleInput struct {
 	// The name of the AWS Config rule that you want to delete.
 	ConfigRuleName *string `min:"1" type:"string" required:"true"`
 
-	metadataDeleteConfigRuleInput `json:"-" xml:"-"`
-}
-
-type metadataDeleteConfigRuleInput struct {
-	SDKShapeTraits bool `type:"structure"`
+	_ struct{} `type:"structure"`
 }
 
 // String returns the string representation
@@ -1391,11 +1331,7 @@ func (s DeleteConfigRuleInput) GoString() string {
 }
 
 type DeleteConfigRuleOutput struct {
-	metadataDeleteConfigRuleOutput `json:"-" xml:"-"`
-}
-
-type metadataDeleteConfigRuleOutput struct {
-	SDKShapeTraits bool `type:"structure"`
+	_ struct{} `type:"structure"`
 }
 
 // String returns the string representation
@@ -1414,11 +1350,7 @@ type DeleteDeliveryChannelInput struct {
 	// The name of the delivery channel to delete.
 	DeliveryChannelName *string `min:"1" type:"string" required:"true"`
 
-	metadataDeleteDeliveryChannelInput `json:"-" xml:"-"`
-}
-
-type metadataDeleteDeliveryChannelInput struct {
-	SDKShapeTraits bool `type:"structure"`
+	_ struct{} `type:"structure"`
 }
 
 // String returns the string representation
@@ -1432,11 +1364,7 @@ func (s DeleteDeliveryChannelInput) GoString() string {
 }
 
 type DeleteDeliveryChannelOutput struct {
-	metadataDeleteDeliveryChannelOutput `json:"-" xml:"-"`
-}
-
-type metadataDeleteDeliveryChannelOutput struct {
-	SDKShapeTraits bool `type:"structure"`
+	_ struct{} `type:"structure"`
 }
 
 // String returns the string representation
@@ -1454,11 +1382,7 @@ type DeliverConfigSnapshotInput struct {
 	// The name of the delivery channel through which the snapshot is delivered.
 	DeliveryChannelName *string `locationName:"deliveryChannelName" min:"1" type:"string" required:"true"`
 
-	metadataDeliverConfigSnapshotInput `json:"-" xml:"-"`
-}
-
-type metadataDeliverConfigSnapshotInput struct {
-	SDKShapeTraits bool `type:"structure"`
+	_ struct{} `type:"structure"`
 }
 
 // String returns the string representation
@@ -1476,11 +1400,7 @@ type DeliverConfigSnapshotOutput struct {
 	// The ID of the snapshot that is being created.
 	ConfigSnapshotId *string `locationName:"configSnapshotId" type:"string"`
 
-	metadataDeliverConfigSnapshotOutput `json:"-" xml:"-"`
-}
-
-type metadataDeliverConfigSnapshotOutput struct {
-	SDKShapeTraits bool `type:"structure"`
+	_ struct{} `type:"structure"`
 }
 
 // String returns the string representation
@@ -1516,11 +1436,7 @@ type DeliveryChannel struct {
 	// notifications to.
 	SnsTopicARN *string `locationName:"snsTopicARN" type:"string"`
 
-	metadataDeliveryChannel `json:"-" xml:"-"`
-}
-
-type metadataDeliveryChannel struct {
-	SDKShapeTraits bool `type:"structure"`
+	_ struct{} `type:"structure"`
 }
 
 // String returns the string representation
@@ -1552,11 +1468,7 @@ type DeliveryChannelStatus struct {
 	// The name of the delivery channel.
 	Name *string `locationName:"name" type:"string"`
 
-	metadataDeliveryChannelStatus `json:"-" xml:"-"`
-}
-
-type metadataDeliveryChannelStatus struct {
-	SDKShapeTraits bool `type:"structure"`
+	_ struct{} `type:"structure"`
 }
 
 // String returns the string representation
@@ -1580,11 +1492,7 @@ type DescribeComplianceByConfigRuleInput struct {
 	// next page of results in a paginated response.
 	NextToken *string `type:"string"`
 
-	metadataDescribeComplianceByConfigRuleInput `json:"-" xml:"-"`
-}
-
-type metadataDescribeComplianceByConfigRuleInput struct {
-	SDKShapeTraits bool `type:"structure"`
+	_ struct{} `type:"structure"`
 }
 
 // String returns the string representation
@@ -1605,11 +1513,7 @@ type DescribeComplianceByConfigRuleOutput struct {
 	// in a paginated response.
 	NextToken *string `type:"string"`
 
-	metadataDescribeComplianceByConfigRuleOutput `json:"-" xml:"-"`
-}
-
-type metadataDescribeComplianceByConfigRuleOutput struct {
-	SDKShapeTraits bool `type:"structure"`
+	_ struct{} `type:"structure"`
 }
 
 // String returns the string representation
@@ -1645,11 +1549,7 @@ type DescribeComplianceByResourceInput struct {
 	// type is an AWS account by specifying AWS::::Account.
 	ResourceType *string `min:"1" type:"string"`
 
-	metadataDescribeComplianceByResourceInput `json:"-" xml:"-"`
-}
-
-type metadataDescribeComplianceByResourceInput struct {
-	SDKShapeTraits bool `type:"structure"`
+	_ struct{} `type:"structure"`
 }
 
 // String returns the string representation
@@ -1671,11 +1571,7 @@ type DescribeComplianceByResourceOutput struct {
 	// in a paginated response.
 	NextToken *string `type:"string"`
 
-	metadataDescribeComplianceByResourceOutput `json:"-" xml:"-"`
-}
-
-type metadataDescribeComplianceByResourceOutput struct {
-	SDKShapeTraits bool `type:"structure"`
+	_ struct{} `type:"structure"`
 }
 
 // String returns the string representation
@@ -1694,11 +1590,7 @@ type DescribeConfigRuleEvaluationStatusInput struct {
 	// all AWS managed Config rules that you use.
 	ConfigRuleNames []*string `type:"list"`
 
-	metadataDescribeConfigRuleEvaluationStatusInput `json:"-" xml:"-"`
-}
-
-type metadataDescribeConfigRuleEvaluationStatusInput struct {
-	SDKShapeTraits bool `type:"structure"`
+	_ struct{} `type:"structure"`
 }
 
 // String returns the string representation
@@ -1715,11 +1607,7 @@ type DescribeConfigRuleEvaluationStatusOutput struct {
 	// Status information about your AWS managed Config rules.
 	ConfigRulesEvaluationStatus []*ConfigRuleEvaluationStatus `type:"list"`
 
-	metadataDescribeConfigRuleEvaluationStatusOutput `json:"-" xml:"-"`
-}
-
-type metadataDescribeConfigRuleEvaluationStatusOutput struct {
-	SDKShapeTraits bool `type:"structure"`
+	_ struct{} `type:"structure"`
 }
 
 // String returns the string representation
@@ -1741,11 +1629,7 @@ type DescribeConfigRulesInput struct {
 	// next page of results in a paginated response.
 	NextToken *string `type:"string"`
 
-	metadataDescribeConfigRulesInput `json:"-" xml:"-"`
-}
-
-type metadataDescribeConfigRulesInput struct {
-	SDKShapeTraits bool `type:"structure"`
+	_ struct{} `type:"structure"`
 }
 
 // String returns the string representation
@@ -1766,11 +1650,7 @@ type DescribeConfigRulesOutput struct {
 	// in a paginated response.
 	NextToken *string `type:"string"`
 
-	metadataDescribeConfigRulesOutput `json:"-" xml:"-"`
-}
-
-type metadataDescribeConfigRulesOutput struct {
-	SDKShapeTraits bool `type:"structure"`
+	_ struct{} `type:"structure"`
 }
 
 // String returns the string representation
@@ -1790,11 +1670,7 @@ type DescribeConfigurationRecorderStatusInput struct {
 	// associated with the account.
 	ConfigurationRecorderNames []*string `type:"list"`
 
-	metadataDescribeConfigurationRecorderStatusInput `json:"-" xml:"-"`
-}
-
-type metadataDescribeConfigurationRecorderStatusInput struct {
-	SDKShapeTraits bool `type:"structure"`
+	_ struct{} `type:"structure"`
 }
 
 // String returns the string representation
@@ -1812,11 +1688,7 @@ type DescribeConfigurationRecorderStatusOutput struct {
 	// A list that contains status of the specified recorders.
 	ConfigurationRecordersStatus []*ConfigurationRecorderStatus `type:"list"`
 
-	metadataDescribeConfigurationRecorderStatusOutput `json:"-" xml:"-"`
-}
-
-type metadataDescribeConfigurationRecorderStatusOutput struct {
-	SDKShapeTraits bool `type:"structure"`
+	_ struct{} `type:"structure"`
 }
 
 // String returns the string representation
@@ -1834,11 +1706,7 @@ type DescribeConfigurationRecordersInput struct {
 	// A list of configuration recorder names.
 	ConfigurationRecorderNames []*string `type:"list"`
 
-	metadataDescribeConfigurationRecordersInput `json:"-" xml:"-"`
-}
-
-type metadataDescribeConfigurationRecordersInput struct {
-	SDKShapeTraits bool `type:"structure"`
+	_ struct{} `type:"structure"`
 }
 
 // String returns the string representation
@@ -1856,11 +1724,7 @@ type DescribeConfigurationRecordersOutput struct {
 	// A list that contains the descriptions of the specified configuration recorders.
 	ConfigurationRecorders []*ConfigurationRecorder `type:"list"`
 
-	metadataDescribeConfigurationRecordersOutput `json:"-" xml:"-"`
-}
-
-type metadataDescribeConfigurationRecordersOutput struct {
-	SDKShapeTraits bool `type:"structure"`
+	_ struct{} `type:"structure"`
 }
 
 // String returns the string representation
@@ -1878,11 +1742,7 @@ type DescribeDeliveryChannelStatusInput struct {
 	// A list of delivery channel names.
 	DeliveryChannelNames []*string `type:"list"`
 
-	metadataDescribeDeliveryChannelStatusInput `json:"-" xml:"-"`
-}
-
-type metadataDescribeDeliveryChannelStatusInput struct {
-	SDKShapeTraits bool `type:"structure"`
+	_ struct{} `type:"structure"`
 }
 
 // String returns the string representation
@@ -1900,11 +1760,7 @@ type DescribeDeliveryChannelStatusOutput struct {
 	// A list that contains the status of a specified delivery channel.
 	DeliveryChannelsStatus []*DeliveryChannelStatus `type:"list"`
 
-	metadataDescribeDeliveryChannelStatusOutput `json:"-" xml:"-"`
-}
-
-type metadataDescribeDeliveryChannelStatusOutput struct {
-	SDKShapeTraits bool `type:"structure"`
+	_ struct{} `type:"structure"`
 }
 
 // String returns the string representation
@@ -1922,11 +1778,7 @@ type DescribeDeliveryChannelsInput struct {
 	// A list of delivery channel names.
 	DeliveryChannelNames []*string `type:"list"`
 
-	metadataDescribeDeliveryChannelsInput `json:"-" xml:"-"`
-}
-
-type metadataDescribeDeliveryChannelsInput struct {
-	SDKShapeTraits bool `type:"structure"`
+	_ struct{} `type:"structure"`
 }
 
 // String returns the string representation
@@ -1944,11 +1796,7 @@ type DescribeDeliveryChannelsOutput struct {
 	// A list that contains the descriptions of the specified delivery channel.
 	DeliveryChannels []*DeliveryChannel `type:"list"`
 
-	metadataDescribeDeliveryChannelsOutput `json:"-" xml:"-"`
-}
-
-type metadataDescribeDeliveryChannelsOutput struct {
-	SDKShapeTraits bool `type:"structure"`
+	_ struct{} `type:"structure"`
 }
 
 // String returns the string representation
@@ -1983,11 +1831,7 @@ type Evaluation struct {
 	// when AWS Config delivered the configuration snapshot that triggered the evaluation.
 	OrderingTimestamp *time.Time `type:"timestamp" timestampFormat:"unix" required:"true"`
 
-	metadataEvaluation `json:"-" xml:"-"`
-}
-
-type metadataEvaluation struct {
-	SDKShapeTraits bool `type:"structure"`
+	_ struct{} `type:"structure"`
 }
 
 // String returns the string representation
@@ -2025,11 +1869,7 @@ type EvaluationResult struct {
 	// event that triggered the evaluation.
 	ResultToken *string `type:"string"`
 
-	metadataEvaluationResult `json:"-" xml:"-"`
-}
-
-type metadataEvaluationResult struct {
-	SDKShapeTraits bool `type:"structure"`
+	_ struct{} `type:"structure"`
 }
 
 // String returns the string representation
@@ -2054,11 +1894,7 @@ type EvaluationResultIdentifier struct {
 	// snapshot, depending on which event triggered the evaluation.
 	OrderingTimestamp *time.Time `type:"timestamp" timestampFormat:"unix"`
 
-	metadataEvaluationResultIdentifier `json:"-" xml:"-"`
-}
-
-type metadataEvaluationResultIdentifier struct {
-	SDKShapeTraits bool `type:"structure"`
+	_ struct{} `type:"structure"`
 }
 
 // String returns the string representation
@@ -2083,11 +1919,7 @@ type EvaluationResultQualifier struct {
 	// The type of AWS resource that was evaluated.
 	ResourceType *string `min:"1" type:"string"`
 
-	metadataEvaluationResultQualifier `json:"-" xml:"-"`
-}
-
-type metadataEvaluationResultQualifier struct {
-	SDKShapeTraits bool `type:"structure"`
+	_ struct{} `type:"structure"`
 }
 
 // String returns the string representation
@@ -2117,11 +1949,7 @@ type GetComplianceDetailsByConfigRuleInput struct {
 	// next page of results in a paginated response.
 	NextToken *string `type:"string"`
 
-	metadataGetComplianceDetailsByConfigRuleInput `json:"-" xml:"-"`
-}
-
-type metadataGetComplianceDetailsByConfigRuleInput struct {
-	SDKShapeTraits bool `type:"structure"`
+	_ struct{} `type:"structure"`
 }
 
 // String returns the string representation
@@ -2143,11 +1971,7 @@ type GetComplianceDetailsByConfigRuleOutput struct {
 	// in a paginated response.
 	NextToken *string `type:"string"`
 
-	metadataGetComplianceDetailsByConfigRuleOutput `json:"-" xml:"-"`
-}
-
-type metadataGetComplianceDetailsByConfigRuleOutput struct {
-	SDKShapeTraits bool `type:"structure"`
+	_ struct{} `type:"structure"`
 }
 
 // String returns the string representation
@@ -2175,11 +1999,7 @@ type GetComplianceDetailsByResourceInput struct {
 	// The type of the AWS resource for which you want compliance information.
 	ResourceType *string `min:"1" type:"string" required:"true"`
 
-	metadataGetComplianceDetailsByResourceInput `json:"-" xml:"-"`
-}
-
-type metadataGetComplianceDetailsByResourceInput struct {
-	SDKShapeTraits bool `type:"structure"`
+	_ struct{} `type:"structure"`
 }
 
 // String returns the string representation
@@ -2200,11 +2020,7 @@ type GetComplianceDetailsByResourceOutput struct {
 	// in a paginated response.
 	NextToken *string `type:"string"`
 
-	metadataGetComplianceDetailsByResourceOutput `json:"-" xml:"-"`
-}
-
-type metadataGetComplianceDetailsByResourceOutput struct {
-	SDKShapeTraits bool `type:"structure"`
+	_ struct{} `type:"structure"`
 }
 
 // String returns the string representation
@@ -2218,11 +2034,7 @@ func (s GetComplianceDetailsByResourceOutput) GoString() string {
 }
 
 type GetComplianceSummaryByConfigRuleInput struct {
-	metadataGetComplianceSummaryByConfigRuleInput `json:"-" xml:"-"`
-}
-
-type metadataGetComplianceSummaryByConfigRuleInput struct {
-	SDKShapeTraits bool `type:"structure"`
+	_ struct{} `type:"structure"`
 }
 
 // String returns the string representation
@@ -2240,11 +2052,7 @@ type GetComplianceSummaryByConfigRuleOutput struct {
 	// noncompliant, up to a maximum of 25 for each.
 	ComplianceSummary *ComplianceSummary `type:"structure"`
 
-	metadataGetComplianceSummaryByConfigRuleOutput `json:"-" xml:"-"`
-}
-
-type metadataGetComplianceSummaryByConfigRuleOutput struct {
-	SDKShapeTraits bool `type:"structure"`
+	_ struct{} `type:"structure"`
 }
 
 // String returns the string representation
@@ -2266,11 +2074,7 @@ type GetComplianceSummaryByResourceTypeInput struct {
 	// AWS::::Account.
 	ResourceTypes []*string `type:"list"`
 
-	metadataGetComplianceSummaryByResourceTypeInput `json:"-" xml:"-"`
-}
-
-type metadataGetComplianceSummaryByResourceTypeInput struct {
-	SDKShapeTraits bool `type:"structure"`
+	_ struct{} `type:"structure"`
 }
 
 // String returns the string representation
@@ -2289,11 +2093,7 @@ type GetComplianceSummaryByResourceTypeOutput struct {
 	// are returned for each resource type. The maximum number returned is 100.
 	ComplianceSummariesByResourceType []*ComplianceSummaryByResourceType `type:"list"`
 
-	metadataGetComplianceSummaryByResourceTypeOutput `json:"-" xml:"-"`
-}
-
-type metadataGetComplianceSummaryByResourceTypeOutput struct {
-	SDKShapeTraits bool `type:"structure"`
+	_ struct{} `type:"structure"`
 }
 
 // String returns the string representation
@@ -2336,11 +2136,7 @@ type GetResourceConfigHistoryInput struct {
 	// The resource type.
 	ResourceType *string `locationName:"resourceType" type:"string" required:"true" enum:"ResourceType"`
 
-	metadataGetResourceConfigHistoryInput `json:"-" xml:"-"`
-}
-
-type metadataGetResourceConfigHistoryInput struct {
-	SDKShapeTraits bool `type:"structure"`
+	_ struct{} `type:"structure"`
 }
 
 // String returns the string representation
@@ -2362,11 +2158,7 @@ type GetResourceConfigHistoryOutput struct {
 	// in a paginated response.
 	NextToken *string `locationName:"nextToken" type:"string"`
 
-	metadataGetResourceConfigHistoryOutput `json:"-" xml:"-"`
-}
-
-type metadataGetResourceConfigHistoryOutput struct {
-	SDKShapeTraits bool `type:"structure"`
+	_ struct{} `type:"structure"`
 }
 
 // String returns the string representation
@@ -2406,11 +2198,7 @@ type ListDiscoveredResourcesInput struct {
 	// The type of resources that you want AWS Config to list in the response.
 	ResourceType *string `locationName:"resourceType" type:"string" required:"true" enum:"ResourceType"`
 
-	metadataListDiscoveredResourcesInput `json:"-" xml:"-"`
-}
-
-type metadataListDiscoveredResourcesInput struct {
-	SDKShapeTraits bool `type:"structure"`
+	_ struct{} `type:"structure"`
 }
 
 // String returns the string representation
@@ -2432,11 +2220,7 @@ type ListDiscoveredResourcesOutput struct {
 	// the resource type, ID, and (if available) the custom resource name.
 	ResourceIdentifiers []*ResourceIdentifier `locationName:"resourceIdentifiers" type:"list"`
 
-	metadataListDiscoveredResourcesOutput `json:"-" xml:"-"`
-}
-
-type metadataListDiscoveredResourcesOutput struct {
-	SDKShapeTraits bool `type:"structure"`
+	_ struct{} `type:"structure"`
 }
 
 // String returns the string representation
@@ -2461,11 +2245,7 @@ type PutConfigRuleInput struct {
 	// in the AWS Config Developer Guide.
 	ConfigRule *ConfigRule `type:"structure" required:"true"`
 
-	metadataPutConfigRuleInput `json:"-" xml:"-"`
-}
-
-type metadataPutConfigRuleInput struct {
-	SDKShapeTraits bool `type:"structure"`
+	_ struct{} `type:"structure"`
 }
 
 // String returns the string representation
@@ -2479,11 +2259,7 @@ func (s PutConfigRuleInput) GoString() string {
 }
 
 type PutConfigRuleOutput struct {
-	metadataPutConfigRuleOutput `json:"-" xml:"-"`
-}
-
-type metadataPutConfigRuleOutput struct {
-	SDKShapeTraits bool `type:"structure"`
+	_ struct{} `type:"structure"`
 }
 
 // String returns the string representation
@@ -2502,11 +2278,7 @@ type PutConfigurationRecorderInput struct {
 	// made to the resources.
 	ConfigurationRecorder *ConfigurationRecorder `type:"structure" required:"true"`
 
-	metadataPutConfigurationRecorderInput `json:"-" xml:"-"`
-}
-
-type metadataPutConfigurationRecorderInput struct {
-	SDKShapeTraits bool `type:"structure"`
+	_ struct{} `type:"structure"`
 }
 
 // String returns the string representation
@@ -2520,11 +2292,7 @@ func (s PutConfigurationRecorderInput) GoString() string {
 }
 
 type PutConfigurationRecorderOutput struct {
-	metadataPutConfigurationRecorderOutput `json:"-" xml:"-"`
-}
-
-type metadataPutConfigurationRecorderOutput struct {
-	SDKShapeTraits bool `type:"structure"`
+	_ struct{} `type:"structure"`
 }
 
 // String returns the string representation
@@ -2543,11 +2311,7 @@ type PutDeliveryChannelInput struct {
 	// information to an Amazon S3 bucket, and to an Amazon SNS topic.
 	DeliveryChannel *DeliveryChannel `type:"structure" required:"true"`
 
-	metadataPutDeliveryChannelInput `json:"-" xml:"-"`
-}
-
-type metadataPutDeliveryChannelInput struct {
-	SDKShapeTraits bool `type:"structure"`
+	_ struct{} `type:"structure"`
 }
 
 // String returns the string representation
@@ -2561,11 +2325,7 @@ func (s PutDeliveryChannelInput) GoString() string {
 }
 
 type PutDeliveryChannelOutput struct {
-	metadataPutDeliveryChannelOutput `json:"-" xml:"-"`
-}
-
-type metadataPutDeliveryChannelOutput struct {
-	SDKShapeTraits bool `type:"structure"`
+	_ struct{} `type:"structure"`
 }
 
 // String returns the string representation
@@ -2588,11 +2348,7 @@ type PutEvaluationsInput struct {
 	// Identifies the rule and the event that triggered the evaluation
 	ResultToken *string `type:"string" required:"true"`
 
-	metadataPutEvaluationsInput `json:"-" xml:"-"`
-}
-
-type metadataPutEvaluationsInput struct {
-	SDKShapeTraits bool `type:"structure"`
+	_ struct{} `type:"structure"`
 }
 
 // String returns the string representation
@@ -2609,11 +2365,7 @@ type PutEvaluationsOutput struct {
 	// Requests that failed because of a client or server error.
 	FailedEvaluations []*Evaluation `type:"list"`
 
-	metadataPutEvaluationsOutput `json:"-" xml:"-"`
-}
-
-type metadataPutEvaluationsOutput struct {
-	SDKShapeTraits bool `type:"structure"`
+	_ struct{} `type:"structure"`
 }
 
 // String returns the string representation
@@ -2644,11 +2396,7 @@ type RecordingGroup struct {
 	// topic: Supported AWS Resource Types (http://docs.aws.amazon.com/config/latest/developerguide/resource-config-reference.html#supported-resources).
 	ResourceTypes []*string `locationName:"resourceTypes" type:"list"`
 
-	metadataRecordingGroup `json:"-" xml:"-"`
-}
-
-type metadataRecordingGroup struct {
-	SDKShapeTraits bool `type:"structure"`
+	_ struct{} `type:"structure"`
 }
 
 // String returns the string representation
@@ -2675,11 +2423,7 @@ type Relationship struct {
 	// The resource type of the related resource.
 	ResourceType *string `locationName:"resourceType" type:"string" enum:"ResourceType"`
 
-	metadataRelationship `json:"-" xml:"-"`
-}
-
-type metadataRelationship struct {
-	SDKShapeTraits bool `type:"structure"`
+	_ struct{} `type:"structure"`
 }
 
 // String returns the string representation
@@ -2707,11 +2451,7 @@ type ResourceIdentifier struct {
 	// The type of resource.
 	ResourceType *string `locationName:"resourceType" type:"string" enum:"ResourceType"`
 
-	metadataResourceIdentifier `json:"-" xml:"-"`
-}
-
-type metadataResourceIdentifier struct {
-	SDKShapeTraits bool `type:"structure"`
+	_ struct{} `type:"structure"`
 }
 
 // String returns the string representation
@@ -2750,11 +2490,7 @@ type Scope struct {
 	// also specify a value for TagKey.
 	TagValue *string `min:"1" type:"string"`
 
-	metadataScope `json:"-" xml:"-"`
-}
-
-type metadataScope struct {
-	SDKShapeTraits bool `type:"structure"`
+	_ struct{} `type:"structure"`
 }
 
 // String returns the string representation
@@ -2784,11 +2520,7 @@ type Source struct {
 	// Name (ARN) of the rule's AWS Lambda function.
 	SourceIdentifier *string `min:"1" type:"string"`
 
-	metadataSource `json:"-" xml:"-"`
-}
-
-type metadataSource struct {
-	SDKShapeTraits bool `type:"structure"`
+	_ struct{} `type:"structure"`
 }
 
 // String returns the string representation
@@ -2815,11 +2547,7 @@ type SourceDetail struct {
 	// you must use ConfigurationSnapshotDeliveryCompleted.
 	MessageType *string `type:"string" enum:"MessageType"`
 
-	metadataSourceDetail `json:"-" xml:"-"`
-}
-
-type metadataSourceDetail struct {
-	SDKShapeTraits bool `type:"structure"`
+	_ struct{} `type:"structure"`
 }
 
 // String returns the string representation
@@ -2838,11 +2566,7 @@ type StartConfigurationRecorderInput struct {
 	// to the resources.
 	ConfigurationRecorderName *string `min:"1" type:"string" required:"true"`
 
-	metadataStartConfigurationRecorderInput `json:"-" xml:"-"`
-}
-
-type metadataStartConfigurationRecorderInput struct {
-	SDKShapeTraits bool `type:"structure"`
+	_ struct{} `type:"structure"`
 }
 
 // String returns the string representation
@@ -2856,11 +2580,7 @@ func (s StartConfigurationRecorderInput) GoString() string {
 }
 
 type StartConfigurationRecorderOutput struct {
-	metadataStartConfigurationRecorderOutput `json:"-" xml:"-"`
-}
-
-type metadataStartConfigurationRecorderOutput struct {
-	SDKShapeTraits bool `type:"structure"`
+	_ struct{} `type:"structure"`
 }
 
 // String returns the string representation
@@ -2879,11 +2599,7 @@ type StopConfigurationRecorderInput struct {
 	// to the resources.
 	ConfigurationRecorderName *string `min:"1" type:"string" required:"true"`
 
-	metadataStopConfigurationRecorderInput `json:"-" xml:"-"`
-}
-
-type metadataStopConfigurationRecorderInput struct {
-	SDKShapeTraits bool `type:"structure"`
+	_ struct{} `type:"structure"`
 }
 
 // String returns the string representation
@@ -2897,11 +2613,7 @@ func (s StopConfigurationRecorderInput) GoString() string {
 }
 
 type StopConfigurationRecorderOutput struct {
-	metadataStopConfigurationRecorderOutput `json:"-" xml:"-"`
-}
-
-type metadataStopConfigurationRecorderOutput struct {
-	SDKShapeTraits bool `type:"structure"`
+	_ struct{} `type:"structure"`
 }
 
 // String returns the string representation

--- a/service/datapipeline/api.go
+++ b/service/datapipeline/api.go
@@ -650,6 +650,8 @@ func (c *DataPipeline) ValidatePipelineDefinition(input *ValidatePipelineDefinit
 
 // Contains the parameters for ActivatePipeline.
 type ActivatePipelineInput struct {
+	_ struct{} `type:"structure"`
+
 	// A list of parameter values to pass to the pipeline at activation.
 	ParameterValues []*ParameterValue `locationName:"parameterValues" type:"list"`
 
@@ -659,8 +661,6 @@ type ActivatePipelineInput struct {
 	// The date and time to resume the pipeline. By default, the pipeline resumes
 	// from the last completed execution.
 	StartTimestamp *time.Time `locationName:"startTimestamp" type:"timestamp" timestampFormat:"unix"`
-
-	_ struct{} `type:"structure"`
 }
 
 // String returns the string representation
@@ -690,13 +690,13 @@ func (s ActivatePipelineOutput) GoString() string {
 
 // Contains the parameters for AddTags.
 type AddTagsInput struct {
+	_ struct{} `type:"structure"`
+
 	// The ID of the pipeline.
 	PipelineId *string `locationName:"pipelineId" min:"1" type:"string" required:"true"`
 
 	// The tags to add, as key/value pairs.
 	Tags []*Tag `locationName:"tags" type:"list" required:"true"`
-
-	_ struct{} `type:"structure"`
 }
 
 // String returns the string representation
@@ -726,6 +726,8 @@ func (s AddTagsOutput) GoString() string {
 
 // Contains the parameters for CreatePipeline.
 type CreatePipelineInput struct {
+	_ struct{} `type:"structure"`
+
 	// The description for the pipeline.
 	Description *string `locationName:"description" type:"string"`
 
@@ -752,8 +754,6 @@ type CreatePipelineInput struct {
 	// The uniqueness of the name and unique identifier combination is scoped to
 	// the AWS account or IAM user credentials.
 	UniqueId *string `locationName:"uniqueId" min:"1" type:"string" required:"true"`
-
-	_ struct{} `type:"structure"`
 }
 
 // String returns the string representation
@@ -768,11 +768,11 @@ func (s CreatePipelineInput) GoString() string {
 
 // Contains the output of CreatePipeline.
 type CreatePipelineOutput struct {
+	_ struct{} `type:"structure"`
+
 	// The ID that AWS Data Pipeline assigns the newly created pipeline. For example,
 	// df-06372391ZG65EXAMPLE.
 	PipelineId *string `locationName:"pipelineId" min:"1" type:"string" required:"true"`
-
-	_ struct{} `type:"structure"`
 }
 
 // String returns the string representation
@@ -787,6 +787,8 @@ func (s CreatePipelineOutput) GoString() string {
 
 // Contains the parameters for DeactivatePipeline.
 type DeactivatePipelineInput struct {
+	_ struct{} `type:"structure"`
+
 	// Indicates whether to cancel any running objects. The default is true, which
 	// sets the state of any running objects to CANCELED. If this value is false,
 	// the pipeline is deactivated after all running objects finish.
@@ -794,8 +796,6 @@ type DeactivatePipelineInput struct {
 
 	// The ID of the pipeline.
 	PipelineId *string `locationName:"pipelineId" min:"1" type:"string" required:"true"`
-
-	_ struct{} `type:"structure"`
 }
 
 // String returns the string representation
@@ -825,10 +825,10 @@ func (s DeactivatePipelineOutput) GoString() string {
 
 // Contains the parameters for DeletePipeline.
 type DeletePipelineInput struct {
+	_ struct{} `type:"structure"`
+
 	// The ID of the pipeline.
 	PipelineId *string `locationName:"pipelineId" min:"1" type:"string" required:"true"`
-
-	_ struct{} `type:"structure"`
 }
 
 // String returns the string representation
@@ -857,6 +857,8 @@ func (s DeletePipelineOutput) GoString() string {
 
 // Contains the parameters for DescribeObjects.
 type DescribeObjectsInput struct {
+	_ struct{} `type:"structure"`
+
 	// Indicates whether any expressions in the object should be evaluated when
 	// the object descriptions are returned.
 	EvaluateExpressions *bool `locationName:"evaluateExpressions" type:"boolean"`
@@ -873,8 +875,6 @@ type DescribeObjectsInput struct {
 
 	// The ID of the pipeline that contains the object definitions.
 	PipelineId *string `locationName:"pipelineId" min:"1" type:"string" required:"true"`
-
-	_ struct{} `type:"structure"`
 }
 
 // String returns the string representation
@@ -889,6 +889,8 @@ func (s DescribeObjectsInput) GoString() string {
 
 // Contains the output of DescribeObjects.
 type DescribeObjectsOutput struct {
+	_ struct{} `type:"structure"`
+
 	// Indicates whether there are more results to return.
 	HasMoreResults *bool `locationName:"hasMoreResults" type:"boolean"`
 
@@ -899,8 +901,6 @@ type DescribeObjectsOutput struct {
 
 	// An array of object definitions.
 	PipelineObjects []*PipelineObject `locationName:"pipelineObjects" type:"list" required:"true"`
-
-	_ struct{} `type:"structure"`
 }
 
 // String returns the string representation
@@ -915,11 +915,11 @@ func (s DescribeObjectsOutput) GoString() string {
 
 // Contains the parameters for DescribePipelines.
 type DescribePipelinesInput struct {
+	_ struct{} `type:"structure"`
+
 	// The IDs of the pipelines to describe. You can pass as many as 25 identifiers
 	// in a single call. To obtain pipeline IDs, call ListPipelines.
 	PipelineIds []*string `locationName:"pipelineIds" type:"list" required:"true"`
-
-	_ struct{} `type:"structure"`
 }
 
 // String returns the string representation
@@ -934,10 +934,10 @@ func (s DescribePipelinesInput) GoString() string {
 
 // Contains the output of DescribePipelines.
 type DescribePipelinesOutput struct {
+	_ struct{} `type:"structure"`
+
 	// An array of descriptions for the specified pipelines.
 	PipelineDescriptionList []*PipelineDescription `locationName:"pipelineDescriptionList" type:"list" required:"true"`
-
-	_ struct{} `type:"structure"`
 }
 
 // String returns the string representation
@@ -952,6 +952,8 @@ func (s DescribePipelinesOutput) GoString() string {
 
 // Contains the parameters for EvaluateExpression.
 type EvaluateExpressionInput struct {
+	_ struct{} `type:"structure"`
+
 	// The expression to evaluate.
 	Expression *string `locationName:"expression" type:"string" required:"true"`
 
@@ -960,8 +962,6 @@ type EvaluateExpressionInput struct {
 
 	// The ID of the pipeline.
 	PipelineId *string `locationName:"pipelineId" min:"1" type:"string" required:"true"`
-
-	_ struct{} `type:"structure"`
 }
 
 // String returns the string representation
@@ -976,10 +976,10 @@ func (s EvaluateExpressionInput) GoString() string {
 
 // Contains the output of EvaluateExpression.
 type EvaluateExpressionOutput struct {
+	_ struct{} `type:"structure"`
+
 	// The evaluated expression.
 	EvaluatedExpression *string `locationName:"evaluatedExpression" type:"string" required:"true"`
-
-	_ struct{} `type:"structure"`
 }
 
 // String returns the string representation
@@ -996,6 +996,8 @@ func (s EvaluateExpressionOutput) GoString() string {
 // is specified as either a string value (StringValue) or a reference to another
 // object (RefValue) but not as both.
 type Field struct {
+	_ struct{} `type:"structure"`
+
 	// The field identifier.
 	Key *string `locationName:"key" min:"1" type:"string" required:"true"`
 
@@ -1004,8 +1006,6 @@ type Field struct {
 
 	// The field value, expressed as a String.
 	StringValue *string `locationName:"stringValue" type:"string"`
-
-	_ struct{} `type:"structure"`
 }
 
 // String returns the string representation
@@ -1020,6 +1020,8 @@ func (s Field) GoString() string {
 
 // Contains the parameters for GetPipelineDefinition.
 type GetPipelineDefinitionInput struct {
+	_ struct{} `type:"structure"`
+
 	// The ID of the pipeline.
 	PipelineId *string `locationName:"pipelineId" min:"1" type:"string" required:"true"`
 
@@ -1027,8 +1029,6 @@ type GetPipelineDefinitionInput struct {
 	// latest (default) to use the last definition saved to the pipeline or active
 	// to use the last definition that was activated.
 	Version *string `locationName:"version" type:"string"`
-
-	_ struct{} `type:"structure"`
 }
 
 // String returns the string representation
@@ -1043,6 +1043,8 @@ func (s GetPipelineDefinitionInput) GoString() string {
 
 // Contains the output of GetPipelineDefinition.
 type GetPipelineDefinitionOutput struct {
+	_ struct{} `type:"structure"`
+
 	// The parameter objects used in the pipeline definition.
 	ParameterObjects []*ParameterObject `locationName:"parameterObjects" type:"list"`
 
@@ -1051,8 +1053,6 @@ type GetPipelineDefinitionOutput struct {
 
 	// The objects defined in the pipeline.
 	PipelineObjects []*PipelineObject `locationName:"pipelineObjects" type:"list"`
-
-	_ struct{} `type:"structure"`
 }
 
 // String returns the string representation
@@ -1072,6 +1072,8 @@ func (s GetPipelineDefinitionOutput) GoString() string {
 // that your task runner is running on an EC2 instance, and ensures the proper
 // AWS Data Pipeline service charges are applied to your pipeline.
 type InstanceIdentity struct {
+	_ struct{} `type:"structure"`
+
 	// A description of an EC2 instance that is generated when the instance is launched
 	// and exposed to the instance via the instance metadata service in the form
 	// of a JSON representation of an object.
@@ -1080,8 +1082,6 @@ type InstanceIdentity struct {
 	// A signature which can be used to verify the accuracy and authenticity of
 	// the information provided in the instance identity document.
 	Signature *string `locationName:"signature" type:"string"`
-
-	_ struct{} `type:"structure"`
 }
 
 // String returns the string representation
@@ -1096,13 +1096,13 @@ func (s InstanceIdentity) GoString() string {
 
 // Contains the parameters for ListPipelines.
 type ListPipelinesInput struct {
+	_ struct{} `type:"structure"`
+
 	// The starting point for the results to be returned. For the first call, this
 	// value should be empty. As long as there are more results, continue to call
 	// ListPipelines with the marker value from the previous call to retrieve the
 	// next set of results.
 	Marker *string `locationName:"marker" type:"string"`
-
-	_ struct{} `type:"structure"`
 }
 
 // String returns the string representation
@@ -1117,6 +1117,8 @@ func (s ListPipelinesInput) GoString() string {
 
 // Contains the output of ListPipelines.
 type ListPipelinesOutput struct {
+	_ struct{} `type:"structure"`
+
 	// Indicates whether there are more results that can be obtained by a subsequent
 	// call.
 	HasMoreResults *bool `locationName:"hasMoreResults" type:"boolean"`
@@ -1129,8 +1131,6 @@ type ListPipelinesOutput struct {
 	// The pipeline identifiers. If you require additional information about the
 	// pipelines, you can use these identifiers to call DescribePipelines and GetPipelineDefinition.
 	PipelineIdList []*PipelineIdName `locationName:"pipelineIdList" type:"list" required:"true"`
-
-	_ struct{} `type:"structure"`
 }
 
 // String returns the string representation
@@ -1146,6 +1146,8 @@ func (s ListPipelinesOutput) GoString() string {
 // Contains a logical operation for comparing the value of a field with a specified
 // value.
 type Operator struct {
+	_ struct{} `type:"structure"`
+
 	// The logical operation to be performed: equal (EQ), equal reference (REF_EQ),
 	// less than or equal (LE), greater than or equal (GE), or between (BETWEEN).
 	// Equal reference (REF_EQ) can be used only with reference fields. The other
@@ -1168,8 +1170,6 @@ type Operator struct {
 
 	// The value that the actual field value will be compared with.
 	Values []*string `locationName:"values" type:"list"`
-
-	_ struct{} `type:"structure"`
 }
 
 // String returns the string representation
@@ -1184,13 +1184,13 @@ func (s Operator) GoString() string {
 
 // The attributes allowed or specified with a parameter object.
 type ParameterAttribute struct {
+	_ struct{} `type:"structure"`
+
 	// The field identifier.
 	Key *string `locationName:"key" min:"1" type:"string" required:"true"`
 
 	// The field value, expressed as a String.
 	StringValue *string `locationName:"stringValue" type:"string" required:"true"`
-
-	_ struct{} `type:"structure"`
 }
 
 // String returns the string representation
@@ -1205,13 +1205,13 @@ func (s ParameterAttribute) GoString() string {
 
 // Contains information about a parameter object.
 type ParameterObject struct {
+	_ struct{} `type:"structure"`
+
 	// The attributes of the parameter object.
 	Attributes []*ParameterAttribute `locationName:"attributes" type:"list" required:"true"`
 
 	// The ID of the parameter object.
 	Id *string `locationName:"id" min:"1" type:"string" required:"true"`
-
-	_ struct{} `type:"structure"`
 }
 
 // String returns the string representation
@@ -1226,13 +1226,13 @@ func (s ParameterObject) GoString() string {
 
 // A value or list of parameter values.
 type ParameterValue struct {
+	_ struct{} `type:"structure"`
+
 	// The ID of the parameter value.
 	Id *string `locationName:"id" min:"1" type:"string" required:"true"`
 
 	// The field value, expressed as a String.
 	StringValue *string `locationName:"stringValue" type:"string" required:"true"`
-
-	_ struct{} `type:"structure"`
 }
 
 // String returns the string representation
@@ -1247,6 +1247,8 @@ func (s ParameterValue) GoString() string {
 
 // Contains pipeline metadata.
 type PipelineDescription struct {
+	_ struct{} `type:"structure"`
+
 	// Description of the pipeline.
 	Description *string `locationName:"description" type:"string"`
 
@@ -1266,8 +1268,6 @@ type PipelineDescription struct {
 	// (http://docs.aws.amazon.com/datapipeline/latest/DeveloperGuide/dp-control-access.html)
 	// in the AWS Data Pipeline Developer Guide.
 	Tags []*Tag `locationName:"tags" type:"list"`
-
-	_ struct{} `type:"structure"`
 }
 
 // String returns the string representation
@@ -1282,14 +1282,14 @@ func (s PipelineDescription) GoString() string {
 
 // Contains the name and identifier of a pipeline.
 type PipelineIdName struct {
+	_ struct{} `type:"structure"`
+
 	// The ID of the pipeline that was assigned by AWS Data Pipeline. This is a
 	// string of the form df-297EG78HU43EEXAMPLE.
 	Id *string `locationName:"id" min:"1" type:"string"`
 
 	// The name of the pipeline.
 	Name *string `locationName:"name" min:"1" type:"string"`
-
-	_ struct{} `type:"structure"`
 }
 
 // String returns the string representation
@@ -1306,6 +1306,8 @@ func (s PipelineIdName) GoString() string {
 // or physical attempt pipeline object. The complete set of components of a
 // pipeline defines the pipeline.
 type PipelineObject struct {
+	_ struct{} `type:"structure"`
+
 	// Key-value pairs that define the properties of the object.
 	Fields []*Field `locationName:"fields" type:"list" required:"true"`
 
@@ -1314,8 +1316,6 @@ type PipelineObject struct {
 
 	// The name of the object.
 	Name *string `locationName:"name" min:"1" type:"string" required:"true"`
-
-	_ struct{} `type:"structure"`
 }
 
 // String returns the string representation
@@ -1330,6 +1330,8 @@ func (s PipelineObject) GoString() string {
 
 // Contains the parameters for PollForTask.
 type PollForTaskInput struct {
+	_ struct{} `type:"structure"`
+
 	// The public DNS name of the calling task runner.
 	Hostname *string `locationName:"hostname" min:"1" type:"string"`
 
@@ -1347,8 +1349,6 @@ type PollForTaskInput struct {
 	// There are no wildcard values permitted in workerGroup; the string must be
 	// an exact, case-sensitive, match.
 	WorkerGroup *string `locationName:"workerGroup" type:"string" required:"true"`
-
-	_ struct{} `type:"structure"`
 }
 
 // String returns the string representation
@@ -1363,13 +1363,13 @@ func (s PollForTaskInput) GoString() string {
 
 // Contains the output of PollForTask.
 type PollForTaskOutput struct {
+	_ struct{} `type:"structure"`
+
 	// The information needed to complete the task that is being assigned to the
 	// task runner. One of the fields returned in this object is taskId, which contains
 	// an identifier for the task being assigned. The calling task runner uses taskId
 	// in subsequent calls to ReportTaskProgress and SetTaskStatus.
 	TaskObject *TaskObject `locationName:"taskObject" type:"structure"`
-
-	_ struct{} `type:"structure"`
 }
 
 // String returns the string representation
@@ -1384,6 +1384,8 @@ func (s PollForTaskOutput) GoString() string {
 
 // Contains the parameters for PutPipelineDefinition.
 type PutPipelineDefinitionInput struct {
+	_ struct{} `type:"structure"`
+
 	// The parameter objects used with the pipeline.
 	ParameterObjects []*ParameterObject `locationName:"parameterObjects" type:"list"`
 
@@ -1396,8 +1398,6 @@ type PutPipelineDefinitionInput struct {
 	// The objects that define the pipeline. These objects overwrite the existing
 	// pipeline definition.
 	PipelineObjects []*PipelineObject `locationName:"pipelineObjects" type:"list" required:"true"`
-
-	_ struct{} `type:"structure"`
 }
 
 // String returns the string representation
@@ -1412,6 +1412,8 @@ func (s PutPipelineDefinitionInput) GoString() string {
 
 // Contains the output of PutPipelineDefinition.
 type PutPipelineDefinitionOutput struct {
+	_ struct{} `type:"structure"`
+
 	// Indicates whether there were validation errors, and the pipeline definition
 	// is stored but cannot be activated until you correct the pipeline and call
 	// PutPipelineDefinition to commit the corrected pipeline.
@@ -1422,8 +1424,6 @@ type PutPipelineDefinitionOutput struct {
 
 	// The validation warnings that are associated with the objects defined in pipelineObjects.
 	ValidationWarnings []*ValidationWarning `locationName:"validationWarnings" type:"list"`
-
-	_ struct{} `type:"structure"`
 }
 
 // String returns the string representation
@@ -1438,11 +1438,11 @@ func (s PutPipelineDefinitionOutput) GoString() string {
 
 // Defines the query to run against an object.
 type Query struct {
+	_ struct{} `type:"structure"`
+
 	// List of selectors that define the query. An object must satisfy all of the
 	// selectors to match the query.
 	Selectors []*Selector `locationName:"selectors" type:"list"`
-
-	_ struct{} `type:"structure"`
 }
 
 // String returns the string representation
@@ -1457,6 +1457,8 @@ func (s Query) GoString() string {
 
 // Contains the parameters for QueryObjects.
 type QueryObjectsInput struct {
+	_ struct{} `type:"structure"`
+
 	// The maximum number of object names that QueryObjects will return in a single
 	// call. The default value is 100.
 	Limit *int64 `locationName:"limit" type:"integer"`
@@ -1479,8 +1481,6 @@ type QueryObjectsInput struct {
 	// Indicates whether the query applies to components or instances. The possible
 	// values are: COMPONENT, INSTANCE, and ATTEMPT.
 	Sphere *string `locationName:"sphere" type:"string" required:"true"`
-
-	_ struct{} `type:"structure"`
 }
 
 // String returns the string representation
@@ -1495,6 +1495,8 @@ func (s QueryObjectsInput) GoString() string {
 
 // Contains the output of QueryObjects.
 type QueryObjectsOutput struct {
+	_ struct{} `type:"structure"`
+
 	// Indicates whether there are more results that can be obtained by a subsequent
 	// call.
 	HasMoreResults *bool `locationName:"hasMoreResults" type:"boolean"`
@@ -1506,8 +1508,6 @@ type QueryObjectsOutput struct {
 	// results, call QueryObjects again with this marker value. If the value is
 	// null, there are no more results.
 	Marker *string `locationName:"marker" type:"string"`
-
-	_ struct{} `type:"structure"`
 }
 
 // String returns the string representation
@@ -1522,13 +1522,13 @@ func (s QueryObjectsOutput) GoString() string {
 
 // Contains the parameters for RemoveTags.
 type RemoveTagsInput struct {
+	_ struct{} `type:"structure"`
+
 	// The ID of the pipeline.
 	PipelineId *string `locationName:"pipelineId" min:"1" type:"string" required:"true"`
 
 	// The keys of the tags to remove.
 	TagKeys []*string `locationName:"tagKeys" type:"list" required:"true"`
-
-	_ struct{} `type:"structure"`
 }
 
 // String returns the string representation
@@ -1558,6 +1558,8 @@ func (s RemoveTagsOutput) GoString() string {
 
 // Contains the parameters for ReportTaskProgress.
 type ReportTaskProgressInput struct {
+	_ struct{} `type:"structure"`
+
 	// Key-value pairs that define the properties of the ReportTaskProgressInput
 	// object.
 	Fields []*Field `locationName:"fields" type:"list"`
@@ -1565,8 +1567,6 @@ type ReportTaskProgressInput struct {
 	// The ID of the task assigned to the task runner. This value is provided in
 	// the response for PollForTask.
 	TaskId *string `locationName:"taskId" min:"1" type:"string" required:"true"`
-
-	_ struct{} `type:"structure"`
 }
 
 // String returns the string representation
@@ -1581,11 +1581,11 @@ func (s ReportTaskProgressInput) GoString() string {
 
 // Contains the output of ReportTaskProgress.
 type ReportTaskProgressOutput struct {
+	_ struct{} `type:"structure"`
+
 	// If true, the calling task runner should cancel processing of the task. The
 	// task runner does not need to call SetTaskStatus for canceled tasks.
 	Canceled *bool `locationName:"canceled" type:"boolean" required:"true"`
-
-	_ struct{} `type:"structure"`
 }
 
 // String returns the string representation
@@ -1600,6 +1600,8 @@ func (s ReportTaskProgressOutput) GoString() string {
 
 // Contains the parameters for ReportTaskRunnerHeartbeat.
 type ReportTaskRunnerHeartbeatInput struct {
+	_ struct{} `type:"structure"`
+
 	// The public DNS name of the task runner.
 	Hostname *string `locationName:"hostname" min:"1" type:"string"`
 
@@ -1616,8 +1618,6 @@ type ReportTaskRunnerHeartbeatInput struct {
 	// values permitted in workerGroup; the string must be an exact, case-sensitive,
 	// match.
 	WorkerGroup *string `locationName:"workerGroup" type:"string"`
-
-	_ struct{} `type:"structure"`
 }
 
 // String returns the string representation
@@ -1632,10 +1632,10 @@ func (s ReportTaskRunnerHeartbeatInput) GoString() string {
 
 // Contains the output of ReportTaskRunnerHeartbeat.
 type ReportTaskRunnerHeartbeatOutput struct {
+	_ struct{} `type:"structure"`
+
 	// Indicates whether the calling task runner should terminate.
 	Terminate *bool `locationName:"terminate" type:"boolean" required:"true"`
-
-	_ struct{} `type:"structure"`
 }
 
 // String returns the string representation
@@ -1651,6 +1651,8 @@ func (s ReportTaskRunnerHeartbeatOutput) GoString() string {
 // A comparision that is used to determine whether a query should return this
 // object.
 type Selector struct {
+	_ struct{} `type:"structure"`
+
 	// The name of the field that the operator will be applied to. The field name
 	// is the "key" portion of the field definition in the pipeline definition syntax
 	// that is used by the AWS Data Pipeline API. If the field is not set on the
@@ -1660,8 +1662,6 @@ type Selector struct {
 	// Contains a logical operation for comparing the value of a field with a specified
 	// value.
 	Operator *Operator `locationName:"operator" type:"structure"`
-
-	_ struct{} `type:"structure"`
 }
 
 // String returns the string representation
@@ -1676,6 +1676,8 @@ func (s Selector) GoString() string {
 
 // Contains the parameters for SetStatus.
 type SetStatusInput struct {
+	_ struct{} `type:"structure"`
+
 	// The IDs of the objects. The corresponding objects can be either physical
 	// or components, but not a mix of both types.
 	ObjectIds []*string `locationName:"objectIds" type:"list" required:"true"`
@@ -1686,8 +1688,6 @@ type SetStatusInput struct {
 	// The status to be set on all the objects specified in objectIds. For components,
 	// use PAUSE or RESUME. For instances, use TRY_CANCEL, RERUN, or MARK_FINISHED.
 	Status *string `locationName:"status" type:"string" required:"true"`
-
-	_ struct{} `type:"structure"`
 }
 
 // String returns the string representation
@@ -1716,6 +1716,8 @@ func (s SetStatusOutput) GoString() string {
 
 // Contains the parameters for SetTaskStatus.
 type SetTaskStatusInput struct {
+	_ struct{} `type:"structure"`
+
 	// If an error occurred during the task, this value specifies the error code.
 	// This value is set on the physical attempt object. It is used to display error
 	// information to the user. It should not start with string "Service_" which
@@ -1741,8 +1743,6 @@ type SetTaskStatusInput struct {
 	// If FINISHED, the task successfully completed. If FAILED, the task ended unsuccessfully.
 	// Preconditions use false.
 	TaskStatus *string `locationName:"taskStatus" type:"string" required:"true" enum:"TaskStatus"`
-
-	_ struct{} `type:"structure"`
 }
 
 // String returns the string representation
@@ -1776,6 +1776,8 @@ func (s SetTaskStatusOutput) GoString() string {
 // (http://docs.aws.amazon.com/datapipeline/latest/DeveloperGuide/dp-control-access.html)
 // in the AWS Data Pipeline Developer Guide.
 type Tag struct {
+	_ struct{} `type:"structure"`
+
 	// The key name of a tag defined by a user. For more information, see Controlling
 	// User Access to Pipelines (http://docs.aws.amazon.com/datapipeline/latest/DeveloperGuide/dp-control-access.html)
 	// in the AWS Data Pipeline Developer Guide.
@@ -1785,8 +1787,6 @@ type Tag struct {
 	// see Controlling User Access to Pipelines (http://docs.aws.amazon.com/datapipeline/latest/DeveloperGuide/dp-control-access.html)
 	// in the AWS Data Pipeline Developer Guide.
 	Value *string `locationName:"value" type:"string" required:"true"`
-
-	_ struct{} `type:"structure"`
 }
 
 // String returns the string representation
@@ -1801,6 +1801,8 @@ func (s Tag) GoString() string {
 
 // Contains information about a pipeline task that is assigned to a task runner.
 type TaskObject struct {
+	_ struct{} `type:"structure"`
+
 	// The ID of the pipeline task attempt object. AWS Data Pipeline uses this value
 	// to track how many times a task is attempted.
 	AttemptId *string `locationName:"attemptId" min:"1" type:"string"`
@@ -1815,8 +1817,6 @@ type TaskObject struct {
 	// An internal identifier for the task. This ID is passed to the SetTaskStatus
 	// and ReportTaskProgress actions.
 	TaskId *string `locationName:"taskId" min:"1" type:"string"`
-
-	_ struct{} `type:"structure"`
 }
 
 // String returns the string representation
@@ -1831,6 +1831,8 @@ func (s TaskObject) GoString() string {
 
 // Contains the parameters for ValidatePipelineDefinition.
 type ValidatePipelineDefinitionInput struct {
+	_ struct{} `type:"structure"`
+
 	// The parameter objects used with the pipeline.
 	ParameterObjects []*ParameterObject `locationName:"parameterObjects" type:"list"`
 
@@ -1842,8 +1844,6 @@ type ValidatePipelineDefinitionInput struct {
 
 	// The objects that define the pipeline changes to validate against the pipeline.
 	PipelineObjects []*PipelineObject `locationName:"pipelineObjects" type:"list" required:"true"`
-
-	_ struct{} `type:"structure"`
 }
 
 // String returns the string representation
@@ -1858,6 +1858,8 @@ func (s ValidatePipelineDefinitionInput) GoString() string {
 
 // Contains the output of ValidatePipelineDefinition.
 type ValidatePipelineDefinitionOutput struct {
+	_ struct{} `type:"structure"`
+
 	// Indicates whether there were validation errors.
 	Errored *bool `locationName:"errored" type:"boolean" required:"true"`
 
@@ -1866,8 +1868,6 @@ type ValidatePipelineDefinitionOutput struct {
 
 	// Any validation warnings that were found.
 	ValidationWarnings []*ValidationWarning `locationName:"validationWarnings" type:"list"`
-
-	_ struct{} `type:"structure"`
 }
 
 // String returns the string representation
@@ -1884,13 +1884,13 @@ func (s ValidatePipelineDefinitionOutput) GoString() string {
 // The set of validation errors that can be returned are defined by AWS Data
 // Pipeline.
 type ValidationError struct {
+	_ struct{} `type:"structure"`
+
 	// A description of the validation error.
 	Errors []*string `locationName:"errors" type:"list"`
 
 	// The identifier of the object that contains the validation error.
 	Id *string `locationName:"id" min:"1" type:"string"`
-
-	_ struct{} `type:"structure"`
 }
 
 // String returns the string representation
@@ -1907,13 +1907,13 @@ func (s ValidationError) GoString() string {
 // activation. The set of validation warnings that can be returned are defined
 // by AWS Data Pipeline.
 type ValidationWarning struct {
+	_ struct{} `type:"structure"`
+
 	// The identifier of the object that contains the validation warning.
 	Id *string `locationName:"id" min:"1" type:"string"`
 
 	// A description of the validation warning.
 	Warnings []*string `locationName:"warnings" type:"list"`
-
-	_ struct{} `type:"structure"`
 }
 
 // String returns the string representation

--- a/service/datapipeline/api.go
+++ b/service/datapipeline/api.go
@@ -660,11 +660,7 @@ type ActivatePipelineInput struct {
 	// from the last completed execution.
 	StartTimestamp *time.Time `locationName:"startTimestamp" type:"timestamp" timestampFormat:"unix"`
 
-	metadataActivatePipelineInput `json:"-" xml:"-"`
-}
-
-type metadataActivatePipelineInput struct {
-	SDKShapeTraits bool `type:"structure"`
+	_ struct{} `type:"structure"`
 }
 
 // String returns the string representation
@@ -679,11 +675,7 @@ func (s ActivatePipelineInput) GoString() string {
 
 // Contains the output of ActivatePipeline.
 type ActivatePipelineOutput struct {
-	metadataActivatePipelineOutput `json:"-" xml:"-"`
-}
-
-type metadataActivatePipelineOutput struct {
-	SDKShapeTraits bool `type:"structure"`
+	_ struct{} `type:"structure"`
 }
 
 // String returns the string representation
@@ -704,11 +696,7 @@ type AddTagsInput struct {
 	// The tags to add, as key/value pairs.
 	Tags []*Tag `locationName:"tags" type:"list" required:"true"`
 
-	metadataAddTagsInput `json:"-" xml:"-"`
-}
-
-type metadataAddTagsInput struct {
-	SDKShapeTraits bool `type:"structure"`
+	_ struct{} `type:"structure"`
 }
 
 // String returns the string representation
@@ -723,11 +711,7 @@ func (s AddTagsInput) GoString() string {
 
 // Contains the output of AddTags.
 type AddTagsOutput struct {
-	metadataAddTagsOutput `json:"-" xml:"-"`
-}
-
-type metadataAddTagsOutput struct {
-	SDKShapeTraits bool `type:"structure"`
+	_ struct{} `type:"structure"`
 }
 
 // String returns the string representation
@@ -769,11 +753,7 @@ type CreatePipelineInput struct {
 	// the AWS account or IAM user credentials.
 	UniqueId *string `locationName:"uniqueId" min:"1" type:"string" required:"true"`
 
-	metadataCreatePipelineInput `json:"-" xml:"-"`
-}
-
-type metadataCreatePipelineInput struct {
-	SDKShapeTraits bool `type:"structure"`
+	_ struct{} `type:"structure"`
 }
 
 // String returns the string representation
@@ -792,11 +772,7 @@ type CreatePipelineOutput struct {
 	// df-06372391ZG65EXAMPLE.
 	PipelineId *string `locationName:"pipelineId" min:"1" type:"string" required:"true"`
 
-	metadataCreatePipelineOutput `json:"-" xml:"-"`
-}
-
-type metadataCreatePipelineOutput struct {
-	SDKShapeTraits bool `type:"structure"`
+	_ struct{} `type:"structure"`
 }
 
 // String returns the string representation
@@ -819,11 +795,7 @@ type DeactivatePipelineInput struct {
 	// The ID of the pipeline.
 	PipelineId *string `locationName:"pipelineId" min:"1" type:"string" required:"true"`
 
-	metadataDeactivatePipelineInput `json:"-" xml:"-"`
-}
-
-type metadataDeactivatePipelineInput struct {
-	SDKShapeTraits bool `type:"structure"`
+	_ struct{} `type:"structure"`
 }
 
 // String returns the string representation
@@ -838,11 +810,7 @@ func (s DeactivatePipelineInput) GoString() string {
 
 // Contains the output of DeactivatePipeline.
 type DeactivatePipelineOutput struct {
-	metadataDeactivatePipelineOutput `json:"-" xml:"-"`
-}
-
-type metadataDeactivatePipelineOutput struct {
-	SDKShapeTraits bool `type:"structure"`
+	_ struct{} `type:"structure"`
 }
 
 // String returns the string representation
@@ -860,11 +828,7 @@ type DeletePipelineInput struct {
 	// The ID of the pipeline.
 	PipelineId *string `locationName:"pipelineId" min:"1" type:"string" required:"true"`
 
-	metadataDeletePipelineInput `json:"-" xml:"-"`
-}
-
-type metadataDeletePipelineInput struct {
-	SDKShapeTraits bool `type:"structure"`
+	_ struct{} `type:"structure"`
 }
 
 // String returns the string representation
@@ -878,11 +842,7 @@ func (s DeletePipelineInput) GoString() string {
 }
 
 type DeletePipelineOutput struct {
-	metadataDeletePipelineOutput `json:"-" xml:"-"`
-}
-
-type metadataDeletePipelineOutput struct {
-	SDKShapeTraits bool `type:"structure"`
+	_ struct{} `type:"structure"`
 }
 
 // String returns the string representation
@@ -914,11 +874,7 @@ type DescribeObjectsInput struct {
 	// The ID of the pipeline that contains the object definitions.
 	PipelineId *string `locationName:"pipelineId" min:"1" type:"string" required:"true"`
 
-	metadataDescribeObjectsInput `json:"-" xml:"-"`
-}
-
-type metadataDescribeObjectsInput struct {
-	SDKShapeTraits bool `type:"structure"`
+	_ struct{} `type:"structure"`
 }
 
 // String returns the string representation
@@ -944,11 +900,7 @@ type DescribeObjectsOutput struct {
 	// An array of object definitions.
 	PipelineObjects []*PipelineObject `locationName:"pipelineObjects" type:"list" required:"true"`
 
-	metadataDescribeObjectsOutput `json:"-" xml:"-"`
-}
-
-type metadataDescribeObjectsOutput struct {
-	SDKShapeTraits bool `type:"structure"`
+	_ struct{} `type:"structure"`
 }
 
 // String returns the string representation
@@ -967,11 +919,7 @@ type DescribePipelinesInput struct {
 	// in a single call. To obtain pipeline IDs, call ListPipelines.
 	PipelineIds []*string `locationName:"pipelineIds" type:"list" required:"true"`
 
-	metadataDescribePipelinesInput `json:"-" xml:"-"`
-}
-
-type metadataDescribePipelinesInput struct {
-	SDKShapeTraits bool `type:"structure"`
+	_ struct{} `type:"structure"`
 }
 
 // String returns the string representation
@@ -989,11 +937,7 @@ type DescribePipelinesOutput struct {
 	// An array of descriptions for the specified pipelines.
 	PipelineDescriptionList []*PipelineDescription `locationName:"pipelineDescriptionList" type:"list" required:"true"`
 
-	metadataDescribePipelinesOutput `json:"-" xml:"-"`
-}
-
-type metadataDescribePipelinesOutput struct {
-	SDKShapeTraits bool `type:"structure"`
+	_ struct{} `type:"structure"`
 }
 
 // String returns the string representation
@@ -1017,11 +961,7 @@ type EvaluateExpressionInput struct {
 	// The ID of the pipeline.
 	PipelineId *string `locationName:"pipelineId" min:"1" type:"string" required:"true"`
 
-	metadataEvaluateExpressionInput `json:"-" xml:"-"`
-}
-
-type metadataEvaluateExpressionInput struct {
-	SDKShapeTraits bool `type:"structure"`
+	_ struct{} `type:"structure"`
 }
 
 // String returns the string representation
@@ -1039,11 +979,7 @@ type EvaluateExpressionOutput struct {
 	// The evaluated expression.
 	EvaluatedExpression *string `locationName:"evaluatedExpression" type:"string" required:"true"`
 
-	metadataEvaluateExpressionOutput `json:"-" xml:"-"`
-}
-
-type metadataEvaluateExpressionOutput struct {
-	SDKShapeTraits bool `type:"structure"`
+	_ struct{} `type:"structure"`
 }
 
 // String returns the string representation
@@ -1069,11 +1005,7 @@ type Field struct {
 	// The field value, expressed as a String.
 	StringValue *string `locationName:"stringValue" type:"string"`
 
-	metadataField `json:"-" xml:"-"`
-}
-
-type metadataField struct {
-	SDKShapeTraits bool `type:"structure"`
+	_ struct{} `type:"structure"`
 }
 
 // String returns the string representation
@@ -1096,11 +1028,7 @@ type GetPipelineDefinitionInput struct {
 	// to use the last definition that was activated.
 	Version *string `locationName:"version" type:"string"`
 
-	metadataGetPipelineDefinitionInput `json:"-" xml:"-"`
-}
-
-type metadataGetPipelineDefinitionInput struct {
-	SDKShapeTraits bool `type:"structure"`
+	_ struct{} `type:"structure"`
 }
 
 // String returns the string representation
@@ -1124,11 +1052,7 @@ type GetPipelineDefinitionOutput struct {
 	// The objects defined in the pipeline.
 	PipelineObjects []*PipelineObject `locationName:"pipelineObjects" type:"list"`
 
-	metadataGetPipelineDefinitionOutput `json:"-" xml:"-"`
-}
-
-type metadataGetPipelineDefinitionOutput struct {
-	SDKShapeTraits bool `type:"structure"`
+	_ struct{} `type:"structure"`
 }
 
 // String returns the string representation
@@ -1157,11 +1081,7 @@ type InstanceIdentity struct {
 	// the information provided in the instance identity document.
 	Signature *string `locationName:"signature" type:"string"`
 
-	metadataInstanceIdentity `json:"-" xml:"-"`
-}
-
-type metadataInstanceIdentity struct {
-	SDKShapeTraits bool `type:"structure"`
+	_ struct{} `type:"structure"`
 }
 
 // String returns the string representation
@@ -1182,11 +1102,7 @@ type ListPipelinesInput struct {
 	// next set of results.
 	Marker *string `locationName:"marker" type:"string"`
 
-	metadataListPipelinesInput `json:"-" xml:"-"`
-}
-
-type metadataListPipelinesInput struct {
-	SDKShapeTraits bool `type:"structure"`
+	_ struct{} `type:"structure"`
 }
 
 // String returns the string representation
@@ -1214,11 +1130,7 @@ type ListPipelinesOutput struct {
 	// pipelines, you can use these identifiers to call DescribePipelines and GetPipelineDefinition.
 	PipelineIdList []*PipelineIdName `locationName:"pipelineIdList" type:"list" required:"true"`
 
-	metadataListPipelinesOutput `json:"-" xml:"-"`
-}
-
-type metadataListPipelinesOutput struct {
-	SDKShapeTraits bool `type:"structure"`
+	_ struct{} `type:"structure"`
 }
 
 // String returns the string representation
@@ -1257,11 +1169,7 @@ type Operator struct {
 	// The value that the actual field value will be compared with.
 	Values []*string `locationName:"values" type:"list"`
 
-	metadataOperator `json:"-" xml:"-"`
-}
-
-type metadataOperator struct {
-	SDKShapeTraits bool `type:"structure"`
+	_ struct{} `type:"structure"`
 }
 
 // String returns the string representation
@@ -1282,11 +1190,7 @@ type ParameterAttribute struct {
 	// The field value, expressed as a String.
 	StringValue *string `locationName:"stringValue" type:"string" required:"true"`
 
-	metadataParameterAttribute `json:"-" xml:"-"`
-}
-
-type metadataParameterAttribute struct {
-	SDKShapeTraits bool `type:"structure"`
+	_ struct{} `type:"structure"`
 }
 
 // String returns the string representation
@@ -1307,11 +1211,7 @@ type ParameterObject struct {
 	// The ID of the parameter object.
 	Id *string `locationName:"id" min:"1" type:"string" required:"true"`
 
-	metadataParameterObject `json:"-" xml:"-"`
-}
-
-type metadataParameterObject struct {
-	SDKShapeTraits bool `type:"structure"`
+	_ struct{} `type:"structure"`
 }
 
 // String returns the string representation
@@ -1332,11 +1232,7 @@ type ParameterValue struct {
 	// The field value, expressed as a String.
 	StringValue *string `locationName:"stringValue" type:"string" required:"true"`
 
-	metadataParameterValue `json:"-" xml:"-"`
-}
-
-type metadataParameterValue struct {
-	SDKShapeTraits bool `type:"structure"`
+	_ struct{} `type:"structure"`
 }
 
 // String returns the string representation
@@ -1371,11 +1267,7 @@ type PipelineDescription struct {
 	// in the AWS Data Pipeline Developer Guide.
 	Tags []*Tag `locationName:"tags" type:"list"`
 
-	metadataPipelineDescription `json:"-" xml:"-"`
-}
-
-type metadataPipelineDescription struct {
-	SDKShapeTraits bool `type:"structure"`
+	_ struct{} `type:"structure"`
 }
 
 // String returns the string representation
@@ -1397,11 +1289,7 @@ type PipelineIdName struct {
 	// The name of the pipeline.
 	Name *string `locationName:"name" min:"1" type:"string"`
 
-	metadataPipelineIdName `json:"-" xml:"-"`
-}
-
-type metadataPipelineIdName struct {
-	SDKShapeTraits bool `type:"structure"`
+	_ struct{} `type:"structure"`
 }
 
 // String returns the string representation
@@ -1427,11 +1315,7 @@ type PipelineObject struct {
 	// The name of the object.
 	Name *string `locationName:"name" min:"1" type:"string" required:"true"`
 
-	metadataPipelineObject `json:"-" xml:"-"`
-}
-
-type metadataPipelineObject struct {
-	SDKShapeTraits bool `type:"structure"`
+	_ struct{} `type:"structure"`
 }
 
 // String returns the string representation
@@ -1464,11 +1348,7 @@ type PollForTaskInput struct {
 	// an exact, case-sensitive, match.
 	WorkerGroup *string `locationName:"workerGroup" type:"string" required:"true"`
 
-	metadataPollForTaskInput `json:"-" xml:"-"`
-}
-
-type metadataPollForTaskInput struct {
-	SDKShapeTraits bool `type:"structure"`
+	_ struct{} `type:"structure"`
 }
 
 // String returns the string representation
@@ -1489,11 +1369,7 @@ type PollForTaskOutput struct {
 	// in subsequent calls to ReportTaskProgress and SetTaskStatus.
 	TaskObject *TaskObject `locationName:"taskObject" type:"structure"`
 
-	metadataPollForTaskOutput `json:"-" xml:"-"`
-}
-
-type metadataPollForTaskOutput struct {
-	SDKShapeTraits bool `type:"structure"`
+	_ struct{} `type:"structure"`
 }
 
 // String returns the string representation
@@ -1521,11 +1397,7 @@ type PutPipelineDefinitionInput struct {
 	// pipeline definition.
 	PipelineObjects []*PipelineObject `locationName:"pipelineObjects" type:"list" required:"true"`
 
-	metadataPutPipelineDefinitionInput `json:"-" xml:"-"`
-}
-
-type metadataPutPipelineDefinitionInput struct {
-	SDKShapeTraits bool `type:"structure"`
+	_ struct{} `type:"structure"`
 }
 
 // String returns the string representation
@@ -1551,11 +1423,7 @@ type PutPipelineDefinitionOutput struct {
 	// The validation warnings that are associated with the objects defined in pipelineObjects.
 	ValidationWarnings []*ValidationWarning `locationName:"validationWarnings" type:"list"`
 
-	metadataPutPipelineDefinitionOutput `json:"-" xml:"-"`
-}
-
-type metadataPutPipelineDefinitionOutput struct {
-	SDKShapeTraits bool `type:"structure"`
+	_ struct{} `type:"structure"`
 }
 
 // String returns the string representation
@@ -1574,11 +1442,7 @@ type Query struct {
 	// selectors to match the query.
 	Selectors []*Selector `locationName:"selectors" type:"list"`
 
-	metadataQuery `json:"-" xml:"-"`
-}
-
-type metadataQuery struct {
-	SDKShapeTraits bool `type:"structure"`
+	_ struct{} `type:"structure"`
 }
 
 // String returns the string representation
@@ -1616,11 +1480,7 @@ type QueryObjectsInput struct {
 	// values are: COMPONENT, INSTANCE, and ATTEMPT.
 	Sphere *string `locationName:"sphere" type:"string" required:"true"`
 
-	metadataQueryObjectsInput `json:"-" xml:"-"`
-}
-
-type metadataQueryObjectsInput struct {
-	SDKShapeTraits bool `type:"structure"`
+	_ struct{} `type:"structure"`
 }
 
 // String returns the string representation
@@ -1647,11 +1507,7 @@ type QueryObjectsOutput struct {
 	// null, there are no more results.
 	Marker *string `locationName:"marker" type:"string"`
 
-	metadataQueryObjectsOutput `json:"-" xml:"-"`
-}
-
-type metadataQueryObjectsOutput struct {
-	SDKShapeTraits bool `type:"structure"`
+	_ struct{} `type:"structure"`
 }
 
 // String returns the string representation
@@ -1672,11 +1528,7 @@ type RemoveTagsInput struct {
 	// The keys of the tags to remove.
 	TagKeys []*string `locationName:"tagKeys" type:"list" required:"true"`
 
-	metadataRemoveTagsInput `json:"-" xml:"-"`
-}
-
-type metadataRemoveTagsInput struct {
-	SDKShapeTraits bool `type:"structure"`
+	_ struct{} `type:"structure"`
 }
 
 // String returns the string representation
@@ -1691,11 +1543,7 @@ func (s RemoveTagsInput) GoString() string {
 
 // Contains the output of RemoveTags.
 type RemoveTagsOutput struct {
-	metadataRemoveTagsOutput `json:"-" xml:"-"`
-}
-
-type metadataRemoveTagsOutput struct {
-	SDKShapeTraits bool `type:"structure"`
+	_ struct{} `type:"structure"`
 }
 
 // String returns the string representation
@@ -1718,11 +1566,7 @@ type ReportTaskProgressInput struct {
 	// the response for PollForTask.
 	TaskId *string `locationName:"taskId" min:"1" type:"string" required:"true"`
 
-	metadataReportTaskProgressInput `json:"-" xml:"-"`
-}
-
-type metadataReportTaskProgressInput struct {
-	SDKShapeTraits bool `type:"structure"`
+	_ struct{} `type:"structure"`
 }
 
 // String returns the string representation
@@ -1741,11 +1585,7 @@ type ReportTaskProgressOutput struct {
 	// task runner does not need to call SetTaskStatus for canceled tasks.
 	Canceled *bool `locationName:"canceled" type:"boolean" required:"true"`
 
-	metadataReportTaskProgressOutput `json:"-" xml:"-"`
-}
-
-type metadataReportTaskProgressOutput struct {
-	SDKShapeTraits bool `type:"structure"`
+	_ struct{} `type:"structure"`
 }
 
 // String returns the string representation
@@ -1777,11 +1617,7 @@ type ReportTaskRunnerHeartbeatInput struct {
 	// match.
 	WorkerGroup *string `locationName:"workerGroup" type:"string"`
 
-	metadataReportTaskRunnerHeartbeatInput `json:"-" xml:"-"`
-}
-
-type metadataReportTaskRunnerHeartbeatInput struct {
-	SDKShapeTraits bool `type:"structure"`
+	_ struct{} `type:"structure"`
 }
 
 // String returns the string representation
@@ -1799,11 +1635,7 @@ type ReportTaskRunnerHeartbeatOutput struct {
 	// Indicates whether the calling task runner should terminate.
 	Terminate *bool `locationName:"terminate" type:"boolean" required:"true"`
 
-	metadataReportTaskRunnerHeartbeatOutput `json:"-" xml:"-"`
-}
-
-type metadataReportTaskRunnerHeartbeatOutput struct {
-	SDKShapeTraits bool `type:"structure"`
+	_ struct{} `type:"structure"`
 }
 
 // String returns the string representation
@@ -1829,11 +1661,7 @@ type Selector struct {
 	// value.
 	Operator *Operator `locationName:"operator" type:"structure"`
 
-	metadataSelector `json:"-" xml:"-"`
-}
-
-type metadataSelector struct {
-	SDKShapeTraits bool `type:"structure"`
+	_ struct{} `type:"structure"`
 }
 
 // String returns the string representation
@@ -1859,11 +1687,7 @@ type SetStatusInput struct {
 	// use PAUSE or RESUME. For instances, use TRY_CANCEL, RERUN, or MARK_FINISHED.
 	Status *string `locationName:"status" type:"string" required:"true"`
 
-	metadataSetStatusInput `json:"-" xml:"-"`
-}
-
-type metadataSetStatusInput struct {
-	SDKShapeTraits bool `type:"structure"`
+	_ struct{} `type:"structure"`
 }
 
 // String returns the string representation
@@ -1877,11 +1701,7 @@ func (s SetStatusInput) GoString() string {
 }
 
 type SetStatusOutput struct {
-	metadataSetStatusOutput `json:"-" xml:"-"`
-}
-
-type metadataSetStatusOutput struct {
-	SDKShapeTraits bool `type:"structure"`
+	_ struct{} `type:"structure"`
 }
 
 // String returns the string representation
@@ -1922,11 +1742,7 @@ type SetTaskStatusInput struct {
 	// Preconditions use false.
 	TaskStatus *string `locationName:"taskStatus" type:"string" required:"true" enum:"TaskStatus"`
 
-	metadataSetTaskStatusInput `json:"-" xml:"-"`
-}
-
-type metadataSetTaskStatusInput struct {
-	SDKShapeTraits bool `type:"structure"`
+	_ struct{} `type:"structure"`
 }
 
 // String returns the string representation
@@ -1941,11 +1757,7 @@ func (s SetTaskStatusInput) GoString() string {
 
 // Contains the output of SetTaskStatus.
 type SetTaskStatusOutput struct {
-	metadataSetTaskStatusOutput `json:"-" xml:"-"`
-}
-
-type metadataSetTaskStatusOutput struct {
-	SDKShapeTraits bool `type:"structure"`
+	_ struct{} `type:"structure"`
 }
 
 // String returns the string representation
@@ -1974,11 +1786,7 @@ type Tag struct {
 	// in the AWS Data Pipeline Developer Guide.
 	Value *string `locationName:"value" type:"string" required:"true"`
 
-	metadataTag `json:"-" xml:"-"`
-}
-
-type metadataTag struct {
-	SDKShapeTraits bool `type:"structure"`
+	_ struct{} `type:"structure"`
 }
 
 // String returns the string representation
@@ -2008,11 +1816,7 @@ type TaskObject struct {
 	// and ReportTaskProgress actions.
 	TaskId *string `locationName:"taskId" min:"1" type:"string"`
 
-	metadataTaskObject `json:"-" xml:"-"`
-}
-
-type metadataTaskObject struct {
-	SDKShapeTraits bool `type:"structure"`
+	_ struct{} `type:"structure"`
 }
 
 // String returns the string representation
@@ -2039,11 +1843,7 @@ type ValidatePipelineDefinitionInput struct {
 	// The objects that define the pipeline changes to validate against the pipeline.
 	PipelineObjects []*PipelineObject `locationName:"pipelineObjects" type:"list" required:"true"`
 
-	metadataValidatePipelineDefinitionInput `json:"-" xml:"-"`
-}
-
-type metadataValidatePipelineDefinitionInput struct {
-	SDKShapeTraits bool `type:"structure"`
+	_ struct{} `type:"structure"`
 }
 
 // String returns the string representation
@@ -2067,11 +1867,7 @@ type ValidatePipelineDefinitionOutput struct {
 	// Any validation warnings that were found.
 	ValidationWarnings []*ValidationWarning `locationName:"validationWarnings" type:"list"`
 
-	metadataValidatePipelineDefinitionOutput `json:"-" xml:"-"`
-}
-
-type metadataValidatePipelineDefinitionOutput struct {
-	SDKShapeTraits bool `type:"structure"`
+	_ struct{} `type:"structure"`
 }
 
 // String returns the string representation
@@ -2094,11 +1890,7 @@ type ValidationError struct {
 	// The identifier of the object that contains the validation error.
 	Id *string `locationName:"id" min:"1" type:"string"`
 
-	metadataValidationError `json:"-" xml:"-"`
-}
-
-type metadataValidationError struct {
-	SDKShapeTraits bool `type:"structure"`
+	_ struct{} `type:"structure"`
 }
 
 // String returns the string representation
@@ -2121,11 +1913,7 @@ type ValidationWarning struct {
 	// A description of the validation warning.
 	Warnings []*string `locationName:"warnings" type:"list"`
 
-	metadataValidationWarning `json:"-" xml:"-"`
-}
-
-type metadataValidationWarning struct {
-	SDKShapeTraits bool `type:"structure"`
+	_ struct{} `type:"structure"`
 }
 
 // String returns the string representation

--- a/service/devicefarm/api.go
+++ b/service/devicefarm/api.go
@@ -1017,11 +1017,7 @@ type AccountSettings struct {
 	// Returns the unmetered devices you have purchased.
 	UnmeteredDevices map[string]*int64 `locationName:"unmeteredDevices" type:"map"`
 
-	metadataAccountSettings `json:"-" xml:"-"`
-}
-
-type metadataAccountSettings struct {
-	SDKShapeTraits bool `type:"structure"`
+	_ struct{} `type:"structure"`
 }
 
 // String returns the string representation
@@ -1087,11 +1083,7 @@ type Artifact struct {
 	// to download the artifact's file.
 	Url *string `locationName:"url" type:"string"`
 
-	metadataArtifact `json:"-" xml:"-"`
-}
-
-type metadataArtifact struct {
-	SDKShapeTraits bool `type:"structure"`
+	_ struct{} `type:"structure"`
 }
 
 // String returns the string representation
@@ -1118,11 +1110,7 @@ type CPU struct {
 	// The CPU's frequency.
 	Frequency *string `locationName:"frequency" type:"string"`
 
-	metadataCPU `json:"-" xml:"-"`
-}
-
-type metadataCPU struct {
-	SDKShapeTraits bool `type:"structure"`
+	_ struct{} `type:"structure"`
 }
 
 // String returns the string representation
@@ -1158,11 +1146,7 @@ type Counters struct {
 	// The number of warned entities.
 	Warned *int64 `locationName:"warned" type:"integer"`
 
-	metadataCounters `json:"-" xml:"-"`
-}
-
-type metadataCounters struct {
-	SDKShapeTraits bool `type:"structure"`
+	_ struct{} `type:"structure"`
 }
 
 // String returns the string representation
@@ -1189,11 +1173,7 @@ type CreateDevicePoolInput struct {
 	// The device pool's rules.
 	Rules []*Rule `locationName:"rules" type:"list" required:"true"`
 
-	metadataCreateDevicePoolInput `json:"-" xml:"-"`
-}
-
-type metadataCreateDevicePoolInput struct {
-	SDKShapeTraits bool `type:"structure"`
+	_ struct{} `type:"structure"`
 }
 
 // String returns the string representation
@@ -1211,11 +1191,7 @@ type CreateDevicePoolOutput struct {
 	// The newly created device pool.
 	DevicePool *DevicePool `locationName:"devicePool" type:"structure"`
 
-	metadataCreateDevicePoolOutput `json:"-" xml:"-"`
-}
-
-type metadataCreateDevicePoolOutput struct {
-	SDKShapeTraits bool `type:"structure"`
+	_ struct{} `type:"structure"`
 }
 
 // String returns the string representation
@@ -1233,11 +1209,7 @@ type CreateProjectInput struct {
 	// The project's name.
 	Name *string `locationName:"name" type:"string" required:"true"`
 
-	metadataCreateProjectInput `json:"-" xml:"-"`
-}
-
-type metadataCreateProjectInput struct {
-	SDKShapeTraits bool `type:"structure"`
+	_ struct{} `type:"structure"`
 }
 
 // String returns the string representation
@@ -1255,11 +1227,7 @@ type CreateProjectOutput struct {
 	// The newly created project.
 	Project *Project `locationName:"project" type:"structure"`
 
-	metadataCreateProjectOutput `json:"-" xml:"-"`
-}
-
-type metadataCreateProjectOutput struct {
-	SDKShapeTraits bool `type:"structure"`
+	_ struct{} `type:"structure"`
 }
 
 // String returns the string representation
@@ -1314,11 +1282,7 @@ type CreateUploadInput struct {
 	// an ArgumentException error.
 	Type *string `locationName:"type" type:"string" required:"true" enum:"UploadType"`
 
-	metadataCreateUploadInput `json:"-" xml:"-"`
-}
-
-type metadataCreateUploadInput struct {
-	SDKShapeTraits bool `type:"structure"`
+	_ struct{} `type:"structure"`
 }
 
 // String returns the string representation
@@ -1336,11 +1300,7 @@ type CreateUploadOutput struct {
 	// The newly created upload.
 	Upload *Upload `locationName:"upload" type:"structure"`
 
-	metadataCreateUploadOutput `json:"-" xml:"-"`
-}
-
-type metadataCreateUploadOutput struct {
-	SDKShapeTraits bool `type:"structure"`
+	_ struct{} `type:"structure"`
 }
 
 // String returns the string representation
@@ -1359,11 +1319,7 @@ type DeleteDevicePoolInput struct {
 	// you wish to delete.
 	Arn *string `locationName:"arn" min:"32" type:"string" required:"true"`
 
-	metadataDeleteDevicePoolInput `json:"-" xml:"-"`
-}
-
-type metadataDeleteDevicePoolInput struct {
-	SDKShapeTraits bool `type:"structure"`
+	_ struct{} `type:"structure"`
 }
 
 // String returns the string representation
@@ -1378,11 +1334,7 @@ func (s DeleteDevicePoolInput) GoString() string {
 
 // Represents the result of a delete device pool request.
 type DeleteDevicePoolOutput struct {
-	metadataDeleteDevicePoolOutput `json:"-" xml:"-"`
-}
-
-type metadataDeleteDevicePoolOutput struct {
-	SDKShapeTraits bool `type:"structure"`
+	_ struct{} `type:"structure"`
 }
 
 // String returns the string representation
@@ -1401,11 +1353,7 @@ type DeleteProjectInput struct {
 	// wish to delete.
 	Arn *string `locationName:"arn" min:"32" type:"string" required:"true"`
 
-	metadataDeleteProjectInput `json:"-" xml:"-"`
-}
-
-type metadataDeleteProjectInput struct {
-	SDKShapeTraits bool `type:"structure"`
+	_ struct{} `type:"structure"`
 }
 
 // String returns the string representation
@@ -1420,11 +1368,7 @@ func (s DeleteProjectInput) GoString() string {
 
 // Represents the result of a delete project request.
 type DeleteProjectOutput struct {
-	metadataDeleteProjectOutput `json:"-" xml:"-"`
-}
-
-type metadataDeleteProjectOutput struct {
-	SDKShapeTraits bool `type:"structure"`
+	_ struct{} `type:"structure"`
 }
 
 // String returns the string representation
@@ -1442,11 +1386,7 @@ type DeleteRunInput struct {
 	// The Amazon Resource Name (ARN) for the run you wish to delete.
 	Arn *string `locationName:"arn" min:"32" type:"string" required:"true"`
 
-	metadataDeleteRunInput `json:"-" xml:"-"`
-}
-
-type metadataDeleteRunInput struct {
-	SDKShapeTraits bool `type:"structure"`
+	_ struct{} `type:"structure"`
 }
 
 // String returns the string representation
@@ -1461,11 +1401,7 @@ func (s DeleteRunInput) GoString() string {
 
 // Represents the result of a delete run request.
 type DeleteRunOutput struct {
-	metadataDeleteRunOutput `json:"-" xml:"-"`
-}
-
-type metadataDeleteRunOutput struct {
-	SDKShapeTraits bool `type:"structure"`
+	_ struct{} `type:"structure"`
 }
 
 // String returns the string representation
@@ -1484,11 +1420,7 @@ type DeleteUploadInput struct {
 	// to delete.
 	Arn *string `locationName:"arn" min:"32" type:"string" required:"true"`
 
-	metadataDeleteUploadInput `json:"-" xml:"-"`
-}
-
-type metadataDeleteUploadInput struct {
-	SDKShapeTraits bool `type:"structure"`
+	_ struct{} `type:"structure"`
 }
 
 // String returns the string representation
@@ -1503,11 +1435,7 @@ func (s DeleteUploadInput) GoString() string {
 
 // Represents the result of a delete upload request.
 type DeleteUploadOutput struct {
-	metadataDeleteUploadOutput `json:"-" xml:"-"`
-}
-
-type metadataDeleteUploadOutput struct {
-	SDKShapeTraits bool `type:"structure"`
+	_ struct{} `type:"structure"`
 }
 
 // String returns the string representation
@@ -1577,11 +1505,7 @@ type Device struct {
 	// in pixels.
 	Resolution *Resolution `locationName:"resolution" type:"structure"`
 
-	metadataDevice `json:"-" xml:"-"`
-}
-
-type metadataDevice struct {
-	SDKShapeTraits bool `type:"structure"`
+	_ struct{} `type:"structure"`
 }
 
 // String returns the string representation
@@ -1609,11 +1533,7 @@ type DeviceMinutes struct {
 	// resource to run tests.
 	Unmetered *float64 `locationName:"unmetered" type:"double"`
 
-	metadataDeviceMinutes `json:"-" xml:"-"`
-}
-
-type metadataDeviceMinutes struct {
-	SDKShapeTraits bool `type:"structure"`
+	_ struct{} `type:"structure"`
 }
 
 // String returns the string representation
@@ -1649,11 +1569,7 @@ type DevicePool struct {
 	// PRIVATE: A device pool that is created and managed by the device pool developer.
 	Type *string `locationName:"type" type:"string" enum:"DevicePoolType"`
 
-	metadataDevicePool `json:"-" xml:"-"`
-}
-
-type metadataDevicePool struct {
-	SDKShapeTraits bool `type:"structure"`
+	_ struct{} `type:"structure"`
 }
 
 // String returns the string representation
@@ -1677,11 +1593,7 @@ type DevicePoolCompatibilityResult struct {
 	// Information about the compatibility.
 	IncompatibilityMessages []*IncompatibilityMessage `locationName:"incompatibilityMessages" type:"list"`
 
-	metadataDevicePoolCompatibilityResult `json:"-" xml:"-"`
-}
-
-type metadataDevicePoolCompatibilityResult struct {
-	SDKShapeTraits bool `type:"structure"`
+	_ struct{} `type:"structure"`
 }
 
 // String returns the string representation
@@ -1695,11 +1607,7 @@ func (s DevicePoolCompatibilityResult) GoString() string {
 }
 
 type GetAccountSettingsInput struct {
-	metadataGetAccountSettingsInput `json:"-" xml:"-"`
-}
-
-type metadataGetAccountSettingsInput struct {
-	SDKShapeTraits bool `type:"structure"`
+	_ struct{} `type:"structure"`
 }
 
 // String returns the string representation
@@ -1716,11 +1624,7 @@ type GetAccountSettingsOutput struct {
 	// A container for account-level settings within AWS Device Farm.
 	AccountSettings *AccountSettings `locationName:"accountSettings" type:"structure"`
 
-	metadataGetAccountSettingsOutput `json:"-" xml:"-"`
-}
-
-type metadataGetAccountSettingsOutput struct {
-	SDKShapeTraits bool `type:"structure"`
+	_ struct{} `type:"structure"`
 }
 
 // String returns the string representation
@@ -1738,11 +1642,7 @@ type GetDeviceInput struct {
 	// The device type's ARN.
 	Arn *string `locationName:"arn" min:"32" type:"string" required:"true"`
 
-	metadataGetDeviceInput `json:"-" xml:"-"`
-}
-
-type metadataGetDeviceInput struct {
-	SDKShapeTraits bool `type:"structure"`
+	_ struct{} `type:"structure"`
 }
 
 // String returns the string representation
@@ -1760,11 +1660,7 @@ type GetDeviceOutput struct {
 	// Represents a device type that an app is tested against.
 	Device *Device `locationName:"device" type:"structure"`
 
-	metadataGetDeviceOutput `json:"-" xml:"-"`
-}
-
-type metadataGetDeviceOutput struct {
-	SDKShapeTraits bool `type:"structure"`
+	_ struct{} `type:"structure"`
 }
 
 // String returns the string representation
@@ -1809,11 +1705,7 @@ type GetDevicePoolCompatibilityInput struct {
 	// XCTEST: The XCode test type.
 	TestType *string `locationName:"testType" type:"string" enum:"TestType"`
 
-	metadataGetDevicePoolCompatibilityInput `json:"-" xml:"-"`
-}
-
-type metadataGetDevicePoolCompatibilityInput struct {
-	SDKShapeTraits bool `type:"structure"`
+	_ struct{} `type:"structure"`
 }
 
 // String returns the string representation
@@ -1834,11 +1726,7 @@ type GetDevicePoolCompatibilityOutput struct {
 	// Information about incompatible devices.
 	IncompatibleDevices []*DevicePoolCompatibilityResult `locationName:"incompatibleDevices" type:"list"`
 
-	metadataGetDevicePoolCompatibilityOutput `json:"-" xml:"-"`
-}
-
-type metadataGetDevicePoolCompatibilityOutput struct {
-	SDKShapeTraits bool `type:"structure"`
+	_ struct{} `type:"structure"`
 }
 
 // String returns the string representation
@@ -1856,11 +1744,7 @@ type GetDevicePoolInput struct {
 	// The device pool's ARN.
 	Arn *string `locationName:"arn" min:"32" type:"string" required:"true"`
 
-	metadataGetDevicePoolInput `json:"-" xml:"-"`
-}
-
-type metadataGetDevicePoolInput struct {
-	SDKShapeTraits bool `type:"structure"`
+	_ struct{} `type:"structure"`
 }
 
 // String returns the string representation
@@ -1878,11 +1762,7 @@ type GetDevicePoolOutput struct {
 	// Represents a collection of device types.
 	DevicePool *DevicePool `locationName:"devicePool" type:"structure"`
 
-	metadataGetDevicePoolOutput `json:"-" xml:"-"`
-}
-
-type metadataGetDevicePoolOutput struct {
-	SDKShapeTraits bool `type:"structure"`
+	_ struct{} `type:"structure"`
 }
 
 // String returns the string representation
@@ -1900,11 +1780,7 @@ type GetJobInput struct {
 	// The job's ARN.
 	Arn *string `locationName:"arn" min:"32" type:"string" required:"true"`
 
-	metadataGetJobInput `json:"-" xml:"-"`
-}
-
-type metadataGetJobInput struct {
-	SDKShapeTraits bool `type:"structure"`
+	_ struct{} `type:"structure"`
 }
 
 // String returns the string representation
@@ -1922,11 +1798,7 @@ type GetJobOutput struct {
 	// Represents a device.
 	Job *Job `locationName:"job" type:"structure"`
 
-	metadataGetJobOutput `json:"-" xml:"-"`
-}
-
-type metadataGetJobOutput struct {
-	SDKShapeTraits bool `type:"structure"`
+	_ struct{} `type:"structure"`
 }
 
 // String returns the string representation
@@ -1944,11 +1816,7 @@ type GetProjectInput struct {
 	// The project's ARN.
 	Arn *string `locationName:"arn" min:"32" type:"string" required:"true"`
 
-	metadataGetProjectInput `json:"-" xml:"-"`
-}
-
-type metadataGetProjectInput struct {
-	SDKShapeTraits bool `type:"structure"`
+	_ struct{} `type:"structure"`
 }
 
 // String returns the string representation
@@ -1967,11 +1835,7 @@ type GetProjectOutput struct {
 	// tests.
 	Project *Project `locationName:"project" type:"structure"`
 
-	metadataGetProjectOutput `json:"-" xml:"-"`
-}
-
-type metadataGetProjectOutput struct {
-	SDKShapeTraits bool `type:"structure"`
+	_ struct{} `type:"structure"`
 }
 
 // String returns the string representation
@@ -1989,11 +1853,7 @@ type GetRunInput struct {
 	// The run's ARN.
 	Arn *string `locationName:"arn" min:"32" type:"string" required:"true"`
 
-	metadataGetRunInput `json:"-" xml:"-"`
-}
-
-type metadataGetRunInput struct {
-	SDKShapeTraits bool `type:"structure"`
+	_ struct{} `type:"structure"`
 }
 
 // String returns the string representation
@@ -2011,11 +1871,7 @@ type GetRunOutput struct {
 	// Represents an app on a set of devices with a specific test and configuration.
 	Run *Run `locationName:"run" type:"structure"`
 
-	metadataGetRunOutput `json:"-" xml:"-"`
-}
-
-type metadataGetRunOutput struct {
-	SDKShapeTraits bool `type:"structure"`
+	_ struct{} `type:"structure"`
 }
 
 // String returns the string representation
@@ -2033,11 +1889,7 @@ type GetSuiteInput struct {
 	// The suite's ARN.
 	Arn *string `locationName:"arn" min:"32" type:"string" required:"true"`
 
-	metadataGetSuiteInput `json:"-" xml:"-"`
-}
-
-type metadataGetSuiteInput struct {
-	SDKShapeTraits bool `type:"structure"`
+	_ struct{} `type:"structure"`
 }
 
 // String returns the string representation
@@ -2055,11 +1907,7 @@ type GetSuiteOutput struct {
 	// Represents a collection of one or more tests.
 	Suite *Suite `locationName:"suite" type:"structure"`
 
-	metadataGetSuiteOutput `json:"-" xml:"-"`
-}
-
-type metadataGetSuiteOutput struct {
-	SDKShapeTraits bool `type:"structure"`
+	_ struct{} `type:"structure"`
 }
 
 // String returns the string representation
@@ -2077,11 +1925,7 @@ type GetTestInput struct {
 	// The test's ARN.
 	Arn *string `locationName:"arn" min:"32" type:"string" required:"true"`
 
-	metadataGetTestInput `json:"-" xml:"-"`
-}
-
-type metadataGetTestInput struct {
-	SDKShapeTraits bool `type:"structure"`
+	_ struct{} `type:"structure"`
 }
 
 // String returns the string representation
@@ -2099,11 +1943,7 @@ type GetTestOutput struct {
 	// Represents a condition that is evaluated.
 	Test *Test `locationName:"test" type:"structure"`
 
-	metadataGetTestOutput `json:"-" xml:"-"`
-}
-
-type metadataGetTestOutput struct {
-	SDKShapeTraits bool `type:"structure"`
+	_ struct{} `type:"structure"`
 }
 
 // String returns the string representation
@@ -2121,11 +1961,7 @@ type GetUploadInput struct {
 	// The upload's ARN.
 	Arn *string `locationName:"arn" min:"32" type:"string" required:"true"`
 
-	metadataGetUploadInput `json:"-" xml:"-"`
-}
-
-type metadataGetUploadInput struct {
-	SDKShapeTraits bool `type:"structure"`
+	_ struct{} `type:"structure"`
 }
 
 // String returns the string representation
@@ -2143,11 +1979,7 @@ type GetUploadOutput struct {
 	// An app or a set of one or more tests to upload or that have been uploaded.
 	Upload *Upload `locationName:"upload" type:"structure"`
 
-	metadataGetUploadOutput `json:"-" xml:"-"`
-}
-
-type metadataGetUploadOutput struct {
-	SDKShapeTraits bool `type:"structure"`
+	_ struct{} `type:"structure"`
 }
 
 // String returns the string representation
@@ -2178,11 +2010,7 @@ type IncompatibilityMessage struct {
 	// PLATFORM: The platform (for example, Android or iOS).
 	Type *string `locationName:"type" type:"string" enum:"DeviceAttribute"`
 
-	metadataIncompatibilityMessage `json:"-" xml:"-"`
-}
-
-type metadataIncompatibilityMessage struct {
-	SDKShapeTraits bool `type:"structure"`
+	_ struct{} `type:"structure"`
 }
 
 // String returns the string representation
@@ -2282,11 +2110,7 @@ type Job struct {
 	// XCTEST: The XCode test type.
 	Type *string `locationName:"type" type:"string" enum:"TestType"`
 
-	metadataJob `json:"-" xml:"-"`
-}
-
-type metadataJob struct {
-	SDKShapeTraits bool `type:"structure"`
+	_ struct{} `type:"structure"`
 }
 
 // String returns the string representation
@@ -2316,11 +2140,7 @@ type ListArtifactsInput struct {
 	// The artifacts are screenshots.
 	Type *string `locationName:"type" type:"string" required:"true" enum:"ArtifactCategory"`
 
-	metadataListArtifactsInput `json:"-" xml:"-"`
-}
-
-type metadataListArtifactsInput struct {
-	SDKShapeTraits bool `type:"structure"`
+	_ struct{} `type:"structure"`
 }
 
 // String returns the string representation
@@ -2343,11 +2163,7 @@ type ListArtifactsOutput struct {
 	// to this operation to return the next set of items in the list.
 	NextToken *string `locationName:"nextToken" min:"4" type:"string"`
 
-	metadataListArtifactsOutput `json:"-" xml:"-"`
-}
-
-type metadataListArtifactsOutput struct {
-	SDKShapeTraits bool `type:"structure"`
+	_ struct{} `type:"structure"`
 }
 
 // String returns the string representation
@@ -2378,11 +2194,7 @@ type ListDevicePoolsInput struct {
 	// PRIVATE: A device pool that is created and managed by the device pool developer.
 	Type *string `locationName:"type" type:"string" enum:"DevicePoolType"`
 
-	metadataListDevicePoolsInput `json:"-" xml:"-"`
-}
-
-type metadataListDevicePoolsInput struct {
-	SDKShapeTraits bool `type:"structure"`
+	_ struct{} `type:"structure"`
 }
 
 // String returns the string representation
@@ -2405,11 +2217,7 @@ type ListDevicePoolsOutput struct {
 	// to this operation to return the next set of items in the list.
 	NextToken *string `locationName:"nextToken" min:"4" type:"string"`
 
-	metadataListDevicePoolsOutput `json:"-" xml:"-"`
-}
-
-type metadataListDevicePoolsOutput struct {
-	SDKShapeTraits bool `type:"structure"`
+	_ struct{} `type:"structure"`
 }
 
 // String returns the string representation
@@ -2431,11 +2239,7 @@ type ListDevicesInput struct {
 	// which can be used to return the next set of items in the list.
 	NextToken *string `locationName:"nextToken" min:"4" type:"string"`
 
-	metadataListDevicesInput `json:"-" xml:"-"`
-}
-
-type metadataListDevicesInput struct {
-	SDKShapeTraits bool `type:"structure"`
+	_ struct{} `type:"structure"`
 }
 
 // String returns the string representation
@@ -2458,11 +2262,7 @@ type ListDevicesOutput struct {
 	// to this operation to return the next set of items in the list.
 	NextToken *string `locationName:"nextToken" min:"4" type:"string"`
 
-	metadataListDevicesOutput `json:"-" xml:"-"`
-}
-
-type metadataListDevicesOutput struct {
-	SDKShapeTraits bool `type:"structure"`
+	_ struct{} `type:"structure"`
 }
 
 // String returns the string representation
@@ -2484,11 +2284,7 @@ type ListJobsInput struct {
 	// which can be used to return the next set of items in the list.
 	NextToken *string `locationName:"nextToken" min:"4" type:"string"`
 
-	metadataListJobsInput `json:"-" xml:"-"`
-}
-
-type metadataListJobsInput struct {
-	SDKShapeTraits bool `type:"structure"`
+	_ struct{} `type:"structure"`
 }
 
 // String returns the string representation
@@ -2511,11 +2307,7 @@ type ListJobsOutput struct {
 	// to this operation to return the next set of items in the list.
 	NextToken *string `locationName:"nextToken" min:"4" type:"string"`
 
-	metadataListJobsOutput `json:"-" xml:"-"`
-}
-
-type metadataListJobsOutput struct {
-	SDKShapeTraits bool `type:"structure"`
+	_ struct{} `type:"structure"`
 }
 
 // String returns the string representation
@@ -2537,11 +2329,7 @@ type ListProjectsInput struct {
 	// which can be used to return the next set of items in the list.
 	NextToken *string `locationName:"nextToken" min:"4" type:"string"`
 
-	metadataListProjectsInput `json:"-" xml:"-"`
-}
-
-type metadataListProjectsInput struct {
-	SDKShapeTraits bool `type:"structure"`
+	_ struct{} `type:"structure"`
 }
 
 // String returns the string representation
@@ -2564,11 +2352,7 @@ type ListProjectsOutput struct {
 	// Information about the projects.
 	Projects []*Project `locationName:"projects" type:"list"`
 
-	metadataListProjectsOutput `json:"-" xml:"-"`
-}
-
-type metadataListProjectsOutput struct {
-	SDKShapeTraits bool `type:"structure"`
+	_ struct{} `type:"structure"`
 }
 
 // String returns the string representation
@@ -2590,11 +2374,7 @@ type ListRunsInput struct {
 	// which can be used to return the next set of items in the list.
 	NextToken *string `locationName:"nextToken" min:"4" type:"string"`
 
-	metadataListRunsInput `json:"-" xml:"-"`
-}
-
-type metadataListRunsInput struct {
-	SDKShapeTraits bool `type:"structure"`
+	_ struct{} `type:"structure"`
 }
 
 // String returns the string representation
@@ -2617,11 +2397,7 @@ type ListRunsOutput struct {
 	// Information about the runs.
 	Runs []*Run `locationName:"runs" type:"list"`
 
-	metadataListRunsOutput `json:"-" xml:"-"`
-}
-
-type metadataListRunsOutput struct {
-	SDKShapeTraits bool `type:"structure"`
+	_ struct{} `type:"structure"`
 }
 
 // String returns the string representation
@@ -2643,11 +2419,7 @@ type ListSamplesInput struct {
 	// which can be used to return the next set of items in the list.
 	NextToken *string `locationName:"nextToken" min:"4" type:"string"`
 
-	metadataListSamplesInput `json:"-" xml:"-"`
-}
-
-type metadataListSamplesInput struct {
-	SDKShapeTraits bool `type:"structure"`
+	_ struct{} `type:"structure"`
 }
 
 // String returns the string representation
@@ -2670,11 +2442,7 @@ type ListSamplesOutput struct {
 	// Information about the samples.
 	Samples []*Sample `locationName:"samples" type:"list"`
 
-	metadataListSamplesOutput `json:"-" xml:"-"`
-}
-
-type metadataListSamplesOutput struct {
-	SDKShapeTraits bool `type:"structure"`
+	_ struct{} `type:"structure"`
 }
 
 // String returns the string representation
@@ -2696,11 +2464,7 @@ type ListSuitesInput struct {
 	// which can be used to return the next set of items in the list.
 	NextToken *string `locationName:"nextToken" min:"4" type:"string"`
 
-	metadataListSuitesInput `json:"-" xml:"-"`
-}
-
-type metadataListSuitesInput struct {
-	SDKShapeTraits bool `type:"structure"`
+	_ struct{} `type:"structure"`
 }
 
 // String returns the string representation
@@ -2723,11 +2487,7 @@ type ListSuitesOutput struct {
 	// Information about the suites.
 	Suites []*Suite `locationName:"suites" type:"list"`
 
-	metadataListSuitesOutput `json:"-" xml:"-"`
-}
-
-type metadataListSuitesOutput struct {
-	SDKShapeTraits bool `type:"structure"`
+	_ struct{} `type:"structure"`
 }
 
 // String returns the string representation
@@ -2749,11 +2509,7 @@ type ListTestsInput struct {
 	// which can be used to return the next set of items in the list.
 	NextToken *string `locationName:"nextToken" min:"4" type:"string"`
 
-	metadataListTestsInput `json:"-" xml:"-"`
-}
-
-type metadataListTestsInput struct {
-	SDKShapeTraits bool `type:"structure"`
+	_ struct{} `type:"structure"`
 }
 
 // String returns the string representation
@@ -2776,11 +2532,7 @@ type ListTestsOutput struct {
 	// Information about the tests.
 	Tests []*Test `locationName:"tests" type:"list"`
 
-	metadataListTestsOutput `json:"-" xml:"-"`
-}
-
-type metadataListTestsOutput struct {
-	SDKShapeTraits bool `type:"structure"`
+	_ struct{} `type:"structure"`
 }
 
 // String returns the string representation
@@ -2802,11 +2554,7 @@ type ListUniqueProblemsInput struct {
 	// which can be used to return the next set of items in the list.
 	NextToken *string `locationName:"nextToken" min:"4" type:"string"`
 
-	metadataListUniqueProblemsInput `json:"-" xml:"-"`
-}
-
-type metadataListUniqueProblemsInput struct {
-	SDKShapeTraits bool `type:"structure"`
+	_ struct{} `type:"structure"`
 }
 
 // String returns the string representation
@@ -2845,11 +2593,7 @@ type ListUniqueProblemsOutput struct {
 	// WARNED: A warning condition.
 	UniqueProblems map[string][]*UniqueProblem `locationName:"uniqueProblems" type:"map"`
 
-	metadataListUniqueProblemsOutput `json:"-" xml:"-"`
-}
-
-type metadataListUniqueProblemsOutput struct {
-	SDKShapeTraits bool `type:"structure"`
+	_ struct{} `type:"structure"`
 }
 
 // String returns the string representation
@@ -2871,11 +2615,7 @@ type ListUploadsInput struct {
 	// which can be used to return the next set of items in the list.
 	NextToken *string `locationName:"nextToken" min:"4" type:"string"`
 
-	metadataListUploadsInput `json:"-" xml:"-"`
-}
-
-type metadataListUploadsInput struct {
-	SDKShapeTraits bool `type:"structure"`
+	_ struct{} `type:"structure"`
 }
 
 // String returns the string representation
@@ -2898,11 +2638,7 @@ type ListUploadsOutput struct {
 	// Information about the uploads.
 	Uploads []*Upload `locationName:"uploads" type:"list"`
 
-	metadataListUploadsOutput `json:"-" xml:"-"`
-}
-
-type metadataListUploadsOutput struct {
-	SDKShapeTraits bool `type:"structure"`
+	_ struct{} `type:"structure"`
 }
 
 // String returns the string representation
@@ -2926,11 +2662,7 @@ type Location struct {
 	// The longitude.
 	Longitude *float64 `locationName:"longitude" type:"double" required:"true"`
 
-	metadataLocation `json:"-" xml:"-"`
-}
-
-type metadataLocation struct {
-	SDKShapeTraits bool `type:"structure"`
+	_ struct{} `type:"structure"`
 }
 
 // String returns the string representation
@@ -2982,11 +2714,7 @@ type Problem struct {
 	// Information about the associated test.
 	Test *ProblemDetail `locationName:"test" type:"structure"`
 
-	metadataProblem `json:"-" xml:"-"`
-}
-
-type metadataProblem struct {
-	SDKShapeTraits bool `type:"structure"`
+	_ struct{} `type:"structure"`
 }
 
 // String returns the string representation
@@ -3007,11 +2735,7 @@ type ProblemDetail struct {
 	// The problem detail's name.
 	Name *string `locationName:"name" type:"string"`
 
-	metadataProblemDetail `json:"-" xml:"-"`
-}
-
-type metadataProblemDetail struct {
-	SDKShapeTraits bool `type:"structure"`
+	_ struct{} `type:"structure"`
 }
 
 // String returns the string representation
@@ -3036,11 +2760,7 @@ type Project struct {
 	// The project's name.
 	Name *string `locationName:"name" type:"string"`
 
-	metadataProject `json:"-" xml:"-"`
-}
-
-type metadataProject struct {
-	SDKShapeTraits bool `type:"structure"`
+	_ struct{} `type:"structure"`
 }
 
 // String returns the string representation
@@ -3068,11 +2788,7 @@ type Radios struct {
 	// True if Wi-Fi is enabled at the beginning of the test; otherwise, false.
 	Wifi *bool `locationName:"wifi" type:"boolean"`
 
-	metadataRadios `json:"-" xml:"-"`
-}
-
-type metadataRadios struct {
-	SDKShapeTraits bool `type:"structure"`
+	_ struct{} `type:"structure"`
 }
 
 // String returns the string representation
@@ -3094,11 +2810,7 @@ type Resolution struct {
 	// The screen resolution's width, expressed in pixels.
 	Width *int64 `locationName:"width" type:"integer"`
 
-	metadataResolution `json:"-" xml:"-"`
-}
-
-type metadataResolution struct {
-	SDKShapeTraits bool `type:"structure"`
+	_ struct{} `type:"structure"`
 }
 
 // String returns the string representation
@@ -3142,11 +2854,7 @@ type Rule struct {
 	// The rule's value.
 	Value *string `locationName:"value" type:"string"`
 
-	metadataRule `json:"-" xml:"-"`
-}
-
-type metadataRule struct {
-	SDKShapeTraits bool `type:"structure"`
+	_ struct{} `type:"structure"`
 }
 
 // String returns the string representation
@@ -3262,11 +2970,7 @@ type Run struct {
 	// XCTEST: The XCode test type.
 	Type *string `locationName:"type" type:"string" enum:"TestType"`
 
-	metadataRun `json:"-" xml:"-"`
-}
-
-type metadataRun struct {
-	SDKShapeTraits bool `type:"structure"`
+	_ struct{} `type:"structure"`
 }
 
 // String returns the string representation
@@ -3332,11 +3036,7 @@ type Sample struct {
 	// to download the sample's file.
 	Url *string `locationName:"url" type:"string"`
 
-	metadataSample `json:"-" xml:"-"`
-}
-
-type metadataSample struct {
-	SDKShapeTraits bool `type:"structure"`
+	_ struct{} `type:"structure"`
 }
 
 // String returns the string representation
@@ -3376,11 +3076,7 @@ type ScheduleRunConfiguration struct {
 	// Information about the radio states for the run.
 	Radios *Radios `locationName:"radios" type:"structure"`
 
-	metadataScheduleRunConfiguration `json:"-" xml:"-"`
-}
-
-type metadataScheduleRunConfiguration struct {
-	SDKShapeTraits bool `type:"structure"`
+	_ struct{} `type:"structure"`
 }
 
 // String returns the string representation
@@ -3413,11 +3109,7 @@ type ScheduleRunInput struct {
 	// Information about the test for the run to be scheduled.
 	Test *ScheduleRunTest `locationName:"test" type:"structure" required:"true"`
 
-	metadataScheduleRunInput `json:"-" xml:"-"`
-}
-
-type metadataScheduleRunInput struct {
-	SDKShapeTraits bool `type:"structure"`
+	_ struct{} `type:"structure"`
 }
 
 // String returns the string representation
@@ -3435,11 +3127,7 @@ type ScheduleRunOutput struct {
 	// Information about the scheduled run.
 	Run *Run `locationName:"run" type:"structure"`
 
-	metadataScheduleRunOutput `json:"-" xml:"-"`
-}
-
-type metadataScheduleRunOutput struct {
-	SDKShapeTraits bool `type:"structure"`
+	_ struct{} `type:"structure"`
 }
 
 // String returns the string representation
@@ -3487,11 +3175,7 @@ type ScheduleRunTest struct {
 	// XCTEST: The XCode test type.
 	Type *string `locationName:"type" type:"string" required:"true" enum:"TestType"`
 
-	metadataScheduleRunTest `json:"-" xml:"-"`
-}
-
-type metadataScheduleRunTest struct {
-	SDKShapeTraits bool `type:"structure"`
+	_ struct{} `type:"structure"`
 }
 
 // String returns the string representation
@@ -3588,11 +3272,7 @@ type Suite struct {
 	// XCTEST: The XCode test type.
 	Type *string `locationName:"type" type:"string" enum:"TestType"`
 
-	metadataSuite `json:"-" xml:"-"`
-}
-
-type metadataSuite struct {
-	SDKShapeTraits bool `type:"structure"`
+	_ struct{} `type:"structure"`
 }
 
 // String returns the string representation
@@ -3689,11 +3369,7 @@ type Test struct {
 	// XCTEST: The XCode test type.
 	Type *string `locationName:"type" type:"string" enum:"TestType"`
 
-	metadataTest `json:"-" xml:"-"`
-}
-
-type metadataTest struct {
-	SDKShapeTraits bool `type:"structure"`
+	_ struct{} `type:"structure"`
 }
 
 // String returns the string representation
@@ -3714,11 +3390,7 @@ type UniqueProblem struct {
 	// Information about the problems.
 	Problems []*Problem `locationName:"problems" type:"list"`
 
-	metadataUniqueProblem `json:"-" xml:"-"`
-}
-
-type metadataUniqueProblem struct {
-	SDKShapeTraits bool `type:"structure"`
+	_ struct{} `type:"structure"`
 }
 
 // String returns the string representation
@@ -3748,11 +3420,7 @@ type UpdateDevicePoolInput struct {
 	// update will replace the existing rules.
 	Rules []*Rule `locationName:"rules" type:"list"`
 
-	metadataUpdateDevicePoolInput `json:"-" xml:"-"`
-}
-
-type metadataUpdateDevicePoolInput struct {
-	SDKShapeTraits bool `type:"structure"`
+	_ struct{} `type:"structure"`
 }
 
 // String returns the string representation
@@ -3770,11 +3438,7 @@ type UpdateDevicePoolOutput struct {
 	// Represents a collection of device types.
 	DevicePool *DevicePool `locationName:"devicePool" type:"structure"`
 
-	metadataUpdateDevicePoolOutput `json:"-" xml:"-"`
-}
-
-type metadataUpdateDevicePoolOutput struct {
-	SDKShapeTraits bool `type:"structure"`
+	_ struct{} `type:"structure"`
 }
 
 // String returns the string representation
@@ -3795,11 +3459,7 @@ type UpdateProjectInput struct {
 	// A string representing the new name of the project that you are updating.
 	Name *string `locationName:"name" type:"string"`
 
-	metadataUpdateProjectInput `json:"-" xml:"-"`
-}
-
-type metadataUpdateProjectInput struct {
-	SDKShapeTraits bool `type:"structure"`
+	_ struct{} `type:"structure"`
 }
 
 // String returns the string representation
@@ -3818,11 +3478,7 @@ type UpdateProjectOutput struct {
 	// tests.
 	Project *Project `locationName:"project" type:"structure"`
 
-	metadataUpdateProjectOutput `json:"-" xml:"-"`
-}
-
-type metadataUpdateProjectOutput struct {
-	SDKShapeTraits bool `type:"structure"`
+	_ struct{} `type:"structure"`
 }
 
 // String returns the string representation
@@ -3902,11 +3558,7 @@ type Upload struct {
 	// PUT request.
 	Url *string `locationName:"url" type:"string"`
 
-	metadataUpload `json:"-" xml:"-"`
-}
-
-type metadataUpload struct {
-	SDKShapeTraits bool `type:"structure"`
+	_ struct{} `type:"structure"`
 }
 
 // String returns the string representation

--- a/service/devicefarm/api.go
+++ b/service/devicefarm/api.go
@@ -1011,13 +1011,13 @@ func (c *DeviceFarm) UpdateProject(input *UpdateProjectInput) (*UpdateProjectOut
 
 // A container for account-level settings within AWS Device Farm.
 type AccountSettings struct {
+	_ struct{} `type:"structure"`
+
 	// The AWS account number specified in the AccountSettings container.
 	AwsAccountNumber *string `locationName:"awsAccountNumber" min:"2" type:"string"`
 
 	// Returns the unmetered devices you have purchased.
 	UnmeteredDevices map[string]*int64 `locationName:"unmeteredDevices" type:"map"`
-
-	_ struct{} `type:"structure"`
 }
 
 // String returns the string representation
@@ -1032,6 +1032,8 @@ func (s AccountSettings) GoString() string {
 
 // Represents the output of a test. Examples of artifacts include logs and screenshots.
 type Artifact struct {
+	_ struct{} `type:"structure"`
+
 	// The artifact's ARN.
 	Arn *string `locationName:"arn" min:"32" type:"string"`
 
@@ -1082,8 +1084,6 @@ type Artifact struct {
 	// The pre-signed Amazon S3 URL that can be used with a corresponding GET request
 	// to download the artifact's file.
 	Url *string `locationName:"url" type:"string"`
-
-	_ struct{} `type:"structure"`
 }
 
 // String returns the string representation
@@ -1100,6 +1100,8 @@ func (s Artifact) GoString() string {
 //
 // Note that this does not represent system-wide CPU usage.
 type CPU struct {
+	_ struct{} `type:"structure"`
+
 	// The CPU's architecture, for example x86 or ARM.
 	Architecture *string `locationName:"architecture" type:"string"`
 
@@ -1109,8 +1111,6 @@ type CPU struct {
 
 	// The CPU's frequency.
 	Frequency *string `locationName:"frequency" type:"string"`
-
-	_ struct{} `type:"structure"`
 }
 
 // String returns the string representation
@@ -1125,6 +1125,8 @@ func (s CPU) GoString() string {
 
 // Represents entity counters.
 type Counters struct {
+	_ struct{} `type:"structure"`
+
 	// The number of errored entities.
 	Errored *int64 `locationName:"errored" type:"integer"`
 
@@ -1145,8 +1147,6 @@ type Counters struct {
 
 	// The number of warned entities.
 	Warned *int64 `locationName:"warned" type:"integer"`
-
-	_ struct{} `type:"structure"`
 }
 
 // String returns the string representation
@@ -1161,6 +1161,8 @@ func (s Counters) GoString() string {
 
 // Represents a request to the create device pool operation.
 type CreateDevicePoolInput struct {
+	_ struct{} `type:"structure"`
+
 	// The device pool's description.
 	Description *string `locationName:"description" type:"string"`
 
@@ -1172,8 +1174,6 @@ type CreateDevicePoolInput struct {
 
 	// The device pool's rules.
 	Rules []*Rule `locationName:"rules" type:"list" required:"true"`
-
-	_ struct{} `type:"structure"`
 }
 
 // String returns the string representation
@@ -1188,10 +1188,10 @@ func (s CreateDevicePoolInput) GoString() string {
 
 // Represents the result of a create device pool request.
 type CreateDevicePoolOutput struct {
+	_ struct{} `type:"structure"`
+
 	// The newly created device pool.
 	DevicePool *DevicePool `locationName:"devicePool" type:"structure"`
-
-	_ struct{} `type:"structure"`
 }
 
 // String returns the string representation
@@ -1206,10 +1206,10 @@ func (s CreateDevicePoolOutput) GoString() string {
 
 // Represents a request to the create project operation.
 type CreateProjectInput struct {
+	_ struct{} `type:"structure"`
+
 	// The project's name.
 	Name *string `locationName:"name" type:"string" required:"true"`
-
-	_ struct{} `type:"structure"`
 }
 
 // String returns the string representation
@@ -1224,10 +1224,10 @@ func (s CreateProjectInput) GoString() string {
 
 // Represents the result of a create project request.
 type CreateProjectOutput struct {
+	_ struct{} `type:"structure"`
+
 	// The newly created project.
 	Project *Project `locationName:"project" type:"structure"`
-
-	_ struct{} `type:"structure"`
 }
 
 // String returns the string representation
@@ -1242,6 +1242,8 @@ func (s CreateProjectOutput) GoString() string {
 
 // Represents a request to the create upload operation.
 type CreateUploadInput struct {
+	_ struct{} `type:"structure"`
+
 	// The upload's content type (for example, "application/octet-stream").
 	ContentType *string `locationName:"contentType" type:"string"`
 
@@ -1281,8 +1283,6 @@ type CreateUploadInput struct {
 	//  Note If you call CreateUpload with WEB_APP specified, AWS Device Farm throws
 	// an ArgumentException error.
 	Type *string `locationName:"type" type:"string" required:"true" enum:"UploadType"`
-
-	_ struct{} `type:"structure"`
 }
 
 // String returns the string representation
@@ -1297,10 +1297,10 @@ func (s CreateUploadInput) GoString() string {
 
 // Represents the result of a create upload request.
 type CreateUploadOutput struct {
+	_ struct{} `type:"structure"`
+
 	// The newly created upload.
 	Upload *Upload `locationName:"upload" type:"structure"`
-
-	_ struct{} `type:"structure"`
 }
 
 // String returns the string representation
@@ -1315,11 +1315,11 @@ func (s CreateUploadOutput) GoString() string {
 
 // Represents a request to the delete device pool operation.
 type DeleteDevicePoolInput struct {
+	_ struct{} `type:"structure"`
+
 	// Represents the Amazon Resource Name (ARN) of the Device Farm device pool
 	// you wish to delete.
 	Arn *string `locationName:"arn" min:"32" type:"string" required:"true"`
-
-	_ struct{} `type:"structure"`
 }
 
 // String returns the string representation
@@ -1349,11 +1349,11 @@ func (s DeleteDevicePoolOutput) GoString() string {
 
 // Represents a request to the delete project operation.
 type DeleteProjectInput struct {
+	_ struct{} `type:"structure"`
+
 	// Represents the Amazon Resource Name (ARN) of the Device Farm project you
 	// wish to delete.
 	Arn *string `locationName:"arn" min:"32" type:"string" required:"true"`
-
-	_ struct{} `type:"structure"`
 }
 
 // String returns the string representation
@@ -1383,10 +1383,10 @@ func (s DeleteProjectOutput) GoString() string {
 
 // Represents a request to the delete run operation.
 type DeleteRunInput struct {
+	_ struct{} `type:"structure"`
+
 	// The Amazon Resource Name (ARN) for the run you wish to delete.
 	Arn *string `locationName:"arn" min:"32" type:"string" required:"true"`
-
-	_ struct{} `type:"structure"`
 }
 
 // String returns the string representation
@@ -1416,11 +1416,11 @@ func (s DeleteRunOutput) GoString() string {
 
 // Represents a request to the delete upload operation.
 type DeleteUploadInput struct {
+	_ struct{} `type:"structure"`
+
 	// Represents the Amazon Resource Name (ARN) of the Device Farm upload you wish
 	// to delete.
 	Arn *string `locationName:"arn" min:"32" type:"string" required:"true"`
-
-	_ struct{} `type:"structure"`
 }
 
 // String returns the string representation
@@ -1450,6 +1450,8 @@ func (s DeleteUploadOutput) GoString() string {
 
 // Represents a device type that an app is tested against.
 type Device struct {
+	_ struct{} `type:"structure"`
+
 	// The device's ARN.
 	Arn *string `locationName:"arn" min:"32" type:"string"`
 
@@ -1504,8 +1506,6 @@ type Device struct {
 	// Represents the screen resolution of a device in height and width, expressed
 	// in pixels.
 	Resolution *Resolution `locationName:"resolution" type:"structure"`
-
-	_ struct{} `type:"structure"`
 }
 
 // String returns the string representation
@@ -1521,6 +1521,8 @@ func (s Device) GoString() string {
 // Represents the total (metered or unmetered) minutes used by the resource
 // to run tests. Contains the sum of minutes consumed by all children.
 type DeviceMinutes struct {
+	_ struct{} `type:"structure"`
+
 	// When specified, represents only the sum of metered minutes used by the resource
 	// to run tests.
 	Metered *float64 `locationName:"metered" type:"double"`
@@ -1532,8 +1534,6 @@ type DeviceMinutes struct {
 	// When specified, represents only the sum of unmetered minutes used by the
 	// resource to run tests.
 	Unmetered *float64 `locationName:"unmetered" type:"double"`
-
-	_ struct{} `type:"structure"`
 }
 
 // String returns the string representation
@@ -1548,6 +1548,8 @@ func (s DeviceMinutes) GoString() string {
 
 // Represents a collection of device types.
 type DevicePool struct {
+	_ struct{} `type:"structure"`
+
 	// The device pool's ARN.
 	Arn *string `locationName:"arn" min:"32" type:"string"`
 
@@ -1568,8 +1570,6 @@ type DevicePool struct {
 	//
 	// PRIVATE: A device pool that is created and managed by the device pool developer.
 	Type *string `locationName:"type" type:"string" enum:"DevicePoolType"`
-
-	_ struct{} `type:"structure"`
 }
 
 // String returns the string representation
@@ -1584,6 +1584,8 @@ func (s DevicePool) GoString() string {
 
 // Represents a device pool compatibility result.
 type DevicePoolCompatibilityResult struct {
+	_ struct{} `type:"structure"`
+
 	// Whether the result was compatible with the device pool.
 	Compatible *bool `locationName:"compatible" type:"boolean"`
 
@@ -1592,8 +1594,6 @@ type DevicePoolCompatibilityResult struct {
 
 	// Information about the compatibility.
 	IncompatibilityMessages []*IncompatibilityMessage `locationName:"incompatibilityMessages" type:"list"`
-
-	_ struct{} `type:"structure"`
 }
 
 // String returns the string representation
@@ -1621,10 +1621,10 @@ func (s GetAccountSettingsInput) GoString() string {
 }
 
 type GetAccountSettingsOutput struct {
+	_ struct{} `type:"structure"`
+
 	// A container for account-level settings within AWS Device Farm.
 	AccountSettings *AccountSettings `locationName:"accountSettings" type:"structure"`
-
-	_ struct{} `type:"structure"`
 }
 
 // String returns the string representation
@@ -1639,10 +1639,10 @@ func (s GetAccountSettingsOutput) GoString() string {
 
 // Represents a request to the get device request.
 type GetDeviceInput struct {
+	_ struct{} `type:"structure"`
+
 	// The device type's ARN.
 	Arn *string `locationName:"arn" min:"32" type:"string" required:"true"`
-
-	_ struct{} `type:"structure"`
 }
 
 // String returns the string representation
@@ -1657,10 +1657,10 @@ func (s GetDeviceInput) GoString() string {
 
 // Represents the result of a get device request.
 type GetDeviceOutput struct {
+	_ struct{} `type:"structure"`
+
 	// Represents a device type that an app is tested against.
 	Device *Device `locationName:"device" type:"structure"`
-
-	_ struct{} `type:"structure"`
 }
 
 // String returns the string representation
@@ -1675,6 +1675,8 @@ func (s GetDeviceOutput) GoString() string {
 
 // Represents a request to the get device pool compatibility operation.
 type GetDevicePoolCompatibilityInput struct {
+	_ struct{} `type:"structure"`
+
 	// The ARN of the app that is associated with the specified device pool.
 	AppArn *string `locationName:"appArn" min:"32" type:"string"`
 
@@ -1704,8 +1706,6 @@ type GetDevicePoolCompatibilityInput struct {
 	//
 	// XCTEST: The XCode test type.
 	TestType *string `locationName:"testType" type:"string" enum:"TestType"`
-
-	_ struct{} `type:"structure"`
 }
 
 // String returns the string representation
@@ -1720,13 +1720,13 @@ func (s GetDevicePoolCompatibilityInput) GoString() string {
 
 // Represents the result of describe device pool compatibility request.
 type GetDevicePoolCompatibilityOutput struct {
+	_ struct{} `type:"structure"`
+
 	// Information about compatible devices.
 	CompatibleDevices []*DevicePoolCompatibilityResult `locationName:"compatibleDevices" type:"list"`
 
 	// Information about incompatible devices.
 	IncompatibleDevices []*DevicePoolCompatibilityResult `locationName:"incompatibleDevices" type:"list"`
-
-	_ struct{} `type:"structure"`
 }
 
 // String returns the string representation
@@ -1741,10 +1741,10 @@ func (s GetDevicePoolCompatibilityOutput) GoString() string {
 
 // Represents a request to the get device pool operation.
 type GetDevicePoolInput struct {
+	_ struct{} `type:"structure"`
+
 	// The device pool's ARN.
 	Arn *string `locationName:"arn" min:"32" type:"string" required:"true"`
-
-	_ struct{} `type:"structure"`
 }
 
 // String returns the string representation
@@ -1759,10 +1759,10 @@ func (s GetDevicePoolInput) GoString() string {
 
 // Represents the result of a get device pool request.
 type GetDevicePoolOutput struct {
+	_ struct{} `type:"structure"`
+
 	// Represents a collection of device types.
 	DevicePool *DevicePool `locationName:"devicePool" type:"structure"`
-
-	_ struct{} `type:"structure"`
 }
 
 // String returns the string representation
@@ -1777,10 +1777,10 @@ func (s GetDevicePoolOutput) GoString() string {
 
 // Represents a request to the get job operation.
 type GetJobInput struct {
+	_ struct{} `type:"structure"`
+
 	// The job's ARN.
 	Arn *string `locationName:"arn" min:"32" type:"string" required:"true"`
-
-	_ struct{} `type:"structure"`
 }
 
 // String returns the string representation
@@ -1795,10 +1795,10 @@ func (s GetJobInput) GoString() string {
 
 // Represents the result of a get job request.
 type GetJobOutput struct {
+	_ struct{} `type:"structure"`
+
 	// Represents a device.
 	Job *Job `locationName:"job" type:"structure"`
-
-	_ struct{} `type:"structure"`
 }
 
 // String returns the string representation
@@ -1813,10 +1813,10 @@ func (s GetJobOutput) GoString() string {
 
 // Represents a request to the get project operation.
 type GetProjectInput struct {
+	_ struct{} `type:"structure"`
+
 	// The project's ARN.
 	Arn *string `locationName:"arn" min:"32" type:"string" required:"true"`
-
-	_ struct{} `type:"structure"`
 }
 
 // String returns the string representation
@@ -1831,11 +1831,11 @@ func (s GetProjectInput) GoString() string {
 
 // Represents the result of a get project request.
 type GetProjectOutput struct {
+	_ struct{} `type:"structure"`
+
 	// Represents an operating-system neutral workspace for running and managing
 	// tests.
 	Project *Project `locationName:"project" type:"structure"`
-
-	_ struct{} `type:"structure"`
 }
 
 // String returns the string representation
@@ -1850,10 +1850,10 @@ func (s GetProjectOutput) GoString() string {
 
 // Represents a request to the get run operation.
 type GetRunInput struct {
+	_ struct{} `type:"structure"`
+
 	// The run's ARN.
 	Arn *string `locationName:"arn" min:"32" type:"string" required:"true"`
-
-	_ struct{} `type:"structure"`
 }
 
 // String returns the string representation
@@ -1868,10 +1868,10 @@ func (s GetRunInput) GoString() string {
 
 // Represents the result of a get run request.
 type GetRunOutput struct {
+	_ struct{} `type:"structure"`
+
 	// Represents an app on a set of devices with a specific test and configuration.
 	Run *Run `locationName:"run" type:"structure"`
-
-	_ struct{} `type:"structure"`
 }
 
 // String returns the string representation
@@ -1886,10 +1886,10 @@ func (s GetRunOutput) GoString() string {
 
 // Represents a request to the get suite operation.
 type GetSuiteInput struct {
+	_ struct{} `type:"structure"`
+
 	// The suite's ARN.
 	Arn *string `locationName:"arn" min:"32" type:"string" required:"true"`
-
-	_ struct{} `type:"structure"`
 }
 
 // String returns the string representation
@@ -1904,10 +1904,10 @@ func (s GetSuiteInput) GoString() string {
 
 // Represents the result of a get suite request.
 type GetSuiteOutput struct {
+	_ struct{} `type:"structure"`
+
 	// Represents a collection of one or more tests.
 	Suite *Suite `locationName:"suite" type:"structure"`
-
-	_ struct{} `type:"structure"`
 }
 
 // String returns the string representation
@@ -1922,10 +1922,10 @@ func (s GetSuiteOutput) GoString() string {
 
 // Represents a request to the get test operation.
 type GetTestInput struct {
+	_ struct{} `type:"structure"`
+
 	// The test's ARN.
 	Arn *string `locationName:"arn" min:"32" type:"string" required:"true"`
-
-	_ struct{} `type:"structure"`
 }
 
 // String returns the string representation
@@ -1940,10 +1940,10 @@ func (s GetTestInput) GoString() string {
 
 // Represents the result of a get test request.
 type GetTestOutput struct {
+	_ struct{} `type:"structure"`
+
 	// Represents a condition that is evaluated.
 	Test *Test `locationName:"test" type:"structure"`
-
-	_ struct{} `type:"structure"`
 }
 
 // String returns the string representation
@@ -1958,10 +1958,10 @@ func (s GetTestOutput) GoString() string {
 
 // Represents a request to the get upload operation.
 type GetUploadInput struct {
+	_ struct{} `type:"structure"`
+
 	// The upload's ARN.
 	Arn *string `locationName:"arn" min:"32" type:"string" required:"true"`
-
-	_ struct{} `type:"structure"`
 }
 
 // String returns the string representation
@@ -1976,10 +1976,10 @@ func (s GetUploadInput) GoString() string {
 
 // Represents the result of a get upload request.
 type GetUploadOutput struct {
+	_ struct{} `type:"structure"`
+
 	// An app or a set of one or more tests to upload or that have been uploaded.
 	Upload *Upload `locationName:"upload" type:"structure"`
-
-	_ struct{} `type:"structure"`
 }
 
 // String returns the string representation
@@ -1994,6 +1994,8 @@ func (s GetUploadOutput) GoString() string {
 
 // Represents information about incompatibility.
 type IncompatibilityMessage struct {
+	_ struct{} `type:"structure"`
+
 	// A message about the incompatibility.
 	Message *string `locationName:"message" type:"string"`
 
@@ -2009,8 +2011,6 @@ type IncompatibilityMessage struct {
 	//
 	// PLATFORM: The platform (for example, Android or iOS).
 	Type *string `locationName:"type" type:"string" enum:"DeviceAttribute"`
-
-	_ struct{} `type:"structure"`
 }
 
 // String returns the string representation
@@ -2025,6 +2025,8 @@ func (s IncompatibilityMessage) GoString() string {
 
 // Represents a device.
 type Job struct {
+	_ struct{} `type:"structure"`
+
 	// The job's ARN.
 	Arn *string `locationName:"arn" min:"32" type:"string"`
 
@@ -2109,8 +2111,6 @@ type Job struct {
 	//
 	// XCTEST: The XCode test type.
 	Type *string `locationName:"type" type:"string" enum:"TestType"`
-
-	_ struct{} `type:"structure"`
 }
 
 // String returns the string representation
@@ -2125,6 +2125,8 @@ func (s Job) GoString() string {
 
 // Represents a request to the list artifacts operation.
 type ListArtifactsInput struct {
+	_ struct{} `type:"structure"`
+
 	// The Run, Job, Suite, or Test ARN.
 	Arn *string `locationName:"arn" min:"32" type:"string" required:"true"`
 
@@ -2139,8 +2141,6 @@ type ListArtifactsInput struct {
 	//  FILE: The artifacts are files. LOG: The artifacts are logs. SCREENSHOT:
 	// The artifacts are screenshots.
 	Type *string `locationName:"type" type:"string" required:"true" enum:"ArtifactCategory"`
-
-	_ struct{} `type:"structure"`
 }
 
 // String returns the string representation
@@ -2155,6 +2155,8 @@ func (s ListArtifactsInput) GoString() string {
 
 // Represents the result of a list artifacts operation.
 type ListArtifactsOutput struct {
+	_ struct{} `type:"structure"`
+
 	// Information about the artifacts.
 	Artifacts []*Artifact `locationName:"artifacts" type:"list"`
 
@@ -2162,8 +2164,6 @@ type ListArtifactsOutput struct {
 	// an identifier that is also returned, which can be used in a subsequent call
 	// to this operation to return the next set of items in the list.
 	NextToken *string `locationName:"nextToken" min:"4" type:"string"`
-
-	_ struct{} `type:"structure"`
 }
 
 // String returns the string representation
@@ -2178,6 +2178,8 @@ func (s ListArtifactsOutput) GoString() string {
 
 // Represents the result of a list device pools request.
 type ListDevicePoolsInput struct {
+	_ struct{} `type:"structure"`
+
 	// The project ARN.
 	Arn *string `locationName:"arn" min:"32" type:"string" required:"true"`
 
@@ -2193,8 +2195,6 @@ type ListDevicePoolsInput struct {
 	//
 	// PRIVATE: A device pool that is created and managed by the device pool developer.
 	Type *string `locationName:"type" type:"string" enum:"DevicePoolType"`
-
-	_ struct{} `type:"structure"`
 }
 
 // String returns the string representation
@@ -2209,6 +2209,8 @@ func (s ListDevicePoolsInput) GoString() string {
 
 // Represents the result of a list device pools request.
 type ListDevicePoolsOutput struct {
+	_ struct{} `type:"structure"`
+
 	// Information about the device pools.
 	DevicePools []*DevicePool `locationName:"devicePools" type:"list"`
 
@@ -2216,8 +2218,6 @@ type ListDevicePoolsOutput struct {
 	// an identifier that is also returned, which can be used in a subsequent call
 	// to this operation to return the next set of items in the list.
 	NextToken *string `locationName:"nextToken" min:"4" type:"string"`
-
-	_ struct{} `type:"structure"`
 }
 
 // String returns the string representation
@@ -2232,14 +2232,14 @@ func (s ListDevicePoolsOutput) GoString() string {
 
 // Represents the result of a list devices request.
 type ListDevicesInput struct {
+	_ struct{} `type:"structure"`
+
 	// The device types' ARNs.
 	Arn *string `locationName:"arn" min:"32" type:"string"`
 
 	// An identifier that was returned from the previous call to this operation,
 	// which can be used to return the next set of items in the list.
 	NextToken *string `locationName:"nextToken" min:"4" type:"string"`
-
-	_ struct{} `type:"structure"`
 }
 
 // String returns the string representation
@@ -2254,6 +2254,8 @@ func (s ListDevicesInput) GoString() string {
 
 // Represents the result of a list devices operation.
 type ListDevicesOutput struct {
+	_ struct{} `type:"structure"`
+
 	// Information about the devices.
 	Devices []*Device `locationName:"devices" type:"list"`
 
@@ -2261,8 +2263,6 @@ type ListDevicesOutput struct {
 	// an identifier that is also returned, which can be used in a subsequent call
 	// to this operation to return the next set of items in the list.
 	NextToken *string `locationName:"nextToken" min:"4" type:"string"`
-
-	_ struct{} `type:"structure"`
 }
 
 // String returns the string representation
@@ -2277,14 +2277,14 @@ func (s ListDevicesOutput) GoString() string {
 
 // Represents a request to the list jobs operation.
 type ListJobsInput struct {
+	_ struct{} `type:"structure"`
+
 	// The jobs' ARNs.
 	Arn *string `locationName:"arn" min:"32" type:"string" required:"true"`
 
 	// An identifier that was returned from the previous call to this operation,
 	// which can be used to return the next set of items in the list.
 	NextToken *string `locationName:"nextToken" min:"4" type:"string"`
-
-	_ struct{} `type:"structure"`
 }
 
 // String returns the string representation
@@ -2299,6 +2299,8 @@ func (s ListJobsInput) GoString() string {
 
 // Represents the result of a list jobs request.
 type ListJobsOutput struct {
+	_ struct{} `type:"structure"`
+
 	// Information about the jobs.
 	Jobs []*Job `locationName:"jobs" type:"list"`
 
@@ -2306,8 +2308,6 @@ type ListJobsOutput struct {
 	// an identifier that is also returned, which can be used in a subsequent call
 	// to this operation to return the next set of items in the list.
 	NextToken *string `locationName:"nextToken" min:"4" type:"string"`
-
-	_ struct{} `type:"structure"`
 }
 
 // String returns the string representation
@@ -2322,14 +2322,14 @@ func (s ListJobsOutput) GoString() string {
 
 // Represents a request to the list projects operation.
 type ListProjectsInput struct {
+	_ struct{} `type:"structure"`
+
 	// The projects' ARNs.
 	Arn *string `locationName:"arn" min:"32" type:"string"`
 
 	// An identifier that was returned from the previous call to this operation,
 	// which can be used to return the next set of items in the list.
 	NextToken *string `locationName:"nextToken" min:"4" type:"string"`
-
-	_ struct{} `type:"structure"`
 }
 
 // String returns the string representation
@@ -2344,6 +2344,8 @@ func (s ListProjectsInput) GoString() string {
 
 // Represents the result of a list projects request.
 type ListProjectsOutput struct {
+	_ struct{} `type:"structure"`
+
 	// If the number of items that are returned is significantly large, this is
 	// an identifier that is also returned, which can be used in a subsequent call
 	// to this operation to return the next set of items in the list.
@@ -2351,8 +2353,6 @@ type ListProjectsOutput struct {
 
 	// Information about the projects.
 	Projects []*Project `locationName:"projects" type:"list"`
-
-	_ struct{} `type:"structure"`
 }
 
 // String returns the string representation
@@ -2367,14 +2367,14 @@ func (s ListProjectsOutput) GoString() string {
 
 // Represents a request to the list runs operation.
 type ListRunsInput struct {
+	_ struct{} `type:"structure"`
+
 	// The runs' ARNs.
 	Arn *string `locationName:"arn" min:"32" type:"string" required:"true"`
 
 	// An identifier that was returned from the previous call to this operation,
 	// which can be used to return the next set of items in the list.
 	NextToken *string `locationName:"nextToken" min:"4" type:"string"`
-
-	_ struct{} `type:"structure"`
 }
 
 // String returns the string representation
@@ -2389,6 +2389,8 @@ func (s ListRunsInput) GoString() string {
 
 // Represents the result of a list runs request.
 type ListRunsOutput struct {
+	_ struct{} `type:"structure"`
+
 	// If the number of items that are returned is significantly large, this is
 	// an identifier that is also returned, which can be used in a subsequent call
 	// to this operation to return the next set of items in the list.
@@ -2396,8 +2398,6 @@ type ListRunsOutput struct {
 
 	// Information about the runs.
 	Runs []*Run `locationName:"runs" type:"list"`
-
-	_ struct{} `type:"structure"`
 }
 
 // String returns the string representation
@@ -2412,14 +2412,14 @@ func (s ListRunsOutput) GoString() string {
 
 // Represents a request to the list samples operation.
 type ListSamplesInput struct {
+	_ struct{} `type:"structure"`
+
 	// The samples' ARNs.
 	Arn *string `locationName:"arn" min:"32" type:"string" required:"true"`
 
 	// An identifier that was returned from the previous call to this operation,
 	// which can be used to return the next set of items in the list.
 	NextToken *string `locationName:"nextToken" min:"4" type:"string"`
-
-	_ struct{} `type:"structure"`
 }
 
 // String returns the string representation
@@ -2434,6 +2434,8 @@ func (s ListSamplesInput) GoString() string {
 
 // Represents the result of a list samples request.
 type ListSamplesOutput struct {
+	_ struct{} `type:"structure"`
+
 	// If the number of items that are returned is significantly large, this is
 	// an identifier that is also returned, which can be used in a subsequent call
 	// to this operation to return the next set of items in the list.
@@ -2441,8 +2443,6 @@ type ListSamplesOutput struct {
 
 	// Information about the samples.
 	Samples []*Sample `locationName:"samples" type:"list"`
-
-	_ struct{} `type:"structure"`
 }
 
 // String returns the string representation
@@ -2457,14 +2457,14 @@ func (s ListSamplesOutput) GoString() string {
 
 // Represents a request to the list suites operation.
 type ListSuitesInput struct {
+	_ struct{} `type:"structure"`
+
 	// The suites' ARNs.
 	Arn *string `locationName:"arn" min:"32" type:"string" required:"true"`
 
 	// An identifier that was returned from the previous call to this operation,
 	// which can be used to return the next set of items in the list.
 	NextToken *string `locationName:"nextToken" min:"4" type:"string"`
-
-	_ struct{} `type:"structure"`
 }
 
 // String returns the string representation
@@ -2479,6 +2479,8 @@ func (s ListSuitesInput) GoString() string {
 
 // Represents the result of a list suites request.
 type ListSuitesOutput struct {
+	_ struct{} `type:"structure"`
+
 	// If the number of items that are returned is significantly large, this is
 	// an identifier that is also returned, which can be used in a subsequent call
 	// to this operation to return the next set of items in the list.
@@ -2486,8 +2488,6 @@ type ListSuitesOutput struct {
 
 	// Information about the suites.
 	Suites []*Suite `locationName:"suites" type:"list"`
-
-	_ struct{} `type:"structure"`
 }
 
 // String returns the string representation
@@ -2502,14 +2502,14 @@ func (s ListSuitesOutput) GoString() string {
 
 // Represents a request to the list tests operation.
 type ListTestsInput struct {
+	_ struct{} `type:"structure"`
+
 	// The tests' ARNs.
 	Arn *string `locationName:"arn" min:"32" type:"string" required:"true"`
 
 	// An identifier that was returned from the previous call to this operation,
 	// which can be used to return the next set of items in the list.
 	NextToken *string `locationName:"nextToken" min:"4" type:"string"`
-
-	_ struct{} `type:"structure"`
 }
 
 // String returns the string representation
@@ -2524,6 +2524,8 @@ func (s ListTestsInput) GoString() string {
 
 // Represents the result of a list tests request.
 type ListTestsOutput struct {
+	_ struct{} `type:"structure"`
+
 	// If the number of items that are returned is significantly large, this is
 	// an identifier that is also returned, which can be used in a subsequent call
 	// to this operation to return the next set of items in the list.
@@ -2531,8 +2533,6 @@ type ListTestsOutput struct {
 
 	// Information about the tests.
 	Tests []*Test `locationName:"tests" type:"list"`
-
-	_ struct{} `type:"structure"`
 }
 
 // String returns the string representation
@@ -2547,14 +2547,14 @@ func (s ListTestsOutput) GoString() string {
 
 // Represents a request to the list unique problems operation.
 type ListUniqueProblemsInput struct {
+	_ struct{} `type:"structure"`
+
 	// The unique problems' ARNs.
 	Arn *string `locationName:"arn" min:"32" type:"string" required:"true"`
 
 	// An identifier that was returned from the previous call to this operation,
 	// which can be used to return the next set of items in the list.
 	NextToken *string `locationName:"nextToken" min:"4" type:"string"`
-
-	_ struct{} `type:"structure"`
 }
 
 // String returns the string representation
@@ -2569,6 +2569,8 @@ func (s ListUniqueProblemsInput) GoString() string {
 
 // Represents the result of a list unique problems request.
 type ListUniqueProblemsOutput struct {
+	_ struct{} `type:"structure"`
+
 	// If the number of items that are returned is significantly large, this is
 	// an identifier that is also returned, which can be used in a subsequent call
 	// to this operation to return the next set of items in the list.
@@ -2592,8 +2594,6 @@ type ListUniqueProblemsOutput struct {
 	//
 	// WARNED: A warning condition.
 	UniqueProblems map[string][]*UniqueProblem `locationName:"uniqueProblems" type:"map"`
-
-	_ struct{} `type:"structure"`
 }
 
 // String returns the string representation
@@ -2608,14 +2608,14 @@ func (s ListUniqueProblemsOutput) GoString() string {
 
 // Represents a request to the list uploads operation.
 type ListUploadsInput struct {
+	_ struct{} `type:"structure"`
+
 	// The uploads' ARNs.
 	Arn *string `locationName:"arn" min:"32" type:"string" required:"true"`
 
 	// An identifier that was returned from the previous call to this operation,
 	// which can be used to return the next set of items in the list.
 	NextToken *string `locationName:"nextToken" min:"4" type:"string"`
-
-	_ struct{} `type:"structure"`
 }
 
 // String returns the string representation
@@ -2630,6 +2630,8 @@ func (s ListUploadsInput) GoString() string {
 
 // Represents the result of a list uploads request.
 type ListUploadsOutput struct {
+	_ struct{} `type:"structure"`
+
 	// If the number of items that are returned is significantly large, this is
 	// an identifier that is also returned, which can be used in a subsequent call
 	// to this operation to return the next set of items in the list.
@@ -2637,8 +2639,6 @@ type ListUploadsOutput struct {
 
 	// Information about the uploads.
 	Uploads []*Upload `locationName:"uploads" type:"list"`
-
-	_ struct{} `type:"structure"`
 }
 
 // String returns the string representation
@@ -2656,13 +2656,13 @@ func (s ListUploadsOutput) GoString() string {
 //
 // Elevation is currently not supported.
 type Location struct {
+	_ struct{} `type:"structure"`
+
 	// The latitude.
 	Latitude *float64 `locationName:"latitude" type:"double" required:"true"`
 
 	// The longitude.
 	Longitude *float64 `locationName:"longitude" type:"double" required:"true"`
-
-	_ struct{} `type:"structure"`
 }
 
 // String returns the string representation
@@ -2677,6 +2677,8 @@ func (s Location) GoString() string {
 
 // Represents a specific warning or failure.
 type Problem struct {
+	_ struct{} `type:"structure"`
+
 	// Information about the associated device.
 	Device *Device `locationName:"device" type:"structure"`
 
@@ -2713,8 +2715,6 @@ type Problem struct {
 
 	// Information about the associated test.
 	Test *ProblemDetail `locationName:"test" type:"structure"`
-
-	_ struct{} `type:"structure"`
 }
 
 // String returns the string representation
@@ -2729,13 +2729,13 @@ func (s Problem) GoString() string {
 
 // Information about a problem detail.
 type ProblemDetail struct {
+	_ struct{} `type:"structure"`
+
 	// The problem detail's ARN.
 	Arn *string `locationName:"arn" min:"32" type:"string"`
 
 	// The problem detail's name.
 	Name *string `locationName:"name" type:"string"`
-
-	_ struct{} `type:"structure"`
 }
 
 // String returns the string representation
@@ -2751,6 +2751,8 @@ func (s ProblemDetail) GoString() string {
 // Represents an operating-system neutral workspace for running and managing
 // tests.
 type Project struct {
+	_ struct{} `type:"structure"`
+
 	// The project's ARN.
 	Arn *string `locationName:"arn" min:"32" type:"string"`
 
@@ -2759,8 +2761,6 @@ type Project struct {
 
 	// The project's name.
 	Name *string `locationName:"name" type:"string"`
-
-	_ struct{} `type:"structure"`
 }
 
 // String returns the string representation
@@ -2776,6 +2776,8 @@ func (s Project) GoString() string {
 // Represents the set of radios and their states on a device. Examples of radios
 // include Wi-Fi, GPS, Bluetooth, and NFC.
 type Radios struct {
+	_ struct{} `type:"structure"`
+
 	// True if Bluetooth is enabled at the beginning of the test; otherwise, false.
 	Bluetooth *bool `locationName:"bluetooth" type:"boolean"`
 
@@ -2787,8 +2789,6 @@ type Radios struct {
 
 	// True if Wi-Fi is enabled at the beginning of the test; otherwise, false.
 	Wifi *bool `locationName:"wifi" type:"boolean"`
-
-	_ struct{} `type:"structure"`
 }
 
 // String returns the string representation
@@ -2804,13 +2804,13 @@ func (s Radios) GoString() string {
 // Represents the screen resolution of a device in height and width, expressed
 // in pixels.
 type Resolution struct {
+	_ struct{} `type:"structure"`
+
 	// The screen resolution's height, expressed in pixels.
 	Height *int64 `locationName:"height" type:"integer"`
 
 	// The screen resolution's width, expressed in pixels.
 	Width *int64 `locationName:"width" type:"integer"`
-
-	_ struct{} `type:"structure"`
 }
 
 // String returns the string representation
@@ -2825,6 +2825,8 @@ func (s Resolution) GoString() string {
 
 // Represents a condition for a device pool.
 type Rule struct {
+	_ struct{} `type:"structure"`
+
 	// The rule's attribute.
 	//
 	// Allowed values include:
@@ -2853,8 +2855,6 @@ type Rule struct {
 
 	// The rule's value.
 	Value *string `locationName:"value" type:"string"`
-
-	_ struct{} `type:"structure"`
 }
 
 // String returns the string representation
@@ -2869,6 +2869,8 @@ func (s Rule) GoString() string {
 
 // Represents an app on a set of devices with a specific test and configuration.
 type Run struct {
+	_ struct{} `type:"structure"`
+
 	// The run's ARN.
 	Arn *string `locationName:"arn" min:"32" type:"string"`
 
@@ -2969,8 +2971,6 @@ type Run struct {
 	//
 	// XCTEST: The XCode test type.
 	Type *string `locationName:"type" type:"string" enum:"TestType"`
-
-	_ struct{} `type:"structure"`
 }
 
 // String returns the string representation
@@ -2985,6 +2985,8 @@ func (s Run) GoString() string {
 
 // Represents a sample of performance data.
 type Sample struct {
+	_ struct{} `type:"structure"`
+
 	// The sample's ARN.
 	Arn *string `locationName:"arn" min:"32" type:"string"`
 
@@ -3035,8 +3037,6 @@ type Sample struct {
 	// The pre-signed Amazon S3 URL that can be used with a corresponding GET request
 	// to download the sample's file.
 	Url *string `locationName:"url" type:"string"`
-
-	_ struct{} `type:"structure"`
 }
 
 // String returns the string representation
@@ -3052,6 +3052,8 @@ func (s Sample) GoString() string {
 // Represents the settings for a run. Includes things like location, radio states,
 // auxiliary apps, and network profiles.
 type ScheduleRunConfiguration struct {
+	_ struct{} `type:"structure"`
+
 	// A list of auxiliary apps for the run.
 	AuxiliaryApps []*string `locationName:"auxiliaryApps" type:"list"`
 
@@ -3075,8 +3077,6 @@ type ScheduleRunConfiguration struct {
 
 	// Information about the radio states for the run.
 	Radios *Radios `locationName:"radios" type:"structure"`
-
-	_ struct{} `type:"structure"`
 }
 
 // String returns the string representation
@@ -3091,6 +3091,8 @@ func (s ScheduleRunConfiguration) GoString() string {
 
 // Represents a request to the schedule run operation.
 type ScheduleRunInput struct {
+	_ struct{} `type:"structure"`
+
 	// The ARN of the app to schedule a run.
 	AppArn *string `locationName:"appArn" min:"32" type:"string"`
 
@@ -3108,8 +3110,6 @@ type ScheduleRunInput struct {
 
 	// Information about the test for the run to be scheduled.
 	Test *ScheduleRunTest `locationName:"test" type:"structure" required:"true"`
-
-	_ struct{} `type:"structure"`
 }
 
 // String returns the string representation
@@ -3124,10 +3124,10 @@ func (s ScheduleRunInput) GoString() string {
 
 // Represents the result of a schedule run request.
 type ScheduleRunOutput struct {
+	_ struct{} `type:"structure"`
+
 	// Information about the scheduled run.
 	Run *Run `locationName:"run" type:"structure"`
-
-	_ struct{} `type:"structure"`
 }
 
 // String returns the string representation
@@ -3142,6 +3142,8 @@ func (s ScheduleRunOutput) GoString() string {
 
 // Represents additional test settings.
 type ScheduleRunTest struct {
+	_ struct{} `type:"structure"`
+
 	// The test's filter.
 	Filter *string `locationName:"filter" type:"string"`
 
@@ -3174,8 +3176,6 @@ type ScheduleRunTest struct {
 	//
 	// XCTEST: The XCode test type.
 	Type *string `locationName:"type" type:"string" required:"true" enum:"TestType"`
-
-	_ struct{} `type:"structure"`
 }
 
 // String returns the string representation
@@ -3190,6 +3190,8 @@ func (s ScheduleRunTest) GoString() string {
 
 // Represents a collection of one or more tests.
 type Suite struct {
+	_ struct{} `type:"structure"`
+
 	// The suite's ARN.
 	Arn *string `locationName:"arn" min:"32" type:"string"`
 
@@ -3271,8 +3273,6 @@ type Suite struct {
 	//
 	// XCTEST: The XCode test type.
 	Type *string `locationName:"type" type:"string" enum:"TestType"`
-
-	_ struct{} `type:"structure"`
 }
 
 // String returns the string representation
@@ -3287,6 +3287,8 @@ func (s Suite) GoString() string {
 
 // Represents a condition that is evaluated.
 type Test struct {
+	_ struct{} `type:"structure"`
+
 	// The test's ARN.
 	Arn *string `locationName:"arn" min:"32" type:"string"`
 
@@ -3368,8 +3370,6 @@ type Test struct {
 	//
 	// XCTEST: The XCode test type.
 	Type *string `locationName:"type" type:"string" enum:"TestType"`
-
-	_ struct{} `type:"structure"`
 }
 
 // String returns the string representation
@@ -3384,13 +3384,13 @@ func (s Test) GoString() string {
 
 // A collection of one or more problems, grouped by their result.
 type UniqueProblem struct {
+	_ struct{} `type:"structure"`
+
 	// A message about the unique problems' result.
 	Message *string `locationName:"message" type:"string"`
 
 	// Information about the problems.
 	Problems []*Problem `locationName:"problems" type:"list"`
-
-	_ struct{} `type:"structure"`
 }
 
 // String returns the string representation
@@ -3405,6 +3405,8 @@ func (s UniqueProblem) GoString() string {
 
 // Represents a request to the update device pool operation.
 type UpdateDevicePoolInput struct {
+	_ struct{} `type:"structure"`
+
 	// The Amazon Resourc Name (ARN) of the Device Farm device pool you wish to
 	// update.
 	Arn *string `locationName:"arn" min:"32" type:"string" required:"true"`
@@ -3419,8 +3421,6 @@ type UpdateDevicePoolInput struct {
 	// is optional; however, if you choose to update rules for your request, the
 	// update will replace the existing rules.
 	Rules []*Rule `locationName:"rules" type:"list"`
-
-	_ struct{} `type:"structure"`
 }
 
 // String returns the string representation
@@ -3435,10 +3435,10 @@ func (s UpdateDevicePoolInput) GoString() string {
 
 // Represents the result of an update device pool request.
 type UpdateDevicePoolOutput struct {
+	_ struct{} `type:"structure"`
+
 	// Represents a collection of device types.
 	DevicePool *DevicePool `locationName:"devicePool" type:"structure"`
-
-	_ struct{} `type:"structure"`
 }
 
 // String returns the string representation
@@ -3453,13 +3453,13 @@ func (s UpdateDevicePoolOutput) GoString() string {
 
 // Represents a request to the update project operation.
 type UpdateProjectInput struct {
+	_ struct{} `type:"structure"`
+
 	// The Amazon Resource Name (ARN) of the project whose name you wish to update.
 	Arn *string `locationName:"arn" min:"32" type:"string" required:"true"`
 
 	// A string representing the new name of the project that you are updating.
 	Name *string `locationName:"name" type:"string"`
-
-	_ struct{} `type:"structure"`
 }
 
 // String returns the string representation
@@ -3474,11 +3474,11 @@ func (s UpdateProjectInput) GoString() string {
 
 // Represents the result of an update project request.
 type UpdateProjectOutput struct {
+	_ struct{} `type:"structure"`
+
 	// Represents an operating-system neutral workspace for running and managing
 	// tests.
 	Project *Project `locationName:"project" type:"structure"`
-
-	_ struct{} `type:"structure"`
 }
 
 // String returns the string representation
@@ -3493,6 +3493,8 @@ func (s UpdateProjectOutput) GoString() string {
 
 // An app or a set of one or more tests to upload or that have been uploaded.
 type Upload struct {
+	_ struct{} `type:"structure"`
+
 	// The upload's ARN.
 	Arn *string `locationName:"arn" min:"32" type:"string"`
 
@@ -3557,8 +3559,6 @@ type Upload struct {
 	// The pre-signed Amazon S3 URL that was used to store a file through a corresponding
 	// PUT request.
 	Url *string `locationName:"url" type:"string"`
-
-	_ struct{} `type:"structure"`
 }
 
 // String returns the string representation

--- a/service/directconnect/api.go
+++ b/service/directconnect/api.go
@@ -610,6 +610,8 @@ func (c *DirectConnect) DescribeVirtualInterfaces(input *DescribeVirtualInterfac
 
 // Container for the parameters to the AllocateConnectionOnInterconnect operation.
 type AllocateConnectionOnInterconnectInput struct {
+	_ struct{} `type:"structure"`
+
 	// Bandwidth of the connection.
 	//
 	// Example: "500Mbps"
@@ -644,8 +646,6 @@ type AllocateConnectionOnInterconnectInput struct {
 	//
 	// Default: None
 	Vlan *int64 `locationName:"vlan" type:"integer" required:"true"`
-
-	_ struct{} `type:"structure"`
 }
 
 // String returns the string representation
@@ -660,6 +660,8 @@ func (s AllocateConnectionOnInterconnectInput) GoString() string {
 
 // Container for the parameters to the AllocatePrivateVirtualInterface operation.
 type AllocatePrivateVirtualInterfaceInput struct {
+	_ struct{} `type:"structure"`
+
 	// The connection ID on which the private virtual interface is provisioned.
 	//
 	// Default: None
@@ -674,8 +676,6 @@ type AllocatePrivateVirtualInterfaceInput struct {
 	//
 	// Default: None
 	OwnerAccount *string `locationName:"ownerAccount" type:"string" required:"true"`
-
-	_ struct{} `type:"structure"`
 }
 
 // String returns the string representation
@@ -690,6 +690,8 @@ func (s AllocatePrivateVirtualInterfaceInput) GoString() string {
 
 // Container for the parameters to the AllocatePublicVirtualInterface operation.
 type AllocatePublicVirtualInterfaceInput struct {
+	_ struct{} `type:"structure"`
+
 	// The connection ID on which the public virtual interface is provisioned.
 	//
 	// Default: None
@@ -704,8 +706,6 @@ type AllocatePublicVirtualInterfaceInput struct {
 	//
 	// Default: None
 	OwnerAccount *string `locationName:"ownerAccount" type:"string" required:"true"`
-
-	_ struct{} `type:"structure"`
 }
 
 // String returns the string representation
@@ -720,14 +720,14 @@ func (s AllocatePublicVirtualInterfaceInput) GoString() string {
 
 // Container for the parameters to the ConfirmConnection operation.
 type ConfirmConnectionInput struct {
+	_ struct{} `type:"structure"`
+
 	// ID of the connection.
 	//
 	// Example: dxcon-fg5678gh
 	//
 	// Default: None
 	ConnectionId *string `locationName:"connectionId" type:"string" required:"true"`
-
-	_ struct{} `type:"structure"`
 }
 
 // String returns the string representation
@@ -742,6 +742,8 @@ func (s ConfirmConnectionInput) GoString() string {
 
 // The response received when ConfirmConnection is called.
 type ConfirmConnectionOutput struct {
+	_ struct{} `type:"structure"`
+
 	// State of the connection.   Ordering: The initial state of a hosted connection
 	// provisioned on an interconnect. The connection stays in the ordering state
 	// until the owner of the hosted connection confirms or declines the connection
@@ -753,8 +755,6 @@ type ConfirmConnectionOutput struct {
 	// deleted.  Rejected: A hosted connection in the 'Ordering' state will enter
 	// the 'Rejected' state if it is deleted by the end customer.
 	ConnectionState *string `locationName:"connectionState" type:"string" enum:"ConnectionState"`
-
-	_ struct{} `type:"structure"`
 }
 
 // String returns the string representation
@@ -769,6 +769,8 @@ func (s ConfirmConnectionOutput) GoString() string {
 
 // Container for the parameters to the ConfirmPrivateVirtualInterface operation.
 type ConfirmPrivateVirtualInterfaceInput struct {
+	_ struct{} `type:"structure"`
+
 	// ID of the virtual private gateway that will be attached to the virtual interface.
 	//
 	//  A virtual private gateway can be managed via the Amazon Virtual Private
@@ -784,8 +786,6 @@ type ConfirmPrivateVirtualInterfaceInput struct {
 	//
 	// Default: None
 	VirtualInterfaceId *string `locationName:"virtualInterfaceId" type:"string" required:"true"`
-
-	_ struct{} `type:"structure"`
 }
 
 // String returns the string representation
@@ -800,6 +800,8 @@ func (s ConfirmPrivateVirtualInterfaceInput) GoString() string {
 
 // The response received when ConfirmPrivateVirtualInterface is called.
 type ConfirmPrivateVirtualInterfaceOutput struct {
+	_ struct{} `type:"structure"`
+
 	// State of the virtual interface.   Confirming: The creation of the virtual
 	// interface is pending confirmation from the virtual interface owner. If the
 	// owner of the virtual interface is different from the owner of the connection
@@ -817,8 +819,6 @@ type ConfirmPrivateVirtualInterfaceOutput struct {
 	// is deleted by the virtual interface owner, the virtual interface will enter
 	// the 'Rejected' state.
 	VirtualInterfaceState *string `locationName:"virtualInterfaceState" type:"string" enum:"VirtualInterfaceState"`
-
-	_ struct{} `type:"structure"`
 }
 
 // String returns the string representation
@@ -833,14 +833,14 @@ func (s ConfirmPrivateVirtualInterfaceOutput) GoString() string {
 
 // Container for the parameters to the ConfirmPublicVirtualInterface operation.
 type ConfirmPublicVirtualInterfaceInput struct {
+	_ struct{} `type:"structure"`
+
 	// ID of the virtual interface.
 	//
 	// Example: dxvif-123dfg56
 	//
 	// Default: None
 	VirtualInterfaceId *string `locationName:"virtualInterfaceId" type:"string" required:"true"`
-
-	_ struct{} `type:"structure"`
 }
 
 // String returns the string representation
@@ -855,6 +855,8 @@ func (s ConfirmPublicVirtualInterfaceInput) GoString() string {
 
 // The response received when ConfirmPublicVirtualInterface is called.
 type ConfirmPublicVirtualInterfaceOutput struct {
+	_ struct{} `type:"structure"`
+
 	// State of the virtual interface.   Confirming: The creation of the virtual
 	// interface is pending confirmation from the virtual interface owner. If the
 	// owner of the virtual interface is different from the owner of the connection
@@ -872,8 +874,6 @@ type ConfirmPublicVirtualInterfaceOutput struct {
 	// is deleted by the virtual interface owner, the virtual interface will enter
 	// the 'Rejected' state.
 	VirtualInterfaceState *string `locationName:"virtualInterfaceState" type:"string" enum:"VirtualInterfaceState"`
-
-	_ struct{} `type:"structure"`
 }
 
 // String returns the string representation
@@ -889,6 +889,8 @@ func (s ConfirmPublicVirtualInterfaceOutput) GoString() string {
 // A connection represents the physical network connection between the AWS Direct
 // Connect location and the customer.
 type Connection struct {
+	_ struct{} `type:"structure"`
+
 	// Bandwidth of the connection.
 	//
 	// Example: 1Gbps (for regular connections), or 500Mbps (for hosted connections)
@@ -944,8 +946,6 @@ type Connection struct {
 	//
 	// Example: 101
 	Vlan *int64 `locationName:"vlan" type:"integer"`
-
-	_ struct{} `type:"structure"`
 }
 
 // String returns the string representation
@@ -960,10 +960,10 @@ func (s Connection) GoString() string {
 
 // A structure containing a list of connections.
 type Connections struct {
+	_ struct{} `type:"structure"`
+
 	// A list of connections.
 	Connections []*Connection `locationName:"connections" type:"list"`
-
-	_ struct{} `type:"structure"`
 }
 
 // String returns the string representation
@@ -978,6 +978,8 @@ func (s Connections) GoString() string {
 
 // Container for the parameters to the CreateConnection operation.
 type CreateConnectionInput struct {
+	_ struct{} `type:"structure"`
+
 	// Bandwidth of the connection.
 	//
 	// Example: 1Gbps
@@ -998,8 +1000,6 @@ type CreateConnectionInput struct {
 	//
 	// Default: None
 	Location *string `locationName:"location" type:"string" required:"true"`
-
-	_ struct{} `type:"structure"`
 }
 
 // String returns the string representation
@@ -1014,6 +1014,8 @@ func (s CreateConnectionInput) GoString() string {
 
 // Container for the parameters to the CreateInterconnect operation.
 type CreateInterconnectInput struct {
+	_ struct{} `type:"structure"`
+
 	// The port bandwidth
 	//
 	// Example: 1Gbps
@@ -1036,8 +1038,6 @@ type CreateInterconnectInput struct {
 	//
 	// Default: None
 	Location *string `locationName:"location" type:"string" required:"true"`
-
-	_ struct{} `type:"structure"`
 }
 
 // String returns the string representation
@@ -1052,6 +1052,8 @@ func (s CreateInterconnectInput) GoString() string {
 
 // Container for the parameters to the CreatePrivateVirtualInterface operation.
 type CreatePrivateVirtualInterfaceInput struct {
+	_ struct{} `type:"structure"`
+
 	// ID of the connection.
 	//
 	// Example: dxcon-fg5678gh
@@ -1063,8 +1065,6 @@ type CreatePrivateVirtualInterfaceInput struct {
 	//
 	// Default: None
 	NewPrivateVirtualInterface *NewPrivateVirtualInterface `locationName:"newPrivateVirtualInterface" type:"structure" required:"true"`
-
-	_ struct{} `type:"structure"`
 }
 
 // String returns the string representation
@@ -1079,6 +1079,8 @@ func (s CreatePrivateVirtualInterfaceInput) GoString() string {
 
 // Container for the parameters to the CreatePublicVirtualInterface operation.
 type CreatePublicVirtualInterfaceInput struct {
+	_ struct{} `type:"structure"`
+
 	// ID of the connection.
 	//
 	// Example: dxcon-fg5678gh
@@ -1090,8 +1092,6 @@ type CreatePublicVirtualInterfaceInput struct {
 	//
 	// Default: None
 	NewPublicVirtualInterface *NewPublicVirtualInterface `locationName:"newPublicVirtualInterface" type:"structure" required:"true"`
-
-	_ struct{} `type:"structure"`
 }
 
 // String returns the string representation
@@ -1106,14 +1106,14 @@ func (s CreatePublicVirtualInterfaceInput) GoString() string {
 
 // Container for the parameters to the DeleteConnection operation.
 type DeleteConnectionInput struct {
+	_ struct{} `type:"structure"`
+
 	// ID of the connection.
 	//
 	// Example: dxcon-fg5678gh
 	//
 	// Default: None
 	ConnectionId *string `locationName:"connectionId" type:"string" required:"true"`
-
-	_ struct{} `type:"structure"`
 }
 
 // String returns the string representation
@@ -1128,12 +1128,12 @@ func (s DeleteConnectionInput) GoString() string {
 
 // Container for the parameters to the DeleteInterconnect operation.
 type DeleteInterconnectInput struct {
+	_ struct{} `type:"structure"`
+
 	// The ID of the interconnect.
 	//
 	// Example: dxcon-abc123
 	InterconnectId *string `locationName:"interconnectId" type:"string" required:"true"`
-
-	_ struct{} `type:"structure"`
 }
 
 // String returns the string representation
@@ -1148,6 +1148,8 @@ func (s DeleteInterconnectInput) GoString() string {
 
 // The response received when DeleteInterconnect is called.
 type DeleteInterconnectOutput struct {
+	_ struct{} `type:"structure"`
+
 	// State of the interconnect.   Requested: The initial state of an interconnect.
 	// The interconnect stays in the requested state until the Letter of Authorization
 	// (LOA) is sent to the customer.  Pending: The interconnect has been approved,
@@ -1155,8 +1157,6 @@ type DeleteInterconnectOutput struct {
 	// is ready for use.  Down: The network link is down.  Deleted: The interconnect
 	// has been deleted.
 	InterconnectState *string `locationName:"interconnectState" type:"string" enum:"InterconnectState"`
-
-	_ struct{} `type:"structure"`
 }
 
 // String returns the string representation
@@ -1171,14 +1171,14 @@ func (s DeleteInterconnectOutput) GoString() string {
 
 // Container for the parameters to the DeleteVirtualInterface operation.
 type DeleteVirtualInterfaceInput struct {
+	_ struct{} `type:"structure"`
+
 	// ID of the virtual interface.
 	//
 	// Example: dxvif-123dfg56
 	//
 	// Default: None
 	VirtualInterfaceId *string `locationName:"virtualInterfaceId" type:"string" required:"true"`
-
-	_ struct{} `type:"structure"`
 }
 
 // String returns the string representation
@@ -1193,6 +1193,8 @@ func (s DeleteVirtualInterfaceInput) GoString() string {
 
 // The response received when DeleteVirtualInterface is called.
 type DeleteVirtualInterfaceOutput struct {
+	_ struct{} `type:"structure"`
+
 	// State of the virtual interface.   Confirming: The creation of the virtual
 	// interface is pending confirmation from the virtual interface owner. If the
 	// owner of the virtual interface is different from the owner of the connection
@@ -1210,8 +1212,6 @@ type DeleteVirtualInterfaceOutput struct {
 	// is deleted by the virtual interface owner, the virtual interface will enter
 	// the 'Rejected' state.
 	VirtualInterfaceState *string `locationName:"virtualInterfaceState" type:"string" enum:"VirtualInterfaceState"`
-
-	_ struct{} `type:"structure"`
 }
 
 // String returns the string representation
@@ -1226,14 +1226,14 @@ func (s DeleteVirtualInterfaceOutput) GoString() string {
 
 // Container for the parameters to the DescribeConnections operation.
 type DescribeConnectionsInput struct {
+	_ struct{} `type:"structure"`
+
 	// ID of the connection.
 	//
 	// Example: dxcon-fg5678gh
 	//
 	// Default: None
 	ConnectionId *string `locationName:"connectionId" type:"string"`
-
-	_ struct{} `type:"structure"`
 }
 
 // String returns the string representation
@@ -1248,14 +1248,14 @@ func (s DescribeConnectionsInput) GoString() string {
 
 // Container for the parameters to the DescribeConnectionsOnInterconnect operation.
 type DescribeConnectionsOnInterconnectInput struct {
+	_ struct{} `type:"structure"`
+
 	// ID of the interconnect on which a list of connection is provisioned.
 	//
 	// Example: dxcon-abc123
 	//
 	// Default: None
 	InterconnectId *string `locationName:"interconnectId" type:"string" required:"true"`
-
-	_ struct{} `type:"structure"`
 }
 
 // String returns the string representation
@@ -1270,12 +1270,12 @@ func (s DescribeConnectionsOnInterconnectInput) GoString() string {
 
 // Container for the parameters to the DescribeInterconnects operation.
 type DescribeInterconnectsInput struct {
+	_ struct{} `type:"structure"`
+
 	// The ID of the interconnect.
 	//
 	// Example: dxcon-abc123
 	InterconnectId *string `locationName:"interconnectId" type:"string"`
-
-	_ struct{} `type:"structure"`
 }
 
 // String returns the string representation
@@ -1290,10 +1290,10 @@ func (s DescribeInterconnectsInput) GoString() string {
 
 // A structure containing a list of interconnects.
 type DescribeInterconnectsOutput struct {
+	_ struct{} `type:"structure"`
+
 	// A list of interconnects.
 	Interconnects []*Interconnect `locationName:"interconnects" type:"list"`
-
-	_ struct{} `type:"structure"`
 }
 
 // String returns the string representation
@@ -1321,9 +1321,9 @@ func (s DescribeLocationsInput) GoString() string {
 }
 
 type DescribeLocationsOutput struct {
-	Locations []*Location `locationName:"locations" type:"list"`
-
 	_ struct{} `type:"structure"`
+
+	Locations []*Location `locationName:"locations" type:"list"`
 }
 
 // String returns the string representation
@@ -1352,10 +1352,10 @@ func (s DescribeVirtualGatewaysInput) GoString() string {
 
 // A structure containing a list of virtual private gateways.
 type DescribeVirtualGatewaysOutput struct {
+	_ struct{} `type:"structure"`
+
 	// A list of virtual private gateways.
 	VirtualGateways []*VirtualGateway `locationName:"virtualGateways" type:"list"`
-
-	_ struct{} `type:"structure"`
 }
 
 // String returns the string representation
@@ -1370,6 +1370,8 @@ func (s DescribeVirtualGatewaysOutput) GoString() string {
 
 // Container for the parameters to the DescribeVirtualInterfaces operation.
 type DescribeVirtualInterfacesInput struct {
+	_ struct{} `type:"structure"`
+
 	// ID of the connection.
 	//
 	// Example: dxcon-fg5678gh
@@ -1383,8 +1385,6 @@ type DescribeVirtualInterfacesInput struct {
 	//
 	// Default: None
 	VirtualInterfaceId *string `locationName:"virtualInterfaceId" type:"string"`
-
-	_ struct{} `type:"structure"`
 }
 
 // String returns the string representation
@@ -1399,10 +1399,10 @@ func (s DescribeVirtualInterfacesInput) GoString() string {
 
 // A structure containing a list of virtual interfaces.
 type DescribeVirtualInterfacesOutput struct {
+	_ struct{} `type:"structure"`
+
 	// A list of virtual interfaces.
 	VirtualInterfaces []*VirtualInterface `locationName:"virtualInterfaces" type:"list"`
-
-	_ struct{} `type:"structure"`
 }
 
 // String returns the string representation
@@ -1428,6 +1428,8 @@ func (s DescribeVirtualInterfacesOutput) GoString() string {
 // are shared by all of the hosted connections on the interconnect, and the
 // owner of the interconnect determines how these resources are assigned.
 type Interconnect struct {
+	_ struct{} `type:"structure"`
+
 	// Bandwidth of the connection.
 	//
 	// Example: 1Gbps
@@ -1466,8 +1468,6 @@ type Interconnect struct {
 	//
 	// Default: None
 	Region *string `locationName:"region" type:"string"`
-
-	_ struct{} `type:"structure"`
 }
 
 // String returns the string representation
@@ -1483,14 +1483,14 @@ func (s Interconnect) GoString() string {
 // An AWS Direct Connect location where connections and interconnects can be
 // requested.
 type Location struct {
+	_ struct{} `type:"structure"`
+
 	// The code used to indicate the AWS Direct Connect location.
 	LocationCode *string `locationName:"locationCode" type:"string"`
 
 	// The name of the AWS Direct Connect location. The name includes the colocation
 	// partner name and the physical site of the lit building.
 	LocationName *string `locationName:"locationName" type:"string"`
-
-	_ struct{} `type:"structure"`
 }
 
 // String returns the string representation
@@ -1505,6 +1505,8 @@ func (s Location) GoString() string {
 
 // A structure containing information about a new private virtual interface.
 type NewPrivateVirtualInterface struct {
+	_ struct{} `type:"structure"`
+
 	// IP address assigned to the Amazon interface.
 	//
 	// Example: 192.168.1.1/30
@@ -1540,8 +1542,6 @@ type NewPrivateVirtualInterface struct {
 	//
 	// Example: 101
 	Vlan *int64 `locationName:"vlan" type:"integer" required:"true"`
-
-	_ struct{} `type:"structure"`
 }
 
 // String returns the string representation
@@ -1557,6 +1557,8 @@ func (s NewPrivateVirtualInterface) GoString() string {
 // A structure containing information about a private virtual interface that
 // will be provisioned on a connection.
 type NewPrivateVirtualInterfaceAllocation struct {
+	_ struct{} `type:"structure"`
+
 	// IP address assigned to the Amazon interface.
 	//
 	// Example: 192.168.1.1/30
@@ -1586,8 +1588,6 @@ type NewPrivateVirtualInterfaceAllocation struct {
 	//
 	// Example: 101
 	Vlan *int64 `locationName:"vlan" type:"integer" required:"true"`
-
-	_ struct{} `type:"structure"`
 }
 
 // String returns the string representation
@@ -1602,6 +1602,8 @@ func (s NewPrivateVirtualInterfaceAllocation) GoString() string {
 
 // A structure containing information about a new public virtual interface.
 type NewPublicVirtualInterface struct {
+	_ struct{} `type:"structure"`
+
 	// IP address assigned to the Amazon interface.
 	//
 	// Example: 192.168.1.1/30
@@ -1635,8 +1637,6 @@ type NewPublicVirtualInterface struct {
 	//
 	// Example: 101
 	Vlan *int64 `locationName:"vlan" type:"integer" required:"true"`
-
-	_ struct{} `type:"structure"`
 }
 
 // String returns the string representation
@@ -1652,6 +1652,8 @@ func (s NewPublicVirtualInterface) GoString() string {
 // A structure containing information about a public virtual interface that
 // will be provisioned on a connection.
 type NewPublicVirtualInterfaceAllocation struct {
+	_ struct{} `type:"structure"`
+
 	// IP address assigned to the Amazon interface.
 	//
 	// Example: 192.168.1.1/30
@@ -1685,8 +1687,6 @@ type NewPublicVirtualInterfaceAllocation struct {
 	//
 	// Example: 101
 	Vlan *int64 `locationName:"vlan" type:"integer" required:"true"`
-
-	_ struct{} `type:"structure"`
 }
 
 // String returns the string representation
@@ -1702,13 +1702,13 @@ func (s NewPublicVirtualInterfaceAllocation) GoString() string {
 // A route filter prefix that the customer can advertise through Border Gateway
 // Protocol (BGP) over a public virtual interface.
 type RouteFilterPrefix struct {
+	_ struct{} `type:"structure"`
+
 	// CIDR notation for the advertised route. Multiple routes are separated by
 	// commas.
 	//
 	// Example: 10.10.10.0/24,10.10.11.0/24
 	Cidr *string `locationName:"cidr" type:"string"`
-
-	_ struct{} `type:"structure"`
 }
 
 // String returns the string representation
@@ -1727,6 +1727,8 @@ func (s RouteFilterPrefix) GoString() string {
 // Virtual private gateways can be managed using the Amazon Virtual Private
 // Cloud (Amazon VPC) console or the Amazon EC2 CreateVpnGateway action (http://docs.aws.amazon.com/AWSEC2/latest/APIReference/ApiReference-query-CreateVpnGateway.html).
 type VirtualGateway struct {
+	_ struct{} `type:"structure"`
+
 	// The ID of the virtual private gateway to a VPC. This only applies to private
 	// virtual interfaces.
 	//
@@ -1739,8 +1741,6 @@ type VirtualGateway struct {
 	//  Deleted: In this state, a private virtual interface is unable to send traffic
 	// over this gateway.
 	VirtualGatewayState *string `locationName:"virtualGatewayState" type:"string"`
-
-	_ struct{} `type:"structure"`
 }
 
 // String returns the string representation
@@ -1756,6 +1756,8 @@ func (s VirtualGateway) GoString() string {
 // A virtual interface (VLAN) transmits the traffic between the AWS Direct Connect
 // location and the customer.
 type VirtualInterface struct {
+	_ struct{} `type:"structure"`
+
 	// IP address assigned to the Amazon interface.
 	//
 	// Example: 192.168.1.1/30
@@ -1845,8 +1847,6 @@ type VirtualInterface struct {
 	//
 	// Example: 101
 	Vlan *int64 `locationName:"vlan" type:"integer"`
-
-	_ struct{} `type:"structure"`
 }
 
 // String returns the string representation

--- a/service/directconnect/api.go
+++ b/service/directconnect/api.go
@@ -645,11 +645,7 @@ type AllocateConnectionOnInterconnectInput struct {
 	// Default: None
 	Vlan *int64 `locationName:"vlan" type:"integer" required:"true"`
 
-	metadataAllocateConnectionOnInterconnectInput `json:"-" xml:"-"`
-}
-
-type metadataAllocateConnectionOnInterconnectInput struct {
-	SDKShapeTraits bool `type:"structure"`
+	_ struct{} `type:"structure"`
 }
 
 // String returns the string representation
@@ -679,11 +675,7 @@ type AllocatePrivateVirtualInterfaceInput struct {
 	// Default: None
 	OwnerAccount *string `locationName:"ownerAccount" type:"string" required:"true"`
 
-	metadataAllocatePrivateVirtualInterfaceInput `json:"-" xml:"-"`
-}
-
-type metadataAllocatePrivateVirtualInterfaceInput struct {
-	SDKShapeTraits bool `type:"structure"`
+	_ struct{} `type:"structure"`
 }
 
 // String returns the string representation
@@ -713,11 +705,7 @@ type AllocatePublicVirtualInterfaceInput struct {
 	// Default: None
 	OwnerAccount *string `locationName:"ownerAccount" type:"string" required:"true"`
 
-	metadataAllocatePublicVirtualInterfaceInput `json:"-" xml:"-"`
-}
-
-type metadataAllocatePublicVirtualInterfaceInput struct {
-	SDKShapeTraits bool `type:"structure"`
+	_ struct{} `type:"structure"`
 }
 
 // String returns the string representation
@@ -739,11 +727,7 @@ type ConfirmConnectionInput struct {
 	// Default: None
 	ConnectionId *string `locationName:"connectionId" type:"string" required:"true"`
 
-	metadataConfirmConnectionInput `json:"-" xml:"-"`
-}
-
-type metadataConfirmConnectionInput struct {
-	SDKShapeTraits bool `type:"structure"`
+	_ struct{} `type:"structure"`
 }
 
 // String returns the string representation
@@ -770,11 +754,7 @@ type ConfirmConnectionOutput struct {
 	// the 'Rejected' state if it is deleted by the end customer.
 	ConnectionState *string `locationName:"connectionState" type:"string" enum:"ConnectionState"`
 
-	metadataConfirmConnectionOutput `json:"-" xml:"-"`
-}
-
-type metadataConfirmConnectionOutput struct {
-	SDKShapeTraits bool `type:"structure"`
+	_ struct{} `type:"structure"`
 }
 
 // String returns the string representation
@@ -805,11 +785,7 @@ type ConfirmPrivateVirtualInterfaceInput struct {
 	// Default: None
 	VirtualInterfaceId *string `locationName:"virtualInterfaceId" type:"string" required:"true"`
 
-	metadataConfirmPrivateVirtualInterfaceInput `json:"-" xml:"-"`
-}
-
-type metadataConfirmPrivateVirtualInterfaceInput struct {
-	SDKShapeTraits bool `type:"structure"`
+	_ struct{} `type:"structure"`
 }
 
 // String returns the string representation
@@ -842,11 +818,7 @@ type ConfirmPrivateVirtualInterfaceOutput struct {
 	// the 'Rejected' state.
 	VirtualInterfaceState *string `locationName:"virtualInterfaceState" type:"string" enum:"VirtualInterfaceState"`
 
-	metadataConfirmPrivateVirtualInterfaceOutput `json:"-" xml:"-"`
-}
-
-type metadataConfirmPrivateVirtualInterfaceOutput struct {
-	SDKShapeTraits bool `type:"structure"`
+	_ struct{} `type:"structure"`
 }
 
 // String returns the string representation
@@ -868,11 +840,7 @@ type ConfirmPublicVirtualInterfaceInput struct {
 	// Default: None
 	VirtualInterfaceId *string `locationName:"virtualInterfaceId" type:"string" required:"true"`
 
-	metadataConfirmPublicVirtualInterfaceInput `json:"-" xml:"-"`
-}
-
-type metadataConfirmPublicVirtualInterfaceInput struct {
-	SDKShapeTraits bool `type:"structure"`
+	_ struct{} `type:"structure"`
 }
 
 // String returns the string representation
@@ -905,11 +873,7 @@ type ConfirmPublicVirtualInterfaceOutput struct {
 	// the 'Rejected' state.
 	VirtualInterfaceState *string `locationName:"virtualInterfaceState" type:"string" enum:"VirtualInterfaceState"`
 
-	metadataConfirmPublicVirtualInterfaceOutput `json:"-" xml:"-"`
-}
-
-type metadataConfirmPublicVirtualInterfaceOutput struct {
-	SDKShapeTraits bool `type:"structure"`
+	_ struct{} `type:"structure"`
 }
 
 // String returns the string representation
@@ -981,11 +945,7 @@ type Connection struct {
 	// Example: 101
 	Vlan *int64 `locationName:"vlan" type:"integer"`
 
-	metadataConnection `json:"-" xml:"-"`
-}
-
-type metadataConnection struct {
-	SDKShapeTraits bool `type:"structure"`
+	_ struct{} `type:"structure"`
 }
 
 // String returns the string representation
@@ -1003,11 +963,7 @@ type Connections struct {
 	// A list of connections.
 	Connections []*Connection `locationName:"connections" type:"list"`
 
-	metadataConnections `json:"-" xml:"-"`
-}
-
-type metadataConnections struct {
-	SDKShapeTraits bool `type:"structure"`
+	_ struct{} `type:"structure"`
 }
 
 // String returns the string representation
@@ -1043,11 +999,7 @@ type CreateConnectionInput struct {
 	// Default: None
 	Location *string `locationName:"location" type:"string" required:"true"`
 
-	metadataCreateConnectionInput `json:"-" xml:"-"`
-}
-
-type metadataCreateConnectionInput struct {
-	SDKShapeTraits bool `type:"structure"`
+	_ struct{} `type:"structure"`
 }
 
 // String returns the string representation
@@ -1085,11 +1037,7 @@ type CreateInterconnectInput struct {
 	// Default: None
 	Location *string `locationName:"location" type:"string" required:"true"`
 
-	metadataCreateInterconnectInput `json:"-" xml:"-"`
-}
-
-type metadataCreateInterconnectInput struct {
-	SDKShapeTraits bool `type:"structure"`
+	_ struct{} `type:"structure"`
 }
 
 // String returns the string representation
@@ -1116,11 +1064,7 @@ type CreatePrivateVirtualInterfaceInput struct {
 	// Default: None
 	NewPrivateVirtualInterface *NewPrivateVirtualInterface `locationName:"newPrivateVirtualInterface" type:"structure" required:"true"`
 
-	metadataCreatePrivateVirtualInterfaceInput `json:"-" xml:"-"`
-}
-
-type metadataCreatePrivateVirtualInterfaceInput struct {
-	SDKShapeTraits bool `type:"structure"`
+	_ struct{} `type:"structure"`
 }
 
 // String returns the string representation
@@ -1147,11 +1091,7 @@ type CreatePublicVirtualInterfaceInput struct {
 	// Default: None
 	NewPublicVirtualInterface *NewPublicVirtualInterface `locationName:"newPublicVirtualInterface" type:"structure" required:"true"`
 
-	metadataCreatePublicVirtualInterfaceInput `json:"-" xml:"-"`
-}
-
-type metadataCreatePublicVirtualInterfaceInput struct {
-	SDKShapeTraits bool `type:"structure"`
+	_ struct{} `type:"structure"`
 }
 
 // String returns the string representation
@@ -1173,11 +1113,7 @@ type DeleteConnectionInput struct {
 	// Default: None
 	ConnectionId *string `locationName:"connectionId" type:"string" required:"true"`
 
-	metadataDeleteConnectionInput `json:"-" xml:"-"`
-}
-
-type metadataDeleteConnectionInput struct {
-	SDKShapeTraits bool `type:"structure"`
+	_ struct{} `type:"structure"`
 }
 
 // String returns the string representation
@@ -1197,11 +1133,7 @@ type DeleteInterconnectInput struct {
 	// Example: dxcon-abc123
 	InterconnectId *string `locationName:"interconnectId" type:"string" required:"true"`
 
-	metadataDeleteInterconnectInput `json:"-" xml:"-"`
-}
-
-type metadataDeleteInterconnectInput struct {
-	SDKShapeTraits bool `type:"structure"`
+	_ struct{} `type:"structure"`
 }
 
 // String returns the string representation
@@ -1224,11 +1156,7 @@ type DeleteInterconnectOutput struct {
 	// has been deleted.
 	InterconnectState *string `locationName:"interconnectState" type:"string" enum:"InterconnectState"`
 
-	metadataDeleteInterconnectOutput `json:"-" xml:"-"`
-}
-
-type metadataDeleteInterconnectOutput struct {
-	SDKShapeTraits bool `type:"structure"`
+	_ struct{} `type:"structure"`
 }
 
 // String returns the string representation
@@ -1250,11 +1178,7 @@ type DeleteVirtualInterfaceInput struct {
 	// Default: None
 	VirtualInterfaceId *string `locationName:"virtualInterfaceId" type:"string" required:"true"`
 
-	metadataDeleteVirtualInterfaceInput `json:"-" xml:"-"`
-}
-
-type metadataDeleteVirtualInterfaceInput struct {
-	SDKShapeTraits bool `type:"structure"`
+	_ struct{} `type:"structure"`
 }
 
 // String returns the string representation
@@ -1287,11 +1211,7 @@ type DeleteVirtualInterfaceOutput struct {
 	// the 'Rejected' state.
 	VirtualInterfaceState *string `locationName:"virtualInterfaceState" type:"string" enum:"VirtualInterfaceState"`
 
-	metadataDeleteVirtualInterfaceOutput `json:"-" xml:"-"`
-}
-
-type metadataDeleteVirtualInterfaceOutput struct {
-	SDKShapeTraits bool `type:"structure"`
+	_ struct{} `type:"structure"`
 }
 
 // String returns the string representation
@@ -1313,11 +1233,7 @@ type DescribeConnectionsInput struct {
 	// Default: None
 	ConnectionId *string `locationName:"connectionId" type:"string"`
 
-	metadataDescribeConnectionsInput `json:"-" xml:"-"`
-}
-
-type metadataDescribeConnectionsInput struct {
-	SDKShapeTraits bool `type:"structure"`
+	_ struct{} `type:"structure"`
 }
 
 // String returns the string representation
@@ -1339,11 +1255,7 @@ type DescribeConnectionsOnInterconnectInput struct {
 	// Default: None
 	InterconnectId *string `locationName:"interconnectId" type:"string" required:"true"`
 
-	metadataDescribeConnectionsOnInterconnectInput `json:"-" xml:"-"`
-}
-
-type metadataDescribeConnectionsOnInterconnectInput struct {
-	SDKShapeTraits bool `type:"structure"`
+	_ struct{} `type:"structure"`
 }
 
 // String returns the string representation
@@ -1363,11 +1275,7 @@ type DescribeInterconnectsInput struct {
 	// Example: dxcon-abc123
 	InterconnectId *string `locationName:"interconnectId" type:"string"`
 
-	metadataDescribeInterconnectsInput `json:"-" xml:"-"`
-}
-
-type metadataDescribeInterconnectsInput struct {
-	SDKShapeTraits bool `type:"structure"`
+	_ struct{} `type:"structure"`
 }
 
 // String returns the string representation
@@ -1385,11 +1293,7 @@ type DescribeInterconnectsOutput struct {
 	// A list of interconnects.
 	Interconnects []*Interconnect `locationName:"interconnects" type:"list"`
 
-	metadataDescribeInterconnectsOutput `json:"-" xml:"-"`
-}
-
-type metadataDescribeInterconnectsOutput struct {
-	SDKShapeTraits bool `type:"structure"`
+	_ struct{} `type:"structure"`
 }
 
 // String returns the string representation
@@ -1403,11 +1307,7 @@ func (s DescribeInterconnectsOutput) GoString() string {
 }
 
 type DescribeLocationsInput struct {
-	metadataDescribeLocationsInput `json:"-" xml:"-"`
-}
-
-type metadataDescribeLocationsInput struct {
-	SDKShapeTraits bool `type:"structure"`
+	_ struct{} `type:"structure"`
 }
 
 // String returns the string representation
@@ -1423,11 +1323,7 @@ func (s DescribeLocationsInput) GoString() string {
 type DescribeLocationsOutput struct {
 	Locations []*Location `locationName:"locations" type:"list"`
 
-	metadataDescribeLocationsOutput `json:"-" xml:"-"`
-}
-
-type metadataDescribeLocationsOutput struct {
-	SDKShapeTraits bool `type:"structure"`
+	_ struct{} `type:"structure"`
 }
 
 // String returns the string representation
@@ -1441,11 +1337,7 @@ func (s DescribeLocationsOutput) GoString() string {
 }
 
 type DescribeVirtualGatewaysInput struct {
-	metadataDescribeVirtualGatewaysInput `json:"-" xml:"-"`
-}
-
-type metadataDescribeVirtualGatewaysInput struct {
-	SDKShapeTraits bool `type:"structure"`
+	_ struct{} `type:"structure"`
 }
 
 // String returns the string representation
@@ -1463,11 +1355,7 @@ type DescribeVirtualGatewaysOutput struct {
 	// A list of virtual private gateways.
 	VirtualGateways []*VirtualGateway `locationName:"virtualGateways" type:"list"`
 
-	metadataDescribeVirtualGatewaysOutput `json:"-" xml:"-"`
-}
-
-type metadataDescribeVirtualGatewaysOutput struct {
-	SDKShapeTraits bool `type:"structure"`
+	_ struct{} `type:"structure"`
 }
 
 // String returns the string representation
@@ -1496,11 +1384,7 @@ type DescribeVirtualInterfacesInput struct {
 	// Default: None
 	VirtualInterfaceId *string `locationName:"virtualInterfaceId" type:"string"`
 
-	metadataDescribeVirtualInterfacesInput `json:"-" xml:"-"`
-}
-
-type metadataDescribeVirtualInterfacesInput struct {
-	SDKShapeTraits bool `type:"structure"`
+	_ struct{} `type:"structure"`
 }
 
 // String returns the string representation
@@ -1518,11 +1402,7 @@ type DescribeVirtualInterfacesOutput struct {
 	// A list of virtual interfaces.
 	VirtualInterfaces []*VirtualInterface `locationName:"virtualInterfaces" type:"list"`
 
-	metadataDescribeVirtualInterfacesOutput `json:"-" xml:"-"`
-}
-
-type metadataDescribeVirtualInterfacesOutput struct {
-	SDKShapeTraits bool `type:"structure"`
+	_ struct{} `type:"structure"`
 }
 
 // String returns the string representation
@@ -1587,11 +1467,7 @@ type Interconnect struct {
 	// Default: None
 	Region *string `locationName:"region" type:"string"`
 
-	metadataInterconnect `json:"-" xml:"-"`
-}
-
-type metadataInterconnect struct {
-	SDKShapeTraits bool `type:"structure"`
+	_ struct{} `type:"structure"`
 }
 
 // String returns the string representation
@@ -1614,11 +1490,7 @@ type Location struct {
 	// partner name and the physical site of the lit building.
 	LocationName *string `locationName:"locationName" type:"string"`
 
-	metadataLocation `json:"-" xml:"-"`
-}
-
-type metadataLocation struct {
-	SDKShapeTraits bool `type:"structure"`
+	_ struct{} `type:"structure"`
 }
 
 // String returns the string representation
@@ -1669,11 +1541,7 @@ type NewPrivateVirtualInterface struct {
 	// Example: 101
 	Vlan *int64 `locationName:"vlan" type:"integer" required:"true"`
 
-	metadataNewPrivateVirtualInterface `json:"-" xml:"-"`
-}
-
-type metadataNewPrivateVirtualInterface struct {
-	SDKShapeTraits bool `type:"structure"`
+	_ struct{} `type:"structure"`
 }
 
 // String returns the string representation
@@ -1719,11 +1587,7 @@ type NewPrivateVirtualInterfaceAllocation struct {
 	// Example: 101
 	Vlan *int64 `locationName:"vlan" type:"integer" required:"true"`
 
-	metadataNewPrivateVirtualInterfaceAllocation `json:"-" xml:"-"`
-}
-
-type metadataNewPrivateVirtualInterfaceAllocation struct {
-	SDKShapeTraits bool `type:"structure"`
+	_ struct{} `type:"structure"`
 }
 
 // String returns the string representation
@@ -1772,11 +1636,7 @@ type NewPublicVirtualInterface struct {
 	// Example: 101
 	Vlan *int64 `locationName:"vlan" type:"integer" required:"true"`
 
-	metadataNewPublicVirtualInterface `json:"-" xml:"-"`
-}
-
-type metadataNewPublicVirtualInterface struct {
-	SDKShapeTraits bool `type:"structure"`
+	_ struct{} `type:"structure"`
 }
 
 // String returns the string representation
@@ -1826,11 +1686,7 @@ type NewPublicVirtualInterfaceAllocation struct {
 	// Example: 101
 	Vlan *int64 `locationName:"vlan" type:"integer" required:"true"`
 
-	metadataNewPublicVirtualInterfaceAllocation `json:"-" xml:"-"`
-}
-
-type metadataNewPublicVirtualInterfaceAllocation struct {
-	SDKShapeTraits bool `type:"structure"`
+	_ struct{} `type:"structure"`
 }
 
 // String returns the string representation
@@ -1852,11 +1708,7 @@ type RouteFilterPrefix struct {
 	// Example: 10.10.10.0/24,10.10.11.0/24
 	Cidr *string `locationName:"cidr" type:"string"`
 
-	metadataRouteFilterPrefix `json:"-" xml:"-"`
-}
-
-type metadataRouteFilterPrefix struct {
-	SDKShapeTraits bool `type:"structure"`
+	_ struct{} `type:"structure"`
 }
 
 // String returns the string representation
@@ -1888,11 +1740,7 @@ type VirtualGateway struct {
 	// over this gateway.
 	VirtualGatewayState *string `locationName:"virtualGatewayState" type:"string"`
 
-	metadataVirtualGateway `json:"-" xml:"-"`
-}
-
-type metadataVirtualGateway struct {
-	SDKShapeTraits bool `type:"structure"`
+	_ struct{} `type:"structure"`
 }
 
 // String returns the string representation
@@ -1998,11 +1846,7 @@ type VirtualInterface struct {
 	// Example: 101
 	Vlan *int64 `locationName:"vlan" type:"integer"`
 
-	metadataVirtualInterface `json:"-" xml:"-"`
-}
-
-type metadataVirtualInterface struct {
-	SDKShapeTraits bool `type:"structure"`
+	_ struct{} `type:"structure"`
 }
 
 // String returns the string representation

--- a/service/directoryservice/api.go
+++ b/service/directoryservice/api.go
@@ -508,13 +508,13 @@ func (c *DirectoryService) UpdateRadius(input *UpdateRadiusInput) (*UpdateRadius
 
 // Represents a named directory attribute.
 type Attribute struct {
+	_ struct{} `type:"structure"`
+
 	// The name of the attribute.
 	Name *string `min:"1" type:"string"`
 
 	// The value of the attribute.
 	Value *string `type:"string"`
-
-	_ struct{} `type:"structure"`
 }
 
 // String returns the string representation
@@ -529,6 +529,8 @@ func (s Attribute) GoString() string {
 
 // Contains information about a computer account in a directory.
 type Computer struct {
+	_ struct{} `type:"structure"`
+
 	// An array of Attribute objects that contain the LDAP attributes that belong
 	// to the computer account.
 	ComputerAttributes []*Attribute `type:"list"`
@@ -538,8 +540,6 @@ type Computer struct {
 
 	// The computer name.
 	ComputerName *string `min:"1" type:"string"`
-
-	_ struct{} `type:"structure"`
 }
 
 // String returns the string representation
@@ -554,6 +554,8 @@ func (s Computer) GoString() string {
 
 // Contains the inputs for the ConnectDirectory operation.
 type ConnectDirectoryInput struct {
+	_ struct{} `type:"structure"`
+
 	// A DirectoryConnectSettings object that contains additional information for
 	// the operation.
 	ConnectSettings *DirectoryConnectSettings `type:"structure" required:"true"`
@@ -572,8 +574,6 @@ type ConnectDirectoryInput struct {
 
 	// The size of the directory.
 	Size *string `type:"string" required:"true" enum:"DirectorySize"`
-
-	_ struct{} `type:"structure"`
 }
 
 // String returns the string representation
@@ -588,10 +588,10 @@ func (s ConnectDirectoryInput) GoString() string {
 
 // Contains the results of the ConnectDirectory operation.
 type ConnectDirectoryOutput struct {
+	_ struct{} `type:"structure"`
+
 	// The identifier of the new directory.
 	DirectoryId *string `type:"string"`
-
-	_ struct{} `type:"structure"`
 }
 
 // String returns the string representation
@@ -606,6 +606,8 @@ func (s ConnectDirectoryOutput) GoString() string {
 
 // Contains the inputs for the CreateAlias operation.
 type CreateAliasInput struct {
+	_ struct{} `type:"structure"`
+
 	// The requested alias.
 	//
 	// The alias must be unique amongst all aliases in AWS. This operation will
@@ -614,8 +616,6 @@ type CreateAliasInput struct {
 
 	// The identifier of the directory to create the alias for.
 	DirectoryId *string `type:"string" required:"true"`
-
-	_ struct{} `type:"structure"`
 }
 
 // String returns the string representation
@@ -630,13 +630,13 @@ func (s CreateAliasInput) GoString() string {
 
 // Contains the results of the CreateAlias operation.
 type CreateAliasOutput struct {
+	_ struct{} `type:"structure"`
+
 	// The alias for the directory.
 	Alias *string `min:"1" type:"string"`
 
 	// The identifier of the directory.
 	DirectoryId *string `type:"string"`
-
-	_ struct{} `type:"structure"`
 }
 
 // String returns the string representation
@@ -651,6 +651,8 @@ func (s CreateAliasOutput) GoString() string {
 
 // Contains the inputs for the CreateComputer operation.
 type CreateComputerInput struct {
+	_ struct{} `type:"structure"`
+
 	// An array of Attribute objects that contain any LDAP attributes to apply to
 	// the computer account.
 	ComputerAttributes []*Attribute `type:"list"`
@@ -668,8 +670,6 @@ type CreateComputerInput struct {
 	// A one-time password that is used to join the computer to the directory. You
 	// should generate a random, strong password to use for this parameter.
 	Password *string `min:"8" type:"string" required:"true"`
-
-	_ struct{} `type:"structure"`
 }
 
 // String returns the string representation
@@ -684,10 +684,10 @@ func (s CreateComputerInput) GoString() string {
 
 // Contains the results for the CreateComputer operation.
 type CreateComputerOutput struct {
+	_ struct{} `type:"structure"`
+
 	// A Computer object the represents the computer account.
 	Computer *Computer `type:"structure"`
-
-	_ struct{} `type:"structure"`
 }
 
 // String returns the string representation
@@ -702,6 +702,8 @@ func (s CreateComputerOutput) GoString() string {
 
 // Contains the inputs for the CreateDirectory operation.
 type CreateDirectoryInput struct {
+	_ struct{} `type:"structure"`
+
 	// A textual description for the directory.
 	Description *string `type:"string"`
 
@@ -722,8 +724,6 @@ type CreateDirectoryInput struct {
 	// A DirectoryVpcSettings object that contains additional information for the
 	// operation.
 	VpcSettings *DirectoryVpcSettings `type:"structure"`
-
-	_ struct{} `type:"structure"`
 }
 
 // String returns the string representation
@@ -738,10 +738,10 @@ func (s CreateDirectoryInput) GoString() string {
 
 // Contains the results of the CreateDirectory operation.
 type CreateDirectoryOutput struct {
+	_ struct{} `type:"structure"`
+
 	// The identifier of the directory that was created.
 	DirectoryId *string `type:"string"`
-
-	_ struct{} `type:"structure"`
 }
 
 // String returns the string representation
@@ -756,13 +756,13 @@ func (s CreateDirectoryOutput) GoString() string {
 
 // Contains the inputs for the CreateSnapshot operation.
 type CreateSnapshotInput struct {
+	_ struct{} `type:"structure"`
+
 	// The identifier of the directory to take a snapshot of.
 	DirectoryId *string `type:"string" required:"true"`
 
 	// The descriptive name to apply to the snapshot.
 	Name *string `type:"string"`
-
-	_ struct{} `type:"structure"`
 }
 
 // String returns the string representation
@@ -777,10 +777,10 @@ func (s CreateSnapshotInput) GoString() string {
 
 // Contains the results of the CreateSnapshot operation.
 type CreateSnapshotOutput struct {
+	_ struct{} `type:"structure"`
+
 	// The identifier of the snapshot that was created.
 	SnapshotId *string `type:"string"`
-
-	_ struct{} `type:"structure"`
 }
 
 // String returns the string representation
@@ -795,10 +795,10 @@ func (s CreateSnapshotOutput) GoString() string {
 
 // Contains the inputs for the DeleteDirectory operation.
 type DeleteDirectoryInput struct {
+	_ struct{} `type:"structure"`
+
 	// The identifier of the directory to delete.
 	DirectoryId *string `type:"string" required:"true"`
-
-	_ struct{} `type:"structure"`
 }
 
 // String returns the string representation
@@ -813,10 +813,10 @@ func (s DeleteDirectoryInput) GoString() string {
 
 // Contains the results of the DeleteDirectory operation.
 type DeleteDirectoryOutput struct {
+	_ struct{} `type:"structure"`
+
 	// The directory identifier.
 	DirectoryId *string `type:"string"`
-
-	_ struct{} `type:"structure"`
 }
 
 // String returns the string representation
@@ -831,10 +831,10 @@ func (s DeleteDirectoryOutput) GoString() string {
 
 // Contains the inputs for the DeleteSnapshot operation.
 type DeleteSnapshotInput struct {
+	_ struct{} `type:"structure"`
+
 	// The identifier of the directory snapshot to be deleted.
 	SnapshotId *string `type:"string" required:"true"`
-
-	_ struct{} `type:"structure"`
 }
 
 // String returns the string representation
@@ -849,10 +849,10 @@ func (s DeleteSnapshotInput) GoString() string {
 
 // Contains the results of the DeleteSnapshot operation.
 type DeleteSnapshotOutput struct {
+	_ struct{} `type:"structure"`
+
 	// The identifier of the directory snapshot that was deleted.
 	SnapshotId *string `type:"string"`
-
-	_ struct{} `type:"structure"`
 }
 
 // String returns the string representation
@@ -867,6 +867,8 @@ func (s DeleteSnapshotOutput) GoString() string {
 
 // Contains the inputs for the DescribeDirectories operation.
 type DescribeDirectoriesInput struct {
+	_ struct{} `type:"structure"`
+
 	// A list of identifiers of the directories to obtain the information for. If
 	// this member is null, all directories that belong to the current account are
 	// returned.
@@ -881,8 +883,6 @@ type DescribeDirectoriesInput struct {
 	// The DescribeDirectoriesResult.NextToken value from a previous call to DescribeDirectories.
 	// Pass null if this is the first call.
 	NextToken *string `type:"string"`
-
-	_ struct{} `type:"structure"`
 }
 
 // String returns the string representation
@@ -897,6 +897,8 @@ func (s DescribeDirectoriesInput) GoString() string {
 
 // Contains the results of the DescribeDirectories operation.
 type DescribeDirectoriesOutput struct {
+	_ struct{} `type:"structure"`
+
 	// The list of DirectoryDescription objects that were retrieved.
 	//
 	// It is possible that this list contains less than the number of items specified
@@ -909,8 +911,6 @@ type DescribeDirectoriesOutput struct {
 	// parameter in a subsequent call to DescribeDirectories to retrieve the next
 	// set of items.
 	NextToken *string `type:"string"`
-
-	_ struct{} `type:"structure"`
 }
 
 // String returns the string representation
@@ -925,6 +925,8 @@ func (s DescribeDirectoriesOutput) GoString() string {
 
 // Contains the inputs for the DescribeSnapshots operation.
 type DescribeSnapshotsInput struct {
+	_ struct{} `type:"structure"`
+
 	// The identifier of the directory to retrieve snapshot information for.
 	DirectoryId *string `type:"string"`
 
@@ -939,8 +941,6 @@ type DescribeSnapshotsInput struct {
 	// this member is null or empty, all snapshots are returned using the Limit
 	// and NextToken members.
 	SnapshotIds []*string `type:"list"`
-
-	_ struct{} `type:"structure"`
 }
 
 // String returns the string representation
@@ -955,6 +955,8 @@ func (s DescribeSnapshotsInput) GoString() string {
 
 // Contains the results of the DescribeSnapshots operation.
 type DescribeSnapshotsOutput struct {
+	_ struct{} `type:"structure"`
+
 	// If not null, more results are available. Pass this value in the NextToken
 	// member of a subsequent call to DescribeSnapshots.
 	NextToken *string `type:"string"`
@@ -966,8 +968,6 @@ type DescribeSnapshotsOutput struct {
 	// requested number of items left to retrieve, or if the limitations of the
 	// operation have been exceeded.
 	Snapshots []*Snapshot `type:"list"`
-
-	_ struct{} `type:"structure"`
 }
 
 // String returns the string representation
@@ -983,6 +983,8 @@ func (s DescribeSnapshotsOutput) GoString() string {
 // Contains information for the ConnectDirectory operation when an AD Connector
 // directory is being created.
 type DirectoryConnectSettings struct {
+	_ struct{} `type:"structure"`
+
 	// A list of one or more IP addresses of DNS servers or domain controllers in
 	// the on-premises directory.
 	CustomerDnsIps []*string `type:"list" required:"true"`
@@ -999,8 +1001,6 @@ type DirectoryConnectSettings struct {
 
 	// The identifier of the VPC that the AD Connector is created in.
 	VpcId *string `type:"string" required:"true"`
-
-	_ struct{} `type:"structure"`
 }
 
 // String returns the string representation
@@ -1015,6 +1015,8 @@ func (s DirectoryConnectSettings) GoString() string {
 
 // Contains information about an AD Connector directory.
 type DirectoryConnectSettingsDescription struct {
+	_ struct{} `type:"structure"`
+
 	// A list of the Availability Zones that the directory is in.
 	AvailabilityZones []*string `type:"list"`
 
@@ -1032,8 +1034,6 @@ type DirectoryConnectSettingsDescription struct {
 
 	// The identifier of the VPC that the AD Connector is in.
 	VpcId *string `type:"string"`
-
-	_ struct{} `type:"structure"`
 }
 
 // String returns the string representation
@@ -1048,6 +1048,8 @@ func (s DirectoryConnectSettingsDescription) GoString() string {
 
 // Contains information about an AWS Directory Service directory.
 type DirectoryDescription struct {
+	_ struct{} `type:"structure"`
+
 	// The access URL for the directory, such as http://<alias>.awsapps.com.
 	AccessUrl *string `min:"1" type:"string"`
 
@@ -1111,8 +1113,6 @@ type DirectoryDescription struct {
 	// about a Simple AD directory. This member is only present if the directory
 	// is a Simple AD directory.
 	VpcSettings *DirectoryVpcSettingsDescription `type:"structure"`
-
-	_ struct{} `type:"structure"`
 }
 
 // String returns the string representation
@@ -1127,6 +1127,8 @@ func (s DirectoryDescription) GoString() string {
 
 // Contains directory limit information for a region.
 type DirectoryLimits struct {
+	_ struct{} `type:"structure"`
+
 	// The current number of cloud directories in the region.
 	CloudOnlyDirectoriesCurrentCount *int64 `type:"integer"`
 
@@ -1144,8 +1146,6 @@ type DirectoryLimits struct {
 
 	// Indicates if the connected directory limit has been reached.
 	ConnectedDirectoriesLimitReached *bool `type:"boolean"`
-
-	_ struct{} `type:"structure"`
 }
 
 // String returns the string representation
@@ -1161,6 +1161,8 @@ func (s DirectoryLimits) GoString() string {
 // Contains information for the CreateDirectory operation when a Simple AD directory
 // is being created.
 type DirectoryVpcSettings struct {
+	_ struct{} `type:"structure"`
+
 	// The identifiers of the subnets for the directory servers. The two subnets
 	// must be in different Availability Zones. AWS Directory Service creates a
 	// directory server and a DNS server in each of these subnets.
@@ -1168,8 +1170,6 @@ type DirectoryVpcSettings struct {
 
 	// The identifier of the VPC to create the Simple AD directory in.
 	VpcId *string `type:"string" required:"true"`
-
-	_ struct{} `type:"structure"`
 }
 
 // String returns the string representation
@@ -1184,6 +1184,8 @@ func (s DirectoryVpcSettings) GoString() string {
 
 // Contains information about a Simple AD directory.
 type DirectoryVpcSettingsDescription struct {
+	_ struct{} `type:"structure"`
+
 	// The list of Availability Zones that the directory is in.
 	AvailabilityZones []*string `type:"list"`
 
@@ -1195,8 +1197,6 @@ type DirectoryVpcSettingsDescription struct {
 
 	// The identifier of the VPC that the directory is in.
 	VpcId *string `type:"string"`
-
-	_ struct{} `type:"structure"`
 }
 
 // String returns the string representation
@@ -1211,10 +1211,10 @@ func (s DirectoryVpcSettingsDescription) GoString() string {
 
 // Contains the inputs for the DisableRadius operation.
 type DisableRadiusInput struct {
+	_ struct{} `type:"structure"`
+
 	// The identifier of the directory to disable MFA for.
 	DirectoryId *string `type:"string" required:"true"`
-
-	_ struct{} `type:"structure"`
 }
 
 // String returns the string representation
@@ -1244,6 +1244,8 @@ func (s DisableRadiusOutput) GoString() string {
 
 // Contains the inputs for the DisableSso operation.
 type DisableSsoInput struct {
+	_ struct{} `type:"structure"`
+
 	// The identifier of the directory to disable single-sign on for.
 	DirectoryId *string `type:"string" required:"true"`
 
@@ -1262,8 +1264,6 @@ type DisableSsoInput struct {
 	// sign-on and are not stored by the service. The AD Connector service account
 	// is not changed.
 	UserName *string `min:"1" type:"string"`
-
-	_ struct{} `type:"structure"`
 }
 
 // String returns the string representation
@@ -1293,13 +1293,13 @@ func (s DisableSsoOutput) GoString() string {
 
 // Contains the inputs for the EnableRadius operation.
 type EnableRadiusInput struct {
+	_ struct{} `type:"structure"`
+
 	// The identifier of the directory to enable MFA for.
 	DirectoryId *string `type:"string" required:"true"`
 
 	// A RadiusSettings object that contains information about the RADIUS server.
 	RadiusSettings *RadiusSettings `type:"structure" required:"true"`
-
-	_ struct{} `type:"structure"`
 }
 
 // String returns the string representation
@@ -1329,6 +1329,8 @@ func (s EnableRadiusOutput) GoString() string {
 
 // Contains the inputs for the EnableSso operation.
 type EnableSsoInput struct {
+	_ struct{} `type:"structure"`
+
 	// The identifier of the directory to enable single-sign on for.
 	DirectoryId *string `type:"string" required:"true"`
 
@@ -1347,8 +1349,6 @@ type EnableSsoInput struct {
 	// and are not stored by the service. The AD Connector service account is not
 	// changed.
 	UserName *string `min:"1" type:"string"`
-
-	_ struct{} `type:"structure"`
 }
 
 // String returns the string representation
@@ -1393,11 +1393,11 @@ func (s GetDirectoryLimitsInput) GoString() string {
 
 // Contains the results of the GetDirectoryLimits operation.
 type GetDirectoryLimitsOutput struct {
+	_ struct{} `type:"structure"`
+
 	// A DirectoryLimits object that contains the directory limits for the current
 	// region.
 	DirectoryLimits *DirectoryLimits `type:"structure"`
-
-	_ struct{} `type:"structure"`
 }
 
 // String returns the string representation
@@ -1412,10 +1412,10 @@ func (s GetDirectoryLimitsOutput) GoString() string {
 
 // Contains the inputs for the GetSnapshotLimits operation.
 type GetSnapshotLimitsInput struct {
+	_ struct{} `type:"structure"`
+
 	// Contains the identifier of the directory to obtain the limits for.
 	DirectoryId *string `type:"string" required:"true"`
-
-	_ struct{} `type:"structure"`
 }
 
 // String returns the string representation
@@ -1430,11 +1430,11 @@ func (s GetSnapshotLimitsInput) GoString() string {
 
 // Contains the results of the GetSnapshotLimits operation.
 type GetSnapshotLimitsOutput struct {
+	_ struct{} `type:"structure"`
+
 	// A SnapshotLimits object that contains the manual snapshot limits for the
 	// specified directory.
 	SnapshotLimits *SnapshotLimits `type:"structure"`
-
-	_ struct{} `type:"structure"`
 }
 
 // String returns the string representation
@@ -1450,6 +1450,8 @@ func (s GetSnapshotLimitsOutput) GoString() string {
 // Contains information about a Remote Authentication Dial In User Service (RADIUS)
 // server.
 type RadiusSettings struct {
+	_ struct{} `type:"structure"`
+
 	// The protocol specified for your RADIUS endpoints.
 	AuthenticationProtocol *string `type:"string" enum:"RadiusAuthenticationProtocol"`
 
@@ -1478,8 +1480,6 @@ type RadiusSettings struct {
 
 	// Not currently used.
 	UseSameUsername *bool `type:"boolean"`
-
-	_ struct{} `type:"structure"`
 }
 
 // String returns the string representation
@@ -1494,10 +1494,10 @@ func (s RadiusSettings) GoString() string {
 
 // An object representing the inputs for the RestoreFromSnapshot operation.
 type RestoreFromSnapshotInput struct {
+	_ struct{} `type:"structure"`
+
 	// The identifier of the snapshot to restore from.
 	SnapshotId *string `type:"string" required:"true"`
-
-	_ struct{} `type:"structure"`
 }
 
 // String returns the string representation
@@ -1527,6 +1527,8 @@ func (s RestoreFromSnapshotOutput) GoString() string {
 
 // Describes a directory snapshot.
 type Snapshot struct {
+	_ struct{} `type:"structure"`
+
 	// The directory identifier.
 	DirectoryId *string `type:"string"`
 
@@ -1544,8 +1546,6 @@ type Snapshot struct {
 
 	// The snapshot type.
 	Type *string `type:"string" enum:"SnapshotType"`
-
-	_ struct{} `type:"structure"`
 }
 
 // String returns the string representation
@@ -1560,6 +1560,8 @@ func (s Snapshot) GoString() string {
 
 // Contains manual snapshot limit information for a directory.
 type SnapshotLimits struct {
+	_ struct{} `type:"structure"`
+
 	// The current number of manual snapshots of the directory.
 	ManualSnapshotsCurrentCount *int64 `type:"integer"`
 
@@ -1568,8 +1570,6 @@ type SnapshotLimits struct {
 
 	// Indicates if the manual snapshot limit has been reached.
 	ManualSnapshotsLimitReached *bool `type:"boolean"`
-
-	_ struct{} `type:"structure"`
 }
 
 // String returns the string representation
@@ -1584,13 +1584,13 @@ func (s SnapshotLimits) GoString() string {
 
 // Contains the inputs for the UpdateRadius operation.
 type UpdateRadiusInput struct {
+	_ struct{} `type:"structure"`
+
 	// The identifier of the directory to update the RADIUS server information for.
 	DirectoryId *string `type:"string" required:"true"`
 
 	// A RadiusSettings object that contains information about the RADIUS server.
 	RadiusSettings *RadiusSettings `type:"structure" required:"true"`
-
-	_ struct{} `type:"structure"`
 }
 
 // String returns the string representation

--- a/service/directoryservice/api.go
+++ b/service/directoryservice/api.go
@@ -514,11 +514,7 @@ type Attribute struct {
 	// The value of the attribute.
 	Value *string `type:"string"`
 
-	metadataAttribute `json:"-" xml:"-"`
-}
-
-type metadataAttribute struct {
-	SDKShapeTraits bool `type:"structure"`
+	_ struct{} `type:"structure"`
 }
 
 // String returns the string representation
@@ -543,11 +539,7 @@ type Computer struct {
 	// The computer name.
 	ComputerName *string `min:"1" type:"string"`
 
-	metadataComputer `json:"-" xml:"-"`
-}
-
-type metadataComputer struct {
-	SDKShapeTraits bool `type:"structure"`
+	_ struct{} `type:"structure"`
 }
 
 // String returns the string representation
@@ -581,11 +573,7 @@ type ConnectDirectoryInput struct {
 	// The size of the directory.
 	Size *string `type:"string" required:"true" enum:"DirectorySize"`
 
-	metadataConnectDirectoryInput `json:"-" xml:"-"`
-}
-
-type metadataConnectDirectoryInput struct {
-	SDKShapeTraits bool `type:"structure"`
+	_ struct{} `type:"structure"`
 }
 
 // String returns the string representation
@@ -603,11 +591,7 @@ type ConnectDirectoryOutput struct {
 	// The identifier of the new directory.
 	DirectoryId *string `type:"string"`
 
-	metadataConnectDirectoryOutput `json:"-" xml:"-"`
-}
-
-type metadataConnectDirectoryOutput struct {
-	SDKShapeTraits bool `type:"structure"`
+	_ struct{} `type:"structure"`
 }
 
 // String returns the string representation
@@ -631,11 +615,7 @@ type CreateAliasInput struct {
 	// The identifier of the directory to create the alias for.
 	DirectoryId *string `type:"string" required:"true"`
 
-	metadataCreateAliasInput `json:"-" xml:"-"`
-}
-
-type metadataCreateAliasInput struct {
-	SDKShapeTraits bool `type:"structure"`
+	_ struct{} `type:"structure"`
 }
 
 // String returns the string representation
@@ -656,11 +636,7 @@ type CreateAliasOutput struct {
 	// The identifier of the directory.
 	DirectoryId *string `type:"string"`
 
-	metadataCreateAliasOutput `json:"-" xml:"-"`
-}
-
-type metadataCreateAliasOutput struct {
-	SDKShapeTraits bool `type:"structure"`
+	_ struct{} `type:"structure"`
 }
 
 // String returns the string representation
@@ -693,11 +669,7 @@ type CreateComputerInput struct {
 	// should generate a random, strong password to use for this parameter.
 	Password *string `min:"8" type:"string" required:"true"`
 
-	metadataCreateComputerInput `json:"-" xml:"-"`
-}
-
-type metadataCreateComputerInput struct {
-	SDKShapeTraits bool `type:"structure"`
+	_ struct{} `type:"structure"`
 }
 
 // String returns the string representation
@@ -715,11 +687,7 @@ type CreateComputerOutput struct {
 	// A Computer object the represents the computer account.
 	Computer *Computer `type:"structure"`
 
-	metadataCreateComputerOutput `json:"-" xml:"-"`
-}
-
-type metadataCreateComputerOutput struct {
-	SDKShapeTraits bool `type:"structure"`
+	_ struct{} `type:"structure"`
 }
 
 // String returns the string representation
@@ -755,11 +723,7 @@ type CreateDirectoryInput struct {
 	// operation.
 	VpcSettings *DirectoryVpcSettings `type:"structure"`
 
-	metadataCreateDirectoryInput `json:"-" xml:"-"`
-}
-
-type metadataCreateDirectoryInput struct {
-	SDKShapeTraits bool `type:"structure"`
+	_ struct{} `type:"structure"`
 }
 
 // String returns the string representation
@@ -777,11 +741,7 @@ type CreateDirectoryOutput struct {
 	// The identifier of the directory that was created.
 	DirectoryId *string `type:"string"`
 
-	metadataCreateDirectoryOutput `json:"-" xml:"-"`
-}
-
-type metadataCreateDirectoryOutput struct {
-	SDKShapeTraits bool `type:"structure"`
+	_ struct{} `type:"structure"`
 }
 
 // String returns the string representation
@@ -802,11 +762,7 @@ type CreateSnapshotInput struct {
 	// The descriptive name to apply to the snapshot.
 	Name *string `type:"string"`
 
-	metadataCreateSnapshotInput `json:"-" xml:"-"`
-}
-
-type metadataCreateSnapshotInput struct {
-	SDKShapeTraits bool `type:"structure"`
+	_ struct{} `type:"structure"`
 }
 
 // String returns the string representation
@@ -824,11 +780,7 @@ type CreateSnapshotOutput struct {
 	// The identifier of the snapshot that was created.
 	SnapshotId *string `type:"string"`
 
-	metadataCreateSnapshotOutput `json:"-" xml:"-"`
-}
-
-type metadataCreateSnapshotOutput struct {
-	SDKShapeTraits bool `type:"structure"`
+	_ struct{} `type:"structure"`
 }
 
 // String returns the string representation
@@ -846,11 +798,7 @@ type DeleteDirectoryInput struct {
 	// The identifier of the directory to delete.
 	DirectoryId *string `type:"string" required:"true"`
 
-	metadataDeleteDirectoryInput `json:"-" xml:"-"`
-}
-
-type metadataDeleteDirectoryInput struct {
-	SDKShapeTraits bool `type:"structure"`
+	_ struct{} `type:"structure"`
 }
 
 // String returns the string representation
@@ -868,11 +816,7 @@ type DeleteDirectoryOutput struct {
 	// The directory identifier.
 	DirectoryId *string `type:"string"`
 
-	metadataDeleteDirectoryOutput `json:"-" xml:"-"`
-}
-
-type metadataDeleteDirectoryOutput struct {
-	SDKShapeTraits bool `type:"structure"`
+	_ struct{} `type:"structure"`
 }
 
 // String returns the string representation
@@ -890,11 +834,7 @@ type DeleteSnapshotInput struct {
 	// The identifier of the directory snapshot to be deleted.
 	SnapshotId *string `type:"string" required:"true"`
 
-	metadataDeleteSnapshotInput `json:"-" xml:"-"`
-}
-
-type metadataDeleteSnapshotInput struct {
-	SDKShapeTraits bool `type:"structure"`
+	_ struct{} `type:"structure"`
 }
 
 // String returns the string representation
@@ -912,11 +852,7 @@ type DeleteSnapshotOutput struct {
 	// The identifier of the directory snapshot that was deleted.
 	SnapshotId *string `type:"string"`
 
-	metadataDeleteSnapshotOutput `json:"-" xml:"-"`
-}
-
-type metadataDeleteSnapshotOutput struct {
-	SDKShapeTraits bool `type:"structure"`
+	_ struct{} `type:"structure"`
 }
 
 // String returns the string representation
@@ -946,11 +882,7 @@ type DescribeDirectoriesInput struct {
 	// Pass null if this is the first call.
 	NextToken *string `type:"string"`
 
-	metadataDescribeDirectoriesInput `json:"-" xml:"-"`
-}
-
-type metadataDescribeDirectoriesInput struct {
-	SDKShapeTraits bool `type:"structure"`
+	_ struct{} `type:"structure"`
 }
 
 // String returns the string representation
@@ -978,11 +910,7 @@ type DescribeDirectoriesOutput struct {
 	// set of items.
 	NextToken *string `type:"string"`
 
-	metadataDescribeDirectoriesOutput `json:"-" xml:"-"`
-}
-
-type metadataDescribeDirectoriesOutput struct {
-	SDKShapeTraits bool `type:"structure"`
+	_ struct{} `type:"structure"`
 }
 
 // String returns the string representation
@@ -1012,11 +940,7 @@ type DescribeSnapshotsInput struct {
 	// and NextToken members.
 	SnapshotIds []*string `type:"list"`
 
-	metadataDescribeSnapshotsInput `json:"-" xml:"-"`
-}
-
-type metadataDescribeSnapshotsInput struct {
-	SDKShapeTraits bool `type:"structure"`
+	_ struct{} `type:"structure"`
 }
 
 // String returns the string representation
@@ -1043,11 +967,7 @@ type DescribeSnapshotsOutput struct {
 	// operation have been exceeded.
 	Snapshots []*Snapshot `type:"list"`
 
-	metadataDescribeSnapshotsOutput `json:"-" xml:"-"`
-}
-
-type metadataDescribeSnapshotsOutput struct {
-	SDKShapeTraits bool `type:"structure"`
+	_ struct{} `type:"structure"`
 }
 
 // String returns the string representation
@@ -1080,11 +1000,7 @@ type DirectoryConnectSettings struct {
 	// The identifier of the VPC that the AD Connector is created in.
 	VpcId *string `type:"string" required:"true"`
 
-	metadataDirectoryConnectSettings `json:"-" xml:"-"`
-}
-
-type metadataDirectoryConnectSettings struct {
-	SDKShapeTraits bool `type:"structure"`
+	_ struct{} `type:"structure"`
 }
 
 // String returns the string representation
@@ -1117,11 +1033,7 @@ type DirectoryConnectSettingsDescription struct {
 	// The identifier of the VPC that the AD Connector is in.
 	VpcId *string `type:"string"`
 
-	metadataDirectoryConnectSettingsDescription `json:"-" xml:"-"`
-}
-
-type metadataDirectoryConnectSettingsDescription struct {
-	SDKShapeTraits bool `type:"structure"`
+	_ struct{} `type:"structure"`
 }
 
 // String returns the string representation
@@ -1200,11 +1112,7 @@ type DirectoryDescription struct {
 	// is a Simple AD directory.
 	VpcSettings *DirectoryVpcSettingsDescription `type:"structure"`
 
-	metadataDirectoryDescription `json:"-" xml:"-"`
-}
-
-type metadataDirectoryDescription struct {
-	SDKShapeTraits bool `type:"structure"`
+	_ struct{} `type:"structure"`
 }
 
 // String returns the string representation
@@ -1237,11 +1145,7 @@ type DirectoryLimits struct {
 	// Indicates if the connected directory limit has been reached.
 	ConnectedDirectoriesLimitReached *bool `type:"boolean"`
 
-	metadataDirectoryLimits `json:"-" xml:"-"`
-}
-
-type metadataDirectoryLimits struct {
-	SDKShapeTraits bool `type:"structure"`
+	_ struct{} `type:"structure"`
 }
 
 // String returns the string representation
@@ -1265,11 +1169,7 @@ type DirectoryVpcSettings struct {
 	// The identifier of the VPC to create the Simple AD directory in.
 	VpcId *string `type:"string" required:"true"`
 
-	metadataDirectoryVpcSettings `json:"-" xml:"-"`
-}
-
-type metadataDirectoryVpcSettings struct {
-	SDKShapeTraits bool `type:"structure"`
+	_ struct{} `type:"structure"`
 }
 
 // String returns the string representation
@@ -1296,11 +1196,7 @@ type DirectoryVpcSettingsDescription struct {
 	// The identifier of the VPC that the directory is in.
 	VpcId *string `type:"string"`
 
-	metadataDirectoryVpcSettingsDescription `json:"-" xml:"-"`
-}
-
-type metadataDirectoryVpcSettingsDescription struct {
-	SDKShapeTraits bool `type:"structure"`
+	_ struct{} `type:"structure"`
 }
 
 // String returns the string representation
@@ -1318,11 +1214,7 @@ type DisableRadiusInput struct {
 	// The identifier of the directory to disable MFA for.
 	DirectoryId *string `type:"string" required:"true"`
 
-	metadataDisableRadiusInput `json:"-" xml:"-"`
-}
-
-type metadataDisableRadiusInput struct {
-	SDKShapeTraits bool `type:"structure"`
+	_ struct{} `type:"structure"`
 }
 
 // String returns the string representation
@@ -1337,11 +1229,7 @@ func (s DisableRadiusInput) GoString() string {
 
 // Contains the results of the DisableRadius operation.
 type DisableRadiusOutput struct {
-	metadataDisableRadiusOutput `json:"-" xml:"-"`
-}
-
-type metadataDisableRadiusOutput struct {
-	SDKShapeTraits bool `type:"structure"`
+	_ struct{} `type:"structure"`
 }
 
 // String returns the string representation
@@ -1375,11 +1263,7 @@ type DisableSsoInput struct {
 	// is not changed.
 	UserName *string `min:"1" type:"string"`
 
-	metadataDisableSsoInput `json:"-" xml:"-"`
-}
-
-type metadataDisableSsoInput struct {
-	SDKShapeTraits bool `type:"structure"`
+	_ struct{} `type:"structure"`
 }
 
 // String returns the string representation
@@ -1394,11 +1278,7 @@ func (s DisableSsoInput) GoString() string {
 
 // Contains the results of the DisableSso operation.
 type DisableSsoOutput struct {
-	metadataDisableSsoOutput `json:"-" xml:"-"`
-}
-
-type metadataDisableSsoOutput struct {
-	SDKShapeTraits bool `type:"structure"`
+	_ struct{} `type:"structure"`
 }
 
 // String returns the string representation
@@ -1419,11 +1299,7 @@ type EnableRadiusInput struct {
 	// A RadiusSettings object that contains information about the RADIUS server.
 	RadiusSettings *RadiusSettings `type:"structure" required:"true"`
 
-	metadataEnableRadiusInput `json:"-" xml:"-"`
-}
-
-type metadataEnableRadiusInput struct {
-	SDKShapeTraits bool `type:"structure"`
+	_ struct{} `type:"structure"`
 }
 
 // String returns the string representation
@@ -1438,11 +1314,7 @@ func (s EnableRadiusInput) GoString() string {
 
 // Contains the results of the EnableRadius operation.
 type EnableRadiusOutput struct {
-	metadataEnableRadiusOutput `json:"-" xml:"-"`
-}
-
-type metadataEnableRadiusOutput struct {
-	SDKShapeTraits bool `type:"structure"`
+	_ struct{} `type:"structure"`
 }
 
 // String returns the string representation
@@ -1476,11 +1348,7 @@ type EnableSsoInput struct {
 	// changed.
 	UserName *string `min:"1" type:"string"`
 
-	metadataEnableSsoInput `json:"-" xml:"-"`
-}
-
-type metadataEnableSsoInput struct {
-	SDKShapeTraits bool `type:"structure"`
+	_ struct{} `type:"structure"`
 }
 
 // String returns the string representation
@@ -1495,11 +1363,7 @@ func (s EnableSsoInput) GoString() string {
 
 // Contains the results of the EnableSso operation.
 type EnableSsoOutput struct {
-	metadataEnableSsoOutput `json:"-" xml:"-"`
-}
-
-type metadataEnableSsoOutput struct {
-	SDKShapeTraits bool `type:"structure"`
+	_ struct{} `type:"structure"`
 }
 
 // String returns the string representation
@@ -1514,11 +1378,7 @@ func (s EnableSsoOutput) GoString() string {
 
 // Contains the inputs for the GetDirectoryLimits operation.
 type GetDirectoryLimitsInput struct {
-	metadataGetDirectoryLimitsInput `json:"-" xml:"-"`
-}
-
-type metadataGetDirectoryLimitsInput struct {
-	SDKShapeTraits bool `type:"structure"`
+	_ struct{} `type:"structure"`
 }
 
 // String returns the string representation
@@ -1537,11 +1397,7 @@ type GetDirectoryLimitsOutput struct {
 	// region.
 	DirectoryLimits *DirectoryLimits `type:"structure"`
 
-	metadataGetDirectoryLimitsOutput `json:"-" xml:"-"`
-}
-
-type metadataGetDirectoryLimitsOutput struct {
-	SDKShapeTraits bool `type:"structure"`
+	_ struct{} `type:"structure"`
 }
 
 // String returns the string representation
@@ -1559,11 +1415,7 @@ type GetSnapshotLimitsInput struct {
 	// Contains the identifier of the directory to obtain the limits for.
 	DirectoryId *string `type:"string" required:"true"`
 
-	metadataGetSnapshotLimitsInput `json:"-" xml:"-"`
-}
-
-type metadataGetSnapshotLimitsInput struct {
-	SDKShapeTraits bool `type:"structure"`
+	_ struct{} `type:"structure"`
 }
 
 // String returns the string representation
@@ -1582,11 +1434,7 @@ type GetSnapshotLimitsOutput struct {
 	// specified directory.
 	SnapshotLimits *SnapshotLimits `type:"structure"`
 
-	metadataGetSnapshotLimitsOutput `json:"-" xml:"-"`
-}
-
-type metadataGetSnapshotLimitsOutput struct {
-	SDKShapeTraits bool `type:"structure"`
+	_ struct{} `type:"structure"`
 }
 
 // String returns the string representation
@@ -1631,11 +1479,7 @@ type RadiusSettings struct {
 	// Not currently used.
 	UseSameUsername *bool `type:"boolean"`
 
-	metadataRadiusSettings `json:"-" xml:"-"`
-}
-
-type metadataRadiusSettings struct {
-	SDKShapeTraits bool `type:"structure"`
+	_ struct{} `type:"structure"`
 }
 
 // String returns the string representation
@@ -1653,11 +1497,7 @@ type RestoreFromSnapshotInput struct {
 	// The identifier of the snapshot to restore from.
 	SnapshotId *string `type:"string" required:"true"`
 
-	metadataRestoreFromSnapshotInput `json:"-" xml:"-"`
-}
-
-type metadataRestoreFromSnapshotInput struct {
-	SDKShapeTraits bool `type:"structure"`
+	_ struct{} `type:"structure"`
 }
 
 // String returns the string representation
@@ -1672,11 +1512,7 @@ func (s RestoreFromSnapshotInput) GoString() string {
 
 // Contains the results of the RestoreFromSnapshot operation.
 type RestoreFromSnapshotOutput struct {
-	metadataRestoreFromSnapshotOutput `json:"-" xml:"-"`
-}
-
-type metadataRestoreFromSnapshotOutput struct {
-	SDKShapeTraits bool `type:"structure"`
+	_ struct{} `type:"structure"`
 }
 
 // String returns the string representation
@@ -1709,11 +1545,7 @@ type Snapshot struct {
 	// The snapshot type.
 	Type *string `type:"string" enum:"SnapshotType"`
 
-	metadataSnapshot `json:"-" xml:"-"`
-}
-
-type metadataSnapshot struct {
-	SDKShapeTraits bool `type:"structure"`
+	_ struct{} `type:"structure"`
 }
 
 // String returns the string representation
@@ -1737,11 +1569,7 @@ type SnapshotLimits struct {
 	// Indicates if the manual snapshot limit has been reached.
 	ManualSnapshotsLimitReached *bool `type:"boolean"`
 
-	metadataSnapshotLimits `json:"-" xml:"-"`
-}
-
-type metadataSnapshotLimits struct {
-	SDKShapeTraits bool `type:"structure"`
+	_ struct{} `type:"structure"`
 }
 
 // String returns the string representation
@@ -1762,11 +1590,7 @@ type UpdateRadiusInput struct {
 	// A RadiusSettings object that contains information about the RADIUS server.
 	RadiusSettings *RadiusSettings `type:"structure" required:"true"`
 
-	metadataUpdateRadiusInput `json:"-" xml:"-"`
-}
-
-type metadataUpdateRadiusInput struct {
-	SDKShapeTraits bool `type:"structure"`
+	_ struct{} `type:"structure"`
 }
 
 // String returns the string representation
@@ -1781,11 +1605,7 @@ func (s UpdateRadiusInput) GoString() string {
 
 // Contains the results of the UpdateRadius operation.
 type UpdateRadiusOutput struct {
-	metadataUpdateRadiusOutput `json:"-" xml:"-"`
-}
-
-type metadataUpdateRadiusOutput struct {
-	SDKShapeTraits bool `type:"structure"`
+	_ struct{} `type:"structure"`
 }
 
 // String returns the string representation

--- a/service/dynamodb/api.go
+++ b/service/dynamodb/api.go
@@ -687,13 +687,13 @@ func (c *DynamoDB) UpdateTable(input *UpdateTableInput) (*UpdateTableOutput, err
 
 // Represents an attribute for describing the key schema for the table and indexes.
 type AttributeDefinition struct {
+	_ struct{} `type:"structure"`
+
 	// A name for the attribute.
 	AttributeName *string `min:"1" type:"string" required:"true"`
 
 	// The data type for the attribute.
 	AttributeType *string `type:"string" required:"true" enum:"ScalarAttributeType"`
-
-	_ struct{} `type:"structure"`
 }
 
 // String returns the string representation
@@ -714,6 +714,8 @@ func (s AttributeDefinition) GoString() string {
 // attributes. Each book has one title but can have many authors. The multi-valued
 // attribute is a set; duplicate values are not allowed.
 type AttributeValue struct {
+	_ struct{} `type:"structure"`
+
 	// A Binary data type.
 	B []byte `type:"blob"`
 
@@ -743,8 +745,6 @@ type AttributeValue struct {
 
 	// A String Set data type.
 	SS []*string `type:"list"`
-
-	_ struct{} `type:"structure"`
 }
 
 // String returns the string representation
@@ -768,6 +768,8 @@ func (s AttributeValue) GoString() string {
 // have lengths greater than zero; and set type attributes must not be empty.
 // Requests with empty values will be rejected with a ValidationException exception.
 type AttributeValueUpdate struct {
+	_ struct{} `type:"structure"`
+
 	// Specifies how to perform the update. Valid values are PUT (default), DELETE,
 	// and ADD. The behavior depends on whether the specified primary key already
 	// exists in the table.
@@ -840,8 +842,6 @@ type AttributeValueUpdate struct {
 	// attributes. Each book has one title but can have many authors. The multi-valued
 	// attribute is a set; duplicate values are not allowed.
 	Value *AttributeValue `type:"structure"`
-
-	_ struct{} `type:"structure"`
 }
 
 // String returns the string representation
@@ -856,6 +856,8 @@ func (s AttributeValueUpdate) GoString() string {
 
 // Represents the input of a BatchGetItem operation.
 type BatchGetItemInput struct {
+	_ struct{} `type:"structure"`
+
 	// A map of one or more table names and, for each table, a map that describes
 	// one or more items to retrieve from that table. Each table name can be used
 	// only once per BatchGetItem request.
@@ -954,8 +956,6 @@ type BatchGetItemInput struct {
 	//
 	// NONE - No ConsumedCapacity details are included in the response.
 	ReturnConsumedCapacity *string `type:"string" enum:"ReturnConsumedCapacity"`
-
-	_ struct{} `type:"structure"`
 }
 
 // String returns the string representation
@@ -970,6 +970,8 @@ func (s BatchGetItemInput) GoString() string {
 
 // Represents the output of a BatchGetItem operation.
 type BatchGetItemOutput struct {
+	_ struct{} `type:"structure"`
+
 	// The read capacity units consumed by the operation.
 	//
 	// Each element consists of:
@@ -1005,8 +1007,6 @@ type BatchGetItemOutput struct {
 	//   If there are no unprocessed keys remaining, the response contains an empty
 	// UnprocessedKeys map.
 	UnprocessedKeys map[string]*KeysAndAttributes `min:"1" type:"map"`
-
-	_ struct{} `type:"structure"`
 }
 
 // String returns the string representation
@@ -1021,6 +1021,8 @@ func (s BatchGetItemOutput) GoString() string {
 
 // Represents the input of a BatchWriteItem operation.
 type BatchWriteItemInput struct {
+	_ struct{} `type:"structure"`
+
 	// A map of one or more table names and, for each table, a list of operations
 	// to be performed (DeleteRequest or PutRequest). Each element in the map consists
 	// of the following:
@@ -1071,8 +1073,6 @@ type BatchWriteItemInput struct {
 	// modified during the operation are returned in the response. If set to NONE
 	// (the default), no statistics are returned.
 	ReturnItemCollectionMetrics *string `type:"string" enum:"ReturnItemCollectionMetrics"`
-
-	_ struct{} `type:"structure"`
 }
 
 // String returns the string representation
@@ -1087,6 +1087,8 @@ func (s BatchWriteItemInput) GoString() string {
 
 // Represents the output of a BatchWriteItem operation.
 type BatchWriteItemOutput struct {
+	_ struct{} `type:"structure"`
+
 	// The capacity units consumed by the operation.
 	//
 	// Each element consists of:
@@ -1147,8 +1149,6 @@ type BatchWriteItemOutput struct {
 	//     If there are no unprocessed items remaining, the response contains an
 	// empty UnprocessedItems map.
 	UnprocessedItems map[string][]*WriteRequest `min:"1" type:"map"`
-
-	_ struct{} `type:"structure"`
 }
 
 // String returns the string representation
@@ -1164,10 +1164,10 @@ func (s BatchWriteItemOutput) GoString() string {
 // Represents the amount of provisioned throughput capacity consumed on a table
 // or an index.
 type Capacity struct {
+	_ struct{} `type:"structure"`
+
 	// The total number of capacity units consumed on a table or an index.
 	CapacityUnits *float64 `type:"double"`
-
-	_ struct{} `type:"structure"`
 }
 
 // String returns the string representation
@@ -1194,6 +1194,8 @@ func (s Capacity) GoString() string {
 //   For a Scan operation, Condition is used in a ScanFilter, which evaluates
 // the scan results and returns only the desired values.
 type Condition struct {
+	_ struct{} `type:"structure"`
+
 	// One or more values to evaluate against the supplied attribute. The number
 	// of values in the list depends on the ComparisonOperator being used.
 	//
@@ -1340,8 +1342,6 @@ type Condition struct {
 	// Conditional Parameters (http://docs.aws.amazon.com/amazondynamodb/latest/developerguide/LegacyConditionalParameters.html)
 	// in the Amazon DynamoDB Developer Guide.
 	ComparisonOperator *string `type:"string" required:"true" enum:"ComparisonOperator"`
-
-	_ struct{} `type:"structure"`
 }
 
 // String returns the string representation
@@ -1361,6 +1361,8 @@ func (s Condition) GoString() string {
 // (http://docs.aws.amazon.com/amazondynamodb/latest/developerguide/ProvisionedThroughputIntro.html)
 // in the Amazon DynamoDB Developer Guide.
 type ConsumedCapacity struct {
+	_ struct{} `type:"structure"`
+
 	// The total number of capacity units consumed by the operation.
 	CapacityUnits *float64 `type:"double"`
 
@@ -1375,8 +1377,6 @@ type ConsumedCapacity struct {
 
 	// The name of the table that was affected by the operation.
 	TableName *string `min:"3" type:"string"`
-
-	_ struct{} `type:"structure"`
 }
 
 // String returns the string representation
@@ -1391,6 +1391,8 @@ func (s ConsumedCapacity) GoString() string {
 
 // Represents a new global secondary index to be added to an existing table.
 type CreateGlobalSecondaryIndexAction struct {
+	_ struct{} `type:"structure"`
+
 	// The name of the global secondary index to be created.
 	IndexName *string `min:"3" type:"string" required:"true"`
 
@@ -1409,8 +1411,6 @@ type CreateGlobalSecondaryIndexAction struct {
 	// (http://docs.aws.amazon.com/amazondynamodb/latest/developerguide/Limits.html)
 	// in the Amazon DynamoDB Developer Guide.
 	ProvisionedThroughput *ProvisionedThroughput `type:"structure" required:"true"`
-
-	_ struct{} `type:"structure"`
 }
 
 // String returns the string representation
@@ -1425,6 +1425,8 @@ func (s CreateGlobalSecondaryIndexAction) GoString() string {
 
 // Represents the input of a CreateTable operation.
 type CreateTableInput struct {
+	_ struct{} `type:"structure"`
+
 	// An array of attributes that describe the key schema for the table and indexes.
 	AttributeDefinitions []*AttributeDefinition `type:"list" required:"true"`
 
@@ -1548,8 +1550,6 @@ type CreateTableInput struct {
 
 	// The name of the table to create.
 	TableName *string `min:"3" type:"string" required:"true"`
-
-	_ struct{} `type:"structure"`
 }
 
 // String returns the string representation
@@ -1564,10 +1564,10 @@ func (s CreateTableInput) GoString() string {
 
 // Represents the output of a CreateTable operation.
 type CreateTableOutput struct {
+	_ struct{} `type:"structure"`
+
 	// Represents the properties of a table.
 	TableDescription *TableDescription `type:"structure"`
-
-	_ struct{} `type:"structure"`
 }
 
 // String returns the string representation
@@ -1582,10 +1582,10 @@ func (s CreateTableOutput) GoString() string {
 
 // Represents a global secondary index to be deleted from an existing table.
 type DeleteGlobalSecondaryIndexAction struct {
+	_ struct{} `type:"structure"`
+
 	// The name of the global secondary index to be deleted.
 	IndexName *string `min:"3" type:"string" required:"true"`
-
-	_ struct{} `type:"structure"`
 }
 
 // String returns the string representation
@@ -1600,6 +1600,8 @@ func (s DeleteGlobalSecondaryIndexAction) GoString() string {
 
 // Represents the input of a DeleteItem operation.
 type DeleteItemInput struct {
+	_ struct{} `type:"structure"`
+
 	// A condition that must be satisfied in order for a conditional DeleteItem
 	// to succeed.
 	//
@@ -1938,8 +1940,6 @@ type DeleteItemInput struct {
 
 	// The name of the table from which to delete the item.
 	TableName *string `min:"3" type:"string" required:"true"`
-
-	_ struct{} `type:"structure"`
 }
 
 // String returns the string representation
@@ -1954,6 +1954,8 @@ func (s DeleteItemInput) GoString() string {
 
 // Represents the output of a DeleteItem operation.
 type DeleteItemOutput struct {
+	_ struct{} `type:"structure"`
+
 	// A map of attribute names to AttributeValue objects, representing the item
 	// as it appeared before the DeleteItem operation. This map appears in the response
 	// only if ReturnValues was specified as ALL_OLD in the request.
@@ -1987,8 +1989,6 @@ type DeleteItemOutput struct {
 	// The estimate is subject to change over time; therefore, do not rely on the
 	// precision or accuracy of the estimate.
 	ItemCollectionMetrics *ItemCollectionMetrics `type:"structure"`
-
-	_ struct{} `type:"structure"`
 }
 
 // String returns the string representation
@@ -2003,12 +2003,12 @@ func (s DeleteItemOutput) GoString() string {
 
 // Represents a request to perform a DeleteItem operation on an item.
 type DeleteRequest struct {
+	_ struct{} `type:"structure"`
+
 	// A map of attribute name to attribute values, representing the primary key
 	// of the item to delete. All of the table's primary key attributes must be
 	// specified, and their data types must match those of the table's key schema.
 	Key map[string]*AttributeValue `type:"map" required:"true"`
-
-	_ struct{} `type:"structure"`
 }
 
 // String returns the string representation
@@ -2023,10 +2023,10 @@ func (s DeleteRequest) GoString() string {
 
 // Represents the input of a DeleteTable operation.
 type DeleteTableInput struct {
+	_ struct{} `type:"structure"`
+
 	// The name of the table to delete.
 	TableName *string `min:"3" type:"string" required:"true"`
-
-	_ struct{} `type:"structure"`
 }
 
 // String returns the string representation
@@ -2041,10 +2041,10 @@ func (s DeleteTableInput) GoString() string {
 
 // Represents the output of a DeleteTable operation.
 type DeleteTableOutput struct {
+	_ struct{} `type:"structure"`
+
 	// Represents the properties of a table.
 	TableDescription *TableDescription `type:"structure"`
-
-	_ struct{} `type:"structure"`
 }
 
 // String returns the string representation
@@ -2059,10 +2059,10 @@ func (s DeleteTableOutput) GoString() string {
 
 // Represents the input of a DescribeTable operation.
 type DescribeTableInput struct {
+	_ struct{} `type:"structure"`
+
 	// The name of the table to describe.
 	TableName *string `min:"3" type:"string" required:"true"`
-
-	_ struct{} `type:"structure"`
 }
 
 // String returns the string representation
@@ -2077,10 +2077,10 @@ func (s DescribeTableInput) GoString() string {
 
 // Represents the output of a DescribeTable operation.
 type DescribeTableOutput struct {
+	_ struct{} `type:"structure"`
+
 	// Represents the properties of a table.
 	Table *TableDescription `type:"structure"`
-
-	_ struct{} `type:"structure"`
 }
 
 // String returns the string representation
@@ -2114,6 +2114,8 @@ func (s DescribeTableOutput) GoString() string {
 // Note that if you use both sets of parameters at once, DynamoDB will return
 // a ValidationException exception.
 type ExpectedAttributeValue struct {
+	_ struct{} `type:"structure"`
+
 	// One or more values to evaluate against the supplied attribute. The number
 	// of values in the list depends on the ComparisonOperator being used.
 	//
@@ -2292,8 +2294,6 @@ type ExpectedAttributeValue struct {
 	// attributes. Each book has one title but can have many authors. The multi-valued
 	// attribute is a set; duplicate values are not allowed.
 	Value *AttributeValue `type:"structure"`
-
-	_ struct{} `type:"structure"`
 }
 
 // String returns the string representation
@@ -2308,6 +2308,8 @@ func (s ExpectedAttributeValue) GoString() string {
 
 // Represents the input of a GetItem operation.
 type GetItemInput struct {
+	_ struct{} `type:"structure"`
+
 	// This is a legacy parameter, for backward compatibility. New applications
 	// should use ProjectionExpression instead. Do not combine legacy parameters
 	// and expression parameters in a single API call; otherwise, DynamoDB will
@@ -2408,8 +2410,6 @@ type GetItemInput struct {
 
 	// The name of the table containing the requested item.
 	TableName *string `min:"3" type:"string" required:"true"`
-
-	_ struct{} `type:"structure"`
 }
 
 // String returns the string representation
@@ -2424,6 +2424,8 @@ func (s GetItemInput) GoString() string {
 
 // Represents the output of a GetItem operation.
 type GetItemOutput struct {
+	_ struct{} `type:"structure"`
+
 	// The capacity units consumed by an operation. The data returned includes the
 	// total provisioned throughput consumed, along with statistics for the table
 	// and any indexes involved in the operation. ConsumedCapacity is only returned
@@ -2434,8 +2436,6 @@ type GetItemOutput struct {
 
 	// A map of attribute names to AttributeValue objects, as specified by AttributesToGet.
 	Item map[string]*AttributeValue `type:"map"`
-
-	_ struct{} `type:"structure"`
 }
 
 // String returns the string representation
@@ -2450,6 +2450,8 @@ func (s GetItemOutput) GoString() string {
 
 // Represents the properties of a global secondary index.
 type GlobalSecondaryIndex struct {
+	_ struct{} `type:"structure"`
+
 	// The name of the global secondary index. The name must be unique among all
 	// other indexes on this table.
 	IndexName *string `min:"3" type:"string" required:"true"`
@@ -2470,8 +2472,6 @@ type GlobalSecondaryIndex struct {
 	// (http://docs.aws.amazon.com/amazondynamodb/latest/developerguide/Limits.html)
 	// in the Amazon DynamoDB Developer Guide.
 	ProvisionedThroughput *ProvisionedThroughput `type:"structure" required:"true"`
-
-	_ struct{} `type:"structure"`
 }
 
 // String returns the string representation
@@ -2486,6 +2486,8 @@ func (s GlobalSecondaryIndex) GoString() string {
 
 // Represents the properties of a global secondary index.
 type GlobalSecondaryIndexDescription struct {
+	_ struct{} `type:"structure"`
+
 	// Indicates whether the index is currently backfilling. Backfilling is the
 	// process of reading items from the table and determining whether they can
 	// be added to the index. (Not all items will qualify: For example, a hash key
@@ -2535,8 +2537,6 @@ type GlobalSecondaryIndexDescription struct {
 	// Represents the provisioned throughput settings for the table, consisting
 	// of read and write capacity units, along with data about increases and decreases.
 	ProvisionedThroughput *ProvisionedThroughputDescription `type:"structure"`
-
-	_ struct{} `type:"structure"`
 }
 
 // String returns the string representation
@@ -2557,6 +2557,8 @@ func (s GlobalSecondaryIndexDescription) GoString() string {
 //
 // An existing global secondary index to be removed from an existing table.
 type GlobalSecondaryIndexUpdate struct {
+	_ struct{} `type:"structure"`
+
 	// The parameters required for creating a global secondary index on an existing
 	// table:
 	//
@@ -2577,8 +2579,6 @@ type GlobalSecondaryIndexUpdate struct {
 	// The name of an existing global secondary index, along with new provisioned
 	// throughput settings to be applied to that index.
 	Update *UpdateGlobalSecondaryIndexAction `type:"structure"`
-
-	_ struct{} `type:"structure"`
 }
 
 // String returns the string representation
@@ -2596,6 +2596,8 @@ func (s GlobalSecondaryIndexUpdate) GoString() string {
 // table does not have any local secondary indexes, this information is not
 // returned in the response.
 type ItemCollectionMetrics struct {
+	_ struct{} `type:"structure"`
+
 	// The hash key value of the item collection. This value is the same as the
 	// hash key of the item.
 	ItemCollectionKey map[string]*AttributeValue `type:"map"`
@@ -2610,8 +2612,6 @@ type ItemCollectionMetrics struct {
 	// The estimate is subject to change over time; therefore, do not rely on the
 	// precision or accuracy of the estimate.
 	SizeEstimateRangeGB []*float64 `type:"list"`
-
-	_ struct{} `type:"structure"`
 }
 
 // String returns the string representation
@@ -2632,13 +2632,13 @@ func (s ItemCollectionMetrics) GoString() string {
 // A hash-and-range type primary key would require one KeySchemaElement for
 // the hash attribute, and another KeySchemaElement for the range attribute.
 type KeySchemaElement struct {
+	_ struct{} `type:"structure"`
+
 	// The name of a key attribute.
 	AttributeName *string `min:"1" type:"string" required:"true"`
 
 	// The attribute data, consisting of the data type and the attribute value itself.
 	KeyType *string `type:"string" required:"true" enum:"KeyType"`
-
-	_ struct{} `type:"structure"`
 }
 
 // String returns the string representation
@@ -2659,6 +2659,8 @@ func (s KeySchemaElement) GoString() string {
 // For a hash-and-range type primary key, you must provide both the hash attribute
 // and the range attribute.
 type KeysAndAttributes struct {
+	_ struct{} `type:"structure"`
+
 	// One or more attributes to retrieve from the table or index. If no attribute
 	// names are specified then all attributes will be returned. If any of the specified
 	// attributes are not found, they will not appear in the result.
@@ -2721,8 +2723,6 @@ type KeysAndAttributes struct {
 	//
 	// ProjectionExpression replaces the legacy AttributesToGet parameter.
 	ProjectionExpression *string `type:"string"`
-
-	_ struct{} `type:"structure"`
 }
 
 // String returns the string representation
@@ -2737,6 +2737,8 @@ func (s KeysAndAttributes) GoString() string {
 
 // Represents the input of a ListTables operation.
 type ListTablesInput struct {
+	_ struct{} `type:"structure"`
+
 	// The first table name that this operation will evaluate. Use the value that
 	// was returned for LastEvaluatedTableName in a previous operation, so that
 	// you can obtain the next page of results.
@@ -2745,8 +2747,6 @@ type ListTablesInput struct {
 	// A maximum number of table names to return. If this parameter is not specified,
 	// the limit is 100.
 	Limit *int64 `min:"1" type:"integer"`
-
-	_ struct{} `type:"structure"`
 }
 
 // String returns the string representation
@@ -2761,6 +2761,8 @@ func (s ListTablesInput) GoString() string {
 
 // Represents the output of a ListTables operation.
 type ListTablesOutput struct {
+	_ struct{} `type:"structure"`
+
 	// The name of the last table in the current page of results. Use this value
 	// as the ExclusiveStartTableName in a new request to obtain the next page of
 	// results, until all the table names are returned.
@@ -2776,8 +2778,6 @@ type ListTablesOutput struct {
 	// as the ExclusiveStartTableName parameter in a subsequent ListTables request
 	// and obtain the next page of results.
 	TableNames []*string `type:"list"`
-
-	_ struct{} `type:"structure"`
 }
 
 // String returns the string representation
@@ -2792,6 +2792,8 @@ func (s ListTablesOutput) GoString() string {
 
 // Represents the properties of a local secondary index.
 type LocalSecondaryIndex struct {
+	_ struct{} `type:"structure"`
+
 	// The name of the local secondary index. The name must be unique among all
 	// other indexes on this table.
 	IndexName *string `min:"3" type:"string" required:"true"`
@@ -2804,8 +2806,6 @@ type LocalSecondaryIndex struct {
 	// index. These are in addition to the primary key attributes and index key
 	// attributes, which are automatically projected.
 	Projection *Projection `type:"structure" required:"true"`
-
-	_ struct{} `type:"structure"`
 }
 
 // String returns the string representation
@@ -2820,6 +2820,8 @@ func (s LocalSecondaryIndex) GoString() string {
 
 // Represents the properties of a local secondary index.
 type LocalSecondaryIndexDescription struct {
+	_ struct{} `type:"structure"`
+
 	// The Amazon Resource Name (ARN) that uniquely identifies the index.
 	IndexArn *string `type:"string"`
 
@@ -2843,8 +2845,6 @@ type LocalSecondaryIndexDescription struct {
 	// index. These are in addition to the primary key attributes and index key
 	// attributes, which are automatically projected.
 	Projection *Projection `type:"structure"`
-
-	_ struct{} `type:"structure"`
 }
 
 // String returns the string representation
@@ -2861,6 +2861,8 @@ func (s LocalSecondaryIndexDescription) GoString() string {
 // index. These are in addition to the primary key attributes and index key
 // attributes, which are automatically projected.
 type Projection struct {
+	_ struct{} `type:"structure"`
+
 	// Represents the non-key attribute names which will be projected into the index.
 	//
 	// For local secondary indexes, the total count of NonKeyAttributes summed
@@ -2878,8 +2880,6 @@ type Projection struct {
 	//
 	//   ALL - All of the table attributes are projected into the index.
 	ProjectionType *string `type:"string" enum:"ProjectionType"`
-
-	_ struct{} `type:"structure"`
 }
 
 // String returns the string representation
@@ -2899,6 +2899,8 @@ func (s Projection) GoString() string {
 // (http://docs.aws.amazon.com/amazondynamodb/latest/developerguide/Limits.html)
 // in the Amazon DynamoDB Developer Guide.
 type ProvisionedThroughput struct {
+	_ struct{} `type:"structure"`
+
 	// The maximum number of strongly consistent reads consumed per second before
 	// DynamoDB returns a ThrottlingException. For more information, see Specifying
 	// Read and Write Requirements (http://docs.aws.amazon.com/amazondynamodb/latest/developerguide/WorkingWithTables.html#ProvisionedThroughput)
@@ -2910,8 +2912,6 @@ type ProvisionedThroughput struct {
 	// Requirements (http://docs.aws.amazon.com/amazondynamodb/latest/developerguide/WorkingWithTables.html#ProvisionedThroughput)
 	// in the Amazon DynamoDB Developer Guide.
 	WriteCapacityUnits *int64 `min:"1" type:"long" required:"true"`
-
-	_ struct{} `type:"structure"`
 }
 
 // String returns the string representation
@@ -2927,6 +2927,8 @@ func (s ProvisionedThroughput) GoString() string {
 // Represents the provisioned throughput settings for the table, consisting
 // of read and write capacity units, along with data about increases and decreases.
 type ProvisionedThroughputDescription struct {
+	_ struct{} `type:"structure"`
+
 	// The date and time of the last provisioned throughput decrease for this table.
 	LastDecreaseDateTime *time.Time `type:"timestamp" timestampFormat:"unix"`
 
@@ -2948,8 +2950,6 @@ type ProvisionedThroughputDescription struct {
 	// The maximum number of writes consumed per second before DynamoDB returns
 	// a ThrottlingException.
 	WriteCapacityUnits *int64 `min:"1" type:"long"`
-
-	_ struct{} `type:"structure"`
 }
 
 // String returns the string representation
@@ -2964,6 +2964,8 @@ func (s ProvisionedThroughputDescription) GoString() string {
 
 // Represents the input of a PutItem operation.
 type PutItemInput struct {
+	_ struct{} `type:"structure"`
+
 	// A condition that must be satisfied in order for a conditional PutItem operation
 	// to succeed.
 	//
@@ -3316,8 +3318,6 @@ type PutItemInput struct {
 
 	// The name of the table to contain the item.
 	TableName *string `min:"3" type:"string" required:"true"`
-
-	_ struct{} `type:"structure"`
 }
 
 // String returns the string representation
@@ -3332,6 +3332,8 @@ func (s PutItemInput) GoString() string {
 
 // Represents the output of a PutItem operation.
 type PutItemOutput struct {
+	_ struct{} `type:"structure"`
+
 	// The attribute values as they appeared before the PutItem operation, but only
 	// if ReturnValues is specified as ALL_OLD in the request. Each element consists
 	// of an attribute name and an attribute value.
@@ -3365,8 +3367,6 @@ type PutItemOutput struct {
 	// The estimate is subject to change over time; therefore, do not rely on the
 	// precision or accuracy of the estimate.
 	ItemCollectionMetrics *ItemCollectionMetrics `type:"structure"`
-
-	_ struct{} `type:"structure"`
 }
 
 // String returns the string representation
@@ -3381,14 +3381,14 @@ func (s PutItemOutput) GoString() string {
 
 // Represents a request to perform a PutItem operation on an item.
 type PutRequest struct {
+	_ struct{} `type:"structure"`
+
 	// A map of attribute name to attribute values, representing the primary key
 	// of an item to be processed by PutItem. All of the table's primary key attributes
 	// must be specified, and their data types must match those of the table's key
 	// schema. If any attributes are present in the item which are part of an index
 	// key schema for the table, their types must match the index key schema.
 	Item map[string]*AttributeValue `type:"map" required:"true"`
-
-	_ struct{} `type:"structure"`
 }
 
 // String returns the string representation
@@ -3403,6 +3403,8 @@ func (s PutRequest) GoString() string {
 
 // Represents the input of a Query operation.
 type QueryInput struct {
+	_ struct{} `type:"structure"`
+
 	// This is a legacy parameter, for backward compatibility. New applications
 	// should use ProjectionExpression instead. Do not combine legacy parameters
 	// and expression parameters in a single API call; otherwise, DynamoDB will
@@ -3879,8 +3881,6 @@ type QueryInput struct {
 
 	// The name of the table containing the requested items.
 	TableName *string `min:"3" type:"string" required:"true"`
-
-	_ struct{} `type:"structure"`
 }
 
 // String returns the string representation
@@ -3895,6 +3895,8 @@ func (s QueryInput) GoString() string {
 
 // Represents the output of a Query operation.
 type QueryOutput struct {
+	_ struct{} `type:"structure"`
+
 	// The capacity units consumed by an operation. The data returned includes the
 	// total provisioned throughput consumed, along with statistics for the table
 	// and any indexes involved in the operation. ConsumedCapacity is only returned
@@ -3937,8 +3939,6 @@ type QueryOutput struct {
 	// If you did not use a filter in the request, then ScannedCount is the same
 	// as Count.
 	ScannedCount *int64 `type:"integer"`
-
-	_ struct{} `type:"structure"`
 }
 
 // String returns the string representation
@@ -3953,6 +3953,8 @@ func (s QueryOutput) GoString() string {
 
 // Represents the input of a Scan operation.
 type ScanInput struct {
+	_ struct{} `type:"structure"`
+
 	// This is a legacy parameter, for backward compatibility. New applications
 	// should use ProjectionExpression instead. Do not combine legacy parameters
 	// and expression parameters in a single API call; otherwise, DynamoDB will
@@ -4239,8 +4241,6 @@ type ScanInput struct {
 	//
 	// If you specify TotalSegments, you must also specify Segment.
 	TotalSegments *int64 `min:"1" type:"integer"`
-
-	_ struct{} `type:"structure"`
 }
 
 // String returns the string representation
@@ -4255,6 +4255,8 @@ func (s ScanInput) GoString() string {
 
 // Represents the output of a Scan operation.
 type ScanOutput struct {
+	_ struct{} `type:"structure"`
+
 	// The capacity units consumed by an operation. The data returned includes the
 	// total provisioned throughput consumed, along with statistics for the table
 	// and any indexes involved in the operation. ConsumedCapacity is only returned
@@ -4296,8 +4298,6 @@ type ScanOutput struct {
 	// If you did not use a filter in the request, then ScannedCount is the same
 	// as Count.
 	ScannedCount *int64 `type:"integer"`
-
-	_ struct{} `type:"structure"`
 }
 
 // String returns the string representation
@@ -4312,6 +4312,8 @@ func (s ScanOutput) GoString() string {
 
 // Represents the DynamoDB Streams configuration for a table in DynamoDB.
 type StreamSpecification struct {
+	_ struct{} `type:"structure"`
+
 	// Indicates whether DynamoDB Streams is enabled (true) or disabled (false)
 	// on the table.
 	StreamEnabled *bool `type:"boolean"`
@@ -4337,8 +4339,6 @@ type StreamSpecification struct {
 	// NEW_AND_OLD_IMAGES - Both the new and the old item images of the item are
 	// written to the stream.
 	StreamViewType *string `type:"string" enum:"StreamViewType"`
-
-	_ struct{} `type:"structure"`
 }
 
 // String returns the string representation
@@ -4353,6 +4353,8 @@ func (s StreamSpecification) GoString() string {
 
 // Represents the properties of a table.
 type TableDescription struct {
+	_ struct{} `type:"structure"`
+
 	// An array of AttributeDefinition objects. Each of these objects describes
 	// one attribute in the table and index key schema.
 	//
@@ -4532,8 +4534,6 @@ type TableDescription struct {
 	//
 	//   ACTIVE - The table is ready for use.
 	TableStatus *string `type:"string" enum:"TableStatus"`
-
-	_ struct{} `type:"structure"`
 }
 
 // String returns the string representation
@@ -4549,6 +4549,8 @@ func (s TableDescription) GoString() string {
 // Represents the new provisioned throughput settings to be applied to a global
 // secondary index.
 type UpdateGlobalSecondaryIndexAction struct {
+	_ struct{} `type:"structure"`
+
 	// The name of the global secondary index to be updated.
 	IndexName *string `min:"3" type:"string" required:"true"`
 
@@ -4559,8 +4561,6 @@ type UpdateGlobalSecondaryIndexAction struct {
 	// (http://docs.aws.amazon.com/amazondynamodb/latest/developerguide/Limits.html)
 	// in the Amazon DynamoDB Developer Guide.
 	ProvisionedThroughput *ProvisionedThroughput `type:"structure" required:"true"`
-
-	_ struct{} `type:"structure"`
 }
 
 // String returns the string representation
@@ -4575,6 +4575,8 @@ func (s UpdateGlobalSecondaryIndexAction) GoString() string {
 
 // Represents the input of an UpdateItem operation.
 type UpdateItemInput struct {
+	_ struct{} `type:"structure"`
+
 	// This is a legacy parameter, for backward compatibility. New applications
 	// should use UpdateExpression instead. Do not combine legacy parameters and
 	// expression parameters in a single API call; otherwise, DynamoDB will return
@@ -5086,8 +5088,6 @@ type UpdateItemInput struct {
 	//
 	// UpdateExpression replaces the legacy AttributeUpdates parameter.
 	UpdateExpression *string `type:"string"`
-
-	_ struct{} `type:"structure"`
 }
 
 // String returns the string representation
@@ -5102,6 +5102,8 @@ func (s UpdateItemInput) GoString() string {
 
 // Represents the output of an UpdateItem operation.
 type UpdateItemOutput struct {
+	_ struct{} `type:"structure"`
+
 	// A map of attribute values as they appeared before the UpdateItem operation.
 	// This map only appears if ReturnValues was specified as something other than
 	// NONE in the request. Each element represents one attribute.
@@ -5120,8 +5122,6 @@ type UpdateItemOutput struct {
 	// table does not have any local secondary indexes, this information is not
 	// returned in the response.
 	ItemCollectionMetrics *ItemCollectionMetrics `type:"structure"`
-
-	_ struct{} `type:"structure"`
 }
 
 // String returns the string representation
@@ -5136,6 +5136,8 @@ func (s UpdateItemOutput) GoString() string {
 
 // Represents the input of an UpdateTable operation.
 type UpdateTableInput struct {
+	_ struct{} `type:"structure"`
+
 	// An array of attributes that describe the key schema for the table and indexes.
 	// If you are adding a new global secondary index to the table, AttributeDefinitions
 	// must include the key element(s) of the new index.
@@ -5172,8 +5174,6 @@ type UpdateTableInput struct {
 
 	// The name of the table to be updated.
 	TableName *string `min:"3" type:"string" required:"true"`
-
-	_ struct{} `type:"structure"`
 }
 
 // String returns the string representation
@@ -5188,10 +5188,10 @@ func (s UpdateTableInput) GoString() string {
 
 // Represents the output of an UpdateTable operation.
 type UpdateTableOutput struct {
+	_ struct{} `type:"structure"`
+
 	// Represents the properties of a table.
 	TableDescription *TableDescription `type:"structure"`
-
-	_ struct{} `type:"structure"`
 }
 
 // String returns the string representation
@@ -5209,13 +5209,13 @@ func (s UpdateTableOutput) GoString() string {
 // If you do need to perform both of these operations, you will need to provide
 // two separate WriteRequest objects.
 type WriteRequest struct {
+	_ struct{} `type:"structure"`
+
 	// A request to perform a DeleteItem operation.
 	DeleteRequest *DeleteRequest `type:"structure"`
 
 	// A request to perform a PutItem operation.
 	PutRequest *PutRequest `type:"structure"`
-
-	_ struct{} `type:"structure"`
 }
 
 // String returns the string representation

--- a/service/dynamodb/api.go
+++ b/service/dynamodb/api.go
@@ -693,11 +693,7 @@ type AttributeDefinition struct {
 	// The data type for the attribute.
 	AttributeType *string `type:"string" required:"true" enum:"ScalarAttributeType"`
 
-	metadataAttributeDefinition `json:"-" xml:"-"`
-}
-
-type metadataAttributeDefinition struct {
-	SDKShapeTraits bool `type:"structure"`
+	_ struct{} `type:"structure"`
 }
 
 // String returns the string representation
@@ -748,11 +744,7 @@ type AttributeValue struct {
 	// A String Set data type.
 	SS []*string `type:"list"`
 
-	metadataAttributeValue `json:"-" xml:"-"`
-}
-
-type metadataAttributeValue struct {
-	SDKShapeTraits bool `type:"structure"`
+	_ struct{} `type:"structure"`
 }
 
 // String returns the string representation
@@ -849,11 +841,7 @@ type AttributeValueUpdate struct {
 	// attribute is a set; duplicate values are not allowed.
 	Value *AttributeValue `type:"structure"`
 
-	metadataAttributeValueUpdate `json:"-" xml:"-"`
-}
-
-type metadataAttributeValueUpdate struct {
-	SDKShapeTraits bool `type:"structure"`
+	_ struct{} `type:"structure"`
 }
 
 // String returns the string representation
@@ -967,11 +955,7 @@ type BatchGetItemInput struct {
 	// NONE - No ConsumedCapacity details are included in the response.
 	ReturnConsumedCapacity *string `type:"string" enum:"ReturnConsumedCapacity"`
 
-	metadataBatchGetItemInput `json:"-" xml:"-"`
-}
-
-type metadataBatchGetItemInput struct {
-	SDKShapeTraits bool `type:"structure"`
+	_ struct{} `type:"structure"`
 }
 
 // String returns the string representation
@@ -1022,11 +1006,7 @@ type BatchGetItemOutput struct {
 	// UnprocessedKeys map.
 	UnprocessedKeys map[string]*KeysAndAttributes `min:"1" type:"map"`
 
-	metadataBatchGetItemOutput `json:"-" xml:"-"`
-}
-
-type metadataBatchGetItemOutput struct {
-	SDKShapeTraits bool `type:"structure"`
+	_ struct{} `type:"structure"`
 }
 
 // String returns the string representation
@@ -1092,11 +1072,7 @@ type BatchWriteItemInput struct {
 	// (the default), no statistics are returned.
 	ReturnItemCollectionMetrics *string `type:"string" enum:"ReturnItemCollectionMetrics"`
 
-	metadataBatchWriteItemInput `json:"-" xml:"-"`
-}
-
-type metadataBatchWriteItemInput struct {
-	SDKShapeTraits bool `type:"structure"`
+	_ struct{} `type:"structure"`
 }
 
 // String returns the string representation
@@ -1172,11 +1148,7 @@ type BatchWriteItemOutput struct {
 	// empty UnprocessedItems map.
 	UnprocessedItems map[string][]*WriteRequest `min:"1" type:"map"`
 
-	metadataBatchWriteItemOutput `json:"-" xml:"-"`
-}
-
-type metadataBatchWriteItemOutput struct {
-	SDKShapeTraits bool `type:"structure"`
+	_ struct{} `type:"structure"`
 }
 
 // String returns the string representation
@@ -1195,11 +1167,7 @@ type Capacity struct {
 	// The total number of capacity units consumed on a table or an index.
 	CapacityUnits *float64 `type:"double"`
 
-	metadataCapacity `json:"-" xml:"-"`
-}
-
-type metadataCapacity struct {
-	SDKShapeTraits bool `type:"structure"`
+	_ struct{} `type:"structure"`
 }
 
 // String returns the string representation
@@ -1373,11 +1341,7 @@ type Condition struct {
 	// in the Amazon DynamoDB Developer Guide.
 	ComparisonOperator *string `type:"string" required:"true" enum:"ComparisonOperator"`
 
-	metadataCondition `json:"-" xml:"-"`
-}
-
-type metadataCondition struct {
-	SDKShapeTraits bool `type:"structure"`
+	_ struct{} `type:"structure"`
 }
 
 // String returns the string representation
@@ -1412,11 +1376,7 @@ type ConsumedCapacity struct {
 	// The name of the table that was affected by the operation.
 	TableName *string `min:"3" type:"string"`
 
-	metadataConsumedCapacity `json:"-" xml:"-"`
-}
-
-type metadataConsumedCapacity struct {
-	SDKShapeTraits bool `type:"structure"`
+	_ struct{} `type:"structure"`
 }
 
 // String returns the string representation
@@ -1450,11 +1410,7 @@ type CreateGlobalSecondaryIndexAction struct {
 	// in the Amazon DynamoDB Developer Guide.
 	ProvisionedThroughput *ProvisionedThroughput `type:"structure" required:"true"`
 
-	metadataCreateGlobalSecondaryIndexAction `json:"-" xml:"-"`
-}
-
-type metadataCreateGlobalSecondaryIndexAction struct {
-	SDKShapeTraits bool `type:"structure"`
+	_ struct{} `type:"structure"`
 }
 
 // String returns the string representation
@@ -1593,11 +1549,7 @@ type CreateTableInput struct {
 	// The name of the table to create.
 	TableName *string `min:"3" type:"string" required:"true"`
 
-	metadataCreateTableInput `json:"-" xml:"-"`
-}
-
-type metadataCreateTableInput struct {
-	SDKShapeTraits bool `type:"structure"`
+	_ struct{} `type:"structure"`
 }
 
 // String returns the string representation
@@ -1615,11 +1567,7 @@ type CreateTableOutput struct {
 	// Represents the properties of a table.
 	TableDescription *TableDescription `type:"structure"`
 
-	metadataCreateTableOutput `json:"-" xml:"-"`
-}
-
-type metadataCreateTableOutput struct {
-	SDKShapeTraits bool `type:"structure"`
+	_ struct{} `type:"structure"`
 }
 
 // String returns the string representation
@@ -1637,11 +1585,7 @@ type DeleteGlobalSecondaryIndexAction struct {
 	// The name of the global secondary index to be deleted.
 	IndexName *string `min:"3" type:"string" required:"true"`
 
-	metadataDeleteGlobalSecondaryIndexAction `json:"-" xml:"-"`
-}
-
-type metadataDeleteGlobalSecondaryIndexAction struct {
-	SDKShapeTraits bool `type:"structure"`
+	_ struct{} `type:"structure"`
 }
 
 // String returns the string representation
@@ -1995,11 +1939,7 @@ type DeleteItemInput struct {
 	// The name of the table from which to delete the item.
 	TableName *string `min:"3" type:"string" required:"true"`
 
-	metadataDeleteItemInput `json:"-" xml:"-"`
-}
-
-type metadataDeleteItemInput struct {
-	SDKShapeTraits bool `type:"structure"`
+	_ struct{} `type:"structure"`
 }
 
 // String returns the string representation
@@ -2048,11 +1988,7 @@ type DeleteItemOutput struct {
 	// precision or accuracy of the estimate.
 	ItemCollectionMetrics *ItemCollectionMetrics `type:"structure"`
 
-	metadataDeleteItemOutput `json:"-" xml:"-"`
-}
-
-type metadataDeleteItemOutput struct {
-	SDKShapeTraits bool `type:"structure"`
+	_ struct{} `type:"structure"`
 }
 
 // String returns the string representation
@@ -2072,11 +2008,7 @@ type DeleteRequest struct {
 	// specified, and their data types must match those of the table's key schema.
 	Key map[string]*AttributeValue `type:"map" required:"true"`
 
-	metadataDeleteRequest `json:"-" xml:"-"`
-}
-
-type metadataDeleteRequest struct {
-	SDKShapeTraits bool `type:"structure"`
+	_ struct{} `type:"structure"`
 }
 
 // String returns the string representation
@@ -2094,11 +2026,7 @@ type DeleteTableInput struct {
 	// The name of the table to delete.
 	TableName *string `min:"3" type:"string" required:"true"`
 
-	metadataDeleteTableInput `json:"-" xml:"-"`
-}
-
-type metadataDeleteTableInput struct {
-	SDKShapeTraits bool `type:"structure"`
+	_ struct{} `type:"structure"`
 }
 
 // String returns the string representation
@@ -2116,11 +2044,7 @@ type DeleteTableOutput struct {
 	// Represents the properties of a table.
 	TableDescription *TableDescription `type:"structure"`
 
-	metadataDeleteTableOutput `json:"-" xml:"-"`
-}
-
-type metadataDeleteTableOutput struct {
-	SDKShapeTraits bool `type:"structure"`
+	_ struct{} `type:"structure"`
 }
 
 // String returns the string representation
@@ -2138,11 +2062,7 @@ type DescribeTableInput struct {
 	// The name of the table to describe.
 	TableName *string `min:"3" type:"string" required:"true"`
 
-	metadataDescribeTableInput `json:"-" xml:"-"`
-}
-
-type metadataDescribeTableInput struct {
-	SDKShapeTraits bool `type:"structure"`
+	_ struct{} `type:"structure"`
 }
 
 // String returns the string representation
@@ -2160,11 +2080,7 @@ type DescribeTableOutput struct {
 	// Represents the properties of a table.
 	Table *TableDescription `type:"structure"`
 
-	metadataDescribeTableOutput `json:"-" xml:"-"`
-}
-
-type metadataDescribeTableOutput struct {
-	SDKShapeTraits bool `type:"structure"`
+	_ struct{} `type:"structure"`
 }
 
 // String returns the string representation
@@ -2377,11 +2293,7 @@ type ExpectedAttributeValue struct {
 	// attribute is a set; duplicate values are not allowed.
 	Value *AttributeValue `type:"structure"`
 
-	metadataExpectedAttributeValue `json:"-" xml:"-"`
-}
-
-type metadataExpectedAttributeValue struct {
-	SDKShapeTraits bool `type:"structure"`
+	_ struct{} `type:"structure"`
 }
 
 // String returns the string representation
@@ -2497,11 +2409,7 @@ type GetItemInput struct {
 	// The name of the table containing the requested item.
 	TableName *string `min:"3" type:"string" required:"true"`
 
-	metadataGetItemInput `json:"-" xml:"-"`
-}
-
-type metadataGetItemInput struct {
-	SDKShapeTraits bool `type:"structure"`
+	_ struct{} `type:"structure"`
 }
 
 // String returns the string representation
@@ -2527,11 +2435,7 @@ type GetItemOutput struct {
 	// A map of attribute names to AttributeValue objects, as specified by AttributesToGet.
 	Item map[string]*AttributeValue `type:"map"`
 
-	metadataGetItemOutput `json:"-" xml:"-"`
-}
-
-type metadataGetItemOutput struct {
-	SDKShapeTraits bool `type:"structure"`
+	_ struct{} `type:"structure"`
 }
 
 // String returns the string representation
@@ -2567,11 +2471,7 @@ type GlobalSecondaryIndex struct {
 	// in the Amazon DynamoDB Developer Guide.
 	ProvisionedThroughput *ProvisionedThroughput `type:"structure" required:"true"`
 
-	metadataGlobalSecondaryIndex `json:"-" xml:"-"`
-}
-
-type metadataGlobalSecondaryIndex struct {
-	SDKShapeTraits bool `type:"structure"`
+	_ struct{} `type:"structure"`
 }
 
 // String returns the string representation
@@ -2636,11 +2536,7 @@ type GlobalSecondaryIndexDescription struct {
 	// of read and write capacity units, along with data about increases and decreases.
 	ProvisionedThroughput *ProvisionedThroughputDescription `type:"structure"`
 
-	metadataGlobalSecondaryIndexDescription `json:"-" xml:"-"`
-}
-
-type metadataGlobalSecondaryIndexDescription struct {
-	SDKShapeTraits bool `type:"structure"`
+	_ struct{} `type:"structure"`
 }
 
 // String returns the string representation
@@ -2682,11 +2578,7 @@ type GlobalSecondaryIndexUpdate struct {
 	// throughput settings to be applied to that index.
 	Update *UpdateGlobalSecondaryIndexAction `type:"structure"`
 
-	metadataGlobalSecondaryIndexUpdate `json:"-" xml:"-"`
-}
-
-type metadataGlobalSecondaryIndexUpdate struct {
-	SDKShapeTraits bool `type:"structure"`
+	_ struct{} `type:"structure"`
 }
 
 // String returns the string representation
@@ -2719,11 +2611,7 @@ type ItemCollectionMetrics struct {
 	// precision or accuracy of the estimate.
 	SizeEstimateRangeGB []*float64 `type:"list"`
 
-	metadataItemCollectionMetrics `json:"-" xml:"-"`
-}
-
-type metadataItemCollectionMetrics struct {
-	SDKShapeTraits bool `type:"structure"`
+	_ struct{} `type:"structure"`
 }
 
 // String returns the string representation
@@ -2750,11 +2638,7 @@ type KeySchemaElement struct {
 	// The attribute data, consisting of the data type and the attribute value itself.
 	KeyType *string `type:"string" required:"true" enum:"KeyType"`
 
-	metadataKeySchemaElement `json:"-" xml:"-"`
-}
-
-type metadataKeySchemaElement struct {
-	SDKShapeTraits bool `type:"structure"`
+	_ struct{} `type:"structure"`
 }
 
 // String returns the string representation
@@ -2838,11 +2722,7 @@ type KeysAndAttributes struct {
 	// ProjectionExpression replaces the legacy AttributesToGet parameter.
 	ProjectionExpression *string `type:"string"`
 
-	metadataKeysAndAttributes `json:"-" xml:"-"`
-}
-
-type metadataKeysAndAttributes struct {
-	SDKShapeTraits bool `type:"structure"`
+	_ struct{} `type:"structure"`
 }
 
 // String returns the string representation
@@ -2866,11 +2746,7 @@ type ListTablesInput struct {
 	// the limit is 100.
 	Limit *int64 `min:"1" type:"integer"`
 
-	metadataListTablesInput `json:"-" xml:"-"`
-}
-
-type metadataListTablesInput struct {
-	SDKShapeTraits bool `type:"structure"`
+	_ struct{} `type:"structure"`
 }
 
 // String returns the string representation
@@ -2901,11 +2777,7 @@ type ListTablesOutput struct {
 	// and obtain the next page of results.
 	TableNames []*string `type:"list"`
 
-	metadataListTablesOutput `json:"-" xml:"-"`
-}
-
-type metadataListTablesOutput struct {
-	SDKShapeTraits bool `type:"structure"`
+	_ struct{} `type:"structure"`
 }
 
 // String returns the string representation
@@ -2933,11 +2805,7 @@ type LocalSecondaryIndex struct {
 	// attributes, which are automatically projected.
 	Projection *Projection `type:"structure" required:"true"`
 
-	metadataLocalSecondaryIndex `json:"-" xml:"-"`
-}
-
-type metadataLocalSecondaryIndex struct {
-	SDKShapeTraits bool `type:"structure"`
+	_ struct{} `type:"structure"`
 }
 
 // String returns the string representation
@@ -2976,11 +2844,7 @@ type LocalSecondaryIndexDescription struct {
 	// attributes, which are automatically projected.
 	Projection *Projection `type:"structure"`
 
-	metadataLocalSecondaryIndexDescription `json:"-" xml:"-"`
-}
-
-type metadataLocalSecondaryIndexDescription struct {
-	SDKShapeTraits bool `type:"structure"`
+	_ struct{} `type:"structure"`
 }
 
 // String returns the string representation
@@ -3015,11 +2879,7 @@ type Projection struct {
 	//   ALL - All of the table attributes are projected into the index.
 	ProjectionType *string `type:"string" enum:"ProjectionType"`
 
-	metadataProjection `json:"-" xml:"-"`
-}
-
-type metadataProjection struct {
-	SDKShapeTraits bool `type:"structure"`
+	_ struct{} `type:"structure"`
 }
 
 // String returns the string representation
@@ -3051,11 +2911,7 @@ type ProvisionedThroughput struct {
 	// in the Amazon DynamoDB Developer Guide.
 	WriteCapacityUnits *int64 `min:"1" type:"long" required:"true"`
 
-	metadataProvisionedThroughput `json:"-" xml:"-"`
-}
-
-type metadataProvisionedThroughput struct {
-	SDKShapeTraits bool `type:"structure"`
+	_ struct{} `type:"structure"`
 }
 
 // String returns the string representation
@@ -3093,11 +2949,7 @@ type ProvisionedThroughputDescription struct {
 	// a ThrottlingException.
 	WriteCapacityUnits *int64 `min:"1" type:"long"`
 
-	metadataProvisionedThroughputDescription `json:"-" xml:"-"`
-}
-
-type metadataProvisionedThroughputDescription struct {
-	SDKShapeTraits bool `type:"structure"`
+	_ struct{} `type:"structure"`
 }
 
 // String returns the string representation
@@ -3465,11 +3317,7 @@ type PutItemInput struct {
 	// The name of the table to contain the item.
 	TableName *string `min:"3" type:"string" required:"true"`
 
-	metadataPutItemInput `json:"-" xml:"-"`
-}
-
-type metadataPutItemInput struct {
-	SDKShapeTraits bool `type:"structure"`
+	_ struct{} `type:"structure"`
 }
 
 // String returns the string representation
@@ -3518,11 +3366,7 @@ type PutItemOutput struct {
 	// precision or accuracy of the estimate.
 	ItemCollectionMetrics *ItemCollectionMetrics `type:"structure"`
 
-	metadataPutItemOutput `json:"-" xml:"-"`
-}
-
-type metadataPutItemOutput struct {
-	SDKShapeTraits bool `type:"structure"`
+	_ struct{} `type:"structure"`
 }
 
 // String returns the string representation
@@ -3544,11 +3388,7 @@ type PutRequest struct {
 	// key schema for the table, their types must match the index key schema.
 	Item map[string]*AttributeValue `type:"map" required:"true"`
 
-	metadataPutRequest `json:"-" xml:"-"`
-}
-
-type metadataPutRequest struct {
-	SDKShapeTraits bool `type:"structure"`
+	_ struct{} `type:"structure"`
 }
 
 // String returns the string representation
@@ -4040,11 +3880,7 @@ type QueryInput struct {
 	// The name of the table containing the requested items.
 	TableName *string `min:"3" type:"string" required:"true"`
 
-	metadataQueryInput `json:"-" xml:"-"`
-}
-
-type metadataQueryInput struct {
-	SDKShapeTraits bool `type:"structure"`
+	_ struct{} `type:"structure"`
 }
 
 // String returns the string representation
@@ -4102,11 +3938,7 @@ type QueryOutput struct {
 	// as Count.
 	ScannedCount *int64 `type:"integer"`
 
-	metadataQueryOutput `json:"-" xml:"-"`
-}
-
-type metadataQueryOutput struct {
-	SDKShapeTraits bool `type:"structure"`
+	_ struct{} `type:"structure"`
 }
 
 // String returns the string representation
@@ -4408,11 +4240,7 @@ type ScanInput struct {
 	// If you specify TotalSegments, you must also specify Segment.
 	TotalSegments *int64 `min:"1" type:"integer"`
 
-	metadataScanInput `json:"-" xml:"-"`
-}
-
-type metadataScanInput struct {
-	SDKShapeTraits bool `type:"structure"`
+	_ struct{} `type:"structure"`
 }
 
 // String returns the string representation
@@ -4469,11 +4297,7 @@ type ScanOutput struct {
 	// as Count.
 	ScannedCount *int64 `type:"integer"`
 
-	metadataScanOutput `json:"-" xml:"-"`
-}
-
-type metadataScanOutput struct {
-	SDKShapeTraits bool `type:"structure"`
+	_ struct{} `type:"structure"`
 }
 
 // String returns the string representation
@@ -4514,11 +4338,7 @@ type StreamSpecification struct {
 	// written to the stream.
 	StreamViewType *string `type:"string" enum:"StreamViewType"`
 
-	metadataStreamSpecification `json:"-" xml:"-"`
-}
-
-type metadataStreamSpecification struct {
-	SDKShapeTraits bool `type:"structure"`
+	_ struct{} `type:"structure"`
 }
 
 // String returns the string representation
@@ -4713,11 +4533,7 @@ type TableDescription struct {
 	//   ACTIVE - The table is ready for use.
 	TableStatus *string `type:"string" enum:"TableStatus"`
 
-	metadataTableDescription `json:"-" xml:"-"`
-}
-
-type metadataTableDescription struct {
-	SDKShapeTraits bool `type:"structure"`
+	_ struct{} `type:"structure"`
 }
 
 // String returns the string representation
@@ -4744,11 +4560,7 @@ type UpdateGlobalSecondaryIndexAction struct {
 	// in the Amazon DynamoDB Developer Guide.
 	ProvisionedThroughput *ProvisionedThroughput `type:"structure" required:"true"`
 
-	metadataUpdateGlobalSecondaryIndexAction `json:"-" xml:"-"`
-}
-
-type metadataUpdateGlobalSecondaryIndexAction struct {
-	SDKShapeTraits bool `type:"structure"`
+	_ struct{} `type:"structure"`
 }
 
 // String returns the string representation
@@ -5275,11 +5087,7 @@ type UpdateItemInput struct {
 	// UpdateExpression replaces the legacy AttributeUpdates parameter.
 	UpdateExpression *string `type:"string"`
 
-	metadataUpdateItemInput `json:"-" xml:"-"`
-}
-
-type metadataUpdateItemInput struct {
-	SDKShapeTraits bool `type:"structure"`
+	_ struct{} `type:"structure"`
 }
 
 // String returns the string representation
@@ -5313,11 +5121,7 @@ type UpdateItemOutput struct {
 	// returned in the response.
 	ItemCollectionMetrics *ItemCollectionMetrics `type:"structure"`
 
-	metadataUpdateItemOutput `json:"-" xml:"-"`
-}
-
-type metadataUpdateItemOutput struct {
-	SDKShapeTraits bool `type:"structure"`
+	_ struct{} `type:"structure"`
 }
 
 // String returns the string representation
@@ -5369,11 +5173,7 @@ type UpdateTableInput struct {
 	// The name of the table to be updated.
 	TableName *string `min:"3" type:"string" required:"true"`
 
-	metadataUpdateTableInput `json:"-" xml:"-"`
-}
-
-type metadataUpdateTableInput struct {
-	SDKShapeTraits bool `type:"structure"`
+	_ struct{} `type:"structure"`
 }
 
 // String returns the string representation
@@ -5391,11 +5191,7 @@ type UpdateTableOutput struct {
 	// Represents the properties of a table.
 	TableDescription *TableDescription `type:"structure"`
 
-	metadataUpdateTableOutput `json:"-" xml:"-"`
-}
-
-type metadataUpdateTableOutput struct {
-	SDKShapeTraits bool `type:"structure"`
+	_ struct{} `type:"structure"`
 }
 
 // String returns the string representation
@@ -5419,11 +5215,7 @@ type WriteRequest struct {
 	// A request to perform a PutItem operation.
 	PutRequest *PutRequest `type:"structure"`
 
-	metadataWriteRequest `json:"-" xml:"-"`
-}
-
-type metadataWriteRequest struct {
-	SDKShapeTraits bool `type:"structure"`
+	_ struct{} `type:"structure"`
 }
 
 // String returns the string representation

--- a/service/dynamodbstreams/api.go
+++ b/service/dynamodbstreams/api.go
@@ -149,6 +149,8 @@ func (c *DynamoDBStreams) ListStreams(input *ListStreamsInput) (*ListStreamsOutp
 
 // Represents the input of a DescribeStream operation.
 type DescribeStreamInput struct {
+	_ struct{} `type:"structure"`
+
 	// The shard ID of the first item that this operation will evaluate. Use the
 	// value that was returned for LastEvaluatedShardId in the previous operation.
 	ExclusiveStartShardId *string `min:"28" type:"string"`
@@ -158,8 +160,6 @@ type DescribeStreamInput struct {
 
 	// The Amazon Resource Name (ARN) for the stream.
 	StreamArn *string `min:"37" type:"string" required:"true"`
-
-	_ struct{} `type:"structure"`
 }
 
 // String returns the string representation
@@ -174,13 +174,13 @@ func (s DescribeStreamInput) GoString() string {
 
 // Represents the output of a DescribeStream operation.
 type DescribeStreamOutput struct {
+	_ struct{} `type:"structure"`
+
 	// A complete description of the stream, including its creation date and time,
 	// the DynamoDB table associated with the stream, the shard IDs within the stream,
 	// and the beginning and ending sequence numbers of stream records within the
 	// shards.
 	StreamDescription *StreamDescription `type:"structure"`
-
-	_ struct{} `type:"structure"`
 }
 
 // String returns the string representation
@@ -195,6 +195,8 @@ func (s DescribeStreamOutput) GoString() string {
 
 // Represents the input of a GetRecords operation.
 type GetRecordsInput struct {
+	_ struct{} `type:"structure"`
+
 	// The maximum number of records to return from the shard. The upper limit is
 	// 1000.
 	Limit *int64 `min:"1" type:"integer"`
@@ -202,8 +204,6 @@ type GetRecordsInput struct {
 	// A shard iterator that was retrieved from a previous GetShardIterator operation.
 	// This iterator can be used to access the stream records in this shard.
 	ShardIterator *string `min:"1" type:"string" required:"true"`
-
-	_ struct{} `type:"structure"`
 }
 
 // String returns the string representation
@@ -218,6 +218,8 @@ func (s GetRecordsInput) GoString() string {
 
 // Represents the output of a GetRecords operation.
 type GetRecordsOutput struct {
+	_ struct{} `type:"structure"`
+
 	// The next position in the shard from which to start sequentially reading stream
 	// records. If set to null, the shard has been closed and the requested iterator
 	// will not return any more data.
@@ -225,8 +227,6 @@ type GetRecordsOutput struct {
 
 	// The stream records from the shard, which were retrieved using the shard iterator.
 	Records []*Record `type:"list"`
-
-	_ struct{} `type:"structure"`
 }
 
 // String returns the string representation
@@ -241,6 +241,8 @@ func (s GetRecordsOutput) GoString() string {
 
 // Represents the input of a GetShardIterator operation.
 type GetShardIteratorInput struct {
+	_ struct{} `type:"structure"`
+
 	// The sequence number of a stream record in the shard from which to start reading.
 	SequenceNumber *string `min:"21" type:"string"`
 
@@ -268,8 +270,6 @@ type GetShardIteratorInput struct {
 
 	// The Amazon Resource Name (ARN) for the stream.
 	StreamArn *string `min:"37" type:"string" required:"true"`
-
-	_ struct{} `type:"structure"`
 }
 
 // String returns the string representation
@@ -284,12 +284,12 @@ func (s GetShardIteratorInput) GoString() string {
 
 // Represents the output of a GetShardIterator operation.
 type GetShardIteratorOutput struct {
+	_ struct{} `type:"structure"`
+
 	// The position in the shard from which to start reading stream records sequentially.
 	// A shard iterator specifies this position using the sequence number of a stream
 	// record in a shard.
 	ShardIterator *string `min:"1" type:"string"`
-
-	_ struct{} `type:"structure"`
 }
 
 // String returns the string representation
@@ -304,6 +304,8 @@ func (s GetShardIteratorOutput) GoString() string {
 
 // Represents the input of a ListStreams operation.
 type ListStreamsInput struct {
+	_ struct{} `type:"structure"`
+
 	// The ARN (Amazon Resource Name) of the first item that this operation will
 	// evaluate. Use the value that was returned for LastEvaluatedStreamArn in the
 	// previous operation.
@@ -315,8 +317,6 @@ type ListStreamsInput struct {
 	// If this parameter is provided, then only the streams associated with this
 	// table name are returned.
 	TableName *string `min:"3" type:"string"`
-
-	_ struct{} `type:"structure"`
 }
 
 // String returns the string representation
@@ -331,6 +331,8 @@ func (s ListStreamsInput) GoString() string {
 
 // Represents the output of a ListStreams operation.
 type ListStreamsOutput struct {
+	_ struct{} `type:"structure"`
+
 	// The stream ARN of the item where the operation stopped, inclusive of the
 	// previous result set. Use this value to start a new operation, excluding this
 	// value in the new request.
@@ -345,8 +347,6 @@ type ListStreamsOutput struct {
 
 	// A list of stream descriptors associated with the current account and endpoint.
 	Streams []*Stream `type:"list"`
-
-	_ struct{} `type:"structure"`
 }
 
 // String returns the string representation
@@ -361,6 +361,8 @@ func (s ListStreamsOutput) GoString() string {
 
 // A description of a unique event within a stream.
 type Record struct {
+	_ struct{} `type:"structure"`
+
 	// The region in which the GetRecords request was received.
 	AwsRegion *string `locationName:"awsRegion" type:"string"`
 
@@ -387,8 +389,6 @@ type Record struct {
 
 	// The version number of the stream record format. Currently, this is 1.0.
 	EventVersion *string `locationName:"eventVersion" type:"string"`
-
-	_ struct{} `type:"structure"`
 }
 
 // String returns the string representation
@@ -404,13 +404,13 @@ func (s Record) GoString() string {
 // The beginning and ending sequence numbers for the stream records contained
 // within a shard.
 type SequenceNumberRange struct {
+	_ struct{} `type:"structure"`
+
 	// The last sequence number.
 	EndingSequenceNumber *string `min:"21" type:"string"`
 
 	// The first sequence number.
 	StartingSequenceNumber *string `min:"21" type:"string"`
-
-	_ struct{} `type:"structure"`
 }
 
 // String returns the string representation
@@ -425,6 +425,8 @@ func (s SequenceNumberRange) GoString() string {
 
 // A uniquely identified group of stream records within a stream.
 type Shard struct {
+	_ struct{} `type:"structure"`
+
 	// The shard ID of the current shard's parent.
 	ParentShardId *string `min:"28" type:"string"`
 
@@ -433,8 +435,6 @@ type Shard struct {
 
 	// The system-generated identifier for this shard.
 	ShardId *string `min:"28" type:"string"`
-
-	_ struct{} `type:"structure"`
 }
 
 // String returns the string representation
@@ -449,6 +449,8 @@ func (s Shard) GoString() string {
 
 // Represents all of the data describing a particular stream.
 type Stream struct {
+	_ struct{} `type:"structure"`
+
 	// The Amazon Resource Name (ARN) for the stream.
 	StreamArn *string `min:"37" type:"string"`
 
@@ -468,8 +470,6 @@ type Stream struct {
 
 	// The DynamoDB table with which the stream is associated.
 	TableName *string `min:"3" type:"string"`
-
-	_ struct{} `type:"structure"`
 }
 
 // String returns the string representation
@@ -484,6 +484,8 @@ func (s Stream) GoString() string {
 
 // Represents all of the data describing a particular stream.
 type StreamDescription struct {
+	_ struct{} `type:"structure"`
+
 	// The date and time when the request to create this stream was issued.
 	CreationRequestDateTime *time.Time `type:"timestamp" timestampFormat:"unix"`
 
@@ -549,8 +551,6 @@ type StreamDescription struct {
 
 	// The DynamoDB table with which the stream is associated.
 	TableName *string `min:"3" type:"string"`
-
-	_ struct{} `type:"structure"`
 }
 
 // String returns the string representation
@@ -566,6 +566,8 @@ func (s StreamDescription) GoString() string {
 // A description of a single data modification that was performed on an item
 // in a DynamoDB table.
 type StreamRecord struct {
+	_ struct{} `type:"structure"`
+
 	// The primary key attribute(s) for the DynamoDB item that was modified.
 	Keys map[string]*dynamodb.AttributeValue `type:"map"`
 
@@ -592,8 +594,6 @@ type StreamRecord struct {
 	//
 	// NEW_AND_OLD_IMAGES — both the new and the old item images of the item.
 	StreamViewType *string `type:"string" enum:"StreamViewType"`
-
-	_ struct{} `type:"structure"`
 }
 
 // String returns the string representation

--- a/service/dynamodbstreams/api.go
+++ b/service/dynamodbstreams/api.go
@@ -159,11 +159,7 @@ type DescribeStreamInput struct {
 	// The Amazon Resource Name (ARN) for the stream.
 	StreamArn *string `min:"37" type:"string" required:"true"`
 
-	metadataDescribeStreamInput `json:"-" xml:"-"`
-}
-
-type metadataDescribeStreamInput struct {
-	SDKShapeTraits bool `type:"structure"`
+	_ struct{} `type:"structure"`
 }
 
 // String returns the string representation
@@ -184,11 +180,7 @@ type DescribeStreamOutput struct {
 	// shards.
 	StreamDescription *StreamDescription `type:"structure"`
 
-	metadataDescribeStreamOutput `json:"-" xml:"-"`
-}
-
-type metadataDescribeStreamOutput struct {
-	SDKShapeTraits bool `type:"structure"`
+	_ struct{} `type:"structure"`
 }
 
 // String returns the string representation
@@ -211,11 +203,7 @@ type GetRecordsInput struct {
 	// This iterator can be used to access the stream records in this shard.
 	ShardIterator *string `min:"1" type:"string" required:"true"`
 
-	metadataGetRecordsInput `json:"-" xml:"-"`
-}
-
-type metadataGetRecordsInput struct {
-	SDKShapeTraits bool `type:"structure"`
+	_ struct{} `type:"structure"`
 }
 
 // String returns the string representation
@@ -238,11 +226,7 @@ type GetRecordsOutput struct {
 	// The stream records from the shard, which were retrieved using the shard iterator.
 	Records []*Record `type:"list"`
 
-	metadataGetRecordsOutput `json:"-" xml:"-"`
-}
-
-type metadataGetRecordsOutput struct {
-	SDKShapeTraits bool `type:"structure"`
+	_ struct{} `type:"structure"`
 }
 
 // String returns the string representation
@@ -285,11 +269,7 @@ type GetShardIteratorInput struct {
 	// The Amazon Resource Name (ARN) for the stream.
 	StreamArn *string `min:"37" type:"string" required:"true"`
 
-	metadataGetShardIteratorInput `json:"-" xml:"-"`
-}
-
-type metadataGetShardIteratorInput struct {
-	SDKShapeTraits bool `type:"structure"`
+	_ struct{} `type:"structure"`
 }
 
 // String returns the string representation
@@ -309,11 +289,7 @@ type GetShardIteratorOutput struct {
 	// record in a shard.
 	ShardIterator *string `min:"1" type:"string"`
 
-	metadataGetShardIteratorOutput `json:"-" xml:"-"`
-}
-
-type metadataGetShardIteratorOutput struct {
-	SDKShapeTraits bool `type:"structure"`
+	_ struct{} `type:"structure"`
 }
 
 // String returns the string representation
@@ -340,11 +316,7 @@ type ListStreamsInput struct {
 	// table name are returned.
 	TableName *string `min:"3" type:"string"`
 
-	metadataListStreamsInput `json:"-" xml:"-"`
-}
-
-type metadataListStreamsInput struct {
-	SDKShapeTraits bool `type:"structure"`
+	_ struct{} `type:"structure"`
 }
 
 // String returns the string representation
@@ -374,11 +346,7 @@ type ListStreamsOutput struct {
 	// A list of stream descriptors associated with the current account and endpoint.
 	Streams []*Stream `type:"list"`
 
-	metadataListStreamsOutput `json:"-" xml:"-"`
-}
-
-type metadataListStreamsOutput struct {
-	SDKShapeTraits bool `type:"structure"`
+	_ struct{} `type:"structure"`
 }
 
 // String returns the string representation
@@ -420,11 +388,7 @@ type Record struct {
 	// The version number of the stream record format. Currently, this is 1.0.
 	EventVersion *string `locationName:"eventVersion" type:"string"`
 
-	metadataRecord `json:"-" xml:"-"`
-}
-
-type metadataRecord struct {
-	SDKShapeTraits bool `type:"structure"`
+	_ struct{} `type:"structure"`
 }
 
 // String returns the string representation
@@ -446,11 +410,7 @@ type SequenceNumberRange struct {
 	// The first sequence number.
 	StartingSequenceNumber *string `min:"21" type:"string"`
 
-	metadataSequenceNumberRange `json:"-" xml:"-"`
-}
-
-type metadataSequenceNumberRange struct {
-	SDKShapeTraits bool `type:"structure"`
+	_ struct{} `type:"structure"`
 }
 
 // String returns the string representation
@@ -474,11 +434,7 @@ type Shard struct {
 	// The system-generated identifier for this shard.
 	ShardId *string `min:"28" type:"string"`
 
-	metadataShard `json:"-" xml:"-"`
-}
-
-type metadataShard struct {
-	SDKShapeTraits bool `type:"structure"`
+	_ struct{} `type:"structure"`
 }
 
 // String returns the string representation
@@ -513,11 +469,7 @@ type Stream struct {
 	// The DynamoDB table with which the stream is associated.
 	TableName *string `min:"3" type:"string"`
 
-	metadataStream `json:"-" xml:"-"`
-}
-
-type metadataStream struct {
-	SDKShapeTraits bool `type:"structure"`
+	_ struct{} `type:"structure"`
 }
 
 // String returns the string representation
@@ -598,11 +550,7 @@ type StreamDescription struct {
 	// The DynamoDB table with which the stream is associated.
 	TableName *string `min:"3" type:"string"`
 
-	metadataStreamDescription `json:"-" xml:"-"`
-}
-
-type metadataStreamDescription struct {
-	SDKShapeTraits bool `type:"structure"`
+	_ struct{} `type:"structure"`
 }
 
 // String returns the string representation
@@ -645,11 +593,7 @@ type StreamRecord struct {
 	// NEW_AND_OLD_IMAGES — both the new and the old item images of the item.
 	StreamViewType *string `type:"string" enum:"StreamViewType"`
 
-	metadataStreamRecord `json:"-" xml:"-"`
-}
-
-type metadataStreamRecord struct {
-	SDKShapeTraits bool `type:"structure"`
+	_ struct{} `type:"structure"`
 }
 
 // String returns the string representation

--- a/service/ec2/api.go
+++ b/service/ec2/api.go
@@ -6630,11 +6630,7 @@ type AcceptVpcPeeringConnectionInput struct {
 	// The ID of the VPC peering connection.
 	VpcPeeringConnectionId *string `locationName:"vpcPeeringConnectionId" type:"string"`
 
-	metadataAcceptVpcPeeringConnectionInput `json:"-" xml:"-"`
-}
-
-type metadataAcceptVpcPeeringConnectionInput struct {
-	SDKShapeTraits bool `type:"structure"`
+	_ struct{} `type:"structure"`
 }
 
 // String returns the string representation
@@ -6651,11 +6647,7 @@ type AcceptVpcPeeringConnectionOutput struct {
 	// Information about the VPC peering connection.
 	VpcPeeringConnection *VpcPeeringConnection `locationName:"vpcPeeringConnection" type:"structure"`
 
-	metadataAcceptVpcPeeringConnectionOutput `json:"-" xml:"-"`
-}
-
-type metadataAcceptVpcPeeringConnectionOutput struct {
-	SDKShapeTraits bool `type:"structure"`
+	_ struct{} `type:"structure"`
 }
 
 // String returns the string representation
@@ -6676,11 +6668,7 @@ type AccountAttribute struct {
 	// One or more values for the account attribute.
 	AttributeValues []*AccountAttributeValue `locationName:"attributeValueSet" locationNameList:"item" type:"list"`
 
-	metadataAccountAttribute `json:"-" xml:"-"`
-}
-
-type metadataAccountAttribute struct {
-	SDKShapeTraits bool `type:"structure"`
+	_ struct{} `type:"structure"`
 }
 
 // String returns the string representation
@@ -6698,11 +6686,7 @@ type AccountAttributeValue struct {
 	// The value of the attribute.
 	AttributeValue *string `locationName:"attributeValue" type:"string"`
 
-	metadataAccountAttributeValue `json:"-" xml:"-"`
-}
-
-type metadataAccountAttributeValue struct {
-	SDKShapeTraits bool `type:"structure"`
+	_ struct{} `type:"structure"`
 }
 
 // String returns the string representation
@@ -6726,11 +6710,7 @@ type ActiveInstance struct {
 	// The ID of the Spot instance request.
 	SpotInstanceRequestId *string `locationName:"spotInstanceRequestId" type:"string"`
 
-	metadataActiveInstance `json:"-" xml:"-"`
-}
-
-type metadataActiveInstance struct {
-	SDKShapeTraits bool `type:"structure"`
+	_ struct{} `type:"structure"`
 }
 
 // String returns the string representation
@@ -6771,11 +6751,7 @@ type Address struct {
 	// The Elastic IP address.
 	PublicIp *string `locationName:"publicIp" type:"string"`
 
-	metadataAddress `json:"-" xml:"-"`
-}
-
-type metadataAddress struct {
-	SDKShapeTraits bool `type:"structure"`
+	_ struct{} `type:"structure"`
 }
 
 // String returns the string representation
@@ -6800,11 +6776,7 @@ type AllocateAddressInput struct {
 	// it is UnauthorizedOperation.
 	DryRun *bool `locationName:"dryRun" type:"boolean"`
 
-	metadataAllocateAddressInput `json:"-" xml:"-"`
-}
-
-type metadataAllocateAddressInput struct {
-	SDKShapeTraits bool `type:"structure"`
+	_ struct{} `type:"structure"`
 }
 
 // String returns the string representation
@@ -6829,11 +6801,7 @@ type AllocateAddressOutput struct {
 	// The Elastic IP address.
 	PublicIp *string `locationName:"publicIp" type:"string"`
 
-	metadataAllocateAddressOutput `json:"-" xml:"-"`
-}
-
-type metadataAllocateAddressOutput struct {
-	SDKShapeTraits bool `type:"structure"`
+	_ struct{} `type:"structure"`
 }
 
 // String returns the string representation
@@ -6871,11 +6839,7 @@ type AllocateHostsInput struct {
 	// parameters.
 	Quantity *int64 `locationName:"quantity" type:"integer" required:"true"`
 
-	metadataAllocateHostsInput `json:"-" xml:"-"`
-}
-
-type metadataAllocateHostsInput struct {
-	SDKShapeTraits bool `type:"structure"`
+	_ struct{} `type:"structure"`
 }
 
 // String returns the string representation
@@ -6893,11 +6857,7 @@ type AllocateHostsOutput struct {
 	// an instance onto a specific host.
 	HostIds []*string `locationName:"hostIdSet" locationNameList:"item" type:"list"`
 
-	metadataAllocateHostsOutput `json:"-" xml:"-"`
-}
-
-type metadataAllocateHostsOutput struct {
-	SDKShapeTraits bool `type:"structure"`
+	_ struct{} `type:"structure"`
 }
 
 // String returns the string representation
@@ -6930,11 +6890,7 @@ type AssignPrivateIpAddressesInput struct {
 	// You can't specify this parameter when also specifying private IP addresses.
 	SecondaryPrivateIpAddressCount *int64 `locationName:"secondaryPrivateIpAddressCount" type:"integer"`
 
-	metadataAssignPrivateIpAddressesInput `json:"-" xml:"-"`
-}
-
-type metadataAssignPrivateIpAddressesInput struct {
-	SDKShapeTraits bool `type:"structure"`
+	_ struct{} `type:"structure"`
 }
 
 // String returns the string representation
@@ -6948,11 +6904,7 @@ func (s AssignPrivateIpAddressesInput) GoString() string {
 }
 
 type AssignPrivateIpAddressesOutput struct {
-	metadataAssignPrivateIpAddressesOutput `json:"-" xml:"-"`
-}
-
-type metadataAssignPrivateIpAddressesOutput struct {
-	SDKShapeTraits bool `type:"structure"`
+	_ struct{} `type:"structure"`
 }
 
 // String returns the string representation
@@ -7001,11 +6953,7 @@ type AssociateAddressInput struct {
 	// The Elastic IP address. This is required for EC2-Classic.
 	PublicIp *string `type:"string"`
 
-	metadataAssociateAddressInput `json:"-" xml:"-"`
-}
-
-type metadataAssociateAddressInput struct {
-	SDKShapeTraits bool `type:"structure"`
+	_ struct{} `type:"structure"`
 }
 
 // String returns the string representation
@@ -7023,11 +6971,7 @@ type AssociateAddressOutput struct {
 	// with an instance.
 	AssociationId *string `locationName:"associationId" type:"string"`
 
-	metadataAssociateAddressOutput `json:"-" xml:"-"`
-}
-
-type metadataAssociateAddressOutput struct {
-	SDKShapeTraits bool `type:"structure"`
+	_ struct{} `type:"structure"`
 }
 
 // String returns the string representation
@@ -7054,11 +6998,7 @@ type AssociateDhcpOptionsInput struct {
 	// The ID of the VPC.
 	VpcId *string `type:"string" required:"true"`
 
-	metadataAssociateDhcpOptionsInput `json:"-" xml:"-"`
-}
-
-type metadataAssociateDhcpOptionsInput struct {
-	SDKShapeTraits bool `type:"structure"`
+	_ struct{} `type:"structure"`
 }
 
 // String returns the string representation
@@ -7072,11 +7012,7 @@ func (s AssociateDhcpOptionsInput) GoString() string {
 }
 
 type AssociateDhcpOptionsOutput struct {
-	metadataAssociateDhcpOptionsOutput `json:"-" xml:"-"`
-}
-
-type metadataAssociateDhcpOptionsOutput struct {
-	SDKShapeTraits bool `type:"structure"`
+	_ struct{} `type:"structure"`
 }
 
 // String returns the string representation
@@ -7102,11 +7038,7 @@ type AssociateRouteTableInput struct {
 	// The ID of the subnet.
 	SubnetId *string `locationName:"subnetId" type:"string" required:"true"`
 
-	metadataAssociateRouteTableInput `json:"-" xml:"-"`
-}
-
-type metadataAssociateRouteTableInput struct {
-	SDKShapeTraits bool `type:"structure"`
+	_ struct{} `type:"structure"`
 }
 
 // String returns the string representation
@@ -7123,11 +7055,7 @@ type AssociateRouteTableOutput struct {
 	// The route table association ID (needed to disassociate the route table).
 	AssociationId *string `locationName:"associationId" type:"string"`
 
-	metadataAssociateRouteTableOutput `json:"-" xml:"-"`
-}
-
-type metadataAssociateRouteTableOutput struct {
-	SDKShapeTraits bool `type:"structure"`
+	_ struct{} `type:"structure"`
 }
 
 // String returns the string representation
@@ -7157,11 +7085,7 @@ type AttachClassicLinkVpcInput struct {
 	// The ID of a ClassicLink-enabled VPC.
 	VpcId *string `locationName:"vpcId" type:"string" required:"true"`
 
-	metadataAttachClassicLinkVpcInput `json:"-" xml:"-"`
-}
-
-type metadataAttachClassicLinkVpcInput struct {
-	SDKShapeTraits bool `type:"structure"`
+	_ struct{} `type:"structure"`
 }
 
 // String returns the string representation
@@ -7178,11 +7102,7 @@ type AttachClassicLinkVpcOutput struct {
 	// Returns true if the request succeeds; otherwise, it returns an error.
 	Return *bool `locationName:"return" type:"boolean"`
 
-	metadataAttachClassicLinkVpcOutput `json:"-" xml:"-"`
-}
-
-type metadataAttachClassicLinkVpcOutput struct {
-	SDKShapeTraits bool `type:"structure"`
+	_ struct{} `type:"structure"`
 }
 
 // String returns the string representation
@@ -7208,11 +7128,7 @@ type AttachInternetGatewayInput struct {
 	// The ID of the VPC.
 	VpcId *string `locationName:"vpcId" type:"string" required:"true"`
 
-	metadataAttachInternetGatewayInput `json:"-" xml:"-"`
-}
-
-type metadataAttachInternetGatewayInput struct {
-	SDKShapeTraits bool `type:"structure"`
+	_ struct{} `type:"structure"`
 }
 
 // String returns the string representation
@@ -7226,11 +7142,7 @@ func (s AttachInternetGatewayInput) GoString() string {
 }
 
 type AttachInternetGatewayOutput struct {
-	metadataAttachInternetGatewayOutput `json:"-" xml:"-"`
-}
-
-type metadataAttachInternetGatewayOutput struct {
-	SDKShapeTraits bool `type:"structure"`
+	_ struct{} `type:"structure"`
 }
 
 // String returns the string representation
@@ -7259,11 +7171,7 @@ type AttachNetworkInterfaceInput struct {
 	// The ID of the network interface.
 	NetworkInterfaceId *string `locationName:"networkInterfaceId" type:"string" required:"true"`
 
-	metadataAttachNetworkInterfaceInput `json:"-" xml:"-"`
-}
-
-type metadataAttachNetworkInterfaceInput struct {
-	SDKShapeTraits bool `type:"structure"`
+	_ struct{} `type:"structure"`
 }
 
 // String returns the string representation
@@ -7280,11 +7188,7 @@ type AttachNetworkInterfaceOutput struct {
 	// The ID of the network interface attachment.
 	AttachmentId *string `locationName:"attachmentId" type:"string"`
 
-	metadataAttachNetworkInterfaceOutput `json:"-" xml:"-"`
-}
-
-type metadataAttachNetworkInterfaceOutput struct {
-	SDKShapeTraits bool `type:"structure"`
+	_ struct{} `type:"structure"`
 }
 
 // String returns the string representation
@@ -7314,11 +7218,7 @@ type AttachVolumeInput struct {
 	// Availability Zone.
 	VolumeId *string `type:"string" required:"true"`
 
-	metadataAttachVolumeInput `json:"-" xml:"-"`
-}
-
-type metadataAttachVolumeInput struct {
-	SDKShapeTraits bool `type:"structure"`
+	_ struct{} `type:"structure"`
 }
 
 // String returns the string representation
@@ -7344,11 +7244,7 @@ type AttachVpnGatewayInput struct {
 	// The ID of the virtual private gateway.
 	VpnGatewayId *string `type:"string" required:"true"`
 
-	metadataAttachVpnGatewayInput `json:"-" xml:"-"`
-}
-
-type metadataAttachVpnGatewayInput struct {
-	SDKShapeTraits bool `type:"structure"`
+	_ struct{} `type:"structure"`
 }
 
 // String returns the string representation
@@ -7365,11 +7261,7 @@ type AttachVpnGatewayOutput struct {
 	// Information about the attachment.
 	VpcAttachment *VpcAttachment `locationName:"attachment" type:"structure"`
 
-	metadataAttachVpnGatewayOutput `json:"-" xml:"-"`
-}
-
-type metadataAttachVpnGatewayOutput struct {
-	SDKShapeTraits bool `type:"structure"`
+	_ struct{} `type:"structure"`
 }
 
 // String returns the string representation
@@ -7387,11 +7279,7 @@ type AttributeBooleanValue struct {
 	// Valid values are true or false.
 	Value *bool `locationName:"value" type:"boolean"`
 
-	metadataAttributeBooleanValue `json:"-" xml:"-"`
-}
-
-type metadataAttributeBooleanValue struct {
-	SDKShapeTraits bool `type:"structure"`
+	_ struct{} `type:"structure"`
 }
 
 // String returns the string representation
@@ -7409,11 +7297,7 @@ type AttributeValue struct {
 	// Valid values are case-sensitive and vary by action.
 	Value *string `locationName:"value" type:"string"`
 
-	metadataAttributeValue `json:"-" xml:"-"`
-}
-
-type metadataAttributeValue struct {
-	SDKShapeTraits bool `type:"structure"`
+	_ struct{} `type:"structure"`
 }
 
 // String returns the string representation
@@ -7466,11 +7350,7 @@ type AuthorizeSecurityGroupEgressInput struct {
 	// For the ICMP code number, use -1 to specify all ICMP codes for the ICMP type.
 	ToPort *int64 `locationName:"toPort" type:"integer"`
 
-	metadataAuthorizeSecurityGroupEgressInput `json:"-" xml:"-"`
-}
-
-type metadataAuthorizeSecurityGroupEgressInput struct {
-	SDKShapeTraits bool `type:"structure"`
+	_ struct{} `type:"structure"`
 }
 
 // String returns the string representation
@@ -7484,11 +7364,7 @@ func (s AuthorizeSecurityGroupEgressInput) GoString() string {
 }
 
 type AuthorizeSecurityGroupEgressOutput struct {
-	metadataAuthorizeSecurityGroupEgressOutput `json:"-" xml:"-"`
-}
-
-type metadataAuthorizeSecurityGroupEgressOutput struct {
-	SDKShapeTraits bool `type:"structure"`
+	_ struct{} `type:"structure"`
 }
 
 // String returns the string representation
@@ -7550,11 +7426,7 @@ type AuthorizeSecurityGroupIngressInput struct {
 	// For the ICMP code number, use -1 to specify all ICMP codes for the ICMP type.
 	ToPort *int64 `type:"integer"`
 
-	metadataAuthorizeSecurityGroupIngressInput `json:"-" xml:"-"`
-}
-
-type metadataAuthorizeSecurityGroupIngressInput struct {
-	SDKShapeTraits bool `type:"structure"`
+	_ struct{} `type:"structure"`
 }
 
 // String returns the string representation
@@ -7568,11 +7440,7 @@ func (s AuthorizeSecurityGroupIngressInput) GoString() string {
 }
 
 type AuthorizeSecurityGroupIngressOutput struct {
-	metadataAuthorizeSecurityGroupIngressOutput `json:"-" xml:"-"`
-}
-
-type metadataAuthorizeSecurityGroupIngressOutput struct {
-	SDKShapeTraits bool `type:"structure"`
+	_ struct{} `type:"structure"`
 }
 
 // String returns the string representation
@@ -7599,11 +7467,7 @@ type AvailabilityZone struct {
 	// The name of the Availability Zone.
 	ZoneName *string `locationName:"zoneName" type:"string"`
 
-	metadataAvailabilityZone `json:"-" xml:"-"`
-}
-
-type metadataAvailabilityZone struct {
-	SDKShapeTraits bool `type:"structure"`
+	_ struct{} `type:"structure"`
 }
 
 // String returns the string representation
@@ -7621,11 +7485,7 @@ type AvailabilityZoneMessage struct {
 	// The message about the Availability Zone.
 	Message *string `locationName:"message" type:"string"`
 
-	metadataAvailabilityZoneMessage `json:"-" xml:"-"`
-}
-
-type metadataAvailabilityZoneMessage struct {
-	SDKShapeTraits bool `type:"structure"`
+	_ struct{} `type:"structure"`
 }
 
 // String returns the string representation
@@ -7645,11 +7505,7 @@ type AvailableCapacity struct {
 	// The number of vCPUs available on the Dedicated host.
 	AvailableVCpus *int64 `locationName:"availableVCpus" type:"integer"`
 
-	metadataAvailableCapacity `json:"-" xml:"-"`
-}
-
-type metadataAvailableCapacity struct {
-	SDKShapeTraits bool `type:"structure"`
+	_ struct{} `type:"structure"`
 }
 
 // String returns the string representation
@@ -7665,11 +7521,7 @@ func (s AvailableCapacity) GoString() string {
 type BlobAttributeValue struct {
 	Value []byte `locationName:"value" type:"blob"`
 
-	metadataBlobAttributeValue `json:"-" xml:"-"`
-}
-
-type metadataBlobAttributeValue struct {
-	SDKShapeTraits bool `type:"structure"`
+	_ struct{} `type:"structure"`
 }
 
 // String returns the string representation
@@ -7707,11 +7559,7 @@ type BlockDeviceMapping struct {
 	// for the AMI.
 	VirtualName *string `locationName:"virtualName" type:"string"`
 
-	metadataBlockDeviceMapping `json:"-" xml:"-"`
-}
-
-type metadataBlockDeviceMapping struct {
-	SDKShapeTraits bool `type:"structure"`
+	_ struct{} `type:"structure"`
 }
 
 // String returns the string representation
@@ -7745,11 +7593,7 @@ type BundleInstanceInput struct {
 	// a bucket that belongs to someone else, Amazon EC2 returns an error.
 	Storage *Storage `type:"structure" required:"true"`
 
-	metadataBundleInstanceInput `json:"-" xml:"-"`
-}
-
-type metadataBundleInstanceInput struct {
-	SDKShapeTraits bool `type:"structure"`
+	_ struct{} `type:"structure"`
 }
 
 // String returns the string representation
@@ -7766,11 +7610,7 @@ type BundleInstanceOutput struct {
 	// Information about the bundle task.
 	BundleTask *BundleTask `locationName:"bundleInstanceTask" type:"structure"`
 
-	metadataBundleInstanceOutput `json:"-" xml:"-"`
-}
-
-type metadataBundleInstanceOutput struct {
-	SDKShapeTraits bool `type:"structure"`
+	_ struct{} `type:"structure"`
 }
 
 // String returns the string representation
@@ -7809,11 +7649,7 @@ type BundleTask struct {
 	// The time of the most recent update for the task.
 	UpdateTime *time.Time `locationName:"updateTime" type:"timestamp" timestampFormat:"iso8601"`
 
-	metadataBundleTask `json:"-" xml:"-"`
-}
-
-type metadataBundleTask struct {
-	SDKShapeTraits bool `type:"structure"`
+	_ struct{} `type:"structure"`
 }
 
 // String returns the string representation
@@ -7834,11 +7670,7 @@ type BundleTaskError struct {
 	// The error message.
 	Message *string `locationName:"message" type:"string"`
 
-	metadataBundleTaskError `json:"-" xml:"-"`
-}
-
-type metadataBundleTaskError struct {
-	SDKShapeTraits bool `type:"structure"`
+	_ struct{} `type:"structure"`
 }
 
 // String returns the string representation
@@ -7861,11 +7693,7 @@ type CancelBundleTaskInput struct {
 	// it is UnauthorizedOperation.
 	DryRun *bool `locationName:"dryRun" type:"boolean"`
 
-	metadataCancelBundleTaskInput `json:"-" xml:"-"`
-}
-
-type metadataCancelBundleTaskInput struct {
-	SDKShapeTraits bool `type:"structure"`
+	_ struct{} `type:"structure"`
 }
 
 // String returns the string representation
@@ -7882,11 +7710,7 @@ type CancelBundleTaskOutput struct {
 	// Information about the bundle task.
 	BundleTask *BundleTask `locationName:"bundleInstanceTask" type:"structure"`
 
-	metadataCancelBundleTaskOutput `json:"-" xml:"-"`
-}
-
-type metadataCancelBundleTaskOutput struct {
-	SDKShapeTraits bool `type:"structure"`
+	_ struct{} `type:"structure"`
 }
 
 // String returns the string representation
@@ -7912,11 +7736,7 @@ type CancelConversionTaskInput struct {
 	// The reason for canceling the conversion task.
 	ReasonMessage *string `locationName:"reasonMessage" type:"string"`
 
-	metadataCancelConversionTaskInput `json:"-" xml:"-"`
-}
-
-type metadataCancelConversionTaskInput struct {
-	SDKShapeTraits bool `type:"structure"`
+	_ struct{} `type:"structure"`
 }
 
 // String returns the string representation
@@ -7930,11 +7750,7 @@ func (s CancelConversionTaskInput) GoString() string {
 }
 
 type CancelConversionTaskOutput struct {
-	metadataCancelConversionTaskOutput `json:"-" xml:"-"`
-}
-
-type metadataCancelConversionTaskOutput struct {
-	SDKShapeTraits bool `type:"structure"`
+	_ struct{} `type:"structure"`
 }
 
 // String returns the string representation
@@ -7951,11 +7767,7 @@ type CancelExportTaskInput struct {
 	// The ID of the export task. This is the ID returned by CreateInstanceExportTask.
 	ExportTaskId *string `locationName:"exportTaskId" type:"string" required:"true"`
 
-	metadataCancelExportTaskInput `json:"-" xml:"-"`
-}
-
-type metadataCancelExportTaskInput struct {
-	SDKShapeTraits bool `type:"structure"`
+	_ struct{} `type:"structure"`
 }
 
 // String returns the string representation
@@ -7969,11 +7781,7 @@ func (s CancelExportTaskInput) GoString() string {
 }
 
 type CancelExportTaskOutput struct {
-	metadataCancelExportTaskOutput `json:"-" xml:"-"`
-}
-
-type metadataCancelExportTaskOutput struct {
-	SDKShapeTraits bool `type:"structure"`
+	_ struct{} `type:"structure"`
 }
 
 // String returns the string representation
@@ -7999,11 +7807,7 @@ type CancelImportTaskInput struct {
 	// The ID of the import image or import snapshot task to be canceled.
 	ImportTaskId *string `type:"string"`
 
-	metadataCancelImportTaskInput `json:"-" xml:"-"`
-}
-
-type metadataCancelImportTaskInput struct {
-	SDKShapeTraits bool `type:"structure"`
+	_ struct{} `type:"structure"`
 }
 
 // String returns the string representation
@@ -8026,11 +7830,7 @@ type CancelImportTaskOutput struct {
 	// The current state of the task being canceled.
 	State *string `locationName:"state" type:"string"`
 
-	metadataCancelImportTaskOutput `json:"-" xml:"-"`
-}
-
-type metadataCancelImportTaskOutput struct {
-	SDKShapeTraits bool `type:"structure"`
+	_ struct{} `type:"structure"`
 }
 
 // String returns the string representation
@@ -8047,11 +7847,7 @@ type CancelReservedInstancesListingInput struct {
 	// The ID of the Reserved instance listing.
 	ReservedInstancesListingId *string `locationName:"reservedInstancesListingId" type:"string" required:"true"`
 
-	metadataCancelReservedInstancesListingInput `json:"-" xml:"-"`
-}
-
-type metadataCancelReservedInstancesListingInput struct {
-	SDKShapeTraits bool `type:"structure"`
+	_ struct{} `type:"structure"`
 }
 
 // String returns the string representation
@@ -8068,11 +7864,7 @@ type CancelReservedInstancesListingOutput struct {
 	// The Reserved instance listing.
 	ReservedInstancesListings []*ReservedInstancesListing `locationName:"reservedInstancesListingsSet" locationNameList:"item" type:"list"`
 
-	metadataCancelReservedInstancesListingOutput `json:"-" xml:"-"`
-}
-
-type metadataCancelReservedInstancesListingOutput struct {
-	SDKShapeTraits bool `type:"structure"`
+	_ struct{} `type:"structure"`
 }
 
 // String returns the string representation
@@ -8093,11 +7885,7 @@ type CancelSpotFleetRequestsError struct {
 	// The description for the error code.
 	Message *string `locationName:"message" type:"string" required:"true"`
 
-	metadataCancelSpotFleetRequestsError `json:"-" xml:"-"`
-}
-
-type metadataCancelSpotFleetRequestsError struct {
-	SDKShapeTraits bool `type:"structure"`
+	_ struct{} `type:"structure"`
 }
 
 // String returns the string representation
@@ -8118,11 +7906,7 @@ type CancelSpotFleetRequestsErrorItem struct {
 	// The ID of the Spot fleet request.
 	SpotFleetRequestId *string `locationName:"spotFleetRequestId" type:"string" required:"true"`
 
-	metadataCancelSpotFleetRequestsErrorItem `json:"-" xml:"-"`
-}
-
-type metadataCancelSpotFleetRequestsErrorItem struct {
-	SDKShapeTraits bool `type:"structure"`
+	_ struct{} `type:"structure"`
 }
 
 // String returns the string representation
@@ -8150,11 +7934,7 @@ type CancelSpotFleetRequestsInput struct {
 	// canceled successfully.
 	TerminateInstances *bool `locationName:"terminateInstances" type:"boolean" required:"true"`
 
-	metadataCancelSpotFleetRequestsInput `json:"-" xml:"-"`
-}
-
-type metadataCancelSpotFleetRequestsInput struct {
-	SDKShapeTraits bool `type:"structure"`
+	_ struct{} `type:"structure"`
 }
 
 // String returns the string representation
@@ -8175,11 +7955,7 @@ type CancelSpotFleetRequestsOutput struct {
 	// Information about the Spot fleet requests that are not successfully canceled.
 	UnsuccessfulFleetRequests []*CancelSpotFleetRequestsErrorItem `locationName:"unsuccessfulFleetRequestSet" locationNameList:"item" type:"list"`
 
-	metadataCancelSpotFleetRequestsOutput `json:"-" xml:"-"`
-}
-
-type metadataCancelSpotFleetRequestsOutput struct {
-	SDKShapeTraits bool `type:"structure"`
+	_ struct{} `type:"structure"`
 }
 
 // String returns the string representation
@@ -8203,11 +7979,7 @@ type CancelSpotFleetRequestsSuccessItem struct {
 	// The ID of the Spot fleet request.
 	SpotFleetRequestId *string `locationName:"spotFleetRequestId" type:"string" required:"true"`
 
-	metadataCancelSpotFleetRequestsSuccessItem `json:"-" xml:"-"`
-}
-
-type metadataCancelSpotFleetRequestsSuccessItem struct {
-	SDKShapeTraits bool `type:"structure"`
+	_ struct{} `type:"structure"`
 }
 
 // String returns the string representation
@@ -8231,11 +8003,7 @@ type CancelSpotInstanceRequestsInput struct {
 	// One or more Spot instance request IDs.
 	SpotInstanceRequestIds []*string `locationName:"SpotInstanceRequestId" locationNameList:"SpotInstanceRequestId" type:"list" required:"true"`
 
-	metadataCancelSpotInstanceRequestsInput `json:"-" xml:"-"`
-}
-
-type metadataCancelSpotInstanceRequestsInput struct {
-	SDKShapeTraits bool `type:"structure"`
+	_ struct{} `type:"structure"`
 }
 
 // String returns the string representation
@@ -8253,11 +8021,7 @@ type CancelSpotInstanceRequestsOutput struct {
 	// One or more Spot instance requests.
 	CancelledSpotInstanceRequests []*CancelledSpotInstanceRequest `locationName:"spotInstanceRequestSet" locationNameList:"item" type:"list"`
 
-	metadataCancelSpotInstanceRequestsOutput `json:"-" xml:"-"`
-}
-
-type metadataCancelSpotInstanceRequestsOutput struct {
-	SDKShapeTraits bool `type:"structure"`
+	_ struct{} `type:"structure"`
 }
 
 // String returns the string representation
@@ -8278,11 +8042,7 @@ type CancelledSpotInstanceRequest struct {
 	// The state of the Spot instance request.
 	State *string `locationName:"state" type:"string" enum:"CancelSpotInstanceRequestState"`
 
-	metadataCancelledSpotInstanceRequest `json:"-" xml:"-"`
-}
-
-type metadataCancelledSpotInstanceRequest struct {
-	SDKShapeTraits bool `type:"structure"`
+	_ struct{} `type:"structure"`
 }
 
 // String returns the string representation
@@ -8309,11 +8069,7 @@ type ClassicLinkInstance struct {
 	// The ID of the VPC.
 	VpcId *string `locationName:"vpcId" type:"string"`
 
-	metadataClassicLinkInstance `json:"-" xml:"-"`
-}
-
-type metadataClassicLinkInstance struct {
-	SDKShapeTraits bool `type:"structure"`
+	_ struct{} `type:"structure"`
 }
 
 // String returns the string representation
@@ -8340,11 +8096,7 @@ type ClientData struct {
 	// The time that the disk upload starts.
 	UploadStart *time.Time `type:"timestamp" timestampFormat:"iso8601"`
 
-	metadataClientData `json:"-" xml:"-"`
-}
-
-type metadataClientData struct {
-	SDKShapeTraits bool `type:"structure"`
+	_ struct{} `type:"structure"`
 }
 
 // String returns the string representation
@@ -8370,11 +8122,7 @@ type ConfirmProductInstanceInput struct {
 	// The product code. This must be a product code that you own.
 	ProductCode *string `type:"string" required:"true"`
 
-	metadataConfirmProductInstanceInput `json:"-" xml:"-"`
-}
-
-type metadataConfirmProductInstanceInput struct {
-	SDKShapeTraits bool `type:"structure"`
+	_ struct{} `type:"structure"`
 }
 
 // String returns the string representation
@@ -8396,11 +8144,7 @@ type ConfirmProductInstanceOutput struct {
 	// is owned by the requester and associated with the specified instance.
 	Return *bool `locationName:"return" type:"boolean"`
 
-	metadataConfirmProductInstanceOutput `json:"-" xml:"-"`
-}
-
-type metadataConfirmProductInstanceOutput struct {
-	SDKShapeTraits bool `type:"structure"`
+	_ struct{} `type:"structure"`
 }
 
 // String returns the string representation
@@ -8439,11 +8183,7 @@ type ConversionTask struct {
 	// Any tags assigned to the task.
 	Tags []*Tag `locationName:"tagSet" locationNameList:"item" type:"list"`
 
-	metadataConversionTask `json:"-" xml:"-"`
-}
-
-type metadataConversionTask struct {
-	SDKShapeTraits bool `type:"structure"`
+	_ struct{} `type:"structure"`
 }
 
 // String returns the string representation
@@ -8480,11 +8220,7 @@ type CopyImageInput struct {
 	// The name of the region that contains the AMI to copy.
 	SourceRegion *string `type:"string" required:"true"`
 
-	metadataCopyImageInput `json:"-" xml:"-"`
-}
-
-type metadataCopyImageInput struct {
-	SDKShapeTraits bool `type:"structure"`
+	_ struct{} `type:"structure"`
 }
 
 // String returns the string representation
@@ -8501,11 +8237,7 @@ type CopyImageOutput struct {
 	// The ID of the new AMI.
 	ImageId *string `locationName:"imageId" type:"string"`
 
-	metadataCopyImageOutput `json:"-" xml:"-"`
-}
-
-type metadataCopyImageOutput struct {
-	SDKShapeTraits bool `type:"structure"`
+	_ struct{} `type:"structure"`
 }
 
 // String returns the string representation
@@ -8577,11 +8309,7 @@ type CopySnapshotInput struct {
 	// The ID of the EBS snapshot to copy.
 	SourceSnapshotId *string `type:"string" required:"true"`
 
-	metadataCopySnapshotInput `json:"-" xml:"-"`
-}
-
-type metadataCopySnapshotInput struct {
-	SDKShapeTraits bool `type:"structure"`
+	_ struct{} `type:"structure"`
 }
 
 // String returns the string representation
@@ -8598,11 +8326,7 @@ type CopySnapshotOutput struct {
 	// The ID of the new snapshot.
 	SnapshotId *string `locationName:"snapshotId" type:"string"`
 
-	metadataCopySnapshotOutput `json:"-" xml:"-"`
-}
-
-type metadataCopySnapshotOutput struct {
-	SDKShapeTraits bool `type:"structure"`
+	_ struct{} `type:"structure"`
 }
 
 // String returns the string representation
@@ -8634,11 +8358,7 @@ type CreateCustomerGatewayInput struct {
 	// The type of VPN connection that this customer gateway supports (ipsec.1).
 	Type *string `type:"string" required:"true" enum:"GatewayType"`
 
-	metadataCreateCustomerGatewayInput `json:"-" xml:"-"`
-}
-
-type metadataCreateCustomerGatewayInput struct {
-	SDKShapeTraits bool `type:"structure"`
+	_ struct{} `type:"structure"`
 }
 
 // String returns the string representation
@@ -8655,11 +8375,7 @@ type CreateCustomerGatewayOutput struct {
 	// Information about the customer gateway.
 	CustomerGateway *CustomerGateway `locationName:"customerGateway" type:"structure"`
 
-	metadataCreateCustomerGatewayOutput `json:"-" xml:"-"`
-}
-
-type metadataCreateCustomerGatewayOutput struct {
-	SDKShapeTraits bool `type:"structure"`
+	_ struct{} `type:"structure"`
 }
 
 // String returns the string representation
@@ -8682,11 +8398,7 @@ type CreateDhcpOptionsInput struct {
 	// it is UnauthorizedOperation.
 	DryRun *bool `locationName:"dryRun" type:"boolean"`
 
-	metadataCreateDhcpOptionsInput `json:"-" xml:"-"`
-}
-
-type metadataCreateDhcpOptionsInput struct {
-	SDKShapeTraits bool `type:"structure"`
+	_ struct{} `type:"structure"`
 }
 
 // String returns the string representation
@@ -8703,11 +8415,7 @@ type CreateDhcpOptionsOutput struct {
 	// A set of DHCP options.
 	DhcpOptions *DhcpOptions `locationName:"dhcpOptions" type:"structure"`
 
-	metadataCreateDhcpOptionsOutput `json:"-" xml:"-"`
-}
-
-type metadataCreateDhcpOptionsOutput struct {
-	SDKShapeTraits bool `type:"structure"`
+	_ struct{} `type:"structure"`
 }
 
 // String returns the string representation
@@ -8741,11 +8449,7 @@ type CreateFlowLogsInput struct {
 	// The type of traffic to log.
 	TrafficType *string `type:"string" required:"true" enum:"TrafficType"`
 
-	metadataCreateFlowLogsInput `json:"-" xml:"-"`
-}
-
-type metadataCreateFlowLogsInput struct {
-	SDKShapeTraits bool `type:"structure"`
+	_ struct{} `type:"structure"`
 }
 
 // String returns the string representation
@@ -8769,11 +8473,7 @@ type CreateFlowLogsOutput struct {
 	// Information about the flow logs that could not be created successfully.
 	Unsuccessful []*UnsuccessfulItem `locationName:"unsuccessful" locationNameList:"item" type:"list"`
 
-	metadataCreateFlowLogsOutput `json:"-" xml:"-"`
-}
-
-type metadataCreateFlowLogsOutput struct {
-	SDKShapeTraits bool `type:"structure"`
+	_ struct{} `type:"structure"`
 }
 
 // String returns the string representation
@@ -8816,11 +8516,7 @@ type CreateImageInput struct {
 	// system integrity on the created image can't be guaranteed.
 	NoReboot *bool `locationName:"noReboot" type:"boolean"`
 
-	metadataCreateImageInput `json:"-" xml:"-"`
-}
-
-type metadataCreateImageInput struct {
-	SDKShapeTraits bool `type:"structure"`
+	_ struct{} `type:"structure"`
 }
 
 // String returns the string representation
@@ -8837,11 +8533,7 @@ type CreateImageOutput struct {
 	// The ID of the new AMI.
 	ImageId *string `locationName:"imageId" type:"string"`
 
-	metadataCreateImageOutput `json:"-" xml:"-"`
-}
-
-type metadataCreateImageOutput struct {
-	SDKShapeTraits bool `type:"structure"`
+	_ struct{} `type:"structure"`
 }
 
 // String returns the string representation
@@ -8868,11 +8560,7 @@ type CreateInstanceExportTaskInput struct {
 	// The target virtualization environment.
 	TargetEnvironment *string `locationName:"targetEnvironment" type:"string" enum:"ExportEnvironment"`
 
-	metadataCreateInstanceExportTaskInput `json:"-" xml:"-"`
-}
-
-type metadataCreateInstanceExportTaskInput struct {
-	SDKShapeTraits bool `type:"structure"`
+	_ struct{} `type:"structure"`
 }
 
 // String returns the string representation
@@ -8889,11 +8577,7 @@ type CreateInstanceExportTaskOutput struct {
 	// Information about the instance export task.
 	ExportTask *ExportTask `locationName:"exportTask" type:"structure"`
 
-	metadataCreateInstanceExportTaskOutput `json:"-" xml:"-"`
-}
-
-type metadataCreateInstanceExportTaskOutput struct {
-	SDKShapeTraits bool `type:"structure"`
+	_ struct{} `type:"structure"`
 }
 
 // String returns the string representation
@@ -8913,11 +8597,7 @@ type CreateInternetGatewayInput struct {
 	// it is UnauthorizedOperation.
 	DryRun *bool `locationName:"dryRun" type:"boolean"`
 
-	metadataCreateInternetGatewayInput `json:"-" xml:"-"`
-}
-
-type metadataCreateInternetGatewayInput struct {
-	SDKShapeTraits bool `type:"structure"`
+	_ struct{} `type:"structure"`
 }
 
 // String returns the string representation
@@ -8934,11 +8614,7 @@ type CreateInternetGatewayOutput struct {
 	// Information about the Internet gateway.
 	InternetGateway *InternetGateway `locationName:"internetGateway" type:"structure"`
 
-	metadataCreateInternetGatewayOutput `json:"-" xml:"-"`
-}
-
-type metadataCreateInternetGatewayOutput struct {
-	SDKShapeTraits bool `type:"structure"`
+	_ struct{} `type:"structure"`
 }
 
 // String returns the string representation
@@ -8963,11 +8639,7 @@ type CreateKeyPairInput struct {
 	// Constraints: Up to 255 ASCII characters
 	KeyName *string `type:"string" required:"true"`
 
-	metadataCreateKeyPairInput `json:"-" xml:"-"`
-}
-
-type metadataCreateKeyPairInput struct {
-	SDKShapeTraits bool `type:"structure"`
+	_ struct{} `type:"structure"`
 }
 
 // String returns the string representation
@@ -8991,11 +8663,7 @@ type CreateKeyPairOutput struct {
 	// The name of the key pair.
 	KeyName *string `locationName:"keyName" type:"string"`
 
-	metadataCreateKeyPairOutput `json:"-" xml:"-"`
-}
-
-type metadataCreateKeyPairOutput struct {
-	SDKShapeTraits bool `type:"structure"`
+	_ struct{} `type:"structure"`
 }
 
 // String returns the string representation
@@ -9044,11 +8712,7 @@ type CreateNetworkAclEntryInput struct {
 	// Constraints: Positive integer from 1 to 32766
 	RuleNumber *int64 `locationName:"ruleNumber" type:"integer" required:"true"`
 
-	metadataCreateNetworkAclEntryInput `json:"-" xml:"-"`
-}
-
-type metadataCreateNetworkAclEntryInput struct {
-	SDKShapeTraits bool `type:"structure"`
+	_ struct{} `type:"structure"`
 }
 
 // String returns the string representation
@@ -9062,11 +8726,7 @@ func (s CreateNetworkAclEntryInput) GoString() string {
 }
 
 type CreateNetworkAclEntryOutput struct {
-	metadataCreateNetworkAclEntryOutput `json:"-" xml:"-"`
-}
-
-type metadataCreateNetworkAclEntryOutput struct {
-	SDKShapeTraits bool `type:"structure"`
+	_ struct{} `type:"structure"`
 }
 
 // String returns the string representation
@@ -9089,11 +8749,7 @@ type CreateNetworkAclInput struct {
 	// The ID of the VPC.
 	VpcId *string `locationName:"vpcId" type:"string" required:"true"`
 
-	metadataCreateNetworkAclInput `json:"-" xml:"-"`
-}
-
-type metadataCreateNetworkAclInput struct {
-	SDKShapeTraits bool `type:"structure"`
+	_ struct{} `type:"structure"`
 }
 
 // String returns the string representation
@@ -9110,11 +8766,7 @@ type CreateNetworkAclOutput struct {
 	// Information about the network ACL.
 	NetworkAcl *NetworkAcl `locationName:"networkAcl" type:"structure"`
 
-	metadataCreateNetworkAclOutput `json:"-" xml:"-"`
-}
-
-type metadataCreateNetworkAclOutput struct {
-	SDKShapeTraits bool `type:"structure"`
+	_ struct{} `type:"structure"`
 }
 
 // String returns the string representation
@@ -9163,11 +8815,7 @@ type CreateNetworkInterfaceInput struct {
 	// The ID of the subnet to associate with the network interface.
 	SubnetId *string `locationName:"subnetId" type:"string" required:"true"`
 
-	metadataCreateNetworkInterfaceInput `json:"-" xml:"-"`
-}
-
-type metadataCreateNetworkInterfaceInput struct {
-	SDKShapeTraits bool `type:"structure"`
+	_ struct{} `type:"structure"`
 }
 
 // String returns the string representation
@@ -9184,11 +8832,7 @@ type CreateNetworkInterfaceOutput struct {
 	// Information about the network interface.
 	NetworkInterface *NetworkInterface `locationName:"networkInterface" type:"structure"`
 
-	metadataCreateNetworkInterfaceOutput `json:"-" xml:"-"`
-}
-
-type metadataCreateNetworkInterfaceOutput struct {
-	SDKShapeTraits bool `type:"structure"`
+	_ struct{} `type:"structure"`
 }
 
 // String returns the string representation
@@ -9216,11 +8860,7 @@ type CreatePlacementGroupInput struct {
 	// The placement strategy.
 	Strategy *string `locationName:"strategy" type:"string" required:"true" enum:"PlacementStrategy"`
 
-	metadataCreatePlacementGroupInput `json:"-" xml:"-"`
-}
-
-type metadataCreatePlacementGroupInput struct {
-	SDKShapeTraits bool `type:"structure"`
+	_ struct{} `type:"structure"`
 }
 
 // String returns the string representation
@@ -9234,11 +8874,7 @@ func (s CreatePlacementGroupInput) GoString() string {
 }
 
 type CreatePlacementGroupOutput struct {
-	metadataCreatePlacementGroupOutput `json:"-" xml:"-"`
-}
-
-type metadataCreatePlacementGroupOutput struct {
-	SDKShapeTraits bool `type:"structure"`
+	_ struct{} `type:"structure"`
 }
 
 // String returns the string representation
@@ -9270,11 +8906,7 @@ type CreateReservedInstancesListingInput struct {
 	// The ID of the active Reserved instance.
 	ReservedInstancesId *string `locationName:"reservedInstancesId" type:"string" required:"true"`
 
-	metadataCreateReservedInstancesListingInput `json:"-" xml:"-"`
-}
-
-type metadataCreateReservedInstancesListingInput struct {
-	SDKShapeTraits bool `type:"structure"`
+	_ struct{} `type:"structure"`
 }
 
 // String returns the string representation
@@ -9291,11 +8923,7 @@ type CreateReservedInstancesListingOutput struct {
 	// Information about the Reserved instance listing.
 	ReservedInstancesListings []*ReservedInstancesListing `locationName:"reservedInstancesListingsSet" locationNameList:"item" type:"list"`
 
-	metadataCreateReservedInstancesListingOutput `json:"-" xml:"-"`
-}
-
-type metadataCreateReservedInstancesListingOutput struct {
-	SDKShapeTraits bool `type:"structure"`
+	_ struct{} `type:"structure"`
 }
 
 // String returns the string representation
@@ -9336,11 +8964,7 @@ type CreateRouteInput struct {
 	// The ID of a VPC peering connection.
 	VpcPeeringConnectionId *string `locationName:"vpcPeeringConnectionId" type:"string"`
 
-	metadataCreateRouteInput `json:"-" xml:"-"`
-}
-
-type metadataCreateRouteInput struct {
-	SDKShapeTraits bool `type:"structure"`
+	_ struct{} `type:"structure"`
 }
 
 // String returns the string representation
@@ -9357,11 +8981,7 @@ type CreateRouteOutput struct {
 	// Returns true if the request succeeds; otherwise, it returns an error.
 	Return *bool `locationName:"return" type:"boolean"`
 
-	metadataCreateRouteOutput `json:"-" xml:"-"`
-}
-
-type metadataCreateRouteOutput struct {
-	SDKShapeTraits bool `type:"structure"`
+	_ struct{} `type:"structure"`
 }
 
 // String returns the string representation
@@ -9384,11 +9004,7 @@ type CreateRouteTableInput struct {
 	// The ID of the VPC.
 	VpcId *string `locationName:"vpcId" type:"string" required:"true"`
 
-	metadataCreateRouteTableInput `json:"-" xml:"-"`
-}
-
-type metadataCreateRouteTableInput struct {
-	SDKShapeTraits bool `type:"structure"`
+	_ struct{} `type:"structure"`
 }
 
 // String returns the string representation
@@ -9405,11 +9021,7 @@ type CreateRouteTableOutput struct {
 	// Information about the route table.
 	RouteTable *RouteTable `locationName:"routeTable" type:"structure"`
 
-	metadataCreateRouteTableOutput `json:"-" xml:"-"`
-}
-
-type metadataCreateRouteTableOutput struct {
-	SDKShapeTraits bool `type:"structure"`
+	_ struct{} `type:"structure"`
 }
 
 // String returns the string representation
@@ -9450,11 +9062,7 @@ type CreateSecurityGroupInput struct {
 	// [EC2-VPC] The ID of the VPC. Required for EC2-VPC.
 	VpcId *string `type:"string"`
 
-	metadataCreateSecurityGroupInput `json:"-" xml:"-"`
-}
-
-type metadataCreateSecurityGroupInput struct {
-	SDKShapeTraits bool `type:"structure"`
+	_ struct{} `type:"structure"`
 }
 
 // String returns the string representation
@@ -9471,11 +9079,7 @@ type CreateSecurityGroupOutput struct {
 	// The ID of the security group.
 	GroupId *string `locationName:"groupId" type:"string"`
 
-	metadataCreateSecurityGroupOutput `json:"-" xml:"-"`
-}
-
-type metadataCreateSecurityGroupOutput struct {
-	SDKShapeTraits bool `type:"structure"`
+	_ struct{} `type:"structure"`
 }
 
 // String returns the string representation
@@ -9501,11 +9105,7 @@ type CreateSnapshotInput struct {
 	// The ID of the EBS volume.
 	VolumeId *string `type:"string" required:"true"`
 
-	metadataCreateSnapshotInput `json:"-" xml:"-"`
-}
-
-type metadataCreateSnapshotInput struct {
-	SDKShapeTraits bool `type:"structure"`
+	_ struct{} `type:"structure"`
 }
 
 // String returns the string representation
@@ -9532,11 +9132,7 @@ type CreateSpotDatafeedSubscriptionInput struct {
 	// A prefix for the data feed file names.
 	Prefix *string `locationName:"prefix" type:"string"`
 
-	metadataCreateSpotDatafeedSubscriptionInput `json:"-" xml:"-"`
-}
-
-type metadataCreateSpotDatafeedSubscriptionInput struct {
-	SDKShapeTraits bool `type:"structure"`
+	_ struct{} `type:"structure"`
 }
 
 // String returns the string representation
@@ -9554,11 +9150,7 @@ type CreateSpotDatafeedSubscriptionOutput struct {
 	// The Spot instance data feed subscription.
 	SpotDatafeedSubscription *SpotDatafeedSubscription `locationName:"spotDatafeedSubscription" type:"structure"`
 
-	metadataCreateSpotDatafeedSubscriptionOutput `json:"-" xml:"-"`
-}
-
-type metadataCreateSpotDatafeedSubscriptionOutput struct {
-	SDKShapeTraits bool `type:"structure"`
+	_ struct{} `type:"structure"`
 }
 
 // String returns the string representation
@@ -9590,11 +9182,7 @@ type CreateSubnetInput struct {
 	// The ID of the VPC.
 	VpcId *string `type:"string" required:"true"`
 
-	metadataCreateSubnetInput `json:"-" xml:"-"`
-}
-
-type metadataCreateSubnetInput struct {
-	SDKShapeTraits bool `type:"structure"`
+	_ struct{} `type:"structure"`
 }
 
 // String returns the string representation
@@ -9611,11 +9199,7 @@ type CreateSubnetOutput struct {
 	// Information about the subnet.
 	Subnet *Subnet `locationName:"subnet" type:"structure"`
 
-	metadataCreateSubnetOutput `json:"-" xml:"-"`
-}
-
-type metadataCreateSubnetOutput struct {
-	SDKShapeTraits bool `type:"structure"`
+	_ struct{} `type:"structure"`
 }
 
 // String returns the string representation
@@ -9643,11 +9227,7 @@ type CreateTagsInput struct {
 	// the value to an empty string.
 	Tags []*Tag `locationName:"Tag" locationNameList:"item" type:"list" required:"true"`
 
-	metadataCreateTagsInput `json:"-" xml:"-"`
-}
-
-type metadataCreateTagsInput struct {
-	SDKShapeTraits bool `type:"structure"`
+	_ struct{} `type:"structure"`
 }
 
 // String returns the string representation
@@ -9661,11 +9241,7 @@ func (s CreateTagsInput) GoString() string {
 }
 
 type CreateTagsOutput struct {
-	metadataCreateTagsOutput `json:"-" xml:"-"`
-}
-
-type metadataCreateTagsOutput struct {
-	SDKShapeTraits bool `type:"structure"`
+	_ struct{} `type:"structure"`
 }
 
 // String returns the string representation
@@ -9733,11 +9309,7 @@ type CreateVolumeInput struct {
 	// Default: standard
 	VolumeType *string `type:"string" enum:"VolumeType"`
 
-	metadataCreateVolumeInput `json:"-" xml:"-"`
-}
-
-type metadataCreateVolumeInput struct {
-	SDKShapeTraits bool `type:"structure"`
+	_ struct{} `type:"structure"`
 }
 
 // String returns the string representation
@@ -9761,11 +9333,7 @@ type CreateVolumePermission struct {
 	// list of create volume permissions.
 	UserId *string `locationName:"userId" type:"string"`
 
-	metadataCreateVolumePermission `json:"-" xml:"-"`
-}
-
-type metadataCreateVolumePermission struct {
-	SDKShapeTraits bool `type:"structure"`
+	_ struct{} `type:"structure"`
 }
 
 // String returns the string representation
@@ -9788,11 +9356,7 @@ type CreateVolumePermissionModifications struct {
 	// volume permissions.
 	Remove []*CreateVolumePermission `locationNameList:"item" type:"list"`
 
-	metadataCreateVolumePermissionModifications `json:"-" xml:"-"`
-}
-
-type metadataCreateVolumePermissionModifications struct {
-	SDKShapeTraits bool `type:"structure"`
+	_ struct{} `type:"structure"`
 }
 
 // String returns the string representation
@@ -9831,11 +9395,7 @@ type CreateVpcEndpointInput struct {
 	// The ID of the VPC in which the endpoint will be used.
 	VpcId *string `type:"string" required:"true"`
 
-	metadataCreateVpcEndpointInput `json:"-" xml:"-"`
-}
-
-type metadataCreateVpcEndpointInput struct {
-	SDKShapeTraits bool `type:"structure"`
+	_ struct{} `type:"structure"`
 }
 
 // String returns the string representation
@@ -9856,11 +9416,7 @@ type CreateVpcEndpointOutput struct {
 	// Information about the endpoint.
 	VpcEndpoint *VpcEndpoint `locationName:"vpcEndpoint" type:"structure"`
 
-	metadataCreateVpcEndpointOutput `json:"-" xml:"-"`
-}
-
-type metadataCreateVpcEndpointOutput struct {
-	SDKShapeTraits bool `type:"structure"`
+	_ struct{} `type:"structure"`
 }
 
 // String returns the string representation
@@ -9895,11 +9451,7 @@ type CreateVpcInput struct {
 	// Default: default
 	InstanceTenancy *string `locationName:"instanceTenancy" type:"string" enum:"Tenancy"`
 
-	metadataCreateVpcInput `json:"-" xml:"-"`
-}
-
-type metadataCreateVpcInput struct {
-	SDKShapeTraits bool `type:"structure"`
+	_ struct{} `type:"structure"`
 }
 
 // String returns the string representation
@@ -9916,11 +9468,7 @@ type CreateVpcOutput struct {
 	// Information about the VPC.
 	Vpc *Vpc `locationName:"vpc" type:"structure"`
 
-	metadataCreateVpcOutput `json:"-" xml:"-"`
-}
-
-type metadataCreateVpcOutput struct {
-	SDKShapeTraits bool `type:"structure"`
+	_ struct{} `type:"structure"`
 }
 
 // String returns the string representation
@@ -9951,11 +9499,7 @@ type CreateVpcPeeringConnectionInput struct {
 	// The ID of the requester VPC.
 	VpcId *string `locationName:"vpcId" type:"string"`
 
-	metadataCreateVpcPeeringConnectionInput `json:"-" xml:"-"`
-}
-
-type metadataCreateVpcPeeringConnectionInput struct {
-	SDKShapeTraits bool `type:"structure"`
+	_ struct{} `type:"structure"`
 }
 
 // String returns the string representation
@@ -9972,11 +9516,7 @@ type CreateVpcPeeringConnectionOutput struct {
 	// Information about the VPC peering connection.
 	VpcPeeringConnection *VpcPeeringConnection `locationName:"vpcPeeringConnection" type:"structure"`
 
-	metadataCreateVpcPeeringConnectionOutput `json:"-" xml:"-"`
-}
-
-type metadataCreateVpcPeeringConnectionOutput struct {
-	SDKShapeTraits bool `type:"structure"`
+	_ struct{} `type:"structure"`
 }
 
 // String returns the string representation
@@ -10012,11 +9552,7 @@ type CreateVpnConnectionInput struct {
 	// The ID of the virtual private gateway.
 	VpnGatewayId *string `type:"string" required:"true"`
 
-	metadataCreateVpnConnectionInput `json:"-" xml:"-"`
-}
-
-type metadataCreateVpnConnectionInput struct {
-	SDKShapeTraits bool `type:"structure"`
+	_ struct{} `type:"structure"`
 }
 
 // String returns the string representation
@@ -10033,11 +9569,7 @@ type CreateVpnConnectionOutput struct {
 	// Information about the VPN connection.
 	VpnConnection *VpnConnection `locationName:"vpnConnection" type:"structure"`
 
-	metadataCreateVpnConnectionOutput `json:"-" xml:"-"`
-}
-
-type metadataCreateVpnConnectionOutput struct {
-	SDKShapeTraits bool `type:"structure"`
+	_ struct{} `type:"structure"`
 }
 
 // String returns the string representation
@@ -10057,11 +9589,7 @@ type CreateVpnConnectionRouteInput struct {
 	// The ID of the VPN connection.
 	VpnConnectionId *string `type:"string" required:"true"`
 
-	metadataCreateVpnConnectionRouteInput `json:"-" xml:"-"`
-}
-
-type metadataCreateVpnConnectionRouteInput struct {
-	SDKShapeTraits bool `type:"structure"`
+	_ struct{} `type:"structure"`
 }
 
 // String returns the string representation
@@ -10075,11 +9603,7 @@ func (s CreateVpnConnectionRouteInput) GoString() string {
 }
 
 type CreateVpnConnectionRouteOutput struct {
-	metadataCreateVpnConnectionRouteOutput `json:"-" xml:"-"`
-}
-
-type metadataCreateVpnConnectionRouteOutput struct {
-	SDKShapeTraits bool `type:"structure"`
+	_ struct{} `type:"structure"`
 }
 
 // String returns the string representation
@@ -10105,11 +9629,7 @@ type CreateVpnGatewayInput struct {
 	// The type of VPN connection this virtual private gateway supports.
 	Type *string `type:"string" required:"true" enum:"GatewayType"`
 
-	metadataCreateVpnGatewayInput `json:"-" xml:"-"`
-}
-
-type metadataCreateVpnGatewayInput struct {
-	SDKShapeTraits bool `type:"structure"`
+	_ struct{} `type:"structure"`
 }
 
 // String returns the string representation
@@ -10126,11 +9646,7 @@ type CreateVpnGatewayOutput struct {
 	// Information about the virtual private gateway.
 	VpnGateway *VpnGateway `locationName:"vpnGateway" type:"structure"`
 
-	metadataCreateVpnGatewayOutput `json:"-" xml:"-"`
-}
-
-type metadataCreateVpnGatewayOutput struct {
-	SDKShapeTraits bool `type:"structure"`
+	_ struct{} `type:"structure"`
 }
 
 // String returns the string representation
@@ -10165,11 +9681,7 @@ type CustomerGateway struct {
 	// The type of VPN connection the customer gateway supports (ipsec.1).
 	Type *string `locationName:"type" type:"string"`
 
-	metadataCustomerGateway `json:"-" xml:"-"`
-}
-
-type metadataCustomerGateway struct {
-	SDKShapeTraits bool `type:"structure"`
+	_ struct{} `type:"structure"`
 }
 
 // String returns the string representation
@@ -10192,11 +9704,7 @@ type DeleteCustomerGatewayInput struct {
 	// it is UnauthorizedOperation.
 	DryRun *bool `locationName:"dryRun" type:"boolean"`
 
-	metadataDeleteCustomerGatewayInput `json:"-" xml:"-"`
-}
-
-type metadataDeleteCustomerGatewayInput struct {
-	SDKShapeTraits bool `type:"structure"`
+	_ struct{} `type:"structure"`
 }
 
 // String returns the string representation
@@ -10210,11 +9718,7 @@ func (s DeleteCustomerGatewayInput) GoString() string {
 }
 
 type DeleteCustomerGatewayOutput struct {
-	metadataDeleteCustomerGatewayOutput `json:"-" xml:"-"`
-}
-
-type metadataDeleteCustomerGatewayOutput struct {
-	SDKShapeTraits bool `type:"structure"`
+	_ struct{} `type:"structure"`
 }
 
 // String returns the string representation
@@ -10237,11 +9741,7 @@ type DeleteDhcpOptionsInput struct {
 	// it is UnauthorizedOperation.
 	DryRun *bool `locationName:"dryRun" type:"boolean"`
 
-	metadataDeleteDhcpOptionsInput `json:"-" xml:"-"`
-}
-
-type metadataDeleteDhcpOptionsInput struct {
-	SDKShapeTraits bool `type:"structure"`
+	_ struct{} `type:"structure"`
 }
 
 // String returns the string representation
@@ -10255,11 +9755,7 @@ func (s DeleteDhcpOptionsInput) GoString() string {
 }
 
 type DeleteDhcpOptionsOutput struct {
-	metadataDeleteDhcpOptionsOutput `json:"-" xml:"-"`
-}
-
-type metadataDeleteDhcpOptionsOutput struct {
-	SDKShapeTraits bool `type:"structure"`
+	_ struct{} `type:"structure"`
 }
 
 // String returns the string representation
@@ -10276,11 +9772,7 @@ type DeleteFlowLogsInput struct {
 	// One or more flow log IDs.
 	FlowLogIds []*string `locationName:"FlowLogId" locationNameList:"item" type:"list" required:"true"`
 
-	metadataDeleteFlowLogsInput `json:"-" xml:"-"`
-}
-
-type metadataDeleteFlowLogsInput struct {
-	SDKShapeTraits bool `type:"structure"`
+	_ struct{} `type:"structure"`
 }
 
 // String returns the string representation
@@ -10297,11 +9789,7 @@ type DeleteFlowLogsOutput struct {
 	// Information about the flow logs that could not be deleted successfully.
 	Unsuccessful []*UnsuccessfulItem `locationName:"unsuccessful" locationNameList:"item" type:"list"`
 
-	metadataDeleteFlowLogsOutput `json:"-" xml:"-"`
-}
-
-type metadataDeleteFlowLogsOutput struct {
-	SDKShapeTraits bool `type:"structure"`
+	_ struct{} `type:"structure"`
 }
 
 // String returns the string representation
@@ -10324,11 +9812,7 @@ type DeleteInternetGatewayInput struct {
 	// The ID of the Internet gateway.
 	InternetGatewayId *string `locationName:"internetGatewayId" type:"string" required:"true"`
 
-	metadataDeleteInternetGatewayInput `json:"-" xml:"-"`
-}
-
-type metadataDeleteInternetGatewayInput struct {
-	SDKShapeTraits bool `type:"structure"`
+	_ struct{} `type:"structure"`
 }
 
 // String returns the string representation
@@ -10342,11 +9826,7 @@ func (s DeleteInternetGatewayInput) GoString() string {
 }
 
 type DeleteInternetGatewayOutput struct {
-	metadataDeleteInternetGatewayOutput `json:"-" xml:"-"`
-}
-
-type metadataDeleteInternetGatewayOutput struct {
-	SDKShapeTraits bool `type:"structure"`
+	_ struct{} `type:"structure"`
 }
 
 // String returns the string representation
@@ -10369,11 +9849,7 @@ type DeleteKeyPairInput struct {
 	// The name of the key pair.
 	KeyName *string `type:"string" required:"true"`
 
-	metadataDeleteKeyPairInput `json:"-" xml:"-"`
-}
-
-type metadataDeleteKeyPairInput struct {
-	SDKShapeTraits bool `type:"structure"`
+	_ struct{} `type:"structure"`
 }
 
 // String returns the string representation
@@ -10387,11 +9863,7 @@ func (s DeleteKeyPairInput) GoString() string {
 }
 
 type DeleteKeyPairOutput struct {
-	metadataDeleteKeyPairOutput `json:"-" xml:"-"`
-}
-
-type metadataDeleteKeyPairOutput struct {
-	SDKShapeTraits bool `type:"structure"`
+	_ struct{} `type:"structure"`
 }
 
 // String returns the string representation
@@ -10420,11 +9892,7 @@ type DeleteNetworkAclEntryInput struct {
 	// The rule number of the entry to delete.
 	RuleNumber *int64 `locationName:"ruleNumber" type:"integer" required:"true"`
 
-	metadataDeleteNetworkAclEntryInput `json:"-" xml:"-"`
-}
-
-type metadataDeleteNetworkAclEntryInput struct {
-	SDKShapeTraits bool `type:"structure"`
+	_ struct{} `type:"structure"`
 }
 
 // String returns the string representation
@@ -10438,11 +9906,7 @@ func (s DeleteNetworkAclEntryInput) GoString() string {
 }
 
 type DeleteNetworkAclEntryOutput struct {
-	metadataDeleteNetworkAclEntryOutput `json:"-" xml:"-"`
-}
-
-type metadataDeleteNetworkAclEntryOutput struct {
-	SDKShapeTraits bool `type:"structure"`
+	_ struct{} `type:"structure"`
 }
 
 // String returns the string representation
@@ -10465,11 +9929,7 @@ type DeleteNetworkAclInput struct {
 	// The ID of the network ACL.
 	NetworkAclId *string `locationName:"networkAclId" type:"string" required:"true"`
 
-	metadataDeleteNetworkAclInput `json:"-" xml:"-"`
-}
-
-type metadataDeleteNetworkAclInput struct {
-	SDKShapeTraits bool `type:"structure"`
+	_ struct{} `type:"structure"`
 }
 
 // String returns the string representation
@@ -10483,11 +9943,7 @@ func (s DeleteNetworkAclInput) GoString() string {
 }
 
 type DeleteNetworkAclOutput struct {
-	metadataDeleteNetworkAclOutput `json:"-" xml:"-"`
-}
-
-type metadataDeleteNetworkAclOutput struct {
-	SDKShapeTraits bool `type:"structure"`
+	_ struct{} `type:"structure"`
 }
 
 // String returns the string representation
@@ -10510,11 +9966,7 @@ type DeleteNetworkInterfaceInput struct {
 	// The ID of the network interface.
 	NetworkInterfaceId *string `locationName:"networkInterfaceId" type:"string" required:"true"`
 
-	metadataDeleteNetworkInterfaceInput `json:"-" xml:"-"`
-}
-
-type metadataDeleteNetworkInterfaceInput struct {
-	SDKShapeTraits bool `type:"structure"`
+	_ struct{} `type:"structure"`
 }
 
 // String returns the string representation
@@ -10528,11 +9980,7 @@ func (s DeleteNetworkInterfaceInput) GoString() string {
 }
 
 type DeleteNetworkInterfaceOutput struct {
-	metadataDeleteNetworkInterfaceOutput `json:"-" xml:"-"`
-}
-
-type metadataDeleteNetworkInterfaceOutput struct {
-	SDKShapeTraits bool `type:"structure"`
+	_ struct{} `type:"structure"`
 }
 
 // String returns the string representation
@@ -10555,11 +10003,7 @@ type DeletePlacementGroupInput struct {
 	// The name of the placement group.
 	GroupName *string `locationName:"groupName" type:"string" required:"true"`
 
-	metadataDeletePlacementGroupInput `json:"-" xml:"-"`
-}
-
-type metadataDeletePlacementGroupInput struct {
-	SDKShapeTraits bool `type:"structure"`
+	_ struct{} `type:"structure"`
 }
 
 // String returns the string representation
@@ -10573,11 +10017,7 @@ func (s DeletePlacementGroupInput) GoString() string {
 }
 
 type DeletePlacementGroupOutput struct {
-	metadataDeletePlacementGroupOutput `json:"-" xml:"-"`
-}
-
-type metadataDeletePlacementGroupOutput struct {
-	SDKShapeTraits bool `type:"structure"`
+	_ struct{} `type:"structure"`
 }
 
 // String returns the string representation
@@ -10604,11 +10044,7 @@ type DeleteRouteInput struct {
 	// The ID of the route table.
 	RouteTableId *string `locationName:"routeTableId" type:"string" required:"true"`
 
-	metadataDeleteRouteInput `json:"-" xml:"-"`
-}
-
-type metadataDeleteRouteInput struct {
-	SDKShapeTraits bool `type:"structure"`
+	_ struct{} `type:"structure"`
 }
 
 // String returns the string representation
@@ -10622,11 +10058,7 @@ func (s DeleteRouteInput) GoString() string {
 }
 
 type DeleteRouteOutput struct {
-	metadataDeleteRouteOutput `json:"-" xml:"-"`
-}
-
-type metadataDeleteRouteOutput struct {
-	SDKShapeTraits bool `type:"structure"`
+	_ struct{} `type:"structure"`
 }
 
 // String returns the string representation
@@ -10649,11 +10081,7 @@ type DeleteRouteTableInput struct {
 	// The ID of the route table.
 	RouteTableId *string `locationName:"routeTableId" type:"string" required:"true"`
 
-	metadataDeleteRouteTableInput `json:"-" xml:"-"`
-}
-
-type metadataDeleteRouteTableInput struct {
-	SDKShapeTraits bool `type:"structure"`
+	_ struct{} `type:"structure"`
 }
 
 // String returns the string representation
@@ -10667,11 +10095,7 @@ func (s DeleteRouteTableInput) GoString() string {
 }
 
 type DeleteRouteTableOutput struct {
-	metadataDeleteRouteTableOutput `json:"-" xml:"-"`
-}
-
-type metadataDeleteRouteTableOutput struct {
-	SDKShapeTraits bool `type:"structure"`
+	_ struct{} `type:"structure"`
 }
 
 // String returns the string representation
@@ -10698,11 +10122,7 @@ type DeleteSecurityGroupInput struct {
 	// either the security group name or the security group ID.
 	GroupName *string `type:"string"`
 
-	metadataDeleteSecurityGroupInput `json:"-" xml:"-"`
-}
-
-type metadataDeleteSecurityGroupInput struct {
-	SDKShapeTraits bool `type:"structure"`
+	_ struct{} `type:"structure"`
 }
 
 // String returns the string representation
@@ -10716,11 +10136,7 @@ func (s DeleteSecurityGroupInput) GoString() string {
 }
 
 type DeleteSecurityGroupOutput struct {
-	metadataDeleteSecurityGroupOutput `json:"-" xml:"-"`
-}
-
-type metadataDeleteSecurityGroupOutput struct {
-	SDKShapeTraits bool `type:"structure"`
+	_ struct{} `type:"structure"`
 }
 
 // String returns the string representation
@@ -10743,11 +10159,7 @@ type DeleteSnapshotInput struct {
 	// The ID of the EBS snapshot.
 	SnapshotId *string `type:"string" required:"true"`
 
-	metadataDeleteSnapshotInput `json:"-" xml:"-"`
-}
-
-type metadataDeleteSnapshotInput struct {
-	SDKShapeTraits bool `type:"structure"`
+	_ struct{} `type:"structure"`
 }
 
 // String returns the string representation
@@ -10761,11 +10173,7 @@ func (s DeleteSnapshotInput) GoString() string {
 }
 
 type DeleteSnapshotOutput struct {
-	metadataDeleteSnapshotOutput `json:"-" xml:"-"`
-}
-
-type metadataDeleteSnapshotOutput struct {
-	SDKShapeTraits bool `type:"structure"`
+	_ struct{} `type:"structure"`
 }
 
 // String returns the string representation
@@ -10786,11 +10194,7 @@ type DeleteSpotDatafeedSubscriptionInput struct {
 	// it is UnauthorizedOperation.
 	DryRun *bool `locationName:"dryRun" type:"boolean"`
 
-	metadataDeleteSpotDatafeedSubscriptionInput `json:"-" xml:"-"`
-}
-
-type metadataDeleteSpotDatafeedSubscriptionInput struct {
-	SDKShapeTraits bool `type:"structure"`
+	_ struct{} `type:"structure"`
 }
 
 // String returns the string representation
@@ -10804,11 +10208,7 @@ func (s DeleteSpotDatafeedSubscriptionInput) GoString() string {
 }
 
 type DeleteSpotDatafeedSubscriptionOutput struct {
-	metadataDeleteSpotDatafeedSubscriptionOutput `json:"-" xml:"-"`
-}
-
-type metadataDeleteSpotDatafeedSubscriptionOutput struct {
-	SDKShapeTraits bool `type:"structure"`
+	_ struct{} `type:"structure"`
 }
 
 // String returns the string representation
@@ -10831,11 +10231,7 @@ type DeleteSubnetInput struct {
 	// The ID of the subnet.
 	SubnetId *string `type:"string" required:"true"`
 
-	metadataDeleteSubnetInput `json:"-" xml:"-"`
-}
-
-type metadataDeleteSubnetInput struct {
-	SDKShapeTraits bool `type:"structure"`
+	_ struct{} `type:"structure"`
 }
 
 // String returns the string representation
@@ -10849,11 +10245,7 @@ func (s DeleteSubnetInput) GoString() string {
 }
 
 type DeleteSubnetOutput struct {
-	metadataDeleteSubnetOutput `json:"-" xml:"-"`
-}
-
-type metadataDeleteSubnetOutput struct {
-	SDKShapeTraits bool `type:"structure"`
+	_ struct{} `type:"structure"`
 }
 
 // String returns the string representation
@@ -10882,11 +10274,7 @@ type DeleteTagsInput struct {
 	// string as the value, we delete the key only if its value is an empty string.
 	Tags []*Tag `locationName:"tag" locationNameList:"item" type:"list"`
 
-	metadataDeleteTagsInput `json:"-" xml:"-"`
-}
-
-type metadataDeleteTagsInput struct {
-	SDKShapeTraits bool `type:"structure"`
+	_ struct{} `type:"structure"`
 }
 
 // String returns the string representation
@@ -10900,11 +10288,7 @@ func (s DeleteTagsInput) GoString() string {
 }
 
 type DeleteTagsOutput struct {
-	metadataDeleteTagsOutput `json:"-" xml:"-"`
-}
-
-type metadataDeleteTagsOutput struct {
-	SDKShapeTraits bool `type:"structure"`
+	_ struct{} `type:"structure"`
 }
 
 // String returns the string representation
@@ -10927,11 +10311,7 @@ type DeleteVolumeInput struct {
 	// The ID of the volume.
 	VolumeId *string `type:"string" required:"true"`
 
-	metadataDeleteVolumeInput `json:"-" xml:"-"`
-}
-
-type metadataDeleteVolumeInput struct {
-	SDKShapeTraits bool `type:"structure"`
+	_ struct{} `type:"structure"`
 }
 
 // String returns the string representation
@@ -10945,11 +10325,7 @@ func (s DeleteVolumeInput) GoString() string {
 }
 
 type DeleteVolumeOutput struct {
-	metadataDeleteVolumeOutput `json:"-" xml:"-"`
-}
-
-type metadataDeleteVolumeOutput struct {
-	SDKShapeTraits bool `type:"structure"`
+	_ struct{} `type:"structure"`
 }
 
 // String returns the string representation
@@ -10972,11 +10348,7 @@ type DeleteVpcEndpointsInput struct {
 	// One or more endpoint IDs.
 	VpcEndpointIds []*string `locationName:"VpcEndpointId" locationNameList:"item" type:"list" required:"true"`
 
-	metadataDeleteVpcEndpointsInput `json:"-" xml:"-"`
-}
-
-type metadataDeleteVpcEndpointsInput struct {
-	SDKShapeTraits bool `type:"structure"`
+	_ struct{} `type:"structure"`
 }
 
 // String returns the string representation
@@ -10993,11 +10365,7 @@ type DeleteVpcEndpointsOutput struct {
 	// Information about the endpoints that were not successfully deleted.
 	Unsuccessful []*UnsuccessfulItem `locationName:"unsuccessful" locationNameList:"item" type:"list"`
 
-	metadataDeleteVpcEndpointsOutput `json:"-" xml:"-"`
-}
-
-type metadataDeleteVpcEndpointsOutput struct {
-	SDKShapeTraits bool `type:"structure"`
+	_ struct{} `type:"structure"`
 }
 
 // String returns the string representation
@@ -11020,11 +10388,7 @@ type DeleteVpcInput struct {
 	// The ID of the VPC.
 	VpcId *string `type:"string" required:"true"`
 
-	metadataDeleteVpcInput `json:"-" xml:"-"`
-}
-
-type metadataDeleteVpcInput struct {
-	SDKShapeTraits bool `type:"structure"`
+	_ struct{} `type:"structure"`
 }
 
 // String returns the string representation
@@ -11038,11 +10402,7 @@ func (s DeleteVpcInput) GoString() string {
 }
 
 type DeleteVpcOutput struct {
-	metadataDeleteVpcOutput `json:"-" xml:"-"`
-}
-
-type metadataDeleteVpcOutput struct {
-	SDKShapeTraits bool `type:"structure"`
+	_ struct{} `type:"structure"`
 }
 
 // String returns the string representation
@@ -11065,11 +10425,7 @@ type DeleteVpcPeeringConnectionInput struct {
 	// The ID of the VPC peering connection.
 	VpcPeeringConnectionId *string `locationName:"vpcPeeringConnectionId" type:"string" required:"true"`
 
-	metadataDeleteVpcPeeringConnectionInput `json:"-" xml:"-"`
-}
-
-type metadataDeleteVpcPeeringConnectionInput struct {
-	SDKShapeTraits bool `type:"structure"`
+	_ struct{} `type:"structure"`
 }
 
 // String returns the string representation
@@ -11086,11 +10442,7 @@ type DeleteVpcPeeringConnectionOutput struct {
 	// Returns true if the request succeeds; otherwise, it returns an error.
 	Return *bool `locationName:"return" type:"boolean"`
 
-	metadataDeleteVpcPeeringConnectionOutput `json:"-" xml:"-"`
-}
-
-type metadataDeleteVpcPeeringConnectionOutput struct {
-	SDKShapeTraits bool `type:"structure"`
+	_ struct{} `type:"structure"`
 }
 
 // String returns the string representation
@@ -11113,11 +10465,7 @@ type DeleteVpnConnectionInput struct {
 	// The ID of the VPN connection.
 	VpnConnectionId *string `type:"string" required:"true"`
 
-	metadataDeleteVpnConnectionInput `json:"-" xml:"-"`
-}
-
-type metadataDeleteVpnConnectionInput struct {
-	SDKShapeTraits bool `type:"structure"`
+	_ struct{} `type:"structure"`
 }
 
 // String returns the string representation
@@ -11131,11 +10479,7 @@ func (s DeleteVpnConnectionInput) GoString() string {
 }
 
 type DeleteVpnConnectionOutput struct {
-	metadataDeleteVpnConnectionOutput `json:"-" xml:"-"`
-}
-
-type metadataDeleteVpnConnectionOutput struct {
-	SDKShapeTraits bool `type:"structure"`
+	_ struct{} `type:"structure"`
 }
 
 // String returns the string representation
@@ -11155,11 +10499,7 @@ type DeleteVpnConnectionRouteInput struct {
 	// The ID of the VPN connection.
 	VpnConnectionId *string `type:"string" required:"true"`
 
-	metadataDeleteVpnConnectionRouteInput `json:"-" xml:"-"`
-}
-
-type metadataDeleteVpnConnectionRouteInput struct {
-	SDKShapeTraits bool `type:"structure"`
+	_ struct{} `type:"structure"`
 }
 
 // String returns the string representation
@@ -11173,11 +10513,7 @@ func (s DeleteVpnConnectionRouteInput) GoString() string {
 }
 
 type DeleteVpnConnectionRouteOutput struct {
-	metadataDeleteVpnConnectionRouteOutput `json:"-" xml:"-"`
-}
-
-type metadataDeleteVpnConnectionRouteOutput struct {
-	SDKShapeTraits bool `type:"structure"`
+	_ struct{} `type:"structure"`
 }
 
 // String returns the string representation
@@ -11200,11 +10536,7 @@ type DeleteVpnGatewayInput struct {
 	// The ID of the virtual private gateway.
 	VpnGatewayId *string `type:"string" required:"true"`
 
-	metadataDeleteVpnGatewayInput `json:"-" xml:"-"`
-}
-
-type metadataDeleteVpnGatewayInput struct {
-	SDKShapeTraits bool `type:"structure"`
+	_ struct{} `type:"structure"`
 }
 
 // String returns the string representation
@@ -11218,11 +10550,7 @@ func (s DeleteVpnGatewayInput) GoString() string {
 }
 
 type DeleteVpnGatewayOutput struct {
-	metadataDeleteVpnGatewayOutput `json:"-" xml:"-"`
-}
-
-type metadataDeleteVpnGatewayOutput struct {
-	SDKShapeTraits bool `type:"structure"`
+	_ struct{} `type:"structure"`
 }
 
 // String returns the string representation
@@ -11245,11 +10573,7 @@ type DeregisterImageInput struct {
 	// The ID of the AMI.
 	ImageId *string `type:"string" required:"true"`
 
-	metadataDeregisterImageInput `json:"-" xml:"-"`
-}
-
-type metadataDeregisterImageInput struct {
-	SDKShapeTraits bool `type:"structure"`
+	_ struct{} `type:"structure"`
 }
 
 // String returns the string representation
@@ -11263,11 +10587,7 @@ func (s DeregisterImageInput) GoString() string {
 }
 
 type DeregisterImageOutput struct {
-	metadataDeregisterImageOutput `json:"-" xml:"-"`
-}
-
-type metadataDeregisterImageOutput struct {
-	SDKShapeTraits bool `type:"structure"`
+	_ struct{} `type:"structure"`
 }
 
 // String returns the string representation
@@ -11290,11 +10610,7 @@ type DescribeAccountAttributesInput struct {
 	// it is UnauthorizedOperation.
 	DryRun *bool `locationName:"dryRun" type:"boolean"`
 
-	metadataDescribeAccountAttributesInput `json:"-" xml:"-"`
-}
-
-type metadataDescribeAccountAttributesInput struct {
-	SDKShapeTraits bool `type:"structure"`
+	_ struct{} `type:"structure"`
 }
 
 // String returns the string representation
@@ -11311,11 +10627,7 @@ type DescribeAccountAttributesOutput struct {
 	// Information about one or more account attributes.
 	AccountAttributes []*AccountAttribute `locationName:"accountAttributeSet" locationNameList:"item" type:"list"`
 
-	metadataDescribeAccountAttributesOutput `json:"-" xml:"-"`
-}
-
-type metadataDescribeAccountAttributesOutput struct {
-	SDKShapeTraits bool `type:"structure"`
+	_ struct{} `type:"structure"`
 }
 
 // String returns the string representation
@@ -11368,11 +10680,7 @@ type DescribeAddressesInput struct {
 	// Default: Describes all your Elastic IP addresses.
 	PublicIps []*string `locationName:"PublicIp" locationNameList:"PublicIp" type:"list"`
 
-	metadataDescribeAddressesInput `json:"-" xml:"-"`
-}
-
-type metadataDescribeAddressesInput struct {
-	SDKShapeTraits bool `type:"structure"`
+	_ struct{} `type:"structure"`
 }
 
 // String returns the string representation
@@ -11389,11 +10697,7 @@ type DescribeAddressesOutput struct {
 	// Information about one or more Elastic IP addresses.
 	Addresses []*Address `locationName:"addressesSet" locationNameList:"item" type:"list"`
 
-	metadataDescribeAddressesOutput `json:"-" xml:"-"`
-}
-
-type metadataDescribeAddressesOutput struct {
-	SDKShapeTraits bool `type:"structure"`
+	_ struct{} `type:"structure"`
 }
 
 // String returns the string representation
@@ -11429,11 +10733,7 @@ type DescribeAvailabilityZonesInput struct {
 	// The names of one or more Availability Zones.
 	ZoneNames []*string `locationName:"ZoneName" locationNameList:"ZoneName" type:"list"`
 
-	metadataDescribeAvailabilityZonesInput `json:"-" xml:"-"`
-}
-
-type metadataDescribeAvailabilityZonesInput struct {
-	SDKShapeTraits bool `type:"structure"`
+	_ struct{} `type:"structure"`
 }
 
 // String returns the string representation
@@ -11450,11 +10750,7 @@ type DescribeAvailabilityZonesOutput struct {
 	// Information about one or more Availability Zones.
 	AvailabilityZones []*AvailabilityZone `locationName:"availabilityZoneInfo" locationNameList:"item" type:"list"`
 
-	metadataDescribeAvailabilityZonesOutput `json:"-" xml:"-"`
-}
-
-type metadataDescribeAvailabilityZonesOutput struct {
-	SDKShapeTraits bool `type:"structure"`
+	_ struct{} `type:"structure"`
 }
 
 // String returns the string representation
@@ -11504,11 +10800,7 @@ type DescribeBundleTasksInput struct {
 	//   update-time - The time of the most recent update for the task.
 	Filters []*Filter `locationName:"Filter" locationNameList:"Filter" type:"list"`
 
-	metadataDescribeBundleTasksInput `json:"-" xml:"-"`
-}
-
-type metadataDescribeBundleTasksInput struct {
-	SDKShapeTraits bool `type:"structure"`
+	_ struct{} `type:"structure"`
 }
 
 // String returns the string representation
@@ -11525,11 +10817,7 @@ type DescribeBundleTasksOutput struct {
 	// Information about one or more bundle tasks.
 	BundleTasks []*BundleTask `locationName:"bundleInstanceTasksSet" locationNameList:"item" type:"list"`
 
-	metadataDescribeBundleTasksOutput `json:"-" xml:"-"`
-}
-
-type metadataDescribeBundleTasksOutput struct {
-	SDKShapeTraits bool `type:"structure"`
+	_ struct{} `type:"structure"`
 }
 
 // String returns the string representation
@@ -11586,11 +10874,7 @@ type DescribeClassicLinkInstancesInput struct {
 	// The token to retrieve the next page of results.
 	NextToken *string `locationName:"nextToken" type:"string"`
 
-	metadataDescribeClassicLinkInstancesInput `json:"-" xml:"-"`
-}
-
-type metadataDescribeClassicLinkInstancesInput struct {
-	SDKShapeTraits bool `type:"structure"`
+	_ struct{} `type:"structure"`
 }
 
 // String returns the string representation
@@ -11611,11 +10895,7 @@ type DescribeClassicLinkInstancesOutput struct {
 	// when there are no more results to return.
 	NextToken *string `locationName:"nextToken" type:"string"`
 
-	metadataDescribeClassicLinkInstancesOutput `json:"-" xml:"-"`
-}
-
-type metadataDescribeClassicLinkInstancesOutput struct {
-	SDKShapeTraits bool `type:"structure"`
+	_ struct{} `type:"structure"`
 }
 
 // String returns the string representation
@@ -11641,11 +10921,7 @@ type DescribeConversionTasksInput struct {
 	// One or more filters.
 	Filters []*Filter `locationName:"filter" locationNameList:"Filter" type:"list"`
 
-	metadataDescribeConversionTasksInput `json:"-" xml:"-"`
-}
-
-type metadataDescribeConversionTasksInput struct {
-	SDKShapeTraits bool `type:"structure"`
+	_ struct{} `type:"structure"`
 }
 
 // String returns the string representation
@@ -11662,11 +10938,7 @@ type DescribeConversionTasksOutput struct {
 	// Information about the conversion tasks.
 	ConversionTasks []*ConversionTask `locationName:"conversionTasks" locationNameList:"item" type:"list"`
 
-	metadataDescribeConversionTasksOutput `json:"-" xml:"-"`
-}
-
-type metadataDescribeConversionTasksOutput struct {
-	SDKShapeTraits bool `type:"structure"`
+	_ struct{} `type:"structure"`
 }
 
 // String returns the string representation
@@ -11720,11 +10992,7 @@ type DescribeCustomerGatewaysInput struct {
 	// independent of the tag-key filter.
 	Filters []*Filter `locationName:"Filter" locationNameList:"Filter" type:"list"`
 
-	metadataDescribeCustomerGatewaysInput `json:"-" xml:"-"`
-}
-
-type metadataDescribeCustomerGatewaysInput struct {
-	SDKShapeTraits bool `type:"structure"`
+	_ struct{} `type:"structure"`
 }
 
 // String returns the string representation
@@ -11741,11 +11009,7 @@ type DescribeCustomerGatewaysOutput struct {
 	// Information about one or more customer gateways.
 	CustomerGateways []*CustomerGateway `locationName:"customerGatewaySet" locationNameList:"item" type:"list"`
 
-	metadataDescribeCustomerGatewaysOutput `json:"-" xml:"-"`
-}
-
-type metadataDescribeCustomerGatewaysOutput struct {
-	SDKShapeTraits bool `type:"structure"`
+	_ struct{} `type:"structure"`
 }
 
 // String returns the string representation
@@ -11791,11 +11055,7 @@ type DescribeDhcpOptionsInput struct {
 	// independent of the tag-key filter.
 	Filters []*Filter `locationName:"Filter" locationNameList:"Filter" type:"list"`
 
-	metadataDescribeDhcpOptionsInput `json:"-" xml:"-"`
-}
-
-type metadataDescribeDhcpOptionsInput struct {
-	SDKShapeTraits bool `type:"structure"`
+	_ struct{} `type:"structure"`
 }
 
 // String returns the string representation
@@ -11812,11 +11072,7 @@ type DescribeDhcpOptionsOutput struct {
 	// Information about one or more DHCP options sets.
 	DhcpOptions []*DhcpOptions `locationName:"dhcpOptionsSet" locationNameList:"item" type:"list"`
 
-	metadataDescribeDhcpOptionsOutput `json:"-" xml:"-"`
-}
-
-type metadataDescribeDhcpOptionsOutput struct {
-	SDKShapeTraits bool `type:"structure"`
+	_ struct{} `type:"structure"`
 }
 
 // String returns the string representation
@@ -11833,11 +11089,7 @@ type DescribeExportTasksInput struct {
 	// One or more export task IDs.
 	ExportTaskIds []*string `locationName:"exportTaskId" locationNameList:"ExportTaskId" type:"list"`
 
-	metadataDescribeExportTasksInput `json:"-" xml:"-"`
-}
-
-type metadataDescribeExportTasksInput struct {
-	SDKShapeTraits bool `type:"structure"`
+	_ struct{} `type:"structure"`
 }
 
 // String returns the string representation
@@ -11854,11 +11106,7 @@ type DescribeExportTasksOutput struct {
 	// Information about the export tasks.
 	ExportTasks []*ExportTask `locationName:"exportTaskSet" locationNameList:"item" type:"list"`
 
-	metadataDescribeExportTasksOutput `json:"-" xml:"-"`
-}
-
-type metadataDescribeExportTasksOutput struct {
-	SDKShapeTraits bool `type:"structure"`
+	_ struct{} `type:"structure"`
 }
 
 // String returns the string representation
@@ -11898,11 +11146,7 @@ type DescribeFlowLogsInput struct {
 	// The token to retrieve the next page of results.
 	NextToken *string `type:"string"`
 
-	metadataDescribeFlowLogsInput `json:"-" xml:"-"`
-}
-
-type metadataDescribeFlowLogsInput struct {
-	SDKShapeTraits bool `type:"structure"`
+	_ struct{} `type:"structure"`
 }
 
 // String returns the string representation
@@ -11923,11 +11167,7 @@ type DescribeFlowLogsOutput struct {
 	// when there are no more results to return.
 	NextToken *string `locationName:"nextToken" type:"string"`
 
-	metadataDescribeFlowLogsOutput `json:"-" xml:"-"`
-}
-
-type metadataDescribeFlowLogsOutput struct {
-	SDKShapeTraits bool `type:"structure"`
+	_ struct{} `type:"structure"`
 }
 
 // String returns the string representation
@@ -11972,11 +11212,7 @@ type DescribeHostsInput struct {
 	// The token to retrieve the next page of results.
 	NextToken *string `locationName:"nextToken" type:"string"`
 
-	metadataDescribeHostsInput `json:"-" xml:"-"`
-}
-
-type metadataDescribeHostsInput struct {
-	SDKShapeTraits bool `type:"structure"`
+	_ struct{} `type:"structure"`
 }
 
 // String returns the string representation
@@ -11997,11 +11233,7 @@ type DescribeHostsOutput struct {
 	// when there are no more results to return.
 	NextToken *string `locationName:"nextToken" type:"string"`
 
-	metadataDescribeHostsOutput `json:"-" xml:"-"`
-}
-
-type metadataDescribeHostsOutput struct {
-	SDKShapeTraits bool `type:"structure"`
+	_ struct{} `type:"structure"`
 }
 
 // String returns the string representation
@@ -12018,11 +11250,7 @@ type DescribeIdFormatInput struct {
 	// The type of resource.
 	Resource *string `type:"string"`
 
-	metadataDescribeIdFormatInput `json:"-" xml:"-"`
-}
-
-type metadataDescribeIdFormatInput struct {
-	SDKShapeTraits bool `type:"structure"`
+	_ struct{} `type:"structure"`
 }
 
 // String returns the string representation
@@ -12039,11 +11267,7 @@ type DescribeIdFormatOutput struct {
 	// Information about the ID format for the resource.
 	Statuses []*IdFormat `locationName:"statusSet" locationNameList:"item" type:"list"`
 
-	metadataDescribeIdFormatOutput `json:"-" xml:"-"`
-}
-
-type metadataDescribeIdFormatOutput struct {
-	SDKShapeTraits bool `type:"structure"`
+	_ struct{} `type:"structure"`
 }
 
 // String returns the string representation
@@ -12073,11 +11297,7 @@ type DescribeImageAttributeInput struct {
 	// The ID of the AMI.
 	ImageId *string `type:"string" required:"true"`
 
-	metadataDescribeImageAttributeInput `json:"-" xml:"-"`
-}
-
-type metadataDescribeImageAttributeInput struct {
-	SDKShapeTraits bool `type:"structure"`
+	_ struct{} `type:"structure"`
 }
 
 // String returns the string representation
@@ -12116,11 +11336,7 @@ type DescribeImageAttributeOutput struct {
 	// The value to use for a resource attribute.
 	SriovNetSupport *AttributeValue `locationName:"sriovNetSupport" type:"structure"`
 
-	metadataDescribeImageAttributeOutput `json:"-" xml:"-"`
-}
-
-type metadataDescribeImageAttributeOutput struct {
-	SDKShapeTraits bool `type:"structure"`
+	_ struct{} `type:"structure"`
 }
 
 // String returns the string representation
@@ -12227,11 +11443,7 @@ type DescribeImagesInput struct {
 	// you have launch permissions, regardless of ownership.
 	Owners []*string `locationName:"Owner" locationNameList:"Owner" type:"list"`
 
-	metadataDescribeImagesInput `json:"-" xml:"-"`
-}
-
-type metadataDescribeImagesInput struct {
-	SDKShapeTraits bool `type:"structure"`
+	_ struct{} `type:"structure"`
 }
 
 // String returns the string representation
@@ -12248,11 +11460,7 @@ type DescribeImagesOutput struct {
 	// Information about one or more images.
 	Images []*Image `locationName:"imagesSet" locationNameList:"item" type:"list"`
 
-	metadataDescribeImagesOutput `json:"-" xml:"-"`
-}
-
-type metadataDescribeImagesOutput struct {
-	SDKShapeTraits bool `type:"structure"`
+	_ struct{} `type:"structure"`
 }
 
 // String returns the string representation
@@ -12284,11 +11492,7 @@ type DescribeImportImageTasksInput struct {
 	// A token that indicates the next page of results.
 	NextToken *string `type:"string"`
 
-	metadataDescribeImportImageTasksInput `json:"-" xml:"-"`
-}
-
-type metadataDescribeImportImageTasksInput struct {
-	SDKShapeTraits bool `type:"structure"`
+	_ struct{} `type:"structure"`
 }
 
 // String returns the string representation
@@ -12310,11 +11514,7 @@ type DescribeImportImageTasksOutput struct {
 	// there are no more results to return.
 	NextToken *string `locationName:"nextToken" type:"string"`
 
-	metadataDescribeImportImageTasksOutput `json:"-" xml:"-"`
-}
-
-type metadataDescribeImportImageTasksOutput struct {
-	SDKShapeTraits bool `type:"structure"`
+	_ struct{} `type:"structure"`
 }
 
 // String returns the string representation
@@ -12346,11 +11546,7 @@ type DescribeImportSnapshotTasksInput struct {
 	// A token that indicates the next page of results.
 	NextToken *string `type:"string"`
 
-	metadataDescribeImportSnapshotTasksInput `json:"-" xml:"-"`
-}
-
-type metadataDescribeImportSnapshotTasksInput struct {
-	SDKShapeTraits bool `type:"structure"`
+	_ struct{} `type:"structure"`
 }
 
 // String returns the string representation
@@ -12372,11 +11568,7 @@ type DescribeImportSnapshotTasksOutput struct {
 	// there are no more results to return.
 	NextToken *string `locationName:"nextToken" type:"string"`
 
-	metadataDescribeImportSnapshotTasksOutput `json:"-" xml:"-"`
-}
-
-type metadataDescribeImportSnapshotTasksOutput struct {
-	SDKShapeTraits bool `type:"structure"`
+	_ struct{} `type:"structure"`
 }
 
 // String returns the string representation
@@ -12402,11 +11594,7 @@ type DescribeInstanceAttributeInput struct {
 	// The ID of the instance.
 	InstanceId *string `locationName:"instanceId" type:"string" required:"true"`
 
-	metadataDescribeInstanceAttributeInput `json:"-" xml:"-"`
-}
-
-type metadataDescribeInstanceAttributeInput struct {
-	SDKShapeTraits bool `type:"structure"`
+	_ struct{} `type:"structure"`
 }
 
 // String returns the string representation
@@ -12467,11 +11655,7 @@ type DescribeInstanceAttributeOutput struct {
 	// The Base64-encoded MIME user data.
 	UserData *AttributeValue `locationName:"userData" type:"structure"`
 
-	metadataDescribeInstanceAttributeOutput `json:"-" xml:"-"`
-}
-
-type metadataDescribeInstanceAttributeOutput struct {
-	SDKShapeTraits bool `type:"structure"`
+	_ struct{} `type:"structure"`
 }
 
 // String returns the string representation
@@ -12552,11 +11736,7 @@ type DescribeInstanceStatusInput struct {
 	// The token to retrieve the next page of results.
 	NextToken *string `type:"string"`
 
-	metadataDescribeInstanceStatusInput `json:"-" xml:"-"`
-}
-
-type metadataDescribeInstanceStatusInput struct {
-	SDKShapeTraits bool `type:"structure"`
+	_ struct{} `type:"structure"`
 }
 
 // String returns the string representation
@@ -12577,11 +11757,7 @@ type DescribeInstanceStatusOutput struct {
 	// when there are no more results to return.
 	NextToken *string `locationName:"nextToken" type:"string"`
 
-	metadataDescribeInstanceStatusOutput `json:"-" xml:"-"`
-}
-
-type metadataDescribeInstanceStatusOutput struct {
-	SDKShapeTraits bool `type:"structure"`
+	_ struct{} `type:"structure"`
 }
 
 // String returns the string representation
@@ -12842,11 +12018,7 @@ type DescribeInstancesInput struct {
 	// The token to request the next page of results.
 	NextToken *string `locationName:"nextToken" type:"string"`
 
-	metadataDescribeInstancesInput `json:"-" xml:"-"`
-}
-
-type metadataDescribeInstancesInput struct {
-	SDKShapeTraits bool `type:"structure"`
+	_ struct{} `type:"structure"`
 }
 
 // String returns the string representation
@@ -12867,11 +12039,7 @@ type DescribeInstancesOutput struct {
 	// Zero or more reservations.
 	Reservations []*Reservation `locationName:"reservationSet" locationNameList:"item" type:"list"`
 
-	metadataDescribeInstancesOutput `json:"-" xml:"-"`
-}
-
-type metadataDescribeInstancesOutput struct {
-	SDKShapeTraits bool `type:"structure"`
+	_ struct{} `type:"structure"`
 }
 
 // String returns the string representation
@@ -12918,11 +12086,7 @@ type DescribeInternetGatewaysInput struct {
 	// Default: Describes all your Internet gateways.
 	InternetGatewayIds []*string `locationName:"internetGatewayId" locationNameList:"item" type:"list"`
 
-	metadataDescribeInternetGatewaysInput `json:"-" xml:"-"`
-}
-
-type metadataDescribeInternetGatewaysInput struct {
-	SDKShapeTraits bool `type:"structure"`
+	_ struct{} `type:"structure"`
 }
 
 // String returns the string representation
@@ -12939,11 +12103,7 @@ type DescribeInternetGatewaysOutput struct {
 	// Information about one or more Internet gateways.
 	InternetGateways []*InternetGateway `locationName:"internetGatewaySet" locationNameList:"item" type:"list"`
 
-	metadataDescribeInternetGatewaysOutput `json:"-" xml:"-"`
-}
-
-type metadataDescribeInternetGatewaysOutput struct {
-	SDKShapeTraits bool `type:"structure"`
+	_ struct{} `type:"structure"`
 }
 
 // String returns the string representation
@@ -12975,11 +12135,7 @@ type DescribeKeyPairsInput struct {
 	// Default: Describes all your key pairs.
 	KeyNames []*string `locationName:"KeyName" locationNameList:"KeyName" type:"list"`
 
-	metadataDescribeKeyPairsInput `json:"-" xml:"-"`
-}
-
-type metadataDescribeKeyPairsInput struct {
-	SDKShapeTraits bool `type:"structure"`
+	_ struct{} `type:"structure"`
 }
 
 // String returns the string representation
@@ -12996,11 +12152,7 @@ type DescribeKeyPairsOutput struct {
 	// Information about one or more key pairs.
 	KeyPairs []*KeyPairInfo `locationName:"keySet" locationNameList:"item" type:"list"`
 
-	metadataDescribeKeyPairsOutput `json:"-" xml:"-"`
-}
-
-type metadataDescribeKeyPairsOutput struct {
-	SDKShapeTraits bool `type:"structure"`
+	_ struct{} `type:"structure"`
 }
 
 // String returns the string representation
@@ -13039,11 +12191,7 @@ type DescribeMovingAddressesInput struct {
 	// One or more Elastic IP addresses.
 	PublicIps []*string `locationName:"publicIp" locationNameList:"item" type:"list"`
 
-	metadataDescribeMovingAddressesInput `json:"-" xml:"-"`
-}
-
-type metadataDescribeMovingAddressesInput struct {
-	SDKShapeTraits bool `type:"structure"`
+	_ struct{} `type:"structure"`
 }
 
 // String returns the string representation
@@ -13064,11 +12212,7 @@ type DescribeMovingAddressesOutput struct {
 	// when there are no more results to return.
 	NextToken *string `locationName:"nextToken" type:"string"`
 
-	metadataDescribeMovingAddressesOutput `json:"-" xml:"-"`
-}
-
-type metadataDescribeMovingAddressesOutput struct {
-	SDKShapeTraits bool `type:"structure"`
+	_ struct{} `type:"structure"`
 }
 
 // String returns the string representation
@@ -13142,11 +12286,7 @@ type DescribeNetworkAclsInput struct {
 	// Default: Describes all your network ACLs.
 	NetworkAclIds []*string `locationName:"NetworkAclId" locationNameList:"item" type:"list"`
 
-	metadataDescribeNetworkAclsInput `json:"-" xml:"-"`
-}
-
-type metadataDescribeNetworkAclsInput struct {
-	SDKShapeTraits bool `type:"structure"`
+	_ struct{} `type:"structure"`
 }
 
 // String returns the string representation
@@ -13163,11 +12303,7 @@ type DescribeNetworkAclsOutput struct {
 	// Information about one or more network ACLs.
 	NetworkAcls []*NetworkAcl `locationName:"networkAclSet" locationNameList:"item" type:"list"`
 
-	metadataDescribeNetworkAclsOutput `json:"-" xml:"-"`
-}
-
-type metadataDescribeNetworkAclsOutput struct {
-	SDKShapeTraits bool `type:"structure"`
+	_ struct{} `type:"structure"`
 }
 
 // String returns the string representation
@@ -13193,11 +12329,7 @@ type DescribeNetworkInterfaceAttributeInput struct {
 	// The ID of the network interface.
 	NetworkInterfaceId *string `locationName:"networkInterfaceId" type:"string" required:"true"`
 
-	metadataDescribeNetworkInterfaceAttributeInput `json:"-" xml:"-"`
-}
-
-type metadataDescribeNetworkInterfaceAttributeInput struct {
-	SDKShapeTraits bool `type:"structure"`
+	_ struct{} `type:"structure"`
 }
 
 // String returns the string representation
@@ -13226,11 +12358,7 @@ type DescribeNetworkInterfaceAttributeOutput struct {
 	// Indicates whether source/destination checking is enabled.
 	SourceDestCheck *AttributeBooleanValue `locationName:"sourceDestCheck" type:"structure"`
 
-	metadataDescribeNetworkInterfaceAttributeOutput `json:"-" xml:"-"`
-}
-
-type metadataDescribeNetworkInterfaceAttributeOutput struct {
-	SDKShapeTraits bool `type:"structure"`
+	_ struct{} `type:"structure"`
 }
 
 // String returns the string representation
@@ -13356,11 +12484,7 @@ type DescribeNetworkInterfacesInput struct {
 	// Default: Describes all your network interfaces.
 	NetworkInterfaceIds []*string `locationName:"NetworkInterfaceId" locationNameList:"item" type:"list"`
 
-	metadataDescribeNetworkInterfacesInput `json:"-" xml:"-"`
-}
-
-type metadataDescribeNetworkInterfacesInput struct {
-	SDKShapeTraits bool `type:"structure"`
+	_ struct{} `type:"structure"`
 }
 
 // String returns the string representation
@@ -13377,11 +12501,7 @@ type DescribeNetworkInterfacesOutput struct {
 	// Information about one or more network interfaces.
 	NetworkInterfaces []*NetworkInterface `locationName:"networkInterfaceSet" locationNameList:"item" type:"list"`
 
-	metadataDescribeNetworkInterfacesOutput `json:"-" xml:"-"`
-}
-
-type metadataDescribeNetworkInterfacesOutput struct {
-	SDKShapeTraits bool `type:"structure"`
+	_ struct{} `type:"structure"`
 }
 
 // String returns the string representation
@@ -13416,11 +12536,7 @@ type DescribePlacementGroupsInput struct {
 	// Default: Describes all your placement groups, or only those otherwise specified.
 	GroupNames []*string `locationName:"groupName" type:"list"`
 
-	metadataDescribePlacementGroupsInput `json:"-" xml:"-"`
-}
-
-type metadataDescribePlacementGroupsInput struct {
-	SDKShapeTraits bool `type:"structure"`
+	_ struct{} `type:"structure"`
 }
 
 // String returns the string representation
@@ -13437,11 +12553,7 @@ type DescribePlacementGroupsOutput struct {
 	// One or more placement groups.
 	PlacementGroups []*PlacementGroup `locationName:"placementGroupSet" locationNameList:"item" type:"list"`
 
-	metadataDescribePlacementGroupsOutput `json:"-" xml:"-"`
-}
-
-type metadataDescribePlacementGroupsOutput struct {
-	SDKShapeTraits bool `type:"structure"`
+	_ struct{} `type:"structure"`
 }
 
 // String returns the string representation
@@ -13483,11 +12595,7 @@ type DescribePrefixListsInput struct {
 	// One or more prefix list IDs.
 	PrefixListIds []*string `locationName:"PrefixListId" locationNameList:"item" type:"list"`
 
-	metadataDescribePrefixListsInput `json:"-" xml:"-"`
-}
-
-type metadataDescribePrefixListsInput struct {
-	SDKShapeTraits bool `type:"structure"`
+	_ struct{} `type:"structure"`
 }
 
 // String returns the string representation
@@ -13508,11 +12616,7 @@ type DescribePrefixListsOutput struct {
 	// All available prefix lists.
 	PrefixLists []*PrefixList `locationName:"prefixListSet" locationNameList:"item" type:"list"`
 
-	metadataDescribePrefixListsOutput `json:"-" xml:"-"`
-}
-
-type metadataDescribePrefixListsOutput struct {
-	SDKShapeTraits bool `type:"structure"`
+	_ struct{} `type:"structure"`
 }
 
 // String returns the string representation
@@ -13542,11 +12646,7 @@ type DescribeRegionsInput struct {
 	// The names of one or more regions.
 	RegionNames []*string `locationName:"RegionName" locationNameList:"RegionName" type:"list"`
 
-	metadataDescribeRegionsInput `json:"-" xml:"-"`
-}
-
-type metadataDescribeRegionsInput struct {
-	SDKShapeTraits bool `type:"structure"`
+	_ struct{} `type:"structure"`
 }
 
 // String returns the string representation
@@ -13563,11 +12663,7 @@ type DescribeRegionsOutput struct {
 	// Information about one or more regions.
 	Regions []*Region `locationName:"regionInfo" locationNameList:"item" type:"list"`
 
-	metadataDescribeRegionsOutput `json:"-" xml:"-"`
-}
-
-type metadataDescribeRegionsOutput struct {
-	SDKShapeTraits bool `type:"structure"`
+	_ struct{} `type:"structure"`
 }
 
 // String returns the string representation
@@ -13648,11 +12744,7 @@ type DescribeReservedInstancesInput struct {
 	// specified.
 	ReservedInstancesIds []*string `locationName:"ReservedInstancesId" locationNameList:"ReservedInstancesId" type:"list"`
 
-	metadataDescribeReservedInstancesInput `json:"-" xml:"-"`
-}
-
-type metadataDescribeReservedInstancesInput struct {
-	SDKShapeTraits bool `type:"structure"`
+	_ struct{} `type:"structure"`
 }
 
 // String returns the string representation
@@ -13684,11 +12776,7 @@ type DescribeReservedInstancesListingsInput struct {
 	// One or more Reserved instance Listing IDs.
 	ReservedInstancesListingId *string `locationName:"reservedInstancesListingId" type:"string"`
 
-	metadataDescribeReservedInstancesListingsInput `json:"-" xml:"-"`
-}
-
-type metadataDescribeReservedInstancesListingsInput struct {
-	SDKShapeTraits bool `type:"structure"`
+	_ struct{} `type:"structure"`
 }
 
 // String returns the string representation
@@ -13705,11 +12793,7 @@ type DescribeReservedInstancesListingsOutput struct {
 	// Information about the Reserved instance listing.
 	ReservedInstancesListings []*ReservedInstancesListing `locationName:"reservedInstancesListingsSet" locationNameList:"item" type:"list"`
 
-	metadataDescribeReservedInstancesListingsOutput `json:"-" xml:"-"`
-}
-
-type metadataDescribeReservedInstancesListingsOutput struct {
-	SDKShapeTraits bool `type:"structure"`
+	_ struct{} `type:"structure"`
 }
 
 // String returns the string representation
@@ -13765,11 +12849,7 @@ type DescribeReservedInstancesModificationsInput struct {
 	// IDs for the submitted modification request.
 	ReservedInstancesModificationIds []*string `locationName:"ReservedInstancesModificationId" locationNameList:"ReservedInstancesModificationId" type:"list"`
 
-	metadataDescribeReservedInstancesModificationsInput `json:"-" xml:"-"`
-}
-
-type metadataDescribeReservedInstancesModificationsInput struct {
-	SDKShapeTraits bool `type:"structure"`
+	_ struct{} `type:"structure"`
 }
 
 // String returns the string representation
@@ -13790,11 +12870,7 @@ type DescribeReservedInstancesModificationsOutput struct {
 	// The Reserved instance modification information.
 	ReservedInstancesModifications []*ReservedInstancesModification `locationName:"reservedInstancesModificationsSet" locationNameList:"item" type:"list"`
 
-	metadataDescribeReservedInstancesModificationsOutput `json:"-" xml:"-"`
-}
-
-type metadataDescribeReservedInstancesModificationsOutput struct {
-	SDKShapeTraits bool `type:"structure"`
+	_ struct{} `type:"structure"`
 }
 
 // String returns the string representation
@@ -13903,11 +12979,7 @@ type DescribeReservedInstancesOfferingsInput struct {
 	// One or more Reserved instances offering IDs.
 	ReservedInstancesOfferingIds []*string `locationName:"ReservedInstancesOfferingId" type:"list"`
 
-	metadataDescribeReservedInstancesOfferingsInput `json:"-" xml:"-"`
-}
-
-type metadataDescribeReservedInstancesOfferingsInput struct {
-	SDKShapeTraits bool `type:"structure"`
+	_ struct{} `type:"structure"`
 }
 
 // String returns the string representation
@@ -13928,11 +13000,7 @@ type DescribeReservedInstancesOfferingsOutput struct {
 	// A list of Reserved instances offerings.
 	ReservedInstancesOfferings []*ReservedInstancesOffering `locationName:"reservedInstancesOfferingsSet" locationNameList:"item" type:"list"`
 
-	metadataDescribeReservedInstancesOfferingsOutput `json:"-" xml:"-"`
-}
-
-type metadataDescribeReservedInstancesOfferingsOutput struct {
-	SDKShapeTraits bool `type:"structure"`
+	_ struct{} `type:"structure"`
 }
 
 // String returns the string representation
@@ -13949,11 +13017,7 @@ type DescribeReservedInstancesOutput struct {
 	// A list of Reserved instances.
 	ReservedInstances []*ReservedInstances `locationName:"reservedInstancesSet" locationNameList:"item" type:"list"`
 
-	metadataDescribeReservedInstancesOutput `json:"-" xml:"-"`
-}
-
-type metadataDescribeReservedInstancesOutput struct {
-	SDKShapeTraits bool `type:"structure"`
+	_ struct{} `type:"structure"`
 }
 
 // String returns the string representation
@@ -14033,11 +13097,7 @@ type DescribeRouteTablesInput struct {
 	// Default: Describes all your route tables.
 	RouteTableIds []*string `locationName:"RouteTableId" locationNameList:"item" type:"list"`
 
-	metadataDescribeRouteTablesInput `json:"-" xml:"-"`
-}
-
-type metadataDescribeRouteTablesInput struct {
-	SDKShapeTraits bool `type:"structure"`
+	_ struct{} `type:"structure"`
 }
 
 // String returns the string representation
@@ -14054,11 +13114,7 @@ type DescribeRouteTablesOutput struct {
 	// Information about one or more route tables.
 	RouteTables []*RouteTable `locationName:"routeTableSet" locationNameList:"item" type:"list"`
 
-	metadataDescribeRouteTablesOutput `json:"-" xml:"-"`
-}
-
-type metadataDescribeRouteTablesOutput struct {
-	SDKShapeTraits bool `type:"structure"`
+	_ struct{} `type:"structure"`
 }
 
 // String returns the string representation
@@ -14134,11 +13190,7 @@ type DescribeSecurityGroupsInput struct {
 	// Default: Describes all your security groups.
 	GroupNames []*string `locationName:"GroupName" locationNameList:"GroupName" type:"list"`
 
-	metadataDescribeSecurityGroupsInput `json:"-" xml:"-"`
-}
-
-type metadataDescribeSecurityGroupsInput struct {
-	SDKShapeTraits bool `type:"structure"`
+	_ struct{} `type:"structure"`
 }
 
 // String returns the string representation
@@ -14155,11 +13207,7 @@ type DescribeSecurityGroupsOutput struct {
 	// Information about one or more security groups.
 	SecurityGroups []*SecurityGroup `locationName:"securityGroupInfo" locationNameList:"item" type:"list"`
 
-	metadataDescribeSecurityGroupsOutput `json:"-" xml:"-"`
-}
-
-type metadataDescribeSecurityGroupsOutput struct {
-	SDKShapeTraits bool `type:"structure"`
+	_ struct{} `type:"structure"`
 }
 
 // String returns the string representation
@@ -14185,11 +13233,7 @@ type DescribeSnapshotAttributeInput struct {
 	// The ID of the EBS snapshot.
 	SnapshotId *string `type:"string" required:"true"`
 
-	metadataDescribeSnapshotAttributeInput `json:"-" xml:"-"`
-}
-
-type metadataDescribeSnapshotAttributeInput struct {
-	SDKShapeTraits bool `type:"structure"`
+	_ struct{} `type:"structure"`
 }
 
 // String returns the string representation
@@ -14212,11 +13256,7 @@ type DescribeSnapshotAttributeOutput struct {
 	// The ID of the EBS snapshot.
 	SnapshotId *string `locationName:"snapshotId" type:"string"`
 
-	metadataDescribeSnapshotAttributeOutput `json:"-" xml:"-"`
-}
-
-type metadataDescribeSnapshotAttributeOutput struct {
-	SDKShapeTraits bool `type:"structure"`
+	_ struct{} `type:"structure"`
 }
 
 // String returns the string representation
@@ -14301,11 +13341,7 @@ type DescribeSnapshotsInput struct {
 	// Default: Describes snapshots for which you have launch permissions.
 	SnapshotIds []*string `locationName:"SnapshotId" locationNameList:"SnapshotId" type:"list"`
 
-	metadataDescribeSnapshotsInput `json:"-" xml:"-"`
-}
-
-type metadataDescribeSnapshotsInput struct {
-	SDKShapeTraits bool `type:"structure"`
+	_ struct{} `type:"structure"`
 }
 
 // String returns the string representation
@@ -14328,11 +13364,7 @@ type DescribeSnapshotsOutput struct {
 	// Information about the snapshots.
 	Snapshots []*Snapshot `locationName:"snapshotSet" locationNameList:"item" type:"list"`
 
-	metadataDescribeSnapshotsOutput `json:"-" xml:"-"`
-}
-
-type metadataDescribeSnapshotsOutput struct {
-	SDKShapeTraits bool `type:"structure"`
+	_ struct{} `type:"structure"`
 }
 
 // String returns the string representation
@@ -14353,11 +13385,7 @@ type DescribeSpotDatafeedSubscriptionInput struct {
 	// it is UnauthorizedOperation.
 	DryRun *bool `locationName:"dryRun" type:"boolean"`
 
-	metadataDescribeSpotDatafeedSubscriptionInput `json:"-" xml:"-"`
-}
-
-type metadataDescribeSpotDatafeedSubscriptionInput struct {
-	SDKShapeTraits bool `type:"structure"`
+	_ struct{} `type:"structure"`
 }
 
 // String returns the string representation
@@ -14375,11 +13403,7 @@ type DescribeSpotDatafeedSubscriptionOutput struct {
 	// The Spot instance data feed subscription.
 	SpotDatafeedSubscription *SpotDatafeedSubscription `locationName:"spotDatafeedSubscription" type:"structure"`
 
-	metadataDescribeSpotDatafeedSubscriptionOutput `json:"-" xml:"-"`
-}
-
-type metadataDescribeSpotDatafeedSubscriptionOutput struct {
-	SDKShapeTraits bool `type:"structure"`
+	_ struct{} `type:"structure"`
 }
 
 // String returns the string representation
@@ -14411,11 +13435,7 @@ type DescribeSpotFleetInstancesInput struct {
 	// The ID of the Spot fleet request.
 	SpotFleetRequestId *string `locationName:"spotFleetRequestId" type:"string" required:"true"`
 
-	metadataDescribeSpotFleetInstancesInput `json:"-" xml:"-"`
-}
-
-type metadataDescribeSpotFleetInstancesInput struct {
-	SDKShapeTraits bool `type:"structure"`
+	_ struct{} `type:"structure"`
 }
 
 // String returns the string representation
@@ -14441,11 +13461,7 @@ type DescribeSpotFleetInstancesOutput struct {
 	// The ID of the Spot fleet request.
 	SpotFleetRequestId *string `locationName:"spotFleetRequestId" type:"string" required:"true"`
 
-	metadataDescribeSpotFleetInstancesOutput `json:"-" xml:"-"`
-}
-
-type metadataDescribeSpotFleetInstancesOutput struct {
-	SDKShapeTraits bool `type:"structure"`
+	_ struct{} `type:"structure"`
 }
 
 // String returns the string representation
@@ -14483,11 +13499,7 @@ type DescribeSpotFleetRequestHistoryInput struct {
 	// The starting date and time for the events, in UTC format (for example, YYYY-MM-DDTHH:MM:SSZ).
 	StartTime *time.Time `locationName:"startTime" type:"timestamp" timestampFormat:"iso8601" required:"true"`
 
-	metadataDescribeSpotFleetRequestHistoryInput `json:"-" xml:"-"`
-}
-
-type metadataDescribeSpotFleetRequestHistoryInput struct {
-	SDKShapeTraits bool `type:"structure"`
+	_ struct{} `type:"structure"`
 }
 
 // String returns the string representation
@@ -14521,11 +13533,7 @@ type DescribeSpotFleetRequestHistoryOutput struct {
 	// The starting date and time for the events, in UTC format (for example, YYYY-MM-DDTHH:MM:SSZ).
 	StartTime *time.Time `locationName:"startTime" type:"timestamp" timestampFormat:"iso8601" required:"true"`
 
-	metadataDescribeSpotFleetRequestHistoryOutput `json:"-" xml:"-"`
-}
-
-type metadataDescribeSpotFleetRequestHistoryOutput struct {
-	SDKShapeTraits bool `type:"structure"`
+	_ struct{} `type:"structure"`
 }
 
 // String returns the string representation
@@ -14557,11 +13565,7 @@ type DescribeSpotFleetRequestsInput struct {
 	// The IDs of the Spot fleet requests.
 	SpotFleetRequestIds []*string `locationName:"spotFleetRequestId" locationNameList:"item" type:"list"`
 
-	metadataDescribeSpotFleetRequestsInput `json:"-" xml:"-"`
-}
-
-type metadataDescribeSpotFleetRequestsInput struct {
-	SDKShapeTraits bool `type:"structure"`
+	_ struct{} `type:"structure"`
 }
 
 // String returns the string representation
@@ -14583,11 +13587,7 @@ type DescribeSpotFleetRequestsOutput struct {
 	// Information about the configuration of your Spot fleet.
 	SpotFleetRequestConfigs []*SpotFleetRequestConfig `locationName:"spotFleetRequestConfigSet" locationNameList:"item" type:"list" required:"true"`
 
-	metadataDescribeSpotFleetRequestsOutput `json:"-" xml:"-"`
-}
-
-type metadataDescribeSpotFleetRequestsOutput struct {
-	SDKShapeTraits bool `type:"structure"`
+	_ struct{} `type:"structure"`
 }
 
 // String returns the string representation
@@ -14721,11 +13721,7 @@ type DescribeSpotInstanceRequestsInput struct {
 	// One or more Spot instance request IDs.
 	SpotInstanceRequestIds []*string `locationName:"SpotInstanceRequestId" locationNameList:"SpotInstanceRequestId" type:"list"`
 
-	metadataDescribeSpotInstanceRequestsInput `json:"-" xml:"-"`
-}
-
-type metadataDescribeSpotInstanceRequestsInput struct {
-	SDKShapeTraits bool `type:"structure"`
+	_ struct{} `type:"structure"`
 }
 
 // String returns the string representation
@@ -14743,11 +13739,7 @@ type DescribeSpotInstanceRequestsOutput struct {
 	// One or more Spot instance requests.
 	SpotInstanceRequests []*SpotInstanceRequest `locationName:"spotInstanceRequestSet" locationNameList:"item" type:"list"`
 
-	metadataDescribeSpotInstanceRequestsOutput `json:"-" xml:"-"`
-}
-
-type metadataDescribeSpotInstanceRequestsOutput struct {
-	SDKShapeTraits bool `type:"structure"`
+	_ struct{} `type:"structure"`
 }
 
 // String returns the string representation
@@ -14811,11 +13803,7 @@ type DescribeSpotPriceHistoryInput struct {
 	// the price history data, in UTC format (for example, YYYY-MM-DDTHH:MM:SSZ).
 	StartTime *time.Time `locationName:"startTime" type:"timestamp" timestampFormat:"iso8601"`
 
-	metadataDescribeSpotPriceHistoryInput `json:"-" xml:"-"`
-}
-
-type metadataDescribeSpotPriceHistoryInput struct {
-	SDKShapeTraits bool `type:"structure"`
+	_ struct{} `type:"structure"`
 }
 
 // String returns the string representation
@@ -14837,11 +13825,7 @@ type DescribeSpotPriceHistoryOutput struct {
 	// The historical Spot prices.
 	SpotPriceHistory []*SpotPrice `locationName:"spotPriceHistorySet" locationNameList:"item" type:"list"`
 
-	metadataDescribeSpotPriceHistoryOutput `json:"-" xml:"-"`
-}
-
-type metadataDescribeSpotPriceHistoryOutput struct {
-	SDKShapeTraits bool `type:"structure"`
+	_ struct{} `type:"structure"`
 }
 
 // String returns the string representation
@@ -14900,11 +13884,7 @@ type DescribeSubnetsInput struct {
 	// Default: Describes all your subnets.
 	SubnetIds []*string `locationName:"SubnetId" locationNameList:"SubnetId" type:"list"`
 
-	metadataDescribeSubnetsInput `json:"-" xml:"-"`
-}
-
-type metadataDescribeSubnetsInput struct {
-	SDKShapeTraits bool `type:"structure"`
+	_ struct{} `type:"structure"`
 }
 
 // String returns the string representation
@@ -14921,11 +13901,7 @@ type DescribeSubnetsOutput struct {
 	// Information about one or more subnets.
 	Subnets []*Subnet `locationName:"subnetSet" locationNameList:"item" type:"list"`
 
-	metadataDescribeSubnetsOutput `json:"-" xml:"-"`
-}
-
-type metadataDescribeSubnetsOutput struct {
-	SDKShapeTraits bool `type:"structure"`
+	_ struct{} `type:"structure"`
 }
 
 // String returns the string representation
@@ -14969,11 +13945,7 @@ type DescribeTagsInput struct {
 	// The token to retrieve the next page of results.
 	NextToken *string `locationName:"nextToken" type:"string"`
 
-	metadataDescribeTagsInput `json:"-" xml:"-"`
-}
-
-type metadataDescribeTagsInput struct {
-	SDKShapeTraits bool `type:"structure"`
+	_ struct{} `type:"structure"`
 }
 
 // String returns the string representation
@@ -14994,11 +13966,7 @@ type DescribeTagsOutput struct {
 	// A list of tags.
 	Tags []*TagDescription `locationName:"tagSet" locationNameList:"item" type:"list"`
 
-	metadataDescribeTagsOutput `json:"-" xml:"-"`
-}
-
-type metadataDescribeTagsOutput struct {
-	SDKShapeTraits bool `type:"structure"`
+	_ struct{} `type:"structure"`
 }
 
 // String returns the string representation
@@ -15024,11 +13992,7 @@ type DescribeVolumeAttributeInput struct {
 	// The ID of the volume.
 	VolumeId *string `type:"string" required:"true"`
 
-	metadataDescribeVolumeAttributeInput `json:"-" xml:"-"`
-}
-
-type metadataDescribeVolumeAttributeInput struct {
-	SDKShapeTraits bool `type:"structure"`
+	_ struct{} `type:"structure"`
 }
 
 // String returns the string representation
@@ -15051,11 +14015,7 @@ type DescribeVolumeAttributeOutput struct {
 	// The ID of the volume.
 	VolumeId *string `locationName:"volumeId" type:"string"`
 
-	metadataDescribeVolumeAttributeOutput `json:"-" xml:"-"`
-}
-
-type metadataDescribeVolumeAttributeOutput struct {
-	SDKShapeTraits bool `type:"structure"`
+	_ struct{} `type:"structure"`
 }
 
 // String returns the string representation
@@ -15129,11 +14089,7 @@ type DescribeVolumeStatusInput struct {
 	// Default: Describes all your volumes.
 	VolumeIds []*string `locationName:"VolumeId" locationNameList:"VolumeId" type:"list"`
 
-	metadataDescribeVolumeStatusInput `json:"-" xml:"-"`
-}
-
-type metadataDescribeVolumeStatusInput struct {
-	SDKShapeTraits bool `type:"structure"`
+	_ struct{} `type:"structure"`
 }
 
 // String returns the string representation
@@ -15154,11 +14110,7 @@ type DescribeVolumeStatusOutput struct {
 	// A list of volumes.
 	VolumeStatuses []*VolumeStatusItem `locationName:"volumeStatusSet" locationNameList:"item" type:"list"`
 
-	metadataDescribeVolumeStatusOutput `json:"-" xml:"-"`
-}
-
-type metadataDescribeVolumeStatusOutput struct {
-	SDKShapeTraits bool `type:"structure"`
+	_ struct{} `type:"structure"`
 }
 
 // String returns the string representation
@@ -15246,11 +14198,7 @@ type DescribeVolumesInput struct {
 	// One or more volume IDs.
 	VolumeIds []*string `locationName:"VolumeId" locationNameList:"VolumeId" type:"list"`
 
-	metadataDescribeVolumesInput `json:"-" xml:"-"`
-}
-
-type metadataDescribeVolumesInput struct {
-	SDKShapeTraits bool `type:"structure"`
+	_ struct{} `type:"structure"`
 }
 
 // String returns the string representation
@@ -15273,11 +14221,7 @@ type DescribeVolumesOutput struct {
 	// Information about the volumes.
 	Volumes []*Volume `locationName:"volumeSet" locationNameList:"item" type:"list"`
 
-	metadataDescribeVolumesOutput `json:"-" xml:"-"`
-}
-
-type metadataDescribeVolumesOutput struct {
-	SDKShapeTraits bool `type:"structure"`
+	_ struct{} `type:"structure"`
 }
 
 // String returns the string representation
@@ -15303,11 +14247,7 @@ type DescribeVpcAttributeInput struct {
 	// The ID of the VPC.
 	VpcId *string `type:"string" required:"true"`
 
-	metadataDescribeVpcAttributeInput `json:"-" xml:"-"`
-}
-
-type metadataDescribeVpcAttributeInput struct {
-	SDKShapeTraits bool `type:"structure"`
+	_ struct{} `type:"structure"`
 }
 
 // String returns the string representation
@@ -15334,11 +14274,7 @@ type DescribeVpcAttributeOutput struct {
 	// The ID of the VPC.
 	VpcId *string `locationName:"vpcId" type:"string"`
 
-	metadataDescribeVpcAttributeOutput `json:"-" xml:"-"`
-}
-
-type metadataDescribeVpcAttributeOutput struct {
-	SDKShapeTraits bool `type:"structure"`
+	_ struct{} `type:"structure"`
 }
 
 // String returns the string representation
@@ -15379,11 +14315,7 @@ type DescribeVpcClassicLinkInput struct {
 	// One or more VPCs for which you want to describe the ClassicLink status.
 	VpcIds []*string `locationName:"VpcId" locationNameList:"VpcId" type:"list"`
 
-	metadataDescribeVpcClassicLinkInput `json:"-" xml:"-"`
-}
-
-type metadataDescribeVpcClassicLinkInput struct {
-	SDKShapeTraits bool `type:"structure"`
+	_ struct{} `type:"structure"`
 }
 
 // String returns the string representation
@@ -15400,11 +14332,7 @@ type DescribeVpcClassicLinkOutput struct {
 	// The ClassicLink status of one or more VPCs.
 	Vpcs []*VpcClassicLink `locationName:"vpcSet" locationNameList:"item" type:"list"`
 
-	metadataDescribeVpcClassicLinkOutput `json:"-" xml:"-"`
-}
-
-type metadataDescribeVpcClassicLinkOutput struct {
-	SDKShapeTraits bool `type:"structure"`
+	_ struct{} `type:"structure"`
 }
 
 // String returns the string representation
@@ -15435,11 +14363,7 @@ type DescribeVpcEndpointServicesInput struct {
 	// a prior call.)
 	NextToken *string `type:"string"`
 
-	metadataDescribeVpcEndpointServicesInput `json:"-" xml:"-"`
-}
-
-type metadataDescribeVpcEndpointServicesInput struct {
-	SDKShapeTraits bool `type:"structure"`
+	_ struct{} `type:"structure"`
 }
 
 // String returns the string representation
@@ -15460,11 +14384,7 @@ type DescribeVpcEndpointServicesOutput struct {
 	// A list of supported AWS services.
 	ServiceNames []*string `locationName:"serviceNameSet" locationNameList:"item" type:"list"`
 
-	metadataDescribeVpcEndpointServicesOutput `json:"-" xml:"-"`
-}
-
-type metadataDescribeVpcEndpointServicesOutput struct {
-	SDKShapeTraits bool `type:"structure"`
+	_ struct{} `type:"structure"`
 }
 
 // String returns the string representation
@@ -15510,11 +14430,7 @@ type DescribeVpcEndpointsInput struct {
 	// One or more endpoint IDs.
 	VpcEndpointIds []*string `locationName:"VpcEndpointId" locationNameList:"item" type:"list"`
 
-	metadataDescribeVpcEndpointsInput `json:"-" xml:"-"`
-}
-
-type metadataDescribeVpcEndpointsInput struct {
-	SDKShapeTraits bool `type:"structure"`
+	_ struct{} `type:"structure"`
 }
 
 // String returns the string representation
@@ -15535,11 +14451,7 @@ type DescribeVpcEndpointsOutput struct {
 	// Information about the endpoints.
 	VpcEndpoints []*VpcEndpoint `locationName:"vpcEndpointSet" locationNameList:"item" type:"list"`
 
-	metadataDescribeVpcEndpointsOutput `json:"-" xml:"-"`
-}
-
-type metadataDescribeVpcEndpointsOutput struct {
-	SDKShapeTraits bool `type:"structure"`
+	_ struct{} `type:"structure"`
 }
 
 // String returns the string representation
@@ -15603,11 +14515,7 @@ type DescribeVpcPeeringConnectionsInput struct {
 	// Default: Describes all your VPC peering connections.
 	VpcPeeringConnectionIds []*string `locationName:"VpcPeeringConnectionId" locationNameList:"item" type:"list"`
 
-	metadataDescribeVpcPeeringConnectionsInput `json:"-" xml:"-"`
-}
-
-type metadataDescribeVpcPeeringConnectionsInput struct {
-	SDKShapeTraits bool `type:"structure"`
+	_ struct{} `type:"structure"`
 }
 
 // String returns the string representation
@@ -15624,11 +14532,7 @@ type DescribeVpcPeeringConnectionsOutput struct {
 	// Information about the VPC peering connections.
 	VpcPeeringConnections []*VpcPeeringConnection `locationName:"vpcPeeringConnectionSet" locationNameList:"item" type:"list"`
 
-	metadataDescribeVpcPeeringConnectionsOutput `json:"-" xml:"-"`
-}
-
-type metadataDescribeVpcPeeringConnectionsOutput struct {
-	SDKShapeTraits bool `type:"structure"`
+	_ struct{} `type:"structure"`
 }
 
 // String returns the string representation
@@ -15680,11 +14584,7 @@ type DescribeVpcsInput struct {
 	// Default: Describes all your VPCs.
 	VpcIds []*string `locationName:"VpcId" locationNameList:"VpcId" type:"list"`
 
-	metadataDescribeVpcsInput `json:"-" xml:"-"`
-}
-
-type metadataDescribeVpcsInput struct {
-	SDKShapeTraits bool `type:"structure"`
+	_ struct{} `type:"structure"`
 }
 
 // String returns the string representation
@@ -15701,11 +14601,7 @@ type DescribeVpcsOutput struct {
 	// Information about one or more VPCs.
 	Vpcs []*Vpc `locationName:"vpcSet" locationNameList:"item" type:"list"`
 
-	metadataDescribeVpcsOutput `json:"-" xml:"-"`
-}
-
-type metadataDescribeVpcsOutput struct {
-	SDKShapeTraits bool `type:"structure"`
+	_ struct{} `type:"structure"`
 }
 
 // String returns the string representation
@@ -15772,11 +14668,7 @@ type DescribeVpnConnectionsInput struct {
 	// Default: Describes your VPN connections.
 	VpnConnectionIds []*string `locationName:"VpnConnectionId" locationNameList:"VpnConnectionId" type:"list"`
 
-	metadataDescribeVpnConnectionsInput `json:"-" xml:"-"`
-}
-
-type metadataDescribeVpnConnectionsInput struct {
-	SDKShapeTraits bool `type:"structure"`
+	_ struct{} `type:"structure"`
 }
 
 // String returns the string representation
@@ -15793,11 +14685,7 @@ type DescribeVpnConnectionsOutput struct {
 	// Information about one or more VPN connections.
 	VpnConnections []*VpnConnection `locationName:"vpnConnectionSet" locationNameList:"item" type:"list"`
 
-	metadataDescribeVpnConnectionsOutput `json:"-" xml:"-"`
-}
-
-type metadataDescribeVpnConnectionsOutput struct {
-	SDKShapeTraits bool `type:"structure"`
+	_ struct{} `type:"structure"`
 }
 
 // String returns the string representation
@@ -15852,11 +14740,7 @@ type DescribeVpnGatewaysInput struct {
 	// Default: Describes all your virtual private gateways.
 	VpnGatewayIds []*string `locationName:"VpnGatewayId" locationNameList:"VpnGatewayId" type:"list"`
 
-	metadataDescribeVpnGatewaysInput `json:"-" xml:"-"`
-}
-
-type metadataDescribeVpnGatewaysInput struct {
-	SDKShapeTraits bool `type:"structure"`
+	_ struct{} `type:"structure"`
 }
 
 // String returns the string representation
@@ -15873,11 +14757,7 @@ type DescribeVpnGatewaysOutput struct {
 	// Information about one or more virtual private gateways.
 	VpnGateways []*VpnGateway `locationName:"vpnGatewaySet" locationNameList:"item" type:"list"`
 
-	metadataDescribeVpnGatewaysOutput `json:"-" xml:"-"`
-}
-
-type metadataDescribeVpnGatewaysOutput struct {
-	SDKShapeTraits bool `type:"structure"`
+	_ struct{} `type:"structure"`
 }
 
 // String returns the string representation
@@ -15903,11 +14783,7 @@ type DetachClassicLinkVpcInput struct {
 	// The ID of the VPC to which the instance is linked.
 	VpcId *string `locationName:"vpcId" type:"string" required:"true"`
 
-	metadataDetachClassicLinkVpcInput `json:"-" xml:"-"`
-}
-
-type metadataDetachClassicLinkVpcInput struct {
-	SDKShapeTraits bool `type:"structure"`
+	_ struct{} `type:"structure"`
 }
 
 // String returns the string representation
@@ -15924,11 +14800,7 @@ type DetachClassicLinkVpcOutput struct {
 	// Returns true if the request succeeds; otherwise, it returns an error.
 	Return *bool `locationName:"return" type:"boolean"`
 
-	metadataDetachClassicLinkVpcOutput `json:"-" xml:"-"`
-}
-
-type metadataDetachClassicLinkVpcOutput struct {
-	SDKShapeTraits bool `type:"structure"`
+	_ struct{} `type:"structure"`
 }
 
 // String returns the string representation
@@ -15954,11 +14826,7 @@ type DetachInternetGatewayInput struct {
 	// The ID of the VPC.
 	VpcId *string `locationName:"vpcId" type:"string" required:"true"`
 
-	metadataDetachInternetGatewayInput `json:"-" xml:"-"`
-}
-
-type metadataDetachInternetGatewayInput struct {
-	SDKShapeTraits bool `type:"structure"`
+	_ struct{} `type:"structure"`
 }
 
 // String returns the string representation
@@ -15972,11 +14840,7 @@ func (s DetachInternetGatewayInput) GoString() string {
 }
 
 type DetachInternetGatewayOutput struct {
-	metadataDetachInternetGatewayOutput `json:"-" xml:"-"`
-}
-
-type metadataDetachInternetGatewayOutput struct {
-	SDKShapeTraits bool `type:"structure"`
+	_ struct{} `type:"structure"`
 }
 
 // String returns the string representation
@@ -16002,11 +14866,7 @@ type DetachNetworkInterfaceInput struct {
 	// Specifies whether to force a detachment.
 	Force *bool `locationName:"force" type:"boolean"`
 
-	metadataDetachNetworkInterfaceInput `json:"-" xml:"-"`
-}
-
-type metadataDetachNetworkInterfaceInput struct {
-	SDKShapeTraits bool `type:"structure"`
+	_ struct{} `type:"structure"`
 }
 
 // String returns the string representation
@@ -16020,11 +14880,7 @@ func (s DetachNetworkInterfaceInput) GoString() string {
 }
 
 type DetachNetworkInterfaceOutput struct {
-	metadataDetachNetworkInterfaceOutput `json:"-" xml:"-"`
-}
-
-type metadataDetachNetworkInterfaceOutput struct {
-	SDKShapeTraits bool `type:"structure"`
+	_ struct{} `type:"structure"`
 }
 
 // String returns the string representation
@@ -16062,11 +14918,7 @@ type DetachVolumeInput struct {
 	// The ID of the volume.
 	VolumeId *string `type:"string" required:"true"`
 
-	metadataDetachVolumeInput `json:"-" xml:"-"`
-}
-
-type metadataDetachVolumeInput struct {
-	SDKShapeTraits bool `type:"structure"`
+	_ struct{} `type:"structure"`
 }
 
 // String returns the string representation
@@ -16092,11 +14944,7 @@ type DetachVpnGatewayInput struct {
 	// The ID of the virtual private gateway.
 	VpnGatewayId *string `type:"string" required:"true"`
 
-	metadataDetachVpnGatewayInput `json:"-" xml:"-"`
-}
-
-type metadataDetachVpnGatewayInput struct {
-	SDKShapeTraits bool `type:"structure"`
+	_ struct{} `type:"structure"`
 }
 
 // String returns the string representation
@@ -16110,11 +14958,7 @@ func (s DetachVpnGatewayInput) GoString() string {
 }
 
 type DetachVpnGatewayOutput struct {
-	metadataDetachVpnGatewayOutput `json:"-" xml:"-"`
-}
-
-type metadataDetachVpnGatewayOutput struct {
-	SDKShapeTraits bool `type:"structure"`
+	_ struct{} `type:"structure"`
 }
 
 // String returns the string representation
@@ -16135,11 +14979,7 @@ type DhcpConfiguration struct {
 	// One or more values for the DHCP option.
 	Values []*AttributeValue `locationName:"valueSet" locationNameList:"item" type:"list"`
 
-	metadataDhcpConfiguration `json:"-" xml:"-"`
-}
-
-type metadataDhcpConfiguration struct {
-	SDKShapeTraits bool `type:"structure"`
+	_ struct{} `type:"structure"`
 }
 
 // String returns the string representation
@@ -16163,11 +15003,7 @@ type DhcpOptions struct {
 	// Any tags assigned to the DHCP options set.
 	Tags []*Tag `locationName:"tagSet" locationNameList:"item" type:"list"`
 
-	metadataDhcpOptions `json:"-" xml:"-"`
-}
-
-type metadataDhcpOptions struct {
-	SDKShapeTraits bool `type:"structure"`
+	_ struct{} `type:"structure"`
 }
 
 // String returns the string representation
@@ -16187,11 +15023,7 @@ type DisableVgwRoutePropagationInput struct {
 	// The ID of the route table.
 	RouteTableId *string `type:"string" required:"true"`
 
-	metadataDisableVgwRoutePropagationInput `json:"-" xml:"-"`
-}
-
-type metadataDisableVgwRoutePropagationInput struct {
-	SDKShapeTraits bool `type:"structure"`
+	_ struct{} `type:"structure"`
 }
 
 // String returns the string representation
@@ -16205,11 +15037,7 @@ func (s DisableVgwRoutePropagationInput) GoString() string {
 }
 
 type DisableVgwRoutePropagationOutput struct {
-	metadataDisableVgwRoutePropagationOutput `json:"-" xml:"-"`
-}
-
-type metadataDisableVgwRoutePropagationOutput struct {
-	SDKShapeTraits bool `type:"structure"`
+	_ struct{} `type:"structure"`
 }
 
 // String returns the string representation
@@ -16232,11 +15060,7 @@ type DisableVpcClassicLinkInput struct {
 	// The ID of the VPC.
 	VpcId *string `locationName:"vpcId" type:"string" required:"true"`
 
-	metadataDisableVpcClassicLinkInput `json:"-" xml:"-"`
-}
-
-type metadataDisableVpcClassicLinkInput struct {
-	SDKShapeTraits bool `type:"structure"`
+	_ struct{} `type:"structure"`
 }
 
 // String returns the string representation
@@ -16253,11 +15077,7 @@ type DisableVpcClassicLinkOutput struct {
 	// Returns true if the request succeeds; otherwise, it returns an error.
 	Return *bool `locationName:"return" type:"boolean"`
 
-	metadataDisableVpcClassicLinkOutput `json:"-" xml:"-"`
-}
-
-type metadataDisableVpcClassicLinkOutput struct {
-	SDKShapeTraits bool `type:"structure"`
+	_ struct{} `type:"structure"`
 }
 
 // String returns the string representation
@@ -16283,11 +15103,7 @@ type DisassociateAddressInput struct {
 	// [EC2-Classic] The Elastic IP address. Required for EC2-Classic.
 	PublicIp *string `type:"string"`
 
-	metadataDisassociateAddressInput `json:"-" xml:"-"`
-}
-
-type metadataDisassociateAddressInput struct {
-	SDKShapeTraits bool `type:"structure"`
+	_ struct{} `type:"structure"`
 }
 
 // String returns the string representation
@@ -16301,11 +15117,7 @@ func (s DisassociateAddressInput) GoString() string {
 }
 
 type DisassociateAddressOutput struct {
-	metadataDisassociateAddressOutput `json:"-" xml:"-"`
-}
-
-type metadataDisassociateAddressOutput struct {
-	SDKShapeTraits bool `type:"structure"`
+	_ struct{} `type:"structure"`
 }
 
 // String returns the string representation
@@ -16329,11 +15141,7 @@ type DisassociateRouteTableInput struct {
 	// it is UnauthorizedOperation.
 	DryRun *bool `locationName:"dryRun" type:"boolean"`
 
-	metadataDisassociateRouteTableInput `json:"-" xml:"-"`
-}
-
-type metadataDisassociateRouteTableInput struct {
-	SDKShapeTraits bool `type:"structure"`
+	_ struct{} `type:"structure"`
 }
 
 // String returns the string representation
@@ -16347,11 +15155,7 @@ func (s DisassociateRouteTableInput) GoString() string {
 }
 
 type DisassociateRouteTableOutput struct {
-	metadataDisassociateRouteTableOutput `json:"-" xml:"-"`
-}
-
-type metadataDisassociateRouteTableOutput struct {
-	SDKShapeTraits bool `type:"structure"`
+	_ struct{} `type:"structure"`
 }
 
 // String returns the string representation
@@ -16375,11 +15179,7 @@ type DiskImage struct {
 	// Information about the volume.
 	Volume *VolumeDetail `type:"structure"`
 
-	metadataDiskImage `json:"-" xml:"-"`
-}
-
-type metadataDiskImage struct {
-	SDKShapeTraits bool `type:"structure"`
+	_ struct{} `type:"structure"`
 }
 
 // String returns the string representation
@@ -16410,11 +15210,7 @@ type DiskImageDescription struct {
 	// The size of the disk image, in GiB.
 	Size *int64 `locationName:"size" type:"long" required:"true"`
 
-	metadataDiskImageDescription `json:"-" xml:"-"`
-}
-
-type metadataDiskImageDescription struct {
-	SDKShapeTraits bool `type:"structure"`
+	_ struct{} `type:"structure"`
 }
 
 // String returns the string representation
@@ -16442,11 +15238,7 @@ type DiskImageDetail struct {
 	// topic in the Amazon Simple Storage Service Developer Guide.
 	ImportManifestUrl *string `locationName:"importManifestUrl" type:"string" required:"true"`
 
-	metadataDiskImageDetail `json:"-" xml:"-"`
-}
-
-type metadataDiskImageDetail struct {
-	SDKShapeTraits bool `type:"structure"`
+	_ struct{} `type:"structure"`
 }
 
 // String returns the string representation
@@ -16467,11 +15259,7 @@ type DiskImageVolumeDescription struct {
 	// The size of the volume, in GiB.
 	Size *int64 `locationName:"size" type:"long"`
 
-	metadataDiskImageVolumeDescription `json:"-" xml:"-"`
-}
-
-type metadataDiskImageVolumeDescription struct {
-	SDKShapeTraits bool `type:"structure"`
+	_ struct{} `type:"structure"`
 }
 
 // String returns the string representation
@@ -16527,11 +15315,7 @@ type EbsBlockDevice struct {
 	// Default: standard
 	VolumeType *string `locationName:"volumeType" type:"string" enum:"VolumeType"`
 
-	metadataEbsBlockDevice `json:"-" xml:"-"`
-}
-
-type metadataEbsBlockDevice struct {
-	SDKShapeTraits bool `type:"structure"`
+	_ struct{} `type:"structure"`
 }
 
 // String returns the string representation
@@ -16558,11 +15342,7 @@ type EbsInstanceBlockDevice struct {
 	// The ID of the EBS volume.
 	VolumeId *string `locationName:"volumeId" type:"string"`
 
-	metadataEbsInstanceBlockDevice `json:"-" xml:"-"`
-}
-
-type metadataEbsInstanceBlockDevice struct {
-	SDKShapeTraits bool `type:"structure"`
+	_ struct{} `type:"structure"`
 }
 
 // String returns the string representation
@@ -16582,11 +15362,7 @@ type EbsInstanceBlockDeviceSpecification struct {
 	// The ID of the EBS volume.
 	VolumeId *string `locationName:"volumeId" type:"string"`
 
-	metadataEbsInstanceBlockDeviceSpecification `json:"-" xml:"-"`
-}
-
-type metadataEbsInstanceBlockDeviceSpecification struct {
-	SDKShapeTraits bool `type:"structure"`
+	_ struct{} `type:"structure"`
 }
 
 // String returns the string representation
@@ -16606,11 +15382,7 @@ type EnableVgwRoutePropagationInput struct {
 	// The ID of the route table.
 	RouteTableId *string `type:"string" required:"true"`
 
-	metadataEnableVgwRoutePropagationInput `json:"-" xml:"-"`
-}
-
-type metadataEnableVgwRoutePropagationInput struct {
-	SDKShapeTraits bool `type:"structure"`
+	_ struct{} `type:"structure"`
 }
 
 // String returns the string representation
@@ -16624,11 +15396,7 @@ func (s EnableVgwRoutePropagationInput) GoString() string {
 }
 
 type EnableVgwRoutePropagationOutput struct {
-	metadataEnableVgwRoutePropagationOutput `json:"-" xml:"-"`
-}
-
-type metadataEnableVgwRoutePropagationOutput struct {
-	SDKShapeTraits bool `type:"structure"`
+	_ struct{} `type:"structure"`
 }
 
 // String returns the string representation
@@ -16651,11 +15419,7 @@ type EnableVolumeIOInput struct {
 	// The ID of the volume.
 	VolumeId *string `locationName:"volumeId" type:"string" required:"true"`
 
-	metadataEnableVolumeIOInput `json:"-" xml:"-"`
-}
-
-type metadataEnableVolumeIOInput struct {
-	SDKShapeTraits bool `type:"structure"`
+	_ struct{} `type:"structure"`
 }
 
 // String returns the string representation
@@ -16669,11 +15433,7 @@ func (s EnableVolumeIOInput) GoString() string {
 }
 
 type EnableVolumeIOOutput struct {
-	metadataEnableVolumeIOOutput `json:"-" xml:"-"`
-}
-
-type metadataEnableVolumeIOOutput struct {
-	SDKShapeTraits bool `type:"structure"`
+	_ struct{} `type:"structure"`
 }
 
 // String returns the string representation
@@ -16696,11 +15456,7 @@ type EnableVpcClassicLinkInput struct {
 	// The ID of the VPC.
 	VpcId *string `locationName:"vpcId" type:"string" required:"true"`
 
-	metadataEnableVpcClassicLinkInput `json:"-" xml:"-"`
-}
-
-type metadataEnableVpcClassicLinkInput struct {
-	SDKShapeTraits bool `type:"structure"`
+	_ struct{} `type:"structure"`
 }
 
 // String returns the string representation
@@ -16717,11 +15473,7 @@ type EnableVpcClassicLinkOutput struct {
 	// Returns true if the request succeeds; otherwise, it returns an error.
 	Return *bool `locationName:"return" type:"boolean"`
 
-	metadataEnableVpcClassicLinkOutput `json:"-" xml:"-"`
-}
-
-type metadataEnableVpcClassicLinkOutput struct {
-	SDKShapeTraits bool `type:"structure"`
+	_ struct{} `type:"structure"`
 }
 
 // String returns the string representation
@@ -16797,11 +15549,7 @@ type EventInformation struct {
 	// events.
 	InstanceId *string `locationName:"instanceId" type:"string"`
 
-	metadataEventInformation `json:"-" xml:"-"`
-}
-
-type metadataEventInformation struct {
-	SDKShapeTraits bool `type:"structure"`
+	_ struct{} `type:"structure"`
 }
 
 // String returns the string representation
@@ -16834,11 +15582,7 @@ type ExportTask struct {
 	// The status message related to the export task.
 	StatusMessage *string `locationName:"statusMessage" type:"string"`
 
-	metadataExportTask `json:"-" xml:"-"`
-}
-
-type metadataExportTask struct {
-	SDKShapeTraits bool `type:"structure"`
+	_ struct{} `type:"structure"`
 }
 
 // String returns the string representation
@@ -16867,11 +15611,7 @@ type ExportToS3Task struct {
 	// The encryption key for your S3 bucket.
 	S3Key *string `locationName:"s3Key" type:"string"`
 
-	metadataExportToS3Task `json:"-" xml:"-"`
-}
-
-type metadataExportToS3Task struct {
-	SDKShapeTraits bool `type:"structure"`
+	_ struct{} `type:"structure"`
 }
 
 // String returns the string representation
@@ -16901,11 +15641,7 @@ type ExportToS3TaskSpecification struct {
 	// + exportTaskId + '.' + diskImageFormat.
 	S3Prefix *string `locationName:"s3Prefix" type:"string"`
 
-	metadataExportToS3TaskSpecification `json:"-" xml:"-"`
-}
-
-type metadataExportToS3TaskSpecification struct {
-	SDKShapeTraits bool `type:"structure"`
+	_ struct{} `type:"structure"`
 }
 
 // String returns the string representation
@@ -16928,11 +15664,7 @@ type Filter struct {
 	// One or more filter values. Filter values are case-sensitive.
 	Values []*string `locationName:"Value" locationNameList:"item" type:"list"`
 
-	metadataFilter `json:"-" xml:"-"`
-}
-
-type metadataFilter struct {
-	SDKShapeTraits bool `type:"structure"`
+	_ struct{} `type:"structure"`
 }
 
 // String returns the string representation
@@ -16978,11 +15710,7 @@ type FlowLog struct {
 	// The type of traffic captured for the flow log.
 	TrafficType *string `locationName:"trafficType" type:"string" enum:"TrafficType"`
 
-	metadataFlowLog `json:"-" xml:"-"`
-}
-
-type metadataFlowLog struct {
-	SDKShapeTraits bool `type:"structure"`
+	_ struct{} `type:"structure"`
 }
 
 // String returns the string representation
@@ -17005,11 +15733,7 @@ type GetConsoleOutputInput struct {
 	// The ID of the instance.
 	InstanceId *string `type:"string" required:"true"`
 
-	metadataGetConsoleOutputInput `json:"-" xml:"-"`
-}
-
-type metadataGetConsoleOutputInput struct {
-	SDKShapeTraits bool `type:"structure"`
+	_ struct{} `type:"structure"`
 }
 
 // String returns the string representation
@@ -17032,11 +15756,7 @@ type GetConsoleOutputOutput struct {
 	// The time the output was last updated.
 	Timestamp *time.Time `locationName:"timestamp" type:"timestamp" timestampFormat:"iso8601"`
 
-	metadataGetConsoleOutputOutput `json:"-" xml:"-"`
-}
-
-type metadataGetConsoleOutputOutput struct {
-	SDKShapeTraits bool `type:"structure"`
+	_ struct{} `type:"structure"`
 }
 
 // String returns the string representation
@@ -17059,11 +15779,7 @@ type GetPasswordDataInput struct {
 	// The ID of the Windows instance.
 	InstanceId *string `type:"string" required:"true"`
 
-	metadataGetPasswordDataInput `json:"-" xml:"-"`
-}
-
-type metadataGetPasswordDataInput struct {
-	SDKShapeTraits bool `type:"structure"`
+	_ struct{} `type:"structure"`
 }
 
 // String returns the string representation
@@ -17086,11 +15802,7 @@ type GetPasswordDataOutput struct {
 	// The time the data was last updated.
 	Timestamp *time.Time `locationName:"timestamp" type:"timestamp" timestampFormat:"iso8601"`
 
-	metadataGetPasswordDataOutput `json:"-" xml:"-"`
-}
-
-type metadataGetPasswordDataOutput struct {
-	SDKShapeTraits bool `type:"structure"`
+	_ struct{} `type:"structure"`
 }
 
 // String returns the string representation
@@ -17111,11 +15823,7 @@ type GroupIdentifier struct {
 	// The name of the security group.
 	GroupName *string `locationName:"groupName" type:"string"`
 
-	metadataGroupIdentifier `json:"-" xml:"-"`
-}
-
-type metadataGroupIdentifier struct {
-	SDKShapeTraits bool `type:"structure"`
+	_ struct{} `type:"structure"`
 }
 
 // String returns the string representation
@@ -17146,11 +15854,7 @@ type HistoryRecord struct {
 	// The date and time of the event, in UTC format (for example, YYYY-MM-DDTHH:MM:SSZ).
 	Timestamp *time.Time `locationName:"timestamp" type:"timestamp" timestampFormat:"iso8601" required:"true"`
 
-	metadataHistoryRecord `json:"-" xml:"-"`
-}
-
-type metadataHistoryRecord struct {
-	SDKShapeTraits bool `type:"structure"`
+	_ struct{} `type:"structure"`
 }
 
 // String returns the string representation
@@ -17194,11 +15898,7 @@ type Host struct {
 	// The Dedicated host's state. Can be "available", "under assessment, or "released".
 	State *string `locationName:"state" type:"string" enum:"AllocationState"`
 
-	metadataHost `json:"-" xml:"-"`
-}
-
-type metadataHost struct {
-	SDKShapeTraits bool `type:"structure"`
+	_ struct{} `type:"structure"`
 }
 
 // String returns the string representation
@@ -17218,11 +15918,7 @@ type HostInstance struct {
 	// The instance type size (e.g., m3.medium) of the running instance.
 	InstanceType *string `locationName:"instanceType" type:"string"`
 
-	metadataHostInstance `json:"-" xml:"-"`
-}
-
-type metadataHostInstance struct {
-	SDKShapeTraits bool `type:"structure"`
+	_ struct{} `type:"structure"`
 }
 
 // String returns the string representation
@@ -17248,11 +15944,7 @@ type HostProperties struct {
 	// The number of vCPUs on the Dedicated host.
 	TotalVCpus *int64 `locationName:"totalVCpus" type:"integer"`
 
-	metadataHostProperties `json:"-" xml:"-"`
-}
-
-type metadataHostProperties struct {
-	SDKShapeTraits bool `type:"structure"`
+	_ struct{} `type:"structure"`
 }
 
 // String returns the string representation
@@ -17273,11 +15965,7 @@ type IamInstanceProfile struct {
 	// The ID of the instance profile.
 	Id *string `locationName:"id" type:"string"`
 
-	metadataIamInstanceProfile `json:"-" xml:"-"`
-}
-
-type metadataIamInstanceProfile struct {
-	SDKShapeTraits bool `type:"structure"`
+	_ struct{} `type:"structure"`
 }
 
 // String returns the string representation
@@ -17298,11 +15986,7 @@ type IamInstanceProfileSpecification struct {
 	// The name of the instance profile.
 	Name *string `locationName:"name" type:"string"`
 
-	metadataIamInstanceProfileSpecification `json:"-" xml:"-"`
-}
-
-type metadataIamInstanceProfileSpecification struct {
-	SDKShapeTraits bool `type:"structure"`
+	_ struct{} `type:"structure"`
 }
 
 // String returns the string representation
@@ -17323,11 +16007,7 @@ type IcmpTypeCode struct {
 	// The ICMP code. A value of -1 means all codes for the specified ICMP type.
 	Type *int64 `locationName:"type" type:"integer"`
 
-	metadataIcmpTypeCode `json:"-" xml:"-"`
-}
-
-type metadataIcmpTypeCode struct {
-	SDKShapeTraits bool `type:"structure"`
+	_ struct{} `type:"structure"`
 }
 
 // String returns the string representation
@@ -17352,11 +16032,7 @@ type IdFormat struct {
 	// Indicates whether longer IDs (17-character IDs) are enabled for the resource.
 	UseLongIds *bool `locationName:"useLongIds" type:"boolean"`
 
-	metadataIdFormat `json:"-" xml:"-"`
-}
-
-type metadataIdFormat struct {
-	SDKShapeTraits bool `type:"structure"`
+	_ struct{} `type:"structure"`
 }
 
 // String returns the string representation
@@ -17447,11 +16123,7 @@ type Image struct {
 	// The type of virtualization of the AMI.
 	VirtualizationType *string `locationName:"virtualizationType" type:"string" enum:"VirtualizationType"`
 
-	metadataImage `json:"-" xml:"-"`
-}
-
-type metadataImage struct {
-	SDKShapeTraits bool `type:"structure"`
+	_ struct{} `type:"structure"`
 }
 
 // String returns the string representation
@@ -17487,11 +16159,7 @@ type ImageDiskContainer struct {
 	// The S3 bucket for the disk image.
 	UserBucket *UserBucket `type:"structure"`
 
-	metadataImageDiskContainer `json:"-" xml:"-"`
-}
-
-type metadataImageDiskContainer struct {
-	SDKShapeTraits bool `type:"structure"`
+	_ struct{} `type:"structure"`
 }
 
 // String returns the string representation
@@ -17551,11 +16219,7 @@ type ImportImageInput struct {
 	// The name of the role to use when not using the default role, 'vmimport'.
 	RoleName *string `type:"string"`
 
-	metadataImportImageInput `json:"-" xml:"-"`
-}
-
-type metadataImportImageInput struct {
-	SDKShapeTraits bool `type:"structure"`
+	_ struct{} `type:"structure"`
 }
 
 // String returns the string representation
@@ -17602,11 +16266,7 @@ type ImportImageOutput struct {
 	// A detailed status message of the import task.
 	StatusMessage *string `locationName:"statusMessage" type:"string"`
 
-	metadataImportImageOutput `json:"-" xml:"-"`
-}
-
-type metadataImportImageOutput struct {
-	SDKShapeTraits bool `type:"structure"`
+	_ struct{} `type:"structure"`
 }
 
 // String returns the string representation
@@ -17658,11 +16318,7 @@ type ImportImageTask struct {
 	// A descriptive status message for the import image task.
 	StatusMessage *string `locationName:"statusMessage" type:"string"`
 
-	metadataImportImageTask `json:"-" xml:"-"`
-}
-
-type metadataImportImageTask struct {
-	SDKShapeTraits bool `type:"structure"`
+	_ struct{} `type:"structure"`
 }
 
 // String returns the string representation
@@ -17694,11 +16350,7 @@ type ImportInstanceInput struct {
 	// The instance operating system.
 	Platform *string `locationName:"platform" type:"string" required:"true" enum:"PlatformValues"`
 
-	metadataImportInstanceInput `json:"-" xml:"-"`
-}
-
-type metadataImportInstanceInput struct {
-	SDKShapeTraits bool `type:"structure"`
+	_ struct{} `type:"structure"`
 }
 
 // String returns the string representation
@@ -17749,11 +16401,7 @@ type ImportInstanceLaunchSpecification struct {
 	// The Base64-encoded MIME user data to be made available to the instance.
 	UserData *UserData `locationName:"userData" type:"structure"`
 
-	metadataImportInstanceLaunchSpecification `json:"-" xml:"-"`
-}
-
-type metadataImportInstanceLaunchSpecification struct {
-	SDKShapeTraits bool `type:"structure"`
+	_ struct{} `type:"structure"`
 }
 
 // String returns the string representation
@@ -17770,11 +16418,7 @@ type ImportInstanceOutput struct {
 	// Information about the conversion task.
 	ConversionTask *ConversionTask `locationName:"conversionTask" type:"structure"`
 
-	metadataImportInstanceOutput `json:"-" xml:"-"`
-}
-
-type metadataImportInstanceOutput struct {
-	SDKShapeTraits bool `type:"structure"`
+	_ struct{} `type:"structure"`
 }
 
 // String returns the string representation
@@ -17801,11 +16445,7 @@ type ImportInstanceTaskDetails struct {
 	// One or more volumes.
 	Volumes []*ImportInstanceVolumeDetailItem `locationName:"volumes" locationNameList:"item" type:"list" required:"true"`
 
-	metadataImportInstanceTaskDetails `json:"-" xml:"-"`
-}
-
-type metadataImportInstanceTaskDetails struct {
-	SDKShapeTraits bool `type:"structure"`
+	_ struct{} `type:"structure"`
 }
 
 // String returns the string representation
@@ -17841,11 +16481,7 @@ type ImportInstanceVolumeDetailItem struct {
 	// The volume.
 	Volume *DiskImageVolumeDescription `locationName:"volume" type:"structure" required:"true"`
 
-	metadataImportInstanceVolumeDetailItem `json:"-" xml:"-"`
-}
-
-type metadataImportInstanceVolumeDetailItem struct {
-	SDKShapeTraits bool `type:"structure"`
+	_ struct{} `type:"structure"`
 }
 
 // String returns the string representation
@@ -17872,11 +16508,7 @@ type ImportKeyPairInput struct {
 	// it to AWS.
 	PublicKeyMaterial []byte `locationName:"publicKeyMaterial" type:"blob" required:"true"`
 
-	metadataImportKeyPairInput `json:"-" xml:"-"`
-}
-
-type metadataImportKeyPairInput struct {
-	SDKShapeTraits bool `type:"structure"`
+	_ struct{} `type:"structure"`
 }
 
 // String returns the string representation
@@ -17896,11 +16528,7 @@ type ImportKeyPairOutput struct {
 	// The key pair name you provided.
 	KeyName *string `locationName:"keyName" type:"string"`
 
-	metadataImportKeyPairOutput `json:"-" xml:"-"`
-}
-
-type metadataImportKeyPairOutput struct {
-	SDKShapeTraits bool `type:"structure"`
+	_ struct{} `type:"structure"`
 }
 
 // String returns the string representation
@@ -17935,11 +16563,7 @@ type ImportSnapshotInput struct {
 	// The name of the role to use when not using the default role, 'vmimport'.
 	RoleName *string `type:"string"`
 
-	metadataImportSnapshotInput `json:"-" xml:"-"`
-}
-
-type metadataImportSnapshotInput struct {
-	SDKShapeTraits bool `type:"structure"`
+	_ struct{} `type:"structure"`
 }
 
 // String returns the string representation
@@ -17962,11 +16586,7 @@ type ImportSnapshotOutput struct {
 	// Information about the import snapshot task.
 	SnapshotTaskDetail *SnapshotTaskDetail `locationName:"snapshotTaskDetail" type:"structure"`
 
-	metadataImportSnapshotOutput `json:"-" xml:"-"`
-}
-
-type metadataImportSnapshotOutput struct {
-	SDKShapeTraits bool `type:"structure"`
+	_ struct{} `type:"structure"`
 }
 
 // String returns the string representation
@@ -17990,11 +16610,7 @@ type ImportSnapshotTask struct {
 	// Describes an import snapshot task.
 	SnapshotTaskDetail *SnapshotTaskDetail `locationName:"snapshotTaskDetail" type:"structure"`
 
-	metadataImportSnapshotTask `json:"-" xml:"-"`
-}
-
-type metadataImportSnapshotTask struct {
-	SDKShapeTraits bool `type:"structure"`
+	_ struct{} `type:"structure"`
 }
 
 // String returns the string representation
@@ -18026,11 +16642,7 @@ type ImportVolumeInput struct {
 	// The volume size.
 	Volume *VolumeDetail `locationName:"volume" type:"structure" required:"true"`
 
-	metadataImportVolumeInput `json:"-" xml:"-"`
-}
-
-type metadataImportVolumeInput struct {
-	SDKShapeTraits bool `type:"structure"`
+	_ struct{} `type:"structure"`
 }
 
 // String returns the string representation
@@ -18047,11 +16659,7 @@ type ImportVolumeOutput struct {
 	// Information about the conversion task.
 	ConversionTask *ConversionTask `locationName:"conversionTask" type:"structure"`
 
-	metadataImportVolumeOutput `json:"-" xml:"-"`
-}
-
-type metadataImportVolumeOutput struct {
-	SDKShapeTraits bool `type:"structure"`
+	_ struct{} `type:"structure"`
 }
 
 // String returns the string representation
@@ -18081,11 +16689,7 @@ type ImportVolumeTaskDetails struct {
 	// The volume.
 	Volume *DiskImageVolumeDescription `locationName:"volume" type:"structure" required:"true"`
 
-	metadataImportVolumeTaskDetails `json:"-" xml:"-"`
-}
-
-type metadataImportVolumeTaskDetails struct {
-	SDKShapeTraits bool `type:"structure"`
+	_ struct{} `type:"structure"`
 }
 
 // String returns the string representation
@@ -18228,11 +16832,7 @@ type Instance struct {
 	// [EC2-VPC] The ID of the VPC in which the instance is running.
 	VpcId *string `locationName:"vpcId" type:"string"`
 
-	metadataInstance `json:"-" xml:"-"`
-}
-
-type metadataInstance struct {
-	SDKShapeTraits bool `type:"structure"`
+	_ struct{} `type:"structure"`
 }
 
 // String returns the string representation
@@ -18254,11 +16854,7 @@ type InstanceBlockDeviceMapping struct {
 	// launched.
 	Ebs *EbsInstanceBlockDevice `locationName:"ebs" type:"structure"`
 
-	metadataInstanceBlockDeviceMapping `json:"-" xml:"-"`
-}
-
-type metadataInstanceBlockDeviceMapping struct {
-	SDKShapeTraits bool `type:"structure"`
+	_ struct{} `type:"structure"`
 }
 
 // String returns the string representation
@@ -18286,11 +16882,7 @@ type InstanceBlockDeviceMappingSpecification struct {
 	// The virtual device name.
 	VirtualName *string `locationName:"virtualName" type:"string"`
 
-	metadataInstanceBlockDeviceMappingSpecification `json:"-" xml:"-"`
-}
-
-type metadataInstanceBlockDeviceMappingSpecification struct {
-	SDKShapeTraits bool `type:"structure"`
+	_ struct{} `type:"structure"`
 }
 
 // String returns the string representation
@@ -18313,11 +16905,7 @@ type InstanceCapacity struct {
 	// The total number of instances that can be launched onto the Dedicated host.
 	TotalCapacity *int64 `locationName:"totalCapacity" type:"integer"`
 
-	metadataInstanceCapacity `json:"-" xml:"-"`
-}
-
-type metadataInstanceCapacity struct {
-	SDKShapeTraits bool `type:"structure"`
+	_ struct{} `type:"structure"`
 }
 
 // String returns the string representation
@@ -18338,11 +16926,7 @@ type InstanceCount struct {
 	// The states of the listed Reserved instances.
 	State *string `locationName:"state" type:"string" enum:"ListingState"`
 
-	metadataInstanceCount `json:"-" xml:"-"`
-}
-
-type metadataInstanceCount struct {
-	SDKShapeTraits bool `type:"structure"`
+	_ struct{} `type:"structure"`
 }
 
 // String returns the string representation
@@ -18363,11 +16947,7 @@ type InstanceExportDetails struct {
 	// The target virtualization environment.
 	TargetEnvironment *string `locationName:"targetEnvironment" type:"string" enum:"ExportEnvironment"`
 
-	metadataInstanceExportDetails `json:"-" xml:"-"`
-}
-
-type metadataInstanceExportDetails struct {
-	SDKShapeTraits bool `type:"structure"`
+	_ struct{} `type:"structure"`
 }
 
 // String returns the string representation
@@ -18388,11 +16968,7 @@ type InstanceMonitoring struct {
 	// The monitoring information.
 	Monitoring *Monitoring `locationName:"monitoring" type:"structure"`
 
-	metadataInstanceMonitoring `json:"-" xml:"-"`
-}
-
-type metadataInstanceMonitoring struct {
-	SDKShapeTraits bool `type:"structure"`
+	_ struct{} `type:"structure"`
 }
 
 // String returns the string representation
@@ -18450,11 +17026,7 @@ type InstanceNetworkInterface struct {
 	// The ID of the VPC.
 	VpcId *string `locationName:"vpcId" type:"string"`
 
-	metadataInstanceNetworkInterface `json:"-" xml:"-"`
-}
-
-type metadataInstanceNetworkInterface struct {
-	SDKShapeTraits bool `type:"structure"`
+	_ struct{} `type:"structure"`
 }
 
 // String returns the string representation
@@ -18478,11 +17050,7 @@ type InstanceNetworkInterfaceAssociation struct {
 	// The public IP address or Elastic IP address bound to the network interface.
 	PublicIp *string `locationName:"publicIp" type:"string"`
 
-	metadataInstanceNetworkInterfaceAssociation `json:"-" xml:"-"`
-}
-
-type metadataInstanceNetworkInterfaceAssociation struct {
-	SDKShapeTraits bool `type:"structure"`
+	_ struct{} `type:"structure"`
 }
 
 // String returns the string representation
@@ -18512,11 +17080,7 @@ type InstanceNetworkInterfaceAttachment struct {
 	// The attachment state.
 	Status *string `locationName:"status" type:"string" enum:"AttachmentStatus"`
 
-	metadataInstanceNetworkInterfaceAttachment `json:"-" xml:"-"`
-}
-
-type metadataInstanceNetworkInterfaceAttachment struct {
-	SDKShapeTraits bool `type:"structure"`
+	_ struct{} `type:"structure"`
 }
 
 // String returns the string representation
@@ -18576,11 +17140,7 @@ type InstanceNetworkInterfaceSpecification struct {
 	// creating a network interface when launching an instance.
 	SubnetId *string `locationName:"subnetId" type:"string"`
 
-	metadataInstanceNetworkInterfaceSpecification `json:"-" xml:"-"`
-}
-
-type metadataInstanceNetworkInterfaceSpecification struct {
-	SDKShapeTraits bool `type:"structure"`
+	_ struct{} `type:"structure"`
 }
 
 // String returns the string representation
@@ -18608,11 +17168,7 @@ type InstancePrivateIpAddress struct {
 	// The private IP address of the network interface.
 	PrivateIpAddress *string `locationName:"privateIpAddress" type:"string"`
 
-	metadataInstancePrivateIpAddress `json:"-" xml:"-"`
-}
-
-type metadataInstancePrivateIpAddress struct {
-	SDKShapeTraits bool `type:"structure"`
+	_ struct{} `type:"structure"`
 }
 
 // String returns the string representation
@@ -18646,11 +17202,7 @@ type InstanceState struct {
 	// The current state of the instance.
 	Name *string `locationName:"name" type:"string" enum:"InstanceStateName"`
 
-	metadataInstanceState `json:"-" xml:"-"`
-}
-
-type metadataInstanceState struct {
-	SDKShapeTraits bool `type:"structure"`
+	_ struct{} `type:"structure"`
 }
 
 // String returns the string representation
@@ -18674,11 +17226,7 @@ type InstanceStateChange struct {
 	// The previous state of the instance.
 	PreviousState *InstanceState `locationName:"previousState" type:"structure"`
 
-	metadataInstanceStateChange `json:"-" xml:"-"`
-}
-
-type metadataInstanceStateChange struct {
-	SDKShapeTraits bool `type:"structure"`
+	_ struct{} `type:"structure"`
 }
 
 // String returns the string representation
@@ -18715,11 +17263,7 @@ type InstanceStatus struct {
 	// problems.
 	SystemStatus *InstanceStatusSummary `locationName:"systemStatus" type:"structure"`
 
-	metadataInstanceStatus `json:"-" xml:"-"`
-}
-
-type metadataInstanceStatus struct {
-	SDKShapeTraits bool `type:"structure"`
+	_ struct{} `type:"structure"`
 }
 
 // String returns the string representation
@@ -18744,11 +17288,7 @@ type InstanceStatusDetails struct {
 	// The status.
 	Status *string `locationName:"status" type:"string" enum:"StatusType"`
 
-	metadataInstanceStatusDetails `json:"-" xml:"-"`
-}
-
-type metadataInstanceStatusDetails struct {
-	SDKShapeTraits bool `type:"structure"`
+	_ struct{} `type:"structure"`
 }
 
 // String returns the string representation
@@ -18779,11 +17319,7 @@ type InstanceStatusEvent struct {
 	// The earliest scheduled start time for the event.
 	NotBefore *time.Time `locationName:"notBefore" type:"timestamp" timestampFormat:"iso8601"`
 
-	metadataInstanceStatusEvent `json:"-" xml:"-"`
-}
-
-type metadataInstanceStatusEvent struct {
-	SDKShapeTraits bool `type:"structure"`
+	_ struct{} `type:"structure"`
 }
 
 // String returns the string representation
@@ -18804,11 +17340,7 @@ type InstanceStatusSummary struct {
 	// The status.
 	Status *string `locationName:"status" type:"string" enum:"SummaryStatus"`
 
-	metadataInstanceStatusSummary `json:"-" xml:"-"`
-}
-
-type metadataInstanceStatusSummary struct {
-	SDKShapeTraits bool `type:"structure"`
+	_ struct{} `type:"structure"`
 }
 
 // String returns the string representation
@@ -18832,11 +17364,7 @@ type InternetGateway struct {
 	// Any tags assigned to the Internet gateway.
 	Tags []*Tag `locationName:"tagSet" locationNameList:"item" type:"list"`
 
-	metadataInternetGateway `json:"-" xml:"-"`
-}
-
-type metadataInternetGateway struct {
-	SDKShapeTraits bool `type:"structure"`
+	_ struct{} `type:"structure"`
 }
 
 // String returns the string representation
@@ -18857,11 +17385,7 @@ type InternetGatewayAttachment struct {
 	// The ID of the VPC.
 	VpcId *string `locationName:"vpcId" type:"string"`
 
-	metadataInternetGatewayAttachment `json:"-" xml:"-"`
-}
-
-type metadataInternetGatewayAttachment struct {
-	SDKShapeTraits bool `type:"structure"`
+	_ struct{} `type:"structure"`
 }
 
 // String returns the string representation
@@ -18906,11 +17430,7 @@ type IpPermission struct {
 	// One or more security group and AWS account ID pairs.
 	UserIdGroupPairs []*UserIdGroupPair `locationName:"groups" locationNameList:"item" type:"list"`
 
-	metadataIpPermission `json:"-" xml:"-"`
-}
-
-type metadataIpPermission struct {
-	SDKShapeTraits bool `type:"structure"`
+	_ struct{} `type:"structure"`
 }
 
 // String returns the string representation
@@ -18929,11 +17449,7 @@ type IpRange struct {
 	// group, not both.
 	CidrIp *string `locationName:"cidrIp" type:"string"`
 
-	metadataIpRange `json:"-" xml:"-"`
-}
-
-type metadataIpRange struct {
-	SDKShapeTraits bool `type:"structure"`
+	_ struct{} `type:"structure"`
 }
 
 // String returns the string representation
@@ -18957,11 +17473,7 @@ type KeyPairInfo struct {
 	// The name of the key pair.
 	KeyName *string `locationName:"keyName" type:"string"`
 
-	metadataKeyPairInfo `json:"-" xml:"-"`
-}
-
-type metadataKeyPairInfo struct {
-	SDKShapeTraits bool `type:"structure"`
+	_ struct{} `type:"structure"`
 }
 
 // String returns the string representation
@@ -18982,11 +17494,7 @@ type LaunchPermission struct {
 	// The AWS account ID.
 	UserId *string `locationName:"userId" type:"string"`
 
-	metadataLaunchPermission `json:"-" xml:"-"`
-}
-
-type metadataLaunchPermission struct {
-	SDKShapeTraits bool `type:"structure"`
+	_ struct{} `type:"structure"`
 }
 
 // String returns the string representation
@@ -19008,11 +17516,7 @@ type LaunchPermissionModifications struct {
 	// AMI.
 	Remove []*LaunchPermission `locationNameList:"item" type:"list"`
 
-	metadataLaunchPermissionModifications `json:"-" xml:"-"`
-}
-
-type metadataLaunchPermissionModifications struct {
-	SDKShapeTraits bool `type:"structure"`
+	_ struct{} `type:"structure"`
 }
 
 // String returns the string representation
@@ -19080,11 +17584,7 @@ type LaunchSpecification struct {
 	// The Base64-encoded MIME user data to make available to the instances.
 	UserData *string `locationName:"userData" type:"string"`
 
-	metadataLaunchSpecification `json:"-" xml:"-"`
-}
-
-type metadataLaunchSpecification struct {
-	SDKShapeTraits bool `type:"structure"`
+	_ struct{} `type:"structure"`
 }
 
 // String returns the string representation
@@ -19104,11 +17604,7 @@ type ModifyHostsInput struct {
 	// The host IDs of the Dedicated hosts you want to modify.
 	HostIds []*string `locationName:"hostId" locationNameList:"item" type:"list" required:"true"`
 
-	metadataModifyHostsInput `json:"-" xml:"-"`
-}
-
-type metadataModifyHostsInput struct {
-	SDKShapeTraits bool `type:"structure"`
+	_ struct{} `type:"structure"`
 }
 
 // String returns the string representation
@@ -19129,11 +17625,7 @@ type ModifyHostsOutput struct {
 	// the setting you requested can be used.
 	Unsuccessful []*UnsuccessfulItem `locationName:"unsuccessful" locationNameList:"item" type:"list"`
 
-	metadataModifyHostsOutput `json:"-" xml:"-"`
-}
-
-type metadataModifyHostsOutput struct {
-	SDKShapeTraits bool `type:"structure"`
+	_ struct{} `type:"structure"`
 }
 
 // String returns the string representation
@@ -19153,11 +17645,7 @@ type ModifyIdFormatInput struct {
 	// Indicate whether the resource should use longer IDs (17-character IDs).
 	UseLongIds *bool `type:"boolean" required:"true"`
 
-	metadataModifyIdFormatInput `json:"-" xml:"-"`
-}
-
-type metadataModifyIdFormatInput struct {
-	SDKShapeTraits bool `type:"structure"`
+	_ struct{} `type:"structure"`
 }
 
 // String returns the string representation
@@ -19171,11 +17659,7 @@ func (s ModifyIdFormatInput) GoString() string {
 }
 
 type ModifyIdFormatOutput struct {
-	metadataModifyIdFormatOutput `json:"-" xml:"-"`
-}
-
-type metadataModifyIdFormatOutput struct {
-	SDKShapeTraits bool `type:"structure"`
+	_ struct{} `type:"structure"`
 }
 
 // String returns the string representation
@@ -19226,11 +17710,7 @@ type ModifyImageAttributeInput struct {
 	// the description attribute.
 	Value *string `type:"string"`
 
-	metadataModifyImageAttributeInput `json:"-" xml:"-"`
-}
-
-type metadataModifyImageAttributeInput struct {
-	SDKShapeTraits bool `type:"structure"`
+	_ struct{} `type:"structure"`
 }
 
 // String returns the string representation
@@ -19244,11 +17724,7 @@ func (s ModifyImageAttributeInput) GoString() string {
 }
 
 type ModifyImageAttributeOutput struct {
-	metadataModifyImageAttributeOutput `json:"-" xml:"-"`
-}
-
-type metadataModifyImageAttributeOutput struct {
-	SDKShapeTraits bool `type:"structure"`
+	_ struct{} `type:"structure"`
 }
 
 // String returns the string representation
@@ -19341,11 +17817,7 @@ type ModifyInstanceAttributeInput struct {
 	// disableApiTermination, or instanceInitiatedShutdownBehavior attribute.
 	Value *string `locationName:"value" type:"string"`
 
-	metadataModifyInstanceAttributeInput `json:"-" xml:"-"`
-}
-
-type metadataModifyInstanceAttributeInput struct {
-	SDKShapeTraits bool `type:"structure"`
+	_ struct{} `type:"structure"`
 }
 
 // String returns the string representation
@@ -19359,11 +17831,7 @@ func (s ModifyInstanceAttributeInput) GoString() string {
 }
 
 type ModifyInstanceAttributeOutput struct {
-	metadataModifyInstanceAttributeOutput `json:"-" xml:"-"`
-}
-
-type metadataModifyInstanceAttributeOutput struct {
-	SDKShapeTraits bool `type:"structure"`
+	_ struct{} `type:"structure"`
 }
 
 // String returns the string representation
@@ -19389,11 +17857,7 @@ type ModifyInstancePlacementInput struct {
 	// The tenancy of the instance that you are modifying.
 	Tenancy *string `locationName:"tenancy" type:"string" enum:"HostTenancy"`
 
-	metadataModifyInstancePlacementInput `json:"-" xml:"-"`
-}
-
-type metadataModifyInstancePlacementInput struct {
-	SDKShapeTraits bool `type:"structure"`
+	_ struct{} `type:"structure"`
 }
 
 // String returns the string representation
@@ -19410,11 +17874,7 @@ type ModifyInstancePlacementOutput struct {
 	// Is true if the request succeeds, and an error otherwise.
 	Return *bool `locationName:"return" type:"boolean"`
 
-	metadataModifyInstancePlacementOutput `json:"-" xml:"-"`
-}
-
-type metadataModifyInstancePlacementOutput struct {
-	SDKShapeTraits bool `type:"structure"`
+	_ struct{} `type:"structure"`
 }
 
 // String returns the string representation
@@ -19457,11 +17917,7 @@ type ModifyNetworkInterfaceAttributeInput struct {
 	// in the Amazon Virtual Private Cloud User Guide.
 	SourceDestCheck *AttributeBooleanValue `locationName:"sourceDestCheck" type:"structure"`
 
-	metadataModifyNetworkInterfaceAttributeInput `json:"-" xml:"-"`
-}
-
-type metadataModifyNetworkInterfaceAttributeInput struct {
-	SDKShapeTraits bool `type:"structure"`
+	_ struct{} `type:"structure"`
 }
 
 // String returns the string representation
@@ -19475,11 +17931,7 @@ func (s ModifyNetworkInterfaceAttributeInput) GoString() string {
 }
 
 type ModifyNetworkInterfaceAttributeOutput struct {
-	metadataModifyNetworkInterfaceAttributeOutput `json:"-" xml:"-"`
-}
-
-type metadataModifyNetworkInterfaceAttributeOutput struct {
-	SDKShapeTraits bool `type:"structure"`
+	_ struct{} `type:"structure"`
 }
 
 // String returns the string representation
@@ -19503,11 +17955,7 @@ type ModifyReservedInstancesInput struct {
 	// The configuration settings for the Reserved instances to modify.
 	TargetConfigurations []*ReservedInstancesConfiguration `locationName:"ReservedInstancesConfigurationSetItemType" locationNameList:"item" type:"list" required:"true"`
 
-	metadataModifyReservedInstancesInput `json:"-" xml:"-"`
-}
-
-type metadataModifyReservedInstancesInput struct {
-	SDKShapeTraits bool `type:"structure"`
+	_ struct{} `type:"structure"`
 }
 
 // String returns the string representation
@@ -19524,11 +17972,7 @@ type ModifyReservedInstancesOutput struct {
 	// The ID for the modification.
 	ReservedInstancesModificationId *string `locationName:"reservedInstancesModificationId" type:"string"`
 
-	metadataModifyReservedInstancesOutput `json:"-" xml:"-"`
-}
-
-type metadataModifyReservedInstancesOutput struct {
-	SDKShapeTraits bool `type:"structure"`
+	_ struct{} `type:"structure"`
 }
 
 // String returns the string representation
@@ -19568,11 +18012,7 @@ type ModifySnapshotAttributeInput struct {
 	// The account ID to modify for the snapshot.
 	UserIds []*string `locationName:"UserId" locationNameList:"UserId" type:"list"`
 
-	metadataModifySnapshotAttributeInput `json:"-" xml:"-"`
-}
-
-type metadataModifySnapshotAttributeInput struct {
-	SDKShapeTraits bool `type:"structure"`
+	_ struct{} `type:"structure"`
 }
 
 // String returns the string representation
@@ -19586,11 +18026,7 @@ func (s ModifySnapshotAttributeInput) GoString() string {
 }
 
 type ModifySnapshotAttributeOutput struct {
-	metadataModifySnapshotAttributeOutput `json:"-" xml:"-"`
-}
-
-type metadataModifySnapshotAttributeOutput struct {
-	SDKShapeTraits bool `type:"structure"`
+	_ struct{} `type:"structure"`
 }
 
 // String returns the string representation
@@ -19616,11 +18052,7 @@ type ModifySpotFleetRequestInput struct {
 	// The size of the fleet.
 	TargetCapacity *int64 `locationName:"targetCapacity" type:"integer"`
 
-	metadataModifySpotFleetRequestInput `json:"-" xml:"-"`
-}
-
-type metadataModifySpotFleetRequestInput struct {
-	SDKShapeTraits bool `type:"structure"`
+	_ struct{} `type:"structure"`
 }
 
 // String returns the string representation
@@ -19638,11 +18070,7 @@ type ModifySpotFleetRequestOutput struct {
 	// Is true if the request succeeds, and an error otherwise.
 	Return *bool `locationName:"return" type:"boolean"`
 
-	metadataModifySpotFleetRequestOutput `json:"-" xml:"-"`
-}
-
-type metadataModifySpotFleetRequestOutput struct {
-	SDKShapeTraits bool `type:"structure"`
+	_ struct{} `type:"structure"`
 }
 
 // String returns the string representation
@@ -19663,11 +18091,7 @@ type ModifySubnetAttributeInput struct {
 	// The ID of the subnet.
 	SubnetId *string `locationName:"subnetId" type:"string" required:"true"`
 
-	metadataModifySubnetAttributeInput `json:"-" xml:"-"`
-}
-
-type metadataModifySubnetAttributeInput struct {
-	SDKShapeTraits bool `type:"structure"`
+	_ struct{} `type:"structure"`
 }
 
 // String returns the string representation
@@ -19681,11 +18105,7 @@ func (s ModifySubnetAttributeInput) GoString() string {
 }
 
 type ModifySubnetAttributeOutput struct {
-	metadataModifySubnetAttributeOutput `json:"-" xml:"-"`
-}
-
-type metadataModifySubnetAttributeOutput struct {
-	SDKShapeTraits bool `type:"structure"`
+	_ struct{} `type:"structure"`
 }
 
 // String returns the string representation
@@ -19711,11 +18131,7 @@ type ModifyVolumeAttributeInput struct {
 	// The ID of the volume.
 	VolumeId *string `type:"string" required:"true"`
 
-	metadataModifyVolumeAttributeInput `json:"-" xml:"-"`
-}
-
-type metadataModifyVolumeAttributeInput struct {
-	SDKShapeTraits bool `type:"structure"`
+	_ struct{} `type:"structure"`
 }
 
 // String returns the string representation
@@ -19729,11 +18145,7 @@ func (s ModifyVolumeAttributeInput) GoString() string {
 }
 
 type ModifyVolumeAttributeOutput struct {
-	metadataModifyVolumeAttributeOutput `json:"-" xml:"-"`
-}
-
-type metadataModifyVolumeAttributeOutput struct {
-	SDKShapeTraits bool `type:"structure"`
+	_ struct{} `type:"structure"`
 }
 
 // String returns the string representation
@@ -19768,11 +18180,7 @@ type ModifyVpcAttributeInput struct {
 	// The ID of the VPC.
 	VpcId *string `locationName:"vpcId" type:"string" required:"true"`
 
-	metadataModifyVpcAttributeInput `json:"-" xml:"-"`
-}
-
-type metadataModifyVpcAttributeInput struct {
-	SDKShapeTraits bool `type:"structure"`
+	_ struct{} `type:"structure"`
 }
 
 // String returns the string representation
@@ -19786,11 +18194,7 @@ func (s ModifyVpcAttributeInput) GoString() string {
 }
 
 type ModifyVpcAttributeOutput struct {
-	metadataModifyVpcAttributeOutput `json:"-" xml:"-"`
-}
-
-type metadataModifyVpcAttributeOutput struct {
-	SDKShapeTraits bool `type:"structure"`
+	_ struct{} `type:"structure"`
 }
 
 // String returns the string representation
@@ -19827,11 +18231,7 @@ type ModifyVpcEndpointInput struct {
 	// The ID of the endpoint.
 	VpcEndpointId *string `type:"string" required:"true"`
 
-	metadataModifyVpcEndpointInput `json:"-" xml:"-"`
-}
-
-type metadataModifyVpcEndpointInput struct {
-	SDKShapeTraits bool `type:"structure"`
+	_ struct{} `type:"structure"`
 }
 
 // String returns the string representation
@@ -19848,11 +18248,7 @@ type ModifyVpcEndpointOutput struct {
 	// Returns true if the request succeeds; otherwise, it returns an error.
 	Return *bool `locationName:"return" type:"boolean"`
 
-	metadataModifyVpcEndpointOutput `json:"-" xml:"-"`
-}
-
-type metadataModifyVpcEndpointOutput struct {
-	SDKShapeTraits bool `type:"structure"`
+	_ struct{} `type:"structure"`
 }
 
 // String returns the string representation
@@ -19875,11 +18271,7 @@ type MonitorInstancesInput struct {
 	// One or more instance IDs.
 	InstanceIds []*string `locationName:"InstanceId" locationNameList:"InstanceId" type:"list" required:"true"`
 
-	metadataMonitorInstancesInput `json:"-" xml:"-"`
-}
-
-type metadataMonitorInstancesInput struct {
-	SDKShapeTraits bool `type:"structure"`
+	_ struct{} `type:"structure"`
 }
 
 // String returns the string representation
@@ -19896,11 +18288,7 @@ type MonitorInstancesOutput struct {
 	// Monitoring information for one or more instances.
 	InstanceMonitorings []*InstanceMonitoring `locationName:"instancesSet" locationNameList:"item" type:"list"`
 
-	metadataMonitorInstancesOutput `json:"-" xml:"-"`
-}
-
-type metadataMonitorInstancesOutput struct {
-	SDKShapeTraits bool `type:"structure"`
+	_ struct{} `type:"structure"`
 }
 
 // String returns the string representation
@@ -19918,11 +18306,7 @@ type Monitoring struct {
 	// Indicates whether monitoring is enabled for the instance.
 	State *string `locationName:"state" type:"string" enum:"MonitoringState"`
 
-	metadataMonitoring `json:"-" xml:"-"`
-}
-
-type metadataMonitoring struct {
-	SDKShapeTraits bool `type:"structure"`
+	_ struct{} `type:"structure"`
 }
 
 // String returns the string representation
@@ -19945,11 +18329,7 @@ type MoveAddressToVpcInput struct {
 	// The Elastic IP address.
 	PublicIp *string `locationName:"publicIp" type:"string" required:"true"`
 
-	metadataMoveAddressToVpcInput `json:"-" xml:"-"`
-}
-
-type metadataMoveAddressToVpcInput struct {
-	SDKShapeTraits bool `type:"structure"`
+	_ struct{} `type:"structure"`
 }
 
 // String returns the string representation
@@ -19969,11 +18349,7 @@ type MoveAddressToVpcOutput struct {
 	// The status of the move of the IP address.
 	Status *string `locationName:"status" type:"string" enum:"Status"`
 
-	metadataMoveAddressToVpcOutput `json:"-" xml:"-"`
-}
-
-type metadataMoveAddressToVpcOutput struct {
-	SDKShapeTraits bool `type:"structure"`
+	_ struct{} `type:"structure"`
 }
 
 // String returns the string representation
@@ -19995,11 +18371,7 @@ type MovingAddressStatus struct {
 	// The Elastic IP address.
 	PublicIp *string `locationName:"publicIp" type:"string"`
 
-	metadataMovingAddressStatus `json:"-" xml:"-"`
-}
-
-type metadataMovingAddressStatus struct {
-	SDKShapeTraits bool `type:"structure"`
+	_ struct{} `type:"structure"`
 }
 
 // String returns the string representation
@@ -20032,11 +18404,7 @@ type NetworkAcl struct {
 	// The ID of the VPC for the network ACL.
 	VpcId *string `locationName:"vpcId" type:"string"`
 
-	metadataNetworkAcl `json:"-" xml:"-"`
-}
-
-type metadataNetworkAcl struct {
-	SDKShapeTraits bool `type:"structure"`
+	_ struct{} `type:"structure"`
 }
 
 // String returns the string representation
@@ -20060,11 +18428,7 @@ type NetworkAclAssociation struct {
 	// The ID of the subnet.
 	SubnetId *string `locationName:"subnetId" type:"string"`
 
-	metadataNetworkAclAssociation `json:"-" xml:"-"`
-}
-
-type metadataNetworkAclAssociation struct {
-	SDKShapeTraits bool `type:"structure"`
+	_ struct{} `type:"structure"`
 }
 
 // String returns the string representation
@@ -20102,11 +18466,7 @@ type NetworkAclEntry struct {
 	// by rule number.
 	RuleNumber *int64 `locationName:"ruleNumber" type:"integer"`
 
-	metadataNetworkAclEntry `json:"-" xml:"-"`
-}
-
-type metadataNetworkAclEntry struct {
-	SDKShapeTraits bool `type:"structure"`
+	_ struct{} `type:"structure"`
 }
 
 // String returns the string representation
@@ -20177,11 +18537,7 @@ type NetworkInterface struct {
 	// The ID of the VPC.
 	VpcId *string `locationName:"vpcId" type:"string"`
 
-	metadataNetworkInterface `json:"-" xml:"-"`
-}
-
-type metadataNetworkInterface struct {
-	SDKShapeTraits bool `type:"structure"`
+	_ struct{} `type:"structure"`
 }
 
 // String returns the string representation
@@ -20211,11 +18567,7 @@ type NetworkInterfaceAssociation struct {
 	// The address of the Elastic IP address bound to the network interface.
 	PublicIp *string `locationName:"publicIp" type:"string"`
 
-	metadataNetworkInterfaceAssociation `json:"-" xml:"-"`
-}
-
-type metadataNetworkInterfaceAssociation struct {
-	SDKShapeTraits bool `type:"structure"`
+	_ struct{} `type:"structure"`
 }
 
 // String returns the string representation
@@ -20251,11 +18603,7 @@ type NetworkInterfaceAttachment struct {
 	// The attachment state.
 	Status *string `locationName:"status" type:"string" enum:"AttachmentStatus"`
 
-	metadataNetworkInterfaceAttachment `json:"-" xml:"-"`
-}
-
-type metadataNetworkInterfaceAttachment struct {
-	SDKShapeTraits bool `type:"structure"`
+	_ struct{} `type:"structure"`
 }
 
 // String returns the string representation
@@ -20276,11 +18624,7 @@ type NetworkInterfaceAttachmentChanges struct {
 	// Indicates whether the network interface is deleted when the instance is terminated.
 	DeleteOnTermination *bool `locationName:"deleteOnTermination" type:"boolean"`
 
-	metadataNetworkInterfaceAttachmentChanges `json:"-" xml:"-"`
-}
-
-type metadataNetworkInterfaceAttachmentChanges struct {
-	SDKShapeTraits bool `type:"structure"`
+	_ struct{} `type:"structure"`
 }
 
 // String returns the string representation
@@ -20309,11 +18653,7 @@ type NetworkInterfacePrivateIpAddress struct {
 	// The private IP address.
 	PrivateIpAddress *string `locationName:"privateIpAddress" type:"string"`
 
-	metadataNetworkInterfacePrivateIpAddress `json:"-" xml:"-"`
-}
-
-type metadataNetworkInterfacePrivateIpAddress struct {
-	SDKShapeTraits bool `type:"structure"`
+	_ struct{} `type:"structure"`
 }
 
 // String returns the string representation
@@ -20331,11 +18671,7 @@ type NewDhcpConfiguration struct {
 
 	Values []*string `locationName:"Value" locationNameList:"item" type:"list"`
 
-	metadataNewDhcpConfiguration `json:"-" xml:"-"`
-}
-
-type metadataNewDhcpConfiguration struct {
-	SDKShapeTraits bool `type:"structure"`
+	_ struct{} `type:"structure"`
 }
 
 // String returns the string representation
@@ -20369,11 +18705,7 @@ type Placement struct {
 	// is not supported for the ImportInstance command.
 	Tenancy *string `locationName:"tenancy" type:"string" enum:"Tenancy"`
 
-	metadataPlacement `json:"-" xml:"-"`
-}
-
-type metadataPlacement struct {
-	SDKShapeTraits bool `type:"structure"`
+	_ struct{} `type:"structure"`
 }
 
 // String returns the string representation
@@ -20397,11 +18729,7 @@ type PlacementGroup struct {
 	// The placement strategy.
 	Strategy *string `locationName:"strategy" type:"string" enum:"PlacementStrategy"`
 
-	metadataPlacementGroup `json:"-" xml:"-"`
-}
-
-type metadataPlacementGroup struct {
-	SDKShapeTraits bool `type:"structure"`
+	_ struct{} `type:"structure"`
 }
 
 // String returns the string representation
@@ -20422,11 +18750,7 @@ type PortRange struct {
 	// The last port in the range.
 	To *int64 `locationName:"to" type:"integer"`
 
-	metadataPortRange `json:"-" xml:"-"`
-}
-
-type metadataPortRange struct {
-	SDKShapeTraits bool `type:"structure"`
+	_ struct{} `type:"structure"`
 }
 
 // String returns the string representation
@@ -20450,11 +18774,7 @@ type PrefixList struct {
 	// The name of the prefix.
 	PrefixListName *string `locationName:"prefixListName" type:"string"`
 
-	metadataPrefixList `json:"-" xml:"-"`
-}
-
-type metadataPrefixList struct {
-	SDKShapeTraits bool `type:"structure"`
+	_ struct{} `type:"structure"`
 }
 
 // String returns the string representation
@@ -20472,11 +18792,7 @@ type PrefixListId struct {
 	// The ID of the prefix.
 	PrefixListId *string `locationName:"prefixListId" type:"string"`
 
-	metadataPrefixListId `json:"-" xml:"-"`
-}
-
-type metadataPrefixListId struct {
-	SDKShapeTraits bool `type:"structure"`
+	_ struct{} `type:"structure"`
 }
 
 // String returns the string representation
@@ -20514,11 +18830,7 @@ type PriceSchedule struct {
 	// second to the last month before the capacity reservation expires.
 	Term *int64 `locationName:"term" type:"long"`
 
-	metadataPriceSchedule `json:"-" xml:"-"`
-}
-
-type metadataPriceSchedule struct {
-	SDKShapeTraits bool `type:"structure"`
+	_ struct{} `type:"structure"`
 }
 
 // String returns the string representation
@@ -20544,11 +18856,7 @@ type PriceScheduleSpecification struct {
 	// second to the last month before the capacity reservation expires.
 	Term *int64 `locationName:"term" type:"long"`
 
-	metadataPriceScheduleSpecification `json:"-" xml:"-"`
-}
-
-type metadataPriceScheduleSpecification struct {
-	SDKShapeTraits bool `type:"structure"`
+	_ struct{} `type:"structure"`
 }
 
 // String returns the string representation
@@ -20569,11 +18877,7 @@ type PricingDetail struct {
 	// The price per instance.
 	Price *float64 `locationName:"price" type:"double"`
 
-	metadataPricingDetail `json:"-" xml:"-"`
-}
-
-type metadataPricingDetail struct {
-	SDKShapeTraits bool `type:"structure"`
+	_ struct{} `type:"structure"`
 }
 
 // String returns the string representation
@@ -20595,11 +18899,7 @@ type PrivateIpAddressSpecification struct {
 	// The private IP addresses.
 	PrivateIpAddress *string `locationName:"privateIpAddress" type:"string" required:"true"`
 
-	metadataPrivateIpAddressSpecification `json:"-" xml:"-"`
-}
-
-type metadataPrivateIpAddressSpecification struct {
-	SDKShapeTraits bool `type:"structure"`
+	_ struct{} `type:"structure"`
 }
 
 // String returns the string representation
@@ -20620,11 +18920,7 @@ type ProductCode struct {
 	// The type of product code.
 	ProductCodeType *string `locationName:"type" type:"string" enum:"ProductCodeValues"`
 
-	metadataProductCode `json:"-" xml:"-"`
-}
-
-type metadataProductCode struct {
-	SDKShapeTraits bool `type:"structure"`
+	_ struct{} `type:"structure"`
 }
 
 // String returns the string representation
@@ -20642,11 +18938,7 @@ type PropagatingVgw struct {
 	// The ID of the virtual private gateway (VGW).
 	GatewayId *string `locationName:"gatewayId" type:"string"`
 
-	metadataPropagatingVgw `json:"-" xml:"-"`
-}
-
-type metadataPropagatingVgw struct {
-	SDKShapeTraits bool `type:"structure"`
+	_ struct{} `type:"structure"`
 }
 
 // String returns the string representation
@@ -20677,11 +18969,7 @@ type PurchaseReservedInstancesOfferingInput struct {
 	// The ID of the Reserved instance offering to purchase.
 	ReservedInstancesOfferingId *string `type:"string" required:"true"`
 
-	metadataPurchaseReservedInstancesOfferingInput `json:"-" xml:"-"`
-}
-
-type metadataPurchaseReservedInstancesOfferingInput struct {
-	SDKShapeTraits bool `type:"structure"`
+	_ struct{} `type:"structure"`
 }
 
 // String returns the string representation
@@ -20698,11 +18986,7 @@ type PurchaseReservedInstancesOfferingOutput struct {
 	// The IDs of the purchased Reserved instances.
 	ReservedInstancesId *string `locationName:"reservedInstancesId" type:"string"`
 
-	metadataPurchaseReservedInstancesOfferingOutput `json:"-" xml:"-"`
-}
-
-type metadataPurchaseReservedInstancesOfferingOutput struct {
-	SDKShapeTraits bool `type:"structure"`
+	_ struct{} `type:"structure"`
 }
 
 // String returns the string representation
@@ -20725,11 +19009,7 @@ type RebootInstancesInput struct {
 	// One or more instance IDs.
 	InstanceIds []*string `locationName:"InstanceId" locationNameList:"InstanceId" type:"list" required:"true"`
 
-	metadataRebootInstancesInput `json:"-" xml:"-"`
-}
-
-type metadataRebootInstancesInput struct {
-	SDKShapeTraits bool `type:"structure"`
+	_ struct{} `type:"structure"`
 }
 
 // String returns the string representation
@@ -20743,11 +19023,7 @@ func (s RebootInstancesInput) GoString() string {
 }
 
 type RebootInstancesOutput struct {
-	metadataRebootInstancesOutput `json:"-" xml:"-"`
-}
-
-type metadataRebootInstancesOutput struct {
-	SDKShapeTraits bool `type:"structure"`
+	_ struct{} `type:"structure"`
 }
 
 // String returns the string representation
@@ -20768,11 +19044,7 @@ type RecurringCharge struct {
 	// The frequency of the recurring charge.
 	Frequency *string `locationName:"frequency" type:"string" enum:"RecurringChargeFrequency"`
 
-	metadataRecurringCharge `json:"-" xml:"-"`
-}
-
-type metadataRecurringCharge struct {
-	SDKShapeTraits bool `type:"structure"`
+	_ struct{} `type:"structure"`
 }
 
 // String returns the string representation
@@ -20793,11 +19065,7 @@ type Region struct {
 	// The name of the region.
 	RegionName *string `locationName:"regionName" type:"string"`
 
-	metadataRegion `json:"-" xml:"-"`
-}
-
-type metadataRegion struct {
-	SDKShapeTraits bool `type:"structure"`
+	_ struct{} `type:"structure"`
 }
 
 // String returns the string representation
@@ -20862,11 +19130,7 @@ type RegisterImageInput struct {
 	// Default: paravirtual
 	VirtualizationType *string `locationName:"virtualizationType" type:"string"`
 
-	metadataRegisterImageInput `json:"-" xml:"-"`
-}
-
-type metadataRegisterImageInput struct {
-	SDKShapeTraits bool `type:"structure"`
+	_ struct{} `type:"structure"`
 }
 
 // String returns the string representation
@@ -20883,11 +19147,7 @@ type RegisterImageOutput struct {
 	// The ID of the newly registered AMI.
 	ImageId *string `locationName:"imageId" type:"string"`
 
-	metadataRegisterImageOutput `json:"-" xml:"-"`
-}
-
-type metadataRegisterImageOutput struct {
-	SDKShapeTraits bool `type:"structure"`
+	_ struct{} `type:"structure"`
 }
 
 // String returns the string representation
@@ -20910,11 +19170,7 @@ type RejectVpcPeeringConnectionInput struct {
 	// The ID of the VPC peering connection.
 	VpcPeeringConnectionId *string `locationName:"vpcPeeringConnectionId" type:"string" required:"true"`
 
-	metadataRejectVpcPeeringConnectionInput `json:"-" xml:"-"`
-}
-
-type metadataRejectVpcPeeringConnectionInput struct {
-	SDKShapeTraits bool `type:"structure"`
+	_ struct{} `type:"structure"`
 }
 
 // String returns the string representation
@@ -20931,11 +19187,7 @@ type RejectVpcPeeringConnectionOutput struct {
 	// Returns true if the request succeeds; otherwise, it returns an error.
 	Return *bool `locationName:"return" type:"boolean"`
 
-	metadataRejectVpcPeeringConnectionOutput `json:"-" xml:"-"`
-}
-
-type metadataRejectVpcPeeringConnectionOutput struct {
-	SDKShapeTraits bool `type:"structure"`
+	_ struct{} `type:"structure"`
 }
 
 // String returns the string representation
@@ -20961,11 +19213,7 @@ type ReleaseAddressInput struct {
 	// [EC2-Classic] The Elastic IP address. Required for EC2-Classic.
 	PublicIp *string `type:"string"`
 
-	metadataReleaseAddressInput `json:"-" xml:"-"`
-}
-
-type metadataReleaseAddressInput struct {
-	SDKShapeTraits bool `type:"structure"`
+	_ struct{} `type:"structure"`
 }
 
 // String returns the string representation
@@ -20979,11 +19227,7 @@ func (s ReleaseAddressInput) GoString() string {
 }
 
 type ReleaseAddressOutput struct {
-	metadataReleaseAddressOutput `json:"-" xml:"-"`
-}
-
-type metadataReleaseAddressOutput struct {
-	SDKShapeTraits bool `type:"structure"`
+	_ struct{} `type:"structure"`
 }
 
 // String returns the string representation
@@ -21000,11 +19244,7 @@ type ReleaseHostsInput struct {
 	// The IDs of the Dedicated hosts you want to release.
 	HostIds []*string `locationName:"hostId" locationNameList:"item" type:"list" required:"true"`
 
-	metadataReleaseHostsInput `json:"-" xml:"-"`
-}
-
-type metadataReleaseHostsInput struct {
-	SDKShapeTraits bool `type:"structure"`
+	_ struct{} `type:"structure"`
 }
 
 // String returns the string representation
@@ -21025,11 +19265,7 @@ type ReleaseHostsOutput struct {
 	// message.
 	Unsuccessful []*UnsuccessfulItem `locationName:"unsuccessful" locationNameList:"item" type:"list"`
 
-	metadataReleaseHostsOutput `json:"-" xml:"-"`
-}
-
-type metadataReleaseHostsOutput struct {
-	SDKShapeTraits bool `type:"structure"`
+	_ struct{} `type:"structure"`
 }
 
 // String returns the string representation
@@ -21056,11 +19292,7 @@ type ReplaceNetworkAclAssociationInput struct {
 	// The ID of the new network ACL to associate with the subnet.
 	NetworkAclId *string `locationName:"networkAclId" type:"string" required:"true"`
 
-	metadataReplaceNetworkAclAssociationInput `json:"-" xml:"-"`
-}
-
-type metadataReplaceNetworkAclAssociationInput struct {
-	SDKShapeTraits bool `type:"structure"`
+	_ struct{} `type:"structure"`
 }
 
 // String returns the string representation
@@ -21077,11 +19309,7 @@ type ReplaceNetworkAclAssociationOutput struct {
 	// The ID of the new association.
 	NewAssociationId *string `locationName:"newAssociationId" type:"string"`
 
-	metadataReplaceNetworkAclAssociationOutput `json:"-" xml:"-"`
-}
-
-type metadataReplaceNetworkAclAssociationOutput struct {
-	SDKShapeTraits bool `type:"structure"`
+	_ struct{} `type:"structure"`
 }
 
 // String returns the string representation
@@ -21129,11 +19357,7 @@ type ReplaceNetworkAclEntryInput struct {
 	// The rule number of the entry to replace.
 	RuleNumber *int64 `locationName:"ruleNumber" type:"integer" required:"true"`
 
-	metadataReplaceNetworkAclEntryInput `json:"-" xml:"-"`
-}
-
-type metadataReplaceNetworkAclEntryInput struct {
-	SDKShapeTraits bool `type:"structure"`
+	_ struct{} `type:"structure"`
 }
 
 // String returns the string representation
@@ -21147,11 +19371,7 @@ func (s ReplaceNetworkAclEntryInput) GoString() string {
 }
 
 type ReplaceNetworkAclEntryOutput struct {
-	metadataReplaceNetworkAclEntryOutput `json:"-" xml:"-"`
-}
-
-type metadataReplaceNetworkAclEntryOutput struct {
-	SDKShapeTraits bool `type:"structure"`
+	_ struct{} `type:"structure"`
 }
 
 // String returns the string representation
@@ -21190,11 +19410,7 @@ type ReplaceRouteInput struct {
 	// The ID of a VPC peering connection.
 	VpcPeeringConnectionId *string `locationName:"vpcPeeringConnectionId" type:"string"`
 
-	metadataReplaceRouteInput `json:"-" xml:"-"`
-}
-
-type metadataReplaceRouteInput struct {
-	SDKShapeTraits bool `type:"structure"`
+	_ struct{} `type:"structure"`
 }
 
 // String returns the string representation
@@ -21208,11 +19424,7 @@ func (s ReplaceRouteInput) GoString() string {
 }
 
 type ReplaceRouteOutput struct {
-	metadataReplaceRouteOutput `json:"-" xml:"-"`
-}
-
-type metadataReplaceRouteOutput struct {
-	SDKShapeTraits bool `type:"structure"`
+	_ struct{} `type:"structure"`
 }
 
 // String returns the string representation
@@ -21238,11 +19450,7 @@ type ReplaceRouteTableAssociationInput struct {
 	// The ID of the new route table to associate with the subnet.
 	RouteTableId *string `locationName:"routeTableId" type:"string" required:"true"`
 
-	metadataReplaceRouteTableAssociationInput `json:"-" xml:"-"`
-}
-
-type metadataReplaceRouteTableAssociationInput struct {
-	SDKShapeTraits bool `type:"structure"`
+	_ struct{} `type:"structure"`
 }
 
 // String returns the string representation
@@ -21259,11 +19467,7 @@ type ReplaceRouteTableAssociationOutput struct {
 	// The ID of the new association.
 	NewAssociationId *string `locationName:"newAssociationId" type:"string"`
 
-	metadataReplaceRouteTableAssociationOutput `json:"-" xml:"-"`
-}
-
-type metadataReplaceRouteTableAssociationOutput struct {
-	SDKShapeTraits bool `type:"structure"`
+	_ struct{} `type:"structure"`
 }
 
 // String returns the string representation
@@ -21322,11 +19526,7 @@ type ReportInstanceStatusInput struct {
 	// The status of all instances listed.
 	Status *string `locationName:"status" type:"string" required:"true" enum:"ReportStatusType"`
 
-	metadataReportInstanceStatusInput `json:"-" xml:"-"`
-}
-
-type metadataReportInstanceStatusInput struct {
-	SDKShapeTraits bool `type:"structure"`
+	_ struct{} `type:"structure"`
 }
 
 // String returns the string representation
@@ -21340,11 +19540,7 @@ func (s ReportInstanceStatusInput) GoString() string {
 }
 
 type ReportInstanceStatusOutput struct {
-	metadataReportInstanceStatusOutput `json:"-" xml:"-"`
-}
-
-type metadataReportInstanceStatusOutput struct {
-	SDKShapeTraits bool `type:"structure"`
+	_ struct{} `type:"structure"`
 }
 
 // String returns the string representation
@@ -21368,11 +19564,7 @@ type RequestSpotFleetInput struct {
 	// The configuration for the Spot fleet request.
 	SpotFleetRequestConfig *SpotFleetRequestConfigData `locationName:"spotFleetRequestConfig" type:"structure" required:"true"`
 
-	metadataRequestSpotFleetInput `json:"-" xml:"-"`
-}
-
-type metadataRequestSpotFleetInput struct {
-	SDKShapeTraits bool `type:"structure"`
+	_ struct{} `type:"structure"`
 }
 
 // String returns the string representation
@@ -21390,11 +19582,7 @@ type RequestSpotFleetOutput struct {
 	// The ID of the Spot fleet request.
 	SpotFleetRequestId *string `locationName:"spotFleetRequestId" type:"string" required:"true"`
 
-	metadataRequestSpotFleetOutput `json:"-" xml:"-"`
-}
-
-type metadataRequestSpotFleetOutput struct {
-	SDKShapeTraits bool `type:"structure"`
+	_ struct{} `type:"structure"`
 }
 
 // String returns the string representation
@@ -21493,11 +19681,7 @@ type RequestSpotInstancesInput struct {
 	// Default: The request is effective indefinitely.
 	ValidUntil *time.Time `locationName:"validUntil" type:"timestamp" timestampFormat:"iso8601"`
 
-	metadataRequestSpotInstancesInput `json:"-" xml:"-"`
-}
-
-type metadataRequestSpotInstancesInput struct {
-	SDKShapeTraits bool `type:"structure"`
+	_ struct{} `type:"structure"`
 }
 
 // String returns the string representation
@@ -21515,11 +19699,7 @@ type RequestSpotInstancesOutput struct {
 	// One or more Spot instance requests.
 	SpotInstanceRequests []*SpotInstanceRequest `locationName:"spotInstanceRequestSet" locationNameList:"item" type:"list"`
 
-	metadataRequestSpotInstancesOutput `json:"-" xml:"-"`
-}
-
-type metadataRequestSpotInstancesOutput struct {
-	SDKShapeTraits bool `type:"structure"`
+	_ struct{} `type:"structure"`
 }
 
 // String returns the string representation
@@ -21586,11 +19766,7 @@ type RequestSpotLaunchSpecification struct {
 	// The Base64-encoded MIME user data to make available to the instances.
 	UserData *string `locationName:"userData" type:"string"`
 
-	metadataRequestSpotLaunchSpecification `json:"-" xml:"-"`
-}
-
-type metadataRequestSpotLaunchSpecification struct {
-	SDKShapeTraits bool `type:"structure"`
+	_ struct{} `type:"structure"`
 }
 
 // String returns the string representation
@@ -21621,11 +19797,7 @@ type Reservation struct {
 	// The ID of the reservation.
 	ReservationId *string `locationName:"reservationId" type:"string"`
 
-	metadataReservation `json:"-" xml:"-"`
-}
-
-type metadataReservation struct {
-	SDKShapeTraits bool `type:"structure"`
+	_ struct{} `type:"structure"`
 }
 
 // String returns the string representation
@@ -21648,11 +19820,7 @@ type ReservedInstanceLimitPrice struct {
 	// only supported currency is USD.
 	CurrencyCode *string `locationName:"currencyCode" type:"string" enum:"CurrencyCodeValues"`
 
-	metadataReservedInstanceLimitPrice `json:"-" xml:"-"`
-}
-
-type metadataReservedInstanceLimitPrice struct {
-	SDKShapeTraits bool `type:"structure"`
+	_ struct{} `type:"structure"`
 }
 
 // String returns the string representation
@@ -21716,11 +19884,7 @@ type ReservedInstances struct {
 	// The usage price of the Reserved instance, per hour.
 	UsagePrice *float64 `locationName:"usagePrice" type:"float"`
 
-	metadataReservedInstances `json:"-" xml:"-"`
-}
-
-type metadataReservedInstances struct {
-	SDKShapeTraits bool `type:"structure"`
+	_ struct{} `type:"structure"`
 }
 
 // String returns the string representation
@@ -21748,11 +19912,7 @@ type ReservedInstancesConfiguration struct {
 	// EC2-Classic or EC2-VPC.
 	Platform *string `locationName:"platform" type:"string"`
 
-	metadataReservedInstancesConfiguration `json:"-" xml:"-"`
-}
-
-type metadataReservedInstancesConfiguration struct {
-	SDKShapeTraits bool `type:"structure"`
+	_ struct{} `type:"structure"`
 }
 
 // String returns the string representation
@@ -21770,11 +19930,7 @@ type ReservedInstancesId struct {
 	// The ID of the Reserved instance.
 	ReservedInstancesId *string `locationName:"reservedInstancesId" type:"string"`
 
-	metadataReservedInstancesId `json:"-" xml:"-"`
-}
-
-type metadataReservedInstancesId struct {
-	SDKShapeTraits bool `type:"structure"`
+	_ struct{} `type:"structure"`
 }
 
 // String returns the string representation
@@ -21821,11 +19977,7 @@ type ReservedInstancesListing struct {
 	// The last modified timestamp of the listing.
 	UpdateDate *time.Time `locationName:"updateDate" type:"timestamp" timestampFormat:"iso8601"`
 
-	metadataReservedInstancesListing `json:"-" xml:"-"`
-}
-
-type metadataReservedInstancesListing struct {
-	SDKShapeTraits bool `type:"structure"`
+	_ struct{} `type:"structure"`
 }
 
 // String returns the string representation
@@ -21869,11 +20021,7 @@ type ReservedInstancesModification struct {
 	// The time when the modification request was last updated.
 	UpdateDate *time.Time `locationName:"updateDate" type:"timestamp" timestampFormat:"iso8601"`
 
-	metadataReservedInstancesModification `json:"-" xml:"-"`
-}
-
-type metadataReservedInstancesModification struct {
-	SDKShapeTraits bool `type:"structure"`
+	_ struct{} `type:"structure"`
 }
 
 // String returns the string representation
@@ -21895,11 +20043,7 @@ type ReservedInstancesModificationResult struct {
 	// request.
 	TargetConfiguration *ReservedInstancesConfiguration `locationName:"targetConfiguration" type:"structure"`
 
-	metadataReservedInstancesModificationResult `json:"-" xml:"-"`
-}
-
-type metadataReservedInstancesModificationResult struct {
-	SDKShapeTraits bool `type:"structure"`
+	_ struct{} `type:"structure"`
 }
 
 // String returns the string representation
@@ -21957,11 +20101,7 @@ type ReservedInstancesOffering struct {
 	// The usage price of the Reserved instance, per hour.
 	UsagePrice *float64 `locationName:"usagePrice" type:"float"`
 
-	metadataReservedInstancesOffering `json:"-" xml:"-"`
-}
-
-type metadataReservedInstancesOffering struct {
-	SDKShapeTraits bool `type:"structure"`
+	_ struct{} `type:"structure"`
 }
 
 // String returns the string representation
@@ -21988,11 +20128,7 @@ type ResetImageAttributeInput struct {
 	// The ID of the AMI.
 	ImageId *string `type:"string" required:"true"`
 
-	metadataResetImageAttributeInput `json:"-" xml:"-"`
-}
-
-type metadataResetImageAttributeInput struct {
-	SDKShapeTraits bool `type:"structure"`
+	_ struct{} `type:"structure"`
 }
 
 // String returns the string representation
@@ -22006,11 +20142,7 @@ func (s ResetImageAttributeInput) GoString() string {
 }
 
 type ResetImageAttributeOutput struct {
-	metadataResetImageAttributeOutput `json:"-" xml:"-"`
-}
-
-type metadataResetImageAttributeOutput struct {
-	SDKShapeTraits bool `type:"structure"`
+	_ struct{} `type:"structure"`
 }
 
 // String returns the string representation
@@ -22036,11 +20168,7 @@ type ResetInstanceAttributeInput struct {
 	// The ID of the instance.
 	InstanceId *string `locationName:"instanceId" type:"string" required:"true"`
 
-	metadataResetInstanceAttributeInput `json:"-" xml:"-"`
-}
-
-type metadataResetInstanceAttributeInput struct {
-	SDKShapeTraits bool `type:"structure"`
+	_ struct{} `type:"structure"`
 }
 
 // String returns the string representation
@@ -22054,11 +20182,7 @@ func (s ResetInstanceAttributeInput) GoString() string {
 }
 
 type ResetInstanceAttributeOutput struct {
-	metadataResetInstanceAttributeOutput `json:"-" xml:"-"`
-}
-
-type metadataResetInstanceAttributeOutput struct {
-	SDKShapeTraits bool `type:"structure"`
+	_ struct{} `type:"structure"`
 }
 
 // String returns the string representation
@@ -22084,11 +20208,7 @@ type ResetNetworkInterfaceAttributeInput struct {
 	// The source/destination checking attribute. Resets the value to true.
 	SourceDestCheck *string `locationName:"sourceDestCheck" type:"string"`
 
-	metadataResetNetworkInterfaceAttributeInput `json:"-" xml:"-"`
-}
-
-type metadataResetNetworkInterfaceAttributeInput struct {
-	SDKShapeTraits bool `type:"structure"`
+	_ struct{} `type:"structure"`
 }
 
 // String returns the string representation
@@ -22102,11 +20222,7 @@ func (s ResetNetworkInterfaceAttributeInput) GoString() string {
 }
 
 type ResetNetworkInterfaceAttributeOutput struct {
-	metadataResetNetworkInterfaceAttributeOutput `json:"-" xml:"-"`
-}
-
-type metadataResetNetworkInterfaceAttributeOutput struct {
-	SDKShapeTraits bool `type:"structure"`
+	_ struct{} `type:"structure"`
 }
 
 // String returns the string representation
@@ -22133,11 +20249,7 @@ type ResetSnapshotAttributeInput struct {
 	// The ID of the snapshot.
 	SnapshotId *string `type:"string" required:"true"`
 
-	metadataResetSnapshotAttributeInput `json:"-" xml:"-"`
-}
-
-type metadataResetSnapshotAttributeInput struct {
-	SDKShapeTraits bool `type:"structure"`
+	_ struct{} `type:"structure"`
 }
 
 // String returns the string representation
@@ -22151,11 +20263,7 @@ func (s ResetSnapshotAttributeInput) GoString() string {
 }
 
 type ResetSnapshotAttributeOutput struct {
-	metadataResetSnapshotAttributeOutput `json:"-" xml:"-"`
-}
-
-type metadataResetSnapshotAttributeOutput struct {
-	SDKShapeTraits bool `type:"structure"`
+	_ struct{} `type:"structure"`
 }
 
 // String returns the string representation
@@ -22178,11 +20286,7 @@ type RestoreAddressToClassicInput struct {
 	// The Elastic IP address.
 	PublicIp *string `locationName:"publicIp" type:"string" required:"true"`
 
-	metadataRestoreAddressToClassicInput `json:"-" xml:"-"`
-}
-
-type metadataRestoreAddressToClassicInput struct {
-	SDKShapeTraits bool `type:"structure"`
+	_ struct{} `type:"structure"`
 }
 
 // String returns the string representation
@@ -22202,11 +20306,7 @@ type RestoreAddressToClassicOutput struct {
 	// The move status for the IP address.
 	Status *string `locationName:"status" type:"string" enum:"Status"`
 
-	metadataRestoreAddressToClassicOutput `json:"-" xml:"-"`
-}
-
-type metadataRestoreAddressToClassicOutput struct {
-	SDKShapeTraits bool `type:"structure"`
+	_ struct{} `type:"structure"`
 }
 
 // String returns the string representation
@@ -22259,11 +20359,7 @@ type RevokeSecurityGroupEgressInput struct {
 	// For the ICMP code number, use -1 to specify all ICMP codes for the ICMP type.
 	ToPort *int64 `locationName:"toPort" type:"integer"`
 
-	metadataRevokeSecurityGroupEgressInput `json:"-" xml:"-"`
-}
-
-type metadataRevokeSecurityGroupEgressInput struct {
-	SDKShapeTraits bool `type:"structure"`
+	_ struct{} `type:"structure"`
 }
 
 // String returns the string representation
@@ -22277,11 +20373,7 @@ func (s RevokeSecurityGroupEgressInput) GoString() string {
 }
 
 type RevokeSecurityGroupEgressOutput struct {
-	metadataRevokeSecurityGroupEgressOutput `json:"-" xml:"-"`
-}
-
-type metadataRevokeSecurityGroupEgressOutput struct {
-	SDKShapeTraits bool `type:"structure"`
+	_ struct{} `type:"structure"`
 }
 
 // String returns the string representation
@@ -22343,11 +20435,7 @@ type RevokeSecurityGroupIngressInput struct {
 	// For the ICMP code number, use -1 to specify all ICMP codes for the ICMP type.
 	ToPort *int64 `type:"integer"`
 
-	metadataRevokeSecurityGroupIngressInput `json:"-" xml:"-"`
-}
-
-type metadataRevokeSecurityGroupIngressInput struct {
-	SDKShapeTraits bool `type:"structure"`
+	_ struct{} `type:"structure"`
 }
 
 // String returns the string representation
@@ -22361,11 +20449,7 @@ func (s RevokeSecurityGroupIngressInput) GoString() string {
 }
 
 type RevokeSecurityGroupIngressOutput struct {
-	metadataRevokeSecurityGroupIngressOutput `json:"-" xml:"-"`
-}
-
-type metadataRevokeSecurityGroupIngressOutput struct {
-	SDKShapeTraits bool `type:"structure"`
+	_ struct{} `type:"structure"`
 }
 
 // String returns the string representation
@@ -22414,11 +20498,7 @@ type Route struct {
 	// The ID of the VPC peering connection.
 	VpcPeeringConnectionId *string `locationName:"vpcPeeringConnectionId" type:"string"`
 
-	metadataRoute `json:"-" xml:"-"`
-}
-
-type metadataRoute struct {
-	SDKShapeTraits bool `type:"structure"`
+	_ struct{} `type:"structure"`
 }
 
 // String returns the string representation
@@ -22451,11 +20531,7 @@ type RouteTable struct {
 	// The ID of the VPC.
 	VpcId *string `locationName:"vpcId" type:"string"`
 
-	metadataRouteTable `json:"-" xml:"-"`
-}
-
-type metadataRouteTable struct {
-	SDKShapeTraits bool `type:"structure"`
+	_ struct{} `type:"structure"`
 }
 
 // String returns the string representation
@@ -22482,11 +20558,7 @@ type RouteTableAssociation struct {
 	// The ID of the subnet. A subnet ID is not returned for an implicit association.
 	SubnetId *string `locationName:"subnetId" type:"string"`
 
-	metadataRouteTableAssociation `json:"-" xml:"-"`
-}
-
-type metadataRouteTableAssociation struct {
-	SDKShapeTraits bool `type:"structure"`
+	_ struct{} `type:"structure"`
 }
 
 // String returns the string representation
@@ -22633,11 +20705,7 @@ type RunInstancesInput struct {
 	// The Base64-encoded MIME user data for the instances.
 	UserData *string `type:"string"`
 
-	metadataRunInstancesInput `json:"-" xml:"-"`
-}
-
-type metadataRunInstancesInput struct {
-	SDKShapeTraits bool `type:"structure"`
+	_ struct{} `type:"structure"`
 }
 
 // String returns the string representation
@@ -22655,11 +20723,7 @@ type RunInstancesMonitoringEnabled struct {
 	// Indicates whether monitoring is enabled for the instance.
 	Enabled *bool `locationName:"enabled" type:"boolean" required:"true"`
 
-	metadataRunInstancesMonitoringEnabled `json:"-" xml:"-"`
-}
-
-type metadataRunInstancesMonitoringEnabled struct {
-	SDKShapeTraits bool `type:"structure"`
+	_ struct{} `type:"structure"`
 }
 
 // String returns the string representation
@@ -22695,11 +20759,7 @@ type S3Storage struct {
 	// The signature of the Base64 encoded JSON document.
 	UploadPolicySignature *string `locationName:"uploadPolicySignature" type:"string"`
 
-	metadataS3Storage `json:"-" xml:"-"`
-}
-
-type metadataS3Storage struct {
-	SDKShapeTraits bool `type:"structure"`
+	_ struct{} `type:"structure"`
 }
 
 // String returns the string representation
@@ -22738,11 +20798,7 @@ type SecurityGroup struct {
 	// [EC2-VPC] The ID of the VPC for the security group.
 	VpcId *string `locationName:"vpcId" type:"string"`
 
-	metadataSecurityGroup `json:"-" xml:"-"`
-}
-
-type metadataSecurityGroup struct {
-	SDKShapeTraits bool `type:"structure"`
+	_ struct{} `type:"structure"`
 }
 
 // String returns the string representation
@@ -22812,11 +20868,7 @@ type Snapshot struct {
 	// The size of the volume, in GiB.
 	VolumeSize *int64 `locationName:"volumeSize" type:"integer"`
 
-	metadataSnapshot `json:"-" xml:"-"`
-}
-
-type metadataSnapshot struct {
-	SDKShapeTraits bool `type:"structure"`
+	_ struct{} `type:"structure"`
 }
 
 // String returns the string representation
@@ -22861,11 +20913,7 @@ type SnapshotDetail struct {
 	// Describes the S3 bucket for the disk image.
 	UserBucket *UserBucketDetails `locationName:"userBucket" type:"structure"`
 
-	metadataSnapshotDetail `json:"-" xml:"-"`
-}
-
-type metadataSnapshotDetail struct {
-	SDKShapeTraits bool `type:"structure"`
+	_ struct{} `type:"structure"`
 }
 
 // String returns the string representation
@@ -22895,11 +20943,7 @@ type SnapshotDiskContainer struct {
 	// Describes the S3 bucket for the disk image.
 	UserBucket *UserBucket `type:"structure"`
 
-	metadataSnapshotDiskContainer `json:"-" xml:"-"`
-}
-
-type metadataSnapshotDiskContainer struct {
-	SDKShapeTraits bool `type:"structure"`
+	_ struct{} `type:"structure"`
 }
 
 // String returns the string representation
@@ -22941,11 +20985,7 @@ type SnapshotTaskDetail struct {
 	// The S3 bucket for the disk image.
 	UserBucket *UserBucketDetails `locationName:"userBucket" type:"structure"`
 
-	metadataSnapshotTaskDetail `json:"-" xml:"-"`
-}
-
-type metadataSnapshotTaskDetail struct {
-	SDKShapeTraits bool `type:"structure"`
+	_ struct{} `type:"structure"`
 }
 
 // String returns the string representation
@@ -22975,11 +21015,7 @@ type SpotDatafeedSubscription struct {
 	// The state of the Spot instance data feed subscription.
 	State *string `locationName:"state" type:"string" enum:"DatafeedSubscriptionState"`
 
-	metadataSpotDatafeedSubscription `json:"-" xml:"-"`
-}
-
-type metadataSpotDatafeedSubscription struct {
-	SDKShapeTraits bool `type:"structure"`
+	_ struct{} `type:"structure"`
 }
 
 // String returns the string representation
@@ -23062,11 +21098,7 @@ type SpotFleetLaunchSpecification struct {
 	// the default is 1.
 	WeightedCapacity *float64 `locationName:"weightedCapacity" type:"double"`
 
-	metadataSpotFleetLaunchSpecification `json:"-" xml:"-"`
-}
-
-type metadataSpotFleetLaunchSpecification struct {
-	SDKShapeTraits bool `type:"structure"`
+	_ struct{} `type:"structure"`
 }
 
 // String returns the string representation
@@ -23086,11 +21118,7 @@ type SpotFleetMonitoring struct {
 	// Default: false
 	Enabled *bool `locationName:"enabled" type:"boolean"`
 
-	metadataSpotFleetMonitoring `json:"-" xml:"-"`
-}
-
-type metadataSpotFleetMonitoring struct {
-	SDKShapeTraits bool `type:"structure"`
+	_ struct{} `type:"structure"`
 }
 
 // String returns the string representation
@@ -23117,11 +21145,7 @@ type SpotFleetRequestConfig struct {
 	// The state of the Spot fleet request.
 	SpotFleetRequestState *string `locationName:"spotFleetRequestState" type:"string" required:"true" enum:"BatchState"`
 
-	metadataSpotFleetRequestConfig `json:"-" xml:"-"`
-}
-
-type metadataSpotFleetRequestConfig struct {
-	SDKShapeTraits bool `type:"structure"`
+	_ struct{} `type:"structure"`
 }
 
 // String returns the string representation
@@ -23179,11 +21203,7 @@ type SpotFleetRequestConfigData struct {
 	// the request.
 	ValidUntil *time.Time `locationName:"validUntil" type:"timestamp" timestampFormat:"iso8601"`
 
-	metadataSpotFleetRequestConfigData `json:"-" xml:"-"`
-}
-
-type metadataSpotFleetRequestConfigData struct {
-	SDKShapeTraits bool `type:"structure"`
+	_ struct{} `type:"structure"`
 }
 
 // String returns the string representation
@@ -23266,11 +21286,7 @@ type SpotInstanceRequest struct {
 	// it remains active until it is canceled or this date is reached.
 	ValidUntil *time.Time `locationName:"validUntil" type:"timestamp" timestampFormat:"iso8601"`
 
-	metadataSpotInstanceRequest `json:"-" xml:"-"`
-}
-
-type metadataSpotInstanceRequest struct {
-	SDKShapeTraits bool `type:"structure"`
+	_ struct{} `type:"structure"`
 }
 
 // String returns the string representation
@@ -23291,11 +21307,7 @@ type SpotInstanceStateFault struct {
 	// The message for the Spot instance state change.
 	Message *string `locationName:"message" type:"string"`
 
-	metadataSpotInstanceStateFault `json:"-" xml:"-"`
-}
-
-type metadataSpotInstanceStateFault struct {
-	SDKShapeTraits bool `type:"structure"`
+	_ struct{} `type:"structure"`
 }
 
 // String returns the string representation
@@ -23321,11 +21333,7 @@ type SpotInstanceStatus struct {
 	// YYYY-MM-DDTHH:MM:SSZ).
 	UpdateTime *time.Time `locationName:"updateTime" type:"timestamp" timestampFormat:"iso8601"`
 
-	metadataSpotInstanceStatus `json:"-" xml:"-"`
-}
-
-type metadataSpotInstanceStatus struct {
-	SDKShapeTraits bool `type:"structure"`
+	_ struct{} `type:"structure"`
 }
 
 // String returns the string representation
@@ -23346,11 +21354,7 @@ type SpotPlacement struct {
 	// The name of the placement group (for cluster instances).
 	GroupName *string `locationName:"groupName" type:"string"`
 
-	metadataSpotPlacement `json:"-" xml:"-"`
-}
-
-type metadataSpotPlacement struct {
-	SDKShapeTraits bool `type:"structure"`
+	_ struct{} `type:"structure"`
 }
 
 // String returns the string representation
@@ -23381,11 +21385,7 @@ type SpotPrice struct {
 	// The date and time the request was created, in UTC format (for example, YYYY-MM-DDTHH:MM:SSZ).
 	Timestamp *time.Time `locationName:"timestamp" type:"timestamp" timestampFormat:"iso8601"`
 
-	metadataSpotPrice `json:"-" xml:"-"`
-}
-
-type metadataSpotPrice struct {
-	SDKShapeTraits bool `type:"structure"`
+	_ struct{} `type:"structure"`
 }
 
 // String returns the string representation
@@ -23411,11 +21411,7 @@ type StartInstancesInput struct {
 	// One or more instance IDs.
 	InstanceIds []*string `locationName:"InstanceId" locationNameList:"InstanceId" type:"list" required:"true"`
 
-	metadataStartInstancesInput `json:"-" xml:"-"`
-}
-
-type metadataStartInstancesInput struct {
-	SDKShapeTraits bool `type:"structure"`
+	_ struct{} `type:"structure"`
 }
 
 // String returns the string representation
@@ -23432,11 +21428,7 @@ type StartInstancesOutput struct {
 	// Information about one or more started instances.
 	StartingInstances []*InstanceStateChange `locationName:"instancesSet" locationNameList:"item" type:"list"`
 
-	metadataStartInstancesOutput `json:"-" xml:"-"`
-}
-
-type metadataStartInstancesOutput struct {
-	SDKShapeTraits bool `type:"structure"`
+	_ struct{} `type:"structure"`
 }
 
 // String returns the string representation
@@ -23479,11 +21471,7 @@ type StateReason struct {
 	// Client.InvalidSnapshot.NotFound: The specified snapshot was not found.
 	Message *string `locationName:"message" type:"string"`
 
-	metadataStateReason `json:"-" xml:"-"`
-}
-
-type metadataStateReason struct {
-	SDKShapeTraits bool `type:"structure"`
+	_ struct{} `type:"structure"`
 }
 
 // String returns the string representation
@@ -23514,11 +21502,7 @@ type StopInstancesInput struct {
 	// One or more instance IDs.
 	InstanceIds []*string `locationName:"InstanceId" locationNameList:"InstanceId" type:"list" required:"true"`
 
-	metadataStopInstancesInput `json:"-" xml:"-"`
-}
-
-type metadataStopInstancesInput struct {
-	SDKShapeTraits bool `type:"structure"`
+	_ struct{} `type:"structure"`
 }
 
 // String returns the string representation
@@ -23535,11 +21519,7 @@ type StopInstancesOutput struct {
 	// Information about one or more stopped instances.
 	StoppingInstances []*InstanceStateChange `locationName:"instancesSet" locationNameList:"item" type:"list"`
 
-	metadataStopInstancesOutput `json:"-" xml:"-"`
-}
-
-type metadataStopInstancesOutput struct {
-	SDKShapeTraits bool `type:"structure"`
+	_ struct{} `type:"structure"`
 }
 
 // String returns the string representation
@@ -23557,11 +21537,7 @@ type Storage struct {
 	// An Amazon S3 storage location.
 	S3 *S3Storage `type:"structure"`
 
-	metadataStorage `json:"-" xml:"-"`
-}
-
-type metadataStorage struct {
-	SDKShapeTraits bool `type:"structure"`
+	_ struct{} `type:"structure"`
 }
 
 // String returns the string representation
@@ -23604,11 +21580,7 @@ type Subnet struct {
 	// The ID of the VPC the subnet is in.
 	VpcId *string `locationName:"vpcId" type:"string"`
 
-	metadataSubnet `json:"-" xml:"-"`
-}
-
-type metadataSubnet struct {
-	SDKShapeTraits bool `type:"structure"`
+	_ struct{} `type:"structure"`
 }
 
 // String returns the string representation
@@ -23635,11 +21607,7 @@ type Tag struct {
 	// characters.
 	Value *string `locationName:"value" type:"string"`
 
-	metadataTag `json:"-" xml:"-"`
-}
-
-type metadataTag struct {
-	SDKShapeTraits bool `type:"structure"`
+	_ struct{} `type:"structure"`
 }
 
 // String returns the string representation
@@ -23666,11 +21634,7 @@ type TagDescription struct {
 	// The tag value.
 	Value *string `locationName:"value" type:"string"`
 
-	metadataTagDescription `json:"-" xml:"-"`
-}
-
-type metadataTagDescription struct {
-	SDKShapeTraits bool `type:"structure"`
+	_ struct{} `type:"structure"`
 }
 
 // String returns the string representation
@@ -23693,11 +21657,7 @@ type TerminateInstancesInput struct {
 	// One or more instance IDs.
 	InstanceIds []*string `locationName:"InstanceId" locationNameList:"InstanceId" type:"list" required:"true"`
 
-	metadataTerminateInstancesInput `json:"-" xml:"-"`
-}
-
-type metadataTerminateInstancesInput struct {
-	SDKShapeTraits bool `type:"structure"`
+	_ struct{} `type:"structure"`
 }
 
 // String returns the string representation
@@ -23714,11 +21674,7 @@ type TerminateInstancesOutput struct {
 	// Information about one or more terminated instances.
 	TerminatingInstances []*InstanceStateChange `locationName:"instancesSet" locationNameList:"item" type:"list"`
 
-	metadataTerminateInstancesOutput `json:"-" xml:"-"`
-}
-
-type metadataTerminateInstancesOutput struct {
-	SDKShapeTraits bool `type:"structure"`
+	_ struct{} `type:"structure"`
 }
 
 // String returns the string representation
@@ -23739,11 +21695,7 @@ type UnassignPrivateIpAddressesInput struct {
 	// You can specify this option multiple times to unassign more than one IP address.
 	PrivateIpAddresses []*string `locationName:"privateIpAddress" locationNameList:"PrivateIpAddress" type:"list" required:"true"`
 
-	metadataUnassignPrivateIpAddressesInput `json:"-" xml:"-"`
-}
-
-type metadataUnassignPrivateIpAddressesInput struct {
-	SDKShapeTraits bool `type:"structure"`
+	_ struct{} `type:"structure"`
 }
 
 // String returns the string representation
@@ -23757,11 +21709,7 @@ func (s UnassignPrivateIpAddressesInput) GoString() string {
 }
 
 type UnassignPrivateIpAddressesOutput struct {
-	metadataUnassignPrivateIpAddressesOutput `json:"-" xml:"-"`
-}
-
-type metadataUnassignPrivateIpAddressesOutput struct {
-	SDKShapeTraits bool `type:"structure"`
+	_ struct{} `type:"structure"`
 }
 
 // String returns the string representation
@@ -23784,11 +21732,7 @@ type UnmonitorInstancesInput struct {
 	// One or more instance IDs.
 	InstanceIds []*string `locationName:"InstanceId" locationNameList:"InstanceId" type:"list" required:"true"`
 
-	metadataUnmonitorInstancesInput `json:"-" xml:"-"`
-}
-
-type metadataUnmonitorInstancesInput struct {
-	SDKShapeTraits bool `type:"structure"`
+	_ struct{} `type:"structure"`
 }
 
 // String returns the string representation
@@ -23805,11 +21749,7 @@ type UnmonitorInstancesOutput struct {
 	// Monitoring information for one or more instances.
 	InstanceMonitorings []*InstanceMonitoring `locationName:"instancesSet" locationNameList:"item" type:"list"`
 
-	metadataUnmonitorInstancesOutput `json:"-" xml:"-"`
-}
-
-type metadataUnmonitorInstancesOutput struct {
-	SDKShapeTraits bool `type:"structure"`
+	_ struct{} `type:"structure"`
 }
 
 // String returns the string representation
@@ -23830,11 +21770,7 @@ type UnsuccessfulItem struct {
 	// The ID of the resource.
 	ResourceId *string `locationName:"resourceId" type:"string"`
 
-	metadataUnsuccessfulItem `json:"-" xml:"-"`
-}
-
-type metadataUnsuccessfulItem struct {
-	SDKShapeTraits bool `type:"structure"`
+	_ struct{} `type:"structure"`
 }
 
 // String returns the string representation
@@ -23856,11 +21792,7 @@ type UnsuccessfulItemError struct {
 	// The error message accompanying the error code.
 	Message *string `locationName:"message" type:"string" required:"true"`
 
-	metadataUnsuccessfulItemError `json:"-" xml:"-"`
-}
-
-type metadataUnsuccessfulItemError struct {
-	SDKShapeTraits bool `type:"structure"`
+	_ struct{} `type:"structure"`
 }
 
 // String returns the string representation
@@ -23881,11 +21813,7 @@ type UserBucket struct {
 	// The key for the disk image.
 	S3Key *string `type:"string"`
 
-	metadataUserBucket `json:"-" xml:"-"`
-}
-
-type metadataUserBucket struct {
-	SDKShapeTraits bool `type:"structure"`
+	_ struct{} `type:"structure"`
 }
 
 // String returns the string representation
@@ -23906,11 +21834,7 @@ type UserBucketDetails struct {
 	// The key from which the disk image was created.
 	S3Key *string `locationName:"s3Key" type:"string"`
 
-	metadataUserBucketDetails `json:"-" xml:"-"`
-}
-
-type metadataUserBucketDetails struct {
-	SDKShapeTraits bool `type:"structure"`
+	_ struct{} `type:"structure"`
 }
 
 // String returns the string representation
@@ -23928,11 +21852,7 @@ type UserData struct {
 	// The Base64-encoded MIME user data for the instance.
 	Data *string `locationName:"data" type:"string"`
 
-	metadataUserData `json:"-" xml:"-"`
-}
-
-type metadataUserData struct {
-	SDKShapeTraits bool `type:"structure"`
+	_ struct{} `type:"structure"`
 }
 
 // String returns the string representation
@@ -23958,11 +21878,7 @@ type UserIdGroupPair struct {
 	// The ID of an AWS account. EC2-Classic only.
 	UserId *string `locationName:"userId" type:"string"`
 
-	metadataUserIdGroupPair `json:"-" xml:"-"`
-}
-
-type metadataUserIdGroupPair struct {
-	SDKShapeTraits bool `type:"structure"`
+	_ struct{} `type:"structure"`
 }
 
 // String returns the string representation
@@ -23993,11 +21909,7 @@ type VgwTelemetry struct {
 	// If an error occurs, a description of the error.
 	StatusMessage *string `locationName:"statusMessage" type:"string"`
 
-	metadataVgwTelemetry `json:"-" xml:"-"`
-}
-
-type metadataVgwTelemetry struct {
-	SDKShapeTraits bool `type:"structure"`
+	_ struct{} `type:"structure"`
 }
 
 // String returns the string representation
@@ -24062,11 +21974,7 @@ type Volume struct {
 	// Provisioned IOPS (SSD) volumes, or standard for Magnetic volumes.
 	VolumeType *string `locationName:"volumeType" type:"string" enum:"VolumeType"`
 
-	metadataVolume `json:"-" xml:"-"`
-}
-
-type metadataVolume struct {
-	SDKShapeTraits bool `type:"structure"`
+	_ struct{} `type:"structure"`
 }
 
 // String returns the string representation
@@ -24099,11 +22007,7 @@ type VolumeAttachment struct {
 	// The ID of the volume.
 	VolumeId *string `locationName:"volumeId" type:"string"`
 
-	metadataVolumeAttachment `json:"-" xml:"-"`
-}
-
-type metadataVolumeAttachment struct {
-	SDKShapeTraits bool `type:"structure"`
+	_ struct{} `type:"structure"`
 }
 
 // String returns the string representation
@@ -24121,11 +22025,7 @@ type VolumeDetail struct {
 	// The size of the volume, in GiB.
 	Size *int64 `locationName:"size" type:"long" required:"true"`
 
-	metadataVolumeDetail `json:"-" xml:"-"`
-}
-
-type metadataVolumeDetail struct {
-	SDKShapeTraits bool `type:"structure"`
+	_ struct{} `type:"structure"`
 }
 
 // String returns the string representation
@@ -24152,11 +22052,7 @@ type VolumeStatusAction struct {
 	// The event type associated with this operation.
 	EventType *string `locationName:"eventType" type:"string"`
 
-	metadataVolumeStatusAction `json:"-" xml:"-"`
-}
-
-type metadataVolumeStatusAction struct {
-	SDKShapeTraits bool `type:"structure"`
+	_ struct{} `type:"structure"`
 }
 
 // String returns the string representation
@@ -24177,11 +22073,7 @@ type VolumeStatusDetails struct {
 	// The intended status of the volume status.
 	Status *string `locationName:"status" type:"string"`
 
-	metadataVolumeStatusDetails `json:"-" xml:"-"`
-}
-
-type metadataVolumeStatusDetails struct {
-	SDKShapeTraits bool `type:"structure"`
+	_ struct{} `type:"structure"`
 }
 
 // String returns the string representation
@@ -24211,11 +22103,7 @@ type VolumeStatusEvent struct {
 	// The earliest start time of the event.
 	NotBefore *time.Time `locationName:"notBefore" type:"timestamp" timestampFormat:"iso8601"`
 
-	metadataVolumeStatusEvent `json:"-" xml:"-"`
-}
-
-type metadataVolumeStatusEvent struct {
-	SDKShapeTraits bool `type:"structure"`
+	_ struct{} `type:"structure"`
 }
 
 // String returns the string representation
@@ -24236,11 +22124,7 @@ type VolumeStatusInfo struct {
 	// The status of the volume.
 	Status *string `locationName:"status" type:"string" enum:"VolumeStatusInfoStatus"`
 
-	metadataVolumeStatusInfo `json:"-" xml:"-"`
-}
-
-type metadataVolumeStatusInfo struct {
-	SDKShapeTraits bool `type:"structure"`
+	_ struct{} `type:"structure"`
 }
 
 // String returns the string representation
@@ -24270,11 +22154,7 @@ type VolumeStatusItem struct {
 	// The volume status.
 	VolumeStatus *VolumeStatusInfo `locationName:"volumeStatus" type:"structure"`
 
-	metadataVolumeStatusItem `json:"-" xml:"-"`
-}
-
-type metadataVolumeStatusItem struct {
-	SDKShapeTraits bool `type:"structure"`
+	_ struct{} `type:"structure"`
 }
 
 // String returns the string representation
@@ -24311,11 +22191,7 @@ type Vpc struct {
 	// The ID of the VPC.
 	VpcId *string `locationName:"vpcId" type:"string"`
 
-	metadataVpc `json:"-" xml:"-"`
-}
-
-type metadataVpc struct {
-	SDKShapeTraits bool `type:"structure"`
+	_ struct{} `type:"structure"`
 }
 
 // String returns the string representation
@@ -24336,11 +22212,7 @@ type VpcAttachment struct {
 	// The ID of the VPC.
 	VpcId *string `locationName:"vpcId" type:"string"`
 
-	metadataVpcAttachment `json:"-" xml:"-"`
-}
-
-type metadataVpcAttachment struct {
-	SDKShapeTraits bool `type:"structure"`
+	_ struct{} `type:"structure"`
 }
 
 // String returns the string representation
@@ -24364,11 +22236,7 @@ type VpcClassicLink struct {
 	// The ID of the VPC.
 	VpcId *string `locationName:"vpcId" type:"string"`
 
-	metadataVpcClassicLink `json:"-" xml:"-"`
-}
-
-type metadataVpcClassicLink struct {
-	SDKShapeTraits bool `type:"structure"`
+	_ struct{} `type:"structure"`
 }
 
 // String returns the string representation
@@ -24404,11 +22272,7 @@ type VpcEndpoint struct {
 	// The ID of the VPC to which the endpoint is associated.
 	VpcId *string `locationName:"vpcId" type:"string"`
 
-	metadataVpcEndpoint `json:"-" xml:"-"`
-}
-
-type metadataVpcEndpoint struct {
-	SDKShapeTraits bool `type:"structure"`
+	_ struct{} `type:"structure"`
 }
 
 // String returns the string representation
@@ -24441,11 +22305,7 @@ type VpcPeeringConnection struct {
 	// The ID of the VPC peering connection.
 	VpcPeeringConnectionId *string `locationName:"vpcPeeringConnectionId" type:"string"`
 
-	metadataVpcPeeringConnection `json:"-" xml:"-"`
-}
-
-type metadataVpcPeeringConnection struct {
-	SDKShapeTraits bool `type:"structure"`
+	_ struct{} `type:"structure"`
 }
 
 // String returns the string representation
@@ -24466,11 +22326,7 @@ type VpcPeeringConnectionStateReason struct {
 	// A message that provides more information about the status, if applicable.
 	Message *string `locationName:"message" type:"string"`
 
-	metadataVpcPeeringConnectionStateReason `json:"-" xml:"-"`
-}
-
-type metadataVpcPeeringConnectionStateReason struct {
-	SDKShapeTraits bool `type:"structure"`
+	_ struct{} `type:"structure"`
 }
 
 // String returns the string representation
@@ -24494,11 +22350,7 @@ type VpcPeeringConnectionVpcInfo struct {
 	// The ID of the VPC.
 	VpcId *string `locationName:"vpcId" type:"string"`
 
-	metadataVpcPeeringConnectionVpcInfo `json:"-" xml:"-"`
-}
-
-type metadataVpcPeeringConnectionVpcInfo struct {
-	SDKShapeTraits bool `type:"structure"`
+	_ struct{} `type:"structure"`
 }
 
 // String returns the string representation
@@ -24546,11 +22398,7 @@ type VpnConnection struct {
 	// The ID of the virtual private gateway at the AWS side of the VPN connection.
 	VpnGatewayId *string `locationName:"vpnGatewayId" type:"string"`
 
-	metadataVpnConnection `json:"-" xml:"-"`
-}
-
-type metadataVpnConnection struct {
-	SDKShapeTraits bool `type:"structure"`
+	_ struct{} `type:"structure"`
 }
 
 // String returns the string representation
@@ -24569,11 +22417,7 @@ type VpnConnectionOptions struct {
 	// must be used for devices that don't support BGP.
 	StaticRoutesOnly *bool `locationName:"staticRoutesOnly" type:"boolean"`
 
-	metadataVpnConnectionOptions `json:"-" xml:"-"`
-}
-
-type metadataVpnConnectionOptions struct {
-	SDKShapeTraits bool `type:"structure"`
+	_ struct{} `type:"structure"`
 }
 
 // String returns the string representation
@@ -24592,11 +22436,7 @@ type VpnConnectionOptionsSpecification struct {
 	// must be used for devices that don't support BGP.
 	StaticRoutesOnly *bool `locationName:"staticRoutesOnly" type:"boolean"`
 
-	metadataVpnConnectionOptionsSpecification `json:"-" xml:"-"`
-}
-
-type metadataVpnConnectionOptionsSpecification struct {
-	SDKShapeTraits bool `type:"structure"`
+	_ struct{} `type:"structure"`
 }
 
 // String returns the string representation
@@ -24629,11 +22469,7 @@ type VpnGateway struct {
 	// The ID of the virtual private gateway.
 	VpnGatewayId *string `locationName:"vpnGatewayId" type:"string"`
 
-	metadataVpnGateway `json:"-" xml:"-"`
-}
-
-type metadataVpnGateway struct {
-	SDKShapeTraits bool `type:"structure"`
+	_ struct{} `type:"structure"`
 }
 
 // String returns the string representation
@@ -24657,11 +22493,7 @@ type VpnStaticRoute struct {
 	// The current state of the static route.
 	State *string `locationName:"state" type:"string" enum:"VpnState"`
 
-	metadataVpnStaticRoute `json:"-" xml:"-"`
-}
-
-type metadataVpnStaticRoute struct {
-	SDKShapeTraits bool `type:"structure"`
+	_ struct{} `type:"structure"`
 }
 
 // String returns the string representation

--- a/service/ec2/api.go
+++ b/service/ec2/api.go
@@ -6621,6 +6621,8 @@ func (c *EC2) UnmonitorInstances(input *UnmonitorInstancesInput) (*UnmonitorInst
 }
 
 type AcceptVpcPeeringConnectionInput struct {
+	_ struct{} `type:"structure"`
+
 	// Checks whether you have the required permissions for the action, without
 	// actually making the request, and provides an error response. If you have
 	// the required permissions, the error response is DryRunOperation. Otherwise,
@@ -6629,8 +6631,6 @@ type AcceptVpcPeeringConnectionInput struct {
 
 	// The ID of the VPC peering connection.
 	VpcPeeringConnectionId *string `locationName:"vpcPeeringConnectionId" type:"string"`
-
-	_ struct{} `type:"structure"`
 }
 
 // String returns the string representation
@@ -6644,10 +6644,10 @@ func (s AcceptVpcPeeringConnectionInput) GoString() string {
 }
 
 type AcceptVpcPeeringConnectionOutput struct {
+	_ struct{} `type:"structure"`
+
 	// Information about the VPC peering connection.
 	VpcPeeringConnection *VpcPeeringConnection `locationName:"vpcPeeringConnection" type:"structure"`
-
-	_ struct{} `type:"structure"`
 }
 
 // String returns the string representation
@@ -6662,13 +6662,13 @@ func (s AcceptVpcPeeringConnectionOutput) GoString() string {
 
 // Describes an account attribute.
 type AccountAttribute struct {
+	_ struct{} `type:"structure"`
+
 	// The name of the account attribute.
 	AttributeName *string `locationName:"attributeName" type:"string"`
 
 	// One or more values for the account attribute.
 	AttributeValues []*AccountAttributeValue `locationName:"attributeValueSet" locationNameList:"item" type:"list"`
-
-	_ struct{} `type:"structure"`
 }
 
 // String returns the string representation
@@ -6683,10 +6683,10 @@ func (s AccountAttribute) GoString() string {
 
 // Describes a value of an account attribute.
 type AccountAttributeValue struct {
+	_ struct{} `type:"structure"`
+
 	// The value of the attribute.
 	AttributeValue *string `locationName:"attributeValue" type:"string"`
-
-	_ struct{} `type:"structure"`
 }
 
 // String returns the string representation
@@ -6701,6 +6701,8 @@ func (s AccountAttributeValue) GoString() string {
 
 // Describes a running instance in a Spot fleet.
 type ActiveInstance struct {
+	_ struct{} `type:"structure"`
+
 	// The ID of the instance.
 	InstanceId *string `locationName:"instanceId" type:"string"`
 
@@ -6709,8 +6711,6 @@ type ActiveInstance struct {
 
 	// The ID of the Spot instance request.
 	SpotInstanceRequestId *string `locationName:"spotInstanceRequestId" type:"string"`
-
-	_ struct{} `type:"structure"`
 }
 
 // String returns the string representation
@@ -6725,6 +6725,8 @@ func (s ActiveInstance) GoString() string {
 
 // Describes an Elastic IP address.
 type Address struct {
+	_ struct{} `type:"structure"`
+
 	// The ID representing the allocation of the address for use with EC2-VPC.
 	AllocationId *string `locationName:"allocationId" type:"string"`
 
@@ -6750,8 +6752,6 @@ type Address struct {
 
 	// The Elastic IP address.
 	PublicIp *string `locationName:"publicIp" type:"string"`
-
-	_ struct{} `type:"structure"`
 }
 
 // String returns the string representation
@@ -6765,6 +6765,8 @@ func (s Address) GoString() string {
 }
 
 type AllocateAddressInput struct {
+	_ struct{} `type:"structure"`
+
 	// Set to vpc to allocate the address for use with instances in a VPC.
 	//
 	// Default: The address is for use with instances in EC2-Classic.
@@ -6775,8 +6777,6 @@ type AllocateAddressInput struct {
 	// the required permissions, the error response is DryRunOperation. Otherwise,
 	// it is UnauthorizedOperation.
 	DryRun *bool `locationName:"dryRun" type:"boolean"`
-
-	_ struct{} `type:"structure"`
 }
 
 // String returns the string representation
@@ -6790,6 +6790,8 @@ func (s AllocateAddressInput) GoString() string {
 }
 
 type AllocateAddressOutput struct {
+	_ struct{} `type:"structure"`
+
 	// [EC2-VPC] The ID that AWS assigns to represent the allocation of the Elastic
 	// IP address for use with instances in a VPC.
 	AllocationId *string `locationName:"allocationId" type:"string"`
@@ -6800,8 +6802,6 @@ type AllocateAddressOutput struct {
 
 	// The Elastic IP address.
 	PublicIp *string `locationName:"publicIp" type:"string"`
-
-	_ struct{} `type:"structure"`
 }
 
 // String returns the string representation
@@ -6815,6 +6815,8 @@ func (s AllocateAddressOutput) GoString() string {
 }
 
 type AllocateHostsInput struct {
+	_ struct{} `type:"structure"`
+
 	// This is enabled by default. This property allows instances to be automatically
 	// placed onto available Dedicated hosts, when you are launching instances without
 	// specifying a host ID.
@@ -6838,8 +6840,6 @@ type AllocateHostsInput struct {
 	// The number of Dedicated hosts you want to allocate to your account with these
 	// parameters.
 	Quantity *int64 `locationName:"quantity" type:"integer" required:"true"`
-
-	_ struct{} `type:"structure"`
 }
 
 // String returns the string representation
@@ -6853,11 +6853,11 @@ func (s AllocateHostsInput) GoString() string {
 }
 
 type AllocateHostsOutput struct {
+	_ struct{} `type:"structure"`
+
 	// The ID of the allocated Dedicated host. This is used when you want to launch
 	// an instance onto a specific host.
 	HostIds []*string `locationName:"hostIdSet" locationNameList:"item" type:"list"`
-
-	_ struct{} `type:"structure"`
 }
 
 // String returns the string representation
@@ -6871,6 +6871,8 @@ func (s AllocateHostsOutput) GoString() string {
 }
 
 type AssignPrivateIpAddressesInput struct {
+	_ struct{} `type:"structure"`
+
 	// Indicates whether to allow an IP address that is already assigned to another
 	// network interface or instance to be reassigned to the specified network interface.
 	AllowReassignment *bool `locationName:"allowReassignment" type:"boolean"`
@@ -6889,8 +6891,6 @@ type AssignPrivateIpAddressesInput struct {
 	// The number of secondary IP addresses to assign to the network interface.
 	// You can't specify this parameter when also specifying private IP addresses.
 	SecondaryPrivateIpAddressCount *int64 `locationName:"secondaryPrivateIpAddressCount" type:"integer"`
-
-	_ struct{} `type:"structure"`
 }
 
 // String returns the string representation
@@ -6918,6 +6918,8 @@ func (s AssignPrivateIpAddressesOutput) GoString() string {
 }
 
 type AssociateAddressInput struct {
+	_ struct{} `type:"structure"`
+
 	// [EC2-VPC] The allocation ID. This is required for EC2-VPC.
 	AllocationId *string `type:"string"`
 
@@ -6952,8 +6954,6 @@ type AssociateAddressInput struct {
 
 	// The Elastic IP address. This is required for EC2-Classic.
 	PublicIp *string `type:"string"`
-
-	_ struct{} `type:"structure"`
 }
 
 // String returns the string representation
@@ -6967,11 +6967,11 @@ func (s AssociateAddressInput) GoString() string {
 }
 
 type AssociateAddressOutput struct {
+	_ struct{} `type:"structure"`
+
 	// [EC2-VPC] The ID that represents the association of the Elastic IP address
 	// with an instance.
 	AssociationId *string `locationName:"associationId" type:"string"`
-
-	_ struct{} `type:"structure"`
 }
 
 // String returns the string representation
@@ -6985,6 +6985,8 @@ func (s AssociateAddressOutput) GoString() string {
 }
 
 type AssociateDhcpOptionsInput struct {
+	_ struct{} `type:"structure"`
+
 	// The ID of the DHCP options set, or default to associate no DHCP options with
 	// the VPC.
 	DhcpOptionsId *string `type:"string" required:"true"`
@@ -6997,8 +6999,6 @@ type AssociateDhcpOptionsInput struct {
 
 	// The ID of the VPC.
 	VpcId *string `type:"string" required:"true"`
-
-	_ struct{} `type:"structure"`
 }
 
 // String returns the string representation
@@ -7026,6 +7026,8 @@ func (s AssociateDhcpOptionsOutput) GoString() string {
 }
 
 type AssociateRouteTableInput struct {
+	_ struct{} `type:"structure"`
+
 	// Checks whether you have the required permissions for the action, without
 	// actually making the request, and provides an error response. If you have
 	// the required permissions, the error response is DryRunOperation. Otherwise,
@@ -7037,8 +7039,6 @@ type AssociateRouteTableInput struct {
 
 	// The ID of the subnet.
 	SubnetId *string `locationName:"subnetId" type:"string" required:"true"`
-
-	_ struct{} `type:"structure"`
 }
 
 // String returns the string representation
@@ -7052,10 +7052,10 @@ func (s AssociateRouteTableInput) GoString() string {
 }
 
 type AssociateRouteTableOutput struct {
+	_ struct{} `type:"structure"`
+
 	// The route table association ID (needed to disassociate the route table).
 	AssociationId *string `locationName:"associationId" type:"string"`
-
-	_ struct{} `type:"structure"`
 }
 
 // String returns the string representation
@@ -7069,6 +7069,8 @@ func (s AssociateRouteTableOutput) GoString() string {
 }
 
 type AttachClassicLinkVpcInput struct {
+	_ struct{} `type:"structure"`
+
 	// Checks whether you have the required permissions for the action, without
 	// actually making the request, and provides an error response. If you have
 	// the required permissions, the error response is DryRunOperation. Otherwise,
@@ -7084,8 +7086,6 @@ type AttachClassicLinkVpcInput struct {
 
 	// The ID of a ClassicLink-enabled VPC.
 	VpcId *string `locationName:"vpcId" type:"string" required:"true"`
-
-	_ struct{} `type:"structure"`
 }
 
 // String returns the string representation
@@ -7099,10 +7099,10 @@ func (s AttachClassicLinkVpcInput) GoString() string {
 }
 
 type AttachClassicLinkVpcOutput struct {
+	_ struct{} `type:"structure"`
+
 	// Returns true if the request succeeds; otherwise, it returns an error.
 	Return *bool `locationName:"return" type:"boolean"`
-
-	_ struct{} `type:"structure"`
 }
 
 // String returns the string representation
@@ -7116,6 +7116,8 @@ func (s AttachClassicLinkVpcOutput) GoString() string {
 }
 
 type AttachInternetGatewayInput struct {
+	_ struct{} `type:"structure"`
+
 	// Checks whether you have the required permissions for the action, without
 	// actually making the request, and provides an error response. If you have
 	// the required permissions, the error response is DryRunOperation. Otherwise,
@@ -7127,8 +7129,6 @@ type AttachInternetGatewayInput struct {
 
 	// The ID of the VPC.
 	VpcId *string `locationName:"vpcId" type:"string" required:"true"`
-
-	_ struct{} `type:"structure"`
 }
 
 // String returns the string representation
@@ -7156,6 +7156,8 @@ func (s AttachInternetGatewayOutput) GoString() string {
 }
 
 type AttachNetworkInterfaceInput struct {
+	_ struct{} `type:"structure"`
+
 	// The index of the device for the network interface attachment.
 	DeviceIndex *int64 `locationName:"deviceIndex" type:"integer" required:"true"`
 
@@ -7170,8 +7172,6 @@ type AttachNetworkInterfaceInput struct {
 
 	// The ID of the network interface.
 	NetworkInterfaceId *string `locationName:"networkInterfaceId" type:"string" required:"true"`
-
-	_ struct{} `type:"structure"`
 }
 
 // String returns the string representation
@@ -7185,10 +7185,10 @@ func (s AttachNetworkInterfaceInput) GoString() string {
 }
 
 type AttachNetworkInterfaceOutput struct {
+	_ struct{} `type:"structure"`
+
 	// The ID of the network interface attachment.
 	AttachmentId *string `locationName:"attachmentId" type:"string"`
-
-	_ struct{} `type:"structure"`
 }
 
 // String returns the string representation
@@ -7202,6 +7202,8 @@ func (s AttachNetworkInterfaceOutput) GoString() string {
 }
 
 type AttachVolumeInput struct {
+	_ struct{} `type:"structure"`
+
 	// The device name to expose to the instance (for example, /dev/sdh or xvdh).
 	Device *string `type:"string" required:"true"`
 
@@ -7217,8 +7219,6 @@ type AttachVolumeInput struct {
 	// The ID of the EBS volume. The volume and instance must be within the same
 	// Availability Zone.
 	VolumeId *string `type:"string" required:"true"`
-
-	_ struct{} `type:"structure"`
 }
 
 // String returns the string representation
@@ -7232,6 +7232,8 @@ func (s AttachVolumeInput) GoString() string {
 }
 
 type AttachVpnGatewayInput struct {
+	_ struct{} `type:"structure"`
+
 	// Checks whether you have the required permissions for the action, without
 	// actually making the request, and provides an error response. If you have
 	// the required permissions, the error response is DryRunOperation. Otherwise,
@@ -7243,8 +7245,6 @@ type AttachVpnGatewayInput struct {
 
 	// The ID of the virtual private gateway.
 	VpnGatewayId *string `type:"string" required:"true"`
-
-	_ struct{} `type:"structure"`
 }
 
 // String returns the string representation
@@ -7258,10 +7258,10 @@ func (s AttachVpnGatewayInput) GoString() string {
 }
 
 type AttachVpnGatewayOutput struct {
+	_ struct{} `type:"structure"`
+
 	// Information about the attachment.
 	VpcAttachment *VpcAttachment `locationName:"attachment" type:"structure"`
-
-	_ struct{} `type:"structure"`
 }
 
 // String returns the string representation
@@ -7276,10 +7276,10 @@ func (s AttachVpnGatewayOutput) GoString() string {
 
 // The value to use when a resource attribute accepts a Boolean value.
 type AttributeBooleanValue struct {
+	_ struct{} `type:"structure"`
+
 	// Valid values are true or false.
 	Value *bool `locationName:"value" type:"boolean"`
-
-	_ struct{} `type:"structure"`
 }
 
 // String returns the string representation
@@ -7294,10 +7294,10 @@ func (s AttributeBooleanValue) GoString() string {
 
 // The value to use for a resource attribute.
 type AttributeValue struct {
+	_ struct{} `type:"structure"`
+
 	// Valid values are case-sensitive and vary by action.
 	Value *string `locationName:"value" type:"string"`
-
-	_ struct{} `type:"structure"`
 }
 
 // String returns the string representation
@@ -7311,6 +7311,8 @@ func (s AttributeValue) GoString() string {
 }
 
 type AuthorizeSecurityGroupEgressInput struct {
+	_ struct{} `type:"structure"`
+
 	// The CIDR IP address range. You can't specify this parameter when specifying
 	// a source security group.
 	CidrIp *string `locationName:"cidrIp" type:"string"`
@@ -7349,8 +7351,6 @@ type AuthorizeSecurityGroupEgressInput struct {
 	// The end of port range for the TCP and UDP protocols, or an ICMP code number.
 	// For the ICMP code number, use -1 to specify all ICMP codes for the ICMP type.
 	ToPort *int64 `locationName:"toPort" type:"integer"`
-
-	_ struct{} `type:"structure"`
 }
 
 // String returns the string representation
@@ -7378,6 +7378,8 @@ func (s AuthorizeSecurityGroupEgressOutput) GoString() string {
 }
 
 type AuthorizeSecurityGroupIngressInput struct {
+	_ struct{} `type:"structure"`
+
 	// The CIDR IP address range. You can't specify this parameter when specifying
 	// a source security group.
 	CidrIp *string `type:"string"`
@@ -7425,8 +7427,6 @@ type AuthorizeSecurityGroupIngressInput struct {
 	// The end of port range for the TCP and UDP protocols, or an ICMP code number.
 	// For the ICMP code number, use -1 to specify all ICMP codes for the ICMP type.
 	ToPort *int64 `type:"integer"`
-
-	_ struct{} `type:"structure"`
 }
 
 // String returns the string representation
@@ -7455,6 +7455,8 @@ func (s AuthorizeSecurityGroupIngressOutput) GoString() string {
 
 // Describes an Availability Zone.
 type AvailabilityZone struct {
+	_ struct{} `type:"structure"`
+
 	// Any messages about the Availability Zone.
 	Messages []*AvailabilityZoneMessage `locationName:"messageSet" locationNameList:"item" type:"list"`
 
@@ -7466,8 +7468,6 @@ type AvailabilityZone struct {
 
 	// The name of the Availability Zone.
 	ZoneName *string `locationName:"zoneName" type:"string"`
-
-	_ struct{} `type:"structure"`
 }
 
 // String returns the string representation
@@ -7482,10 +7482,10 @@ func (s AvailabilityZone) GoString() string {
 
 // Describes a message about an Availability Zone.
 type AvailabilityZoneMessage struct {
+	_ struct{} `type:"structure"`
+
 	// The message about the Availability Zone.
 	Message *string `locationName:"message" type:"string"`
-
-	_ struct{} `type:"structure"`
 }
 
 // String returns the string representation
@@ -7499,13 +7499,13 @@ func (s AvailabilityZoneMessage) GoString() string {
 }
 
 type AvailableCapacity struct {
+	_ struct{} `type:"structure"`
+
 	// The total number of instances that the Dedicated host supports.
 	AvailableInstanceCapacity []*InstanceCapacity `locationName:"availableInstanceCapacity" locationNameList:"item" type:"list"`
 
 	// The number of vCPUs available on the Dedicated host.
 	AvailableVCpus *int64 `locationName:"availableVCpus" type:"integer"`
-
-	_ struct{} `type:"structure"`
 }
 
 // String returns the string representation
@@ -7519,9 +7519,9 @@ func (s AvailableCapacity) GoString() string {
 }
 
 type BlobAttributeValue struct {
-	Value []byte `locationName:"value" type:"blob"`
-
 	_ struct{} `type:"structure"`
+
+	Value []byte `locationName:"value" type:"blob"`
 }
 
 // String returns the string representation
@@ -7536,6 +7536,8 @@ func (s BlobAttributeValue) GoString() string {
 
 // Describes a block device mapping.
 type BlockDeviceMapping struct {
+	_ struct{} `type:"structure"`
+
 	// The device name exposed to the instance (for example, /dev/sdh or xvdh).
 	DeviceName *string `locationName:"deviceName" type:"string"`
 
@@ -7558,8 +7560,6 @@ type BlockDeviceMapping struct {
 	// we ignore any instance store volumes specified in the block device mapping
 	// for the AMI.
 	VirtualName *string `locationName:"virtualName" type:"string"`
-
-	_ struct{} `type:"structure"`
 }
 
 // String returns the string representation
@@ -7573,6 +7573,8 @@ func (s BlockDeviceMapping) GoString() string {
 }
 
 type BundleInstanceInput struct {
+	_ struct{} `type:"structure"`
+
 	// Checks whether you have the required permissions for the action, without
 	// actually making the request, and provides an error response. If you have
 	// the required permissions, the error response is DryRunOperation. Otherwise,
@@ -7592,8 +7594,6 @@ type BundleInstanceInput struct {
 	// own or a new bucket that Amazon EC2 creates on your behalf. If you specify
 	// a bucket that belongs to someone else, Amazon EC2 returns an error.
 	Storage *Storage `type:"structure" required:"true"`
-
-	_ struct{} `type:"structure"`
 }
 
 // String returns the string representation
@@ -7607,10 +7607,10 @@ func (s BundleInstanceInput) GoString() string {
 }
 
 type BundleInstanceOutput struct {
+	_ struct{} `type:"structure"`
+
 	// Information about the bundle task.
 	BundleTask *BundleTask `locationName:"bundleInstanceTask" type:"structure"`
-
-	_ struct{} `type:"structure"`
 }
 
 // String returns the string representation
@@ -7625,6 +7625,8 @@ func (s BundleInstanceOutput) GoString() string {
 
 // Describes a bundle task.
 type BundleTask struct {
+	_ struct{} `type:"structure"`
+
 	// The ID of the bundle task.
 	BundleId *string `locationName:"bundleId" type:"string"`
 
@@ -7648,8 +7650,6 @@ type BundleTask struct {
 
 	// The time of the most recent update for the task.
 	UpdateTime *time.Time `locationName:"updateTime" type:"timestamp" timestampFormat:"iso8601"`
-
-	_ struct{} `type:"structure"`
 }
 
 // String returns the string representation
@@ -7664,13 +7664,13 @@ func (s BundleTask) GoString() string {
 
 // Describes an error for BundleInstance.
 type BundleTaskError struct {
+	_ struct{} `type:"structure"`
+
 	// The error code.
 	Code *string `locationName:"code" type:"string"`
 
 	// The error message.
 	Message *string `locationName:"message" type:"string"`
-
-	_ struct{} `type:"structure"`
 }
 
 // String returns the string representation
@@ -7684,6 +7684,8 @@ func (s BundleTaskError) GoString() string {
 }
 
 type CancelBundleTaskInput struct {
+	_ struct{} `type:"structure"`
+
 	// The ID of the bundle task.
 	BundleId *string `type:"string" required:"true"`
 
@@ -7692,8 +7694,6 @@ type CancelBundleTaskInput struct {
 	// the required permissions, the error response is DryRunOperation. Otherwise,
 	// it is UnauthorizedOperation.
 	DryRun *bool `locationName:"dryRun" type:"boolean"`
-
-	_ struct{} `type:"structure"`
 }
 
 // String returns the string representation
@@ -7707,10 +7707,10 @@ func (s CancelBundleTaskInput) GoString() string {
 }
 
 type CancelBundleTaskOutput struct {
+	_ struct{} `type:"structure"`
+
 	// Information about the bundle task.
 	BundleTask *BundleTask `locationName:"bundleInstanceTask" type:"structure"`
-
-	_ struct{} `type:"structure"`
 }
 
 // String returns the string representation
@@ -7724,6 +7724,8 @@ func (s CancelBundleTaskOutput) GoString() string {
 }
 
 type CancelConversionTaskInput struct {
+	_ struct{} `type:"structure"`
+
 	// The ID of the conversion task.
 	ConversionTaskId *string `locationName:"conversionTaskId" type:"string" required:"true"`
 
@@ -7735,8 +7737,6 @@ type CancelConversionTaskInput struct {
 
 	// The reason for canceling the conversion task.
 	ReasonMessage *string `locationName:"reasonMessage" type:"string"`
-
-	_ struct{} `type:"structure"`
 }
 
 // String returns the string representation
@@ -7764,10 +7764,10 @@ func (s CancelConversionTaskOutput) GoString() string {
 }
 
 type CancelExportTaskInput struct {
+	_ struct{} `type:"structure"`
+
 	// The ID of the export task. This is the ID returned by CreateInstanceExportTask.
 	ExportTaskId *string `locationName:"exportTaskId" type:"string" required:"true"`
-
-	_ struct{} `type:"structure"`
 }
 
 // String returns the string representation
@@ -7795,6 +7795,8 @@ func (s CancelExportTaskOutput) GoString() string {
 }
 
 type CancelImportTaskInput struct {
+	_ struct{} `type:"structure"`
+
 	// The reason for canceling the task.
 	CancelReason *string `type:"string"`
 
@@ -7806,8 +7808,6 @@ type CancelImportTaskInput struct {
 
 	// The ID of the import image or import snapshot task to be canceled.
 	ImportTaskId *string `type:"string"`
-
-	_ struct{} `type:"structure"`
 }
 
 // String returns the string representation
@@ -7821,6 +7821,8 @@ func (s CancelImportTaskInput) GoString() string {
 }
 
 type CancelImportTaskOutput struct {
+	_ struct{} `type:"structure"`
+
 	// The ID of the task being canceled.
 	ImportTaskId *string `locationName:"importTaskId" type:"string"`
 
@@ -7829,8 +7831,6 @@ type CancelImportTaskOutput struct {
 
 	// The current state of the task being canceled.
 	State *string `locationName:"state" type:"string"`
-
-	_ struct{} `type:"structure"`
 }
 
 // String returns the string representation
@@ -7844,10 +7844,10 @@ func (s CancelImportTaskOutput) GoString() string {
 }
 
 type CancelReservedInstancesListingInput struct {
+	_ struct{} `type:"structure"`
+
 	// The ID of the Reserved instance listing.
 	ReservedInstancesListingId *string `locationName:"reservedInstancesListingId" type:"string" required:"true"`
-
-	_ struct{} `type:"structure"`
 }
 
 // String returns the string representation
@@ -7861,10 +7861,10 @@ func (s CancelReservedInstancesListingInput) GoString() string {
 }
 
 type CancelReservedInstancesListingOutput struct {
+	_ struct{} `type:"structure"`
+
 	// The Reserved instance listing.
 	ReservedInstancesListings []*ReservedInstancesListing `locationName:"reservedInstancesListingsSet" locationNameList:"item" type:"list"`
-
-	_ struct{} `type:"structure"`
 }
 
 // String returns the string representation
@@ -7879,13 +7879,13 @@ func (s CancelReservedInstancesListingOutput) GoString() string {
 
 // Describes a Spot fleet error.
 type CancelSpotFleetRequestsError struct {
+	_ struct{} `type:"structure"`
+
 	// The error code.
 	Code *string `locationName:"code" type:"string" required:"true" enum:"CancelBatchErrorCode"`
 
 	// The description for the error code.
 	Message *string `locationName:"message" type:"string" required:"true"`
-
-	_ struct{} `type:"structure"`
 }
 
 // String returns the string representation
@@ -7900,13 +7900,13 @@ func (s CancelSpotFleetRequestsError) GoString() string {
 
 // Describes a Spot fleet request that was not successfully canceled.
 type CancelSpotFleetRequestsErrorItem struct {
+	_ struct{} `type:"structure"`
+
 	// The error.
 	Error *CancelSpotFleetRequestsError `locationName:"error" type:"structure" required:"true"`
 
 	// The ID of the Spot fleet request.
 	SpotFleetRequestId *string `locationName:"spotFleetRequestId" type:"string" required:"true"`
-
-	_ struct{} `type:"structure"`
 }
 
 // String returns the string representation
@@ -7921,6 +7921,8 @@ func (s CancelSpotFleetRequestsErrorItem) GoString() string {
 
 // Contains the parameters for CancelSpotFleetRequests.
 type CancelSpotFleetRequestsInput struct {
+	_ struct{} `type:"structure"`
+
 	// Checks whether you have the required permissions for the action, without
 	// actually making the request, and provides an error response. If you have
 	// the required permissions, the error response is DryRunOperation. Otherwise,
@@ -7933,8 +7935,6 @@ type CancelSpotFleetRequestsInput struct {
 	// Indicates whether to terminate instances for a Spot fleet request if it is
 	// canceled successfully.
 	TerminateInstances *bool `locationName:"terminateInstances" type:"boolean" required:"true"`
-
-	_ struct{} `type:"structure"`
 }
 
 // String returns the string representation
@@ -7949,13 +7949,13 @@ func (s CancelSpotFleetRequestsInput) GoString() string {
 
 // Contains the output of CancelSpotFleetRequests.
 type CancelSpotFleetRequestsOutput struct {
+	_ struct{} `type:"structure"`
+
 	// Information about the Spot fleet requests that are successfully canceled.
 	SuccessfulFleetRequests []*CancelSpotFleetRequestsSuccessItem `locationName:"successfulFleetRequestSet" locationNameList:"item" type:"list"`
 
 	// Information about the Spot fleet requests that are not successfully canceled.
 	UnsuccessfulFleetRequests []*CancelSpotFleetRequestsErrorItem `locationName:"unsuccessfulFleetRequestSet" locationNameList:"item" type:"list"`
-
-	_ struct{} `type:"structure"`
 }
 
 // String returns the string representation
@@ -7970,6 +7970,8 @@ func (s CancelSpotFleetRequestsOutput) GoString() string {
 
 // Describes a Spot fleet request that was successfully canceled.
 type CancelSpotFleetRequestsSuccessItem struct {
+	_ struct{} `type:"structure"`
+
 	// The current state of the Spot fleet request.
 	CurrentSpotFleetRequestState *string `locationName:"currentSpotFleetRequestState" type:"string" required:"true" enum:"BatchState"`
 
@@ -7978,8 +7980,6 @@ type CancelSpotFleetRequestsSuccessItem struct {
 
 	// The ID of the Spot fleet request.
 	SpotFleetRequestId *string `locationName:"spotFleetRequestId" type:"string" required:"true"`
-
-	_ struct{} `type:"structure"`
 }
 
 // String returns the string representation
@@ -7994,6 +7994,8 @@ func (s CancelSpotFleetRequestsSuccessItem) GoString() string {
 
 // Contains the parameters for CancelSpotInstanceRequests.
 type CancelSpotInstanceRequestsInput struct {
+	_ struct{} `type:"structure"`
+
 	// Checks whether you have the required permissions for the action, without
 	// actually making the request, and provides an error response. If you have
 	// the required permissions, the error response is DryRunOperation. Otherwise,
@@ -8002,8 +8004,6 @@ type CancelSpotInstanceRequestsInput struct {
 
 	// One or more Spot instance request IDs.
 	SpotInstanceRequestIds []*string `locationName:"SpotInstanceRequestId" locationNameList:"SpotInstanceRequestId" type:"list" required:"true"`
-
-	_ struct{} `type:"structure"`
 }
 
 // String returns the string representation
@@ -8018,10 +8018,10 @@ func (s CancelSpotInstanceRequestsInput) GoString() string {
 
 // Contains the output of CancelSpotInstanceRequests.
 type CancelSpotInstanceRequestsOutput struct {
+	_ struct{} `type:"structure"`
+
 	// One or more Spot instance requests.
 	CancelledSpotInstanceRequests []*CancelledSpotInstanceRequest `locationName:"spotInstanceRequestSet" locationNameList:"item" type:"list"`
-
-	_ struct{} `type:"structure"`
 }
 
 // String returns the string representation
@@ -8036,13 +8036,13 @@ func (s CancelSpotInstanceRequestsOutput) GoString() string {
 
 // Describes a request to cancel a Spot instance.
 type CancelledSpotInstanceRequest struct {
+	_ struct{} `type:"structure"`
+
 	// The ID of the Spot instance request.
 	SpotInstanceRequestId *string `locationName:"spotInstanceRequestId" type:"string"`
 
 	// The state of the Spot instance request.
 	State *string `locationName:"state" type:"string" enum:"CancelSpotInstanceRequestState"`
-
-	_ struct{} `type:"structure"`
 }
 
 // String returns the string representation
@@ -8057,6 +8057,8 @@ func (s CancelledSpotInstanceRequest) GoString() string {
 
 // Describes a linked EC2-Classic instance.
 type ClassicLinkInstance struct {
+	_ struct{} `type:"structure"`
+
 	// A list of security groups.
 	Groups []*GroupIdentifier `locationName:"groupSet" locationNameList:"item" type:"list"`
 
@@ -8068,8 +8070,6 @@ type ClassicLinkInstance struct {
 
 	// The ID of the VPC.
 	VpcId *string `locationName:"vpcId" type:"string"`
-
-	_ struct{} `type:"structure"`
 }
 
 // String returns the string representation
@@ -8084,6 +8084,8 @@ func (s ClassicLinkInstance) GoString() string {
 
 // Describes the client-specific data.
 type ClientData struct {
+	_ struct{} `type:"structure"`
+
 	// A user-defined comment about the disk upload.
 	Comment *string `type:"string"`
 
@@ -8095,8 +8097,6 @@ type ClientData struct {
 
 	// The time that the disk upload starts.
 	UploadStart *time.Time `type:"timestamp" timestampFormat:"iso8601"`
-
-	_ struct{} `type:"structure"`
 }
 
 // String returns the string representation
@@ -8110,6 +8110,8 @@ func (s ClientData) GoString() string {
 }
 
 type ConfirmProductInstanceInput struct {
+	_ struct{} `type:"structure"`
+
 	// Checks whether you have the required permissions for the action, without
 	// actually making the request, and provides an error response. If you have
 	// the required permissions, the error response is DryRunOperation. Otherwise,
@@ -8121,8 +8123,6 @@ type ConfirmProductInstanceInput struct {
 
 	// The product code. This must be a product code that you own.
 	ProductCode *string `type:"string" required:"true"`
-
-	_ struct{} `type:"structure"`
 }
 
 // String returns the string representation
@@ -8136,6 +8136,8 @@ func (s ConfirmProductInstanceInput) GoString() string {
 }
 
 type ConfirmProductInstanceOutput struct {
+	_ struct{} `type:"structure"`
+
 	// The AWS account ID of the instance owner. This is only present if the product
 	// code is attached to the instance.
 	OwnerId *string `locationName:"ownerId" type:"string"`
@@ -8143,8 +8145,6 @@ type ConfirmProductInstanceOutput struct {
 	// The return value of the request. Returns true if the specified product code
 	// is owned by the requester and associated with the specified instance.
 	Return *bool `locationName:"return" type:"boolean"`
-
-	_ struct{} `type:"structure"`
 }
 
 // String returns the string representation
@@ -8159,6 +8159,8 @@ func (s ConfirmProductInstanceOutput) GoString() string {
 
 // Describes a conversion task.
 type ConversionTask struct {
+	_ struct{} `type:"structure"`
+
 	// The ID of the conversion task.
 	ConversionTaskId *string `locationName:"conversionTaskId" type:"string" required:"true"`
 
@@ -8182,8 +8184,6 @@ type ConversionTask struct {
 
 	// Any tags assigned to the task.
 	Tags []*Tag `locationName:"tagSet" locationNameList:"item" type:"list"`
-
-	_ struct{} `type:"structure"`
 }
 
 // String returns the string representation
@@ -8197,6 +8197,8 @@ func (s ConversionTask) GoString() string {
 }
 
 type CopyImageInput struct {
+	_ struct{} `type:"structure"`
+
 	// Unique, case-sensitive identifier you provide to ensure idempotency of the
 	// request. For more information, see How to Ensure Idempotency (http://docs.aws.amazon.com/AWSEC2/latest/UserGuide/Run_Instance_Idempotency.html)
 	// in the Amazon Elastic Compute Cloud User Guide.
@@ -8219,8 +8221,6 @@ type CopyImageInput struct {
 
 	// The name of the region that contains the AMI to copy.
 	SourceRegion *string `type:"string" required:"true"`
-
-	_ struct{} `type:"structure"`
 }
 
 // String returns the string representation
@@ -8234,10 +8234,10 @@ func (s CopyImageInput) GoString() string {
 }
 
 type CopyImageOutput struct {
+	_ struct{} `type:"structure"`
+
 	// The ID of the new AMI.
 	ImageId *string `locationName:"imageId" type:"string"`
-
-	_ struct{} `type:"structure"`
 }
 
 // String returns the string representation
@@ -8251,6 +8251,8 @@ func (s CopyImageOutput) GoString() string {
 }
 
 type CopySnapshotInput struct {
+	_ struct{} `type:"structure"`
+
 	// A description for the EBS snapshot.
 	Description *string `type:"string"`
 
@@ -8308,8 +8310,6 @@ type CopySnapshotInput struct {
 
 	// The ID of the EBS snapshot to copy.
 	SourceSnapshotId *string `type:"string" required:"true"`
-
-	_ struct{} `type:"structure"`
 }
 
 // String returns the string representation
@@ -8323,10 +8323,10 @@ func (s CopySnapshotInput) GoString() string {
 }
 
 type CopySnapshotOutput struct {
+	_ struct{} `type:"structure"`
+
 	// The ID of the new snapshot.
 	SnapshotId *string `locationName:"snapshotId" type:"string"`
-
-	_ struct{} `type:"structure"`
 }
 
 // String returns the string representation
@@ -8340,6 +8340,8 @@ func (s CopySnapshotOutput) GoString() string {
 }
 
 type CreateCustomerGatewayInput struct {
+	_ struct{} `type:"structure"`
+
 	// For devices that support BGP, the customer gateway's BGP ASN.
 	//
 	// Default: 65000
@@ -8357,8 +8359,6 @@ type CreateCustomerGatewayInput struct {
 
 	// The type of VPN connection that this customer gateway supports (ipsec.1).
 	Type *string `type:"string" required:"true" enum:"GatewayType"`
-
-	_ struct{} `type:"structure"`
 }
 
 // String returns the string representation
@@ -8372,10 +8372,10 @@ func (s CreateCustomerGatewayInput) GoString() string {
 }
 
 type CreateCustomerGatewayOutput struct {
+	_ struct{} `type:"structure"`
+
 	// Information about the customer gateway.
 	CustomerGateway *CustomerGateway `locationName:"customerGateway" type:"structure"`
-
-	_ struct{} `type:"structure"`
 }
 
 // String returns the string representation
@@ -8389,6 +8389,8 @@ func (s CreateCustomerGatewayOutput) GoString() string {
 }
 
 type CreateDhcpOptionsInput struct {
+	_ struct{} `type:"structure"`
+
 	// A DHCP configuration option.
 	DhcpConfigurations []*NewDhcpConfiguration `locationName:"dhcpConfiguration" locationNameList:"item" type:"list" required:"true"`
 
@@ -8397,8 +8399,6 @@ type CreateDhcpOptionsInput struct {
 	// the required permissions, the error response is DryRunOperation. Otherwise,
 	// it is UnauthorizedOperation.
 	DryRun *bool `locationName:"dryRun" type:"boolean"`
-
-	_ struct{} `type:"structure"`
 }
 
 // String returns the string representation
@@ -8412,10 +8412,10 @@ func (s CreateDhcpOptionsInput) GoString() string {
 }
 
 type CreateDhcpOptionsOutput struct {
+	_ struct{} `type:"structure"`
+
 	// A set of DHCP options.
 	DhcpOptions *DhcpOptions `locationName:"dhcpOptions" type:"structure"`
-
-	_ struct{} `type:"structure"`
 }
 
 // String returns the string representation
@@ -8429,6 +8429,8 @@ func (s CreateDhcpOptionsOutput) GoString() string {
 }
 
 type CreateFlowLogsInput struct {
+	_ struct{} `type:"structure"`
+
 	// Unique, case-sensitive identifier you provide to ensure the idempotency of
 	// the request. For more information, see How to Ensure Idempotency (http://docs.aws.amazon.com/AWSEC2/latest/UserGuide/Run_Instance_Idempotency.html).
 	ClientToken *string `type:"string"`
@@ -8448,8 +8450,6 @@ type CreateFlowLogsInput struct {
 
 	// The type of traffic to log.
 	TrafficType *string `type:"string" required:"true" enum:"TrafficType"`
-
-	_ struct{} `type:"structure"`
 }
 
 // String returns the string representation
@@ -8463,6 +8463,8 @@ func (s CreateFlowLogsInput) GoString() string {
 }
 
 type CreateFlowLogsOutput struct {
+	_ struct{} `type:"structure"`
+
 	// Unique, case-sensitive identifier you provide to ensure the idempotency of
 	// the request.
 	ClientToken *string `locationName:"clientToken" type:"string"`
@@ -8472,8 +8474,6 @@ type CreateFlowLogsOutput struct {
 
 	// Information about the flow logs that could not be created successfully.
 	Unsuccessful []*UnsuccessfulItem `locationName:"unsuccessful" locationNameList:"item" type:"list"`
-
-	_ struct{} `type:"structure"`
 }
 
 // String returns the string representation
@@ -8487,6 +8487,8 @@ func (s CreateFlowLogsOutput) GoString() string {
 }
 
 type CreateImageInput struct {
+	_ struct{} `type:"structure"`
+
 	// Information about one or more block device mappings.
 	BlockDeviceMappings []*BlockDeviceMapping `locationName:"blockDeviceMapping" locationNameList:"BlockDeviceMapping" type:"list"`
 
@@ -8515,8 +8517,6 @@ type CreateImageInput struct {
 	// down the instance before creating the image. When this option is used, file
 	// system integrity on the created image can't be guaranteed.
 	NoReboot *bool `locationName:"noReboot" type:"boolean"`
-
-	_ struct{} `type:"structure"`
 }
 
 // String returns the string representation
@@ -8530,10 +8530,10 @@ func (s CreateImageInput) GoString() string {
 }
 
 type CreateImageOutput struct {
+	_ struct{} `type:"structure"`
+
 	// The ID of the new AMI.
 	ImageId *string `locationName:"imageId" type:"string"`
-
-	_ struct{} `type:"structure"`
 }
 
 // String returns the string representation
@@ -8547,6 +8547,8 @@ func (s CreateImageOutput) GoString() string {
 }
 
 type CreateInstanceExportTaskInput struct {
+	_ struct{} `type:"structure"`
+
 	// A description for the conversion task or the resource being exported. The
 	// maximum length is 255 bytes.
 	Description *string `locationName:"description" type:"string"`
@@ -8559,8 +8561,6 @@ type CreateInstanceExportTaskInput struct {
 
 	// The target virtualization environment.
 	TargetEnvironment *string `locationName:"targetEnvironment" type:"string" enum:"ExportEnvironment"`
-
-	_ struct{} `type:"structure"`
 }
 
 // String returns the string representation
@@ -8574,10 +8574,10 @@ func (s CreateInstanceExportTaskInput) GoString() string {
 }
 
 type CreateInstanceExportTaskOutput struct {
+	_ struct{} `type:"structure"`
+
 	// Information about the instance export task.
 	ExportTask *ExportTask `locationName:"exportTask" type:"structure"`
-
-	_ struct{} `type:"structure"`
 }
 
 // String returns the string representation
@@ -8591,13 +8591,13 @@ func (s CreateInstanceExportTaskOutput) GoString() string {
 }
 
 type CreateInternetGatewayInput struct {
+	_ struct{} `type:"structure"`
+
 	// Checks whether you have the required permissions for the action, without
 	// actually making the request, and provides an error response. If you have
 	// the required permissions, the error response is DryRunOperation. Otherwise,
 	// it is UnauthorizedOperation.
 	DryRun *bool `locationName:"dryRun" type:"boolean"`
-
-	_ struct{} `type:"structure"`
 }
 
 // String returns the string representation
@@ -8611,10 +8611,10 @@ func (s CreateInternetGatewayInput) GoString() string {
 }
 
 type CreateInternetGatewayOutput struct {
+	_ struct{} `type:"structure"`
+
 	// Information about the Internet gateway.
 	InternetGateway *InternetGateway `locationName:"internetGateway" type:"structure"`
-
-	_ struct{} `type:"structure"`
 }
 
 // String returns the string representation
@@ -8628,6 +8628,8 @@ func (s CreateInternetGatewayOutput) GoString() string {
 }
 
 type CreateKeyPairInput struct {
+	_ struct{} `type:"structure"`
+
 	// Checks whether you have the required permissions for the action, without
 	// actually making the request, and provides an error response. If you have
 	// the required permissions, the error response is DryRunOperation. Otherwise,
@@ -8638,8 +8640,6 @@ type CreateKeyPairInput struct {
 	//
 	// Constraints: Up to 255 ASCII characters
 	KeyName *string `type:"string" required:"true"`
-
-	_ struct{} `type:"structure"`
 }
 
 // String returns the string representation
@@ -8654,6 +8654,8 @@ func (s CreateKeyPairInput) GoString() string {
 
 // Describes a key pair.
 type CreateKeyPairOutput struct {
+	_ struct{} `type:"structure"`
+
 	// The SHA-1 digest of the DER encoded private key.
 	KeyFingerprint *string `locationName:"keyFingerprint" type:"string"`
 
@@ -8662,8 +8664,6 @@ type CreateKeyPairOutput struct {
 
 	// The name of the key pair.
 	KeyName *string `locationName:"keyName" type:"string"`
-
-	_ struct{} `type:"structure"`
 }
 
 // String returns the string representation
@@ -8677,6 +8677,8 @@ func (s CreateKeyPairOutput) GoString() string {
 }
 
 type CreateNetworkAclEntryInput struct {
+	_ struct{} `type:"structure"`
+
 	// The network range to allow or deny, in CIDR notation (for example 172.16.0.0/24).
 	CidrBlock *string `locationName:"cidrBlock" type:"string" required:"true"`
 
@@ -8711,8 +8713,6 @@ type CreateNetworkAclEntryInput struct {
 	//
 	// Constraints: Positive integer from 1 to 32766
 	RuleNumber *int64 `locationName:"ruleNumber" type:"integer" required:"true"`
-
-	_ struct{} `type:"structure"`
 }
 
 // String returns the string representation
@@ -8740,6 +8740,8 @@ func (s CreateNetworkAclEntryOutput) GoString() string {
 }
 
 type CreateNetworkAclInput struct {
+	_ struct{} `type:"structure"`
+
 	// Checks whether you have the required permissions for the action, without
 	// actually making the request, and provides an error response. If you have
 	// the required permissions, the error response is DryRunOperation. Otherwise,
@@ -8748,8 +8750,6 @@ type CreateNetworkAclInput struct {
 
 	// The ID of the VPC.
 	VpcId *string `locationName:"vpcId" type:"string" required:"true"`
-
-	_ struct{} `type:"structure"`
 }
 
 // String returns the string representation
@@ -8763,10 +8763,10 @@ func (s CreateNetworkAclInput) GoString() string {
 }
 
 type CreateNetworkAclOutput struct {
+	_ struct{} `type:"structure"`
+
 	// Information about the network ACL.
 	NetworkAcl *NetworkAcl `locationName:"networkAcl" type:"structure"`
-
-	_ struct{} `type:"structure"`
 }
 
 // String returns the string representation
@@ -8780,6 +8780,8 @@ func (s CreateNetworkAclOutput) GoString() string {
 }
 
 type CreateNetworkInterfaceInput struct {
+	_ struct{} `type:"structure"`
+
 	// A description for the network interface.
 	Description *string `locationName:"description" type:"string"`
 
@@ -8814,8 +8816,6 @@ type CreateNetworkInterfaceInput struct {
 
 	// The ID of the subnet to associate with the network interface.
 	SubnetId *string `locationName:"subnetId" type:"string" required:"true"`
-
-	_ struct{} `type:"structure"`
 }
 
 // String returns the string representation
@@ -8829,10 +8829,10 @@ func (s CreateNetworkInterfaceInput) GoString() string {
 }
 
 type CreateNetworkInterfaceOutput struct {
+	_ struct{} `type:"structure"`
+
 	// Information about the network interface.
 	NetworkInterface *NetworkInterface `locationName:"networkInterface" type:"structure"`
-
-	_ struct{} `type:"structure"`
 }
 
 // String returns the string representation
@@ -8846,6 +8846,8 @@ func (s CreateNetworkInterfaceOutput) GoString() string {
 }
 
 type CreatePlacementGroupInput struct {
+	_ struct{} `type:"structure"`
+
 	// Checks whether you have the required permissions for the action, without
 	// actually making the request, and provides an error response. If you have
 	// the required permissions, the error response is DryRunOperation. Otherwise,
@@ -8859,8 +8861,6 @@ type CreatePlacementGroupInput struct {
 
 	// The placement strategy.
 	Strategy *string `locationName:"strategy" type:"string" required:"true" enum:"PlacementStrategy"`
-
-	_ struct{} `type:"structure"`
 }
 
 // String returns the string representation
@@ -8888,6 +8888,8 @@ func (s CreatePlacementGroupOutput) GoString() string {
 }
 
 type CreateReservedInstancesListingInput struct {
+	_ struct{} `type:"structure"`
+
 	// Unique, case-sensitive identifier you provide to ensure idempotency of your
 	// listings. This helps avoid duplicate listings. For more information, see
 	// Ensuring Idempotency (http://docs.aws.amazon.com/AWSEC2/latest/APIReference/Run_Instance_Idempotency.html).
@@ -8905,8 +8907,6 @@ type CreateReservedInstancesListingInput struct {
 
 	// The ID of the active Reserved instance.
 	ReservedInstancesId *string `locationName:"reservedInstancesId" type:"string" required:"true"`
-
-	_ struct{} `type:"structure"`
 }
 
 // String returns the string representation
@@ -8920,10 +8920,10 @@ func (s CreateReservedInstancesListingInput) GoString() string {
 }
 
 type CreateReservedInstancesListingOutput struct {
+	_ struct{} `type:"structure"`
+
 	// Information about the Reserved instance listing.
 	ReservedInstancesListings []*ReservedInstancesListing `locationName:"reservedInstancesListingsSet" locationNameList:"item" type:"list"`
-
-	_ struct{} `type:"structure"`
 }
 
 // String returns the string representation
@@ -8937,6 +8937,8 @@ func (s CreateReservedInstancesListingOutput) GoString() string {
 }
 
 type CreateRouteInput struct {
+	_ struct{} `type:"structure"`
+
 	// The CIDR address block used for the destination match. Routing decisions
 	// are based on the most specific match.
 	DestinationCidrBlock *string `locationName:"destinationCidrBlock" type:"string" required:"true"`
@@ -8963,8 +8965,6 @@ type CreateRouteInput struct {
 
 	// The ID of a VPC peering connection.
 	VpcPeeringConnectionId *string `locationName:"vpcPeeringConnectionId" type:"string"`
-
-	_ struct{} `type:"structure"`
 }
 
 // String returns the string representation
@@ -8978,10 +8978,10 @@ func (s CreateRouteInput) GoString() string {
 }
 
 type CreateRouteOutput struct {
+	_ struct{} `type:"structure"`
+
 	// Returns true if the request succeeds; otherwise, it returns an error.
 	Return *bool `locationName:"return" type:"boolean"`
-
-	_ struct{} `type:"structure"`
 }
 
 // String returns the string representation
@@ -8995,6 +8995,8 @@ func (s CreateRouteOutput) GoString() string {
 }
 
 type CreateRouteTableInput struct {
+	_ struct{} `type:"structure"`
+
 	// Checks whether you have the required permissions for the action, without
 	// actually making the request, and provides an error response. If you have
 	// the required permissions, the error response is DryRunOperation. Otherwise,
@@ -9003,8 +9005,6 @@ type CreateRouteTableInput struct {
 
 	// The ID of the VPC.
 	VpcId *string `locationName:"vpcId" type:"string" required:"true"`
-
-	_ struct{} `type:"structure"`
 }
 
 // String returns the string representation
@@ -9018,10 +9018,10 @@ func (s CreateRouteTableInput) GoString() string {
 }
 
 type CreateRouteTableOutput struct {
+	_ struct{} `type:"structure"`
+
 	// Information about the route table.
 	RouteTable *RouteTable `locationName:"routeTable" type:"structure"`
-
-	_ struct{} `type:"structure"`
 }
 
 // String returns the string representation
@@ -9035,6 +9035,8 @@ func (s CreateRouteTableOutput) GoString() string {
 }
 
 type CreateSecurityGroupInput struct {
+	_ struct{} `type:"structure"`
+
 	// A description for the security group. This is informational only.
 	//
 	// Constraints: Up to 255 characters in length
@@ -9061,8 +9063,6 @@ type CreateSecurityGroupInput struct {
 
 	// [EC2-VPC] The ID of the VPC. Required for EC2-VPC.
 	VpcId *string `type:"string"`
-
-	_ struct{} `type:"structure"`
 }
 
 // String returns the string representation
@@ -9076,10 +9076,10 @@ func (s CreateSecurityGroupInput) GoString() string {
 }
 
 type CreateSecurityGroupOutput struct {
+	_ struct{} `type:"structure"`
+
 	// The ID of the security group.
 	GroupId *string `locationName:"groupId" type:"string"`
-
-	_ struct{} `type:"structure"`
 }
 
 // String returns the string representation
@@ -9093,6 +9093,8 @@ func (s CreateSecurityGroupOutput) GoString() string {
 }
 
 type CreateSnapshotInput struct {
+	_ struct{} `type:"structure"`
+
 	// A description for the snapshot.
 	Description *string `type:"string"`
 
@@ -9104,8 +9106,6 @@ type CreateSnapshotInput struct {
 
 	// The ID of the EBS volume.
 	VolumeId *string `type:"string" required:"true"`
-
-	_ struct{} `type:"structure"`
 }
 
 // String returns the string representation
@@ -9120,6 +9120,8 @@ func (s CreateSnapshotInput) GoString() string {
 
 // Contains the parameters for CreateSpotDatafeedSubscription.
 type CreateSpotDatafeedSubscriptionInput struct {
+	_ struct{} `type:"structure"`
+
 	// The Amazon S3 bucket in which to store the Spot instance data feed.
 	Bucket *string `locationName:"bucket" type:"string" required:"true"`
 
@@ -9131,8 +9133,6 @@ type CreateSpotDatafeedSubscriptionInput struct {
 
 	// A prefix for the data feed file names.
 	Prefix *string `locationName:"prefix" type:"string"`
-
-	_ struct{} `type:"structure"`
 }
 
 // String returns the string representation
@@ -9147,10 +9147,10 @@ func (s CreateSpotDatafeedSubscriptionInput) GoString() string {
 
 // Contains the output of CreateSpotDatafeedSubscription.
 type CreateSpotDatafeedSubscriptionOutput struct {
+	_ struct{} `type:"structure"`
+
 	// The Spot instance data feed subscription.
 	SpotDatafeedSubscription *SpotDatafeedSubscription `locationName:"spotDatafeedSubscription" type:"structure"`
-
-	_ struct{} `type:"structure"`
 }
 
 // String returns the string representation
@@ -9164,6 +9164,8 @@ func (s CreateSpotDatafeedSubscriptionOutput) GoString() string {
 }
 
 type CreateSubnetInput struct {
+	_ struct{} `type:"structure"`
+
 	// The Availability Zone for the subnet.
 	//
 	// Default: AWS selects one for you. If you create more than one subnet in
@@ -9181,8 +9183,6 @@ type CreateSubnetInput struct {
 
 	// The ID of the VPC.
 	VpcId *string `type:"string" required:"true"`
-
-	_ struct{} `type:"structure"`
 }
 
 // String returns the string representation
@@ -9196,10 +9196,10 @@ func (s CreateSubnetInput) GoString() string {
 }
 
 type CreateSubnetOutput struct {
+	_ struct{} `type:"structure"`
+
 	// Information about the subnet.
 	Subnet *Subnet `locationName:"subnet" type:"structure"`
-
-	_ struct{} `type:"structure"`
 }
 
 // String returns the string representation
@@ -9213,6 +9213,8 @@ func (s CreateSubnetOutput) GoString() string {
 }
 
 type CreateTagsInput struct {
+	_ struct{} `type:"structure"`
+
 	// Checks whether you have the required permissions for the action, without
 	// actually making the request, and provides an error response. If you have
 	// the required permissions, the error response is DryRunOperation. Otherwise,
@@ -9226,8 +9228,6 @@ type CreateTagsInput struct {
 	// the tag to have a value, specify the parameter with no value, and we set
 	// the value to an empty string.
 	Tags []*Tag `locationName:"Tag" locationNameList:"item" type:"list" required:"true"`
-
-	_ struct{} `type:"structure"`
 }
 
 // String returns the string representation
@@ -9255,6 +9255,8 @@ func (s CreateTagsOutput) GoString() string {
 }
 
 type CreateVolumeInput struct {
+	_ struct{} `type:"structure"`
+
 	// The Availability Zone in which to create the volume. Use DescribeAvailabilityZones
 	// to list the Availability Zones that are currently available to you.
 	AvailabilityZone *string `type:"string" required:"true"`
@@ -9308,8 +9310,6 @@ type CreateVolumeInput struct {
 	//
 	// Default: standard
 	VolumeType *string `type:"string" enum:"VolumeType"`
-
-	_ struct{} `type:"structure"`
 }
 
 // String returns the string representation
@@ -9325,6 +9325,8 @@ func (s CreateVolumeInput) GoString() string {
 // Describes the user or group to be added or removed from the permissions for
 // a volume.
 type CreateVolumePermission struct {
+	_ struct{} `type:"structure"`
+
 	// The specific group that is to be added or removed from a volume's list of
 	// create volume permissions.
 	Group *string `locationName:"group" type:"string" enum:"PermissionGroup"`
@@ -9332,8 +9334,6 @@ type CreateVolumePermission struct {
 	// The specific AWS account ID that is to be added or removed from a volume's
 	// list of create volume permissions.
 	UserId *string `locationName:"userId" type:"string"`
-
-	_ struct{} `type:"structure"`
 }
 
 // String returns the string representation
@@ -9348,6 +9348,8 @@ func (s CreateVolumePermission) GoString() string {
 
 // Describes modifications to the permissions for a volume.
 type CreateVolumePermissionModifications struct {
+	_ struct{} `type:"structure"`
+
 	// Adds a specific AWS account ID or group to a volume's list of create volume
 	// permissions.
 	Add []*CreateVolumePermission `locationNameList:"item" type:"list"`
@@ -9355,8 +9357,6 @@ type CreateVolumePermissionModifications struct {
 	// Removes a specific AWS account ID or group from a volume's list of create
 	// volume permissions.
 	Remove []*CreateVolumePermission `locationNameList:"item" type:"list"`
-
-	_ struct{} `type:"structure"`
 }
 
 // String returns the string representation
@@ -9370,6 +9370,8 @@ func (s CreateVolumePermissionModifications) GoString() string {
 }
 
 type CreateVpcEndpointInput struct {
+	_ struct{} `type:"structure"`
+
 	// Unique, case-sensitive identifier you provide to ensure the idempotency of
 	// the request. For more information, see How to Ensure Idempotency (http://docs.aws.amazon.com/AWSEC2/latest/APIReference/Run_Instance_Idempotency.html).
 	ClientToken *string `type:"string"`
@@ -9394,8 +9396,6 @@ type CreateVpcEndpointInput struct {
 
 	// The ID of the VPC in which the endpoint will be used.
 	VpcId *string `type:"string" required:"true"`
-
-	_ struct{} `type:"structure"`
 }
 
 // String returns the string representation
@@ -9409,14 +9409,14 @@ func (s CreateVpcEndpointInput) GoString() string {
 }
 
 type CreateVpcEndpointOutput struct {
+	_ struct{} `type:"structure"`
+
 	// Unique, case-sensitive identifier you provide to ensure the idempotency of
 	// the request.
 	ClientToken *string `locationName:"clientToken" type:"string"`
 
 	// Information about the endpoint.
 	VpcEndpoint *VpcEndpoint `locationName:"vpcEndpoint" type:"structure"`
-
-	_ struct{} `type:"structure"`
 }
 
 // String returns the string representation
@@ -9430,6 +9430,8 @@ func (s CreateVpcEndpointOutput) GoString() string {
 }
 
 type CreateVpcInput struct {
+	_ struct{} `type:"structure"`
+
 	// The network range for the VPC, in CIDR notation. For example, 10.0.0.0/16.
 	CidrBlock *string `type:"string" required:"true"`
 
@@ -9450,8 +9452,6 @@ type CreateVpcInput struct {
 	//
 	// Default: default
 	InstanceTenancy *string `locationName:"instanceTenancy" type:"string" enum:"Tenancy"`
-
-	_ struct{} `type:"structure"`
 }
 
 // String returns the string representation
@@ -9465,10 +9465,10 @@ func (s CreateVpcInput) GoString() string {
 }
 
 type CreateVpcOutput struct {
+	_ struct{} `type:"structure"`
+
 	// Information about the VPC.
 	Vpc *Vpc `locationName:"vpc" type:"structure"`
-
-	_ struct{} `type:"structure"`
 }
 
 // String returns the string representation
@@ -9482,6 +9482,8 @@ func (s CreateVpcOutput) GoString() string {
 }
 
 type CreateVpcPeeringConnectionInput struct {
+	_ struct{} `type:"structure"`
+
 	// Checks whether you have the required permissions for the action, without
 	// actually making the request, and provides an error response. If you have
 	// the required permissions, the error response is DryRunOperation. Otherwise,
@@ -9498,8 +9500,6 @@ type CreateVpcPeeringConnectionInput struct {
 
 	// The ID of the requester VPC.
 	VpcId *string `locationName:"vpcId" type:"string"`
-
-	_ struct{} `type:"structure"`
 }
 
 // String returns the string representation
@@ -9513,10 +9513,10 @@ func (s CreateVpcPeeringConnectionInput) GoString() string {
 }
 
 type CreateVpcPeeringConnectionOutput struct {
+	_ struct{} `type:"structure"`
+
 	// Information about the VPC peering connection.
 	VpcPeeringConnection *VpcPeeringConnection `locationName:"vpcPeeringConnection" type:"structure"`
-
-	_ struct{} `type:"structure"`
 }
 
 // String returns the string representation
@@ -9530,6 +9530,8 @@ func (s CreateVpcPeeringConnectionOutput) GoString() string {
 }
 
 type CreateVpnConnectionInput struct {
+	_ struct{} `type:"structure"`
+
 	// The ID of the customer gateway.
 	CustomerGatewayId *string `type:"string" required:"true"`
 
@@ -9551,8 +9553,6 @@ type CreateVpnConnectionInput struct {
 
 	// The ID of the virtual private gateway.
 	VpnGatewayId *string `type:"string" required:"true"`
-
-	_ struct{} `type:"structure"`
 }
 
 // String returns the string representation
@@ -9566,10 +9566,10 @@ func (s CreateVpnConnectionInput) GoString() string {
 }
 
 type CreateVpnConnectionOutput struct {
+	_ struct{} `type:"structure"`
+
 	// Information about the VPN connection.
 	VpnConnection *VpnConnection `locationName:"vpnConnection" type:"structure"`
-
-	_ struct{} `type:"structure"`
 }
 
 // String returns the string representation
@@ -9583,13 +9583,13 @@ func (s CreateVpnConnectionOutput) GoString() string {
 }
 
 type CreateVpnConnectionRouteInput struct {
+	_ struct{} `type:"structure"`
+
 	// The CIDR block associated with the local subnet of the customer network.
 	DestinationCidrBlock *string `type:"string" required:"true"`
 
 	// The ID of the VPN connection.
 	VpnConnectionId *string `type:"string" required:"true"`
-
-	_ struct{} `type:"structure"`
 }
 
 // String returns the string representation
@@ -9617,6 +9617,8 @@ func (s CreateVpnConnectionRouteOutput) GoString() string {
 }
 
 type CreateVpnGatewayInput struct {
+	_ struct{} `type:"structure"`
+
 	// The Availability Zone for the virtual private gateway.
 	AvailabilityZone *string `type:"string"`
 
@@ -9628,8 +9630,6 @@ type CreateVpnGatewayInput struct {
 
 	// The type of VPN connection this virtual private gateway supports.
 	Type *string `type:"string" required:"true" enum:"GatewayType"`
-
-	_ struct{} `type:"structure"`
 }
 
 // String returns the string representation
@@ -9643,10 +9643,10 @@ func (s CreateVpnGatewayInput) GoString() string {
 }
 
 type CreateVpnGatewayOutput struct {
+	_ struct{} `type:"structure"`
+
 	// Information about the virtual private gateway.
 	VpnGateway *VpnGateway `locationName:"vpnGateway" type:"structure"`
-
-	_ struct{} `type:"structure"`
 }
 
 // String returns the string representation
@@ -9661,6 +9661,8 @@ func (s CreateVpnGatewayOutput) GoString() string {
 
 // Describes a customer gateway.
 type CustomerGateway struct {
+	_ struct{} `type:"structure"`
+
 	// The customer gateway's Border Gateway Protocol (BGP) Autonomous System Number
 	// (ASN).
 	BgpAsn *string `locationName:"bgpAsn" type:"string"`
@@ -9680,8 +9682,6 @@ type CustomerGateway struct {
 
 	// The type of VPN connection the customer gateway supports (ipsec.1).
 	Type *string `locationName:"type" type:"string"`
-
-	_ struct{} `type:"structure"`
 }
 
 // String returns the string representation
@@ -9695,6 +9695,8 @@ func (s CustomerGateway) GoString() string {
 }
 
 type DeleteCustomerGatewayInput struct {
+	_ struct{} `type:"structure"`
+
 	// The ID of the customer gateway.
 	CustomerGatewayId *string `type:"string" required:"true"`
 
@@ -9703,8 +9705,6 @@ type DeleteCustomerGatewayInput struct {
 	// the required permissions, the error response is DryRunOperation. Otherwise,
 	// it is UnauthorizedOperation.
 	DryRun *bool `locationName:"dryRun" type:"boolean"`
-
-	_ struct{} `type:"structure"`
 }
 
 // String returns the string representation
@@ -9732,6 +9732,8 @@ func (s DeleteCustomerGatewayOutput) GoString() string {
 }
 
 type DeleteDhcpOptionsInput struct {
+	_ struct{} `type:"structure"`
+
 	// The ID of the DHCP options set.
 	DhcpOptionsId *string `type:"string" required:"true"`
 
@@ -9740,8 +9742,6 @@ type DeleteDhcpOptionsInput struct {
 	// the required permissions, the error response is DryRunOperation. Otherwise,
 	// it is UnauthorizedOperation.
 	DryRun *bool `locationName:"dryRun" type:"boolean"`
-
-	_ struct{} `type:"structure"`
 }
 
 // String returns the string representation
@@ -9769,10 +9769,10 @@ func (s DeleteDhcpOptionsOutput) GoString() string {
 }
 
 type DeleteFlowLogsInput struct {
+	_ struct{} `type:"structure"`
+
 	// One or more flow log IDs.
 	FlowLogIds []*string `locationName:"FlowLogId" locationNameList:"item" type:"list" required:"true"`
-
-	_ struct{} `type:"structure"`
 }
 
 // String returns the string representation
@@ -9786,10 +9786,10 @@ func (s DeleteFlowLogsInput) GoString() string {
 }
 
 type DeleteFlowLogsOutput struct {
+	_ struct{} `type:"structure"`
+
 	// Information about the flow logs that could not be deleted successfully.
 	Unsuccessful []*UnsuccessfulItem `locationName:"unsuccessful" locationNameList:"item" type:"list"`
-
-	_ struct{} `type:"structure"`
 }
 
 // String returns the string representation
@@ -9803,6 +9803,8 @@ func (s DeleteFlowLogsOutput) GoString() string {
 }
 
 type DeleteInternetGatewayInput struct {
+	_ struct{} `type:"structure"`
+
 	// Checks whether you have the required permissions for the action, without
 	// actually making the request, and provides an error response. If you have
 	// the required permissions, the error response is DryRunOperation. Otherwise,
@@ -9811,8 +9813,6 @@ type DeleteInternetGatewayInput struct {
 
 	// The ID of the Internet gateway.
 	InternetGatewayId *string `locationName:"internetGatewayId" type:"string" required:"true"`
-
-	_ struct{} `type:"structure"`
 }
 
 // String returns the string representation
@@ -9840,6 +9840,8 @@ func (s DeleteInternetGatewayOutput) GoString() string {
 }
 
 type DeleteKeyPairInput struct {
+	_ struct{} `type:"structure"`
+
 	// Checks whether you have the required permissions for the action, without
 	// actually making the request, and provides an error response. If you have
 	// the required permissions, the error response is DryRunOperation. Otherwise,
@@ -9848,8 +9850,6 @@ type DeleteKeyPairInput struct {
 
 	// The name of the key pair.
 	KeyName *string `type:"string" required:"true"`
-
-	_ struct{} `type:"structure"`
 }
 
 // String returns the string representation
@@ -9877,6 +9877,8 @@ func (s DeleteKeyPairOutput) GoString() string {
 }
 
 type DeleteNetworkAclEntryInput struct {
+	_ struct{} `type:"structure"`
+
 	// Checks whether you have the required permissions for the action, without
 	// actually making the request, and provides an error response. If you have
 	// the required permissions, the error response is DryRunOperation. Otherwise,
@@ -9891,8 +9893,6 @@ type DeleteNetworkAclEntryInput struct {
 
 	// The rule number of the entry to delete.
 	RuleNumber *int64 `locationName:"ruleNumber" type:"integer" required:"true"`
-
-	_ struct{} `type:"structure"`
 }
 
 // String returns the string representation
@@ -9920,6 +9920,8 @@ func (s DeleteNetworkAclEntryOutput) GoString() string {
 }
 
 type DeleteNetworkAclInput struct {
+	_ struct{} `type:"structure"`
+
 	// Checks whether you have the required permissions for the action, without
 	// actually making the request, and provides an error response. If you have
 	// the required permissions, the error response is DryRunOperation. Otherwise,
@@ -9928,8 +9930,6 @@ type DeleteNetworkAclInput struct {
 
 	// The ID of the network ACL.
 	NetworkAclId *string `locationName:"networkAclId" type:"string" required:"true"`
-
-	_ struct{} `type:"structure"`
 }
 
 // String returns the string representation
@@ -9957,6 +9957,8 @@ func (s DeleteNetworkAclOutput) GoString() string {
 }
 
 type DeleteNetworkInterfaceInput struct {
+	_ struct{} `type:"structure"`
+
 	// Checks whether you have the required permissions for the action, without
 	// actually making the request, and provides an error response. If you have
 	// the required permissions, the error response is DryRunOperation. Otherwise,
@@ -9965,8 +9967,6 @@ type DeleteNetworkInterfaceInput struct {
 
 	// The ID of the network interface.
 	NetworkInterfaceId *string `locationName:"networkInterfaceId" type:"string" required:"true"`
-
-	_ struct{} `type:"structure"`
 }
 
 // String returns the string representation
@@ -9994,6 +9994,8 @@ func (s DeleteNetworkInterfaceOutput) GoString() string {
 }
 
 type DeletePlacementGroupInput struct {
+	_ struct{} `type:"structure"`
+
 	// Checks whether you have the required permissions for the action, without
 	// actually making the request, and provides an error response. If you have
 	// the required permissions, the error response is DryRunOperation. Otherwise,
@@ -10002,8 +10004,6 @@ type DeletePlacementGroupInput struct {
 
 	// The name of the placement group.
 	GroupName *string `locationName:"groupName" type:"string" required:"true"`
-
-	_ struct{} `type:"structure"`
 }
 
 // String returns the string representation
@@ -10031,6 +10031,8 @@ func (s DeletePlacementGroupOutput) GoString() string {
 }
 
 type DeleteRouteInput struct {
+	_ struct{} `type:"structure"`
+
 	// The CIDR range for the route. The value you specify must match the CIDR for
 	// the route exactly.
 	DestinationCidrBlock *string `locationName:"destinationCidrBlock" type:"string" required:"true"`
@@ -10043,8 +10045,6 @@ type DeleteRouteInput struct {
 
 	// The ID of the route table.
 	RouteTableId *string `locationName:"routeTableId" type:"string" required:"true"`
-
-	_ struct{} `type:"structure"`
 }
 
 // String returns the string representation
@@ -10072,6 +10072,8 @@ func (s DeleteRouteOutput) GoString() string {
 }
 
 type DeleteRouteTableInput struct {
+	_ struct{} `type:"structure"`
+
 	// Checks whether you have the required permissions for the action, without
 	// actually making the request, and provides an error response. If you have
 	// the required permissions, the error response is DryRunOperation. Otherwise,
@@ -10080,8 +10082,6 @@ type DeleteRouteTableInput struct {
 
 	// The ID of the route table.
 	RouteTableId *string `locationName:"routeTableId" type:"string" required:"true"`
-
-	_ struct{} `type:"structure"`
 }
 
 // String returns the string representation
@@ -10109,6 +10109,8 @@ func (s DeleteRouteTableOutput) GoString() string {
 }
 
 type DeleteSecurityGroupInput struct {
+	_ struct{} `type:"structure"`
+
 	// Checks whether you have the required permissions for the action, without
 	// actually making the request, and provides an error response. If you have
 	// the required permissions, the error response is DryRunOperation. Otherwise,
@@ -10121,8 +10123,6 @@ type DeleteSecurityGroupInput struct {
 	// [EC2-Classic, default VPC] The name of the security group. You can specify
 	// either the security group name or the security group ID.
 	GroupName *string `type:"string"`
-
-	_ struct{} `type:"structure"`
 }
 
 // String returns the string representation
@@ -10150,6 +10150,8 @@ func (s DeleteSecurityGroupOutput) GoString() string {
 }
 
 type DeleteSnapshotInput struct {
+	_ struct{} `type:"structure"`
+
 	// Checks whether you have the required permissions for the action, without
 	// actually making the request, and provides an error response. If you have
 	// the required permissions, the error response is DryRunOperation. Otherwise,
@@ -10158,8 +10160,6 @@ type DeleteSnapshotInput struct {
 
 	// The ID of the EBS snapshot.
 	SnapshotId *string `type:"string" required:"true"`
-
-	_ struct{} `type:"structure"`
 }
 
 // String returns the string representation
@@ -10188,13 +10188,13 @@ func (s DeleteSnapshotOutput) GoString() string {
 
 // Contains the parameters for DeleteSpotDatafeedSubscription.
 type DeleteSpotDatafeedSubscriptionInput struct {
+	_ struct{} `type:"structure"`
+
 	// Checks whether you have the required permissions for the action, without
 	// actually making the request, and provides an error response. If you have
 	// the required permissions, the error response is DryRunOperation. Otherwise,
 	// it is UnauthorizedOperation.
 	DryRun *bool `locationName:"dryRun" type:"boolean"`
-
-	_ struct{} `type:"structure"`
 }
 
 // String returns the string representation
@@ -10222,6 +10222,8 @@ func (s DeleteSpotDatafeedSubscriptionOutput) GoString() string {
 }
 
 type DeleteSubnetInput struct {
+	_ struct{} `type:"structure"`
+
 	// Checks whether you have the required permissions for the action, without
 	// actually making the request, and provides an error response. If you have
 	// the required permissions, the error response is DryRunOperation. Otherwise,
@@ -10230,8 +10232,6 @@ type DeleteSubnetInput struct {
 
 	// The ID of the subnet.
 	SubnetId *string `type:"string" required:"true"`
-
-	_ struct{} `type:"structure"`
 }
 
 // String returns the string representation
@@ -10259,6 +10259,8 @@ func (s DeleteSubnetOutput) GoString() string {
 }
 
 type DeleteTagsInput struct {
+	_ struct{} `type:"structure"`
+
 	// Checks whether you have the required permissions for the action, without
 	// actually making the request, and provides an error response. If you have
 	// the required permissions, the error response is DryRunOperation. Otherwise,
@@ -10273,8 +10275,6 @@ type DeleteTagsInput struct {
 	// tag regardless of its value. If you specify this parameter with an empty
 	// string as the value, we delete the key only if its value is an empty string.
 	Tags []*Tag `locationName:"tag" locationNameList:"item" type:"list"`
-
-	_ struct{} `type:"structure"`
 }
 
 // String returns the string representation
@@ -10302,6 +10302,8 @@ func (s DeleteTagsOutput) GoString() string {
 }
 
 type DeleteVolumeInput struct {
+	_ struct{} `type:"structure"`
+
 	// Checks whether you have the required permissions for the action, without
 	// actually making the request, and provides an error response. If you have
 	// the required permissions, the error response is DryRunOperation. Otherwise,
@@ -10310,8 +10312,6 @@ type DeleteVolumeInput struct {
 
 	// The ID of the volume.
 	VolumeId *string `type:"string" required:"true"`
-
-	_ struct{} `type:"structure"`
 }
 
 // String returns the string representation
@@ -10339,6 +10339,8 @@ func (s DeleteVolumeOutput) GoString() string {
 }
 
 type DeleteVpcEndpointsInput struct {
+	_ struct{} `type:"structure"`
+
 	// Checks whether you have the required permissions for the action, without
 	// actually making the request, and provides an error response. If you have
 	// the required permissions, the error response is DryRunOperation. Otherwise,
@@ -10347,8 +10349,6 @@ type DeleteVpcEndpointsInput struct {
 
 	// One or more endpoint IDs.
 	VpcEndpointIds []*string `locationName:"VpcEndpointId" locationNameList:"item" type:"list" required:"true"`
-
-	_ struct{} `type:"structure"`
 }
 
 // String returns the string representation
@@ -10362,10 +10362,10 @@ func (s DeleteVpcEndpointsInput) GoString() string {
 }
 
 type DeleteVpcEndpointsOutput struct {
+	_ struct{} `type:"structure"`
+
 	// Information about the endpoints that were not successfully deleted.
 	Unsuccessful []*UnsuccessfulItem `locationName:"unsuccessful" locationNameList:"item" type:"list"`
-
-	_ struct{} `type:"structure"`
 }
 
 // String returns the string representation
@@ -10379,6 +10379,8 @@ func (s DeleteVpcEndpointsOutput) GoString() string {
 }
 
 type DeleteVpcInput struct {
+	_ struct{} `type:"structure"`
+
 	// Checks whether you have the required permissions for the action, without
 	// actually making the request, and provides an error response. If you have
 	// the required permissions, the error response is DryRunOperation. Otherwise,
@@ -10387,8 +10389,6 @@ type DeleteVpcInput struct {
 
 	// The ID of the VPC.
 	VpcId *string `type:"string" required:"true"`
-
-	_ struct{} `type:"structure"`
 }
 
 // String returns the string representation
@@ -10416,6 +10416,8 @@ func (s DeleteVpcOutput) GoString() string {
 }
 
 type DeleteVpcPeeringConnectionInput struct {
+	_ struct{} `type:"structure"`
+
 	// Checks whether you have the required permissions for the action, without
 	// actually making the request, and provides an error response. If you have
 	// the required permissions, the error response is DryRunOperation. Otherwise,
@@ -10424,8 +10426,6 @@ type DeleteVpcPeeringConnectionInput struct {
 
 	// The ID of the VPC peering connection.
 	VpcPeeringConnectionId *string `locationName:"vpcPeeringConnectionId" type:"string" required:"true"`
-
-	_ struct{} `type:"structure"`
 }
 
 // String returns the string representation
@@ -10439,10 +10439,10 @@ func (s DeleteVpcPeeringConnectionInput) GoString() string {
 }
 
 type DeleteVpcPeeringConnectionOutput struct {
+	_ struct{} `type:"structure"`
+
 	// Returns true if the request succeeds; otherwise, it returns an error.
 	Return *bool `locationName:"return" type:"boolean"`
-
-	_ struct{} `type:"structure"`
 }
 
 // String returns the string representation
@@ -10456,6 +10456,8 @@ func (s DeleteVpcPeeringConnectionOutput) GoString() string {
 }
 
 type DeleteVpnConnectionInput struct {
+	_ struct{} `type:"structure"`
+
 	// Checks whether you have the required permissions for the action, without
 	// actually making the request, and provides an error response. If you have
 	// the required permissions, the error response is DryRunOperation. Otherwise,
@@ -10464,8 +10466,6 @@ type DeleteVpnConnectionInput struct {
 
 	// The ID of the VPN connection.
 	VpnConnectionId *string `type:"string" required:"true"`
-
-	_ struct{} `type:"structure"`
 }
 
 // String returns the string representation
@@ -10493,13 +10493,13 @@ func (s DeleteVpnConnectionOutput) GoString() string {
 }
 
 type DeleteVpnConnectionRouteInput struct {
+	_ struct{} `type:"structure"`
+
 	// The CIDR block associated with the local subnet of the customer network.
 	DestinationCidrBlock *string `type:"string" required:"true"`
 
 	// The ID of the VPN connection.
 	VpnConnectionId *string `type:"string" required:"true"`
-
-	_ struct{} `type:"structure"`
 }
 
 // String returns the string representation
@@ -10527,6 +10527,8 @@ func (s DeleteVpnConnectionRouteOutput) GoString() string {
 }
 
 type DeleteVpnGatewayInput struct {
+	_ struct{} `type:"structure"`
+
 	// Checks whether you have the required permissions for the action, without
 	// actually making the request, and provides an error response. If you have
 	// the required permissions, the error response is DryRunOperation. Otherwise,
@@ -10535,8 +10537,6 @@ type DeleteVpnGatewayInput struct {
 
 	// The ID of the virtual private gateway.
 	VpnGatewayId *string `type:"string" required:"true"`
-
-	_ struct{} `type:"structure"`
 }
 
 // String returns the string representation
@@ -10564,6 +10564,8 @@ func (s DeleteVpnGatewayOutput) GoString() string {
 }
 
 type DeregisterImageInput struct {
+	_ struct{} `type:"structure"`
+
 	// Checks whether you have the required permissions for the action, without
 	// actually making the request, and provides an error response. If you have
 	// the required permissions, the error response is DryRunOperation. Otherwise,
@@ -10572,8 +10574,6 @@ type DeregisterImageInput struct {
 
 	// The ID of the AMI.
 	ImageId *string `type:"string" required:"true"`
-
-	_ struct{} `type:"structure"`
 }
 
 // String returns the string representation
@@ -10601,6 +10601,8 @@ func (s DeregisterImageOutput) GoString() string {
 }
 
 type DescribeAccountAttributesInput struct {
+	_ struct{} `type:"structure"`
+
 	// One or more account attribute names.
 	AttributeNames []*string `locationName:"attributeName" locationNameList:"attributeName" type:"list"`
 
@@ -10609,8 +10611,6 @@ type DescribeAccountAttributesInput struct {
 	// the required permissions, the error response is DryRunOperation. Otherwise,
 	// it is UnauthorizedOperation.
 	DryRun *bool `locationName:"dryRun" type:"boolean"`
-
-	_ struct{} `type:"structure"`
 }
 
 // String returns the string representation
@@ -10624,10 +10624,10 @@ func (s DescribeAccountAttributesInput) GoString() string {
 }
 
 type DescribeAccountAttributesOutput struct {
+	_ struct{} `type:"structure"`
+
 	// Information about one or more account attributes.
 	AccountAttributes []*AccountAttribute `locationName:"accountAttributeSet" locationNameList:"item" type:"list"`
-
-	_ struct{} `type:"structure"`
 }
 
 // String returns the string representation
@@ -10641,6 +10641,8 @@ func (s DescribeAccountAttributesOutput) GoString() string {
 }
 
 type DescribeAddressesInput struct {
+	_ struct{} `type:"structure"`
+
 	// [EC2-VPC] One or more allocation IDs.
 	//
 	// Default: Describes all your Elastic IP addresses.
@@ -10679,8 +10681,6 @@ type DescribeAddressesInput struct {
 	//
 	// Default: Describes all your Elastic IP addresses.
 	PublicIps []*string `locationName:"PublicIp" locationNameList:"PublicIp" type:"list"`
-
-	_ struct{} `type:"structure"`
 }
 
 // String returns the string representation
@@ -10694,10 +10694,10 @@ func (s DescribeAddressesInput) GoString() string {
 }
 
 type DescribeAddressesOutput struct {
+	_ struct{} `type:"structure"`
+
 	// Information about one or more Elastic IP addresses.
 	Addresses []*Address `locationName:"addressesSet" locationNameList:"item" type:"list"`
-
-	_ struct{} `type:"structure"`
 }
 
 // String returns the string representation
@@ -10711,6 +10711,8 @@ func (s DescribeAddressesOutput) GoString() string {
 }
 
 type DescribeAvailabilityZonesInput struct {
+	_ struct{} `type:"structure"`
+
 	// Checks whether you have the required permissions for the action, without
 	// actually making the request, and provides an error response. If you have
 	// the required permissions, the error response is DryRunOperation. Otherwise,
@@ -10732,8 +10734,6 @@ type DescribeAvailabilityZonesInput struct {
 
 	// The names of one or more Availability Zones.
 	ZoneNames []*string `locationName:"ZoneName" locationNameList:"ZoneName" type:"list"`
-
-	_ struct{} `type:"structure"`
 }
 
 // String returns the string representation
@@ -10747,10 +10747,10 @@ func (s DescribeAvailabilityZonesInput) GoString() string {
 }
 
 type DescribeAvailabilityZonesOutput struct {
+	_ struct{} `type:"structure"`
+
 	// Information about one or more Availability Zones.
 	AvailabilityZones []*AvailabilityZone `locationName:"availabilityZoneInfo" locationNameList:"item" type:"list"`
-
-	_ struct{} `type:"structure"`
 }
 
 // String returns the string representation
@@ -10764,6 +10764,8 @@ func (s DescribeAvailabilityZonesOutput) GoString() string {
 }
 
 type DescribeBundleTasksInput struct {
+	_ struct{} `type:"structure"`
+
 	// One or more bundle task IDs.
 	//
 	// Default: Describes all your bundle tasks.
@@ -10799,8 +10801,6 @@ type DescribeBundleTasksInput struct {
 	//
 	//   update-time - The time of the most recent update for the task.
 	Filters []*Filter `locationName:"Filter" locationNameList:"Filter" type:"list"`
-
-	_ struct{} `type:"structure"`
 }
 
 // String returns the string representation
@@ -10814,10 +10814,10 @@ func (s DescribeBundleTasksInput) GoString() string {
 }
 
 type DescribeBundleTasksOutput struct {
+	_ struct{} `type:"structure"`
+
 	// Information about one or more bundle tasks.
 	BundleTasks []*BundleTask `locationName:"bundleInstanceTasksSet" locationNameList:"item" type:"list"`
-
-	_ struct{} `type:"structure"`
 }
 
 // String returns the string representation
@@ -10831,6 +10831,8 @@ func (s DescribeBundleTasksOutput) GoString() string {
 }
 
 type DescribeClassicLinkInstancesInput struct {
+	_ struct{} `type:"structure"`
+
 	// Checks whether you have the required permissions for the action, without
 	// actually making the request, and provides an error response. If you have
 	// the required permissions, the error response is DryRunOperation. Otherwise,
@@ -10873,8 +10875,6 @@ type DescribeClassicLinkInstancesInput struct {
 
 	// The token to retrieve the next page of results.
 	NextToken *string `locationName:"nextToken" type:"string"`
-
-	_ struct{} `type:"structure"`
 }
 
 // String returns the string representation
@@ -10888,14 +10888,14 @@ func (s DescribeClassicLinkInstancesInput) GoString() string {
 }
 
 type DescribeClassicLinkInstancesOutput struct {
+	_ struct{} `type:"structure"`
+
 	// Information about one or more linked EC2-Classic instances.
 	Instances []*ClassicLinkInstance `locationName:"instancesSet" locationNameList:"item" type:"list"`
 
 	// The token to use to retrieve the next page of results. This value is null
 	// when there are no more results to return.
 	NextToken *string `locationName:"nextToken" type:"string"`
-
-	_ struct{} `type:"structure"`
 }
 
 // String returns the string representation
@@ -10909,6 +10909,8 @@ func (s DescribeClassicLinkInstancesOutput) GoString() string {
 }
 
 type DescribeConversionTasksInput struct {
+	_ struct{} `type:"structure"`
+
 	// One or more conversion task IDs.
 	ConversionTaskIds []*string `locationName:"conversionTaskId" locationNameList:"item" type:"list"`
 
@@ -10920,8 +10922,6 @@ type DescribeConversionTasksInput struct {
 
 	// One or more filters.
 	Filters []*Filter `locationName:"filter" locationNameList:"Filter" type:"list"`
-
-	_ struct{} `type:"structure"`
 }
 
 // String returns the string representation
@@ -10935,10 +10935,10 @@ func (s DescribeConversionTasksInput) GoString() string {
 }
 
 type DescribeConversionTasksOutput struct {
+	_ struct{} `type:"structure"`
+
 	// Information about the conversion tasks.
 	ConversionTasks []*ConversionTask `locationName:"conversionTasks" locationNameList:"item" type:"list"`
-
-	_ struct{} `type:"structure"`
 }
 
 // String returns the string representation
@@ -10952,6 +10952,8 @@ func (s DescribeConversionTasksOutput) GoString() string {
 }
 
 type DescribeCustomerGatewaysInput struct {
+	_ struct{} `type:"structure"`
+
 	// One or more customer gateway IDs.
 	//
 	// Default: Describes all your customer gateways.
@@ -10991,8 +10993,6 @@ type DescribeCustomerGatewaysInput struct {
 	//   tag-value - The value of a tag assigned to the resource. This filter is
 	// independent of the tag-key filter.
 	Filters []*Filter `locationName:"Filter" locationNameList:"Filter" type:"list"`
-
-	_ struct{} `type:"structure"`
 }
 
 // String returns the string representation
@@ -11006,10 +11006,10 @@ func (s DescribeCustomerGatewaysInput) GoString() string {
 }
 
 type DescribeCustomerGatewaysOutput struct {
+	_ struct{} `type:"structure"`
+
 	// Information about one or more customer gateways.
 	CustomerGateways []*CustomerGateway `locationName:"customerGatewaySet" locationNameList:"item" type:"list"`
-
-	_ struct{} `type:"structure"`
 }
 
 // String returns the string representation
@@ -11023,6 +11023,8 @@ func (s DescribeCustomerGatewaysOutput) GoString() string {
 }
 
 type DescribeDhcpOptionsInput struct {
+	_ struct{} `type:"structure"`
+
 	// The IDs of one or more DHCP options sets.
 	//
 	// Default: Describes all your DHCP options sets.
@@ -11054,8 +11056,6 @@ type DescribeDhcpOptionsInput struct {
 	//   tag-value - The value of a tag assigned to the resource. This filter is
 	// independent of the tag-key filter.
 	Filters []*Filter `locationName:"Filter" locationNameList:"Filter" type:"list"`
-
-	_ struct{} `type:"structure"`
 }
 
 // String returns the string representation
@@ -11069,10 +11069,10 @@ func (s DescribeDhcpOptionsInput) GoString() string {
 }
 
 type DescribeDhcpOptionsOutput struct {
+	_ struct{} `type:"structure"`
+
 	// Information about one or more DHCP options sets.
 	DhcpOptions []*DhcpOptions `locationName:"dhcpOptionsSet" locationNameList:"item" type:"list"`
-
-	_ struct{} `type:"structure"`
 }
 
 // String returns the string representation
@@ -11086,10 +11086,10 @@ func (s DescribeDhcpOptionsOutput) GoString() string {
 }
 
 type DescribeExportTasksInput struct {
+	_ struct{} `type:"structure"`
+
 	// One or more export task IDs.
 	ExportTaskIds []*string `locationName:"exportTaskId" locationNameList:"ExportTaskId" type:"list"`
-
-	_ struct{} `type:"structure"`
 }
 
 // String returns the string representation
@@ -11103,10 +11103,10 @@ func (s DescribeExportTasksInput) GoString() string {
 }
 
 type DescribeExportTasksOutput struct {
+	_ struct{} `type:"structure"`
+
 	// Information about the export tasks.
 	ExportTasks []*ExportTask `locationName:"exportTaskSet" locationNameList:"item" type:"list"`
-
-	_ struct{} `type:"structure"`
 }
 
 // String returns the string representation
@@ -11120,6 +11120,8 @@ func (s DescribeExportTasksOutput) GoString() string {
 }
 
 type DescribeFlowLogsInput struct {
+	_ struct{} `type:"structure"`
+
 	// One or more filters.
 	//
 	//  deliver-log-status - The status of the logs delivery (SUCCESS | FAILED).
@@ -11145,8 +11147,6 @@ type DescribeFlowLogsInput struct {
 
 	// The token to retrieve the next page of results.
 	NextToken *string `type:"string"`
-
-	_ struct{} `type:"structure"`
 }
 
 // String returns the string representation
@@ -11160,14 +11160,14 @@ func (s DescribeFlowLogsInput) GoString() string {
 }
 
 type DescribeFlowLogsOutput struct {
+	_ struct{} `type:"structure"`
+
 	// Information about the flow logs.
 	FlowLogs []*FlowLog `locationName:"flowLogSet" locationNameList:"item" type:"list"`
 
 	// The token to use to retrieve the next page of results. This value is null
 	// when there are no more results to return.
 	NextToken *string `locationName:"nextToken" type:"string"`
-
-	_ struct{} `type:"structure"`
 }
 
 // String returns the string representation
@@ -11181,6 +11181,8 @@ func (s DescribeFlowLogsOutput) GoString() string {
 }
 
 type DescribeHostsInput struct {
+	_ struct{} `type:"structure"`
+
 	// One or more filters.
 	//
 	//  instance-type - The instance type size that the Dedicated host is configured
@@ -11211,8 +11213,6 @@ type DescribeHostsInput struct {
 
 	// The token to retrieve the next page of results.
 	NextToken *string `locationName:"nextToken" type:"string"`
-
-	_ struct{} `type:"structure"`
 }
 
 // String returns the string representation
@@ -11226,14 +11226,14 @@ func (s DescribeHostsInput) GoString() string {
 }
 
 type DescribeHostsOutput struct {
+	_ struct{} `type:"structure"`
+
 	// Information about the Dedicated hosts.
 	Hosts []*Host `locationName:"hostSet" locationNameList:"item" type:"list"`
 
 	// The token to use to retrieve the next page of results. This value is null
 	// when there are no more results to return.
 	NextToken *string `locationName:"nextToken" type:"string"`
-
-	_ struct{} `type:"structure"`
 }
 
 // String returns the string representation
@@ -11247,10 +11247,10 @@ func (s DescribeHostsOutput) GoString() string {
 }
 
 type DescribeIdFormatInput struct {
+	_ struct{} `type:"structure"`
+
 	// The type of resource.
 	Resource *string `type:"string"`
-
-	_ struct{} `type:"structure"`
 }
 
 // String returns the string representation
@@ -11264,10 +11264,10 @@ func (s DescribeIdFormatInput) GoString() string {
 }
 
 type DescribeIdFormatOutput struct {
+	_ struct{} `type:"structure"`
+
 	// Information about the ID format for the resource.
 	Statuses []*IdFormat `locationName:"statusSet" locationNameList:"item" type:"list"`
-
-	_ struct{} `type:"structure"`
 }
 
 // String returns the string representation
@@ -11281,6 +11281,8 @@ func (s DescribeIdFormatOutput) GoString() string {
 }
 
 type DescribeImageAttributeInput struct {
+	_ struct{} `type:"structure"`
+
 	// The AMI attribute.
 	//
 	// Note: Depending on your account privileges, the blockDeviceMapping attribute
@@ -11296,8 +11298,6 @@ type DescribeImageAttributeInput struct {
 
 	// The ID of the AMI.
 	ImageId *string `type:"string" required:"true"`
-
-	_ struct{} `type:"structure"`
 }
 
 // String returns the string representation
@@ -11312,6 +11312,8 @@ func (s DescribeImageAttributeInput) GoString() string {
 
 // Describes an image attribute.
 type DescribeImageAttributeOutput struct {
+	_ struct{} `type:"structure"`
+
 	// One or more block device mapping entries.
 	BlockDeviceMappings []*BlockDeviceMapping `locationName:"blockDeviceMapping" locationNameList:"item" type:"list"`
 
@@ -11335,8 +11337,6 @@ type DescribeImageAttributeOutput struct {
 
 	// The value to use for a resource attribute.
 	SriovNetSupport *AttributeValue `locationName:"sriovNetSupport" type:"structure"`
-
-	_ struct{} `type:"structure"`
 }
 
 // String returns the string representation
@@ -11350,6 +11350,8 @@ func (s DescribeImageAttributeOutput) GoString() string {
 }
 
 type DescribeImagesInput struct {
+	_ struct{} `type:"structure"`
+
 	// Checks whether you have the required permissions for the action, without
 	// actually making the request, and provides an error response. If you have
 	// the required permissions, the error response is DryRunOperation. Otherwise,
@@ -11442,8 +11444,6 @@ type DescribeImagesInput struct {
 	// sender of the request). Omitting this option returns all images for which
 	// you have launch permissions, regardless of ownership.
 	Owners []*string `locationName:"Owner" locationNameList:"Owner" type:"list"`
-
-	_ struct{} `type:"structure"`
 }
 
 // String returns the string representation
@@ -11457,10 +11457,10 @@ func (s DescribeImagesInput) GoString() string {
 }
 
 type DescribeImagesOutput struct {
+	_ struct{} `type:"structure"`
+
 	// Information about one or more images.
 	Images []*Image `locationName:"imagesSet" locationNameList:"item" type:"list"`
-
-	_ struct{} `type:"structure"`
 }
 
 // String returns the string representation
@@ -11474,6 +11474,8 @@ func (s DescribeImagesOutput) GoString() string {
 }
 
 type DescribeImportImageTasksInput struct {
+	_ struct{} `type:"structure"`
+
 	// Checks whether you have the required permissions for the action, without
 	// actually making the request, and provides an error response. If you have
 	// the required permissions, the error response is DryRunOperation. Otherwise,
@@ -11491,8 +11493,6 @@ type DescribeImportImageTasksInput struct {
 
 	// A token that indicates the next page of results.
 	NextToken *string `type:"string"`
-
-	_ struct{} `type:"structure"`
 }
 
 // String returns the string representation
@@ -11506,6 +11506,8 @@ func (s DescribeImportImageTasksInput) GoString() string {
 }
 
 type DescribeImportImageTasksOutput struct {
+	_ struct{} `type:"structure"`
+
 	// A list of zero or more import image tasks that are currently active or were
 	// completed or canceled in the previous 7 days.
 	ImportImageTasks []*ImportImageTask `locationName:"importImageTaskSet" locationNameList:"item" type:"list"`
@@ -11513,8 +11515,6 @@ type DescribeImportImageTasksOutput struct {
 	// The token to use to get the next page of results. This value is null when
 	// there are no more results to return.
 	NextToken *string `locationName:"nextToken" type:"string"`
-
-	_ struct{} `type:"structure"`
 }
 
 // String returns the string representation
@@ -11528,6 +11528,8 @@ func (s DescribeImportImageTasksOutput) GoString() string {
 }
 
 type DescribeImportSnapshotTasksInput struct {
+	_ struct{} `type:"structure"`
+
 	// Checks whether you have the required permissions for the action, without
 	// actually making the request, and provides an error response. If you have
 	// the required permissions, the error response is DryRunOperation. Otherwise,
@@ -11545,8 +11547,6 @@ type DescribeImportSnapshotTasksInput struct {
 
 	// A token that indicates the next page of results.
 	NextToken *string `type:"string"`
-
-	_ struct{} `type:"structure"`
 }
 
 // String returns the string representation
@@ -11560,6 +11560,8 @@ func (s DescribeImportSnapshotTasksInput) GoString() string {
 }
 
 type DescribeImportSnapshotTasksOutput struct {
+	_ struct{} `type:"structure"`
+
 	// A list of zero or more import snapshot tasks that are currently active or
 	// were completed or canceled in the previous 7 days.
 	ImportSnapshotTasks []*ImportSnapshotTask `locationName:"importSnapshotTaskSet" locationNameList:"item" type:"list"`
@@ -11567,8 +11569,6 @@ type DescribeImportSnapshotTasksOutput struct {
 	// The token to use to get the next page of results. This value is null when
 	// there are no more results to return.
 	NextToken *string `locationName:"nextToken" type:"string"`
-
-	_ struct{} `type:"structure"`
 }
 
 // String returns the string representation
@@ -11582,6 +11582,8 @@ func (s DescribeImportSnapshotTasksOutput) GoString() string {
 }
 
 type DescribeInstanceAttributeInput struct {
+	_ struct{} `type:"structure"`
+
 	// The instance attribute.
 	Attribute *string `locationName:"attribute" type:"string" required:"true" enum:"InstanceAttributeName"`
 
@@ -11593,8 +11595,6 @@ type DescribeInstanceAttributeInput struct {
 
 	// The ID of the instance.
 	InstanceId *string `locationName:"instanceId" type:"string" required:"true"`
-
-	_ struct{} `type:"structure"`
 }
 
 // String returns the string representation
@@ -11609,6 +11609,8 @@ func (s DescribeInstanceAttributeInput) GoString() string {
 
 // Describes an instance attribute.
 type DescribeInstanceAttributeOutput struct {
+	_ struct{} `type:"structure"`
+
 	// The block device mapping of the instance.
 	BlockDeviceMappings []*InstanceBlockDeviceMapping `locationName:"blockDeviceMapping" locationNameList:"item" type:"list"`
 
@@ -11654,8 +11656,6 @@ type DescribeInstanceAttributeOutput struct {
 
 	// The Base64-encoded MIME user data.
 	UserData *AttributeValue `locationName:"userData" type:"structure"`
-
-	_ struct{} `type:"structure"`
 }
 
 // String returns the string representation
@@ -11669,6 +11669,8 @@ func (s DescribeInstanceAttributeOutput) GoString() string {
 }
 
 type DescribeInstanceStatusInput struct {
+	_ struct{} `type:"structure"`
+
 	// Checks whether you have the required permissions for the action, without
 	// actually making the request, and provides an error response. If you have
 	// the required permissions, the error response is DryRunOperation. Otherwise,
@@ -11735,8 +11737,6 @@ type DescribeInstanceStatusInput struct {
 
 	// The token to retrieve the next page of results.
 	NextToken *string `type:"string"`
-
-	_ struct{} `type:"structure"`
 }
 
 // String returns the string representation
@@ -11750,14 +11750,14 @@ func (s DescribeInstanceStatusInput) GoString() string {
 }
 
 type DescribeInstanceStatusOutput struct {
+	_ struct{} `type:"structure"`
+
 	// One or more instance status descriptions.
 	InstanceStatuses []*InstanceStatus `locationName:"instanceStatusSet" locationNameList:"item" type:"list"`
 
 	// The token to use to retrieve the next page of results. This value is null
 	// when there are no more results to return.
 	NextToken *string `locationName:"nextToken" type:"string"`
-
-	_ struct{} `type:"structure"`
 }
 
 // String returns the string representation
@@ -11771,6 +11771,8 @@ func (s DescribeInstanceStatusOutput) GoString() string {
 }
 
 type DescribeInstancesInput struct {
+	_ struct{} `type:"structure"`
+
 	// Checks whether you have the required permissions for the action, without
 	// actually making the request, and provides an error response. If you have
 	// the required permissions, the error response is DryRunOperation. Otherwise,
@@ -12017,8 +12019,6 @@ type DescribeInstancesInput struct {
 
 	// The token to request the next page of results.
 	NextToken *string `locationName:"nextToken" type:"string"`
-
-	_ struct{} `type:"structure"`
 }
 
 // String returns the string representation
@@ -12032,14 +12032,14 @@ func (s DescribeInstancesInput) GoString() string {
 }
 
 type DescribeInstancesOutput struct {
+	_ struct{} `type:"structure"`
+
 	// The token to use to retrieve the next page of results. This value is null
 	// when there are no more results to return.
 	NextToken *string `locationName:"nextToken" type:"string"`
 
 	// Zero or more reservations.
 	Reservations []*Reservation `locationName:"reservationSet" locationNameList:"item" type:"list"`
-
-	_ struct{} `type:"structure"`
 }
 
 // String returns the string representation
@@ -12053,6 +12053,8 @@ func (s DescribeInstancesOutput) GoString() string {
 }
 
 type DescribeInternetGatewaysInput struct {
+	_ struct{} `type:"structure"`
+
 	// Checks whether you have the required permissions for the action, without
 	// actually making the request, and provides an error response. If you have
 	// the required permissions, the error response is DryRunOperation. Otherwise,
@@ -12085,8 +12087,6 @@ type DescribeInternetGatewaysInput struct {
 	//
 	// Default: Describes all your Internet gateways.
 	InternetGatewayIds []*string `locationName:"internetGatewayId" locationNameList:"item" type:"list"`
-
-	_ struct{} `type:"structure"`
 }
 
 // String returns the string representation
@@ -12100,10 +12100,10 @@ func (s DescribeInternetGatewaysInput) GoString() string {
 }
 
 type DescribeInternetGatewaysOutput struct {
+	_ struct{} `type:"structure"`
+
 	// Information about one or more Internet gateways.
 	InternetGateways []*InternetGateway `locationName:"internetGatewaySet" locationNameList:"item" type:"list"`
-
-	_ struct{} `type:"structure"`
 }
 
 // String returns the string representation
@@ -12117,6 +12117,8 @@ func (s DescribeInternetGatewaysOutput) GoString() string {
 }
 
 type DescribeKeyPairsInput struct {
+	_ struct{} `type:"structure"`
+
 	// Checks whether you have the required permissions for the action, without
 	// actually making the request, and provides an error response. If you have
 	// the required permissions, the error response is DryRunOperation. Otherwise,
@@ -12134,8 +12136,6 @@ type DescribeKeyPairsInput struct {
 	//
 	// Default: Describes all your key pairs.
 	KeyNames []*string `locationName:"KeyName" locationNameList:"KeyName" type:"list"`
-
-	_ struct{} `type:"structure"`
 }
 
 // String returns the string representation
@@ -12149,10 +12149,10 @@ func (s DescribeKeyPairsInput) GoString() string {
 }
 
 type DescribeKeyPairsOutput struct {
+	_ struct{} `type:"structure"`
+
 	// Information about one or more key pairs.
 	KeyPairs []*KeyPairInfo `locationName:"keySet" locationNameList:"item" type:"list"`
-
-	_ struct{} `type:"structure"`
 }
 
 // String returns the string representation
@@ -12166,6 +12166,8 @@ func (s DescribeKeyPairsOutput) GoString() string {
 }
 
 type DescribeMovingAddressesInput struct {
+	_ struct{} `type:"structure"`
+
 	// Checks whether you have the required permissions for the action, without
 	// actually making the request, and provides an error response. If you have
 	// the required permissions, the error response is DryRunOperation. Otherwise,
@@ -12190,8 +12192,6 @@ type DescribeMovingAddressesInput struct {
 
 	// One or more Elastic IP addresses.
 	PublicIps []*string `locationName:"publicIp" locationNameList:"item" type:"list"`
-
-	_ struct{} `type:"structure"`
 }
 
 // String returns the string representation
@@ -12205,14 +12205,14 @@ func (s DescribeMovingAddressesInput) GoString() string {
 }
 
 type DescribeMovingAddressesOutput struct {
+	_ struct{} `type:"structure"`
+
 	// The status for each Elastic IP address.
 	MovingAddressStatuses []*MovingAddressStatus `locationName:"movingAddressStatusSet" locationNameList:"item" type:"list"`
 
 	// The token to use to retrieve the next page of results. This value is null
 	// when there are no more results to return.
 	NextToken *string `locationName:"nextToken" type:"string"`
-
-	_ struct{} `type:"structure"`
 }
 
 // String returns the string representation
@@ -12226,6 +12226,8 @@ func (s DescribeMovingAddressesOutput) GoString() string {
 }
 
 type DescribeNetworkAclsInput struct {
+	_ struct{} `type:"structure"`
+
 	// Checks whether you have the required permissions for the action, without
 	// actually making the request, and provides an error response. If you have
 	// the required permissions, the error response is DryRunOperation. Otherwise,
@@ -12285,8 +12287,6 @@ type DescribeNetworkAclsInput struct {
 	//
 	// Default: Describes all your network ACLs.
 	NetworkAclIds []*string `locationName:"NetworkAclId" locationNameList:"item" type:"list"`
-
-	_ struct{} `type:"structure"`
 }
 
 // String returns the string representation
@@ -12300,10 +12300,10 @@ func (s DescribeNetworkAclsInput) GoString() string {
 }
 
 type DescribeNetworkAclsOutput struct {
+	_ struct{} `type:"structure"`
+
 	// Information about one or more network ACLs.
 	NetworkAcls []*NetworkAcl `locationName:"networkAclSet" locationNameList:"item" type:"list"`
-
-	_ struct{} `type:"structure"`
 }
 
 // String returns the string representation
@@ -12317,6 +12317,8 @@ func (s DescribeNetworkAclsOutput) GoString() string {
 }
 
 type DescribeNetworkInterfaceAttributeInput struct {
+	_ struct{} `type:"structure"`
+
 	// The attribute of the network interface.
 	Attribute *string `locationName:"attribute" type:"string" enum:"NetworkInterfaceAttribute"`
 
@@ -12328,8 +12330,6 @@ type DescribeNetworkInterfaceAttributeInput struct {
 
 	// The ID of the network interface.
 	NetworkInterfaceId *string `locationName:"networkInterfaceId" type:"string" required:"true"`
-
-	_ struct{} `type:"structure"`
 }
 
 // String returns the string representation
@@ -12343,6 +12343,8 @@ func (s DescribeNetworkInterfaceAttributeInput) GoString() string {
 }
 
 type DescribeNetworkInterfaceAttributeOutput struct {
+	_ struct{} `type:"structure"`
+
 	// The attachment (if any) of the network interface.
 	Attachment *NetworkInterfaceAttachment `locationName:"attachment" type:"structure"`
 
@@ -12357,8 +12359,6 @@ type DescribeNetworkInterfaceAttributeOutput struct {
 
 	// Indicates whether source/destination checking is enabled.
 	SourceDestCheck *AttributeBooleanValue `locationName:"sourceDestCheck" type:"structure"`
-
-	_ struct{} `type:"structure"`
 }
 
 // String returns the string representation
@@ -12372,6 +12372,8 @@ func (s DescribeNetworkInterfaceAttributeOutput) GoString() string {
 }
 
 type DescribeNetworkInterfacesInput struct {
+	_ struct{} `type:"structure"`
+
 	// Checks whether you have the required permissions for the action, without
 	// actually making the request, and provides an error response. If you have
 	// the required permissions, the error response is DryRunOperation. Otherwise,
@@ -12483,8 +12485,6 @@ type DescribeNetworkInterfacesInput struct {
 	//
 	// Default: Describes all your network interfaces.
 	NetworkInterfaceIds []*string `locationName:"NetworkInterfaceId" locationNameList:"item" type:"list"`
-
-	_ struct{} `type:"structure"`
 }
 
 // String returns the string representation
@@ -12498,10 +12498,10 @@ func (s DescribeNetworkInterfacesInput) GoString() string {
 }
 
 type DescribeNetworkInterfacesOutput struct {
+	_ struct{} `type:"structure"`
+
 	// Information about one or more network interfaces.
 	NetworkInterfaces []*NetworkInterface `locationName:"networkInterfaceSet" locationNameList:"item" type:"list"`
-
-	_ struct{} `type:"structure"`
 }
 
 // String returns the string representation
@@ -12515,6 +12515,8 @@ func (s DescribeNetworkInterfacesOutput) GoString() string {
 }
 
 type DescribePlacementGroupsInput struct {
+	_ struct{} `type:"structure"`
+
 	// Checks whether you have the required permissions for the action, without
 	// actually making the request, and provides an error response. If you have
 	// the required permissions, the error response is DryRunOperation. Otherwise,
@@ -12535,8 +12537,6 @@ type DescribePlacementGroupsInput struct {
 	//
 	// Default: Describes all your placement groups, or only those otherwise specified.
 	GroupNames []*string `locationName:"groupName" type:"list"`
-
-	_ struct{} `type:"structure"`
 }
 
 // String returns the string representation
@@ -12550,10 +12550,10 @@ func (s DescribePlacementGroupsInput) GoString() string {
 }
 
 type DescribePlacementGroupsOutput struct {
+	_ struct{} `type:"structure"`
+
 	// One or more placement groups.
 	PlacementGroups []*PlacementGroup `locationName:"placementGroupSet" locationNameList:"item" type:"list"`
-
-	_ struct{} `type:"structure"`
 }
 
 // String returns the string representation
@@ -12567,6 +12567,8 @@ func (s DescribePlacementGroupsOutput) GoString() string {
 }
 
 type DescribePrefixListsInput struct {
+	_ struct{} `type:"structure"`
+
 	// Checks whether you have the required permissions for the action, without
 	// actually making the request, and provides an error response. If you have
 	// the required permissions, the error response is DryRunOperation. Otherwise,
@@ -12594,8 +12596,6 @@ type DescribePrefixListsInput struct {
 
 	// One or more prefix list IDs.
 	PrefixListIds []*string `locationName:"PrefixListId" locationNameList:"item" type:"list"`
-
-	_ struct{} `type:"structure"`
 }
 
 // String returns the string representation
@@ -12609,14 +12609,14 @@ func (s DescribePrefixListsInput) GoString() string {
 }
 
 type DescribePrefixListsOutput struct {
+	_ struct{} `type:"structure"`
+
 	// The token to use when requesting the next set of items. If there are no additional
 	// items to return, the string is empty.
 	NextToken *string `locationName:"nextToken" type:"string"`
 
 	// All available prefix lists.
 	PrefixLists []*PrefixList `locationName:"prefixListSet" locationNameList:"item" type:"list"`
-
-	_ struct{} `type:"structure"`
 }
 
 // String returns the string representation
@@ -12630,6 +12630,8 @@ func (s DescribePrefixListsOutput) GoString() string {
 }
 
 type DescribeRegionsInput struct {
+	_ struct{} `type:"structure"`
+
 	// Checks whether you have the required permissions for the action, without
 	// actually making the request, and provides an error response. If you have
 	// the required permissions, the error response is DryRunOperation. Otherwise,
@@ -12645,8 +12647,6 @@ type DescribeRegionsInput struct {
 
 	// The names of one or more regions.
 	RegionNames []*string `locationName:"RegionName" locationNameList:"RegionName" type:"list"`
-
-	_ struct{} `type:"structure"`
 }
 
 // String returns the string representation
@@ -12660,10 +12660,10 @@ func (s DescribeRegionsInput) GoString() string {
 }
 
 type DescribeRegionsOutput struct {
+	_ struct{} `type:"structure"`
+
 	// Information about one or more regions.
 	Regions []*Region `locationName:"regionInfo" locationNameList:"item" type:"list"`
-
-	_ struct{} `type:"structure"`
 }
 
 // String returns the string representation
@@ -12677,6 +12677,8 @@ func (s DescribeRegionsOutput) GoString() string {
 }
 
 type DescribeReservedInstancesInput struct {
+	_ struct{} `type:"structure"`
+
 	// Checks whether you have the required permissions for the action, without
 	// actually making the request, and provides an error response. If you have
 	// the required permissions, the error response is DryRunOperation. Otherwise,
@@ -12743,8 +12745,6 @@ type DescribeReservedInstancesInput struct {
 	// Default: Describes all your Reserved instances, or only those otherwise
 	// specified.
 	ReservedInstancesIds []*string `locationName:"ReservedInstancesId" locationNameList:"ReservedInstancesId" type:"list"`
-
-	_ struct{} `type:"structure"`
 }
 
 // String returns the string representation
@@ -12758,6 +12758,8 @@ func (s DescribeReservedInstancesInput) GoString() string {
 }
 
 type DescribeReservedInstancesListingsInput struct {
+	_ struct{} `type:"structure"`
+
 	// One or more filters.
 	//
 	//   reserved-instances-id - The ID of the Reserved instances.
@@ -12775,8 +12777,6 @@ type DescribeReservedInstancesListingsInput struct {
 
 	// One or more Reserved instance Listing IDs.
 	ReservedInstancesListingId *string `locationName:"reservedInstancesListingId" type:"string"`
-
-	_ struct{} `type:"structure"`
 }
 
 // String returns the string representation
@@ -12790,10 +12790,10 @@ func (s DescribeReservedInstancesListingsInput) GoString() string {
 }
 
 type DescribeReservedInstancesListingsOutput struct {
+	_ struct{} `type:"structure"`
+
 	// Information about the Reserved instance listing.
 	ReservedInstancesListings []*ReservedInstancesListing `locationName:"reservedInstancesListingsSet" locationNameList:"item" type:"list"`
-
-	_ struct{} `type:"structure"`
 }
 
 // String returns the string representation
@@ -12807,6 +12807,8 @@ func (s DescribeReservedInstancesListingsOutput) GoString() string {
 }
 
 type DescribeReservedInstancesModificationsInput struct {
+	_ struct{} `type:"structure"`
+
 	// One or more filters.
 	//
 	//   client-token - The idempotency token for the modification request.
@@ -12848,8 +12850,6 @@ type DescribeReservedInstancesModificationsInput struct {
 
 	// IDs for the submitted modification request.
 	ReservedInstancesModificationIds []*string `locationName:"ReservedInstancesModificationId" locationNameList:"ReservedInstancesModificationId" type:"list"`
-
-	_ struct{} `type:"structure"`
 }
 
 // String returns the string representation
@@ -12863,14 +12863,14 @@ func (s DescribeReservedInstancesModificationsInput) GoString() string {
 }
 
 type DescribeReservedInstancesModificationsOutput struct {
+	_ struct{} `type:"structure"`
+
 	// The token to use to retrieve the next page of results. This value is null
 	// when there are no more results to return.
 	NextToken *string `locationName:"nextToken" type:"string"`
 
 	// The Reserved instance modification information.
 	ReservedInstancesModifications []*ReservedInstancesModification `locationName:"reservedInstancesModificationsSet" locationNameList:"item" type:"list"`
-
-	_ struct{} `type:"structure"`
 }
 
 // String returns the string representation
@@ -12884,6 +12884,8 @@ func (s DescribeReservedInstancesModificationsOutput) GoString() string {
 }
 
 type DescribeReservedInstancesOfferingsInput struct {
+	_ struct{} `type:"structure"`
+
 	// The Availability Zone in which the Reserved instance can be used.
 	AvailabilityZone *string `type:"string"`
 
@@ -12978,8 +12980,6 @@ type DescribeReservedInstancesOfferingsInput struct {
 
 	// One or more Reserved instances offering IDs.
 	ReservedInstancesOfferingIds []*string `locationName:"ReservedInstancesOfferingId" type:"list"`
-
-	_ struct{} `type:"structure"`
 }
 
 // String returns the string representation
@@ -12993,14 +12993,14 @@ func (s DescribeReservedInstancesOfferingsInput) GoString() string {
 }
 
 type DescribeReservedInstancesOfferingsOutput struct {
+	_ struct{} `type:"structure"`
+
 	// The token to use to retrieve the next page of results. This value is null
 	// when there are no more results to return.
 	NextToken *string `locationName:"nextToken" type:"string"`
 
 	// A list of Reserved instances offerings.
 	ReservedInstancesOfferings []*ReservedInstancesOffering `locationName:"reservedInstancesOfferingsSet" locationNameList:"item" type:"list"`
-
-	_ struct{} `type:"structure"`
 }
 
 // String returns the string representation
@@ -13014,10 +13014,10 @@ func (s DescribeReservedInstancesOfferingsOutput) GoString() string {
 }
 
 type DescribeReservedInstancesOutput struct {
+	_ struct{} `type:"structure"`
+
 	// A list of Reserved instances.
 	ReservedInstances []*ReservedInstances `locationName:"reservedInstancesSet" locationNameList:"item" type:"list"`
-
-	_ struct{} `type:"structure"`
 }
 
 // String returns the string representation
@@ -13031,6 +13031,8 @@ func (s DescribeReservedInstancesOutput) GoString() string {
 }
 
 type DescribeRouteTablesInput struct {
+	_ struct{} `type:"structure"`
+
 	// Checks whether you have the required permissions for the action, without
 	// actually making the request, and provides an error response. If you have
 	// the required permissions, the error response is DryRunOperation. Otherwise,
@@ -13096,8 +13098,6 @@ type DescribeRouteTablesInput struct {
 	//
 	// Default: Describes all your route tables.
 	RouteTableIds []*string `locationName:"RouteTableId" locationNameList:"item" type:"list"`
-
-	_ struct{} `type:"structure"`
 }
 
 // String returns the string representation
@@ -13111,10 +13111,10 @@ func (s DescribeRouteTablesInput) GoString() string {
 }
 
 type DescribeRouteTablesOutput struct {
+	_ struct{} `type:"structure"`
+
 	// Information about one or more route tables.
 	RouteTables []*RouteTable `locationName:"routeTableSet" locationNameList:"item" type:"list"`
-
-	_ struct{} `type:"structure"`
 }
 
 // String returns the string representation
@@ -13128,6 +13128,8 @@ func (s DescribeRouteTablesOutput) GoString() string {
 }
 
 type DescribeSecurityGroupsInput struct {
+	_ struct{} `type:"structure"`
+
 	// Checks whether you have the required permissions for the action, without
 	// actually making the request, and provides an error response. If you have
 	// the required permissions, the error response is DryRunOperation. Otherwise,
@@ -13189,8 +13191,6 @@ type DescribeSecurityGroupsInput struct {
 	//
 	// Default: Describes all your security groups.
 	GroupNames []*string `locationName:"GroupName" locationNameList:"GroupName" type:"list"`
-
-	_ struct{} `type:"structure"`
 }
 
 // String returns the string representation
@@ -13204,10 +13204,10 @@ func (s DescribeSecurityGroupsInput) GoString() string {
 }
 
 type DescribeSecurityGroupsOutput struct {
+	_ struct{} `type:"structure"`
+
 	// Information about one or more security groups.
 	SecurityGroups []*SecurityGroup `locationName:"securityGroupInfo" locationNameList:"item" type:"list"`
-
-	_ struct{} `type:"structure"`
 }
 
 // String returns the string representation
@@ -13221,6 +13221,8 @@ func (s DescribeSecurityGroupsOutput) GoString() string {
 }
 
 type DescribeSnapshotAttributeInput struct {
+	_ struct{} `type:"structure"`
+
 	// The snapshot attribute you would like to view.
 	Attribute *string `type:"string" required:"true" enum:"SnapshotAttributeName"`
 
@@ -13232,8 +13234,6 @@ type DescribeSnapshotAttributeInput struct {
 
 	// The ID of the EBS snapshot.
 	SnapshotId *string `type:"string" required:"true"`
-
-	_ struct{} `type:"structure"`
 }
 
 // String returns the string representation
@@ -13247,6 +13247,8 @@ func (s DescribeSnapshotAttributeInput) GoString() string {
 }
 
 type DescribeSnapshotAttributeOutput struct {
+	_ struct{} `type:"structure"`
+
 	// A list of permissions for creating volumes from the snapshot.
 	CreateVolumePermissions []*CreateVolumePermission `locationName:"createVolumePermission" locationNameList:"item" type:"list"`
 
@@ -13255,8 +13257,6 @@ type DescribeSnapshotAttributeOutput struct {
 
 	// The ID of the EBS snapshot.
 	SnapshotId *string `locationName:"snapshotId" type:"string"`
-
-	_ struct{} `type:"structure"`
 }
 
 // String returns the string representation
@@ -13270,6 +13270,8 @@ func (s DescribeSnapshotAttributeOutput) GoString() string {
 }
 
 type DescribeSnapshotsInput struct {
+	_ struct{} `type:"structure"`
+
 	// Checks whether you have the required permissions for the action, without
 	// actually making the request, and provides an error response. If you have
 	// the required permissions, the error response is DryRunOperation. Otherwise,
@@ -13340,8 +13342,6 @@ type DescribeSnapshotsInput struct {
 	//
 	// Default: Describes snapshots for which you have launch permissions.
 	SnapshotIds []*string `locationName:"SnapshotId" locationNameList:"SnapshotId" type:"list"`
-
-	_ struct{} `type:"structure"`
 }
 
 // String returns the string representation
@@ -13355,6 +13355,8 @@ func (s DescribeSnapshotsInput) GoString() string {
 }
 
 type DescribeSnapshotsOutput struct {
+	_ struct{} `type:"structure"`
+
 	// The NextToken value to include in a future DescribeSnapshots request. When
 	// the results of a DescribeSnapshots request exceed MaxResults, this value
 	// can be used to retrieve the next page of results. This value is null when
@@ -13363,8 +13365,6 @@ type DescribeSnapshotsOutput struct {
 
 	// Information about the snapshots.
 	Snapshots []*Snapshot `locationName:"snapshotSet" locationNameList:"item" type:"list"`
-
-	_ struct{} `type:"structure"`
 }
 
 // String returns the string representation
@@ -13379,13 +13379,13 @@ func (s DescribeSnapshotsOutput) GoString() string {
 
 // Contains the parameters for DescribeSpotDatafeedSubscription.
 type DescribeSpotDatafeedSubscriptionInput struct {
+	_ struct{} `type:"structure"`
+
 	// Checks whether you have the required permissions for the action, without
 	// actually making the request, and provides an error response. If you have
 	// the required permissions, the error response is DryRunOperation. Otherwise,
 	// it is UnauthorizedOperation.
 	DryRun *bool `locationName:"dryRun" type:"boolean"`
-
-	_ struct{} `type:"structure"`
 }
 
 // String returns the string representation
@@ -13400,10 +13400,10 @@ func (s DescribeSpotDatafeedSubscriptionInput) GoString() string {
 
 // Contains the output of DescribeSpotDatafeedSubscription.
 type DescribeSpotDatafeedSubscriptionOutput struct {
+	_ struct{} `type:"structure"`
+
 	// The Spot instance data feed subscription.
 	SpotDatafeedSubscription *SpotDatafeedSubscription `locationName:"spotDatafeedSubscription" type:"structure"`
-
-	_ struct{} `type:"structure"`
 }
 
 // String returns the string representation
@@ -13418,6 +13418,8 @@ func (s DescribeSpotDatafeedSubscriptionOutput) GoString() string {
 
 // Contains the parameters for DescribeSpotFleetInstances.
 type DescribeSpotFleetInstancesInput struct {
+	_ struct{} `type:"structure"`
+
 	// Checks whether you have the required permissions for the action, without
 	// actually making the request, and provides an error response. If you have
 	// the required permissions, the error response is DryRunOperation. Otherwise,
@@ -13434,8 +13436,6 @@ type DescribeSpotFleetInstancesInput struct {
 
 	// The ID of the Spot fleet request.
 	SpotFleetRequestId *string `locationName:"spotFleetRequestId" type:"string" required:"true"`
-
-	_ struct{} `type:"structure"`
 }
 
 // String returns the string representation
@@ -13450,6 +13450,8 @@ func (s DescribeSpotFleetInstancesInput) GoString() string {
 
 // Contains the output of DescribeSpotFleetInstances.
 type DescribeSpotFleetInstancesOutput struct {
+	_ struct{} `type:"structure"`
+
 	// The running instances. Note that this list is refreshed periodically and
 	// might be out of date.
 	ActiveInstances []*ActiveInstance `locationName:"activeInstanceSet" locationNameList:"item" type:"list" required:"true"`
@@ -13460,8 +13462,6 @@ type DescribeSpotFleetInstancesOutput struct {
 
 	// The ID of the Spot fleet request.
 	SpotFleetRequestId *string `locationName:"spotFleetRequestId" type:"string" required:"true"`
-
-	_ struct{} `type:"structure"`
 }
 
 // String returns the string representation
@@ -13476,6 +13476,8 @@ func (s DescribeSpotFleetInstancesOutput) GoString() string {
 
 // Contains the parameters for DescribeSpotFleetRequestHistory.
 type DescribeSpotFleetRequestHistoryInput struct {
+	_ struct{} `type:"structure"`
+
 	// Checks whether you have the required permissions for the action, without
 	// actually making the request, and provides an error response. If you have
 	// the required permissions, the error response is DryRunOperation. Otherwise,
@@ -13498,8 +13500,6 @@ type DescribeSpotFleetRequestHistoryInput struct {
 
 	// The starting date and time for the events, in UTC format (for example, YYYY-MM-DDTHH:MM:SSZ).
 	StartTime *time.Time `locationName:"startTime" type:"timestamp" timestampFormat:"iso8601" required:"true"`
-
-	_ struct{} `type:"structure"`
 }
 
 // String returns the string representation
@@ -13514,6 +13514,8 @@ func (s DescribeSpotFleetRequestHistoryInput) GoString() string {
 
 // Contains the output of DescribeSpotFleetRequestHistory.
 type DescribeSpotFleetRequestHistoryOutput struct {
+	_ struct{} `type:"structure"`
+
 	// Information about the events in the history of the Spot fleet request.
 	HistoryRecords []*HistoryRecord `locationName:"historyRecordSet" locationNameList:"item" type:"list" required:"true"`
 
@@ -13532,8 +13534,6 @@ type DescribeSpotFleetRequestHistoryOutput struct {
 
 	// The starting date and time for the events, in UTC format (for example, YYYY-MM-DDTHH:MM:SSZ).
 	StartTime *time.Time `locationName:"startTime" type:"timestamp" timestampFormat:"iso8601" required:"true"`
-
-	_ struct{} `type:"structure"`
 }
 
 // String returns the string representation
@@ -13548,6 +13548,8 @@ func (s DescribeSpotFleetRequestHistoryOutput) GoString() string {
 
 // Contains the parameters for DescribeSpotFleetRequests.
 type DescribeSpotFleetRequestsInput struct {
+	_ struct{} `type:"structure"`
+
 	// Checks whether you have the required permissions for the action, without
 	// actually making the request, and provides an error response. If you have
 	// the required permissions, the error response is DryRunOperation. Otherwise,
@@ -13564,8 +13566,6 @@ type DescribeSpotFleetRequestsInput struct {
 
 	// The IDs of the Spot fleet requests.
 	SpotFleetRequestIds []*string `locationName:"spotFleetRequestId" locationNameList:"item" type:"list"`
-
-	_ struct{} `type:"structure"`
 }
 
 // String returns the string representation
@@ -13580,14 +13580,14 @@ func (s DescribeSpotFleetRequestsInput) GoString() string {
 
 // Contains the output of DescribeSpotFleetRequests.
 type DescribeSpotFleetRequestsOutput struct {
+	_ struct{} `type:"structure"`
+
 	// The token required to retrieve the next set of results. This value is null
 	// when there are no more results to return.
 	NextToken *string `locationName:"nextToken" type:"string"`
 
 	// Information about the configuration of your Spot fleet.
 	SpotFleetRequestConfigs []*SpotFleetRequestConfig `locationName:"spotFleetRequestConfigSet" locationNameList:"item" type:"list" required:"true"`
-
-	_ struct{} `type:"structure"`
 }
 
 // String returns the string representation
@@ -13602,6 +13602,8 @@ func (s DescribeSpotFleetRequestsOutput) GoString() string {
 
 // Contains the parameters for DescribeSpotInstanceRequests.
 type DescribeSpotInstanceRequestsInput struct {
+	_ struct{} `type:"structure"`
+
 	// Checks whether you have the required permissions for the action, without
 	// actually making the request, and provides an error response. If you have
 	// the required permissions, the error response is DryRunOperation. Otherwise,
@@ -13720,8 +13722,6 @@ type DescribeSpotInstanceRequestsInput struct {
 
 	// One or more Spot instance request IDs.
 	SpotInstanceRequestIds []*string `locationName:"SpotInstanceRequestId" locationNameList:"SpotInstanceRequestId" type:"list"`
-
-	_ struct{} `type:"structure"`
 }
 
 // String returns the string representation
@@ -13736,10 +13736,10 @@ func (s DescribeSpotInstanceRequestsInput) GoString() string {
 
 // Contains the output of DescribeSpotInstanceRequests.
 type DescribeSpotInstanceRequestsOutput struct {
+	_ struct{} `type:"structure"`
+
 	// One or more Spot instance requests.
 	SpotInstanceRequests []*SpotInstanceRequest `locationName:"spotInstanceRequestSet" locationNameList:"item" type:"list"`
-
-	_ struct{} `type:"structure"`
 }
 
 // String returns the string representation
@@ -13754,6 +13754,8 @@ func (s DescribeSpotInstanceRequestsOutput) GoString() string {
 
 // Contains the parameters for DescribeSpotPriceHistory.
 type DescribeSpotPriceHistoryInput struct {
+	_ struct{} `type:"structure"`
+
 	// Filters the results by the specified Availability Zone.
 	AvailabilityZone *string `locationName:"availabilityZone" type:"string"`
 
@@ -13802,8 +13804,6 @@ type DescribeSpotPriceHistoryInput struct {
 	// The date and time, up to the past 90 days, from which to start retrieving
 	// the price history data, in UTC format (for example, YYYY-MM-DDTHH:MM:SSZ).
 	StartTime *time.Time `locationName:"startTime" type:"timestamp" timestampFormat:"iso8601"`
-
-	_ struct{} `type:"structure"`
 }
 
 // String returns the string representation
@@ -13818,14 +13818,14 @@ func (s DescribeSpotPriceHistoryInput) GoString() string {
 
 // Contains the output of DescribeSpotPriceHistory.
 type DescribeSpotPriceHistoryOutput struct {
+	_ struct{} `type:"structure"`
+
 	// The token required to retrieve the next set of results. This value is null
 	// when there are no more results to return.
 	NextToken *string `locationName:"nextToken" type:"string"`
 
 	// The historical Spot prices.
 	SpotPriceHistory []*SpotPrice `locationName:"spotPriceHistorySet" locationNameList:"item" type:"list"`
-
-	_ struct{} `type:"structure"`
 }
 
 // String returns the string representation
@@ -13839,6 +13839,8 @@ func (s DescribeSpotPriceHistoryOutput) GoString() string {
 }
 
 type DescribeSubnetsInput struct {
+	_ struct{} `type:"structure"`
+
 	// Checks whether you have the required permissions for the action, without
 	// actually making the request, and provides an error response. If you have
 	// the required permissions, the error response is DryRunOperation. Otherwise,
@@ -13883,8 +13885,6 @@ type DescribeSubnetsInput struct {
 	//
 	// Default: Describes all your subnets.
 	SubnetIds []*string `locationName:"SubnetId" locationNameList:"SubnetId" type:"list"`
-
-	_ struct{} `type:"structure"`
 }
 
 // String returns the string representation
@@ -13898,10 +13898,10 @@ func (s DescribeSubnetsInput) GoString() string {
 }
 
 type DescribeSubnetsOutput struct {
+	_ struct{} `type:"structure"`
+
 	// Information about one or more subnets.
 	Subnets []*Subnet `locationName:"subnetSet" locationNameList:"item" type:"list"`
-
-	_ struct{} `type:"structure"`
 }
 
 // String returns the string representation
@@ -13915,6 +13915,8 @@ func (s DescribeSubnetsOutput) GoString() string {
 }
 
 type DescribeTagsInput struct {
+	_ struct{} `type:"structure"`
+
 	// Checks whether you have the required permissions for the action, without
 	// actually making the request, and provides an error response. If you have
 	// the required permissions, the error response is DryRunOperation. Otherwise,
@@ -13944,8 +13946,6 @@ type DescribeTagsInput struct {
 
 	// The token to retrieve the next page of results.
 	NextToken *string `locationName:"nextToken" type:"string"`
-
-	_ struct{} `type:"structure"`
 }
 
 // String returns the string representation
@@ -13959,14 +13959,14 @@ func (s DescribeTagsInput) GoString() string {
 }
 
 type DescribeTagsOutput struct {
+	_ struct{} `type:"structure"`
+
 	// The token to use to retrieve the next page of results. This value is null
 	// when there are no more results to return..
 	NextToken *string `locationName:"nextToken" type:"string"`
 
 	// A list of tags.
 	Tags []*TagDescription `locationName:"tagSet" locationNameList:"item" type:"list"`
-
-	_ struct{} `type:"structure"`
 }
 
 // String returns the string representation
@@ -13980,6 +13980,8 @@ func (s DescribeTagsOutput) GoString() string {
 }
 
 type DescribeVolumeAttributeInput struct {
+	_ struct{} `type:"structure"`
+
 	// The instance attribute.
 	Attribute *string `type:"string" enum:"VolumeAttributeName"`
 
@@ -13991,8 +13993,6 @@ type DescribeVolumeAttributeInput struct {
 
 	// The ID of the volume.
 	VolumeId *string `type:"string" required:"true"`
-
-	_ struct{} `type:"structure"`
 }
 
 // String returns the string representation
@@ -14006,6 +14006,8 @@ func (s DescribeVolumeAttributeInput) GoString() string {
 }
 
 type DescribeVolumeAttributeOutput struct {
+	_ struct{} `type:"structure"`
+
 	// The state of autoEnableIO attribute.
 	AutoEnableIO *AttributeBooleanValue `locationName:"autoEnableIO" type:"structure"`
 
@@ -14014,8 +14016,6 @@ type DescribeVolumeAttributeOutput struct {
 
 	// The ID of the volume.
 	VolumeId *string `locationName:"volumeId" type:"string"`
-
-	_ struct{} `type:"structure"`
 }
 
 // String returns the string representation
@@ -14029,6 +14029,8 @@ func (s DescribeVolumeAttributeOutput) GoString() string {
 }
 
 type DescribeVolumeStatusInput struct {
+	_ struct{} `type:"structure"`
+
 	// Checks whether you have the required permissions for the action, without
 	// actually making the request, and provides an error response. If you have
 	// the required permissions, the error response is DryRunOperation. Otherwise,
@@ -14088,8 +14090,6 @@ type DescribeVolumeStatusInput struct {
 	//
 	// Default: Describes all your volumes.
 	VolumeIds []*string `locationName:"VolumeId" locationNameList:"VolumeId" type:"list"`
-
-	_ struct{} `type:"structure"`
 }
 
 // String returns the string representation
@@ -14103,14 +14103,14 @@ func (s DescribeVolumeStatusInput) GoString() string {
 }
 
 type DescribeVolumeStatusOutput struct {
+	_ struct{} `type:"structure"`
+
 	// The token to use to retrieve the next page of results. This value is null
 	// when there are no more results to return.
 	NextToken *string `locationName:"nextToken" type:"string"`
 
 	// A list of volumes.
 	VolumeStatuses []*VolumeStatusItem `locationName:"volumeStatusSet" locationNameList:"item" type:"list"`
-
-	_ struct{} `type:"structure"`
 }
 
 // String returns the string representation
@@ -14124,6 +14124,8 @@ func (s DescribeVolumeStatusOutput) GoString() string {
 }
 
 type DescribeVolumesInput struct {
+	_ struct{} `type:"structure"`
+
 	// Checks whether you have the required permissions for the action, without
 	// actually making the request, and provides an error response. If you have
 	// the required permissions, the error response is DryRunOperation. Otherwise,
@@ -14197,8 +14199,6 @@ type DescribeVolumesInput struct {
 
 	// One or more volume IDs.
 	VolumeIds []*string `locationName:"VolumeId" locationNameList:"VolumeId" type:"list"`
-
-	_ struct{} `type:"structure"`
 }
 
 // String returns the string representation
@@ -14212,6 +14212,8 @@ func (s DescribeVolumesInput) GoString() string {
 }
 
 type DescribeVolumesOutput struct {
+	_ struct{} `type:"structure"`
+
 	// The NextToken value to include in a future DescribeVolumes request. When
 	// the results of a DescribeVolumes request exceed MaxResults, this value can
 	// be used to retrieve the next page of results. This value is null when there
@@ -14220,8 +14222,6 @@ type DescribeVolumesOutput struct {
 
 	// Information about the volumes.
 	Volumes []*Volume `locationName:"volumeSet" locationNameList:"item" type:"list"`
-
-	_ struct{} `type:"structure"`
 }
 
 // String returns the string representation
@@ -14235,6 +14235,8 @@ func (s DescribeVolumesOutput) GoString() string {
 }
 
 type DescribeVpcAttributeInput struct {
+	_ struct{} `type:"structure"`
+
 	// The VPC attribute.
 	Attribute *string `type:"string" enum:"VpcAttributeName"`
 
@@ -14246,8 +14248,6 @@ type DescribeVpcAttributeInput struct {
 
 	// The ID of the VPC.
 	VpcId *string `type:"string" required:"true"`
-
-	_ struct{} `type:"structure"`
 }
 
 // String returns the string representation
@@ -14261,6 +14261,8 @@ func (s DescribeVpcAttributeInput) GoString() string {
 }
 
 type DescribeVpcAttributeOutput struct {
+	_ struct{} `type:"structure"`
+
 	// Indicates whether the instances launched in the VPC get DNS hostnames. If
 	// this attribute is true, instances in the VPC get DNS hostnames; otherwise,
 	// they do not.
@@ -14273,8 +14275,6 @@ type DescribeVpcAttributeOutput struct {
 
 	// The ID of the VPC.
 	VpcId *string `locationName:"vpcId" type:"string"`
-
-	_ struct{} `type:"structure"`
 }
 
 // String returns the string representation
@@ -14288,6 +14288,8 @@ func (s DescribeVpcAttributeOutput) GoString() string {
 }
 
 type DescribeVpcClassicLinkInput struct {
+	_ struct{} `type:"structure"`
+
 	// Checks whether you have the required permissions for the action, without
 	// actually making the request, and provides an error response. If you have
 	// the required permissions, the error response is DryRunOperation. Otherwise,
@@ -14314,8 +14316,6 @@ type DescribeVpcClassicLinkInput struct {
 
 	// One or more VPCs for which you want to describe the ClassicLink status.
 	VpcIds []*string `locationName:"VpcId" locationNameList:"VpcId" type:"list"`
-
-	_ struct{} `type:"structure"`
 }
 
 // String returns the string representation
@@ -14329,10 +14329,10 @@ func (s DescribeVpcClassicLinkInput) GoString() string {
 }
 
 type DescribeVpcClassicLinkOutput struct {
+	_ struct{} `type:"structure"`
+
 	// The ClassicLink status of one or more VPCs.
 	Vpcs []*VpcClassicLink `locationName:"vpcSet" locationNameList:"item" type:"list"`
-
-	_ struct{} `type:"structure"`
 }
 
 // String returns the string representation
@@ -14346,6 +14346,8 @@ func (s DescribeVpcClassicLinkOutput) GoString() string {
 }
 
 type DescribeVpcEndpointServicesInput struct {
+	_ struct{} `type:"structure"`
+
 	// Checks whether you have the required permissions for the action, without
 	// actually making the request, and provides an error response. If you have
 	// the required permissions, the error response is DryRunOperation. Otherwise,
@@ -14362,8 +14364,6 @@ type DescribeVpcEndpointServicesInput struct {
 	// The token for the next set of items to return. (You received this token from
 	// a prior call.)
 	NextToken *string `type:"string"`
-
-	_ struct{} `type:"structure"`
 }
 
 // String returns the string representation
@@ -14377,14 +14377,14 @@ func (s DescribeVpcEndpointServicesInput) GoString() string {
 }
 
 type DescribeVpcEndpointServicesOutput struct {
+	_ struct{} `type:"structure"`
+
 	// The token to use when requesting the next set of items. If there are no additional
 	// items to return, the string is empty.
 	NextToken *string `locationName:"nextToken" type:"string"`
 
 	// A list of supported AWS services.
 	ServiceNames []*string `locationName:"serviceNameSet" locationNameList:"item" type:"list"`
-
-	_ struct{} `type:"structure"`
 }
 
 // String returns the string representation
@@ -14398,6 +14398,8 @@ func (s DescribeVpcEndpointServicesOutput) GoString() string {
 }
 
 type DescribeVpcEndpointsInput struct {
+	_ struct{} `type:"structure"`
+
 	// Checks whether you have the required permissions for the action, without
 	// actually making the request, and provides an error response. If you have
 	// the required permissions, the error response is DryRunOperation. Otherwise,
@@ -14429,8 +14431,6 @@ type DescribeVpcEndpointsInput struct {
 
 	// One or more endpoint IDs.
 	VpcEndpointIds []*string `locationName:"VpcEndpointId" locationNameList:"item" type:"list"`
-
-	_ struct{} `type:"structure"`
 }
 
 // String returns the string representation
@@ -14444,14 +14444,14 @@ func (s DescribeVpcEndpointsInput) GoString() string {
 }
 
 type DescribeVpcEndpointsOutput struct {
+	_ struct{} `type:"structure"`
+
 	// The token to use when requesting the next set of items. If there are no additional
 	// items to return, the string is empty.
 	NextToken *string `locationName:"nextToken" type:"string"`
 
 	// Information about the endpoints.
 	VpcEndpoints []*VpcEndpoint `locationName:"vpcEndpointSet" locationNameList:"item" type:"list"`
-
-	_ struct{} `type:"structure"`
 }
 
 // String returns the string representation
@@ -14465,6 +14465,8 @@ func (s DescribeVpcEndpointsOutput) GoString() string {
 }
 
 type DescribeVpcPeeringConnectionsInput struct {
+	_ struct{} `type:"structure"`
+
 	// Checks whether you have the required permissions for the action, without
 	// actually making the request, and provides an error response. If you have
 	// the required permissions, the error response is DryRunOperation. Otherwise,
@@ -14514,8 +14516,6 @@ type DescribeVpcPeeringConnectionsInput struct {
 	//
 	// Default: Describes all your VPC peering connections.
 	VpcPeeringConnectionIds []*string `locationName:"VpcPeeringConnectionId" locationNameList:"item" type:"list"`
-
-	_ struct{} `type:"structure"`
 }
 
 // String returns the string representation
@@ -14529,10 +14529,10 @@ func (s DescribeVpcPeeringConnectionsInput) GoString() string {
 }
 
 type DescribeVpcPeeringConnectionsOutput struct {
+	_ struct{} `type:"structure"`
+
 	// Information about the VPC peering connections.
 	VpcPeeringConnections []*VpcPeeringConnection `locationName:"vpcPeeringConnectionSet" locationNameList:"item" type:"list"`
-
-	_ struct{} `type:"structure"`
 }
 
 // String returns the string representation
@@ -14546,6 +14546,8 @@ func (s DescribeVpcPeeringConnectionsOutput) GoString() string {
 }
 
 type DescribeVpcsInput struct {
+	_ struct{} `type:"structure"`
+
 	// Checks whether you have the required permissions for the action, without
 	// actually making the request, and provides an error response. If you have
 	// the required permissions, the error response is DryRunOperation. Otherwise,
@@ -14583,8 +14585,6 @@ type DescribeVpcsInput struct {
 	//
 	// Default: Describes all your VPCs.
 	VpcIds []*string `locationName:"VpcId" locationNameList:"VpcId" type:"list"`
-
-	_ struct{} `type:"structure"`
 }
 
 // String returns the string representation
@@ -14598,10 +14598,10 @@ func (s DescribeVpcsInput) GoString() string {
 }
 
 type DescribeVpcsOutput struct {
+	_ struct{} `type:"structure"`
+
 	// Information about one or more VPCs.
 	Vpcs []*Vpc `locationName:"vpcSet" locationNameList:"item" type:"list"`
-
-	_ struct{} `type:"structure"`
 }
 
 // String returns the string representation
@@ -14615,6 +14615,8 @@ func (s DescribeVpcsOutput) GoString() string {
 }
 
 type DescribeVpnConnectionsInput struct {
+	_ struct{} `type:"structure"`
+
 	// Checks whether you have the required permissions for the action, without
 	// actually making the request, and provides an error response. If you have
 	// the required permissions, the error response is DryRunOperation. Otherwise,
@@ -14667,8 +14669,6 @@ type DescribeVpnConnectionsInput struct {
 	//
 	// Default: Describes your VPN connections.
 	VpnConnectionIds []*string `locationName:"VpnConnectionId" locationNameList:"VpnConnectionId" type:"list"`
-
-	_ struct{} `type:"structure"`
 }
 
 // String returns the string representation
@@ -14682,10 +14682,10 @@ func (s DescribeVpnConnectionsInput) GoString() string {
 }
 
 type DescribeVpnConnectionsOutput struct {
+	_ struct{} `type:"structure"`
+
 	// Information about one or more VPN connections.
 	VpnConnections []*VpnConnection `locationName:"vpnConnectionSet" locationNameList:"item" type:"list"`
-
-	_ struct{} `type:"structure"`
 }
 
 // String returns the string representation
@@ -14699,6 +14699,8 @@ func (s DescribeVpnConnectionsOutput) GoString() string {
 }
 
 type DescribeVpnGatewaysInput struct {
+	_ struct{} `type:"structure"`
+
 	// Checks whether you have the required permissions for the action, without
 	// actually making the request, and provides an error response. If you have
 	// the required permissions, the error response is DryRunOperation. Otherwise,
@@ -14739,8 +14741,6 @@ type DescribeVpnGatewaysInput struct {
 	//
 	// Default: Describes all your virtual private gateways.
 	VpnGatewayIds []*string `locationName:"VpnGatewayId" locationNameList:"VpnGatewayId" type:"list"`
-
-	_ struct{} `type:"structure"`
 }
 
 // String returns the string representation
@@ -14754,10 +14754,10 @@ func (s DescribeVpnGatewaysInput) GoString() string {
 }
 
 type DescribeVpnGatewaysOutput struct {
+	_ struct{} `type:"structure"`
+
 	// Information about one or more virtual private gateways.
 	VpnGateways []*VpnGateway `locationName:"vpnGatewaySet" locationNameList:"item" type:"list"`
-
-	_ struct{} `type:"structure"`
 }
 
 // String returns the string representation
@@ -14771,6 +14771,8 @@ func (s DescribeVpnGatewaysOutput) GoString() string {
 }
 
 type DetachClassicLinkVpcInput struct {
+	_ struct{} `type:"structure"`
+
 	// Checks whether you have the required permissions for the action, without
 	// actually making the request, and provides an error response. If you have
 	// the required permissions, the error response is DryRunOperation. Otherwise,
@@ -14782,8 +14784,6 @@ type DetachClassicLinkVpcInput struct {
 
 	// The ID of the VPC to which the instance is linked.
 	VpcId *string `locationName:"vpcId" type:"string" required:"true"`
-
-	_ struct{} `type:"structure"`
 }
 
 // String returns the string representation
@@ -14797,10 +14797,10 @@ func (s DetachClassicLinkVpcInput) GoString() string {
 }
 
 type DetachClassicLinkVpcOutput struct {
+	_ struct{} `type:"structure"`
+
 	// Returns true if the request succeeds; otherwise, it returns an error.
 	Return *bool `locationName:"return" type:"boolean"`
-
-	_ struct{} `type:"structure"`
 }
 
 // String returns the string representation
@@ -14814,6 +14814,8 @@ func (s DetachClassicLinkVpcOutput) GoString() string {
 }
 
 type DetachInternetGatewayInput struct {
+	_ struct{} `type:"structure"`
+
 	// Checks whether you have the required permissions for the action, without
 	// actually making the request, and provides an error response. If you have
 	// the required permissions, the error response is DryRunOperation. Otherwise,
@@ -14825,8 +14827,6 @@ type DetachInternetGatewayInput struct {
 
 	// The ID of the VPC.
 	VpcId *string `locationName:"vpcId" type:"string" required:"true"`
-
-	_ struct{} `type:"structure"`
 }
 
 // String returns the string representation
@@ -14854,6 +14854,8 @@ func (s DetachInternetGatewayOutput) GoString() string {
 }
 
 type DetachNetworkInterfaceInput struct {
+	_ struct{} `type:"structure"`
+
 	// The ID of the attachment.
 	AttachmentId *string `locationName:"attachmentId" type:"string" required:"true"`
 
@@ -14865,8 +14867,6 @@ type DetachNetworkInterfaceInput struct {
 
 	// Specifies whether to force a detachment.
 	Force *bool `locationName:"force" type:"boolean"`
-
-	_ struct{} `type:"structure"`
 }
 
 // String returns the string representation
@@ -14894,6 +14894,8 @@ func (s DetachNetworkInterfaceOutput) GoString() string {
 }
 
 type DetachVolumeInput struct {
+	_ struct{} `type:"structure"`
+
 	// The device name.
 	Device *string `type:"string"`
 
@@ -14917,8 +14919,6 @@ type DetachVolumeInput struct {
 
 	// The ID of the volume.
 	VolumeId *string `type:"string" required:"true"`
-
-	_ struct{} `type:"structure"`
 }
 
 // String returns the string representation
@@ -14932,6 +14932,8 @@ func (s DetachVolumeInput) GoString() string {
 }
 
 type DetachVpnGatewayInput struct {
+	_ struct{} `type:"structure"`
+
 	// Checks whether you have the required permissions for the action, without
 	// actually making the request, and provides an error response. If you have
 	// the required permissions, the error response is DryRunOperation. Otherwise,
@@ -14943,8 +14945,6 @@ type DetachVpnGatewayInput struct {
 
 	// The ID of the virtual private gateway.
 	VpnGatewayId *string `type:"string" required:"true"`
-
-	_ struct{} `type:"structure"`
 }
 
 // String returns the string representation
@@ -14973,13 +14973,13 @@ func (s DetachVpnGatewayOutput) GoString() string {
 
 // Describes a DHCP configuration option.
 type DhcpConfiguration struct {
+	_ struct{} `type:"structure"`
+
 	// The name of a DHCP option.
 	Key *string `locationName:"key" type:"string"`
 
 	// One or more values for the DHCP option.
 	Values []*AttributeValue `locationName:"valueSet" locationNameList:"item" type:"list"`
-
-	_ struct{} `type:"structure"`
 }
 
 // String returns the string representation
@@ -14994,6 +14994,8 @@ func (s DhcpConfiguration) GoString() string {
 
 // Describes a set of DHCP options.
 type DhcpOptions struct {
+	_ struct{} `type:"structure"`
+
 	// One or more DHCP options in the set.
 	DhcpConfigurations []*DhcpConfiguration `locationName:"dhcpConfigurationSet" locationNameList:"item" type:"list"`
 
@@ -15002,8 +15004,6 @@ type DhcpOptions struct {
 
 	// Any tags assigned to the DHCP options set.
 	Tags []*Tag `locationName:"tagSet" locationNameList:"item" type:"list"`
-
-	_ struct{} `type:"structure"`
 }
 
 // String returns the string representation
@@ -15017,13 +15017,13 @@ func (s DhcpOptions) GoString() string {
 }
 
 type DisableVgwRoutePropagationInput struct {
+	_ struct{} `type:"structure"`
+
 	// The ID of the virtual private gateway.
 	GatewayId *string `type:"string" required:"true"`
 
 	// The ID of the route table.
 	RouteTableId *string `type:"string" required:"true"`
-
-	_ struct{} `type:"structure"`
 }
 
 // String returns the string representation
@@ -15051,6 +15051,8 @@ func (s DisableVgwRoutePropagationOutput) GoString() string {
 }
 
 type DisableVpcClassicLinkInput struct {
+	_ struct{} `type:"structure"`
+
 	// Checks whether you have the required permissions for the action, without
 	// actually making the request, and provides an error response. If you have
 	// the required permissions, the error response is DryRunOperation. Otherwise,
@@ -15059,8 +15061,6 @@ type DisableVpcClassicLinkInput struct {
 
 	// The ID of the VPC.
 	VpcId *string `locationName:"vpcId" type:"string" required:"true"`
-
-	_ struct{} `type:"structure"`
 }
 
 // String returns the string representation
@@ -15074,10 +15074,10 @@ func (s DisableVpcClassicLinkInput) GoString() string {
 }
 
 type DisableVpcClassicLinkOutput struct {
+	_ struct{} `type:"structure"`
+
 	// Returns true if the request succeeds; otherwise, it returns an error.
 	Return *bool `locationName:"return" type:"boolean"`
-
-	_ struct{} `type:"structure"`
 }
 
 // String returns the string representation
@@ -15091,6 +15091,8 @@ func (s DisableVpcClassicLinkOutput) GoString() string {
 }
 
 type DisassociateAddressInput struct {
+	_ struct{} `type:"structure"`
+
 	// [EC2-VPC] The association ID. Required for EC2-VPC.
 	AssociationId *string `type:"string"`
 
@@ -15102,8 +15104,6 @@ type DisassociateAddressInput struct {
 
 	// [EC2-Classic] The Elastic IP address. Required for EC2-Classic.
 	PublicIp *string `type:"string"`
-
-	_ struct{} `type:"structure"`
 }
 
 // String returns the string representation
@@ -15131,6 +15131,8 @@ func (s DisassociateAddressOutput) GoString() string {
 }
 
 type DisassociateRouteTableInput struct {
+	_ struct{} `type:"structure"`
+
 	// The association ID representing the current association between the route
 	// table and subnet.
 	AssociationId *string `locationName:"associationId" type:"string" required:"true"`
@@ -15140,8 +15142,6 @@ type DisassociateRouteTableInput struct {
 	// the required permissions, the error response is DryRunOperation. Otherwise,
 	// it is UnauthorizedOperation.
 	DryRun *bool `locationName:"dryRun" type:"boolean"`
-
-	_ struct{} `type:"structure"`
 }
 
 // String returns the string representation
@@ -15170,6 +15170,8 @@ func (s DisassociateRouteTableOutput) GoString() string {
 
 // Describes a disk image.
 type DiskImage struct {
+	_ struct{} `type:"structure"`
+
 	// A description of the disk image.
 	Description *string `type:"string"`
 
@@ -15178,8 +15180,6 @@ type DiskImage struct {
 
 	// Information about the volume.
 	Volume *VolumeDetail `type:"structure"`
-
-	_ struct{} `type:"structure"`
 }
 
 // String returns the string representation
@@ -15194,6 +15194,8 @@ func (s DiskImage) GoString() string {
 
 // Describes a disk image.
 type DiskImageDescription struct {
+	_ struct{} `type:"structure"`
+
 	// The checksum computed for the disk image.
 	Checksum *string `locationName:"checksum" type:"string"`
 
@@ -15209,8 +15211,6 @@ type DiskImageDescription struct {
 
 	// The size of the disk image, in GiB.
 	Size *int64 `locationName:"size" type:"long" required:"true"`
-
-	_ struct{} `type:"structure"`
 }
 
 // String returns the string representation
@@ -15225,6 +15225,8 @@ func (s DiskImageDescription) GoString() string {
 
 // Describes a disk image.
 type DiskImageDetail struct {
+	_ struct{} `type:"structure"`
+
 	// The size of the disk image, in GiB.
 	Bytes *int64 `locationName:"bytes" type:"long" required:"true"`
 
@@ -15237,8 +15239,6 @@ type DiskImageDetail struct {
 	// Alternative" section of the Authenticating REST Requests (http://docs.aws.amazon.com/AmazonS3/latest/dev/RESTAuthentication.html)
 	// topic in the Amazon Simple Storage Service Developer Guide.
 	ImportManifestUrl *string `locationName:"importManifestUrl" type:"string" required:"true"`
-
-	_ struct{} `type:"structure"`
 }
 
 // String returns the string representation
@@ -15253,13 +15253,13 @@ func (s DiskImageDetail) GoString() string {
 
 // Describes a disk image volume.
 type DiskImageVolumeDescription struct {
+	_ struct{} `type:"structure"`
+
 	// The volume identifier.
 	Id *string `locationName:"id" type:"string" required:"true"`
 
 	// The size of the volume, in GiB.
 	Size *int64 `locationName:"size" type:"long"`
-
-	_ struct{} `type:"structure"`
 }
 
 // String returns the string representation
@@ -15274,6 +15274,8 @@ func (s DiskImageVolumeDescription) GoString() string {
 
 // Describes a block device for an EBS volume.
 type EbsBlockDevice struct {
+	_ struct{} `type:"structure"`
+
 	// Indicates whether the EBS volume is deleted on instance termination.
 	DeleteOnTermination *bool `locationName:"deleteOnTermination" type:"boolean"`
 
@@ -15314,8 +15316,6 @@ type EbsBlockDevice struct {
 	//
 	// Default: standard
 	VolumeType *string `locationName:"volumeType" type:"string" enum:"VolumeType"`
-
-	_ struct{} `type:"structure"`
 }
 
 // String returns the string representation
@@ -15330,6 +15330,8 @@ func (s EbsBlockDevice) GoString() string {
 
 // Describes a parameter used to set up an EBS volume in a block device mapping.
 type EbsInstanceBlockDevice struct {
+	_ struct{} `type:"structure"`
+
 	// The time stamp when the attachment initiated.
 	AttachTime *time.Time `locationName:"attachTime" type:"timestamp" timestampFormat:"iso8601"`
 
@@ -15341,8 +15343,6 @@ type EbsInstanceBlockDevice struct {
 
 	// The ID of the EBS volume.
 	VolumeId *string `locationName:"volumeId" type:"string"`
-
-	_ struct{} `type:"structure"`
 }
 
 // String returns the string representation
@@ -15356,13 +15356,13 @@ func (s EbsInstanceBlockDevice) GoString() string {
 }
 
 type EbsInstanceBlockDeviceSpecification struct {
+	_ struct{} `type:"structure"`
+
 	// Indicates whether the volume is deleted on instance termination.
 	DeleteOnTermination *bool `locationName:"deleteOnTermination" type:"boolean"`
 
 	// The ID of the EBS volume.
 	VolumeId *string `locationName:"volumeId" type:"string"`
-
-	_ struct{} `type:"structure"`
 }
 
 // String returns the string representation
@@ -15376,13 +15376,13 @@ func (s EbsInstanceBlockDeviceSpecification) GoString() string {
 }
 
 type EnableVgwRoutePropagationInput struct {
+	_ struct{} `type:"structure"`
+
 	// The ID of the virtual private gateway.
 	GatewayId *string `type:"string" required:"true"`
 
 	// The ID of the route table.
 	RouteTableId *string `type:"string" required:"true"`
-
-	_ struct{} `type:"structure"`
 }
 
 // String returns the string representation
@@ -15410,6 +15410,8 @@ func (s EnableVgwRoutePropagationOutput) GoString() string {
 }
 
 type EnableVolumeIOInput struct {
+	_ struct{} `type:"structure"`
+
 	// Checks whether you have the required permissions for the action, without
 	// actually making the request, and provides an error response. If you have
 	// the required permissions, the error response is DryRunOperation. Otherwise,
@@ -15418,8 +15420,6 @@ type EnableVolumeIOInput struct {
 
 	// The ID of the volume.
 	VolumeId *string `locationName:"volumeId" type:"string" required:"true"`
-
-	_ struct{} `type:"structure"`
 }
 
 // String returns the string representation
@@ -15447,6 +15447,8 @@ func (s EnableVolumeIOOutput) GoString() string {
 }
 
 type EnableVpcClassicLinkInput struct {
+	_ struct{} `type:"structure"`
+
 	// Checks whether you have the required permissions for the action, without
 	// actually making the request, and provides an error response. If you have
 	// the required permissions, the error response is DryRunOperation. Otherwise,
@@ -15455,8 +15457,6 @@ type EnableVpcClassicLinkInput struct {
 
 	// The ID of the VPC.
 	VpcId *string `locationName:"vpcId" type:"string" required:"true"`
-
-	_ struct{} `type:"structure"`
 }
 
 // String returns the string representation
@@ -15470,10 +15470,10 @@ func (s EnableVpcClassicLinkInput) GoString() string {
 }
 
 type EnableVpcClassicLinkOutput struct {
+	_ struct{} `type:"structure"`
+
 	// Returns true if the request succeeds; otherwise, it returns an error.
 	Return *bool `locationName:"return" type:"boolean"`
-
-	_ struct{} `type:"structure"`
 }
 
 // String returns the string representation
@@ -15488,6 +15488,8 @@ func (s EnableVpcClassicLinkOutput) GoString() string {
 
 // Describes a Spot fleet event.
 type EventInformation struct {
+	_ struct{} `type:"structure"`
+
 	// The description of the event.
 	EventDescription *string `locationName:"eventDescription" type:"string"`
 
@@ -15548,8 +15550,6 @@ type EventInformation struct {
 	// The ID of the instance. This information is available only for instanceChange
 	// events.
 	InstanceId *string `locationName:"instanceId" type:"string"`
-
-	_ struct{} `type:"structure"`
 }
 
 // String returns the string representation
@@ -15564,6 +15564,8 @@ func (s EventInformation) GoString() string {
 
 // Describes an instance export task.
 type ExportTask struct {
+	_ struct{} `type:"structure"`
+
 	// A description of the resource being exported.
 	Description *string `locationName:"description" type:"string"`
 
@@ -15581,8 +15583,6 @@ type ExportTask struct {
 
 	// The status message related to the export task.
 	StatusMessage *string `locationName:"statusMessage" type:"string"`
-
-	_ struct{} `type:"structure"`
 }
 
 // String returns the string representation
@@ -15597,6 +15597,8 @@ func (s ExportTask) GoString() string {
 
 // Describes the format and location for an instance export task.
 type ExportToS3Task struct {
+	_ struct{} `type:"structure"`
+
 	// The container format used to combine disk images with metadata (such as OVF).
 	// If absent, only the disk image is exported.
 	ContainerFormat *string `locationName:"containerFormat" type:"string" enum:"ContainerFormat"`
@@ -15610,8 +15612,6 @@ type ExportToS3Task struct {
 
 	// The encryption key for your S3 bucket.
 	S3Key *string `locationName:"s3Key" type:"string"`
-
-	_ struct{} `type:"structure"`
 }
 
 // String returns the string representation
@@ -15626,6 +15626,8 @@ func (s ExportToS3Task) GoString() string {
 
 // Describes an instance export task.
 type ExportToS3TaskSpecification struct {
+	_ struct{} `type:"structure"`
+
 	// The container format used to combine disk images with metadata (such as OVF).
 	// If absent, only the disk image is exported.
 	ContainerFormat *string `locationName:"containerFormat" type:"string" enum:"ContainerFormat"`
@@ -15640,8 +15642,6 @@ type ExportToS3TaskSpecification struct {
 	// The image is written to a single object in the S3 bucket at the S3 key s3prefix
 	// + exportTaskId + '.' + diskImageFormat.
 	S3Prefix *string `locationName:"s3Prefix" type:"string"`
-
-	_ struct{} `type:"structure"`
 }
 
 // String returns the string representation
@@ -15658,13 +15658,13 @@ func (s ExportToS3TaskSpecification) GoString() string {
 // of results. Filters can be used to match a set of resources by various criteria,
 // such as tags, attributes, or IDs.
 type Filter struct {
+	_ struct{} `type:"structure"`
+
 	// The name of the filter. Filter names are case-sensitive.
 	Name *string `type:"string"`
 
 	// One or more filter values. Filter values are case-sensitive.
 	Values []*string `locationName:"Value" locationNameList:"item" type:"list"`
-
-	_ struct{} `type:"structure"`
 }
 
 // String returns the string representation
@@ -15679,6 +15679,8 @@ func (s Filter) GoString() string {
 
 // Describes a flow log.
 type FlowLog struct {
+	_ struct{} `type:"structure"`
+
 	// The date and time the flow log was created.
 	CreationTime *time.Time `locationName:"creationTime" type:"timestamp" timestampFormat:"iso8601"`
 
@@ -15709,8 +15711,6 @@ type FlowLog struct {
 
 	// The type of traffic captured for the flow log.
 	TrafficType *string `locationName:"trafficType" type:"string" enum:"TrafficType"`
-
-	_ struct{} `type:"structure"`
 }
 
 // String returns the string representation
@@ -15724,6 +15724,8 @@ func (s FlowLog) GoString() string {
 }
 
 type GetConsoleOutputInput struct {
+	_ struct{} `type:"structure"`
+
 	// Checks whether you have the required permissions for the action, without
 	// actually making the request, and provides an error response. If you have
 	// the required permissions, the error response is DryRunOperation. Otherwise,
@@ -15732,8 +15734,6 @@ type GetConsoleOutputInput struct {
 
 	// The ID of the instance.
 	InstanceId *string `type:"string" required:"true"`
-
-	_ struct{} `type:"structure"`
 }
 
 // String returns the string representation
@@ -15747,6 +15747,8 @@ func (s GetConsoleOutputInput) GoString() string {
 }
 
 type GetConsoleOutputOutput struct {
+	_ struct{} `type:"structure"`
+
 	// The ID of the instance.
 	InstanceId *string `locationName:"instanceId" type:"string"`
 
@@ -15755,8 +15757,6 @@ type GetConsoleOutputOutput struct {
 
 	// The time the output was last updated.
 	Timestamp *time.Time `locationName:"timestamp" type:"timestamp" timestampFormat:"iso8601"`
-
-	_ struct{} `type:"structure"`
 }
 
 // String returns the string representation
@@ -15770,6 +15770,8 @@ func (s GetConsoleOutputOutput) GoString() string {
 }
 
 type GetPasswordDataInput struct {
+	_ struct{} `type:"structure"`
+
 	// Checks whether you have the required permissions for the action, without
 	// actually making the request, and provides an error response. If you have
 	// the required permissions, the error response is DryRunOperation. Otherwise,
@@ -15778,8 +15780,6 @@ type GetPasswordDataInput struct {
 
 	// The ID of the Windows instance.
 	InstanceId *string `type:"string" required:"true"`
-
-	_ struct{} `type:"structure"`
 }
 
 // String returns the string representation
@@ -15793,6 +15793,8 @@ func (s GetPasswordDataInput) GoString() string {
 }
 
 type GetPasswordDataOutput struct {
+	_ struct{} `type:"structure"`
+
 	// The ID of the Windows instance.
 	InstanceId *string `locationName:"instanceId" type:"string"`
 
@@ -15801,8 +15803,6 @@ type GetPasswordDataOutput struct {
 
 	// The time the data was last updated.
 	Timestamp *time.Time `locationName:"timestamp" type:"timestamp" timestampFormat:"iso8601"`
-
-	_ struct{} `type:"structure"`
 }
 
 // String returns the string representation
@@ -15817,13 +15817,13 @@ func (s GetPasswordDataOutput) GoString() string {
 
 // Describes a security group.
 type GroupIdentifier struct {
+	_ struct{} `type:"structure"`
+
 	// The ID of the security group.
 	GroupId *string `locationName:"groupId" type:"string"`
 
 	// The name of the security group.
 	GroupName *string `locationName:"groupName" type:"string"`
-
-	_ struct{} `type:"structure"`
 }
 
 // String returns the string representation
@@ -15838,6 +15838,8 @@ func (s GroupIdentifier) GoString() string {
 
 // Describes an event in the history of the Spot fleet request.
 type HistoryRecord struct {
+	_ struct{} `type:"structure"`
+
 	// Information about the event.
 	EventInformation *EventInformation `locationName:"eventInformation" type:"structure" required:"true"`
 
@@ -15853,8 +15855,6 @@ type HistoryRecord struct {
 
 	// The date and time of the event, in UTC format (for example, YYYY-MM-DDTHH:MM:SSZ).
 	Timestamp *time.Time `locationName:"timestamp" type:"timestamp" timestampFormat:"iso8601" required:"true"`
-
-	_ struct{} `type:"structure"`
 }
 
 // String returns the string representation
@@ -15868,6 +15868,8 @@ func (s HistoryRecord) GoString() string {
 }
 
 type Host struct {
+	_ struct{} `type:"structure"`
+
 	// Whether auto-placement is on or off.
 	AutoPlacement *string `locationName:"autoPlacement" type:"string" enum:"AutoPlacement"`
 
@@ -15897,8 +15899,6 @@ type Host struct {
 
 	// The Dedicated host's state. Can be "available", "under assessment, or "released".
 	State *string `locationName:"state" type:"string" enum:"AllocationState"`
-
-	_ struct{} `type:"structure"`
 }
 
 // String returns the string representation
@@ -15912,13 +15912,13 @@ func (s Host) GoString() string {
 }
 
 type HostInstance struct {
+	_ struct{} `type:"structure"`
+
 	// the IDs of instances that are running on the Dedicated host.
 	InstanceId *string `locationName:"instanceId" type:"string"`
 
 	// The instance type size (e.g., m3.medium) of the running instance.
 	InstanceType *string `locationName:"instanceType" type:"string"`
-
-	_ struct{} `type:"structure"`
 }
 
 // String returns the string representation
@@ -15932,6 +15932,8 @@ func (s HostInstance) GoString() string {
 }
 
 type HostProperties struct {
+	_ struct{} `type:"structure"`
+
 	// The number of cores on the Dedicated host.
 	Cores *int64 `locationName:"cores" type:"integer"`
 
@@ -15943,8 +15945,6 @@ type HostProperties struct {
 
 	// The number of vCPUs on the Dedicated host.
 	TotalVCpus *int64 `locationName:"totalVCpus" type:"integer"`
-
-	_ struct{} `type:"structure"`
 }
 
 // String returns the string representation
@@ -15959,13 +15959,13 @@ func (s HostProperties) GoString() string {
 
 // Describes an IAM instance profile.
 type IamInstanceProfile struct {
+	_ struct{} `type:"structure"`
+
 	// The Amazon Resource Name (ARN) of the instance profile.
 	Arn *string `locationName:"arn" type:"string"`
 
 	// The ID of the instance profile.
 	Id *string `locationName:"id" type:"string"`
-
-	_ struct{} `type:"structure"`
 }
 
 // String returns the string representation
@@ -15980,13 +15980,13 @@ func (s IamInstanceProfile) GoString() string {
 
 // Describes an IAM instance profile.
 type IamInstanceProfileSpecification struct {
+	_ struct{} `type:"structure"`
+
 	// The Amazon Resource Name (ARN) of the instance profile.
 	Arn *string `locationName:"arn" type:"string"`
 
 	// The name of the instance profile.
 	Name *string `locationName:"name" type:"string"`
-
-	_ struct{} `type:"structure"`
 }
 
 // String returns the string representation
@@ -16001,13 +16001,13 @@ func (s IamInstanceProfileSpecification) GoString() string {
 
 // Describes the ICMP type and code.
 type IcmpTypeCode struct {
+	_ struct{} `type:"structure"`
+
 	// The ICMP type. A value of -1 means all types.
 	Code *int64 `locationName:"code" type:"integer"`
 
 	// The ICMP code. A value of -1 means all codes for the specified ICMP type.
 	Type *int64 `locationName:"type" type:"integer"`
-
-	_ struct{} `type:"structure"`
 }
 
 // String returns the string representation
@@ -16022,6 +16022,8 @@ func (s IcmpTypeCode) GoString() string {
 
 // Describes the ID format for a resource.
 type IdFormat struct {
+	_ struct{} `type:"structure"`
+
 	// The date in UTC at which you are permanently switched over to using longer
 	// IDs.
 	Deadline *time.Time `locationName:"deadline" type:"timestamp" timestampFormat:"iso8601"`
@@ -16031,8 +16033,6 @@ type IdFormat struct {
 
 	// Indicates whether longer IDs (17-character IDs) are enabled for the resource.
 	UseLongIds *bool `locationName:"useLongIds" type:"boolean"`
-
-	_ struct{} `type:"structure"`
 }
 
 // String returns the string representation
@@ -16047,6 +16047,8 @@ func (s IdFormat) GoString() string {
 
 // Describes an image.
 type Image struct {
+	_ struct{} `type:"structure"`
+
 	// The architecture of the image.
 	Architecture *string `locationName:"architecture" type:"string" enum:"ArchitectureValues"`
 
@@ -16122,8 +16124,6 @@ type Image struct {
 
 	// The type of virtualization of the AMI.
 	VirtualizationType *string `locationName:"virtualizationType" type:"string" enum:"VirtualizationType"`
-
-	_ struct{} `type:"structure"`
 }
 
 // String returns the string representation
@@ -16138,6 +16138,8 @@ func (s Image) GoString() string {
 
 // Describes the disk container object for an import image task.
 type ImageDiskContainer struct {
+	_ struct{} `type:"structure"`
+
 	// The description of the disk image.
 	Description *string `type:"string"`
 
@@ -16158,8 +16160,6 @@ type ImageDiskContainer struct {
 
 	// The S3 bucket for the disk image.
 	UserBucket *UserBucket `type:"structure"`
-
-	_ struct{} `type:"structure"`
 }
 
 // String returns the string representation
@@ -16173,6 +16173,8 @@ func (s ImageDiskContainer) GoString() string {
 }
 
 type ImportImageInput struct {
+	_ struct{} `type:"structure"`
+
 	// The architecture of the virtual machine.
 	//
 	// Valid values: i386 | x86_64
@@ -16218,8 +16220,6 @@ type ImportImageInput struct {
 
 	// The name of the role to use when not using the default role, 'vmimport'.
 	RoleName *string `type:"string"`
-
-	_ struct{} `type:"structure"`
 }
 
 // String returns the string representation
@@ -16233,6 +16233,8 @@ func (s ImportImageInput) GoString() string {
 }
 
 type ImportImageOutput struct {
+	_ struct{} `type:"structure"`
+
 	// The architecture of the virtual machine.
 	Architecture *string `locationName:"architecture" type:"string"`
 
@@ -16265,8 +16267,6 @@ type ImportImageOutput struct {
 
 	// A detailed status message of the import task.
 	StatusMessage *string `locationName:"statusMessage" type:"string"`
-
-	_ struct{} `type:"structure"`
 }
 
 // String returns the string representation
@@ -16281,6 +16281,8 @@ func (s ImportImageOutput) GoString() string {
 
 // Describes an import image task.
 type ImportImageTask struct {
+	_ struct{} `type:"structure"`
+
 	// The architecture of the virtual machine.
 	//
 	// Valid values: i386 | x86_64
@@ -16317,8 +16319,6 @@ type ImportImageTask struct {
 
 	// A descriptive status message for the import image task.
 	StatusMessage *string `locationName:"statusMessage" type:"string"`
-
-	_ struct{} `type:"structure"`
 }
 
 // String returns the string representation
@@ -16332,6 +16332,8 @@ func (s ImportImageTask) GoString() string {
 }
 
 type ImportInstanceInput struct {
+	_ struct{} `type:"structure"`
+
 	// A description for the instance being imported.
 	Description *string `locationName:"description" type:"string"`
 
@@ -16349,8 +16351,6 @@ type ImportInstanceInput struct {
 
 	// The instance operating system.
 	Platform *string `locationName:"platform" type:"string" required:"true" enum:"PlatformValues"`
-
-	_ struct{} `type:"structure"`
 }
 
 // String returns the string representation
@@ -16365,6 +16365,8 @@ func (s ImportInstanceInput) GoString() string {
 
 // Describes the launch specification for VM import.
 type ImportInstanceLaunchSpecification struct {
+	_ struct{} `type:"structure"`
+
 	// Reserved.
 	AdditionalInfo *string `locationName:"additionalInfo" type:"string"`
 
@@ -16400,8 +16402,6 @@ type ImportInstanceLaunchSpecification struct {
 
 	// The Base64-encoded MIME user data to be made available to the instance.
 	UserData *UserData `locationName:"userData" type:"structure"`
-
-	_ struct{} `type:"structure"`
 }
 
 // String returns the string representation
@@ -16415,10 +16415,10 @@ func (s ImportInstanceLaunchSpecification) GoString() string {
 }
 
 type ImportInstanceOutput struct {
+	_ struct{} `type:"structure"`
+
 	// Information about the conversion task.
 	ConversionTask *ConversionTask `locationName:"conversionTask" type:"structure"`
-
-	_ struct{} `type:"structure"`
 }
 
 // String returns the string representation
@@ -16433,6 +16433,8 @@ func (s ImportInstanceOutput) GoString() string {
 
 // Describes an import instance task.
 type ImportInstanceTaskDetails struct {
+	_ struct{} `type:"structure"`
+
 	// A description of the task.
 	Description *string `locationName:"description" type:"string"`
 
@@ -16444,8 +16446,6 @@ type ImportInstanceTaskDetails struct {
 
 	// One or more volumes.
 	Volumes []*ImportInstanceVolumeDetailItem `locationName:"volumes" locationNameList:"item" type:"list" required:"true"`
-
-	_ struct{} `type:"structure"`
 }
 
 // String returns the string representation
@@ -16460,6 +16460,8 @@ func (s ImportInstanceTaskDetails) GoString() string {
 
 // Describes an import volume task.
 type ImportInstanceVolumeDetailItem struct {
+	_ struct{} `type:"structure"`
+
 	// The Availability Zone where the resulting instance will reside.
 	AvailabilityZone *string `locationName:"availabilityZone" type:"string" required:"true"`
 
@@ -16480,8 +16482,6 @@ type ImportInstanceVolumeDetailItem struct {
 
 	// The volume.
 	Volume *DiskImageVolumeDescription `locationName:"volume" type:"structure" required:"true"`
-
-	_ struct{} `type:"structure"`
 }
 
 // String returns the string representation
@@ -16495,6 +16495,8 @@ func (s ImportInstanceVolumeDetailItem) GoString() string {
 }
 
 type ImportKeyPairInput struct {
+	_ struct{} `type:"structure"`
+
 	// Checks whether you have the required permissions for the action, without
 	// actually making the request, and provides an error response. If you have
 	// the required permissions, the error response is DryRunOperation. Otherwise,
@@ -16507,8 +16509,6 @@ type ImportKeyPairInput struct {
 	// The public key. You must base64 encode the public key material before sending
 	// it to AWS.
 	PublicKeyMaterial []byte `locationName:"publicKeyMaterial" type:"blob" required:"true"`
-
-	_ struct{} `type:"structure"`
 }
 
 // String returns the string representation
@@ -16522,13 +16522,13 @@ func (s ImportKeyPairInput) GoString() string {
 }
 
 type ImportKeyPairOutput struct {
+	_ struct{} `type:"structure"`
+
 	// The MD5 public key fingerprint as specified in section 4 of RFC 4716.
 	KeyFingerprint *string `locationName:"keyFingerprint" type:"string"`
 
 	// The key pair name you provided.
 	KeyName *string `locationName:"keyName" type:"string"`
-
-	_ struct{} `type:"structure"`
 }
 
 // String returns the string representation
@@ -16542,6 +16542,8 @@ func (s ImportKeyPairOutput) GoString() string {
 }
 
 type ImportSnapshotInput struct {
+	_ struct{} `type:"structure"`
+
 	// The client-specific data.
 	ClientData *ClientData `type:"structure"`
 
@@ -16562,8 +16564,6 @@ type ImportSnapshotInput struct {
 
 	// The name of the role to use when not using the default role, 'vmimport'.
 	RoleName *string `type:"string"`
-
-	_ struct{} `type:"structure"`
 }
 
 // String returns the string representation
@@ -16577,6 +16577,8 @@ func (s ImportSnapshotInput) GoString() string {
 }
 
 type ImportSnapshotOutput struct {
+	_ struct{} `type:"structure"`
+
 	// A description of the import snapshot task.
 	Description *string `locationName:"description" type:"string"`
 
@@ -16585,8 +16587,6 @@ type ImportSnapshotOutput struct {
 
 	// Information about the import snapshot task.
 	SnapshotTaskDetail *SnapshotTaskDetail `locationName:"snapshotTaskDetail" type:"structure"`
-
-	_ struct{} `type:"structure"`
 }
 
 // String returns the string representation
@@ -16601,6 +16601,8 @@ func (s ImportSnapshotOutput) GoString() string {
 
 // Describes an import snapshot task.
 type ImportSnapshotTask struct {
+	_ struct{} `type:"structure"`
+
 	// A description of the import snapshot task.
 	Description *string `locationName:"description" type:"string"`
 
@@ -16609,8 +16611,6 @@ type ImportSnapshotTask struct {
 
 	// Describes an import snapshot task.
 	SnapshotTaskDetail *SnapshotTaskDetail `locationName:"snapshotTaskDetail" type:"structure"`
-
-	_ struct{} `type:"structure"`
 }
 
 // String returns the string representation
@@ -16624,6 +16624,8 @@ func (s ImportSnapshotTask) GoString() string {
 }
 
 type ImportVolumeInput struct {
+	_ struct{} `type:"structure"`
+
 	// The Availability Zone for the resulting EBS volume.
 	AvailabilityZone *string `locationName:"availabilityZone" type:"string" required:"true"`
 
@@ -16641,8 +16643,6 @@ type ImportVolumeInput struct {
 
 	// The volume size.
 	Volume *VolumeDetail `locationName:"volume" type:"structure" required:"true"`
-
-	_ struct{} `type:"structure"`
 }
 
 // String returns the string representation
@@ -16656,10 +16656,10 @@ func (s ImportVolumeInput) GoString() string {
 }
 
 type ImportVolumeOutput struct {
+	_ struct{} `type:"structure"`
+
 	// Information about the conversion task.
 	ConversionTask *ConversionTask `locationName:"conversionTask" type:"structure"`
-
-	_ struct{} `type:"structure"`
 }
 
 // String returns the string representation
@@ -16674,6 +16674,8 @@ func (s ImportVolumeOutput) GoString() string {
 
 // Describes an import volume task.
 type ImportVolumeTaskDetails struct {
+	_ struct{} `type:"structure"`
+
 	// The Availability Zone where the resulting volume will reside.
 	AvailabilityZone *string `locationName:"availabilityZone" type:"string" required:"true"`
 
@@ -16688,8 +16690,6 @@ type ImportVolumeTaskDetails struct {
 
 	// The volume.
 	Volume *DiskImageVolumeDescription `locationName:"volume" type:"structure" required:"true"`
-
-	_ struct{} `type:"structure"`
 }
 
 // String returns the string representation
@@ -16704,6 +16704,8 @@ func (s ImportVolumeTaskDetails) GoString() string {
 
 // Describes an instance.
 type Instance struct {
+	_ struct{} `type:"structure"`
+
 	// The AMI launch index, which can be used to find this instance in the launch
 	// group.
 	AmiLaunchIndex *int64 `locationName:"amiLaunchIndex" type:"integer"`
@@ -16831,8 +16833,6 @@ type Instance struct {
 
 	// [EC2-VPC] The ID of the VPC in which the instance is running.
 	VpcId *string `locationName:"vpcId" type:"string"`
-
-	_ struct{} `type:"structure"`
 }
 
 // String returns the string representation
@@ -16847,14 +16847,14 @@ func (s Instance) GoString() string {
 
 // Describes a block device mapping.
 type InstanceBlockDeviceMapping struct {
+	_ struct{} `type:"structure"`
+
 	// The device name exposed to the instance (for example, /dev/sdh or xvdh).
 	DeviceName *string `locationName:"deviceName" type:"string"`
 
 	// Parameters used to automatically set up EBS volumes when the instance is
 	// launched.
 	Ebs *EbsInstanceBlockDevice `locationName:"ebs" type:"structure"`
-
-	_ struct{} `type:"structure"`
 }
 
 // String returns the string representation
@@ -16869,6 +16869,8 @@ func (s InstanceBlockDeviceMapping) GoString() string {
 
 // Describes a block device mapping entry.
 type InstanceBlockDeviceMappingSpecification struct {
+	_ struct{} `type:"structure"`
+
 	// The device name exposed to the instance (for example, /dev/sdh or xvdh).
 	DeviceName *string `locationName:"deviceName" type:"string"`
 
@@ -16881,8 +16883,6 @@ type InstanceBlockDeviceMappingSpecification struct {
 
 	// The virtual device name.
 	VirtualName *string `locationName:"virtualName" type:"string"`
-
-	_ struct{} `type:"structure"`
 }
 
 // String returns the string representation
@@ -16896,6 +16896,8 @@ func (s InstanceBlockDeviceMappingSpecification) GoString() string {
 }
 
 type InstanceCapacity struct {
+	_ struct{} `type:"structure"`
+
 	// The number of instances that can still be launched onto the Dedicated host.
 	AvailableCapacity *int64 `locationName:"availableCapacity" type:"integer"`
 
@@ -16904,8 +16906,6 @@ type InstanceCapacity struct {
 
 	// The total number of instances that can be launched onto the Dedicated host.
 	TotalCapacity *int64 `locationName:"totalCapacity" type:"integer"`
-
-	_ struct{} `type:"structure"`
 }
 
 // String returns the string representation
@@ -16920,13 +16920,13 @@ func (s InstanceCapacity) GoString() string {
 
 // Describes a Reserved instance listing state.
 type InstanceCount struct {
+	_ struct{} `type:"structure"`
+
 	// The number of listed Reserved instances in the state specified by the state.
 	InstanceCount *int64 `locationName:"instanceCount" type:"integer"`
 
 	// The states of the listed Reserved instances.
 	State *string `locationName:"state" type:"string" enum:"ListingState"`
-
-	_ struct{} `type:"structure"`
 }
 
 // String returns the string representation
@@ -16941,13 +16941,13 @@ func (s InstanceCount) GoString() string {
 
 // Describes an instance to export.
 type InstanceExportDetails struct {
+	_ struct{} `type:"structure"`
+
 	// The ID of the resource being exported.
 	InstanceId *string `locationName:"instanceId" type:"string"`
 
 	// The target virtualization environment.
 	TargetEnvironment *string `locationName:"targetEnvironment" type:"string" enum:"ExportEnvironment"`
-
-	_ struct{} `type:"structure"`
 }
 
 // String returns the string representation
@@ -16962,13 +16962,13 @@ func (s InstanceExportDetails) GoString() string {
 
 // Describes the monitoring information of the instance.
 type InstanceMonitoring struct {
+	_ struct{} `type:"structure"`
+
 	// The ID of the instance.
 	InstanceId *string `locationName:"instanceId" type:"string"`
 
 	// The monitoring information.
 	Monitoring *Monitoring `locationName:"monitoring" type:"structure"`
-
-	_ struct{} `type:"structure"`
 }
 
 // String returns the string representation
@@ -16983,6 +16983,8 @@ func (s InstanceMonitoring) GoString() string {
 
 // Describes a network interface.
 type InstanceNetworkInterface struct {
+	_ struct{} `type:"structure"`
+
 	// The association information for an Elastic IP associated with the network
 	// interface.
 	Association *InstanceNetworkInterfaceAssociation `locationName:"association" type:"structure"`
@@ -17025,8 +17027,6 @@ type InstanceNetworkInterface struct {
 
 	// The ID of the VPC.
 	VpcId *string `locationName:"vpcId" type:"string"`
-
-	_ struct{} `type:"structure"`
 }
 
 // String returns the string representation
@@ -17041,6 +17041,8 @@ func (s InstanceNetworkInterface) GoString() string {
 
 // Describes association information for an Elastic IP address.
 type InstanceNetworkInterfaceAssociation struct {
+	_ struct{} `type:"structure"`
+
 	// The ID of the owner of the Elastic IP address.
 	IpOwnerId *string `locationName:"ipOwnerId" type:"string"`
 
@@ -17049,8 +17051,6 @@ type InstanceNetworkInterfaceAssociation struct {
 
 	// The public IP address or Elastic IP address bound to the network interface.
 	PublicIp *string `locationName:"publicIp" type:"string"`
-
-	_ struct{} `type:"structure"`
 }
 
 // String returns the string representation
@@ -17065,6 +17065,8 @@ func (s InstanceNetworkInterfaceAssociation) GoString() string {
 
 // Describes a network interface attachment.
 type InstanceNetworkInterfaceAttachment struct {
+	_ struct{} `type:"structure"`
+
 	// The time stamp when the attachment initiated.
 	AttachTime *time.Time `locationName:"attachTime" type:"timestamp" timestampFormat:"iso8601"`
 
@@ -17079,8 +17081,6 @@ type InstanceNetworkInterfaceAttachment struct {
 
 	// The attachment state.
 	Status *string `locationName:"status" type:"string" enum:"AttachmentStatus"`
-
-	_ struct{} `type:"structure"`
 }
 
 // String returns the string representation
@@ -17095,6 +17095,8 @@ func (s InstanceNetworkInterfaceAttachment) GoString() string {
 
 // Describes a network interface.
 type InstanceNetworkInterfaceSpecification struct {
+	_ struct{} `type:"structure"`
+
 	// Indicates whether to assign a public IP address to an instance you launch
 	// in a VPC. The public IP address can only be assigned to a network interface
 	// for eth0, and can only be assigned to a new network interface, not an existing
@@ -17139,8 +17141,6 @@ type InstanceNetworkInterfaceSpecification struct {
 	// The ID of the subnet associated with the network string. Applies only if
 	// creating a network interface when launching an instance.
 	SubnetId *string `locationName:"subnetId" type:"string"`
-
-	_ struct{} `type:"structure"`
 }
 
 // String returns the string representation
@@ -17155,6 +17155,8 @@ func (s InstanceNetworkInterfaceSpecification) GoString() string {
 
 // Describes a private IP address.
 type InstancePrivateIpAddress struct {
+	_ struct{} `type:"structure"`
+
 	// The association information for an Elastic IP address for the network interface.
 	Association *InstanceNetworkInterfaceAssociation `locationName:"association" type:"structure"`
 
@@ -17167,8 +17169,6 @@ type InstancePrivateIpAddress struct {
 
 	// The private IP address of the network interface.
 	PrivateIpAddress *string `locationName:"privateIpAddress" type:"string"`
-
-	_ struct{} `type:"structure"`
 }
 
 // String returns the string representation
@@ -17183,6 +17183,8 @@ func (s InstancePrivateIpAddress) GoString() string {
 
 // Describes the current state of the instance.
 type InstanceState struct {
+	_ struct{} `type:"structure"`
+
 	// The low byte represents the state. The high byte is an opaque internal value
 	// and should be ignored.
 	//
@@ -17201,8 +17203,6 @@ type InstanceState struct {
 
 	// The current state of the instance.
 	Name *string `locationName:"name" type:"string" enum:"InstanceStateName"`
-
-	_ struct{} `type:"structure"`
 }
 
 // String returns the string representation
@@ -17217,6 +17217,8 @@ func (s InstanceState) GoString() string {
 
 // Describes an instance state change.
 type InstanceStateChange struct {
+	_ struct{} `type:"structure"`
+
 	// The current state of the instance.
 	CurrentState *InstanceState `locationName:"currentState" type:"structure"`
 
@@ -17225,8 +17227,6 @@ type InstanceStateChange struct {
 
 	// The previous state of the instance.
 	PreviousState *InstanceState `locationName:"previousState" type:"structure"`
-
-	_ struct{} `type:"structure"`
 }
 
 // String returns the string representation
@@ -17241,6 +17241,8 @@ func (s InstanceStateChange) GoString() string {
 
 // Describes the status of an instance.
 type InstanceStatus struct {
+	_ struct{} `type:"structure"`
+
 	// The Availability Zone of the instance.
 	AvailabilityZone *string `locationName:"availabilityZone" type:"string"`
 
@@ -17262,8 +17264,6 @@ type InstanceStatus struct {
 	// that support an instance, such as hardware failures and network connectivity
 	// problems.
 	SystemStatus *InstanceStatusSummary `locationName:"systemStatus" type:"structure"`
-
-	_ struct{} `type:"structure"`
 }
 
 // String returns the string representation
@@ -17278,6 +17278,8 @@ func (s InstanceStatus) GoString() string {
 
 // Describes the instance status.
 type InstanceStatusDetails struct {
+	_ struct{} `type:"structure"`
+
 	// The time when a status check failed. For an instance that was launched and
 	// impaired, this is the time when the instance was launched.
 	ImpairedSince *time.Time `locationName:"impairedSince" type:"timestamp" timestampFormat:"iso8601"`
@@ -17287,8 +17289,6 @@ type InstanceStatusDetails struct {
 
 	// The status.
 	Status *string `locationName:"status" type:"string" enum:"StatusType"`
-
-	_ struct{} `type:"structure"`
 }
 
 // String returns the string representation
@@ -17303,6 +17303,8 @@ func (s InstanceStatusDetails) GoString() string {
 
 // Describes a scheduled event for an instance.
 type InstanceStatusEvent struct {
+	_ struct{} `type:"structure"`
+
 	// The event code.
 	Code *string `locationName:"code" type:"string" enum:"EventCode"`
 
@@ -17318,8 +17320,6 @@ type InstanceStatusEvent struct {
 
 	// The earliest scheduled start time for the event.
 	NotBefore *time.Time `locationName:"notBefore" type:"timestamp" timestampFormat:"iso8601"`
-
-	_ struct{} `type:"structure"`
 }
 
 // String returns the string representation
@@ -17334,13 +17334,13 @@ func (s InstanceStatusEvent) GoString() string {
 
 // Describes the status of an instance.
 type InstanceStatusSummary struct {
+	_ struct{} `type:"structure"`
+
 	// The system instance health or application instance health.
 	Details []*InstanceStatusDetails `locationName:"details" locationNameList:"item" type:"list"`
 
 	// The status.
 	Status *string `locationName:"status" type:"string" enum:"SummaryStatus"`
-
-	_ struct{} `type:"structure"`
 }
 
 // String returns the string representation
@@ -17355,6 +17355,8 @@ func (s InstanceStatusSummary) GoString() string {
 
 // Describes an Internet gateway.
 type InternetGateway struct {
+	_ struct{} `type:"structure"`
+
 	// Any VPCs attached to the Internet gateway.
 	Attachments []*InternetGatewayAttachment `locationName:"attachmentSet" locationNameList:"item" type:"list"`
 
@@ -17363,8 +17365,6 @@ type InternetGateway struct {
 
 	// Any tags assigned to the Internet gateway.
 	Tags []*Tag `locationName:"tagSet" locationNameList:"item" type:"list"`
-
-	_ struct{} `type:"structure"`
 }
 
 // String returns the string representation
@@ -17379,13 +17379,13 @@ func (s InternetGateway) GoString() string {
 
 // Describes the attachment of a VPC to an Internet gateway.
 type InternetGatewayAttachment struct {
+	_ struct{} `type:"structure"`
+
 	// The current state of the attachment.
 	State *string `locationName:"state" type:"string" enum:"AttachmentStatus"`
 
 	// The ID of the VPC.
 	VpcId *string `locationName:"vpcId" type:"string"`
-
-	_ struct{} `type:"structure"`
 }
 
 // String returns the string representation
@@ -17400,6 +17400,8 @@ func (s InternetGatewayAttachment) GoString() string {
 
 // Describes a security group rule.
 type IpPermission struct {
+	_ struct{} `type:"structure"`
+
 	// The start of port range for the TCP and UDP protocols, or an ICMP type number.
 	// A value of -1 indicates all ICMP types.
 	FromPort *int64 `locationName:"fromPort" type:"integer"`
@@ -17429,8 +17431,6 @@ type IpPermission struct {
 
 	// One or more security group and AWS account ID pairs.
 	UserIdGroupPairs []*UserIdGroupPair `locationName:"groups" locationNameList:"item" type:"list"`
-
-	_ struct{} `type:"structure"`
 }
 
 // String returns the string representation
@@ -17445,11 +17445,11 @@ func (s IpPermission) GoString() string {
 
 // Describes an IP range.
 type IpRange struct {
+	_ struct{} `type:"structure"`
+
 	// The CIDR range. You can either specify a CIDR range or a source security
 	// group, not both.
 	CidrIp *string `locationName:"cidrIp" type:"string"`
-
-	_ struct{} `type:"structure"`
 }
 
 // String returns the string representation
@@ -17464,6 +17464,8 @@ func (s IpRange) GoString() string {
 
 // Describes a key pair.
 type KeyPairInfo struct {
+	_ struct{} `type:"structure"`
+
 	// If you used CreateKeyPair to create the key pair, this is the SHA-1 digest
 	// of the DER encoded private key. If you used ImportKeyPair to provide AWS
 	// the public key, this is the MD5 public key fingerprint as specified in section
@@ -17472,8 +17474,6 @@ type KeyPairInfo struct {
 
 	// The name of the key pair.
 	KeyName *string `locationName:"keyName" type:"string"`
-
-	_ struct{} `type:"structure"`
 }
 
 // String returns the string representation
@@ -17488,13 +17488,13 @@ func (s KeyPairInfo) GoString() string {
 
 // Describes a launch permission.
 type LaunchPermission struct {
+	_ struct{} `type:"structure"`
+
 	// The name of the group.
 	Group *string `locationName:"group" type:"string" enum:"PermissionGroup"`
 
 	// The AWS account ID.
 	UserId *string `locationName:"userId" type:"string"`
-
-	_ struct{} `type:"structure"`
 }
 
 // String returns the string representation
@@ -17509,14 +17509,14 @@ func (s LaunchPermission) GoString() string {
 
 // Describes a launch permission modification.
 type LaunchPermissionModifications struct {
+	_ struct{} `type:"structure"`
+
 	// The AWS account ID to add to the list of launch permissions for the AMI.
 	Add []*LaunchPermission `locationNameList:"item" type:"list"`
 
 	// The AWS account ID to remove from the list of launch permissions for the
 	// AMI.
 	Remove []*LaunchPermission `locationNameList:"item" type:"list"`
-
-	_ struct{} `type:"structure"`
 }
 
 // String returns the string representation
@@ -17531,6 +17531,8 @@ func (s LaunchPermissionModifications) GoString() string {
 
 // Describes the launch specification for an instance.
 type LaunchSpecification struct {
+	_ struct{} `type:"structure"`
+
 	// Deprecated.
 	AddressingType *string `locationName:"addressingType" type:"string"`
 
@@ -17583,8 +17585,6 @@ type LaunchSpecification struct {
 
 	// The Base64-encoded MIME user data to make available to the instances.
 	UserData *string `locationName:"userData" type:"string"`
-
-	_ struct{} `type:"structure"`
 }
 
 // String returns the string representation
@@ -17598,13 +17598,13 @@ func (s LaunchSpecification) GoString() string {
 }
 
 type ModifyHostsInput struct {
+	_ struct{} `type:"structure"`
+
 	// Specify whether to enable or disable auto-placement.
 	AutoPlacement *string `locationName:"autoPlacement" type:"string" required:"true" enum:"AutoPlacement"`
 
 	// The host IDs of the Dedicated hosts you want to modify.
 	HostIds []*string `locationName:"hostId" locationNameList:"item" type:"list" required:"true"`
-
-	_ struct{} `type:"structure"`
 }
 
 // String returns the string representation
@@ -17618,14 +17618,14 @@ func (s ModifyHostsInput) GoString() string {
 }
 
 type ModifyHostsOutput struct {
+	_ struct{} `type:"structure"`
+
 	// The IDs of the Dedicated hosts that were successfully modified.
 	Successful []*string `locationName:"successful" locationNameList:"item" type:"list"`
 
 	// The IDs of the Dedicated hosts that could not be modified. Check whether
 	// the setting you requested can be used.
 	Unsuccessful []*UnsuccessfulItem `locationName:"unsuccessful" locationNameList:"item" type:"list"`
-
-	_ struct{} `type:"structure"`
 }
 
 // String returns the string representation
@@ -17639,13 +17639,13 @@ func (s ModifyHostsOutput) GoString() string {
 }
 
 type ModifyIdFormatInput struct {
+	_ struct{} `type:"structure"`
+
 	// The type of resource.
 	Resource *string `type:"string" required:"true"`
 
 	// Indicate whether the resource should use longer IDs (17-character IDs).
 	UseLongIds *bool `type:"boolean" required:"true"`
-
-	_ struct{} `type:"structure"`
 }
 
 // String returns the string representation
@@ -17673,6 +17673,8 @@ func (s ModifyIdFormatOutput) GoString() string {
 }
 
 type ModifyImageAttributeInput struct {
+	_ struct{} `type:"structure"`
+
 	// The name of the attribute to modify.
 	Attribute *string `type:"string"`
 
@@ -17709,8 +17711,6 @@ type ModifyImageAttributeInput struct {
 	// The value of the attribute being modified. This is only valid when modifying
 	// the description attribute.
 	Value *string `type:"string"`
-
-	_ struct{} `type:"structure"`
 }
 
 // String returns the string representation
@@ -17738,6 +17738,8 @@ func (s ModifyImageAttributeOutput) GoString() string {
 }
 
 type ModifyInstanceAttributeInput struct {
+	_ struct{} `type:"structure"`
+
 	// The name of the attribute.
 	Attribute *string `locationName:"attribute" type:"string" enum:"InstanceAttributeName"`
 
@@ -17816,8 +17818,6 @@ type ModifyInstanceAttributeInput struct {
 	// A new value for the attribute. Use only with the kernel, ramdisk, userData,
 	// disableApiTermination, or instanceInitiatedShutdownBehavior attribute.
 	Value *string `locationName:"value" type:"string"`
-
-	_ struct{} `type:"structure"`
 }
 
 // String returns the string representation
@@ -17845,6 +17845,8 @@ func (s ModifyInstanceAttributeOutput) GoString() string {
 }
 
 type ModifyInstancePlacementInput struct {
+	_ struct{} `type:"structure"`
+
 	// The new affinity setting for the instance.
 	Affinity *string `locationName:"affinity" type:"string" enum:"Affinity"`
 
@@ -17856,8 +17858,6 @@ type ModifyInstancePlacementInput struct {
 
 	// The tenancy of the instance that you are modifying.
 	Tenancy *string `locationName:"tenancy" type:"string" enum:"HostTenancy"`
-
-	_ struct{} `type:"structure"`
 }
 
 // String returns the string representation
@@ -17871,10 +17871,10 @@ func (s ModifyInstancePlacementInput) GoString() string {
 }
 
 type ModifyInstancePlacementOutput struct {
+	_ struct{} `type:"structure"`
+
 	// Is true if the request succeeds, and an error otherwise.
 	Return *bool `locationName:"return" type:"boolean"`
-
-	_ struct{} `type:"structure"`
 }
 
 // String returns the string representation
@@ -17888,6 +17888,8 @@ func (s ModifyInstancePlacementOutput) GoString() string {
 }
 
 type ModifyNetworkInterfaceAttributeInput struct {
+	_ struct{} `type:"structure"`
+
 	// Information about the interface attachment. If modifying the 'delete on termination'
 	// attribute, you must specify the ID of the interface attachment.
 	Attachment *NetworkInterfaceAttachmentChanges `locationName:"attachment" type:"structure"`
@@ -17916,8 +17918,6 @@ type ModifyNetworkInterfaceAttributeInput struct {
 	// NAT Instances (http://docs.aws.amazon.com/AmazonVPC/latest/UserGuide/VPC_NAT_Instance.html)
 	// in the Amazon Virtual Private Cloud User Guide.
 	SourceDestCheck *AttributeBooleanValue `locationName:"sourceDestCheck" type:"structure"`
-
-	_ struct{} `type:"structure"`
 }
 
 // String returns the string representation
@@ -17945,6 +17945,8 @@ func (s ModifyNetworkInterfaceAttributeOutput) GoString() string {
 }
 
 type ModifyReservedInstancesInput struct {
+	_ struct{} `type:"structure"`
+
 	// A unique, case-sensitive token you provide to ensure idempotency of your
 	// modification request. For more information, see Ensuring Idempotency (http://docs.aws.amazon.com/AWSEC2/latest/APIReference/Run_Instance_Idempotency.html).
 	ClientToken *string `locationName:"clientToken" type:"string"`
@@ -17954,8 +17956,6 @@ type ModifyReservedInstancesInput struct {
 
 	// The configuration settings for the Reserved instances to modify.
 	TargetConfigurations []*ReservedInstancesConfiguration `locationName:"ReservedInstancesConfigurationSetItemType" locationNameList:"item" type:"list" required:"true"`
-
-	_ struct{} `type:"structure"`
 }
 
 // String returns the string representation
@@ -17969,10 +17969,10 @@ func (s ModifyReservedInstancesInput) GoString() string {
 }
 
 type ModifyReservedInstancesOutput struct {
+	_ struct{} `type:"structure"`
+
 	// The ID for the modification.
 	ReservedInstancesModificationId *string `locationName:"reservedInstancesModificationId" type:"string"`
-
-	_ struct{} `type:"structure"`
 }
 
 // String returns the string representation
@@ -17986,6 +17986,8 @@ func (s ModifyReservedInstancesOutput) GoString() string {
 }
 
 type ModifySnapshotAttributeInput struct {
+	_ struct{} `type:"structure"`
+
 	// The snapshot attribute to modify.
 	//
 	//  Only volume creation permissions may be modified at the customer level.
@@ -18011,8 +18013,6 @@ type ModifySnapshotAttributeInput struct {
 
 	// The account ID to modify for the snapshot.
 	UserIds []*string `locationName:"UserId" locationNameList:"UserId" type:"list"`
-
-	_ struct{} `type:"structure"`
 }
 
 // String returns the string representation
@@ -18041,6 +18041,8 @@ func (s ModifySnapshotAttributeOutput) GoString() string {
 
 // Contains the parameters for ModifySpotFleetRequest.
 type ModifySpotFleetRequestInput struct {
+	_ struct{} `type:"structure"`
+
 	// Indicates whether running Spot instances should be terminated if the target
 	// capacity of the Spot fleet request is decreased below the current size of
 	// the Spot fleet.
@@ -18051,8 +18053,6 @@ type ModifySpotFleetRequestInput struct {
 
 	// The size of the fleet.
 	TargetCapacity *int64 `locationName:"targetCapacity" type:"integer"`
-
-	_ struct{} `type:"structure"`
 }
 
 // String returns the string representation
@@ -18067,10 +18067,10 @@ func (s ModifySpotFleetRequestInput) GoString() string {
 
 // Contains the output of ModifySpotFleetRequest.
 type ModifySpotFleetRequestOutput struct {
+	_ struct{} `type:"structure"`
+
 	// Is true if the request succeeds, and an error otherwise.
 	Return *bool `locationName:"return" type:"boolean"`
-
-	_ struct{} `type:"structure"`
 }
 
 // String returns the string representation
@@ -18084,14 +18084,14 @@ func (s ModifySpotFleetRequestOutput) GoString() string {
 }
 
 type ModifySubnetAttributeInput struct {
+	_ struct{} `type:"structure"`
+
 	// Specify true to indicate that instances launched into the specified subnet
 	// should be assigned public IP address.
 	MapPublicIpOnLaunch *AttributeBooleanValue `type:"structure"`
 
 	// The ID of the subnet.
 	SubnetId *string `locationName:"subnetId" type:"string" required:"true"`
-
-	_ struct{} `type:"structure"`
 }
 
 // String returns the string representation
@@ -18119,6 +18119,8 @@ func (s ModifySubnetAttributeOutput) GoString() string {
 }
 
 type ModifyVolumeAttributeInput struct {
+	_ struct{} `type:"structure"`
+
 	// Indicates whether the volume should be auto-enabled for I/O operations.
 	AutoEnableIO *AttributeBooleanValue `type:"structure"`
 
@@ -18130,8 +18132,6 @@ type ModifyVolumeAttributeInput struct {
 
 	// The ID of the volume.
 	VolumeId *string `type:"string" required:"true"`
-
-	_ struct{} `type:"structure"`
 }
 
 // String returns the string representation
@@ -18159,6 +18159,8 @@ func (s ModifyVolumeAttributeOutput) GoString() string {
 }
 
 type ModifyVpcAttributeInput struct {
+	_ struct{} `type:"structure"`
+
 	// Indicates whether the instances launched in the VPC get DNS hostnames. If
 	// enabled, instances in the VPC get DNS hostnames; otherwise, they do not.
 	//
@@ -18179,8 +18181,6 @@ type ModifyVpcAttributeInput struct {
 
 	// The ID of the VPC.
 	VpcId *string `locationName:"vpcId" type:"string" required:"true"`
-
-	_ struct{} `type:"structure"`
 }
 
 // String returns the string representation
@@ -18208,6 +18208,8 @@ func (s ModifyVpcAttributeOutput) GoString() string {
 }
 
 type ModifyVpcEndpointInput struct {
+	_ struct{} `type:"structure"`
+
 	// One or more route tables IDs to associate with the endpoint.
 	AddRouteTableIds []*string `locationName:"AddRouteTableId" locationNameList:"item" type:"list"`
 
@@ -18230,8 +18232,6 @@ type ModifyVpcEndpointInput struct {
 
 	// The ID of the endpoint.
 	VpcEndpointId *string `type:"string" required:"true"`
-
-	_ struct{} `type:"structure"`
 }
 
 // String returns the string representation
@@ -18245,10 +18245,10 @@ func (s ModifyVpcEndpointInput) GoString() string {
 }
 
 type ModifyVpcEndpointOutput struct {
+	_ struct{} `type:"structure"`
+
 	// Returns true if the request succeeds; otherwise, it returns an error.
 	Return *bool `locationName:"return" type:"boolean"`
-
-	_ struct{} `type:"structure"`
 }
 
 // String returns the string representation
@@ -18262,6 +18262,8 @@ func (s ModifyVpcEndpointOutput) GoString() string {
 }
 
 type MonitorInstancesInput struct {
+	_ struct{} `type:"structure"`
+
 	// Checks whether you have the required permissions for the action, without
 	// actually making the request, and provides an error response. If you have
 	// the required permissions, the error response is DryRunOperation. Otherwise,
@@ -18270,8 +18272,6 @@ type MonitorInstancesInput struct {
 
 	// One or more instance IDs.
 	InstanceIds []*string `locationName:"InstanceId" locationNameList:"InstanceId" type:"list" required:"true"`
-
-	_ struct{} `type:"structure"`
 }
 
 // String returns the string representation
@@ -18285,10 +18285,10 @@ func (s MonitorInstancesInput) GoString() string {
 }
 
 type MonitorInstancesOutput struct {
+	_ struct{} `type:"structure"`
+
 	// Monitoring information for one or more instances.
 	InstanceMonitorings []*InstanceMonitoring `locationName:"instancesSet" locationNameList:"item" type:"list"`
-
-	_ struct{} `type:"structure"`
 }
 
 // String returns the string representation
@@ -18303,10 +18303,10 @@ func (s MonitorInstancesOutput) GoString() string {
 
 // Describes the monitoring for the instance.
 type Monitoring struct {
+	_ struct{} `type:"structure"`
+
 	// Indicates whether monitoring is enabled for the instance.
 	State *string `locationName:"state" type:"string" enum:"MonitoringState"`
-
-	_ struct{} `type:"structure"`
 }
 
 // String returns the string representation
@@ -18320,6 +18320,8 @@ func (s Monitoring) GoString() string {
 }
 
 type MoveAddressToVpcInput struct {
+	_ struct{} `type:"structure"`
+
 	// Checks whether you have the required permissions for the action, without
 	// actually making the request, and provides an error response. If you have
 	// the required permissions, the error response is DryRunOperation. Otherwise,
@@ -18328,8 +18330,6 @@ type MoveAddressToVpcInput struct {
 
 	// The Elastic IP address.
 	PublicIp *string `locationName:"publicIp" type:"string" required:"true"`
-
-	_ struct{} `type:"structure"`
 }
 
 // String returns the string representation
@@ -18343,13 +18343,13 @@ func (s MoveAddressToVpcInput) GoString() string {
 }
 
 type MoveAddressToVpcOutput struct {
+	_ struct{} `type:"structure"`
+
 	// The allocation ID for the Elastic IP address.
 	AllocationId *string `locationName:"allocationId" type:"string"`
 
 	// The status of the move of the IP address.
 	Status *string `locationName:"status" type:"string" enum:"Status"`
-
-	_ struct{} `type:"structure"`
 }
 
 // String returns the string representation
@@ -18364,14 +18364,14 @@ func (s MoveAddressToVpcOutput) GoString() string {
 
 // Describes the status of a moving Elastic IP address.
 type MovingAddressStatus struct {
+	_ struct{} `type:"structure"`
+
 	// The status of the Elastic IP address that's being moved to the EC2-VPC platform,
 	// or restored to the EC2-Classic platform.
 	MoveStatus *string `locationName:"moveStatus" type:"string" enum:"MoveStatus"`
 
 	// The Elastic IP address.
 	PublicIp *string `locationName:"publicIp" type:"string"`
-
-	_ struct{} `type:"structure"`
 }
 
 // String returns the string representation
@@ -18386,6 +18386,8 @@ func (s MovingAddressStatus) GoString() string {
 
 // Describes a network ACL.
 type NetworkAcl struct {
+	_ struct{} `type:"structure"`
+
 	// Any associations between the network ACL and one or more subnets
 	Associations []*NetworkAclAssociation `locationName:"associationSet" locationNameList:"item" type:"list"`
 
@@ -18403,8 +18405,6 @@ type NetworkAcl struct {
 
 	// The ID of the VPC for the network ACL.
 	VpcId *string `locationName:"vpcId" type:"string"`
-
-	_ struct{} `type:"structure"`
 }
 
 // String returns the string representation
@@ -18419,6 +18419,8 @@ func (s NetworkAcl) GoString() string {
 
 // Describes an association between a network ACL and a subnet.
 type NetworkAclAssociation struct {
+	_ struct{} `type:"structure"`
+
 	// The ID of the association between a network ACL and a subnet.
 	NetworkAclAssociationId *string `locationName:"networkAclAssociationId" type:"string"`
 
@@ -18427,8 +18429,6 @@ type NetworkAclAssociation struct {
 
 	// The ID of the subnet.
 	SubnetId *string `locationName:"subnetId" type:"string"`
-
-	_ struct{} `type:"structure"`
 }
 
 // String returns the string representation
@@ -18443,6 +18443,8 @@ func (s NetworkAclAssociation) GoString() string {
 
 // Describes an entry in a network ACL.
 type NetworkAclEntry struct {
+	_ struct{} `type:"structure"`
+
 	// The network range to allow or deny, in CIDR notation.
 	CidrBlock *string `locationName:"cidrBlock" type:"string"`
 
@@ -18465,8 +18467,6 @@ type NetworkAclEntry struct {
 	// The rule number for the entry. ACL entries are processed in ascending order
 	// by rule number.
 	RuleNumber *int64 `locationName:"ruleNumber" type:"integer"`
-
-	_ struct{} `type:"structure"`
 }
 
 // String returns the string representation
@@ -18481,6 +18481,8 @@ func (s NetworkAclEntry) GoString() string {
 
 // Describes a network interface.
 type NetworkInterface struct {
+	_ struct{} `type:"structure"`
+
 	// The association information for an Elastic IP associated with the network
 	// interface.
 	Association *NetworkInterfaceAssociation `locationName:"association" type:"structure"`
@@ -18536,8 +18538,6 @@ type NetworkInterface struct {
 
 	// The ID of the VPC.
 	VpcId *string `locationName:"vpcId" type:"string"`
-
-	_ struct{} `type:"structure"`
 }
 
 // String returns the string representation
@@ -18552,6 +18552,8 @@ func (s NetworkInterface) GoString() string {
 
 // Describes association information for an Elastic IP address.
 type NetworkInterfaceAssociation struct {
+	_ struct{} `type:"structure"`
+
 	// The allocation ID.
 	AllocationId *string `locationName:"allocationId" type:"string"`
 
@@ -18566,8 +18568,6 @@ type NetworkInterfaceAssociation struct {
 
 	// The address of the Elastic IP address bound to the network interface.
 	PublicIp *string `locationName:"publicIp" type:"string"`
-
-	_ struct{} `type:"structure"`
 }
 
 // String returns the string representation
@@ -18582,6 +18582,8 @@ func (s NetworkInterfaceAssociation) GoString() string {
 
 // Describes a network interface attachment.
 type NetworkInterfaceAttachment struct {
+	_ struct{} `type:"structure"`
+
 	// The timestamp indicating when the attachment initiated.
 	AttachTime *time.Time `locationName:"attachTime" type:"timestamp" timestampFormat:"iso8601"`
 
@@ -18602,8 +18604,6 @@ type NetworkInterfaceAttachment struct {
 
 	// The attachment state.
 	Status *string `locationName:"status" type:"string" enum:"AttachmentStatus"`
-
-	_ struct{} `type:"structure"`
 }
 
 // String returns the string representation
@@ -18618,13 +18618,13 @@ func (s NetworkInterfaceAttachment) GoString() string {
 
 // Describes an attachment change.
 type NetworkInterfaceAttachmentChanges struct {
+	_ struct{} `type:"structure"`
+
 	// The ID of the network interface attachment.
 	AttachmentId *string `locationName:"attachmentId" type:"string"`
 
 	// Indicates whether the network interface is deleted when the instance is terminated.
 	DeleteOnTermination *bool `locationName:"deleteOnTermination" type:"boolean"`
-
-	_ struct{} `type:"structure"`
 }
 
 // String returns the string representation
@@ -18639,6 +18639,8 @@ func (s NetworkInterfaceAttachmentChanges) GoString() string {
 
 // Describes the private IP address of a network interface.
 type NetworkInterfacePrivateIpAddress struct {
+	_ struct{} `type:"structure"`
+
 	// The association information for an Elastic IP address associated with the
 	// network interface.
 	Association *NetworkInterfaceAssociation `locationName:"association" type:"structure"`
@@ -18652,8 +18654,6 @@ type NetworkInterfacePrivateIpAddress struct {
 
 	// The private IP address.
 	PrivateIpAddress *string `locationName:"privateIpAddress" type:"string"`
-
-	_ struct{} `type:"structure"`
 }
 
 // String returns the string representation
@@ -18667,11 +18667,11 @@ func (s NetworkInterfacePrivateIpAddress) GoString() string {
 }
 
 type NewDhcpConfiguration struct {
+	_ struct{} `type:"structure"`
+
 	Key *string `locationName:"key" type:"string"`
 
 	Values []*string `locationName:"Value" locationNameList:"item" type:"list"`
-
-	_ struct{} `type:"structure"`
 }
 
 // String returns the string representation
@@ -18686,6 +18686,8 @@ func (s NewDhcpConfiguration) GoString() string {
 
 // Describes the placement for the instance.
 type Placement struct {
+	_ struct{} `type:"structure"`
+
 	// The affinity setting for the instance on the Dedicated host. This parameter
 	// is not supported for the ImportInstance command.
 	Affinity *string `locationName:"affinity" type:"string"`
@@ -18704,8 +18706,6 @@ type Placement struct {
 	// with a tenancy of dedicated runs on single-tenant hardware. The host tenancy
 	// is not supported for the ImportInstance command.
 	Tenancy *string `locationName:"tenancy" type:"string" enum:"Tenancy"`
-
-	_ struct{} `type:"structure"`
 }
 
 // String returns the string representation
@@ -18720,6 +18720,8 @@ func (s Placement) GoString() string {
 
 // Describes a placement group.
 type PlacementGroup struct {
+	_ struct{} `type:"structure"`
+
 	// The name of the placement group.
 	GroupName *string `locationName:"groupName" type:"string"`
 
@@ -18728,8 +18730,6 @@ type PlacementGroup struct {
 
 	// The placement strategy.
 	Strategy *string `locationName:"strategy" type:"string" enum:"PlacementStrategy"`
-
-	_ struct{} `type:"structure"`
 }
 
 // String returns the string representation
@@ -18744,13 +18744,13 @@ func (s PlacementGroup) GoString() string {
 
 // Describes a range of ports.
 type PortRange struct {
+	_ struct{} `type:"structure"`
+
 	// The first port in the range.
 	From *int64 `locationName:"from" type:"integer"`
 
 	// The last port in the range.
 	To *int64 `locationName:"to" type:"integer"`
-
-	_ struct{} `type:"structure"`
 }
 
 // String returns the string representation
@@ -18765,6 +18765,8 @@ func (s PortRange) GoString() string {
 
 // Describes prefixes for AWS services.
 type PrefixList struct {
+	_ struct{} `type:"structure"`
+
 	// The IP address range of the AWS service.
 	Cidrs []*string `locationName:"cidrSet" locationNameList:"item" type:"list"`
 
@@ -18773,8 +18775,6 @@ type PrefixList struct {
 
 	// The name of the prefix.
 	PrefixListName *string `locationName:"prefixListName" type:"string"`
-
-	_ struct{} `type:"structure"`
 }
 
 // String returns the string representation
@@ -18789,10 +18789,10 @@ func (s PrefixList) GoString() string {
 
 // The ID of the prefix.
 type PrefixListId struct {
+	_ struct{} `type:"structure"`
+
 	// The ID of the prefix.
 	PrefixListId *string `locationName:"prefixListId" type:"string"`
-
-	_ struct{} `type:"structure"`
 }
 
 // String returns the string representation
@@ -18807,6 +18807,8 @@ func (s PrefixListId) GoString() string {
 
 // Describes the price for a Reserved instance.
 type PriceSchedule struct {
+	_ struct{} `type:"structure"`
+
 	// The current price schedule, as determined by the term remaining for the Reserved
 	// Instance in the listing.
 	//
@@ -18829,8 +18831,6 @@ type PriceSchedule struct {
 	// The number of months remaining in the reservation. For example, 2 is the
 	// second to the last month before the capacity reservation expires.
 	Term *int64 `locationName:"term" type:"long"`
-
-	_ struct{} `type:"structure"`
 }
 
 // String returns the string representation
@@ -18845,6 +18845,8 @@ func (s PriceSchedule) GoString() string {
 
 // Describes the price for a Reserved instance.
 type PriceScheduleSpecification struct {
+	_ struct{} `type:"structure"`
+
 	// The currency for transacting the Reserved instance resale. At this time,
 	// the only supported currency is USD.
 	CurrencyCode *string `locationName:"currencyCode" type:"string" enum:"CurrencyCodeValues"`
@@ -18855,8 +18857,6 @@ type PriceScheduleSpecification struct {
 	// The number of months remaining in the reservation. For example, 2 is the
 	// second to the last month before the capacity reservation expires.
 	Term *int64 `locationName:"term" type:"long"`
-
-	_ struct{} `type:"structure"`
 }
 
 // String returns the string representation
@@ -18871,13 +18871,13 @@ func (s PriceScheduleSpecification) GoString() string {
 
 // Describes a Reserved instance offering.
 type PricingDetail struct {
+	_ struct{} `type:"structure"`
+
 	// The number of instances available for the price.
 	Count *int64 `locationName:"count" type:"integer"`
 
 	// The price per instance.
 	Price *float64 `locationName:"price" type:"double"`
-
-	_ struct{} `type:"structure"`
 }
 
 // String returns the string representation
@@ -18892,14 +18892,14 @@ func (s PricingDetail) GoString() string {
 
 // Describes a secondary private IP address for a network interface.
 type PrivateIpAddressSpecification struct {
+	_ struct{} `type:"structure"`
+
 	// Indicates whether the private IP address is the primary private IP address.
 	// Only one IP address can be designated as primary.
 	Primary *bool `locationName:"primary" type:"boolean"`
 
 	// The private IP addresses.
 	PrivateIpAddress *string `locationName:"privateIpAddress" type:"string" required:"true"`
-
-	_ struct{} `type:"structure"`
 }
 
 // String returns the string representation
@@ -18914,13 +18914,13 @@ func (s PrivateIpAddressSpecification) GoString() string {
 
 // Describes a product code.
 type ProductCode struct {
+	_ struct{} `type:"structure"`
+
 	// The product code.
 	ProductCodeId *string `locationName:"productCode" type:"string"`
 
 	// The type of product code.
 	ProductCodeType *string `locationName:"type" type:"string" enum:"ProductCodeValues"`
-
-	_ struct{} `type:"structure"`
 }
 
 // String returns the string representation
@@ -18935,10 +18935,10 @@ func (s ProductCode) GoString() string {
 
 // Describes a virtual private gateway propagating route.
 type PropagatingVgw struct {
+	_ struct{} `type:"structure"`
+
 	// The ID of the virtual private gateway (VGW).
 	GatewayId *string `locationName:"gatewayId" type:"string"`
-
-	_ struct{} `type:"structure"`
 }
 
 // String returns the string representation
@@ -18952,6 +18952,8 @@ func (s PropagatingVgw) GoString() string {
 }
 
 type PurchaseReservedInstancesOfferingInput struct {
+	_ struct{} `type:"structure"`
+
 	// Checks whether you have the required permissions for the action, without
 	// actually making the request, and provides an error response. If you have
 	// the required permissions, the error response is DryRunOperation. Otherwise,
@@ -18968,8 +18970,6 @@ type PurchaseReservedInstancesOfferingInput struct {
 
 	// The ID of the Reserved instance offering to purchase.
 	ReservedInstancesOfferingId *string `type:"string" required:"true"`
-
-	_ struct{} `type:"structure"`
 }
 
 // String returns the string representation
@@ -18983,10 +18983,10 @@ func (s PurchaseReservedInstancesOfferingInput) GoString() string {
 }
 
 type PurchaseReservedInstancesOfferingOutput struct {
+	_ struct{} `type:"structure"`
+
 	// The IDs of the purchased Reserved instances.
 	ReservedInstancesId *string `locationName:"reservedInstancesId" type:"string"`
-
-	_ struct{} `type:"structure"`
 }
 
 // String returns the string representation
@@ -19000,6 +19000,8 @@ func (s PurchaseReservedInstancesOfferingOutput) GoString() string {
 }
 
 type RebootInstancesInput struct {
+	_ struct{} `type:"structure"`
+
 	// Checks whether you have the required permissions for the action, without
 	// actually making the request, and provides an error response. If you have
 	// the required permissions, the error response is DryRunOperation. Otherwise,
@@ -19008,8 +19010,6 @@ type RebootInstancesInput struct {
 
 	// One or more instance IDs.
 	InstanceIds []*string `locationName:"InstanceId" locationNameList:"InstanceId" type:"list" required:"true"`
-
-	_ struct{} `type:"structure"`
 }
 
 // String returns the string representation
@@ -19038,13 +19038,13 @@ func (s RebootInstancesOutput) GoString() string {
 
 // Describes a recurring charge.
 type RecurringCharge struct {
+	_ struct{} `type:"structure"`
+
 	// The amount of the recurring charge.
 	Amount *float64 `locationName:"amount" type:"double"`
 
 	// The frequency of the recurring charge.
 	Frequency *string `locationName:"frequency" type:"string" enum:"RecurringChargeFrequency"`
-
-	_ struct{} `type:"structure"`
 }
 
 // String returns the string representation
@@ -19059,13 +19059,13 @@ func (s RecurringCharge) GoString() string {
 
 // Describes a region.
 type Region struct {
+	_ struct{} `type:"structure"`
+
 	// The region service endpoint.
 	Endpoint *string `locationName:"regionEndpoint" type:"string"`
 
 	// The name of the region.
 	RegionName *string `locationName:"regionName" type:"string"`
-
-	_ struct{} `type:"structure"`
 }
 
 // String returns the string representation
@@ -19079,6 +19079,8 @@ func (s Region) GoString() string {
 }
 
 type RegisterImageInput struct {
+	_ struct{} `type:"structure"`
+
 	// The architecture of the AMI.
 	//
 	// Default: For Amazon EBS-backed AMIs, i386. For instance store-backed AMIs,
@@ -19129,8 +19131,6 @@ type RegisterImageInput struct {
 	//
 	// Default: paravirtual
 	VirtualizationType *string `locationName:"virtualizationType" type:"string"`
-
-	_ struct{} `type:"structure"`
 }
 
 // String returns the string representation
@@ -19144,10 +19144,10 @@ func (s RegisterImageInput) GoString() string {
 }
 
 type RegisterImageOutput struct {
+	_ struct{} `type:"structure"`
+
 	// The ID of the newly registered AMI.
 	ImageId *string `locationName:"imageId" type:"string"`
-
-	_ struct{} `type:"structure"`
 }
 
 // String returns the string representation
@@ -19161,6 +19161,8 @@ func (s RegisterImageOutput) GoString() string {
 }
 
 type RejectVpcPeeringConnectionInput struct {
+	_ struct{} `type:"structure"`
+
 	// Checks whether you have the required permissions for the action, without
 	// actually making the request, and provides an error response. If you have
 	// the required permissions, the error response is DryRunOperation. Otherwise,
@@ -19169,8 +19171,6 @@ type RejectVpcPeeringConnectionInput struct {
 
 	// The ID of the VPC peering connection.
 	VpcPeeringConnectionId *string `locationName:"vpcPeeringConnectionId" type:"string" required:"true"`
-
-	_ struct{} `type:"structure"`
 }
 
 // String returns the string representation
@@ -19184,10 +19184,10 @@ func (s RejectVpcPeeringConnectionInput) GoString() string {
 }
 
 type RejectVpcPeeringConnectionOutput struct {
+	_ struct{} `type:"structure"`
+
 	// Returns true if the request succeeds; otherwise, it returns an error.
 	Return *bool `locationName:"return" type:"boolean"`
-
-	_ struct{} `type:"structure"`
 }
 
 // String returns the string representation
@@ -19201,6 +19201,8 @@ func (s RejectVpcPeeringConnectionOutput) GoString() string {
 }
 
 type ReleaseAddressInput struct {
+	_ struct{} `type:"structure"`
+
 	// [EC2-VPC] The allocation ID. Required for EC2-VPC.
 	AllocationId *string `type:"string"`
 
@@ -19212,8 +19214,6 @@ type ReleaseAddressInput struct {
 
 	// [EC2-Classic] The Elastic IP address. Required for EC2-Classic.
 	PublicIp *string `type:"string"`
-
-	_ struct{} `type:"structure"`
 }
 
 // String returns the string representation
@@ -19241,10 +19241,10 @@ func (s ReleaseAddressOutput) GoString() string {
 }
 
 type ReleaseHostsInput struct {
+	_ struct{} `type:"structure"`
+
 	// The IDs of the Dedicated hosts you want to release.
 	HostIds []*string `locationName:"hostId" locationNameList:"item" type:"list" required:"true"`
-
-	_ struct{} `type:"structure"`
 }
 
 // String returns the string representation
@@ -19258,14 +19258,14 @@ func (s ReleaseHostsInput) GoString() string {
 }
 
 type ReleaseHostsOutput struct {
+	_ struct{} `type:"structure"`
+
 	// The IDs of the Dedicated hosts that were successfully released.
 	Successful []*string `locationName:"successful" locationNameList:"item" type:"list"`
 
 	// The IDs of the Dedicated hosts that could not be released, including an error
 	// message.
 	Unsuccessful []*UnsuccessfulItem `locationName:"unsuccessful" locationNameList:"item" type:"list"`
-
-	_ struct{} `type:"structure"`
 }
 
 // String returns the string representation
@@ -19279,6 +19279,8 @@ func (s ReleaseHostsOutput) GoString() string {
 }
 
 type ReplaceNetworkAclAssociationInput struct {
+	_ struct{} `type:"structure"`
+
 	// The ID of the current association between the original network ACL and the
 	// subnet.
 	AssociationId *string `locationName:"associationId" type:"string" required:"true"`
@@ -19291,8 +19293,6 @@ type ReplaceNetworkAclAssociationInput struct {
 
 	// The ID of the new network ACL to associate with the subnet.
 	NetworkAclId *string `locationName:"networkAclId" type:"string" required:"true"`
-
-	_ struct{} `type:"structure"`
 }
 
 // String returns the string representation
@@ -19306,10 +19306,10 @@ func (s ReplaceNetworkAclAssociationInput) GoString() string {
 }
 
 type ReplaceNetworkAclAssociationOutput struct {
+	_ struct{} `type:"structure"`
+
 	// The ID of the new association.
 	NewAssociationId *string `locationName:"newAssociationId" type:"string"`
-
-	_ struct{} `type:"structure"`
 }
 
 // String returns the string representation
@@ -19323,6 +19323,8 @@ func (s ReplaceNetworkAclAssociationOutput) GoString() string {
 }
 
 type ReplaceNetworkAclEntryInput struct {
+	_ struct{} `type:"structure"`
+
 	// The network range to allow or deny, in CIDR notation.
 	CidrBlock *string `locationName:"cidrBlock" type:"string" required:"true"`
 
@@ -19356,8 +19358,6 @@ type ReplaceNetworkAclEntryInput struct {
 
 	// The rule number of the entry to replace.
 	RuleNumber *int64 `locationName:"ruleNumber" type:"integer" required:"true"`
-
-	_ struct{} `type:"structure"`
 }
 
 // String returns the string representation
@@ -19385,6 +19385,8 @@ func (s ReplaceNetworkAclEntryOutput) GoString() string {
 }
 
 type ReplaceRouteInput struct {
+	_ struct{} `type:"structure"`
+
 	// The CIDR address block used for the destination match. The value you provide
 	// must match the CIDR of an existing route in the table.
 	DestinationCidrBlock *string `locationName:"destinationCidrBlock" type:"string" required:"true"`
@@ -19409,8 +19411,6 @@ type ReplaceRouteInput struct {
 
 	// The ID of a VPC peering connection.
 	VpcPeeringConnectionId *string `locationName:"vpcPeeringConnectionId" type:"string"`
-
-	_ struct{} `type:"structure"`
 }
 
 // String returns the string representation
@@ -19438,6 +19438,8 @@ func (s ReplaceRouteOutput) GoString() string {
 }
 
 type ReplaceRouteTableAssociationInput struct {
+	_ struct{} `type:"structure"`
+
 	// The association ID.
 	AssociationId *string `locationName:"associationId" type:"string" required:"true"`
 
@@ -19449,8 +19451,6 @@ type ReplaceRouteTableAssociationInput struct {
 
 	// The ID of the new route table to associate with the subnet.
 	RouteTableId *string `locationName:"routeTableId" type:"string" required:"true"`
-
-	_ struct{} `type:"structure"`
 }
 
 // String returns the string representation
@@ -19464,10 +19464,10 @@ func (s ReplaceRouteTableAssociationInput) GoString() string {
 }
 
 type ReplaceRouteTableAssociationOutput struct {
+	_ struct{} `type:"structure"`
+
 	// The ID of the new association.
 	NewAssociationId *string `locationName:"newAssociationId" type:"string"`
-
-	_ struct{} `type:"structure"`
 }
 
 // String returns the string representation
@@ -19481,6 +19481,8 @@ func (s ReplaceRouteTableAssociationOutput) GoString() string {
 }
 
 type ReportInstanceStatusInput struct {
+	_ struct{} `type:"structure"`
+
 	// Descriptive text about the health state of your instance.
 	Description *string `locationName:"description" type:"string"`
 
@@ -19525,8 +19527,6 @@ type ReportInstanceStatusInput struct {
 
 	// The status of all instances listed.
 	Status *string `locationName:"status" type:"string" required:"true" enum:"ReportStatusType"`
-
-	_ struct{} `type:"structure"`
 }
 
 // String returns the string representation
@@ -19555,6 +19555,8 @@ func (s ReportInstanceStatusOutput) GoString() string {
 
 // Contains the parameters for RequestSpotFleet.
 type RequestSpotFleetInput struct {
+	_ struct{} `type:"structure"`
+
 	// Checks whether you have the required permissions for the action, without
 	// actually making the request, and provides an error response. If you have
 	// the required permissions, the error response is DryRunOperation. Otherwise,
@@ -19563,8 +19565,6 @@ type RequestSpotFleetInput struct {
 
 	// The configuration for the Spot fleet request.
 	SpotFleetRequestConfig *SpotFleetRequestConfigData `locationName:"spotFleetRequestConfig" type:"structure" required:"true"`
-
-	_ struct{} `type:"structure"`
 }
 
 // String returns the string representation
@@ -19579,10 +19579,10 @@ func (s RequestSpotFleetInput) GoString() string {
 
 // Contains the output of RequestSpotFleet.
 type RequestSpotFleetOutput struct {
+	_ struct{} `type:"structure"`
+
 	// The ID of the Spot fleet request.
 	SpotFleetRequestId *string `locationName:"spotFleetRequestId" type:"string" required:"true"`
-
-	_ struct{} `type:"structure"`
 }
 
 // String returns the string representation
@@ -19597,6 +19597,8 @@ func (s RequestSpotFleetOutput) GoString() string {
 
 // Contains the parameters for RequestSpotInstances.
 type RequestSpotInstancesInput struct {
+	_ struct{} `type:"structure"`
+
 	// The user-specified name for a logical grouping of bids.
 	//
 	// When you specify an Availability Zone group in a Spot Instance request,
@@ -19680,8 +19682,6 @@ type RequestSpotInstancesInput struct {
 	//
 	// Default: The request is effective indefinitely.
 	ValidUntil *time.Time `locationName:"validUntil" type:"timestamp" timestampFormat:"iso8601"`
-
-	_ struct{} `type:"structure"`
 }
 
 // String returns the string representation
@@ -19696,10 +19696,10 @@ func (s RequestSpotInstancesInput) GoString() string {
 
 // Contains the output of RequestSpotInstances.
 type RequestSpotInstancesOutput struct {
+	_ struct{} `type:"structure"`
+
 	// One or more Spot instance requests.
 	SpotInstanceRequests []*SpotInstanceRequest `locationName:"spotInstanceRequestSet" locationNameList:"item" type:"list"`
-
-	_ struct{} `type:"structure"`
 }
 
 // String returns the string representation
@@ -19714,6 +19714,8 @@ func (s RequestSpotInstancesOutput) GoString() string {
 
 // Describes the launch specification for an instance.
 type RequestSpotLaunchSpecification struct {
+	_ struct{} `type:"structure"`
+
 	// Deprecated.
 	AddressingType *string `locationName:"addressingType" type:"string"`
 
@@ -19765,8 +19767,6 @@ type RequestSpotLaunchSpecification struct {
 
 	// The Base64-encoded MIME user data to make available to the instances.
 	UserData *string `locationName:"userData" type:"string"`
-
-	_ struct{} `type:"structure"`
 }
 
 // String returns the string representation
@@ -19781,6 +19781,8 @@ func (s RequestSpotLaunchSpecification) GoString() string {
 
 // Describes a reservation.
 type Reservation struct {
+	_ struct{} `type:"structure"`
+
 	// One or more security groups.
 	Groups []*GroupIdentifier `locationName:"groupSet" locationNameList:"item" type:"list"`
 
@@ -19796,8 +19798,6 @@ type Reservation struct {
 
 	// The ID of the reservation.
 	ReservationId *string `locationName:"reservationId" type:"string"`
-
-	_ struct{} `type:"structure"`
 }
 
 // String returns the string representation
@@ -19812,6 +19812,8 @@ func (s Reservation) GoString() string {
 
 // Describes the limit price of a Reserved instance offering.
 type ReservedInstanceLimitPrice struct {
+	_ struct{} `type:"structure"`
+
 	// Used for Reserved Instance Marketplace offerings. Specifies the limit price
 	// on the total order (instanceCount * price).
 	Amount *float64 `locationName:"amount" type:"double"`
@@ -19819,8 +19821,6 @@ type ReservedInstanceLimitPrice struct {
 	// The currency in which the limitPrice amount is specified. At this time, the
 	// only supported currency is USD.
 	CurrencyCode *string `locationName:"currencyCode" type:"string" enum:"CurrencyCodeValues"`
-
-	_ struct{} `type:"structure"`
 }
 
 // String returns the string representation
@@ -19835,6 +19835,8 @@ func (s ReservedInstanceLimitPrice) GoString() string {
 
 // Describes a Reserved instance.
 type ReservedInstances struct {
+	_ struct{} `type:"structure"`
+
 	// The Availability Zone in which the Reserved instance can be used.
 	AvailabilityZone *string `locationName:"availabilityZone" type:"string"`
 
@@ -19883,8 +19885,6 @@ type ReservedInstances struct {
 
 	// The usage price of the Reserved instance, per hour.
 	UsagePrice *float64 `locationName:"usagePrice" type:"float"`
-
-	_ struct{} `type:"structure"`
 }
 
 // String returns the string representation
@@ -19899,6 +19899,8 @@ func (s ReservedInstances) GoString() string {
 
 // Describes the configuration settings for the modified Reserved instances.
 type ReservedInstancesConfiguration struct {
+	_ struct{} `type:"structure"`
+
 	// The Availability Zone for the modified Reserved instances.
 	AvailabilityZone *string `locationName:"availabilityZone" type:"string"`
 
@@ -19911,8 +19913,6 @@ type ReservedInstancesConfiguration struct {
 	// The network platform of the modified Reserved instances, which is either
 	// EC2-Classic or EC2-VPC.
 	Platform *string `locationName:"platform" type:"string"`
-
-	_ struct{} `type:"structure"`
 }
 
 // String returns the string representation
@@ -19927,10 +19927,10 @@ func (s ReservedInstancesConfiguration) GoString() string {
 
 // Describes the ID of a Reserved instance.
 type ReservedInstancesId struct {
+	_ struct{} `type:"structure"`
+
 	// The ID of the Reserved instance.
 	ReservedInstancesId *string `locationName:"reservedInstancesId" type:"string"`
-
-	_ struct{} `type:"structure"`
 }
 
 // String returns the string representation
@@ -19945,6 +19945,8 @@ func (s ReservedInstancesId) GoString() string {
 
 // Describes a Reserved instance listing.
 type ReservedInstancesListing struct {
+	_ struct{} `type:"structure"`
+
 	// A unique, case-sensitive key supplied by the client to ensure that the request
 	// is idempotent. For more information, see Ensuring Idempotency (http://docs.aws.amazon.com/AWSEC2/latest/APIReference/Run_Instance_Idempotency.html).
 	ClientToken *string `locationName:"clientToken" type:"string"`
@@ -19976,8 +19978,6 @@ type ReservedInstancesListing struct {
 
 	// The last modified timestamp of the listing.
 	UpdateDate *time.Time `locationName:"updateDate" type:"timestamp" timestampFormat:"iso8601"`
-
-	_ struct{} `type:"structure"`
 }
 
 // String returns the string representation
@@ -19992,6 +19992,8 @@ func (s ReservedInstancesListing) GoString() string {
 
 // Describes a Reserved instance modification.
 type ReservedInstancesModification struct {
+	_ struct{} `type:"structure"`
+
 	// A unique, case-sensitive key supplied by the client to ensure that the request
 	// is idempotent. For more information, see Ensuring Idempotency (http://docs.aws.amazon.com/AWSEC2/latest/APIReference/Run_Instance_Idempotency.html).
 	ClientToken *string `locationName:"clientToken" type:"string"`
@@ -20020,8 +20022,6 @@ type ReservedInstancesModification struct {
 
 	// The time when the modification request was last updated.
 	UpdateDate *time.Time `locationName:"updateDate" type:"timestamp" timestampFormat:"iso8601"`
-
-	_ struct{} `type:"structure"`
 }
 
 // String returns the string representation
@@ -20035,6 +20035,8 @@ func (s ReservedInstancesModification) GoString() string {
 }
 
 type ReservedInstancesModificationResult struct {
+	_ struct{} `type:"structure"`
+
 	// The ID for the Reserved instances that were created as part of the modification
 	// request. This field is only available when the modification is fulfilled.
 	ReservedInstancesId *string `locationName:"reservedInstancesId" type:"string"`
@@ -20042,8 +20044,6 @@ type ReservedInstancesModificationResult struct {
 	// The target Reserved instances configurations supplied as part of the modification
 	// request.
 	TargetConfiguration *ReservedInstancesConfiguration `locationName:"targetConfiguration" type:"structure"`
-
-	_ struct{} `type:"structure"`
 }
 
 // String returns the string representation
@@ -20058,6 +20058,8 @@ func (s ReservedInstancesModificationResult) GoString() string {
 
 // Describes a Reserved instance offering.
 type ReservedInstancesOffering struct {
+	_ struct{} `type:"structure"`
+
 	// The Availability Zone in which the Reserved instance can be used.
 	AvailabilityZone *string `locationName:"availabilityZone" type:"string"`
 
@@ -20100,8 +20102,6 @@ type ReservedInstancesOffering struct {
 
 	// The usage price of the Reserved instance, per hour.
 	UsagePrice *float64 `locationName:"usagePrice" type:"float"`
-
-	_ struct{} `type:"structure"`
 }
 
 // String returns the string representation
@@ -20115,6 +20115,8 @@ func (s ReservedInstancesOffering) GoString() string {
 }
 
 type ResetImageAttributeInput struct {
+	_ struct{} `type:"structure"`
+
 	// The attribute to reset (currently you can only reset the launch permission
 	// attribute).
 	Attribute *string `type:"string" required:"true" enum:"ResetImageAttributeName"`
@@ -20127,8 +20129,6 @@ type ResetImageAttributeInput struct {
 
 	// The ID of the AMI.
 	ImageId *string `type:"string" required:"true"`
-
-	_ struct{} `type:"structure"`
 }
 
 // String returns the string representation
@@ -20156,6 +20156,8 @@ func (s ResetImageAttributeOutput) GoString() string {
 }
 
 type ResetInstanceAttributeInput struct {
+	_ struct{} `type:"structure"`
+
 	// The attribute to reset.
 	Attribute *string `locationName:"attribute" type:"string" required:"true" enum:"InstanceAttributeName"`
 
@@ -20167,8 +20169,6 @@ type ResetInstanceAttributeInput struct {
 
 	// The ID of the instance.
 	InstanceId *string `locationName:"instanceId" type:"string" required:"true"`
-
-	_ struct{} `type:"structure"`
 }
 
 // String returns the string representation
@@ -20196,6 +20196,8 @@ func (s ResetInstanceAttributeOutput) GoString() string {
 }
 
 type ResetNetworkInterfaceAttributeInput struct {
+	_ struct{} `type:"structure"`
+
 	// Checks whether you have the required permissions for the action, without
 	// actually making the request, and provides an error response. If you have
 	// the required permissions, the error response is DryRunOperation. Otherwise,
@@ -20207,8 +20209,6 @@ type ResetNetworkInterfaceAttributeInput struct {
 
 	// The source/destination checking attribute. Resets the value to true.
 	SourceDestCheck *string `locationName:"sourceDestCheck" type:"string"`
-
-	_ struct{} `type:"structure"`
 }
 
 // String returns the string representation
@@ -20236,6 +20236,8 @@ func (s ResetNetworkInterfaceAttributeOutput) GoString() string {
 }
 
 type ResetSnapshotAttributeInput struct {
+	_ struct{} `type:"structure"`
+
 	// The attribute to reset. Currently, only the attribute for permission to create
 	// volumes can be reset.
 	Attribute *string `type:"string" required:"true" enum:"SnapshotAttributeName"`
@@ -20248,8 +20250,6 @@ type ResetSnapshotAttributeInput struct {
 
 	// The ID of the snapshot.
 	SnapshotId *string `type:"string" required:"true"`
-
-	_ struct{} `type:"structure"`
 }
 
 // String returns the string representation
@@ -20277,6 +20277,8 @@ func (s ResetSnapshotAttributeOutput) GoString() string {
 }
 
 type RestoreAddressToClassicInput struct {
+	_ struct{} `type:"structure"`
+
 	// Checks whether you have the required permissions for the action, without
 	// actually making the request, and provides an error response. If you have
 	// the required permissions, the error response is DryRunOperation. Otherwise,
@@ -20285,8 +20287,6 @@ type RestoreAddressToClassicInput struct {
 
 	// The Elastic IP address.
 	PublicIp *string `locationName:"publicIp" type:"string" required:"true"`
-
-	_ struct{} `type:"structure"`
 }
 
 // String returns the string representation
@@ -20300,13 +20300,13 @@ func (s RestoreAddressToClassicInput) GoString() string {
 }
 
 type RestoreAddressToClassicOutput struct {
+	_ struct{} `type:"structure"`
+
 	// The Elastic IP address.
 	PublicIp *string `locationName:"publicIp" type:"string"`
 
 	// The move status for the IP address.
 	Status *string `locationName:"status" type:"string" enum:"Status"`
-
-	_ struct{} `type:"structure"`
 }
 
 // String returns the string representation
@@ -20320,6 +20320,8 @@ func (s RestoreAddressToClassicOutput) GoString() string {
 }
 
 type RevokeSecurityGroupEgressInput struct {
+	_ struct{} `type:"structure"`
+
 	// The CIDR IP address range. You can't specify this parameter when specifying
 	// a source security group.
 	CidrIp *string `locationName:"cidrIp" type:"string"`
@@ -20358,8 +20360,6 @@ type RevokeSecurityGroupEgressInput struct {
 	// The end of port range for the TCP and UDP protocols, or an ICMP code number.
 	// For the ICMP code number, use -1 to specify all ICMP codes for the ICMP type.
 	ToPort *int64 `locationName:"toPort" type:"integer"`
-
-	_ struct{} `type:"structure"`
 }
 
 // String returns the string representation
@@ -20387,6 +20387,8 @@ func (s RevokeSecurityGroupEgressOutput) GoString() string {
 }
 
 type RevokeSecurityGroupIngressInput struct {
+	_ struct{} `type:"structure"`
+
 	// The CIDR IP address range. You can't specify this parameter when specifying
 	// a source security group.
 	CidrIp *string `type:"string"`
@@ -20434,8 +20436,6 @@ type RevokeSecurityGroupIngressInput struct {
 	// The end of port range for the TCP and UDP protocols, or an ICMP code number.
 	// For the ICMP code number, use -1 to specify all ICMP codes for the ICMP type.
 	ToPort *int64 `type:"integer"`
-
-	_ struct{} `type:"structure"`
 }
 
 // String returns the string representation
@@ -20464,6 +20464,8 @@ func (s RevokeSecurityGroupIngressOutput) GoString() string {
 
 // Describes a route in a route table.
 type Route struct {
+	_ struct{} `type:"structure"`
+
 	// The CIDR block used for the destination match.
 	DestinationCidrBlock *string `locationName:"destinationCidrBlock" type:"string"`
 
@@ -20497,8 +20499,6 @@ type Route struct {
 
 	// The ID of the VPC peering connection.
 	VpcPeeringConnectionId *string `locationName:"vpcPeeringConnectionId" type:"string"`
-
-	_ struct{} `type:"structure"`
 }
 
 // String returns the string representation
@@ -20513,6 +20513,8 @@ func (s Route) GoString() string {
 
 // Describes a route table.
 type RouteTable struct {
+	_ struct{} `type:"structure"`
+
 	// The associations between the route table and one or more subnets.
 	Associations []*RouteTableAssociation `locationName:"associationSet" locationNameList:"item" type:"list"`
 
@@ -20530,8 +20532,6 @@ type RouteTable struct {
 
 	// The ID of the VPC.
 	VpcId *string `locationName:"vpcId" type:"string"`
-
-	_ struct{} `type:"structure"`
 }
 
 // String returns the string representation
@@ -20546,6 +20546,8 @@ func (s RouteTable) GoString() string {
 
 // Describes an association between a route table and a subnet.
 type RouteTableAssociation struct {
+	_ struct{} `type:"structure"`
+
 	// Indicates whether this is the main route table.
 	Main *bool `locationName:"main" type:"boolean"`
 
@@ -20557,8 +20559,6 @@ type RouteTableAssociation struct {
 
 	// The ID of the subnet. A subnet ID is not returned for an implicit association.
 	SubnetId *string `locationName:"subnetId" type:"string"`
-
-	_ struct{} `type:"structure"`
 }
 
 // String returns the string representation
@@ -20572,6 +20572,8 @@ func (s RouteTableAssociation) GoString() string {
 }
 
 type RunInstancesInput struct {
+	_ struct{} `type:"structure"`
+
 	// Reserved.
 	AdditionalInfo *string `locationName:"additionalInfo" type:"string"`
 
@@ -20704,8 +20706,6 @@ type RunInstancesInput struct {
 
 	// The Base64-encoded MIME user data for the instances.
 	UserData *string `type:"string"`
-
-	_ struct{} `type:"structure"`
 }
 
 // String returns the string representation
@@ -20720,10 +20720,10 @@ func (s RunInstancesInput) GoString() string {
 
 // Describes the monitoring for the instance.
 type RunInstancesMonitoringEnabled struct {
+	_ struct{} `type:"structure"`
+
 	// Indicates whether monitoring is enabled for the instance.
 	Enabled *bool `locationName:"enabled" type:"boolean" required:"true"`
-
-	_ struct{} `type:"structure"`
 }
 
 // String returns the string representation
@@ -20739,6 +20739,8 @@ func (s RunInstancesMonitoringEnabled) GoString() string {
 // Describes the storage parameters for S3 and S3 buckets for an instance store-backed
 // AMI.
 type S3Storage struct {
+	_ struct{} `type:"structure"`
+
 	// The access key ID of the owner of the bucket. Before you specify a value
 	// for your access key ID, review and follow the guidance in Best Practices
 	// for Managing AWS Access Keys (http://docs.aws.amazon.com/general/latest/gr/aws-access-keys-best-practices.html).
@@ -20758,8 +20760,6 @@ type S3Storage struct {
 
 	// The signature of the Base64 encoded JSON document.
 	UploadPolicySignature *string `locationName:"uploadPolicySignature" type:"string"`
-
-	_ struct{} `type:"structure"`
 }
 
 // String returns the string representation
@@ -20774,6 +20774,8 @@ func (s S3Storage) GoString() string {
 
 // Describes a security group
 type SecurityGroup struct {
+	_ struct{} `type:"structure"`
+
 	// A description of the security group.
 	Description *string `locationName:"groupDescription" type:"string"`
 
@@ -20797,8 +20799,6 @@ type SecurityGroup struct {
 
 	// [EC2-VPC] The ID of the VPC for the security group.
 	VpcId *string `locationName:"vpcId" type:"string"`
-
-	_ struct{} `type:"structure"`
 }
 
 // String returns the string representation
@@ -20813,6 +20813,8 @@ func (s SecurityGroup) GoString() string {
 
 // Describes a snapshot.
 type Snapshot struct {
+	_ struct{} `type:"structure"`
+
 	// The data encryption key identifier for the snapshot. This value is a unique
 	// identifier that corresponds to the data encryption key that was used to encrypt
 	// the original volume or snapshot copy. Because data encryption keys are inherited
@@ -20867,8 +20869,6 @@ type Snapshot struct {
 
 	// The size of the volume, in GiB.
 	VolumeSize *int64 `locationName:"volumeSize" type:"integer"`
-
-	_ struct{} `type:"structure"`
 }
 
 // String returns the string representation
@@ -20883,6 +20883,8 @@ func (s Snapshot) GoString() string {
 
 // Describes the snapshot created from the imported disk.
 type SnapshotDetail struct {
+	_ struct{} `type:"structure"`
+
 	// A description for the snapshot.
 	Description *string `locationName:"description" type:"string"`
 
@@ -20912,8 +20914,6 @@ type SnapshotDetail struct {
 
 	// Describes the S3 bucket for the disk image.
 	UserBucket *UserBucketDetails `locationName:"userBucket" type:"structure"`
-
-	_ struct{} `type:"structure"`
 }
 
 // String returns the string representation
@@ -20928,6 +20928,8 @@ func (s SnapshotDetail) GoString() string {
 
 // The disk container object for the import snapshot request.
 type SnapshotDiskContainer struct {
+	_ struct{} `type:"structure"`
+
 	// The description of the disk image being imported.
 	Description *string `type:"string"`
 
@@ -20942,8 +20944,6 @@ type SnapshotDiskContainer struct {
 
 	// Describes the S3 bucket for the disk image.
 	UserBucket *UserBucket `type:"structure"`
-
-	_ struct{} `type:"structure"`
 }
 
 // String returns the string representation
@@ -20958,6 +20958,8 @@ func (s SnapshotDiskContainer) GoString() string {
 
 // Details about the import snapshot task.
 type SnapshotTaskDetail struct {
+	_ struct{} `type:"structure"`
+
 	// The description of the snapshot.
 	Description *string `locationName:"description" type:"string"`
 
@@ -20984,8 +20986,6 @@ type SnapshotTaskDetail struct {
 
 	// The S3 bucket for the disk image.
 	UserBucket *UserBucketDetails `locationName:"userBucket" type:"structure"`
-
-	_ struct{} `type:"structure"`
 }
 
 // String returns the string representation
@@ -21000,6 +21000,8 @@ func (s SnapshotTaskDetail) GoString() string {
 
 // Describes the data feed for a Spot instance.
 type SpotDatafeedSubscription struct {
+	_ struct{} `type:"structure"`
+
 	// The Amazon S3 bucket where the Spot instance data feed is located.
 	Bucket *string `locationName:"bucket" type:"string"`
 
@@ -21014,8 +21016,6 @@ type SpotDatafeedSubscription struct {
 
 	// The state of the Spot instance data feed subscription.
 	State *string `locationName:"state" type:"string" enum:"DatafeedSubscriptionState"`
-
-	_ struct{} `type:"structure"`
 }
 
 // String returns the string representation
@@ -21030,6 +21030,8 @@ func (s SpotDatafeedSubscription) GoString() string {
 
 // Describes the launch specification for one or more Spot instances.
 type SpotFleetLaunchSpecification struct {
+	_ struct{} `type:"structure"`
+
 	// Deprecated.
 	AddressingType *string `locationName:"addressingType" type:"string"`
 
@@ -21097,8 +21099,6 @@ type SpotFleetLaunchSpecification struct {
 	// the number of instances to the next whole number. If this value is not specified,
 	// the default is 1.
 	WeightedCapacity *float64 `locationName:"weightedCapacity" type:"double"`
-
-	_ struct{} `type:"structure"`
 }
 
 // String returns the string representation
@@ -21113,12 +21113,12 @@ func (s SpotFleetLaunchSpecification) GoString() string {
 
 // Describes whether monitoring is enabled.
 type SpotFleetMonitoring struct {
+	_ struct{} `type:"structure"`
+
 	// Enables monitoring for the instance.
 	//
 	// Default: false
 	Enabled *bool `locationName:"enabled" type:"boolean"`
-
-	_ struct{} `type:"structure"`
 }
 
 // String returns the string representation
@@ -21133,6 +21133,8 @@ func (s SpotFleetMonitoring) GoString() string {
 
 // Describes a Spot fleet request.
 type SpotFleetRequestConfig struct {
+	_ struct{} `type:"structure"`
+
 	// The creation date and time of the request.
 	CreateTime *time.Time `locationName:"createTime" type:"timestamp" timestampFormat:"iso8601" required:"true"`
 
@@ -21144,8 +21146,6 @@ type SpotFleetRequestConfig struct {
 
 	// The state of the Spot fleet request.
 	SpotFleetRequestState *string `locationName:"spotFleetRequestState" type:"string" required:"true" enum:"BatchState"`
-
-	_ struct{} `type:"structure"`
 }
 
 // String returns the string representation
@@ -21160,6 +21160,8 @@ func (s SpotFleetRequestConfig) GoString() string {
 
 // Describes the configuration of a Spot fleet request.
 type SpotFleetRequestConfigData struct {
+	_ struct{} `type:"structure"`
+
 	// Indicates how to allocate the target capacity across the Spot pools specified
 	// by the Spot fleet request. The default is lowestPrice.
 	AllocationStrategy *string `locationName:"allocationStrategy" type:"string" enum:"AllocationStrategy"`
@@ -21202,8 +21204,6 @@ type SpotFleetRequestConfigData struct {
 	// At this point, no new Spot instance requests are placed or enabled to fulfill
 	// the request.
 	ValidUntil *time.Time `locationName:"validUntil" type:"timestamp" timestampFormat:"iso8601"`
-
-	_ struct{} `type:"structure"`
 }
 
 // String returns the string representation
@@ -21218,6 +21218,8 @@ func (s SpotFleetRequestConfigData) GoString() string {
 
 // Describes a Spot instance request.
 type SpotInstanceRequest struct {
+	_ struct{} `type:"structure"`
+
 	// If you specified a duration and your Spot instance request was fulfilled,
 	// this is the fixed hourly price in effect for the Spot instance while it runs.
 	ActualBlockHourlyPrice *string `locationName:"actualBlockHourlyPrice" type:"string"`
@@ -21285,8 +21287,6 @@ type SpotInstanceRequest struct {
 	// the request is canceled, or this date is reached. If the request is persistent,
 	// it remains active until it is canceled or this date is reached.
 	ValidUntil *time.Time `locationName:"validUntil" type:"timestamp" timestampFormat:"iso8601"`
-
-	_ struct{} `type:"structure"`
 }
 
 // String returns the string representation
@@ -21301,13 +21301,13 @@ func (s SpotInstanceRequest) GoString() string {
 
 // Describes a Spot instance state change.
 type SpotInstanceStateFault struct {
+	_ struct{} `type:"structure"`
+
 	// The reason code for the Spot instance state change.
 	Code *string `locationName:"code" type:"string"`
 
 	// The message for the Spot instance state change.
 	Message *string `locationName:"message" type:"string"`
-
-	_ struct{} `type:"structure"`
 }
 
 // String returns the string representation
@@ -21322,6 +21322,8 @@ func (s SpotInstanceStateFault) GoString() string {
 
 // Describes the status of a Spot instance request.
 type SpotInstanceStatus struct {
+	_ struct{} `type:"structure"`
+
 	// The status code. For a list of status codes, see Spot Bid Status Codes (http://docs.aws.amazon.com/AWSEC2/latest/UserGuide/spot-bid-status.html#spot-instance-bid-status-understand)
 	// in the Amazon Elastic Compute Cloud User Guide.
 	Code *string `locationName:"code" type:"string"`
@@ -21332,8 +21334,6 @@ type SpotInstanceStatus struct {
 	// The date and time of the most recent status update, in UTC format (for example,
 	// YYYY-MM-DDTHH:MM:SSZ).
 	UpdateTime *time.Time `locationName:"updateTime" type:"timestamp" timestampFormat:"iso8601"`
-
-	_ struct{} `type:"structure"`
 }
 
 // String returns the string representation
@@ -21348,13 +21348,13 @@ func (s SpotInstanceStatus) GoString() string {
 
 // Describes Spot instance placement.
 type SpotPlacement struct {
+	_ struct{} `type:"structure"`
+
 	// The Availability Zone.
 	AvailabilityZone *string `locationName:"availabilityZone" type:"string"`
 
 	// The name of the placement group (for cluster instances).
 	GroupName *string `locationName:"groupName" type:"string"`
-
-	_ struct{} `type:"structure"`
 }
 
 // String returns the string representation
@@ -21370,6 +21370,8 @@ func (s SpotPlacement) GoString() string {
 // Describes the maximum hourly price (bid) for any Spot instance launched to
 // fulfill the request.
 type SpotPrice struct {
+	_ struct{} `type:"structure"`
+
 	// The Availability Zone.
 	AvailabilityZone *string `locationName:"availabilityZone" type:"string"`
 
@@ -21384,8 +21386,6 @@ type SpotPrice struct {
 
 	// The date and time the request was created, in UTC format (for example, YYYY-MM-DDTHH:MM:SSZ).
 	Timestamp *time.Time `locationName:"timestamp" type:"timestamp" timestampFormat:"iso8601"`
-
-	_ struct{} `type:"structure"`
 }
 
 // String returns the string representation
@@ -21399,6 +21399,8 @@ func (s SpotPrice) GoString() string {
 }
 
 type StartInstancesInput struct {
+	_ struct{} `type:"structure"`
+
 	// Reserved.
 	AdditionalInfo *string `locationName:"additionalInfo" type:"string"`
 
@@ -21410,8 +21412,6 @@ type StartInstancesInput struct {
 
 	// One or more instance IDs.
 	InstanceIds []*string `locationName:"InstanceId" locationNameList:"InstanceId" type:"list" required:"true"`
-
-	_ struct{} `type:"structure"`
 }
 
 // String returns the string representation
@@ -21425,10 +21425,10 @@ func (s StartInstancesInput) GoString() string {
 }
 
 type StartInstancesOutput struct {
+	_ struct{} `type:"structure"`
+
 	// Information about one or more started instances.
 	StartingInstances []*InstanceStateChange `locationName:"instancesSet" locationNameList:"item" type:"list"`
-
-	_ struct{} `type:"structure"`
 }
 
 // String returns the string representation
@@ -21443,6 +21443,8 @@ func (s StartInstancesOutput) GoString() string {
 
 // Describes a state change.
 type StateReason struct {
+	_ struct{} `type:"structure"`
+
 	// The reason code for the state change.
 	Code *string `locationName:"code" type:"string"`
 
@@ -21470,8 +21472,6 @@ type StateReason struct {
 	//
 	// Client.InvalidSnapshot.NotFound: The specified snapshot was not found.
 	Message *string `locationName:"message" type:"string"`
-
-	_ struct{} `type:"structure"`
 }
 
 // String returns the string representation
@@ -21485,6 +21485,8 @@ func (s StateReason) GoString() string {
 }
 
 type StopInstancesInput struct {
+	_ struct{} `type:"structure"`
+
 	// Checks whether you have the required permissions for the action, without
 	// actually making the request, and provides an error response. If you have
 	// the required permissions, the error response is DryRunOperation. Otherwise,
@@ -21501,8 +21503,6 @@ type StopInstancesInput struct {
 
 	// One or more instance IDs.
 	InstanceIds []*string `locationName:"InstanceId" locationNameList:"InstanceId" type:"list" required:"true"`
-
-	_ struct{} `type:"structure"`
 }
 
 // String returns the string representation
@@ -21516,10 +21516,10 @@ func (s StopInstancesInput) GoString() string {
 }
 
 type StopInstancesOutput struct {
+	_ struct{} `type:"structure"`
+
 	// Information about one or more stopped instances.
 	StoppingInstances []*InstanceStateChange `locationName:"instancesSet" locationNameList:"item" type:"list"`
-
-	_ struct{} `type:"structure"`
 }
 
 // String returns the string representation
@@ -21534,10 +21534,10 @@ func (s StopInstancesOutput) GoString() string {
 
 // Describes the storage location for an instance store-backed AMI.
 type Storage struct {
+	_ struct{} `type:"structure"`
+
 	// An Amazon S3 storage location.
 	S3 *S3Storage `type:"structure"`
-
-	_ struct{} `type:"structure"`
 }
 
 // String returns the string representation
@@ -21552,6 +21552,8 @@ func (s Storage) GoString() string {
 
 // Describes a subnet.
 type Subnet struct {
+	_ struct{} `type:"structure"`
+
 	// The Availability Zone of the subnet.
 	AvailabilityZone *string `locationName:"availabilityZone" type:"string"`
 
@@ -21579,8 +21581,6 @@ type Subnet struct {
 
 	// The ID of the VPC the subnet is in.
 	VpcId *string `locationName:"vpcId" type:"string"`
-
-	_ struct{} `type:"structure"`
 }
 
 // String returns the string representation
@@ -21595,6 +21595,8 @@ func (s Subnet) GoString() string {
 
 // Describes a tag.
 type Tag struct {
+	_ struct{} `type:"structure"`
+
 	// The key of the tag.
 	//
 	// Constraints: Tag keys are case-sensitive and accept a maximum of 127 Unicode
@@ -21606,8 +21608,6 @@ type Tag struct {
 	// Constraints: Tag values are case-sensitive and accept a maximum of 255 Unicode
 	// characters.
 	Value *string `locationName:"value" type:"string"`
-
-	_ struct{} `type:"structure"`
 }
 
 // String returns the string representation
@@ -21622,6 +21622,8 @@ func (s Tag) GoString() string {
 
 // Describes a tag.
 type TagDescription struct {
+	_ struct{} `type:"structure"`
+
 	// The tag key.
 	Key *string `locationName:"key" type:"string"`
 
@@ -21633,8 +21635,6 @@ type TagDescription struct {
 
 	// The tag value.
 	Value *string `locationName:"value" type:"string"`
-
-	_ struct{} `type:"structure"`
 }
 
 // String returns the string representation
@@ -21648,6 +21648,8 @@ func (s TagDescription) GoString() string {
 }
 
 type TerminateInstancesInput struct {
+	_ struct{} `type:"structure"`
+
 	// Checks whether you have the required permissions for the action, without
 	// actually making the request, and provides an error response. If you have
 	// the required permissions, the error response is DryRunOperation. Otherwise,
@@ -21656,8 +21658,6 @@ type TerminateInstancesInput struct {
 
 	// One or more instance IDs.
 	InstanceIds []*string `locationName:"InstanceId" locationNameList:"InstanceId" type:"list" required:"true"`
-
-	_ struct{} `type:"structure"`
 }
 
 // String returns the string representation
@@ -21671,10 +21671,10 @@ func (s TerminateInstancesInput) GoString() string {
 }
 
 type TerminateInstancesOutput struct {
+	_ struct{} `type:"structure"`
+
 	// Information about one or more terminated instances.
 	TerminatingInstances []*InstanceStateChange `locationName:"instancesSet" locationNameList:"item" type:"list"`
-
-	_ struct{} `type:"structure"`
 }
 
 // String returns the string representation
@@ -21688,14 +21688,14 @@ func (s TerminateInstancesOutput) GoString() string {
 }
 
 type UnassignPrivateIpAddressesInput struct {
+	_ struct{} `type:"structure"`
+
 	// The ID of the network interface.
 	NetworkInterfaceId *string `locationName:"networkInterfaceId" type:"string" required:"true"`
 
 	// The secondary private IP addresses to unassign from the network interface.
 	// You can specify this option multiple times to unassign more than one IP address.
 	PrivateIpAddresses []*string `locationName:"privateIpAddress" locationNameList:"PrivateIpAddress" type:"list" required:"true"`
-
-	_ struct{} `type:"structure"`
 }
 
 // String returns the string representation
@@ -21723,6 +21723,8 @@ func (s UnassignPrivateIpAddressesOutput) GoString() string {
 }
 
 type UnmonitorInstancesInput struct {
+	_ struct{} `type:"structure"`
+
 	// Checks whether you have the required permissions for the action, without
 	// actually making the request, and provides an error response. If you have
 	// the required permissions, the error response is DryRunOperation. Otherwise,
@@ -21731,8 +21733,6 @@ type UnmonitorInstancesInput struct {
 
 	// One or more instance IDs.
 	InstanceIds []*string `locationName:"InstanceId" locationNameList:"InstanceId" type:"list" required:"true"`
-
-	_ struct{} `type:"structure"`
 }
 
 // String returns the string representation
@@ -21746,10 +21746,10 @@ func (s UnmonitorInstancesInput) GoString() string {
 }
 
 type UnmonitorInstancesOutput struct {
+	_ struct{} `type:"structure"`
+
 	// Monitoring information for one or more instances.
 	InstanceMonitorings []*InstanceMonitoring `locationName:"instancesSet" locationNameList:"item" type:"list"`
-
-	_ struct{} `type:"structure"`
 }
 
 // String returns the string representation
@@ -21764,13 +21764,13 @@ func (s UnmonitorInstancesOutput) GoString() string {
 
 // Information about items that were not successfully processed in a batch call.
 type UnsuccessfulItem struct {
+	_ struct{} `type:"structure"`
+
 	// Information about the error.
 	Error *UnsuccessfulItemError `locationName:"error" type:"structure" required:"true"`
 
 	// The ID of the resource.
 	ResourceId *string `locationName:"resourceId" type:"string"`
-
-	_ struct{} `type:"structure"`
 }
 
 // String returns the string representation
@@ -21786,13 +21786,13 @@ func (s UnsuccessfulItem) GoString() string {
 // Information about the error that occurred. For more information about errors,
 // see Error Codes (http://docs.aws.amazon.com/AWSEC2/latest/APIReference/errors-overview.html).
 type UnsuccessfulItemError struct {
+	_ struct{} `type:"structure"`
+
 	// The error code.
 	Code *string `locationName:"code" type:"string" required:"true"`
 
 	// The error message accompanying the error code.
 	Message *string `locationName:"message" type:"string" required:"true"`
-
-	_ struct{} `type:"structure"`
 }
 
 // String returns the string representation
@@ -21807,13 +21807,13 @@ func (s UnsuccessfulItemError) GoString() string {
 
 // Describes the S3 bucket for the disk image.
 type UserBucket struct {
+	_ struct{} `type:"structure"`
+
 	// The name of the S3 bucket where the disk image is located.
 	S3Bucket *string `type:"string"`
 
 	// The key for the disk image.
 	S3Key *string `type:"string"`
-
-	_ struct{} `type:"structure"`
 }
 
 // String returns the string representation
@@ -21828,13 +21828,13 @@ func (s UserBucket) GoString() string {
 
 // Describes the S3 bucket for the disk image.
 type UserBucketDetails struct {
+	_ struct{} `type:"structure"`
+
 	// The S3 bucket from which the disk image was created.
 	S3Bucket *string `locationName:"s3Bucket" type:"string"`
 
 	// The key from which the disk image was created.
 	S3Key *string `locationName:"s3Key" type:"string"`
-
-	_ struct{} `type:"structure"`
 }
 
 // String returns the string representation
@@ -21849,10 +21849,10 @@ func (s UserBucketDetails) GoString() string {
 
 // Describes the user data to be made available to an instance.
 type UserData struct {
+	_ struct{} `type:"structure"`
+
 	// The Base64-encoded MIME user data for the instance.
 	Data *string `locationName:"data" type:"string"`
-
-	_ struct{} `type:"structure"`
 }
 
 // String returns the string representation
@@ -21867,6 +21867,8 @@ func (s UserData) GoString() string {
 
 // Describes a security group and AWS account ID pair.
 type UserIdGroupPair struct {
+	_ struct{} `type:"structure"`
+
 	// The ID of the security group.
 	GroupId *string `locationName:"groupId" type:"string"`
 
@@ -21877,8 +21879,6 @@ type UserIdGroupPair struct {
 
 	// The ID of an AWS account. EC2-Classic only.
 	UserId *string `locationName:"userId" type:"string"`
-
-	_ struct{} `type:"structure"`
 }
 
 // String returns the string representation
@@ -21893,6 +21893,8 @@ func (s UserIdGroupPair) GoString() string {
 
 // Describes telemetry for a VPN tunnel.
 type VgwTelemetry struct {
+	_ struct{} `type:"structure"`
+
 	// The number of accepted routes.
 	AcceptedRouteCount *int64 `locationName:"acceptedRouteCount" type:"integer"`
 
@@ -21908,8 +21910,6 @@ type VgwTelemetry struct {
 
 	// If an error occurs, a description of the error.
 	StatusMessage *string `locationName:"statusMessage" type:"string"`
-
-	_ struct{} `type:"structure"`
 }
 
 // String returns the string representation
@@ -21924,6 +21924,8 @@ func (s VgwTelemetry) GoString() string {
 
 // Describes a volume.
 type Volume struct {
+	_ struct{} `type:"structure"`
+
 	// Information about the volume attachments.
 	Attachments []*VolumeAttachment `locationName:"attachmentSet" locationNameList:"item" type:"list"`
 
@@ -21973,8 +21975,6 @@ type Volume struct {
 	// The volume type. This can be gp2 for General Purpose (SSD) volumes, io1 for
 	// Provisioned IOPS (SSD) volumes, or standard for Magnetic volumes.
 	VolumeType *string `locationName:"volumeType" type:"string" enum:"VolumeType"`
-
-	_ struct{} `type:"structure"`
 }
 
 // String returns the string representation
@@ -21989,6 +21989,8 @@ func (s Volume) GoString() string {
 
 // Describes volume attachment details.
 type VolumeAttachment struct {
+	_ struct{} `type:"structure"`
+
 	// The time stamp when the attachment initiated.
 	AttachTime *time.Time `locationName:"attachTime" type:"timestamp" timestampFormat:"iso8601"`
 
@@ -22006,8 +22008,6 @@ type VolumeAttachment struct {
 
 	// The ID of the volume.
 	VolumeId *string `locationName:"volumeId" type:"string"`
-
-	_ struct{} `type:"structure"`
 }
 
 // String returns the string representation
@@ -22022,10 +22022,10 @@ func (s VolumeAttachment) GoString() string {
 
 // Describes an EBS volume.
 type VolumeDetail struct {
+	_ struct{} `type:"structure"`
+
 	// The size of the volume, in GiB.
 	Size *int64 `locationName:"size" type:"long" required:"true"`
-
-	_ struct{} `type:"structure"`
 }
 
 // String returns the string representation
@@ -22040,6 +22040,8 @@ func (s VolumeDetail) GoString() string {
 
 // Describes a volume status operation code.
 type VolumeStatusAction struct {
+	_ struct{} `type:"structure"`
+
 	// The code identifying the operation, for example, enable-volume-io.
 	Code *string `locationName:"code" type:"string"`
 
@@ -22051,8 +22053,6 @@ type VolumeStatusAction struct {
 
 	// The event type associated with this operation.
 	EventType *string `locationName:"eventType" type:"string"`
-
-	_ struct{} `type:"structure"`
 }
 
 // String returns the string representation
@@ -22067,13 +22067,13 @@ func (s VolumeStatusAction) GoString() string {
 
 // Describes a volume status.
 type VolumeStatusDetails struct {
+	_ struct{} `type:"structure"`
+
 	// The name of the volume status.
 	Name *string `locationName:"name" type:"string" enum:"VolumeStatusName"`
 
 	// The intended status of the volume status.
 	Status *string `locationName:"status" type:"string"`
-
-	_ struct{} `type:"structure"`
 }
 
 // String returns the string representation
@@ -22088,6 +22088,8 @@ func (s VolumeStatusDetails) GoString() string {
 
 // Describes a volume status event.
 type VolumeStatusEvent struct {
+	_ struct{} `type:"structure"`
+
 	// A description of the event.
 	Description *string `locationName:"description" type:"string"`
 
@@ -22102,8 +22104,6 @@ type VolumeStatusEvent struct {
 
 	// The earliest start time of the event.
 	NotBefore *time.Time `locationName:"notBefore" type:"timestamp" timestampFormat:"iso8601"`
-
-	_ struct{} `type:"structure"`
 }
 
 // String returns the string representation
@@ -22118,13 +22118,13 @@ func (s VolumeStatusEvent) GoString() string {
 
 // Describes the status of a volume.
 type VolumeStatusInfo struct {
+	_ struct{} `type:"structure"`
+
 	// The details of the volume status.
 	Details []*VolumeStatusDetails `locationName:"details" locationNameList:"item" type:"list"`
 
 	// The status of the volume.
 	Status *string `locationName:"status" type:"string" enum:"VolumeStatusInfoStatus"`
-
-	_ struct{} `type:"structure"`
 }
 
 // String returns the string representation
@@ -22139,6 +22139,8 @@ func (s VolumeStatusInfo) GoString() string {
 
 // Describes the volume status.
 type VolumeStatusItem struct {
+	_ struct{} `type:"structure"`
+
 	// The details of the operation.
 	Actions []*VolumeStatusAction `locationName:"actionsSet" locationNameList:"item" type:"list"`
 
@@ -22153,8 +22155,6 @@ type VolumeStatusItem struct {
 
 	// The volume status.
 	VolumeStatus *VolumeStatusInfo `locationName:"volumeStatus" type:"structure"`
-
-	_ struct{} `type:"structure"`
 }
 
 // String returns the string representation
@@ -22169,6 +22169,8 @@ func (s VolumeStatusItem) GoString() string {
 
 // Describes a VPC.
 type Vpc struct {
+	_ struct{} `type:"structure"`
+
 	// The CIDR block for the VPC.
 	CidrBlock *string `locationName:"cidrBlock" type:"string"`
 
@@ -22190,8 +22192,6 @@ type Vpc struct {
 
 	// The ID of the VPC.
 	VpcId *string `locationName:"vpcId" type:"string"`
-
-	_ struct{} `type:"structure"`
 }
 
 // String returns the string representation
@@ -22206,13 +22206,13 @@ func (s Vpc) GoString() string {
 
 // Describes an attachment between a virtual private gateway and a VPC.
 type VpcAttachment struct {
+	_ struct{} `type:"structure"`
+
 	// The current state of the attachment.
 	State *string `locationName:"state" type:"string" enum:"AttachmentStatus"`
 
 	// The ID of the VPC.
 	VpcId *string `locationName:"vpcId" type:"string"`
-
-	_ struct{} `type:"structure"`
 }
 
 // String returns the string representation
@@ -22227,6 +22227,8 @@ func (s VpcAttachment) GoString() string {
 
 // Describes whether a VPC is enabled for ClassicLink.
 type VpcClassicLink struct {
+	_ struct{} `type:"structure"`
+
 	// Indicates whether the VPC is enabled for ClassicLink.
 	ClassicLinkEnabled *bool `locationName:"classicLinkEnabled" type:"boolean"`
 
@@ -22235,8 +22237,6 @@ type VpcClassicLink struct {
 
 	// The ID of the VPC.
 	VpcId *string `locationName:"vpcId" type:"string"`
-
-	_ struct{} `type:"structure"`
 }
 
 // String returns the string representation
@@ -22251,6 +22251,8 @@ func (s VpcClassicLink) GoString() string {
 
 // Describes a VPC endpoint.
 type VpcEndpoint struct {
+	_ struct{} `type:"structure"`
+
 	// The date and time the VPC endpoint was created.
 	CreationTimestamp *time.Time `locationName:"creationTimestamp" type:"timestamp" timestampFormat:"iso8601"`
 
@@ -22271,8 +22273,6 @@ type VpcEndpoint struct {
 
 	// The ID of the VPC to which the endpoint is associated.
 	VpcId *string `locationName:"vpcId" type:"string"`
-
-	_ struct{} `type:"structure"`
 }
 
 // String returns the string representation
@@ -22287,6 +22287,8 @@ func (s VpcEndpoint) GoString() string {
 
 // Describes a VPC peering connection.
 type VpcPeeringConnection struct {
+	_ struct{} `type:"structure"`
+
 	// The information of the peer VPC.
 	AccepterVpcInfo *VpcPeeringConnectionVpcInfo `locationName:"accepterVpcInfo" type:"structure"`
 
@@ -22304,8 +22306,6 @@ type VpcPeeringConnection struct {
 
 	// The ID of the VPC peering connection.
 	VpcPeeringConnectionId *string `locationName:"vpcPeeringConnectionId" type:"string"`
-
-	_ struct{} `type:"structure"`
 }
 
 // String returns the string representation
@@ -22320,13 +22320,13 @@ func (s VpcPeeringConnection) GoString() string {
 
 // Describes the status of a VPC peering connection.
 type VpcPeeringConnectionStateReason struct {
+	_ struct{} `type:"structure"`
+
 	// The status of the VPC peering connection.
 	Code *string `locationName:"code" type:"string" enum:"VpcPeeringConnectionStateReasonCode"`
 
 	// A message that provides more information about the status, if applicable.
 	Message *string `locationName:"message" type:"string"`
-
-	_ struct{} `type:"structure"`
 }
 
 // String returns the string representation
@@ -22341,6 +22341,8 @@ func (s VpcPeeringConnectionStateReason) GoString() string {
 
 // Describes a VPC in a VPC peering connection.
 type VpcPeeringConnectionVpcInfo struct {
+	_ struct{} `type:"structure"`
+
 	// The CIDR block for the VPC.
 	CidrBlock *string `locationName:"cidrBlock" type:"string"`
 
@@ -22349,8 +22351,6 @@ type VpcPeeringConnectionVpcInfo struct {
 
 	// The ID of the VPC.
 	VpcId *string `locationName:"vpcId" type:"string"`
-
-	_ struct{} `type:"structure"`
 }
 
 // String returns the string representation
@@ -22365,6 +22365,8 @@ func (s VpcPeeringConnectionVpcInfo) GoString() string {
 
 // Describes a VPN connection.
 type VpnConnection struct {
+	_ struct{} `type:"structure"`
+
 	// The configuration information for the VPN connection's customer gateway (in
 	// the native XML format). This element is always present in the CreateVpnConnection
 	// response; however, it's present in the DescribeVpnConnections response only
@@ -22397,8 +22399,6 @@ type VpnConnection struct {
 
 	// The ID of the virtual private gateway at the AWS side of the VPN connection.
 	VpnGatewayId *string `locationName:"vpnGatewayId" type:"string"`
-
-	_ struct{} `type:"structure"`
 }
 
 // String returns the string representation
@@ -22413,11 +22413,11 @@ func (s VpnConnection) GoString() string {
 
 // Describes VPN connection options.
 type VpnConnectionOptions struct {
+	_ struct{} `type:"structure"`
+
 	// Indicates whether the VPN connection uses static routes only. Static routes
 	// must be used for devices that don't support BGP.
 	StaticRoutesOnly *bool `locationName:"staticRoutesOnly" type:"boolean"`
-
-	_ struct{} `type:"structure"`
 }
 
 // String returns the string representation
@@ -22432,11 +22432,11 @@ func (s VpnConnectionOptions) GoString() string {
 
 // Describes VPN connection options.
 type VpnConnectionOptionsSpecification struct {
+	_ struct{} `type:"structure"`
+
 	// Indicates whether the VPN connection uses static routes only. Static routes
 	// must be used for devices that don't support BGP.
 	StaticRoutesOnly *bool `locationName:"staticRoutesOnly" type:"boolean"`
-
-	_ struct{} `type:"structure"`
 }
 
 // String returns the string representation
@@ -22451,6 +22451,8 @@ func (s VpnConnectionOptionsSpecification) GoString() string {
 
 // Describes a virtual private gateway.
 type VpnGateway struct {
+	_ struct{} `type:"structure"`
+
 	// The Availability Zone where the virtual private gateway was created.
 	AvailabilityZone *string `locationName:"availabilityZone" type:"string"`
 
@@ -22468,8 +22470,6 @@ type VpnGateway struct {
 
 	// The ID of the virtual private gateway.
 	VpnGatewayId *string `locationName:"vpnGatewayId" type:"string"`
-
-	_ struct{} `type:"structure"`
 }
 
 // String returns the string representation
@@ -22484,6 +22484,8 @@ func (s VpnGateway) GoString() string {
 
 // Describes a static route for a VPN connection.
 type VpnStaticRoute struct {
+	_ struct{} `type:"structure"`
+
 	// The CIDR block associated with the local subnet of the customer data center.
 	DestinationCidrBlock *string `locationName:"destinationCidrBlock" type:"string"`
 
@@ -22492,8 +22494,6 @@ type VpnStaticRoute struct {
 
 	// The current state of the static route.
 	State *string `locationName:"state" type:"string" enum:"VpnState"`
-
-	_ struct{} `type:"structure"`
 }
 
 // String returns the string representation

--- a/service/ecs/api.go
+++ b/service/ecs/api.go
@@ -975,13 +975,13 @@ func (c *ECS) UpdateService(input *UpdateServiceInput) (*UpdateServiceOutput, er
 
 // The attributes applicable to a container instance when it is registered.
 type Attribute struct {
+	_ struct{} `type:"structure"`
+
 	// The name of the container instance attribute.
 	Name *string `locationName:"name" type:"string" required:"true"`
 
 	// The value of the container instance attribute.
 	Value *string `locationName:"value" type:"string"`
-
-	_ struct{} `type:"structure"`
 }
 
 // String returns the string representation
@@ -999,6 +999,8 @@ func (s Attribute) GoString() string {
 // use the Amazon ECS service, but you may also create other clusters. Clusters
 // may contain more than one instance type simultaneously.
 type Cluster struct {
+	_ struct{} `type:"structure"`
+
 	// The number of services that are running on the cluster in an ACTIVE state.
 	// You can view these services with ListServices.
 	ActiveServicesCount *int64 `locationName:"activeServicesCount" type:"integer"`
@@ -1025,8 +1027,6 @@ type Cluster struct {
 	// indicates that you can register container instances with the cluster and
 	// the associated instances can accept tasks.
 	Status *string `locationName:"status" type:"string"`
-
-	_ struct{} `type:"structure"`
 }
 
 // String returns the string representation
@@ -1041,6 +1041,8 @@ func (s Cluster) GoString() string {
 
 // A Docker container that is part of a task.
 type Container struct {
+	_ struct{} `type:"structure"`
+
 	// The Amazon Resource Name (ARN) of the container.
 	ContainerArn *string `locationName:"containerArn" type:"string"`
 
@@ -1062,8 +1064,6 @@ type Container struct {
 
 	// The Amazon Resource Name (ARN) of the task.
 	TaskArn *string `locationName:"taskArn" type:"string"`
-
-	_ struct{} `type:"structure"`
 }
 
 // String returns the string representation
@@ -1079,6 +1079,8 @@ func (s Container) GoString() string {
 // Container definitions are used in task definitions to describe the different
 // containers that are launched as part of a task.
 type ContainerDefinition struct {
+	_ struct{} `type:"structure"`
+
 	// The command that is passed to the container. This parameter maps to Cmd in
 	// the Create a container (https://docs.docker.com/reference/api/docker_remote_api_v1.19/#create-a-container)
 	// section of the Docker Remote API (https://docs.docker.com/reference/api/docker_remote_api_v1.19/)
@@ -1327,8 +1329,6 @@ type ContainerDefinition struct {
 	// section of the Docker Remote API (https://docs.docker.com/reference/api/docker_remote_api_v1.19/)
 	// and the --workdir option to docker run (https://docs.docker.com/reference/commandline/run/).
 	WorkingDirectory *string `locationName:"workingDirectory" type:"string"`
-
-	_ struct{} `type:"structure"`
 }
 
 // String returns the string representation
@@ -1344,6 +1344,8 @@ func (s ContainerDefinition) GoString() string {
 // An EC2 instance that is running the Amazon ECS agent and has been registered
 // with a cluster.
 type ContainerInstance struct {
+	_ struct{} `type:"structure"`
+
 	// This parameter returns true if the agent is actually connected to Amazon
 	// ECS. Registered instances with an agent that may be unhealthy or stopped
 	// return false, and instances without a connected agent cannot accept placement
@@ -1388,8 +1390,6 @@ type ContainerInstance struct {
 	// The version information for the Amazon ECS container agent and Docker daemon
 	// running on the container instance.
 	VersionInfo *VersionInfo `locationName:"versionInfo" type:"structure"`
-
-	_ struct{} `type:"structure"`
 }
 
 // String returns the string representation
@@ -1404,6 +1404,8 @@ func (s ContainerInstance) GoString() string {
 
 // The overrides that should be sent to a container.
 type ContainerOverride struct {
+	_ struct{} `type:"structure"`
+
 	// The command to send to the container that overrides the default command from
 	// the Docker image or the task definition.
 	Command []*string `locationName:"command" type:"list"`
@@ -1415,8 +1417,6 @@ type ContainerOverride struct {
 
 	// The name of the container that receives the override.
 	Name *string `locationName:"name" type:"string"`
-
-	_ struct{} `type:"structure"`
 }
 
 // String returns the string representation
@@ -1430,12 +1430,12 @@ func (s ContainerOverride) GoString() string {
 }
 
 type CreateClusterInput struct {
+	_ struct{} `type:"structure"`
+
 	// The name of your cluster. If you do not specify a name for your cluster,
 	// you create a cluster named default. Up to 255 letters (uppercase and lowercase),
 	// numbers, hyphens, and underscores are allowed.
 	ClusterName *string `locationName:"clusterName" type:"string"`
-
-	_ struct{} `type:"structure"`
 }
 
 // String returns the string representation
@@ -1449,10 +1449,10 @@ func (s CreateClusterInput) GoString() string {
 }
 
 type CreateClusterOutput struct {
+	_ struct{} `type:"structure"`
+
 	// The full description of your new cluster.
 	Cluster *Cluster `locationName:"cluster" type:"structure"`
-
-	_ struct{} `type:"structure"`
 }
 
 // String returns the string representation
@@ -1466,6 +1466,8 @@ func (s CreateClusterOutput) GoString() string {
 }
 
 type CreateServiceInput struct {
+	_ struct{} `type:"structure"`
+
 	// Unique, case-sensitive identifier you provide to ensure the idempotency of
 	// the request. Up to 32 ASCII characters are allowed.
 	ClientToken *string `locationName:"clientToken" type:"string"`
@@ -1500,8 +1502,6 @@ type CreateServiceInput struct {
 	// of the task definition to run in your service. If a revision is not specified,
 	// the latest ACTIVE revision is used.
 	TaskDefinition *string `locationName:"taskDefinition" type:"string" required:"true"`
-
-	_ struct{} `type:"structure"`
 }
 
 // String returns the string representation
@@ -1515,10 +1515,10 @@ func (s CreateServiceInput) GoString() string {
 }
 
 type CreateServiceOutput struct {
+	_ struct{} `type:"structure"`
+
 	// The full description of your service following the create call.
 	Service *Service `locationName:"service" type:"structure"`
-
-	_ struct{} `type:"structure"`
 }
 
 // String returns the string representation
@@ -1532,10 +1532,10 @@ func (s CreateServiceOutput) GoString() string {
 }
 
 type DeleteClusterInput struct {
+	_ struct{} `type:"structure"`
+
 	// The short name or full Amazon Resource Name (ARN) of the cluster to delete.
 	Cluster *string `locationName:"cluster" type:"string" required:"true"`
-
-	_ struct{} `type:"structure"`
 }
 
 // String returns the string representation
@@ -1549,10 +1549,10 @@ func (s DeleteClusterInput) GoString() string {
 }
 
 type DeleteClusterOutput struct {
+	_ struct{} `type:"structure"`
+
 	// The full description of the deleted cluster.
 	Cluster *Cluster `locationName:"cluster" type:"structure"`
-
-	_ struct{} `type:"structure"`
 }
 
 // String returns the string representation
@@ -1566,14 +1566,14 @@ func (s DeleteClusterOutput) GoString() string {
 }
 
 type DeleteServiceInput struct {
+	_ struct{} `type:"structure"`
+
 	// The name of the cluster that hosts the service to delete. If you do not specify
 	// a cluster, the default cluster is assumed.
 	Cluster *string `locationName:"cluster" type:"string"`
 
 	// The name of the service to delete.
 	Service *string `locationName:"service" type:"string" required:"true"`
-
-	_ struct{} `type:"structure"`
 }
 
 // String returns the string representation
@@ -1587,10 +1587,10 @@ func (s DeleteServiceInput) GoString() string {
 }
 
 type DeleteServiceOutput struct {
+	_ struct{} `type:"structure"`
+
 	// The full description of the deleted service.
 	Service *Service `locationName:"service" type:"structure"`
-
-	_ struct{} `type:"structure"`
 }
 
 // String returns the string representation
@@ -1605,6 +1605,8 @@ func (s DeleteServiceOutput) GoString() string {
 
 // The details of an Amazon ECS service deployment.
 type Deployment struct {
+	_ struct{} `type:"structure"`
+
 	// The Unix time in seconds and milliseconds when the service was created.
 	CreatedAt *time.Time `locationName:"createdAt" type:"timestamp" timestampFormat:"unix"`
 
@@ -1632,8 +1634,6 @@ type Deployment struct {
 
 	// The Unix time in seconds and milliseconds when the service was last updated.
 	UpdatedAt *time.Time `locationName:"updatedAt" type:"timestamp" timestampFormat:"unix"`
-
-	_ struct{} `type:"structure"`
 }
 
 // String returns the string representation
@@ -1647,6 +1647,8 @@ func (s Deployment) GoString() string {
 }
 
 type DeregisterContainerInstanceInput struct {
+	_ struct{} `type:"structure"`
+
 	// The short name or full Amazon Resource Name (ARN) of the cluster that hosts
 	// the container instance to deregister. If you do not specify a cluster, the
 	// default cluster is assumed.
@@ -1668,8 +1670,6 @@ type DeregisterContainerInstanceInput struct {
 	// of an Amazon ECS service, then the service scheduler starts another copy
 	// of that task, on a different container instance if possible.
 	Force *bool `locationName:"force" type:"boolean"`
-
-	_ struct{} `type:"structure"`
 }
 
 // String returns the string representation
@@ -1683,11 +1683,11 @@ func (s DeregisterContainerInstanceInput) GoString() string {
 }
 
 type DeregisterContainerInstanceOutput struct {
+	_ struct{} `type:"structure"`
+
 	// An EC2 instance that is running the Amazon ECS agent and has been registered
 	// with a cluster.
 	ContainerInstance *ContainerInstance `locationName:"containerInstance" type:"structure"`
-
-	_ struct{} `type:"structure"`
 }
 
 // String returns the string representation
@@ -1701,11 +1701,11 @@ func (s DeregisterContainerInstanceOutput) GoString() string {
 }
 
 type DeregisterTaskDefinitionInput struct {
+	_ struct{} `type:"structure"`
+
 	// The family and revision (family:revision) or full Amazon Resource Name (ARN)
 	// of the task definition to deregister. You must specify a revision.
 	TaskDefinition *string `locationName:"taskDefinition" type:"string" required:"true"`
-
-	_ struct{} `type:"structure"`
 }
 
 // String returns the string representation
@@ -1719,10 +1719,10 @@ func (s DeregisterTaskDefinitionInput) GoString() string {
 }
 
 type DeregisterTaskDefinitionOutput struct {
+	_ struct{} `type:"structure"`
+
 	// The full description of the deregistered task.
 	TaskDefinition *TaskDefinition `locationName:"taskDefinition" type:"structure"`
-
-	_ struct{} `type:"structure"`
 }
 
 // String returns the string representation
@@ -1736,11 +1736,11 @@ func (s DeregisterTaskDefinitionOutput) GoString() string {
 }
 
 type DescribeClustersInput struct {
+	_ struct{} `type:"structure"`
+
 	// A space-separated list of cluster names or full cluster Amazon Resource Name
 	// (ARN) entries. If you do not specify a cluster, the default cluster is assumed.
 	Clusters []*string `locationName:"clusters" type:"list"`
-
-	_ struct{} `type:"structure"`
 }
 
 // String returns the string representation
@@ -1754,13 +1754,13 @@ func (s DescribeClustersInput) GoString() string {
 }
 
 type DescribeClustersOutput struct {
+	_ struct{} `type:"structure"`
+
 	// The list of clusters.
 	Clusters []*Cluster `locationName:"clusters" type:"list"`
 
 	// Any failures associated with the call.
 	Failures []*Failure `locationName:"failures" type:"list"`
-
-	_ struct{} `type:"structure"`
 }
 
 // String returns the string representation
@@ -1774,6 +1774,8 @@ func (s DescribeClustersOutput) GoString() string {
 }
 
 type DescribeContainerInstancesInput struct {
+	_ struct{} `type:"structure"`
+
 	// The short name or full Amazon Resource Name (ARN) of the cluster that hosts
 	// the container instances to describe. If you do not specify a cluster, the
 	// default cluster is assumed.
@@ -1782,8 +1784,6 @@ type DescribeContainerInstancesInput struct {
 	// A space-separated list of container instance IDs or full Amazon Resource
 	// Name (ARN) entries.
 	ContainerInstances []*string `locationName:"containerInstances" type:"list" required:"true"`
-
-	_ struct{} `type:"structure"`
 }
 
 // String returns the string representation
@@ -1797,13 +1797,13 @@ func (s DescribeContainerInstancesInput) GoString() string {
 }
 
 type DescribeContainerInstancesOutput struct {
+	_ struct{} `type:"structure"`
+
 	// The list of container instances.
 	ContainerInstances []*ContainerInstance `locationName:"containerInstances" type:"list"`
 
 	// Any failures associated with the call.
 	Failures []*Failure `locationName:"failures" type:"list"`
-
-	_ struct{} `type:"structure"`
 }
 
 // String returns the string representation
@@ -1817,14 +1817,14 @@ func (s DescribeContainerInstancesOutput) GoString() string {
 }
 
 type DescribeServicesInput struct {
+	_ struct{} `type:"structure"`
+
 	// The name of the cluster that hosts the service to describe. If you do not
 	// specify a cluster, the default cluster is assumed.
 	Cluster *string `locationName:"cluster" type:"string"`
 
 	// A list of services to describe.
 	Services []*string `locationName:"services" type:"list" required:"true"`
-
-	_ struct{} `type:"structure"`
 }
 
 // String returns the string representation
@@ -1838,13 +1838,13 @@ func (s DescribeServicesInput) GoString() string {
 }
 
 type DescribeServicesOutput struct {
+	_ struct{} `type:"structure"`
+
 	// Any failures associated with the call.
 	Failures []*Failure `locationName:"failures" type:"list"`
 
 	// The list of services described.
 	Services []*Service `locationName:"services" type:"list"`
-
-	_ struct{} `type:"structure"`
 }
 
 // String returns the string representation
@@ -1858,12 +1858,12 @@ func (s DescribeServicesOutput) GoString() string {
 }
 
 type DescribeTaskDefinitionInput struct {
+	_ struct{} `type:"structure"`
+
 	// The family for the latest ACTIVE revision, family and revision (family:revision)
 	// for a specific revision in the family, or full Amazon Resource Name (ARN)
 	// of the task definition to describe.
 	TaskDefinition *string `locationName:"taskDefinition" type:"string" required:"true"`
-
-	_ struct{} `type:"structure"`
 }
 
 // String returns the string representation
@@ -1877,10 +1877,10 @@ func (s DescribeTaskDefinitionInput) GoString() string {
 }
 
 type DescribeTaskDefinitionOutput struct {
+	_ struct{} `type:"structure"`
+
 	// The full task definition description.
 	TaskDefinition *TaskDefinition `locationName:"taskDefinition" type:"structure"`
-
-	_ struct{} `type:"structure"`
 }
 
 // String returns the string representation
@@ -1894,6 +1894,8 @@ func (s DescribeTaskDefinitionOutput) GoString() string {
 }
 
 type DescribeTasksInput struct {
+	_ struct{} `type:"structure"`
+
 	// The short name or full Amazon Resource Name (ARN) of the cluster that hosts
 	// the task to describe. If you do not specify a cluster, the default cluster
 	// is assumed.
@@ -1901,8 +1903,6 @@ type DescribeTasksInput struct {
 
 	// A space-separated list of task IDs or full Amazon Resource Name (ARN) entries.
 	Tasks []*string `locationName:"tasks" type:"list" required:"true"`
-
-	_ struct{} `type:"structure"`
 }
 
 // String returns the string representation
@@ -1916,13 +1916,13 @@ func (s DescribeTasksInput) GoString() string {
 }
 
 type DescribeTasksOutput struct {
+	_ struct{} `type:"structure"`
+
 	// Any failures associated with the call.
 	Failures []*Failure `locationName:"failures" type:"list"`
 
 	// The list of tasks.
 	Tasks []*Task `locationName:"tasks" type:"list"`
-
-	_ struct{} `type:"structure"`
 }
 
 // String returns the string representation
@@ -1936,6 +1936,8 @@ func (s DescribeTasksOutput) GoString() string {
 }
 
 type DiscoverPollEndpointInput struct {
+	_ struct{} `type:"structure"`
+
 	// The cluster that the container instance belongs to.
 	Cluster *string `locationName:"cluster" type:"string"`
 
@@ -1945,8 +1947,6 @@ type DiscoverPollEndpointInput struct {
 	// the container-instance namespace, and then the container instance ID. For
 	// example, arn:aws:ecs:region:aws_account_id:container-instance/container_instance_ID.
 	ContainerInstance *string `locationName:"containerInstance" type:"string"`
-
-	_ struct{} `type:"structure"`
 }
 
 // String returns the string representation
@@ -1960,13 +1960,13 @@ func (s DiscoverPollEndpointInput) GoString() string {
 }
 
 type DiscoverPollEndpointOutput struct {
+	_ struct{} `type:"structure"`
+
 	// The endpoint for the Amazon ECS agent to poll.
 	Endpoint *string `locationName:"endpoint" type:"string"`
 
 	// The telemetry endpoint for the Amazon ECS agent.
 	TelemetryEndpoint *string `locationName:"telemetryEndpoint" type:"string"`
-
-	_ struct{} `type:"structure"`
 }
 
 // String returns the string representation
@@ -1981,13 +1981,13 @@ func (s DiscoverPollEndpointOutput) GoString() string {
 
 // A failed resource.
 type Failure struct {
+	_ struct{} `type:"structure"`
+
 	// The Amazon Resource Name (ARN) of the failed resource.
 	Arn *string `locationName:"arn" type:"string"`
 
 	// The reason for the failure.
 	Reason *string `locationName:"reason" type:"string"`
-
-	_ struct{} `type:"structure"`
 }
 
 // String returns the string representation
@@ -2003,13 +2003,13 @@ func (s Failure) GoString() string {
 // Hostnames and IP address entries that are added to the /etc/hosts file of
 // a container via the extraHosts parameter of its ContainerDefinition.
 type HostEntry struct {
+	_ struct{} `type:"structure"`
+
 	// The hostname to use in the /etc/hosts entry.
 	Hostname *string `locationName:"hostname" type:"string" required:"true"`
 
 	// The IP address to use in the /etc/hosts entry.
 	IpAddress *string `locationName:"ipAddress" type:"string" required:"true"`
-
-	_ struct{} `type:"structure"`
 }
 
 // String returns the string representation
@@ -2024,12 +2024,12 @@ func (s HostEntry) GoString() string {
 
 // Details on a container instance host volume.
 type HostVolumeProperties struct {
+	_ struct{} `type:"structure"`
+
 	// The path on the host container instance that is presented to the container.
 	// If this parameter is empty, then the Docker daemon has assigned a host path
 	// for you.
 	SourcePath *string `locationName:"sourcePath" type:"string"`
-
-	_ struct{} `type:"structure"`
 }
 
 // String returns the string representation
@@ -2044,6 +2044,8 @@ func (s HostVolumeProperties) GoString() string {
 
 // A key and value pair object.
 type KeyValuePair struct {
+	_ struct{} `type:"structure"`
+
 	// The name of the key value pair. For environment variables, this is the name
 	// of the environment variable.
 	Name *string `locationName:"name" type:"string"`
@@ -2051,8 +2053,6 @@ type KeyValuePair struct {
 	// The value of the key value pair. For environment variables, this is the value
 	// of the environment variable.
 	Value *string `locationName:"value" type:"string"`
-
-	_ struct{} `type:"structure"`
 }
 
 // String returns the string representation
@@ -2066,6 +2066,8 @@ func (s KeyValuePair) GoString() string {
 }
 
 type ListClustersInput struct {
+	_ struct{} `type:"structure"`
+
 	// The maximum number of cluster results returned by ListClusters in paginated
 	// output. When this parameter is used, ListClusters only returns maxResults
 	// results in a single page along with a nextToken response element. The remaining
@@ -2080,8 +2082,6 @@ type ListClustersInput struct {
 	// Pagination continues from the end of the previous results that returned the
 	// nextToken value. This value is null when there are no more results to return.
 	NextToken *string `locationName:"nextToken" type:"string"`
-
-	_ struct{} `type:"structure"`
 }
 
 // String returns the string representation
@@ -2095,6 +2095,8 @@ func (s ListClustersInput) GoString() string {
 }
 
 type ListClustersOutput struct {
+	_ struct{} `type:"structure"`
+
 	// The list of full Amazon Resource Name (ARN) entries for each cluster associated
 	// with your account.
 	ClusterArns []*string `locationName:"clusterArns" type:"list"`
@@ -2104,8 +2106,6 @@ type ListClustersOutput struct {
 	// to retrieve the next page of results. This value is null when there are no
 	// more results to return.
 	NextToken *string `locationName:"nextToken" type:"string"`
-
-	_ struct{} `type:"structure"`
 }
 
 // String returns the string representation
@@ -2119,6 +2119,8 @@ func (s ListClustersOutput) GoString() string {
 }
 
 type ListContainerInstancesInput struct {
+	_ struct{} `type:"structure"`
+
 	// The short name or full Amazon Resource Name (ARN) of the cluster that hosts
 	// the container instances to list. If you do not specify a cluster, the default
 	// cluster is assumed..
@@ -2140,8 +2142,6 @@ type ListContainerInstancesInput struct {
 	// returned the nextToken value. This value is null when there are no more results
 	// to return.
 	NextToken *string `locationName:"nextToken" type:"string"`
-
-	_ struct{} `type:"structure"`
 }
 
 // String returns the string representation
@@ -2155,6 +2155,8 @@ func (s ListContainerInstancesInput) GoString() string {
 }
 
 type ListContainerInstancesOutput struct {
+	_ struct{} `type:"structure"`
+
 	// The list of container instances with full Amazon Resource Name (ARN) entries
 	// for each container instance associated with the specified cluster.
 	ContainerInstanceArns []*string `locationName:"containerInstanceArns" type:"list"`
@@ -2164,8 +2166,6 @@ type ListContainerInstancesOutput struct {
 	// value can be used to retrieve the next page of results. This value is null
 	// when there are no more results to return.
 	NextToken *string `locationName:"nextToken" type:"string"`
-
-	_ struct{} `type:"structure"`
 }
 
 // String returns the string representation
@@ -2179,6 +2179,8 @@ func (s ListContainerInstancesOutput) GoString() string {
 }
 
 type ListServicesInput struct {
+	_ struct{} `type:"structure"`
+
 	// The short name or full Amazon Resource Name (ARN) of the cluster that hosts
 	// the services to list. If you do not specify a cluster, the default cluster
 	// is assumed..
@@ -2198,8 +2200,6 @@ type ListServicesInput struct {
 	// Pagination continues from the end of the previous results that returned the
 	// nextToken value. This value is null when there are no more results to return.
 	NextToken *string `locationName:"nextToken" type:"string"`
-
-	_ struct{} `type:"structure"`
 }
 
 // String returns the string representation
@@ -2213,6 +2213,8 @@ func (s ListServicesInput) GoString() string {
 }
 
 type ListServicesOutput struct {
+	_ struct{} `type:"structure"`
+
 	// The nextToken value to include in a future ListServices request. When the
 	// results of a ListServices request exceed maxResults, this value can be used
 	// to retrieve the next page of results. This value is null when there are no
@@ -2222,8 +2224,6 @@ type ListServicesOutput struct {
 	// The list of full Amazon Resource Name (ARN) entries for each service associated
 	// with the specified cluster.
 	ServiceArns []*string `locationName:"serviceArns" type:"list"`
-
-	_ struct{} `type:"structure"`
 }
 
 // String returns the string representation
@@ -2237,6 +2237,8 @@ func (s ListServicesOutput) GoString() string {
 }
 
 type ListTaskDefinitionFamiliesInput struct {
+	_ struct{} `type:"structure"`
+
 	// The familyPrefix is a string that is used to filter the results of ListTaskDefinitionFamilies.
 	// If you specify a familyPrefix, only task definition family names that begin
 	// with the familyPrefix string are returned.
@@ -2258,8 +2260,6 @@ type ListTaskDefinitionFamiliesInput struct {
 	// returned the nextToken value. This value is null when there are no more results
 	// to return.
 	NextToken *string `locationName:"nextToken" type:"string"`
-
-	_ struct{} `type:"structure"`
 }
 
 // String returns the string representation
@@ -2273,6 +2273,8 @@ func (s ListTaskDefinitionFamiliesInput) GoString() string {
 }
 
 type ListTaskDefinitionFamiliesOutput struct {
+	_ struct{} `type:"structure"`
+
 	// The list of task definition family names that match the ListTaskDefinitionFamilies
 	// request.
 	Families []*string `locationName:"families" type:"list"`
@@ -2282,8 +2284,6 @@ type ListTaskDefinitionFamiliesOutput struct {
 	// this value can be used to retrieve the next page of results. This value is
 	// null when there are no more results to return.
 	NextToken *string `locationName:"nextToken" type:"string"`
-
-	_ struct{} `type:"structure"`
 }
 
 // String returns the string representation
@@ -2297,6 +2297,8 @@ func (s ListTaskDefinitionFamiliesOutput) GoString() string {
 }
 
 type ListTaskDefinitionsInput struct {
+	_ struct{} `type:"structure"`
+
 	// The full family name with which to filter the ListTaskDefinitions results.
 	// Specifying a familyPrefix limits the listed task definitions to task definition
 	// revisions that belong to that family.
@@ -2332,8 +2334,6 @@ type ListTaskDefinitionsInput struct {
 	// active task or service still references them. If you paginate the resulting
 	// output, be sure to keep the status value constant in each subsequent request.
 	Status *string `locationName:"status" type:"string" enum:"TaskDefinitionStatus"`
-
-	_ struct{} `type:"structure"`
 }
 
 // String returns the string representation
@@ -2347,6 +2347,8 @@ func (s ListTaskDefinitionsInput) GoString() string {
 }
 
 type ListTaskDefinitionsOutput struct {
+	_ struct{} `type:"structure"`
+
 	// The nextToken value to include in a future ListTaskDefinitions request. When
 	// the results of a ListTaskDefinitions request exceed maxResults, this value
 	// can be used to retrieve the next page of results. This value is null when
@@ -2356,8 +2358,6 @@ type ListTaskDefinitionsOutput struct {
 	// The list of task definition Amazon Resource Name (ARN) entries for the ListTaskDefinitions
 	// request.
 	TaskDefinitionArns []*string `locationName:"taskDefinitionArns" type:"list"`
-
-	_ struct{} `type:"structure"`
 }
 
 // String returns the string representation
@@ -2371,6 +2371,8 @@ func (s ListTaskDefinitionsOutput) GoString() string {
 }
 
 type ListTasksInput struct {
+	_ struct{} `type:"structure"`
+
 	// The short name or full Amazon Resource Name (ARN) of the cluster that hosts
 	// the tasks to list. If you do not specify a cluster, the default cluster is
 	// assumed..
@@ -2413,8 +2415,6 @@ type ListTasksInput struct {
 	// The startedBy value with which to filter the task results. Specifying a startedBy
 	// value limits the results to tasks that were started with that value.
 	StartedBy *string `locationName:"startedBy" type:"string"`
-
-	_ struct{} `type:"structure"`
 }
 
 // String returns the string representation
@@ -2428,6 +2428,8 @@ func (s ListTasksInput) GoString() string {
 }
 
 type ListTasksOutput struct {
+	_ struct{} `type:"structure"`
+
 	// The nextToken value to include in a future ListTasks request. When the results
 	// of a ListTasks request exceed maxResults, this value can be used to retrieve
 	// the next page of results. This value is null when there are no more results
@@ -2436,8 +2438,6 @@ type ListTasksOutput struct {
 
 	// The list of task Amazon Resource Name (ARN) entries for the ListTasks request.
 	TaskArns []*string `locationName:"taskArns" type:"list"`
-
-	_ struct{} `type:"structure"`
 }
 
 // String returns the string representation
@@ -2452,6 +2452,8 @@ func (s ListTasksOutput) GoString() string {
 
 // Details on a load balancer that is used with a service.
 type LoadBalancer struct {
+	_ struct{} `type:"structure"`
+
 	// The name of the container to associate with the load balancer.
 	ContainerName *string `locationName:"containerName" type:"string"`
 
@@ -2463,8 +2465,6 @@ type LoadBalancer struct {
 
 	// The name of the load balancer.
 	LoadBalancerName *string `locationName:"loadBalancerName" type:"string"`
-
-	_ struct{} `type:"structure"`
 }
 
 // String returns the string representation
@@ -2479,6 +2479,8 @@ func (s LoadBalancer) GoString() string {
 
 // Log configuration options to send to a custom log driver for the container.
 type LogConfiguration struct {
+	_ struct{} `type:"structure"`
+
 	// The log driver to use for the container. This parameter requires version
 	// 1.18 of the Docker Remote API or greater on your container instance. To check
 	// the Docker Remote API version on your container instance, log into your container
@@ -2492,8 +2494,6 @@ type LogConfiguration struct {
 	// your container instance and run the following command: sudo docker version
 	// | grep "Server API version"
 	Options map[string]*string `locationName:"options" type:"map"`
-
-	_ struct{} `type:"structure"`
 }
 
 // String returns the string representation
@@ -2508,6 +2508,8 @@ func (s LogConfiguration) GoString() string {
 
 // Details on a volume mount point that is used in a container definition.
 type MountPoint struct {
+	_ struct{} `type:"structure"`
+
 	// The path on the container to mount the host volume at.
 	ContainerPath *string `locationName:"containerPath" type:"string"`
 
@@ -2518,8 +2520,6 @@ type MountPoint struct {
 
 	// The name of the volume to mount.
 	SourceVolume *string `locationName:"sourceVolume" type:"string"`
-
-	_ struct{} `type:"structure"`
 }
 
 // String returns the string representation
@@ -2537,6 +2537,8 @@ func (s MountPoint) GoString() string {
 // and container port assignments are visible in the networkBindings section
 // of DescribeTasks API responses.
 type NetworkBinding struct {
+	_ struct{} `type:"structure"`
+
 	// The IP address that the container is bound to on the container instance.
 	BindIP *string `locationName:"bindIP" type:"string"`
 
@@ -2548,8 +2550,6 @@ type NetworkBinding struct {
 
 	// The protocol used for the network binding.
 	Protocol *string `locationName:"protocol" type:"string" enum:"TransportProtocol"`
-
-	_ struct{} `type:"structure"`
 }
 
 // String returns the string representation
@@ -2568,6 +2568,8 @@ func (s NetworkBinding) GoString() string {
 // host and container port assignments are visible in the networkBindings section
 // of DescribeTasks API responses.
 type PortMapping struct {
+	_ struct{} `type:"structure"`
+
 	// The port number on the container that is bound to the user-specified or automatically
 	// assigned host port. If you specify a container port and not a host port,
 	// your container automatically receives a host port in the ephemeral port range
@@ -2600,8 +2602,6 @@ type PortMapping struct {
 	// The protocol used for the port mapping. Valid values are tcp and udp. The
 	// default is tcp.
 	Protocol *string `locationName:"protocol" type:"string" enum:"TransportProtocol"`
-
-	_ struct{} `type:"structure"`
 }
 
 // String returns the string representation
@@ -2615,6 +2615,8 @@ func (s PortMapping) GoString() string {
 }
 
 type RegisterContainerInstanceInput struct {
+	_ struct{} `type:"structure"`
+
 	// The container instance attributes that this container instance supports.
 	Attributes []*Attribute `locationName:"attributes" type:"list"`
 
@@ -2642,8 +2644,6 @@ type RegisterContainerInstanceInput struct {
 	// The version information for the Amazon ECS container agent and Docker daemon
 	// running on the container instance.
 	VersionInfo *VersionInfo `locationName:"versionInfo" type:"structure"`
-
-	_ struct{} `type:"structure"`
 }
 
 // String returns the string representation
@@ -2657,11 +2657,11 @@ func (s RegisterContainerInstanceInput) GoString() string {
 }
 
 type RegisterContainerInstanceOutput struct {
+	_ struct{} `type:"structure"`
+
 	// An EC2 instance that is running the Amazon ECS agent and has been registered
 	// with a cluster.
 	ContainerInstance *ContainerInstance `locationName:"containerInstance" type:"structure"`
-
-	_ struct{} `type:"structure"`
 }
 
 // String returns the string representation
@@ -2675,6 +2675,8 @@ func (s RegisterContainerInstanceOutput) GoString() string {
 }
 
 type RegisterTaskDefinitionInput struct {
+	_ struct{} `type:"structure"`
+
 	// A list of container definitions in JSON format that describe the different
 	// containers that make up your task.
 	ContainerDefinitions []*ContainerDefinition `locationName:"containerDefinitions" type:"list" required:"true"`
@@ -2688,8 +2690,6 @@ type RegisterTaskDefinitionInput struct {
 	// A list of volume definitions in JSON format that containers in your task
 	// may use.
 	Volumes []*Volume `locationName:"volumes" type:"list"`
-
-	_ struct{} `type:"structure"`
 }
 
 // String returns the string representation
@@ -2703,10 +2703,10 @@ func (s RegisterTaskDefinitionInput) GoString() string {
 }
 
 type RegisterTaskDefinitionOutput struct {
+	_ struct{} `type:"structure"`
+
 	// The full description of the registered task definition.
 	TaskDefinition *TaskDefinition `locationName:"taskDefinition" type:"structure"`
-
-	_ struct{} `type:"structure"`
 }
 
 // String returns the string representation
@@ -2721,6 +2721,8 @@ func (s RegisterTaskDefinitionOutput) GoString() string {
 
 // Describes the resources available for a container instance.
 type Resource struct {
+	_ struct{} `type:"structure"`
+
 	// When the doubleValue type is set, the value of the resource must be a double
 	// precision floating-point type.
 	DoubleValue *float64 `locationName:"doubleValue" type:"double"`
@@ -2741,8 +2743,6 @@ type Resource struct {
 
 	// The type of the resource, such as INTEGER, DOUBLE, LONG, or STRINGSET.
 	Type *string `locationName:"type" type:"string"`
-
-	_ struct{} `type:"structure"`
 }
 
 // String returns the string representation
@@ -2756,6 +2756,8 @@ func (s Resource) GoString() string {
 }
 
 type RunTaskInput struct {
+	_ struct{} `type:"structure"`
+
 	// The short name or full Amazon Resource Name (ARN) of the cluster on which
 	// to run your task. If you do not specify a cluster, the default cluster is
 	// assumed..
@@ -2792,8 +2794,6 @@ type RunTaskInput struct {
 	// of the task definition to run. If a revision is not specified, the latest
 	// ACTIVE revision is used.
 	TaskDefinition *string `locationName:"taskDefinition" type:"string" required:"true"`
-
-	_ struct{} `type:"structure"`
 }
 
 // String returns the string representation
@@ -2807,14 +2807,14 @@ func (s RunTaskInput) GoString() string {
 }
 
 type RunTaskOutput struct {
+	_ struct{} `type:"structure"`
+
 	// Any failures associated with the call.
 	Failures []*Failure `locationName:"failures" type:"list"`
 
 	// A full description of the tasks that were run. Each task that was successfully
 	// placed on your cluster are described here.
 	Tasks []*Task `locationName:"tasks" type:"list"`
-
-	_ struct{} `type:"structure"`
 }
 
 // String returns the string representation
@@ -2829,6 +2829,8 @@ func (s RunTaskOutput) GoString() string {
 
 // Details on a service within a cluster
 type Service struct {
+	_ struct{} `type:"structure"`
+
 	// The Amazon Resource Name (ARN) of the of the cluster that hosts the service.
 	ClusterArn *string `locationName:"clusterArn" type:"string"`
 
@@ -2876,8 +2878,6 @@ type Service struct {
 	// when the service is created with CreateService, and it can be modified with
 	// UpdateService.
 	TaskDefinition *string `locationName:"taskDefinition" type:"string"`
-
-	_ struct{} `type:"structure"`
 }
 
 // String returns the string representation
@@ -2892,6 +2892,8 @@ func (s Service) GoString() string {
 
 // Details on an event associated with a service.
 type ServiceEvent struct {
+	_ struct{} `type:"structure"`
+
 	// The Unix time in seconds and milliseconds when the event was triggered.
 	CreatedAt *time.Time `locationName:"createdAt" type:"timestamp" timestampFormat:"unix"`
 
@@ -2900,8 +2902,6 @@ type ServiceEvent struct {
 
 	// The event message.
 	Message *string `locationName:"message" type:"string"`
-
-	_ struct{} `type:"structure"`
 }
 
 // String returns the string representation
@@ -2915,6 +2915,8 @@ func (s ServiceEvent) GoString() string {
 }
 
 type StartTaskInput struct {
+	_ struct{} `type:"structure"`
+
 	// The short name or full Amazon Resource Name (ARN) of the cluster on which
 	// to start your task. If you do not specify a cluster, the default cluster
 	// is assumed..
@@ -2952,8 +2954,6 @@ type StartTaskInput struct {
 	// of the task definition to start. If a revision is not specified, the latest
 	// ACTIVE revision is used.
 	TaskDefinition *string `locationName:"taskDefinition" type:"string" required:"true"`
-
-	_ struct{} `type:"structure"`
 }
 
 // String returns the string representation
@@ -2967,14 +2967,14 @@ func (s StartTaskInput) GoString() string {
 }
 
 type StartTaskOutput struct {
+	_ struct{} `type:"structure"`
+
 	// Any failures associated with the call.
 	Failures []*Failure `locationName:"failures" type:"list"`
 
 	// A full description of the tasks that were started. Each task that was successfully
 	// placed on your container instances are described here.
 	Tasks []*Task `locationName:"tasks" type:"list"`
-
-	_ struct{} `type:"structure"`
 }
 
 // String returns the string representation
@@ -2988,6 +2988,8 @@ func (s StartTaskOutput) GoString() string {
 }
 
 type StopTaskInput struct {
+	_ struct{} `type:"structure"`
+
 	// The short name or full Amazon Resource Name (ARN) of the cluster that hosts
 	// the task to stop. If you do not specify a cluster, the default cluster is
 	// assumed..
@@ -3001,8 +3003,6 @@ type StopTaskInput struct {
 
 	// The task ID or full Amazon Resource Name (ARN) entry of the task to stop.
 	Task *string `locationName:"task" type:"string" required:"true"`
-
-	_ struct{} `type:"structure"`
 }
 
 // String returns the string representation
@@ -3016,10 +3016,10 @@ func (s StopTaskInput) GoString() string {
 }
 
 type StopTaskOutput struct {
+	_ struct{} `type:"structure"`
+
 	// Details on a task in a cluster.
 	Task *Task `locationName:"task" type:"structure"`
-
-	_ struct{} `type:"structure"`
 }
 
 // String returns the string representation
@@ -3033,6 +3033,8 @@ func (s StopTaskOutput) GoString() string {
 }
 
 type SubmitContainerStateChangeInput struct {
+	_ struct{} `type:"structure"`
+
 	// The short name or full Amazon Resource Name (ARN) of the cluster that hosts
 	// the container.
 	Cluster *string `locationName:"cluster" type:"string"`
@@ -3055,8 +3057,6 @@ type SubmitContainerStateChangeInput struct {
 	// The task ID or full Amazon Resource Name (ARN) of the task that hosts the
 	// container.
 	Task *string `locationName:"task" type:"string"`
-
-	_ struct{} `type:"structure"`
 }
 
 // String returns the string representation
@@ -3070,10 +3070,10 @@ func (s SubmitContainerStateChangeInput) GoString() string {
 }
 
 type SubmitContainerStateChangeOutput struct {
+	_ struct{} `type:"structure"`
+
 	// Acknowledgement of the state change.
 	Acknowledgment *string `locationName:"acknowledgment" type:"string"`
-
-	_ struct{} `type:"structure"`
 }
 
 // String returns the string representation
@@ -3087,6 +3087,8 @@ func (s SubmitContainerStateChangeOutput) GoString() string {
 }
 
 type SubmitTaskStateChangeInput struct {
+	_ struct{} `type:"structure"`
+
 	// The short name or full Amazon Resource Name (ARN) of the cluster that hosts
 	// the task.
 	Cluster *string `locationName:"cluster" type:"string"`
@@ -3100,8 +3102,6 @@ type SubmitTaskStateChangeInput struct {
 	// The task ID or full Amazon Resource Name (ARN) of the task in the state change
 	// request.
 	Task *string `locationName:"task" type:"string"`
-
-	_ struct{} `type:"structure"`
 }
 
 // String returns the string representation
@@ -3115,10 +3115,10 @@ func (s SubmitTaskStateChangeInput) GoString() string {
 }
 
 type SubmitTaskStateChangeOutput struct {
+	_ struct{} `type:"structure"`
+
 	// Acknowledgement of the state change.
 	Acknowledgment *string `locationName:"acknowledgment" type:"string"`
-
-	_ struct{} `type:"structure"`
 }
 
 // String returns the string representation
@@ -3133,6 +3133,8 @@ func (s SubmitTaskStateChangeOutput) GoString() string {
 
 // Details on a task in a cluster.
 type Task struct {
+	_ struct{} `type:"structure"`
+
 	// The Amazon Resource Name (ARN) of the of the cluster that hosts the task.
 	ClusterArn *string `locationName:"clusterArn" type:"string"`
 
@@ -3177,8 +3179,6 @@ type Task struct {
 	// The Amazon Resource Name (ARN) of the of the task definition that creates
 	// the task.
 	TaskDefinitionArn *string `locationName:"taskDefinitionArn" type:"string"`
-
-	_ struct{} `type:"structure"`
 }
 
 // String returns the string representation
@@ -3193,6 +3193,8 @@ func (s Task) GoString() string {
 
 // Details of a task definition.
 type TaskDefinition struct {
+	_ struct{} `type:"structure"`
+
 	// A list of container definitions in JSON format that describe the different
 	// containers that make up your task. For more information about container definition
 	// parameters and defaults, see Amazon ECS Task Definitions (http://docs.aws.amazon.com/AmazonECS/latest/developerguide/task_defintions.html)
@@ -3222,8 +3224,6 @@ type TaskDefinition struct {
 	// parameters and defaults, see Amazon ECS Task Definitions (http://docs.aws.amazon.com/AmazonECS/latest/developerguide/task_defintions.html)
 	// in the Amazon EC2 Container Service Developer Guide.
 	Volumes []*Volume `locationName:"volumes" type:"list"`
-
-	_ struct{} `type:"structure"`
 }
 
 // String returns the string representation
@@ -3238,10 +3238,10 @@ func (s TaskDefinition) GoString() string {
 
 // The overrides associated with a task.
 type TaskOverride struct {
+	_ struct{} `type:"structure"`
+
 	// One or more container overrides sent to a task.
 	ContainerOverrides []*ContainerOverride `locationName:"containerOverrides" type:"list"`
-
-	_ struct{} `type:"structure"`
 }
 
 // String returns the string representation
@@ -3256,6 +3256,8 @@ func (s TaskOverride) GoString() string {
 
 // The ulimit settings to pass to the container.
 type Ulimit struct {
+	_ struct{} `type:"structure"`
+
 	// The hard limit for the ulimit type.
 	HardLimit *int64 `locationName:"hardLimit" type:"integer" required:"true"`
 
@@ -3264,8 +3266,6 @@ type Ulimit struct {
 
 	// The soft limit for the ulimit type.
 	SoftLimit *int64 `locationName:"softLimit" type:"integer" required:"true"`
-
-	_ struct{} `type:"structure"`
 }
 
 // String returns the string representation
@@ -3279,6 +3279,8 @@ func (s Ulimit) GoString() string {
 }
 
 type UpdateContainerAgentInput struct {
+	_ struct{} `type:"structure"`
+
 	// The short name or full Amazon Resource Name (ARN) of the cluster that your
 	// container instance is running on. If you do not specify a cluster, the default
 	// cluster is assumed.
@@ -3288,8 +3290,6 @@ type UpdateContainerAgentInput struct {
 	// the container instance on which you would like to update the Amazon ECS container
 	// agent.
 	ContainerInstance *string `locationName:"containerInstance" type:"string" required:"true"`
-
-	_ struct{} `type:"structure"`
 }
 
 // String returns the string representation
@@ -3303,11 +3303,11 @@ func (s UpdateContainerAgentInput) GoString() string {
 }
 
 type UpdateContainerAgentOutput struct {
+	_ struct{} `type:"structure"`
+
 	// An EC2 instance that is running the Amazon ECS agent and has been registered
 	// with a cluster.
 	ContainerInstance *ContainerInstance `locationName:"containerInstance" type:"structure"`
-
-	_ struct{} `type:"structure"`
 }
 
 // String returns the string representation
@@ -3321,6 +3321,8 @@ func (s UpdateContainerAgentOutput) GoString() string {
 }
 
 type UpdateServiceInput struct {
+	_ struct{} `type:"structure"`
+
 	// The short name or full Amazon Resource Name (ARN) of the cluster that your
 	// service is running on. If you do not specify a cluster, the default cluster
 	// is assumed.
@@ -3339,8 +3341,6 @@ type UpdateServiceInput struct {
 	// UpdateService, Amazon ECS spawns a task with the new version of the task
 	// definition and then stops an old task after the new version is running.
 	TaskDefinition *string `locationName:"taskDefinition" type:"string"`
-
-	_ struct{} `type:"structure"`
 }
 
 // String returns the string representation
@@ -3354,10 +3354,10 @@ func (s UpdateServiceInput) GoString() string {
 }
 
 type UpdateServiceOutput struct {
+	_ struct{} `type:"structure"`
+
 	// The full description of your service following the update call.
 	Service *Service `locationName:"service" type:"structure"`
-
-	_ struct{} `type:"structure"`
 }
 
 // String returns the string representation
@@ -3373,6 +3373,8 @@ func (s UpdateServiceOutput) GoString() string {
 // The Docker and Amazon ECS container agent version information about a container
 // instance.
 type VersionInfo struct {
+	_ struct{} `type:"structure"`
+
 	// The Git commit hash for the Amazon ECS container agent build on the amazon-ecs-agent
 	//  (https://github.com/aws/amazon-ecs-agent/commits/master) GitHub repository.
 	AgentHash *string `locationName:"agentHash" type:"string"`
@@ -3382,8 +3384,6 @@ type VersionInfo struct {
 
 	// The Docker version running on the container instance.
 	DockerVersion *string `locationName:"dockerVersion" type:"string"`
-
-	_ struct{} `type:"structure"`
 }
 
 // String returns the string representation
@@ -3398,6 +3398,8 @@ func (s VersionInfo) GoString() string {
 
 // A data volume used in a task definition.
 type Volume struct {
+	_ struct{} `type:"structure"`
+
 	// The path on the host container instance that is presented to the containers
 	// which access the volume. If this parameter is empty, then the Docker daemon
 	// assigns a host path for you.
@@ -3406,8 +3408,6 @@ type Volume struct {
 	// The name of the volume. This name is referenced in the sourceVolume parameter
 	// of container definition mountPoints.
 	Name *string `locationName:"name" type:"string"`
-
-	_ struct{} `type:"structure"`
 }
 
 // String returns the string representation
@@ -3422,6 +3422,8 @@ func (s Volume) GoString() string {
 
 // Details on a data volume from another container.
 type VolumeFrom struct {
+	_ struct{} `type:"structure"`
+
 	// If this value is true, the container has read-only access to the volume.
 	// If this value is false, then the container can write to the volume. The default
 	// value is false.
@@ -3429,8 +3431,6 @@ type VolumeFrom struct {
 
 	// The name of the container to mount volumes from.
 	SourceContainer *string `locationName:"sourceContainer" type:"string"`
-
-	_ struct{} `type:"structure"`
 }
 
 // String returns the string representation

--- a/service/ecs/api.go
+++ b/service/ecs/api.go
@@ -981,11 +981,7 @@ type Attribute struct {
 	// The value of the container instance attribute.
 	Value *string `locationName:"value" type:"string"`
 
-	metadataAttribute `json:"-" xml:"-"`
-}
-
-type metadataAttribute struct {
-	SDKShapeTraits bool `type:"structure"`
+	_ struct{} `type:"structure"`
 }
 
 // String returns the string representation
@@ -1030,11 +1026,7 @@ type Cluster struct {
 	// the associated instances can accept tasks.
 	Status *string `locationName:"status" type:"string"`
 
-	metadataCluster `json:"-" xml:"-"`
-}
-
-type metadataCluster struct {
-	SDKShapeTraits bool `type:"structure"`
+	_ struct{} `type:"structure"`
 }
 
 // String returns the string representation
@@ -1071,11 +1063,7 @@ type Container struct {
 	// The Amazon Resource Name (ARN) of the task.
 	TaskArn *string `locationName:"taskArn" type:"string"`
 
-	metadataContainer `json:"-" xml:"-"`
-}
-
-type metadataContainer struct {
-	SDKShapeTraits bool `type:"structure"`
+	_ struct{} `type:"structure"`
 }
 
 // String returns the string representation
@@ -1340,11 +1328,7 @@ type ContainerDefinition struct {
 	// and the --workdir option to docker run (https://docs.docker.com/reference/commandline/run/).
 	WorkingDirectory *string `locationName:"workingDirectory" type:"string"`
 
-	metadataContainerDefinition `json:"-" xml:"-"`
-}
-
-type metadataContainerDefinition struct {
-	SDKShapeTraits bool `type:"structure"`
+	_ struct{} `type:"structure"`
 }
 
 // String returns the string representation
@@ -1405,11 +1389,7 @@ type ContainerInstance struct {
 	// running on the container instance.
 	VersionInfo *VersionInfo `locationName:"versionInfo" type:"structure"`
 
-	metadataContainerInstance `json:"-" xml:"-"`
-}
-
-type metadataContainerInstance struct {
-	SDKShapeTraits bool `type:"structure"`
+	_ struct{} `type:"structure"`
 }
 
 // String returns the string representation
@@ -1436,11 +1416,7 @@ type ContainerOverride struct {
 	// The name of the container that receives the override.
 	Name *string `locationName:"name" type:"string"`
 
-	metadataContainerOverride `json:"-" xml:"-"`
-}
-
-type metadataContainerOverride struct {
-	SDKShapeTraits bool `type:"structure"`
+	_ struct{} `type:"structure"`
 }
 
 // String returns the string representation
@@ -1459,11 +1435,7 @@ type CreateClusterInput struct {
 	// numbers, hyphens, and underscores are allowed.
 	ClusterName *string `locationName:"clusterName" type:"string"`
 
-	metadataCreateClusterInput `json:"-" xml:"-"`
-}
-
-type metadataCreateClusterInput struct {
-	SDKShapeTraits bool `type:"structure"`
+	_ struct{} `type:"structure"`
 }
 
 // String returns the string representation
@@ -1480,11 +1452,7 @@ type CreateClusterOutput struct {
 	// The full description of your new cluster.
 	Cluster *Cluster `locationName:"cluster" type:"structure"`
 
-	metadataCreateClusterOutput `json:"-" xml:"-"`
-}
-
-type metadataCreateClusterOutput struct {
-	SDKShapeTraits bool `type:"structure"`
+	_ struct{} `type:"structure"`
 }
 
 // String returns the string representation
@@ -1533,11 +1501,7 @@ type CreateServiceInput struct {
 	// the latest ACTIVE revision is used.
 	TaskDefinition *string `locationName:"taskDefinition" type:"string" required:"true"`
 
-	metadataCreateServiceInput `json:"-" xml:"-"`
-}
-
-type metadataCreateServiceInput struct {
-	SDKShapeTraits bool `type:"structure"`
+	_ struct{} `type:"structure"`
 }
 
 // String returns the string representation
@@ -1554,11 +1518,7 @@ type CreateServiceOutput struct {
 	// The full description of your service following the create call.
 	Service *Service `locationName:"service" type:"structure"`
 
-	metadataCreateServiceOutput `json:"-" xml:"-"`
-}
-
-type metadataCreateServiceOutput struct {
-	SDKShapeTraits bool `type:"structure"`
+	_ struct{} `type:"structure"`
 }
 
 // String returns the string representation
@@ -1575,11 +1535,7 @@ type DeleteClusterInput struct {
 	// The short name or full Amazon Resource Name (ARN) of the cluster to delete.
 	Cluster *string `locationName:"cluster" type:"string" required:"true"`
 
-	metadataDeleteClusterInput `json:"-" xml:"-"`
-}
-
-type metadataDeleteClusterInput struct {
-	SDKShapeTraits bool `type:"structure"`
+	_ struct{} `type:"structure"`
 }
 
 // String returns the string representation
@@ -1596,11 +1552,7 @@ type DeleteClusterOutput struct {
 	// The full description of the deleted cluster.
 	Cluster *Cluster `locationName:"cluster" type:"structure"`
 
-	metadataDeleteClusterOutput `json:"-" xml:"-"`
-}
-
-type metadataDeleteClusterOutput struct {
-	SDKShapeTraits bool `type:"structure"`
+	_ struct{} `type:"structure"`
 }
 
 // String returns the string representation
@@ -1621,11 +1573,7 @@ type DeleteServiceInput struct {
 	// The name of the service to delete.
 	Service *string `locationName:"service" type:"string" required:"true"`
 
-	metadataDeleteServiceInput `json:"-" xml:"-"`
-}
-
-type metadataDeleteServiceInput struct {
-	SDKShapeTraits bool `type:"structure"`
+	_ struct{} `type:"structure"`
 }
 
 // String returns the string representation
@@ -1642,11 +1590,7 @@ type DeleteServiceOutput struct {
 	// The full description of the deleted service.
 	Service *Service `locationName:"service" type:"structure"`
 
-	metadataDeleteServiceOutput `json:"-" xml:"-"`
-}
-
-type metadataDeleteServiceOutput struct {
-	SDKShapeTraits bool `type:"structure"`
+	_ struct{} `type:"structure"`
 }
 
 // String returns the string representation
@@ -1689,11 +1633,7 @@ type Deployment struct {
 	// The Unix time in seconds and milliseconds when the service was last updated.
 	UpdatedAt *time.Time `locationName:"updatedAt" type:"timestamp" timestampFormat:"unix"`
 
-	metadataDeployment `json:"-" xml:"-"`
-}
-
-type metadataDeployment struct {
-	SDKShapeTraits bool `type:"structure"`
+	_ struct{} `type:"structure"`
 }
 
 // String returns the string representation
@@ -1729,11 +1669,7 @@ type DeregisterContainerInstanceInput struct {
 	// of that task, on a different container instance if possible.
 	Force *bool `locationName:"force" type:"boolean"`
 
-	metadataDeregisterContainerInstanceInput `json:"-" xml:"-"`
-}
-
-type metadataDeregisterContainerInstanceInput struct {
-	SDKShapeTraits bool `type:"structure"`
+	_ struct{} `type:"structure"`
 }
 
 // String returns the string representation
@@ -1751,11 +1687,7 @@ type DeregisterContainerInstanceOutput struct {
 	// with a cluster.
 	ContainerInstance *ContainerInstance `locationName:"containerInstance" type:"structure"`
 
-	metadataDeregisterContainerInstanceOutput `json:"-" xml:"-"`
-}
-
-type metadataDeregisterContainerInstanceOutput struct {
-	SDKShapeTraits bool `type:"structure"`
+	_ struct{} `type:"structure"`
 }
 
 // String returns the string representation
@@ -1773,11 +1705,7 @@ type DeregisterTaskDefinitionInput struct {
 	// of the task definition to deregister. You must specify a revision.
 	TaskDefinition *string `locationName:"taskDefinition" type:"string" required:"true"`
 
-	metadataDeregisterTaskDefinitionInput `json:"-" xml:"-"`
-}
-
-type metadataDeregisterTaskDefinitionInput struct {
-	SDKShapeTraits bool `type:"structure"`
+	_ struct{} `type:"structure"`
 }
 
 // String returns the string representation
@@ -1794,11 +1722,7 @@ type DeregisterTaskDefinitionOutput struct {
 	// The full description of the deregistered task.
 	TaskDefinition *TaskDefinition `locationName:"taskDefinition" type:"structure"`
 
-	metadataDeregisterTaskDefinitionOutput `json:"-" xml:"-"`
-}
-
-type metadataDeregisterTaskDefinitionOutput struct {
-	SDKShapeTraits bool `type:"structure"`
+	_ struct{} `type:"structure"`
 }
 
 // String returns the string representation
@@ -1816,11 +1740,7 @@ type DescribeClustersInput struct {
 	// (ARN) entries. If you do not specify a cluster, the default cluster is assumed.
 	Clusters []*string `locationName:"clusters" type:"list"`
 
-	metadataDescribeClustersInput `json:"-" xml:"-"`
-}
-
-type metadataDescribeClustersInput struct {
-	SDKShapeTraits bool `type:"structure"`
+	_ struct{} `type:"structure"`
 }
 
 // String returns the string representation
@@ -1840,11 +1760,7 @@ type DescribeClustersOutput struct {
 	// Any failures associated with the call.
 	Failures []*Failure `locationName:"failures" type:"list"`
 
-	metadataDescribeClustersOutput `json:"-" xml:"-"`
-}
-
-type metadataDescribeClustersOutput struct {
-	SDKShapeTraits bool `type:"structure"`
+	_ struct{} `type:"structure"`
 }
 
 // String returns the string representation
@@ -1867,11 +1783,7 @@ type DescribeContainerInstancesInput struct {
 	// Name (ARN) entries.
 	ContainerInstances []*string `locationName:"containerInstances" type:"list" required:"true"`
 
-	metadataDescribeContainerInstancesInput `json:"-" xml:"-"`
-}
-
-type metadataDescribeContainerInstancesInput struct {
-	SDKShapeTraits bool `type:"structure"`
+	_ struct{} `type:"structure"`
 }
 
 // String returns the string representation
@@ -1891,11 +1803,7 @@ type DescribeContainerInstancesOutput struct {
 	// Any failures associated with the call.
 	Failures []*Failure `locationName:"failures" type:"list"`
 
-	metadataDescribeContainerInstancesOutput `json:"-" xml:"-"`
-}
-
-type metadataDescribeContainerInstancesOutput struct {
-	SDKShapeTraits bool `type:"structure"`
+	_ struct{} `type:"structure"`
 }
 
 // String returns the string representation
@@ -1916,11 +1824,7 @@ type DescribeServicesInput struct {
 	// A list of services to describe.
 	Services []*string `locationName:"services" type:"list" required:"true"`
 
-	metadataDescribeServicesInput `json:"-" xml:"-"`
-}
-
-type metadataDescribeServicesInput struct {
-	SDKShapeTraits bool `type:"structure"`
+	_ struct{} `type:"structure"`
 }
 
 // String returns the string representation
@@ -1940,11 +1844,7 @@ type DescribeServicesOutput struct {
 	// The list of services described.
 	Services []*Service `locationName:"services" type:"list"`
 
-	metadataDescribeServicesOutput `json:"-" xml:"-"`
-}
-
-type metadataDescribeServicesOutput struct {
-	SDKShapeTraits bool `type:"structure"`
+	_ struct{} `type:"structure"`
 }
 
 // String returns the string representation
@@ -1963,11 +1863,7 @@ type DescribeTaskDefinitionInput struct {
 	// of the task definition to describe.
 	TaskDefinition *string `locationName:"taskDefinition" type:"string" required:"true"`
 
-	metadataDescribeTaskDefinitionInput `json:"-" xml:"-"`
-}
-
-type metadataDescribeTaskDefinitionInput struct {
-	SDKShapeTraits bool `type:"structure"`
+	_ struct{} `type:"structure"`
 }
 
 // String returns the string representation
@@ -1984,11 +1880,7 @@ type DescribeTaskDefinitionOutput struct {
 	// The full task definition description.
 	TaskDefinition *TaskDefinition `locationName:"taskDefinition" type:"structure"`
 
-	metadataDescribeTaskDefinitionOutput `json:"-" xml:"-"`
-}
-
-type metadataDescribeTaskDefinitionOutput struct {
-	SDKShapeTraits bool `type:"structure"`
+	_ struct{} `type:"structure"`
 }
 
 // String returns the string representation
@@ -2010,11 +1902,7 @@ type DescribeTasksInput struct {
 	// A space-separated list of task IDs or full Amazon Resource Name (ARN) entries.
 	Tasks []*string `locationName:"tasks" type:"list" required:"true"`
 
-	metadataDescribeTasksInput `json:"-" xml:"-"`
-}
-
-type metadataDescribeTasksInput struct {
-	SDKShapeTraits bool `type:"structure"`
+	_ struct{} `type:"structure"`
 }
 
 // String returns the string representation
@@ -2034,11 +1922,7 @@ type DescribeTasksOutput struct {
 	// The list of tasks.
 	Tasks []*Task `locationName:"tasks" type:"list"`
 
-	metadataDescribeTasksOutput `json:"-" xml:"-"`
-}
-
-type metadataDescribeTasksOutput struct {
-	SDKShapeTraits bool `type:"structure"`
+	_ struct{} `type:"structure"`
 }
 
 // String returns the string representation
@@ -2062,11 +1946,7 @@ type DiscoverPollEndpointInput struct {
 	// example, arn:aws:ecs:region:aws_account_id:container-instance/container_instance_ID.
 	ContainerInstance *string `locationName:"containerInstance" type:"string"`
 
-	metadataDiscoverPollEndpointInput `json:"-" xml:"-"`
-}
-
-type metadataDiscoverPollEndpointInput struct {
-	SDKShapeTraits bool `type:"structure"`
+	_ struct{} `type:"structure"`
 }
 
 // String returns the string representation
@@ -2086,11 +1966,7 @@ type DiscoverPollEndpointOutput struct {
 	// The telemetry endpoint for the Amazon ECS agent.
 	TelemetryEndpoint *string `locationName:"telemetryEndpoint" type:"string"`
 
-	metadataDiscoverPollEndpointOutput `json:"-" xml:"-"`
-}
-
-type metadataDiscoverPollEndpointOutput struct {
-	SDKShapeTraits bool `type:"structure"`
+	_ struct{} `type:"structure"`
 }
 
 // String returns the string representation
@@ -2111,11 +1987,7 @@ type Failure struct {
 	// The reason for the failure.
 	Reason *string `locationName:"reason" type:"string"`
 
-	metadataFailure `json:"-" xml:"-"`
-}
-
-type metadataFailure struct {
-	SDKShapeTraits bool `type:"structure"`
+	_ struct{} `type:"structure"`
 }
 
 // String returns the string representation
@@ -2137,11 +2009,7 @@ type HostEntry struct {
 	// The IP address to use in the /etc/hosts entry.
 	IpAddress *string `locationName:"ipAddress" type:"string" required:"true"`
 
-	metadataHostEntry `json:"-" xml:"-"`
-}
-
-type metadataHostEntry struct {
-	SDKShapeTraits bool `type:"structure"`
+	_ struct{} `type:"structure"`
 }
 
 // String returns the string representation
@@ -2161,11 +2029,7 @@ type HostVolumeProperties struct {
 	// for you.
 	SourcePath *string `locationName:"sourcePath" type:"string"`
 
-	metadataHostVolumeProperties `json:"-" xml:"-"`
-}
-
-type metadataHostVolumeProperties struct {
-	SDKShapeTraits bool `type:"structure"`
+	_ struct{} `type:"structure"`
 }
 
 // String returns the string representation
@@ -2188,11 +2052,7 @@ type KeyValuePair struct {
 	// of the environment variable.
 	Value *string `locationName:"value" type:"string"`
 
-	metadataKeyValuePair `json:"-" xml:"-"`
-}
-
-type metadataKeyValuePair struct {
-	SDKShapeTraits bool `type:"structure"`
+	_ struct{} `type:"structure"`
 }
 
 // String returns the string representation
@@ -2221,11 +2081,7 @@ type ListClustersInput struct {
 	// nextToken value. This value is null when there are no more results to return.
 	NextToken *string `locationName:"nextToken" type:"string"`
 
-	metadataListClustersInput `json:"-" xml:"-"`
-}
-
-type metadataListClustersInput struct {
-	SDKShapeTraits bool `type:"structure"`
+	_ struct{} `type:"structure"`
 }
 
 // String returns the string representation
@@ -2249,11 +2105,7 @@ type ListClustersOutput struct {
 	// more results to return.
 	NextToken *string `locationName:"nextToken" type:"string"`
 
-	metadataListClustersOutput `json:"-" xml:"-"`
-}
-
-type metadataListClustersOutput struct {
-	SDKShapeTraits bool `type:"structure"`
+	_ struct{} `type:"structure"`
 }
 
 // String returns the string representation
@@ -2289,11 +2141,7 @@ type ListContainerInstancesInput struct {
 	// to return.
 	NextToken *string `locationName:"nextToken" type:"string"`
 
-	metadataListContainerInstancesInput `json:"-" xml:"-"`
-}
-
-type metadataListContainerInstancesInput struct {
-	SDKShapeTraits bool `type:"structure"`
+	_ struct{} `type:"structure"`
 }
 
 // String returns the string representation
@@ -2317,11 +2165,7 @@ type ListContainerInstancesOutput struct {
 	// when there are no more results to return.
 	NextToken *string `locationName:"nextToken" type:"string"`
 
-	metadataListContainerInstancesOutput `json:"-" xml:"-"`
-}
-
-type metadataListContainerInstancesOutput struct {
-	SDKShapeTraits bool `type:"structure"`
+	_ struct{} `type:"structure"`
 }
 
 // String returns the string representation
@@ -2355,11 +2199,7 @@ type ListServicesInput struct {
 	// nextToken value. This value is null when there are no more results to return.
 	NextToken *string `locationName:"nextToken" type:"string"`
 
-	metadataListServicesInput `json:"-" xml:"-"`
-}
-
-type metadataListServicesInput struct {
-	SDKShapeTraits bool `type:"structure"`
+	_ struct{} `type:"structure"`
 }
 
 // String returns the string representation
@@ -2383,11 +2223,7 @@ type ListServicesOutput struct {
 	// with the specified cluster.
 	ServiceArns []*string `locationName:"serviceArns" type:"list"`
 
-	metadataListServicesOutput `json:"-" xml:"-"`
-}
-
-type metadataListServicesOutput struct {
-	SDKShapeTraits bool `type:"structure"`
+	_ struct{} `type:"structure"`
 }
 
 // String returns the string representation
@@ -2423,11 +2259,7 @@ type ListTaskDefinitionFamiliesInput struct {
 	// to return.
 	NextToken *string `locationName:"nextToken" type:"string"`
 
-	metadataListTaskDefinitionFamiliesInput `json:"-" xml:"-"`
-}
-
-type metadataListTaskDefinitionFamiliesInput struct {
-	SDKShapeTraits bool `type:"structure"`
+	_ struct{} `type:"structure"`
 }
 
 // String returns the string representation
@@ -2451,11 +2283,7 @@ type ListTaskDefinitionFamiliesOutput struct {
 	// null when there are no more results to return.
 	NextToken *string `locationName:"nextToken" type:"string"`
 
-	metadataListTaskDefinitionFamiliesOutput `json:"-" xml:"-"`
-}
-
-type metadataListTaskDefinitionFamiliesOutput struct {
-	SDKShapeTraits bool `type:"structure"`
+	_ struct{} `type:"structure"`
 }
 
 // String returns the string representation
@@ -2505,11 +2333,7 @@ type ListTaskDefinitionsInput struct {
 	// output, be sure to keep the status value constant in each subsequent request.
 	Status *string `locationName:"status" type:"string" enum:"TaskDefinitionStatus"`
 
-	metadataListTaskDefinitionsInput `json:"-" xml:"-"`
-}
-
-type metadataListTaskDefinitionsInput struct {
-	SDKShapeTraits bool `type:"structure"`
+	_ struct{} `type:"structure"`
 }
 
 // String returns the string representation
@@ -2533,11 +2357,7 @@ type ListTaskDefinitionsOutput struct {
 	// request.
 	TaskDefinitionArns []*string `locationName:"taskDefinitionArns" type:"list"`
 
-	metadataListTaskDefinitionsOutput `json:"-" xml:"-"`
-}
-
-type metadataListTaskDefinitionsOutput struct {
-	SDKShapeTraits bool `type:"structure"`
+	_ struct{} `type:"structure"`
 }
 
 // String returns the string representation
@@ -2594,11 +2414,7 @@ type ListTasksInput struct {
 	// value limits the results to tasks that were started with that value.
 	StartedBy *string `locationName:"startedBy" type:"string"`
 
-	metadataListTasksInput `json:"-" xml:"-"`
-}
-
-type metadataListTasksInput struct {
-	SDKShapeTraits bool `type:"structure"`
+	_ struct{} `type:"structure"`
 }
 
 // String returns the string representation
@@ -2621,11 +2437,7 @@ type ListTasksOutput struct {
 	// The list of task Amazon Resource Name (ARN) entries for the ListTasks request.
 	TaskArns []*string `locationName:"taskArns" type:"list"`
 
-	metadataListTasksOutput `json:"-" xml:"-"`
-}
-
-type metadataListTasksOutput struct {
-	SDKShapeTraits bool `type:"structure"`
+	_ struct{} `type:"structure"`
 }
 
 // String returns the string representation
@@ -2652,11 +2464,7 @@ type LoadBalancer struct {
 	// The name of the load balancer.
 	LoadBalancerName *string `locationName:"loadBalancerName" type:"string"`
 
-	metadataLoadBalancer `json:"-" xml:"-"`
-}
-
-type metadataLoadBalancer struct {
-	SDKShapeTraits bool `type:"structure"`
+	_ struct{} `type:"structure"`
 }
 
 // String returns the string representation
@@ -2685,11 +2493,7 @@ type LogConfiguration struct {
 	// | grep "Server API version"
 	Options map[string]*string `locationName:"options" type:"map"`
 
-	metadataLogConfiguration `json:"-" xml:"-"`
-}
-
-type metadataLogConfiguration struct {
-	SDKShapeTraits bool `type:"structure"`
+	_ struct{} `type:"structure"`
 }
 
 // String returns the string representation
@@ -2715,11 +2519,7 @@ type MountPoint struct {
 	// The name of the volume to mount.
 	SourceVolume *string `locationName:"sourceVolume" type:"string"`
 
-	metadataMountPoint `json:"-" xml:"-"`
-}
-
-type metadataMountPoint struct {
-	SDKShapeTraits bool `type:"structure"`
+	_ struct{} `type:"structure"`
 }
 
 // String returns the string representation
@@ -2749,11 +2549,7 @@ type NetworkBinding struct {
 	// The protocol used for the network binding.
 	Protocol *string `locationName:"protocol" type:"string" enum:"TransportProtocol"`
 
-	metadataNetworkBinding `json:"-" xml:"-"`
-}
-
-type metadataNetworkBinding struct {
-	SDKShapeTraits bool `type:"structure"`
+	_ struct{} `type:"structure"`
 }
 
 // String returns the string representation
@@ -2805,11 +2601,7 @@ type PortMapping struct {
 	// default is tcp.
 	Protocol *string `locationName:"protocol" type:"string" enum:"TransportProtocol"`
 
-	metadataPortMapping `json:"-" xml:"-"`
-}
-
-type metadataPortMapping struct {
-	SDKShapeTraits bool `type:"structure"`
+	_ struct{} `type:"structure"`
 }
 
 // String returns the string representation
@@ -2851,11 +2643,7 @@ type RegisterContainerInstanceInput struct {
 	// running on the container instance.
 	VersionInfo *VersionInfo `locationName:"versionInfo" type:"structure"`
 
-	metadataRegisterContainerInstanceInput `json:"-" xml:"-"`
-}
-
-type metadataRegisterContainerInstanceInput struct {
-	SDKShapeTraits bool `type:"structure"`
+	_ struct{} `type:"structure"`
 }
 
 // String returns the string representation
@@ -2873,11 +2661,7 @@ type RegisterContainerInstanceOutput struct {
 	// with a cluster.
 	ContainerInstance *ContainerInstance `locationName:"containerInstance" type:"structure"`
 
-	metadataRegisterContainerInstanceOutput `json:"-" xml:"-"`
-}
-
-type metadataRegisterContainerInstanceOutput struct {
-	SDKShapeTraits bool `type:"structure"`
+	_ struct{} `type:"structure"`
 }
 
 // String returns the string representation
@@ -2905,11 +2689,7 @@ type RegisterTaskDefinitionInput struct {
 	// may use.
 	Volumes []*Volume `locationName:"volumes" type:"list"`
 
-	metadataRegisterTaskDefinitionInput `json:"-" xml:"-"`
-}
-
-type metadataRegisterTaskDefinitionInput struct {
-	SDKShapeTraits bool `type:"structure"`
+	_ struct{} `type:"structure"`
 }
 
 // String returns the string representation
@@ -2926,11 +2706,7 @@ type RegisterTaskDefinitionOutput struct {
 	// The full description of the registered task definition.
 	TaskDefinition *TaskDefinition `locationName:"taskDefinition" type:"structure"`
 
-	metadataRegisterTaskDefinitionOutput `json:"-" xml:"-"`
-}
-
-type metadataRegisterTaskDefinitionOutput struct {
-	SDKShapeTraits bool `type:"structure"`
+	_ struct{} `type:"structure"`
 }
 
 // String returns the string representation
@@ -2966,11 +2742,7 @@ type Resource struct {
 	// The type of the resource, such as INTEGER, DOUBLE, LONG, or STRINGSET.
 	Type *string `locationName:"type" type:"string"`
 
-	metadataResource `json:"-" xml:"-"`
-}
-
-type metadataResource struct {
-	SDKShapeTraits bool `type:"structure"`
+	_ struct{} `type:"structure"`
 }
 
 // String returns the string representation
@@ -3021,11 +2793,7 @@ type RunTaskInput struct {
 	// ACTIVE revision is used.
 	TaskDefinition *string `locationName:"taskDefinition" type:"string" required:"true"`
 
-	metadataRunTaskInput `json:"-" xml:"-"`
-}
-
-type metadataRunTaskInput struct {
-	SDKShapeTraits bool `type:"structure"`
+	_ struct{} `type:"structure"`
 }
 
 // String returns the string representation
@@ -3046,11 +2814,7 @@ type RunTaskOutput struct {
 	// placed on your cluster are described here.
 	Tasks []*Task `locationName:"tasks" type:"list"`
 
-	metadataRunTaskOutput `json:"-" xml:"-"`
-}
-
-type metadataRunTaskOutput struct {
-	SDKShapeTraits bool `type:"structure"`
+	_ struct{} `type:"structure"`
 }
 
 // String returns the string representation
@@ -3113,11 +2877,7 @@ type Service struct {
 	// UpdateService.
 	TaskDefinition *string `locationName:"taskDefinition" type:"string"`
 
-	metadataService `json:"-" xml:"-"`
-}
-
-type metadataService struct {
-	SDKShapeTraits bool `type:"structure"`
+	_ struct{} `type:"structure"`
 }
 
 // String returns the string representation
@@ -3141,11 +2901,7 @@ type ServiceEvent struct {
 	// The event message.
 	Message *string `locationName:"message" type:"string"`
 
-	metadataServiceEvent `json:"-" xml:"-"`
-}
-
-type metadataServiceEvent struct {
-	SDKShapeTraits bool `type:"structure"`
+	_ struct{} `type:"structure"`
 }
 
 // String returns the string representation
@@ -3197,11 +2953,7 @@ type StartTaskInput struct {
 	// ACTIVE revision is used.
 	TaskDefinition *string `locationName:"taskDefinition" type:"string" required:"true"`
 
-	metadataStartTaskInput `json:"-" xml:"-"`
-}
-
-type metadataStartTaskInput struct {
-	SDKShapeTraits bool `type:"structure"`
+	_ struct{} `type:"structure"`
 }
 
 // String returns the string representation
@@ -3222,11 +2974,7 @@ type StartTaskOutput struct {
 	// placed on your container instances are described here.
 	Tasks []*Task `locationName:"tasks" type:"list"`
 
-	metadataStartTaskOutput `json:"-" xml:"-"`
-}
-
-type metadataStartTaskOutput struct {
-	SDKShapeTraits bool `type:"structure"`
+	_ struct{} `type:"structure"`
 }
 
 // String returns the string representation
@@ -3254,11 +3002,7 @@ type StopTaskInput struct {
 	// The task ID or full Amazon Resource Name (ARN) entry of the task to stop.
 	Task *string `locationName:"task" type:"string" required:"true"`
 
-	metadataStopTaskInput `json:"-" xml:"-"`
-}
-
-type metadataStopTaskInput struct {
-	SDKShapeTraits bool `type:"structure"`
+	_ struct{} `type:"structure"`
 }
 
 // String returns the string representation
@@ -3275,11 +3019,7 @@ type StopTaskOutput struct {
 	// Details on a task in a cluster.
 	Task *Task `locationName:"task" type:"structure"`
 
-	metadataStopTaskOutput `json:"-" xml:"-"`
-}
-
-type metadataStopTaskOutput struct {
-	SDKShapeTraits bool `type:"structure"`
+	_ struct{} `type:"structure"`
 }
 
 // String returns the string representation
@@ -3316,11 +3056,7 @@ type SubmitContainerStateChangeInput struct {
 	// container.
 	Task *string `locationName:"task" type:"string"`
 
-	metadataSubmitContainerStateChangeInput `json:"-" xml:"-"`
-}
-
-type metadataSubmitContainerStateChangeInput struct {
-	SDKShapeTraits bool `type:"structure"`
+	_ struct{} `type:"structure"`
 }
 
 // String returns the string representation
@@ -3337,11 +3073,7 @@ type SubmitContainerStateChangeOutput struct {
 	// Acknowledgement of the state change.
 	Acknowledgment *string `locationName:"acknowledgment" type:"string"`
 
-	metadataSubmitContainerStateChangeOutput `json:"-" xml:"-"`
-}
-
-type metadataSubmitContainerStateChangeOutput struct {
-	SDKShapeTraits bool `type:"structure"`
+	_ struct{} `type:"structure"`
 }
 
 // String returns the string representation
@@ -3369,11 +3101,7 @@ type SubmitTaskStateChangeInput struct {
 	// request.
 	Task *string `locationName:"task" type:"string"`
 
-	metadataSubmitTaskStateChangeInput `json:"-" xml:"-"`
-}
-
-type metadataSubmitTaskStateChangeInput struct {
-	SDKShapeTraits bool `type:"structure"`
+	_ struct{} `type:"structure"`
 }
 
 // String returns the string representation
@@ -3390,11 +3118,7 @@ type SubmitTaskStateChangeOutput struct {
 	// Acknowledgement of the state change.
 	Acknowledgment *string `locationName:"acknowledgment" type:"string"`
 
-	metadataSubmitTaskStateChangeOutput `json:"-" xml:"-"`
-}
-
-type metadataSubmitTaskStateChangeOutput struct {
-	SDKShapeTraits bool `type:"structure"`
+	_ struct{} `type:"structure"`
 }
 
 // String returns the string representation
@@ -3454,11 +3178,7 @@ type Task struct {
 	// the task.
 	TaskDefinitionArn *string `locationName:"taskDefinitionArn" type:"string"`
 
-	metadataTask `json:"-" xml:"-"`
-}
-
-type metadataTask struct {
-	SDKShapeTraits bool `type:"structure"`
+	_ struct{} `type:"structure"`
 }
 
 // String returns the string representation
@@ -3503,11 +3223,7 @@ type TaskDefinition struct {
 	// in the Amazon EC2 Container Service Developer Guide.
 	Volumes []*Volume `locationName:"volumes" type:"list"`
 
-	metadataTaskDefinition `json:"-" xml:"-"`
-}
-
-type metadataTaskDefinition struct {
-	SDKShapeTraits bool `type:"structure"`
+	_ struct{} `type:"structure"`
 }
 
 // String returns the string representation
@@ -3525,11 +3241,7 @@ type TaskOverride struct {
 	// One or more container overrides sent to a task.
 	ContainerOverrides []*ContainerOverride `locationName:"containerOverrides" type:"list"`
 
-	metadataTaskOverride `json:"-" xml:"-"`
-}
-
-type metadataTaskOverride struct {
-	SDKShapeTraits bool `type:"structure"`
+	_ struct{} `type:"structure"`
 }
 
 // String returns the string representation
@@ -3553,11 +3265,7 @@ type Ulimit struct {
 	// The soft limit for the ulimit type.
 	SoftLimit *int64 `locationName:"softLimit" type:"integer" required:"true"`
 
-	metadataUlimit `json:"-" xml:"-"`
-}
-
-type metadataUlimit struct {
-	SDKShapeTraits bool `type:"structure"`
+	_ struct{} `type:"structure"`
 }
 
 // String returns the string representation
@@ -3581,11 +3289,7 @@ type UpdateContainerAgentInput struct {
 	// agent.
 	ContainerInstance *string `locationName:"containerInstance" type:"string" required:"true"`
 
-	metadataUpdateContainerAgentInput `json:"-" xml:"-"`
-}
-
-type metadataUpdateContainerAgentInput struct {
-	SDKShapeTraits bool `type:"structure"`
+	_ struct{} `type:"structure"`
 }
 
 // String returns the string representation
@@ -3603,11 +3307,7 @@ type UpdateContainerAgentOutput struct {
 	// with a cluster.
 	ContainerInstance *ContainerInstance `locationName:"containerInstance" type:"structure"`
 
-	metadataUpdateContainerAgentOutput `json:"-" xml:"-"`
-}
-
-type metadataUpdateContainerAgentOutput struct {
-	SDKShapeTraits bool `type:"structure"`
+	_ struct{} `type:"structure"`
 }
 
 // String returns the string representation
@@ -3640,11 +3340,7 @@ type UpdateServiceInput struct {
 	// definition and then stops an old task after the new version is running.
 	TaskDefinition *string `locationName:"taskDefinition" type:"string"`
 
-	metadataUpdateServiceInput `json:"-" xml:"-"`
-}
-
-type metadataUpdateServiceInput struct {
-	SDKShapeTraits bool `type:"structure"`
+	_ struct{} `type:"structure"`
 }
 
 // String returns the string representation
@@ -3661,11 +3357,7 @@ type UpdateServiceOutput struct {
 	// The full description of your service following the update call.
 	Service *Service `locationName:"service" type:"structure"`
 
-	metadataUpdateServiceOutput `json:"-" xml:"-"`
-}
-
-type metadataUpdateServiceOutput struct {
-	SDKShapeTraits bool `type:"structure"`
+	_ struct{} `type:"structure"`
 }
 
 // String returns the string representation
@@ -3691,11 +3383,7 @@ type VersionInfo struct {
 	// The Docker version running on the container instance.
 	DockerVersion *string `locationName:"dockerVersion" type:"string"`
 
-	metadataVersionInfo `json:"-" xml:"-"`
-}
-
-type metadataVersionInfo struct {
-	SDKShapeTraits bool `type:"structure"`
+	_ struct{} `type:"structure"`
 }
 
 // String returns the string representation
@@ -3719,11 +3407,7 @@ type Volume struct {
 	// of container definition mountPoints.
 	Name *string `locationName:"name" type:"string"`
 
-	metadataVolume `json:"-" xml:"-"`
-}
-
-type metadataVolume struct {
-	SDKShapeTraits bool `type:"structure"`
+	_ struct{} `type:"structure"`
 }
 
 // String returns the string representation
@@ -3746,11 +3430,7 @@ type VolumeFrom struct {
 	// The name of the container to mount volumes from.
 	SourceContainer *string `locationName:"sourceContainer" type:"string"`
 
-	metadataVolumeFrom `json:"-" xml:"-"`
-}
-
-type metadataVolumeFrom struct {
-	SDKShapeTraits bool `type:"structure"`
+	_ struct{} `type:"structure"`
 }
 
 // String returns the string representation

--- a/service/efs/api.go
+++ b/service/efs/api.go
@@ -523,11 +523,7 @@ type CreateFileSystemInput struct {
 	// creation.
 	CreationToken *string `min:"1" type:"string" required:"true"`
 
-	metadataCreateFileSystemInput `json:"-" xml:"-"`
-}
-
-type metadataCreateFileSystemInput struct {
-	SDKShapeTraits bool `type:"structure"`
+	_ struct{} `type:"structure"`
 }
 
 // String returns the string representation
@@ -554,11 +550,7 @@ type CreateMountTargetInput struct {
 	// The ID of the subnet to add the mount target in.
 	SubnetId *string `type:"string" required:"true"`
 
-	metadataCreateMountTargetInput `json:"-" xml:"-"`
-}
-
-type metadataCreateMountTargetInput struct {
-	SDKShapeTraits bool `type:"structure"`
+	_ struct{} `type:"structure"`
 }
 
 // String returns the string representation
@@ -579,11 +571,7 @@ type CreateTagsInput struct {
 	// An array of Tag objects to add. Each Tag object is a key-value pair.
 	Tags []*Tag `type:"list" required:"true"`
 
-	metadataCreateTagsInput `json:"-" xml:"-"`
-}
-
-type metadataCreateTagsInput struct {
-	SDKShapeTraits bool `type:"structure"`
+	_ struct{} `type:"structure"`
 }
 
 // String returns the string representation
@@ -597,11 +585,7 @@ func (s CreateTagsInput) GoString() string {
 }
 
 type CreateTagsOutput struct {
-	metadataCreateTagsOutput `json:"-" xml:"-"`
-}
-
-type metadataCreateTagsOutput struct {
-	SDKShapeTraits bool `type:"structure"`
+	_ struct{} `type:"structure"`
 }
 
 // String returns the string representation
@@ -618,11 +602,7 @@ type DeleteFileSystemInput struct {
 	// The ID of the file system you want to delete.
 	FileSystemId *string `location:"uri" locationName:"FileSystemId" type:"string" required:"true"`
 
-	metadataDeleteFileSystemInput `json:"-" xml:"-"`
-}
-
-type metadataDeleteFileSystemInput struct {
-	SDKShapeTraits bool `type:"structure"`
+	_ struct{} `type:"structure"`
 }
 
 // String returns the string representation
@@ -636,11 +616,7 @@ func (s DeleteFileSystemInput) GoString() string {
 }
 
 type DeleteFileSystemOutput struct {
-	metadataDeleteFileSystemOutput `json:"-" xml:"-"`
-}
-
-type metadataDeleteFileSystemOutput struct {
-	SDKShapeTraits bool `type:"structure"`
+	_ struct{} `type:"structure"`
 }
 
 // String returns the string representation
@@ -657,11 +633,7 @@ type DeleteMountTargetInput struct {
 	// String. The ID of the mount target to delete.
 	MountTargetId *string `location:"uri" locationName:"MountTargetId" type:"string" required:"true"`
 
-	metadataDeleteMountTargetInput `json:"-" xml:"-"`
-}
-
-type metadataDeleteMountTargetInput struct {
-	SDKShapeTraits bool `type:"structure"`
+	_ struct{} `type:"structure"`
 }
 
 // String returns the string representation
@@ -675,11 +647,7 @@ func (s DeleteMountTargetInput) GoString() string {
 }
 
 type DeleteMountTargetOutput struct {
-	metadataDeleteMountTargetOutput `json:"-" xml:"-"`
-}
-
-type metadataDeleteMountTargetOutput struct {
-	SDKShapeTraits bool `type:"structure"`
+	_ struct{} `type:"structure"`
 }
 
 // String returns the string representation
@@ -699,11 +667,7 @@ type DeleteTagsInput struct {
 	// A list of tag keys to delete.
 	TagKeys []*string `type:"list" required:"true"`
 
-	metadataDeleteTagsInput `json:"-" xml:"-"`
-}
-
-type metadataDeleteTagsInput struct {
-	SDKShapeTraits bool `type:"structure"`
+	_ struct{} `type:"structure"`
 }
 
 // String returns the string representation
@@ -717,11 +681,7 @@ func (s DeleteTagsInput) GoString() string {
 }
 
 type DeleteTagsOutput struct {
-	metadataDeleteTagsOutput `json:"-" xml:"-"`
-}
-
-type metadataDeleteTagsOutput struct {
-	SDKShapeTraits bool `type:"structure"`
+	_ struct{} `type:"structure"`
 }
 
 // String returns the string representation
@@ -755,11 +715,7 @@ type DescribeFileSystemsInput struct {
 	// per page.
 	MaxItems *int64 `location:"querystring" locationName:"MaxItems" min:"1" type:"integer"`
 
-	metadataDescribeFileSystemsInput `json:"-" xml:"-"`
-}
-
-type metadataDescribeFileSystemsInput struct {
-	SDKShapeTraits bool `type:"structure"`
+	_ struct{} `type:"structure"`
 }
 
 // String returns the string representation
@@ -783,11 +739,7 @@ type DescribeFileSystemsOutput struct {
 	// You can use the NextMarker in the subsequent request to fetch the descriptions.
 	NextMarker *string `type:"string"`
 
-	metadataDescribeFileSystemsOutput `json:"-" xml:"-"`
-}
-
-type metadataDescribeFileSystemsOutput struct {
-	SDKShapeTraits bool `type:"structure"`
+	_ struct{} `type:"structure"`
 }
 
 // String returns the string representation
@@ -804,11 +756,7 @@ type DescribeMountTargetSecurityGroupsInput struct {
 	// The ID of the mount target whose security groups you want to retrieve.
 	MountTargetId *string `location:"uri" locationName:"MountTargetId" type:"string" required:"true"`
 
-	metadataDescribeMountTargetSecurityGroupsInput `json:"-" xml:"-"`
-}
-
-type metadataDescribeMountTargetSecurityGroupsInput struct {
-	SDKShapeTraits bool `type:"structure"`
+	_ struct{} `type:"structure"`
 }
 
 // String returns the string representation
@@ -825,11 +773,7 @@ type DescribeMountTargetSecurityGroupsOutput struct {
 	// An array of security groups.
 	SecurityGroups []*string `type:"list" required:"true"`
 
-	metadataDescribeMountTargetSecurityGroupsOutput `json:"-" xml:"-"`
-}
-
-type metadataDescribeMountTargetSecurityGroupsOutput struct {
-	SDKShapeTraits bool `type:"structure"`
+	_ struct{} `type:"structure"`
 }
 
 // String returns the string representation
@@ -860,11 +804,7 @@ type DescribeMountTargetsInput struct {
 	// It must be included in your request if FileSystemId is not included.
 	MountTargetId *string `location:"querystring" locationName:"MountTargetId" type:"string"`
 
-	metadataDescribeMountTargetsInput `json:"-" xml:"-"`
-}
-
-type metadataDescribeMountTargetsInput struct {
-	SDKShapeTraits bool `type:"structure"`
+	_ struct{} `type:"structure"`
 }
 
 // String returns the string representation
@@ -891,11 +831,7 @@ type DescribeMountTargetsOutput struct {
 	// the next set of mount targets.
 	NextMarker *string `type:"string"`
 
-	metadataDescribeMountTargetsOutput `json:"-" xml:"-"`
-}
-
-type metadataDescribeMountTargetsOutput struct {
-	SDKShapeTraits bool `type:"structure"`
+	_ struct{} `type:"structure"`
 }
 
 // String returns the string representation
@@ -921,11 +857,7 @@ type DescribeTagsInput struct {
 	// must be an integer with a value greater than zero.
 	MaxItems *int64 `location:"querystring" locationName:"MaxItems" min:"1" type:"integer"`
 
-	metadataDescribeTagsInput `json:"-" xml:"-"`
-}
-
-type metadataDescribeTagsInput struct {
-	SDKShapeTraits bool `type:"structure"`
+	_ struct{} `type:"structure"`
 }
 
 // String returns the string representation
@@ -951,11 +883,7 @@ type DescribeTagsOutput struct {
 	// Returns tags associated with the file system as an array of Tag objects.
 	Tags []*Tag `type:"list" required:"true"`
 
-	metadataDescribeTagsOutput `json:"-" xml:"-"`
-}
-
-type metadataDescribeTagsOutput struct {
-	SDKShapeTraits bool `type:"structure"`
+	_ struct{} `type:"structure"`
 }
 
 // String returns the string representation
@@ -1007,11 +935,7 @@ type FileSystemDescription struct {
 	// exact size the file system was at any instant in time.
 	SizeInBytes *FileSystemSize `type:"structure" required:"true"`
 
-	metadataFileSystemDescription `json:"-" xml:"-"`
-}
-
-type metadataFileSystemDescription struct {
-	SDKShapeTraits bool `type:"structure"`
+	_ struct{} `type:"structure"`
 }
 
 // String returns the string representation
@@ -1040,11 +964,7 @@ type FileSystemSize struct {
 	// The latest known metered size, in bytes, of data stored in the file system.
 	Value *int64 `type:"long" required:"true"`
 
-	metadataFileSystemSize `json:"-" xml:"-"`
-}
-
-type metadataFileSystemSize struct {
-	SDKShapeTraits bool `type:"structure"`
+	_ struct{} `type:"structure"`
 }
 
 // String returns the string representation
@@ -1064,11 +984,7 @@ type ModifyMountTargetSecurityGroupsInput struct {
 	// An array of up to five VPC security group IDs.
 	SecurityGroups []*string `type:"list"`
 
-	metadataModifyMountTargetSecurityGroupsInput `json:"-" xml:"-"`
-}
-
-type metadataModifyMountTargetSecurityGroupsInput struct {
-	SDKShapeTraits bool `type:"structure"`
+	_ struct{} `type:"structure"`
 }
 
 // String returns the string representation
@@ -1082,11 +998,7 @@ func (s ModifyMountTargetSecurityGroupsInput) GoString() string {
 }
 
 type ModifyMountTargetSecurityGroupsOutput struct {
-	metadataModifyMountTargetSecurityGroupsOutput `json:"-" xml:"-"`
-}
-
-type metadataModifyMountTargetSecurityGroupsOutput struct {
-	SDKShapeTraits bool `type:"structure"`
+	_ struct{} `type:"structure"`
 }
 
 // String returns the string representation
@@ -1123,11 +1035,7 @@ type MountTargetDescription struct {
 	// The ID of the subnet that the mount target is in.
 	SubnetId *string `type:"string" required:"true"`
 
-	metadataMountTargetDescription `json:"-" xml:"-"`
-}
-
-type metadataMountTargetDescription struct {
-	SDKShapeTraits bool `type:"structure"`
+	_ struct{} `type:"structure"`
 }
 
 // String returns the string representation
@@ -1150,11 +1058,7 @@ type Tag struct {
 	// Value of the tag key.
 	Value *string `type:"string" required:"true"`
 
-	metadataTag `json:"-" xml:"-"`
-}
-
-type metadataTag struct {
-	SDKShapeTraits bool `type:"structure"`
+	_ struct{} `type:"structure"`
 }
 
 // String returns the string representation

--- a/service/efs/api.go
+++ b/service/efs/api.go
@@ -519,11 +519,11 @@ func (c *EFS) ModifyMountTargetSecurityGroups(input *ModifyMountTargetSecurityGr
 }
 
 type CreateFileSystemInput struct {
+	_ struct{} `type:"structure"`
+
 	// String of up to 64 ASCII characters. Amazon EFS uses this to ensure idempotent
 	// creation.
 	CreationToken *string `min:"1" type:"string" required:"true"`
-
-	_ struct{} `type:"structure"`
 }
 
 // String returns the string representation
@@ -537,6 +537,8 @@ func (s CreateFileSystemInput) GoString() string {
 }
 
 type CreateMountTargetInput struct {
+	_ struct{} `type:"structure"`
+
 	// The ID of the file system for which to create the mount target.
 	FileSystemId *string `type:"string" required:"true"`
 
@@ -549,8 +551,6 @@ type CreateMountTargetInput struct {
 
 	// The ID of the subnet to add the mount target in.
 	SubnetId *string `type:"string" required:"true"`
-
-	_ struct{} `type:"structure"`
 }
 
 // String returns the string representation
@@ -564,14 +564,14 @@ func (s CreateMountTargetInput) GoString() string {
 }
 
 type CreateTagsInput struct {
+	_ struct{} `type:"structure"`
+
 	// String. The ID of the file system whose tags you want to modify. This operation
 	// modifies only the tags and not the file system.
 	FileSystemId *string `location:"uri" locationName:"FileSystemId" type:"string" required:"true"`
 
 	// An array of Tag objects to add. Each Tag object is a key-value pair.
 	Tags []*Tag `type:"list" required:"true"`
-
-	_ struct{} `type:"structure"`
 }
 
 // String returns the string representation
@@ -599,10 +599,10 @@ func (s CreateTagsOutput) GoString() string {
 }
 
 type DeleteFileSystemInput struct {
+	_ struct{} `type:"structure"`
+
 	// The ID of the file system you want to delete.
 	FileSystemId *string `location:"uri" locationName:"FileSystemId" type:"string" required:"true"`
-
-	_ struct{} `type:"structure"`
 }
 
 // String returns the string representation
@@ -630,10 +630,10 @@ func (s DeleteFileSystemOutput) GoString() string {
 }
 
 type DeleteMountTargetInput struct {
+	_ struct{} `type:"structure"`
+
 	// String. The ID of the mount target to delete.
 	MountTargetId *string `location:"uri" locationName:"MountTargetId" type:"string" required:"true"`
-
-	_ struct{} `type:"structure"`
 }
 
 // String returns the string representation
@@ -661,13 +661,13 @@ func (s DeleteMountTargetOutput) GoString() string {
 }
 
 type DeleteTagsInput struct {
+	_ struct{} `type:"structure"`
+
 	// String. The ID of the file system whose tags you want to delete.
 	FileSystemId *string `location:"uri" locationName:"FileSystemId" type:"string" required:"true"`
 
 	// A list of tag keys to delete.
 	TagKeys []*string `type:"list" required:"true"`
-
-	_ struct{} `type:"structure"`
 }
 
 // String returns the string representation
@@ -695,6 +695,8 @@ func (s DeleteTagsOutput) GoString() string {
 }
 
 type DescribeFileSystemsInput struct {
+	_ struct{} `type:"structure"`
+
 	// Optional string. Restricts the list to the file system with this creation
 	// token (you specify a creation token at the time of creating an Amazon EFS
 	// file system).
@@ -714,8 +716,6 @@ type DescribeFileSystemsInput struct {
 	// specified in the request and the service's internal maximum number of items
 	// per page.
 	MaxItems *int64 `location:"querystring" locationName:"MaxItems" min:"1" type:"integer"`
-
-	_ struct{} `type:"structure"`
 }
 
 // String returns the string representation
@@ -729,6 +729,8 @@ func (s DescribeFileSystemsInput) GoString() string {
 }
 
 type DescribeFileSystemsOutput struct {
+	_ struct{} `type:"structure"`
+
 	// An array of file system descriptions.
 	FileSystems []*FileSystemDescription `type:"list"`
 
@@ -738,8 +740,6 @@ type DescribeFileSystemsOutput struct {
 	// A string, present if there are more file systems than returned in the response.
 	// You can use the NextMarker in the subsequent request to fetch the descriptions.
 	NextMarker *string `type:"string"`
-
-	_ struct{} `type:"structure"`
 }
 
 // String returns the string representation
@@ -753,10 +753,10 @@ func (s DescribeFileSystemsOutput) GoString() string {
 }
 
 type DescribeMountTargetSecurityGroupsInput struct {
+	_ struct{} `type:"structure"`
+
 	// The ID of the mount target whose security groups you want to retrieve.
 	MountTargetId *string `location:"uri" locationName:"MountTargetId" type:"string" required:"true"`
-
-	_ struct{} `type:"structure"`
 }
 
 // String returns the string representation
@@ -770,10 +770,10 @@ func (s DescribeMountTargetSecurityGroupsInput) GoString() string {
 }
 
 type DescribeMountTargetSecurityGroupsOutput struct {
+	_ struct{} `type:"structure"`
+
 	// An array of security groups.
 	SecurityGroups []*string `type:"list" required:"true"`
-
-	_ struct{} `type:"structure"`
 }
 
 // String returns the string representation
@@ -787,6 +787,8 @@ func (s DescribeMountTargetSecurityGroupsOutput) GoString() string {
 }
 
 type DescribeMountTargetsInput struct {
+	_ struct{} `type:"structure"`
+
 	// Optional. String. The ID of the file system whose mount targets you want
 	// to list. It must be included in your request if MountTargetId is not included.
 	FileSystemId *string `location:"querystring" locationName:"FileSystemId" type:"string"`
@@ -803,8 +805,6 @@ type DescribeMountTargetsInput struct {
 	// Optional. String. The ID of the mount target that you want to have described.
 	// It must be included in your request if FileSystemId is not included.
 	MountTargetId *string `location:"querystring" locationName:"MountTargetId" type:"string"`
-
-	_ struct{} `type:"structure"`
 }
 
 // String returns the string representation
@@ -818,6 +818,8 @@ func (s DescribeMountTargetsInput) GoString() string {
 }
 
 type DescribeMountTargetsOutput struct {
+	_ struct{} `type:"structure"`
+
 	// If the request included the Marker, the response returns that value in this
 	// field.
 	Marker *string `type:"string"`
@@ -830,8 +832,6 @@ type DescribeMountTargetsOutput struct {
 	// request, you can provide Marker in your request with this value to retrieve
 	// the next set of mount targets.
 	NextMarker *string `type:"string"`
-
-	_ struct{} `type:"structure"`
 }
 
 // String returns the string representation
@@ -845,6 +845,8 @@ func (s DescribeMountTargetsOutput) GoString() string {
 }
 
 type DescribeTagsInput struct {
+	_ struct{} `type:"structure"`
+
 	// The ID of the file system whose tag set you want to retrieve.
 	FileSystemId *string `location:"uri" locationName:"FileSystemId" type:"string" required:"true"`
 
@@ -856,8 +858,6 @@ type DescribeTagsInput struct {
 	// Optional. Maximum number of file system tags to return in the response. It
 	// must be an integer with a value greater than zero.
 	MaxItems *int64 `location:"querystring" locationName:"MaxItems" min:"1" type:"integer"`
-
-	_ struct{} `type:"structure"`
 }
 
 // String returns the string representation
@@ -871,6 +871,8 @@ func (s DescribeTagsInput) GoString() string {
 }
 
 type DescribeTagsOutput struct {
+	_ struct{} `type:"structure"`
+
 	// If the request included a Marker, the response returns that value in this
 	// field.
 	Marker *string `type:"string"`
@@ -882,8 +884,6 @@ type DescribeTagsOutput struct {
 
 	// Returns tags associated with the file system as an array of Tag objects.
 	Tags []*Tag `type:"list" required:"true"`
-
-	_ struct{} `type:"structure"`
 }
 
 // String returns the string representation
@@ -898,6 +898,8 @@ func (s DescribeTagsOutput) GoString() string {
 
 // This object provides description of a file system.
 type FileSystemDescription struct {
+	_ struct{} `type:"structure"`
+
 	// The time at which the file system was created, in seconds, since 1970-01-01T00:00:00Z.
 	CreationTime *time.Time `type:"timestamp" timestampFormat:"unix" required:"true"`
 
@@ -934,8 +936,6 @@ type FileSystemDescription struct {
 	// for a period longer than a couple of hours. Otherwise, the value is not the
 	// exact size the file system was at any instant in time.
 	SizeInBytes *FileSystemSize `type:"structure" required:"true"`
-
-	_ struct{} `type:"structure"`
 }
 
 // String returns the string representation
@@ -957,14 +957,14 @@ func (s FileSystemDescription) GoString() string {
 // a period longer than a couple of hours. Otherwise, the value is not necessarily
 // the exact size the file system was at any instant in time.
 type FileSystemSize struct {
+	_ struct{} `type:"structure"`
+
 	// The time at which the size of data, returned in the Value field, was determined.
 	// The value is the integer number of seconds since 1970-01-01T00:00:00Z.
 	Timestamp *time.Time `type:"timestamp" timestampFormat:"unix"`
 
 	// The latest known metered size, in bytes, of data stored in the file system.
 	Value *int64 `type:"long" required:"true"`
-
-	_ struct{} `type:"structure"`
 }
 
 // String returns the string representation
@@ -978,13 +978,13 @@ func (s FileSystemSize) GoString() string {
 }
 
 type ModifyMountTargetSecurityGroupsInput struct {
+	_ struct{} `type:"structure"`
+
 	// The ID of the mount target whose security groups you want to modify.
 	MountTargetId *string `location:"uri" locationName:"MountTargetId" type:"string" required:"true"`
 
 	// An array of up to five VPC security group IDs.
 	SecurityGroups []*string `type:"list"`
-
-	_ struct{} `type:"structure"`
 }
 
 // String returns the string representation
@@ -1013,6 +1013,8 @@ func (s ModifyMountTargetSecurityGroupsOutput) GoString() string {
 
 // This object provides description of a mount target.
 type MountTargetDescription struct {
+	_ struct{} `type:"structure"`
+
 	// The ID of the file system for which the mount target is intended.
 	FileSystemId *string `type:"string" required:"true"`
 
@@ -1034,8 +1036,6 @@ type MountTargetDescription struct {
 
 	// The ID of the subnet that the mount target is in.
 	SubnetId *string `type:"string" required:"true"`
-
-	_ struct{} `type:"structure"`
 }
 
 // String returns the string representation
@@ -1052,13 +1052,13 @@ func (s MountTargetDescription) GoString() string {
 // are letters, whitespace, and numbers, representable in UTF-8, and the characters
 // '+', '-', '=', '.', '_', ':', and '/'.
 type Tag struct {
+	_ struct{} `type:"structure"`
+
 	// Tag key, a string. The key must not start with "aws:".
 	Key *string `min:"1" type:"string" required:"true"`
 
 	// Value of the tag key.
 	Value *string `type:"string" required:"true"`
-
-	_ struct{} `type:"structure"`
 }
 
 // String returns the string representation

--- a/service/elasticache/api.go
+++ b/service/elasticache/api.go
@@ -1313,14 +1313,14 @@ func (c *ElastiCache) RevokeCacheSecurityGroupIngress(input *RevokeCacheSecurity
 
 // Represents the input of an AddTagsToResource action.
 type AddTagsToResourceInput struct {
+	_ struct{} `type:"structure"`
+
 	// The name of the resource to which the tags are to be added, for example arn:aws:elasticache:us-west-2:0123456789:cluster:myCluster.
 	ResourceName *string `type:"string" required:"true"`
 
 	// A list of cost allocation tags to be added to this resource. A tag is a key-value
 	// pair. A tag key must be accompanied by a tag value.
 	Tags []*Tag `locationNameList:"Tag" type:"list" required:"true"`
-
-	_ struct{} `type:"structure"`
 }
 
 // String returns the string representation
@@ -1335,6 +1335,8 @@ func (s AddTagsToResourceInput) GoString() string {
 
 // Represents the input of an AuthorizeCacheSecurityGroupIngress action.
 type AuthorizeCacheSecurityGroupIngressInput struct {
+	_ struct{} `type:"structure"`
+
 	// The cache security group which will allow network ingress.
 	CacheSecurityGroupName *string `type:"string" required:"true"`
 
@@ -1346,8 +1348,6 @@ type AuthorizeCacheSecurityGroupIngressInput struct {
 	// this is not the same thing as an AWS access key ID - you must provide a valid
 	// AWS account number for this parameter.
 	EC2SecurityGroupOwnerId *string `type:"string" required:"true"`
-
-	_ struct{} `type:"structure"`
 }
 
 // String returns the string representation
@@ -1361,12 +1361,12 @@ func (s AuthorizeCacheSecurityGroupIngressInput) GoString() string {
 }
 
 type AuthorizeCacheSecurityGroupIngressOutput struct {
+	_ struct{} `type:"structure"`
+
 	// Represents the output of one of the following actions:
 	//
 	//   AuthorizeCacheSecurityGroupIngress   CreateCacheSecurityGroup   RevokeCacheSecurityGroupIngress
 	CacheSecurityGroup *CacheSecurityGroup `type:"structure"`
-
-	_ struct{} `type:"structure"`
 }
 
 // String returns the string representation
@@ -1381,10 +1381,10 @@ func (s AuthorizeCacheSecurityGroupIngressOutput) GoString() string {
 
 // Describes an Availability Zone in which the cache cluster is launched.
 type AvailabilityZone struct {
+	_ struct{} `type:"structure"`
+
 	// The name of the Availability Zone.
 	Name *string `type:"string"`
-
-	_ struct{} `type:"structure"`
 }
 
 // String returns the string representation
@@ -1399,6 +1399,8 @@ func (s AvailabilityZone) GoString() string {
 
 // Contains all of the attributes of a specific cache cluster.
 type CacheCluster struct {
+	_ struct{} `type:"structure"`
+
 	// This parameter is currently disabled.
 	AutoMinorVersionUpgrade *bool `type:"boolean"`
 
@@ -1510,8 +1512,6 @@ type CacheCluster struct {
 	//
 	// Example: 05:00-09:00
 	SnapshotWindow *string `type:"string"`
-
-	_ struct{} `type:"structure"`
 }
 
 // String returns the string representation
@@ -1526,6 +1526,8 @@ func (s CacheCluster) GoString() string {
 
 // Provides all of the details about a particular cache engine version.
 type CacheEngineVersion struct {
+	_ struct{} `type:"structure"`
+
 	// The description of the cache engine.
 	CacheEngineDescription *string `type:"string"`
 
@@ -1540,8 +1542,6 @@ type CacheEngineVersion struct {
 
 	// The version number of the cache engine.
 	EngineVersion *string `type:"string"`
-
-	_ struct{} `type:"structure"`
 }
 
 // String returns the string representation
@@ -1576,6 +1576,8 @@ func (s CacheEngineVersion) GoString() string {
 // and Cache Node Type-Specific Parameters for Memcached (http://docs.aws.amazon.com/AmazonElastiCache/latest/UserGuide/CacheParameterGroups.Memcached.html#CacheParameterGroups.Memcached.NodeSpecific)
 // or Cache Node Type-Specific Parameters for Redis (http://docs.aws.amazon.com/AmazonElastiCache/latest/UserGuide/CacheParameterGroups.Redis.html#CacheParameterGroups.Redis.NodeSpecific).
 type CacheNode struct {
+	_ struct{} `type:"structure"`
+
 	// The date and time when the cache node was created.
 	CacheNodeCreateTime *time.Time `type:"timestamp" timestampFormat:"iso8601"`
 
@@ -1600,8 +1602,6 @@ type CacheNode struct {
 	// If this field is empty, then this node is not associated with a primary cache
 	// cluster.
 	SourceCacheNodeId *string `type:"string"`
-
-	_ struct{} `type:"structure"`
 }
 
 // String returns the string representation
@@ -1618,6 +1618,8 @@ func (s CacheNode) GoString() string {
 // to. For example, in a Redis cache cluster, a cache.m1.large cache node type
 // would have a larger maxmemory value than a cache.m1.small type.
 type CacheNodeTypeSpecificParameter struct {
+	_ struct{} `type:"structure"`
+
 	// The valid range of values for the parameter.
 	AllowedValues *string `type:"string"`
 
@@ -1643,8 +1645,6 @@ type CacheNodeTypeSpecificParameter struct {
 
 	// The source of the parameter value.
 	Source *string `type:"string"`
-
-	_ struct{} `type:"structure"`
 }
 
 // String returns the string representation
@@ -1659,13 +1659,13 @@ func (s CacheNodeTypeSpecificParameter) GoString() string {
 
 // A value that applies only to a certain cache node type.
 type CacheNodeTypeSpecificValue struct {
+	_ struct{} `type:"structure"`
+
 	// The cache node type for which this value applies.
 	CacheNodeType *string `type:"string"`
 
 	// The value for the cache node type.
 	Value *string `type:"string"`
-
-	_ struct{} `type:"structure"`
 }
 
 // String returns the string representation
@@ -1680,6 +1680,8 @@ func (s CacheNodeTypeSpecificValue) GoString() string {
 
 // Represents the output of a CreateCacheParameterGroup action.
 type CacheParameterGroup struct {
+	_ struct{} `type:"structure"`
+
 	// The name of the cache parameter group family that this cache parameter group
 	// is compatible with.
 	CacheParameterGroupFamily *string `type:"string"`
@@ -1689,8 +1691,6 @@ type CacheParameterGroup struct {
 
 	// The description for this cache parameter group.
 	Description *string `type:"string"`
-
-	_ struct{} `type:"structure"`
 }
 
 // String returns the string representation
@@ -1707,10 +1707,10 @@ func (s CacheParameterGroup) GoString() string {
 //
 //   ModifyCacheParameterGroup   ResetCacheParameterGroup
 type CacheParameterGroupNameMessage struct {
+	_ struct{} `type:"structure"`
+
 	// The name of the cache parameter group.
 	CacheParameterGroupName *string `type:"string"`
-
-	_ struct{} `type:"structure"`
 }
 
 // String returns the string representation
@@ -1725,6 +1725,8 @@ func (s CacheParameterGroupNameMessage) GoString() string {
 
 // The status of the cache parameter group.
 type CacheParameterGroupStatus struct {
+	_ struct{} `type:"structure"`
+
 	// A list of the cache node IDs which need to be rebooted for parameter changes
 	// to be applied. A node ID is a numeric identifier (0001, 0002, etc.).
 	CacheNodeIdsToReboot []*string `locationNameList:"CacheNodeId" type:"list"`
@@ -1734,8 +1736,6 @@ type CacheParameterGroupStatus struct {
 
 	// The status of parameter updates.
 	ParameterApplyStatus *string `type:"string"`
-
-	_ struct{} `type:"structure"`
 }
 
 // String returns the string representation
@@ -1752,6 +1752,8 @@ func (s CacheParameterGroupStatus) GoString() string {
 //
 //   AuthorizeCacheSecurityGroupIngress   CreateCacheSecurityGroup   RevokeCacheSecurityGroupIngress
 type CacheSecurityGroup struct {
+	_ struct{} `type:"structure"`
+
 	// The name of the cache security group.
 	CacheSecurityGroupName *string `type:"string"`
 
@@ -1764,8 +1766,6 @@ type CacheSecurityGroup struct {
 
 	// The AWS account ID of the cache security group owner.
 	OwnerId *string `type:"string"`
-
-	_ struct{} `type:"structure"`
 }
 
 // String returns the string representation
@@ -1780,6 +1780,8 @@ func (s CacheSecurityGroup) GoString() string {
 
 // Represents a cache cluster's status within a particular cache security group.
 type CacheSecurityGroupMembership struct {
+	_ struct{} `type:"structure"`
+
 	// The name of the cache security group.
 	CacheSecurityGroupName *string `type:"string"`
 
@@ -1787,8 +1789,6 @@ type CacheSecurityGroupMembership struct {
 	// a cache security group is modified, or when the cache security groups assigned
 	// to a cache cluster are modified.
 	Status *string `type:"string"`
-
-	_ struct{} `type:"structure"`
 }
 
 // String returns the string representation
@@ -1805,6 +1805,8 @@ func (s CacheSecurityGroupMembership) GoString() string {
 //
 //   CreateCacheSubnetGroup   ModifyCacheSubnetGroup
 type CacheSubnetGroup struct {
+	_ struct{} `type:"structure"`
+
 	// The description of the cache subnet group.
 	CacheSubnetGroupDescription *string `type:"string"`
 
@@ -1817,8 +1819,6 @@ type CacheSubnetGroup struct {
 	// The Amazon Virtual Private Cloud identifier (VPC ID) of the cache subnet
 	// group.
 	VpcId *string `type:"string"`
-
-	_ struct{} `type:"structure"`
 }
 
 // String returns the string representation
@@ -1833,13 +1833,13 @@ func (s CacheSubnetGroup) GoString() string {
 
 // Represents the input of a CopySnapshotMessage action.
 type CopySnapshotInput struct {
+	_ struct{} `type:"structure"`
+
 	// The name of an existing snapshot from which to copy.
 	SourceSnapshotName *string `type:"string" required:"true"`
 
 	// A name for the copied snapshot.
 	TargetSnapshotName *string `type:"string" required:"true"`
-
-	_ struct{} `type:"structure"`
 }
 
 // String returns the string representation
@@ -1853,11 +1853,11 @@ func (s CopySnapshotInput) GoString() string {
 }
 
 type CopySnapshotOutput struct {
+	_ struct{} `type:"structure"`
+
 	// Represents a copy of an entire cache cluster as of the time when the snapshot
 	// was taken.
 	Snapshot *Snapshot `type:"structure"`
-
-	_ struct{} `type:"structure"`
 }
 
 // String returns the string representation
@@ -1872,6 +1872,8 @@ func (s CopySnapshotOutput) GoString() string {
 
 // Represents the input of a CreateCacheCluster action.
 type CreateCacheClusterInput struct {
+	_ struct{} `type:"structure"`
+
 	// Specifies whether the nodes in this Memcached node group are created in a
 	// single Availability Zone or created across multiple Availability Zones in
 	// the cluster's region.
@@ -2061,8 +2063,6 @@ type CreateCacheClusterInput struct {
 	// A list of cost allocation tags to be added to this resource. A tag is a key-value
 	// pair. A tag key must be accompanied by a tag value.
 	Tags []*Tag `locationNameList:"Tag" type:"list"`
-
-	_ struct{} `type:"structure"`
 }
 
 // String returns the string representation
@@ -2076,10 +2076,10 @@ func (s CreateCacheClusterInput) GoString() string {
 }
 
 type CreateCacheClusterOutput struct {
+	_ struct{} `type:"structure"`
+
 	// Contains all of the attributes of a specific cache cluster.
 	CacheCluster *CacheCluster `type:"structure"`
-
-	_ struct{} `type:"structure"`
 }
 
 // String returns the string representation
@@ -2094,6 +2094,8 @@ func (s CreateCacheClusterOutput) GoString() string {
 
 // Represents the input of a CreateCacheParameterGroup action.
 type CreateCacheParameterGroupInput struct {
+	_ struct{} `type:"structure"`
+
 	// The name of the cache parameter group family the cache parameter group can
 	// be used with.
 	//
@@ -2105,8 +2107,6 @@ type CreateCacheParameterGroupInput struct {
 
 	// A user-specified description for the cache parameter group.
 	Description *string `type:"string" required:"true"`
-
-	_ struct{} `type:"structure"`
 }
 
 // String returns the string representation
@@ -2120,10 +2120,10 @@ func (s CreateCacheParameterGroupInput) GoString() string {
 }
 
 type CreateCacheParameterGroupOutput struct {
+	_ struct{} `type:"structure"`
+
 	// Represents the output of a CreateCacheParameterGroup action.
 	CacheParameterGroup *CacheParameterGroup `type:"structure"`
-
-	_ struct{} `type:"structure"`
 }
 
 // String returns the string representation
@@ -2138,6 +2138,8 @@ func (s CreateCacheParameterGroupOutput) GoString() string {
 
 // Represents the input of a CreateCacheSecurityGroup action.
 type CreateCacheSecurityGroupInput struct {
+	_ struct{} `type:"structure"`
+
 	// A name for the cache security group. This value is stored as a lowercase
 	// string.
 	//
@@ -2149,8 +2151,6 @@ type CreateCacheSecurityGroupInput struct {
 
 	// A description for the cache security group.
 	Description *string `type:"string" required:"true"`
-
-	_ struct{} `type:"structure"`
 }
 
 // String returns the string representation
@@ -2164,12 +2164,12 @@ func (s CreateCacheSecurityGroupInput) GoString() string {
 }
 
 type CreateCacheSecurityGroupOutput struct {
+	_ struct{} `type:"structure"`
+
 	// Represents the output of one of the following actions:
 	//
 	//   AuthorizeCacheSecurityGroupIngress   CreateCacheSecurityGroup   RevokeCacheSecurityGroupIngress
 	CacheSecurityGroup *CacheSecurityGroup `type:"structure"`
-
-	_ struct{} `type:"structure"`
 }
 
 // String returns the string representation
@@ -2184,6 +2184,8 @@ func (s CreateCacheSecurityGroupOutput) GoString() string {
 
 // Represents the input of a CreateCacheSubnetGroup action.
 type CreateCacheSubnetGroupInput struct {
+	_ struct{} `type:"structure"`
+
 	// A description for the cache subnet group.
 	CacheSubnetGroupDescription *string `type:"string" required:"true"`
 
@@ -2196,8 +2198,6 @@ type CreateCacheSubnetGroupInput struct {
 
 	// A list of VPC subnet IDs for the cache subnet group.
 	SubnetIds []*string `locationNameList:"SubnetIdentifier" type:"list" required:"true"`
-
-	_ struct{} `type:"structure"`
 }
 
 // String returns the string representation
@@ -2211,12 +2211,12 @@ func (s CreateCacheSubnetGroupInput) GoString() string {
 }
 
 type CreateCacheSubnetGroupOutput struct {
+	_ struct{} `type:"structure"`
+
 	// Represents the output of one of the following actions:
 	//
 	//   CreateCacheSubnetGroup   ModifyCacheSubnetGroup
 	CacheSubnetGroup *CacheSubnetGroup `type:"structure"`
-
-	_ struct{} `type:"structure"`
 }
 
 // String returns the string representation
@@ -2231,6 +2231,8 @@ func (s CreateCacheSubnetGroupOutput) GoString() string {
 
 // Represents the input of a CreateReplicationGroup action.
 type CreateReplicationGroupInput struct {
+	_ struct{} `type:"structure"`
+
 	// This parameter is currently disabled.
 	AutoMinorVersionUpgrade *bool `type:"boolean"`
 
@@ -2399,8 +2401,6 @@ type CreateReplicationGroupInput struct {
 	// A list of cost allocation tags to be added to this resource. A tag is a key-value
 	// pair. A tag key must be accompanied by a tag value.
 	Tags []*Tag `locationNameList:"Tag" type:"list"`
-
-	_ struct{} `type:"structure"`
 }
 
 // String returns the string representation
@@ -2414,10 +2414,10 @@ func (s CreateReplicationGroupInput) GoString() string {
 }
 
 type CreateReplicationGroupOutput struct {
+	_ struct{} `type:"structure"`
+
 	// Contains all of the attributes of a specific replication group.
 	ReplicationGroup *ReplicationGroup `type:"structure"`
-
-	_ struct{} `type:"structure"`
 }
 
 // String returns the string representation
@@ -2432,14 +2432,14 @@ func (s CreateReplicationGroupOutput) GoString() string {
 
 // Represents the input of a CreateSnapshot action.
 type CreateSnapshotInput struct {
+	_ struct{} `type:"structure"`
+
 	// The identifier of an existing cache cluster. The snapshot will be created
 	// from this cache cluster.
 	CacheClusterId *string `type:"string" required:"true"`
 
 	// A name for the snapshot being created.
 	SnapshotName *string `type:"string" required:"true"`
-
-	_ struct{} `type:"structure"`
 }
 
 // String returns the string representation
@@ -2453,11 +2453,11 @@ func (s CreateSnapshotInput) GoString() string {
 }
 
 type CreateSnapshotOutput struct {
+	_ struct{} `type:"structure"`
+
 	// Represents a copy of an entire cache cluster as of the time when the snapshot
 	// was taken.
 	Snapshot *Snapshot `type:"structure"`
-
-	_ struct{} `type:"structure"`
 }
 
 // String returns the string representation
@@ -2472,6 +2472,8 @@ func (s CreateSnapshotOutput) GoString() string {
 
 // Represents the input of a DeleteCacheCluster action.
 type DeleteCacheClusterInput struct {
+	_ struct{} `type:"structure"`
+
 	// The cache cluster identifier for the cluster to be deleted. This parameter
 	// is not case sensitive.
 	CacheClusterId *string `type:"string" required:"true"`
@@ -2480,8 +2482,6 @@ type DeleteCacheClusterInput struct {
 	// name that identifies the snapshot. ElastiCache creates the snapshot, and
 	// then deletes the cache cluster immediately afterward.
 	FinalSnapshotIdentifier *string `type:"string"`
-
-	_ struct{} `type:"structure"`
 }
 
 // String returns the string representation
@@ -2495,10 +2495,10 @@ func (s DeleteCacheClusterInput) GoString() string {
 }
 
 type DeleteCacheClusterOutput struct {
+	_ struct{} `type:"structure"`
+
 	// Contains all of the attributes of a specific cache cluster.
 	CacheCluster *CacheCluster `type:"structure"`
-
-	_ struct{} `type:"structure"`
 }
 
 // String returns the string representation
@@ -2513,13 +2513,13 @@ func (s DeleteCacheClusterOutput) GoString() string {
 
 // Represents the input of a DeleteCacheParameterGroup action.
 type DeleteCacheParameterGroupInput struct {
+	_ struct{} `type:"structure"`
+
 	// The name of the cache parameter group to delete.
 	//
 	// The specified cache security group must not be associated with any cache
 	// clusters.
 	CacheParameterGroupName *string `type:"string" required:"true"`
-
-	_ struct{} `type:"structure"`
 }
 
 // String returns the string representation
@@ -2548,12 +2548,12 @@ func (s DeleteCacheParameterGroupOutput) GoString() string {
 
 // Represents the input of a DeleteCacheSecurityGroup action.
 type DeleteCacheSecurityGroupInput struct {
+	_ struct{} `type:"structure"`
+
 	// The name of the cache security group to delete.
 	//
 	// You cannot delete the default security group.
 	CacheSecurityGroupName *string `type:"string" required:"true"`
-
-	_ struct{} `type:"structure"`
 }
 
 // String returns the string representation
@@ -2582,12 +2582,12 @@ func (s DeleteCacheSecurityGroupOutput) GoString() string {
 
 // Represents the input of a DeleteCacheSubnetGroup action.
 type DeleteCacheSubnetGroupInput struct {
+	_ struct{} `type:"structure"`
+
 	// The name of the cache subnet group to delete.
 	//
 	// Constraints: Must contain no more than 255 alphanumeric characters or hyphens.
 	CacheSubnetGroupName *string `type:"string" required:"true"`
-
-	_ struct{} `type:"structure"`
 }
 
 // String returns the string representation
@@ -2616,6 +2616,8 @@ func (s DeleteCacheSubnetGroupOutput) GoString() string {
 
 // Represents the input of a DeleteReplicationGroup action.
 type DeleteReplicationGroupInput struct {
+	_ struct{} `type:"structure"`
+
 	// The name of a final node group snapshot. ElastiCache creates the snapshot
 	// from the primary node in the cluster, rather than one of the replicas; this
 	// is to ensure that it captures the freshest data. After the final snapshot
@@ -2629,8 +2631,6 @@ type DeleteReplicationGroupInput struct {
 	// If set to true, all of the read replicas will be deleted, but the primary
 	// node will be retained.
 	RetainPrimaryCluster *bool `type:"boolean"`
-
-	_ struct{} `type:"structure"`
 }
 
 // String returns the string representation
@@ -2644,10 +2644,10 @@ func (s DeleteReplicationGroupInput) GoString() string {
 }
 
 type DeleteReplicationGroupOutput struct {
+	_ struct{} `type:"structure"`
+
 	// Contains all of the attributes of a specific replication group.
 	ReplicationGroup *ReplicationGroup `type:"structure"`
-
-	_ struct{} `type:"structure"`
 }
 
 // String returns the string representation
@@ -2662,10 +2662,10 @@ func (s DeleteReplicationGroupOutput) GoString() string {
 
 // Represents the input of a DeleteSnapshot action.
 type DeleteSnapshotInput struct {
+	_ struct{} `type:"structure"`
+
 	// The name of the snapshot to be deleted.
 	SnapshotName *string `type:"string" required:"true"`
-
-	_ struct{} `type:"structure"`
 }
 
 // String returns the string representation
@@ -2679,11 +2679,11 @@ func (s DeleteSnapshotInput) GoString() string {
 }
 
 type DeleteSnapshotOutput struct {
+	_ struct{} `type:"structure"`
+
 	// Represents a copy of an entire cache cluster as of the time when the snapshot
 	// was taken.
 	Snapshot *Snapshot `type:"structure"`
-
-	_ struct{} `type:"structure"`
 }
 
 // String returns the string representation
@@ -2698,6 +2698,8 @@ func (s DeleteSnapshotOutput) GoString() string {
 
 // Represents the input of a DescribeCacheClusters action.
 type DescribeCacheClustersInput struct {
+	_ struct{} `type:"structure"`
+
 	// The user-supplied cluster identifier. If this parameter is specified, only
 	// information about that specific cache cluster is returned. This parameter
 	// isn't case sensitive.
@@ -2720,8 +2722,6 @@ type DescribeCacheClustersInput struct {
 	// An optional flag that can be included in the DescribeCacheCluster request
 	// to retrieve information about the individual cache nodes.
 	ShowCacheNodeInfo *bool `type:"boolean"`
-
-	_ struct{} `type:"structure"`
 }
 
 // String returns the string representation
@@ -2736,14 +2736,14 @@ func (s DescribeCacheClustersInput) GoString() string {
 
 // Represents the output of a DescribeCacheClusters action.
 type DescribeCacheClustersOutput struct {
+	_ struct{} `type:"structure"`
+
 	// A list of cache clusters. Each item in the list contains detailed information
 	// about one cache cluster.
 	CacheClusters []*CacheCluster `locationNameList:"CacheCluster" type:"list"`
 
 	// Provides an identifier to allow retrieval of paginated results.
 	Marker *string `type:"string"`
-
-	_ struct{} `type:"structure"`
 }
 
 // String returns the string representation
@@ -2758,6 +2758,8 @@ func (s DescribeCacheClustersOutput) GoString() string {
 
 // Represents the input of a DescribeCacheEngineVersions action.
 type DescribeCacheEngineVersionsInput struct {
+	_ struct{} `type:"structure"`
+
 	// The name of a specific cache parameter group family to return details for.
 	//
 	// Constraints:
@@ -2791,8 +2793,6 @@ type DescribeCacheEngineVersionsInput struct {
 	//
 	// Constraints: minimum 20; maximum 100.
 	MaxRecords *int64 `type:"integer"`
-
-	_ struct{} `type:"structure"`
 }
 
 // String returns the string representation
@@ -2807,14 +2807,14 @@ func (s DescribeCacheEngineVersionsInput) GoString() string {
 
 // Represents the output of a DescribeCacheEngineVersions action.
 type DescribeCacheEngineVersionsOutput struct {
+	_ struct{} `type:"structure"`
+
 	// A list of cache engine version details. Each element in the list contains
 	// detailed information about one cache engine version.
 	CacheEngineVersions []*CacheEngineVersion `locationNameList:"CacheEngineVersion" type:"list"`
 
 	// Provides an identifier to allow retrieval of paginated results.
 	Marker *string `type:"string"`
-
-	_ struct{} `type:"structure"`
 }
 
 // String returns the string representation
@@ -2829,6 +2829,8 @@ func (s DescribeCacheEngineVersionsOutput) GoString() string {
 
 // Represents the input of a DescribeCacheParameterGroups action.
 type DescribeCacheParameterGroupsInput struct {
+	_ struct{} `type:"structure"`
+
 	// The name of a specific cache parameter group to return details for.
 	CacheParameterGroupName *string `type:"string"`
 
@@ -2845,8 +2847,6 @@ type DescribeCacheParameterGroupsInput struct {
 	//
 	// Constraints: minimum 20; maximum 100.
 	MaxRecords *int64 `type:"integer"`
-
-	_ struct{} `type:"structure"`
 }
 
 // String returns the string representation
@@ -2861,14 +2861,14 @@ func (s DescribeCacheParameterGroupsInput) GoString() string {
 
 // Represents the output of a DescribeCacheParameterGroups action.
 type DescribeCacheParameterGroupsOutput struct {
+	_ struct{} `type:"structure"`
+
 	// A list of cache parameter groups. Each element in the list contains detailed
 	// information about one cache parameter group.
 	CacheParameterGroups []*CacheParameterGroup `locationNameList:"CacheParameterGroup" type:"list"`
 
 	// Provides an identifier to allow retrieval of paginated results.
 	Marker *string `type:"string"`
-
-	_ struct{} `type:"structure"`
 }
 
 // String returns the string representation
@@ -2883,6 +2883,8 @@ func (s DescribeCacheParameterGroupsOutput) GoString() string {
 
 // Represents the input of a DescribeCacheParameters action.
 type DescribeCacheParametersInput struct {
+	_ struct{} `type:"structure"`
+
 	// The name of a specific cache parameter group to return details for.
 	CacheParameterGroupName *string `type:"string" required:"true"`
 
@@ -2904,8 +2906,6 @@ type DescribeCacheParametersInput struct {
 	//
 	// Valid values: user | system | engine-default
 	Source *string `type:"string"`
-
-	_ struct{} `type:"structure"`
 }
 
 // String returns the string representation
@@ -2920,6 +2920,8 @@ func (s DescribeCacheParametersInput) GoString() string {
 
 // Represents the output of a DescribeCacheParameters action.
 type DescribeCacheParametersOutput struct {
+	_ struct{} `type:"structure"`
+
 	// A list of parameters specific to a particular cache node type. Each element
 	// in the list contains detailed information about one parameter.
 	CacheNodeTypeSpecificParameters []*CacheNodeTypeSpecificParameter `locationNameList:"CacheNodeTypeSpecificParameter" type:"list"`
@@ -2929,8 +2931,6 @@ type DescribeCacheParametersOutput struct {
 
 	// A list of Parameter instances.
 	Parameters []*Parameter `locationNameList:"Parameter" type:"list"`
-
-	_ struct{} `type:"structure"`
 }
 
 // String returns the string representation
@@ -2945,6 +2945,8 @@ func (s DescribeCacheParametersOutput) GoString() string {
 
 // Represents the input of a DescribeCacheSecurityGroups action.
 type DescribeCacheSecurityGroupsInput struct {
+	_ struct{} `type:"structure"`
+
 	// The name of the cache security group to return details for.
 	CacheSecurityGroupName *string `type:"string"`
 
@@ -2961,8 +2963,6 @@ type DescribeCacheSecurityGroupsInput struct {
 	//
 	// Constraints: minimum 20; maximum 100.
 	MaxRecords *int64 `type:"integer"`
-
-	_ struct{} `type:"structure"`
 }
 
 // String returns the string representation
@@ -2977,14 +2977,14 @@ func (s DescribeCacheSecurityGroupsInput) GoString() string {
 
 // Represents the output of a DescribeCacheSecurityGroups action.
 type DescribeCacheSecurityGroupsOutput struct {
+	_ struct{} `type:"structure"`
+
 	// A list of cache security groups. Each element in the list contains detailed
 	// information about one group.
 	CacheSecurityGroups []*CacheSecurityGroup `locationNameList:"CacheSecurityGroup" type:"list"`
 
 	// Provides an identifier to allow retrieval of paginated results.
 	Marker *string `type:"string"`
-
-	_ struct{} `type:"structure"`
 }
 
 // String returns the string representation
@@ -2999,6 +2999,8 @@ func (s DescribeCacheSecurityGroupsOutput) GoString() string {
 
 // Represents the input of a DescribeCacheSubnetGroups action.
 type DescribeCacheSubnetGroupsInput struct {
+	_ struct{} `type:"structure"`
+
 	// The name of the cache subnet group to return details for.
 	CacheSubnetGroupName *string `type:"string"`
 
@@ -3015,8 +3017,6 @@ type DescribeCacheSubnetGroupsInput struct {
 	//
 	// Constraints: minimum 20; maximum 100.
 	MaxRecords *int64 `type:"integer"`
-
-	_ struct{} `type:"structure"`
 }
 
 // String returns the string representation
@@ -3031,14 +3031,14 @@ func (s DescribeCacheSubnetGroupsInput) GoString() string {
 
 // Represents the output of a DescribeCacheSubnetGroups action.
 type DescribeCacheSubnetGroupsOutput struct {
+	_ struct{} `type:"structure"`
+
 	// A list of cache subnet groups. Each element in the list contains detailed
 	// information about one group.
 	CacheSubnetGroups []*CacheSubnetGroup `locationNameList:"CacheSubnetGroup" type:"list"`
 
 	// Provides an identifier to allow retrieval of paginated results.
 	Marker *string `type:"string"`
-
-	_ struct{} `type:"structure"`
 }
 
 // String returns the string representation
@@ -3053,6 +3053,8 @@ func (s DescribeCacheSubnetGroupsOutput) GoString() string {
 
 // Represents the input of a DescribeEngineDefaultParameters action.
 type DescribeEngineDefaultParametersInput struct {
+	_ struct{} `type:"structure"`
+
 	// The name of the cache parameter group family. Valid values are: memcached1.4
 	// | redis2.6 | redis2.8
 	CacheParameterGroupFamily *string `type:"string" required:"true"`
@@ -3070,8 +3072,6 @@ type DescribeEngineDefaultParametersInput struct {
 	//
 	// Constraints: minimum 20; maximum 100.
 	MaxRecords *int64 `type:"integer"`
-
-	_ struct{} `type:"structure"`
 }
 
 // String returns the string representation
@@ -3085,10 +3085,10 @@ func (s DescribeEngineDefaultParametersInput) GoString() string {
 }
 
 type DescribeEngineDefaultParametersOutput struct {
+	_ struct{} `type:"structure"`
+
 	// Represents the output of a DescribeEngineDefaultParameters action.
 	EngineDefaults *EngineDefaults `type:"structure"`
-
-	_ struct{} `type:"structure"`
 }
 
 // String returns the string representation
@@ -3103,6 +3103,8 @@ func (s DescribeEngineDefaultParametersOutput) GoString() string {
 
 // Represents the input of a DescribeEvents action.
 type DescribeEventsInput struct {
+	_ struct{} `type:"structure"`
+
 	// The number of minutes' worth of events to retrieve.
 	Duration *int64 `type:"integer"`
 
@@ -3138,8 +3140,6 @@ type DescribeEventsInput struct {
 	// The beginning of the time interval to retrieve events for, specified in ISO
 	// 8601 format.
 	StartTime *time.Time `type:"timestamp" timestampFormat:"iso8601"`
-
-	_ struct{} `type:"structure"`
 }
 
 // String returns the string representation
@@ -3154,14 +3154,14 @@ func (s DescribeEventsInput) GoString() string {
 
 // Represents the output of a DescribeEvents action.
 type DescribeEventsOutput struct {
+	_ struct{} `type:"structure"`
+
 	// A list of events. Each element in the list contains detailed information
 	// about one event.
 	Events []*Event `locationNameList:"Event" type:"list"`
 
 	// Provides an identifier to allow retrieval of paginated results.
 	Marker *string `type:"string"`
-
-	_ struct{} `type:"structure"`
 }
 
 // String returns the string representation
@@ -3176,6 +3176,8 @@ func (s DescribeEventsOutput) GoString() string {
 
 // Represents the input of a DescribeReplicationGroups action.
 type DescribeReplicationGroupsInput struct {
+	_ struct{} `type:"structure"`
+
 	// An optional marker returned from a prior request. Use this marker for pagination
 	// of results from this action. If this parameter is specified, the response
 	// includes only records beyond the marker, up to the value specified by MaxRecords.
@@ -3196,8 +3198,6 @@ type DescribeReplicationGroupsInput struct {
 	// If you do not specify this parameter, information about all replication
 	// groups is returned.
 	ReplicationGroupId *string `type:"string"`
-
-	_ struct{} `type:"structure"`
 }
 
 // String returns the string representation
@@ -3212,14 +3212,14 @@ func (s DescribeReplicationGroupsInput) GoString() string {
 
 // Represents the output of a DescribeReplicationGroups action.
 type DescribeReplicationGroupsOutput struct {
+	_ struct{} `type:"structure"`
+
 	// Provides an identifier to allow retrieval of paginated results.
 	Marker *string `type:"string"`
 
 	// A list of replication groups. Each item in the list contains detailed information
 	// about one replication group.
 	ReplicationGroups []*ReplicationGroup `locationNameList:"ReplicationGroup" type:"list"`
-
-	_ struct{} `type:"structure"`
 }
 
 // String returns the string representation
@@ -3234,6 +3234,8 @@ func (s DescribeReplicationGroupsOutput) GoString() string {
 
 // Represents the input of a DescribeReservedCacheNodes action.
 type DescribeReservedCacheNodesInput struct {
+	_ struct{} `type:"structure"`
+
 	// The cache node type filter value. Use this parameter to show only those reservations
 	// matching the specified cache node type.
 	//
@@ -3293,8 +3295,6 @@ type DescribeReservedCacheNodesInput struct {
 	// The offering identifier filter value. Use this parameter to show only purchased
 	// reservations matching the specified offering identifier.
 	ReservedCacheNodesOfferingId *string `type:"string"`
-
-	_ struct{} `type:"structure"`
 }
 
 // String returns the string representation
@@ -3309,6 +3309,8 @@ func (s DescribeReservedCacheNodesInput) GoString() string {
 
 // Represents the input of a DescribeReservedCacheNodesOfferings action.
 type DescribeReservedCacheNodesOfferingsInput struct {
+	_ struct{} `type:"structure"`
+
 	// The cache node type filter value. Use this parameter to show only the available
 	// offerings matching the specified cache node type.
 	//
@@ -3366,8 +3368,6 @@ type DescribeReservedCacheNodesOfferingsInput struct {
 	//
 	// Example: 438012d3-4052-4cc7-b2e3-8d3372e0e706
 	ReservedCacheNodesOfferingId *string `type:"string"`
-
-	_ struct{} `type:"structure"`
 }
 
 // String returns the string representation
@@ -3382,14 +3382,14 @@ func (s DescribeReservedCacheNodesOfferingsInput) GoString() string {
 
 // Represents the output of a DescribeReservedCacheNodesOfferings action.
 type DescribeReservedCacheNodesOfferingsOutput struct {
+	_ struct{} `type:"structure"`
+
 	// Provides an identifier to allow retrieval of paginated results.
 	Marker *string `type:"string"`
 
 	// A list of reserved cache node offerings. Each element in the list contains
 	// detailed information about one offering.
 	ReservedCacheNodesOfferings []*ReservedCacheNodesOffering `locationNameList:"ReservedCacheNodesOffering" type:"list"`
-
-	_ struct{} `type:"structure"`
 }
 
 // String returns the string representation
@@ -3404,14 +3404,14 @@ func (s DescribeReservedCacheNodesOfferingsOutput) GoString() string {
 
 // Represents the output of a DescribeReservedCacheNodes action.
 type DescribeReservedCacheNodesOutput struct {
+	_ struct{} `type:"structure"`
+
 	// Provides an identifier to allow retrieval of paginated results.
 	Marker *string `type:"string"`
 
 	// A list of reserved cache nodes. Each element in the list contains detailed
 	// information about one node.
 	ReservedCacheNodes []*ReservedCacheNode `locationNameList:"ReservedCacheNode" type:"list"`
-
-	_ struct{} `type:"structure"`
 }
 
 // String returns the string representation
@@ -3426,6 +3426,8 @@ func (s DescribeReservedCacheNodesOutput) GoString() string {
 
 // Represents the input of a DescribeSnapshotsMessage action.
 type DescribeSnapshotsInput struct {
+	_ struct{} `type:"structure"`
+
 	// A user-supplied cluster identifier. If this parameter is specified, only
 	// snapshots associated with that specific cache cluster will be described.
 	CacheClusterId *string `type:"string"`
@@ -3453,8 +3455,6 @@ type DescribeSnapshotsInput struct {
 	// created. If omitted, the output shows both automatically and manually created
 	// snapshots.
 	SnapshotSource *string `type:"string"`
-
-	_ struct{} `type:"structure"`
 }
 
 // String returns the string representation
@@ -3469,6 +3469,8 @@ func (s DescribeSnapshotsInput) GoString() string {
 
 // Represents the output of a DescribeSnapshots action.
 type DescribeSnapshotsOutput struct {
+	_ struct{} `type:"structure"`
+
 	// An optional marker returned from a prior request. Use this marker for pagination
 	// of results from this action. If this parameter is specified, the response
 	// includes only records beyond the marker, up to the value specified by MaxRecords.
@@ -3477,8 +3479,6 @@ type DescribeSnapshotsOutput struct {
 	// A list of snapshots. Each item in the list contains detailed information
 	// about one snapshot.
 	Snapshots []*Snapshot `locationNameList:"Snapshot" type:"list"`
-
-	_ struct{} `type:"structure"`
 }
 
 // String returns the string representation
@@ -3493,6 +3493,8 @@ func (s DescribeSnapshotsOutput) GoString() string {
 
 // Provides ownership and status information for an Amazon EC2 security group.
 type EC2SecurityGroup struct {
+	_ struct{} `type:"structure"`
+
 	// The name of the Amazon EC2 security group.
 	EC2SecurityGroupName *string `type:"string"`
 
@@ -3501,8 +3503,6 @@ type EC2SecurityGroup struct {
 
 	// The status of the Amazon EC2 security group.
 	Status *string `type:"string"`
-
-	_ struct{} `type:"structure"`
 }
 
 // String returns the string representation
@@ -3518,13 +3518,13 @@ func (s EC2SecurityGroup) GoString() string {
 // Represents the information required for client programs to connect to a cache
 // node.
 type Endpoint struct {
+	_ struct{} `type:"structure"`
+
 	// The DNS hostname of the cache node.
 	Address *string `type:"string"`
 
 	// The port number that the cache engine is listening on.
 	Port *int64 `type:"integer"`
-
-	_ struct{} `type:"structure"`
 }
 
 // String returns the string representation
@@ -3539,6 +3539,8 @@ func (s Endpoint) GoString() string {
 
 // Represents the output of a DescribeEngineDefaultParameters action.
 type EngineDefaults struct {
+	_ struct{} `type:"structure"`
+
 	// A list of parameters specific to a particular cache node type. Each element
 	// in the list contains detailed information about one parameter.
 	CacheNodeTypeSpecificParameters []*CacheNodeTypeSpecificParameter `locationNameList:"CacheNodeTypeSpecificParameter" type:"list"`
@@ -3552,8 +3554,6 @@ type EngineDefaults struct {
 
 	// Contains a list of engine default parameters.
 	Parameters []*Parameter `locationNameList:"Parameter" type:"list"`
-
-	_ struct{} `type:"structure"`
 }
 
 // String returns the string representation
@@ -3570,6 +3570,8 @@ func (s EngineDefaults) GoString() string {
 // Some examples of events are creating a cache cluster, adding or removing
 // a cache node, or rebooting a node.
 type Event struct {
+	_ struct{} `type:"structure"`
+
 	// The date and time when the event occurred.
 	Date *time.Time `type:"timestamp" timestampFormat:"iso8601"`
 
@@ -3584,8 +3586,6 @@ type Event struct {
 	// Specifies the origin of this event - a cache cluster, a parameter group,
 	// a security group, etc.
 	SourceType *string `type:"string" enum:"SourceType"`
-
-	_ struct{} `type:"structure"`
 }
 
 // String returns the string representation
@@ -3600,11 +3600,11 @@ func (s Event) GoString() string {
 
 // The input parameters for the ListTagsForResource action.
 type ListTagsForResourceInput struct {
+	_ struct{} `type:"structure"`
+
 	// The name of the resource for which you want the list of tags, for example
 	// arn:aws:elasticache:us-west-2:0123456789:cluster:myCluster.
 	ResourceName *string `type:"string" required:"true"`
-
-	_ struct{} `type:"structure"`
 }
 
 // String returns the string representation
@@ -3619,6 +3619,8 @@ func (s ListTagsForResourceInput) GoString() string {
 
 // Represents the input of a ModifyCacheCluster action.
 type ModifyCacheClusterInput struct {
+	_ struct{} `type:"structure"`
+
 	// Specifies whether the new nodes in this Memcached cache cluster are all created
 	// in a single Availability Zone or created across multiple Availability Zones.
 	//
@@ -3796,8 +3798,6 @@ type ModifyCacheClusterInput struct {
 	// The daily time range (in UTC) during which ElastiCache will begin taking
 	// a daily snapshot of your cache cluster.
 	SnapshotWindow *string `type:"string"`
-
-	_ struct{} `type:"structure"`
 }
 
 // String returns the string representation
@@ -3811,10 +3811,10 @@ func (s ModifyCacheClusterInput) GoString() string {
 }
 
 type ModifyCacheClusterOutput struct {
+	_ struct{} `type:"structure"`
+
 	// Contains all of the attributes of a specific cache cluster.
 	CacheCluster *CacheCluster `type:"structure"`
-
-	_ struct{} `type:"structure"`
 }
 
 // String returns the string representation
@@ -3829,6 +3829,8 @@ func (s ModifyCacheClusterOutput) GoString() string {
 
 // Represents the input of a ModifyCacheParameterGroup action.
 type ModifyCacheParameterGroupInput struct {
+	_ struct{} `type:"structure"`
+
 	// The name of the cache parameter group to modify.
 	CacheParameterGroupName *string `type:"string" required:"true"`
 
@@ -3836,8 +3838,6 @@ type ModifyCacheParameterGroupInput struct {
 	// supply at least one parameter name and value; subsequent arguments are optional.
 	// A maximum of 20 parameters may be modified per request.
 	ParameterNameValues []*ParameterNameValue `locationNameList:"ParameterNameValue" type:"list" required:"true"`
-
-	_ struct{} `type:"structure"`
 }
 
 // String returns the string representation
@@ -3852,6 +3852,8 @@ func (s ModifyCacheParameterGroupInput) GoString() string {
 
 // Represents the input of a ModifyCacheSubnetGroup action.
 type ModifyCacheSubnetGroupInput struct {
+	_ struct{} `type:"structure"`
+
 	// A description for the cache subnet group.
 	CacheSubnetGroupDescription *string `type:"string"`
 
@@ -3865,8 +3867,6 @@ type ModifyCacheSubnetGroupInput struct {
 
 	// The EC2 subnet IDs for the cache subnet group.
 	SubnetIds []*string `locationNameList:"SubnetIdentifier" type:"list"`
-
-	_ struct{} `type:"structure"`
 }
 
 // String returns the string representation
@@ -3880,12 +3880,12 @@ func (s ModifyCacheSubnetGroupInput) GoString() string {
 }
 
 type ModifyCacheSubnetGroupOutput struct {
+	_ struct{} `type:"structure"`
+
 	// Represents the output of one of the following actions:
 	//
 	//   CreateCacheSubnetGroup   ModifyCacheSubnetGroup
 	CacheSubnetGroup *CacheSubnetGroup `type:"structure"`
-
-	_ struct{} `type:"structure"`
 }
 
 // String returns the string representation
@@ -3900,6 +3900,8 @@ func (s ModifyCacheSubnetGroupOutput) GoString() string {
 
 // Represents the input of a ModifyReplicationGroups action.
 type ModifyReplicationGroupInput struct {
+	_ struct{} `type:"structure"`
+
 	// If true, this parameter causes the modifications in this request and any
 	// pending modifications to be applied, asynchronously and as soon as possible,
 	// regardless of the PreferredMaintenanceWindow setting for the replication
@@ -4006,8 +4008,6 @@ type ModifyReplicationGroupInput struct {
 	// The cache cluster ID that will be used as the daily snapshot source for the
 	// replication group.
 	SnapshottingClusterId *string `type:"string"`
-
-	_ struct{} `type:"structure"`
 }
 
 // String returns the string representation
@@ -4021,10 +4021,10 @@ func (s ModifyReplicationGroupInput) GoString() string {
 }
 
 type ModifyReplicationGroupOutput struct {
+	_ struct{} `type:"structure"`
+
 	// Contains all of the attributes of a specific replication group.
 	ReplicationGroup *ReplicationGroup `type:"structure"`
-
-	_ struct{} `type:"structure"`
 }
 
 // String returns the string representation
@@ -4039,6 +4039,8 @@ func (s ModifyReplicationGroupOutput) GoString() string {
 
 // Represents a collection of cache nodes in a replication group.
 type NodeGroup struct {
+	_ struct{} `type:"structure"`
+
 	// The identifier for the node group. A replication group contains only one
 	// node group; therefore, the node group ID is 0001.
 	NodeGroupId *string `type:"string"`
@@ -4052,8 +4054,6 @@ type NodeGroup struct {
 
 	// The current state of this replication group - creating, available, etc.
 	Status *string `type:"string"`
-
-	_ struct{} `type:"structure"`
 }
 
 // String returns the string representation
@@ -4068,6 +4068,8 @@ func (s NodeGroup) GoString() string {
 
 // Represents a single node within a node group.
 type NodeGroupMember struct {
+	_ struct{} `type:"structure"`
+
 	// The ID of the cache cluster to which the node belongs.
 	CacheClusterId *string `type:"string"`
 
@@ -4084,8 +4086,6 @@ type NodeGroupMember struct {
 	// Represents the information required for client programs to connect to a cache
 	// node.
 	ReadEndpoint *Endpoint `type:"structure"`
-
-	_ struct{} `type:"structure"`
 }
 
 // String returns the string representation
@@ -4100,6 +4100,8 @@ func (s NodeGroupMember) GoString() string {
 
 // Represents an individual cache node in a snapshot of a cache cluster.
 type NodeSnapshot struct {
+	_ struct{} `type:"structure"`
+
 	// The date and time when the cache node was created in the source cache cluster.
 	CacheNodeCreateTime *time.Time `type:"timestamp" timestampFormat:"iso8601"`
 
@@ -4112,8 +4114,6 @@ type NodeSnapshot struct {
 	// The date and time when the source node's metadata and cache data set was
 	// obtained for the snapshot.
 	SnapshotCreateTime *time.Time `type:"timestamp" timestampFormat:"iso8601"`
-
-	_ struct{} `type:"structure"`
 }
 
 // String returns the string representation
@@ -4130,13 +4130,13 @@ func (s NodeSnapshot) GoString() string {
 // for publishing ElastiCache events to subscribers using Amazon Simple Notification
 // Service (SNS).
 type NotificationConfiguration struct {
+	_ struct{} `type:"structure"`
+
 	// The Amazon Resource Name (ARN) that identifies the topic.
 	TopicArn *string `type:"string"`
 
 	// The current state of the topic.
 	TopicStatus *string `type:"string"`
-
-	_ struct{} `type:"structure"`
 }
 
 // String returns the string representation
@@ -4152,6 +4152,8 @@ func (s NotificationConfiguration) GoString() string {
 // Describes an individual setting that controls some aspect of ElastiCache
 // behavior.
 type Parameter struct {
+	_ struct{} `type:"structure"`
+
 	// The valid range of values for the parameter.
 	AllowedValues *string `type:"string"`
 
@@ -4177,8 +4179,6 @@ type Parameter struct {
 
 	// The source of the parameter.
 	Source *string `type:"string"`
-
-	_ struct{} `type:"structure"`
 }
 
 // String returns the string representation
@@ -4193,13 +4193,13 @@ func (s Parameter) GoString() string {
 
 // Describes a name-value pair that is used to update the value of a parameter.
 type ParameterNameValue struct {
+	_ struct{} `type:"structure"`
+
 	// The name of the parameter.
 	ParameterName *string `type:"string"`
 
 	// The value of the parameter.
 	ParameterValue *string `type:"string"`
-
-	_ struct{} `type:"structure"`
 }
 
 // String returns the string representation
@@ -4215,6 +4215,8 @@ func (s ParameterNameValue) GoString() string {
 // A group of settings that will be applied to the cache cluster in the future,
 // or that are currently being applied.
 type PendingModifiedValues struct {
+	_ struct{} `type:"structure"`
+
 	// A list of cache node IDs that are being removed (or will be removed) from
 	// the cache cluster. A node ID is a numeric identifier (0001, 0002, etc.).
 	CacheNodeIdsToRemove []*string `locationNameList:"CacheNodeId" type:"list"`
@@ -4227,8 +4229,6 @@ type PendingModifiedValues struct {
 	// For clusters running Redis, this value must be 1. For clusters running Memcached,
 	// this value must be between 1 and 20.
 	NumCacheNodes *int64 `type:"integer"`
-
-	_ struct{} `type:"structure"`
 }
 
 // String returns the string representation
@@ -4243,6 +4243,8 @@ func (s PendingModifiedValues) GoString() string {
 
 // Represents the input of a PurchaseReservedCacheNodesOffering action.
 type PurchaseReservedCacheNodesOfferingInput struct {
+	_ struct{} `type:"structure"`
+
 	// The number of cache node instances to reserve.
 	//
 	// Default: 1
@@ -4257,8 +4259,6 @@ type PurchaseReservedCacheNodesOfferingInput struct {
 	//
 	// Example: 438012d3-4052-4cc7-b2e3-8d3372e0e706
 	ReservedCacheNodesOfferingId *string `type:"string" required:"true"`
-
-	_ struct{} `type:"structure"`
 }
 
 // String returns the string representation
@@ -4272,10 +4272,10 @@ func (s PurchaseReservedCacheNodesOfferingInput) GoString() string {
 }
 
 type PurchaseReservedCacheNodesOfferingOutput struct {
+	_ struct{} `type:"structure"`
+
 	// Represents the output of a PurchaseReservedCacheNodesOffering action.
 	ReservedCacheNode *ReservedCacheNode `type:"structure"`
-
-	_ struct{} `type:"structure"`
 }
 
 // String returns the string representation
@@ -4290,6 +4290,8 @@ func (s PurchaseReservedCacheNodesOfferingOutput) GoString() string {
 
 // Represents the input of a RebootCacheCluster action.
 type RebootCacheClusterInput struct {
+	_ struct{} `type:"structure"`
+
 	// The cache cluster identifier. This parameter is stored as a lowercase string.
 	CacheClusterId *string `type:"string" required:"true"`
 
@@ -4297,8 +4299,6 @@ type RebootCacheClusterInput struct {
 	// 0002, etc.). To reboot an entire cache cluster, specify all of the cache
 	// node IDs.
 	CacheNodeIdsToReboot []*string `locationNameList:"CacheNodeId" type:"list" required:"true"`
-
-	_ struct{} `type:"structure"`
 }
 
 // String returns the string representation
@@ -4312,10 +4312,10 @@ func (s RebootCacheClusterInput) GoString() string {
 }
 
 type RebootCacheClusterOutput struct {
+	_ struct{} `type:"structure"`
+
 	// Contains all of the attributes of a specific cache cluster.
 	CacheCluster *CacheCluster `type:"structure"`
-
-	_ struct{} `type:"structure"`
 }
 
 // String returns the string representation
@@ -4331,13 +4331,13 @@ func (s RebootCacheClusterOutput) GoString() string {
 // Contains the specific price and frequency of a recurring charges for a reserved
 // cache node, or for a reserved cache node offering.
 type RecurringCharge struct {
+	_ struct{} `type:"structure"`
+
 	// The monetary amount of the recurring charge.
 	RecurringChargeAmount *float64 `type:"double"`
 
 	// The frequency of the recurring charge.
 	RecurringChargeFrequency *string `type:"string"`
-
-	_ struct{} `type:"structure"`
 }
 
 // String returns the string representation
@@ -4352,6 +4352,8 @@ func (s RecurringCharge) GoString() string {
 
 // Represents the input of a RemoveTagsFromResource action.
 type RemoveTagsFromResourceInput struct {
+	_ struct{} `type:"structure"`
+
 	// The name of the ElastiCache resource from which you want the listed tags
 	// removed, for example arn:aws:elasticache:us-west-2:0123456789:cluster:myCluster.
 	ResourceName *string `type:"string" required:"true"`
@@ -4360,8 +4362,6 @@ type RemoveTagsFromResourceInput struct {
 	// For example, TagKeys.member.1=Region removes the cost allocation tag with
 	// the key name Region from the resource named by the ResourceName parameter.
 	TagKeys []*string `type:"list" required:"true"`
-
-	_ struct{} `type:"structure"`
 }
 
 // String returns the string representation
@@ -4376,6 +4376,8 @@ func (s RemoveTagsFromResourceInput) GoString() string {
 
 // Contains all of the attributes of a specific replication group.
 type ReplicationGroup struct {
+	_ struct{} `type:"structure"`
+
 	// Indicates the status of Multi-AZ for this replication group.
 	//
 	// ElastiCache Multi-AZ replication groups are not supported on:
@@ -4406,8 +4408,6 @@ type ReplicationGroup struct {
 
 	// The current state of this replication group - creating, available, etc.
 	Status *string `type:"string"`
-
-	_ struct{} `type:"structure"`
 }
 
 // String returns the string representation
@@ -4423,6 +4423,8 @@ func (s ReplicationGroup) GoString() string {
 // The settings to be applied to the replication group, either immediately or
 // during the next maintenance window.
 type ReplicationGroupPendingModifiedValues struct {
+	_ struct{} `type:"structure"`
+
 	// Indicates the status of Multi-AZ for this replication group.
 	//
 	// ElastiCache Multi-AZ replication groups are not supported on:
@@ -4433,8 +4435,6 @@ type ReplicationGroupPendingModifiedValues struct {
 	// The primary cluster ID which will be applied immediately (if --apply-immediately
 	// was specified), or during the next maintenance window.
 	PrimaryClusterId *string `type:"string"`
-
-	_ struct{} `type:"structure"`
 }
 
 // String returns the string representation
@@ -4449,6 +4449,8 @@ func (s ReplicationGroupPendingModifiedValues) GoString() string {
 
 // Represents the output of a PurchaseReservedCacheNodesOffering action.
 type ReservedCacheNode struct {
+	_ struct{} `type:"structure"`
+
 	// The number of cache nodes that have been reserved.
 	CacheNodeCount *int64 `type:"integer"`
 
@@ -4502,8 +4504,6 @@ type ReservedCacheNode struct {
 
 	// The hourly price charged for this reserved cache node.
 	UsagePrice *float64 `type:"double"`
-
-	_ struct{} `type:"structure"`
 }
 
 // String returns the string representation
@@ -4518,6 +4518,8 @@ func (s ReservedCacheNode) GoString() string {
 
 // Describes all of the attributes of a reserved cache node offering.
 type ReservedCacheNodesOffering struct {
+	_ struct{} `type:"structure"`
+
 	// The cache node type for the reserved cache node.
 	//
 	// Valid node types are as follows:
@@ -4559,8 +4561,6 @@ type ReservedCacheNodesOffering struct {
 
 	// The hourly price charged for this offering.
 	UsagePrice *float64 `type:"double"`
-
-	_ struct{} `type:"structure"`
 }
 
 // String returns the string representation
@@ -4575,6 +4575,8 @@ func (s ReservedCacheNodesOffering) GoString() string {
 
 // Represents the input of a ResetCacheParameterGroup action.
 type ResetCacheParameterGroupInput struct {
+	_ struct{} `type:"structure"`
+
 	// The name of the cache parameter group to reset.
 	CacheParameterGroupName *string `type:"string" required:"true"`
 
@@ -4587,8 +4589,6 @@ type ResetCacheParameterGroupInput struct {
 	//
 	// Valid values: true | false
 	ResetAllParameters *bool `type:"boolean"`
-
-	_ struct{} `type:"structure"`
 }
 
 // String returns the string representation
@@ -4603,6 +4603,8 @@ func (s ResetCacheParameterGroupInput) GoString() string {
 
 // Represents the input of a RevokeCacheSecurityGroupIngress action.
 type RevokeCacheSecurityGroupIngressInput struct {
+	_ struct{} `type:"structure"`
+
 	// The name of the cache security group to revoke ingress from.
 	CacheSecurityGroupName *string `type:"string" required:"true"`
 
@@ -4613,8 +4615,6 @@ type RevokeCacheSecurityGroupIngressInput struct {
 	// this is not the same thing as an AWS access key ID - you must provide a valid
 	// AWS account number for this parameter.
 	EC2SecurityGroupOwnerId *string `type:"string" required:"true"`
-
-	_ struct{} `type:"structure"`
 }
 
 // String returns the string representation
@@ -4628,12 +4628,12 @@ func (s RevokeCacheSecurityGroupIngressInput) GoString() string {
 }
 
 type RevokeCacheSecurityGroupIngressOutput struct {
+	_ struct{} `type:"structure"`
+
 	// Represents the output of one of the following actions:
 	//
 	//   AuthorizeCacheSecurityGroupIngress   CreateCacheSecurityGroup   RevokeCacheSecurityGroupIngress
 	CacheSecurityGroup *CacheSecurityGroup `type:"structure"`
-
-	_ struct{} `type:"structure"`
 }
 
 // String returns the string representation
@@ -4648,6 +4648,8 @@ func (s RevokeCacheSecurityGroupIngressOutput) GoString() string {
 
 // Represents a single cache security group and its status.
 type SecurityGroupMembership struct {
+	_ struct{} `type:"structure"`
+
 	// The identifier of the cache security group.
 	SecurityGroupId *string `type:"string"`
 
@@ -4655,8 +4657,6 @@ type SecurityGroupMembership struct {
 	// a cache security group is modified, or when the cache security groups assigned
 	// to a cache cluster are modified.
 	Status *string `type:"string"`
-
-	_ struct{} `type:"structure"`
 }
 
 // String returns the string representation
@@ -4672,6 +4672,8 @@ func (s SecurityGroupMembership) GoString() string {
 // Represents a copy of an entire cache cluster as of the time when the snapshot
 // was taken.
 type Snapshot struct {
+	_ struct{} `type:"structure"`
+
 	// This parameter is currently disabled.
 	AutoMinorVersionUpgrade *bool `type:"boolean"`
 
@@ -4775,8 +4777,6 @@ type Snapshot struct {
 	// The Amazon Virtual Private Cloud identifier (VPC ID) of the cache subnet
 	// group for the source cache cluster.
 	VpcId *string `type:"string"`
-
-	_ struct{} `type:"structure"`
 }
 
 // String returns the string representation
@@ -4793,13 +4793,13 @@ func (s Snapshot) GoString() string {
 // to subnets defined in Amazon Virtual Private Cloud (Amazon VPC) and used
 // with ElastiCache.
 type Subnet struct {
+	_ struct{} `type:"structure"`
+
 	// The Availability Zone associated with the subnet.
 	SubnetAvailabilityZone *AvailabilityZone `type:"structure"`
 
 	// The unique identifier for the subnet.
 	SubnetIdentifier *string `type:"string"`
-
-	_ struct{} `type:"structure"`
 }
 
 // String returns the string representation
@@ -4816,13 +4816,13 @@ func (s Subnet) GoString() string {
 // group. Tags are composed of a Key/Value pair. A tag with a null Value is
 // permitted.
 type Tag struct {
+	_ struct{} `type:"structure"`
+
 	// The key for the tag.
 	Key *string `type:"string"`
 
 	// The tag's value. May not be null.
 	Value *string `type:"string"`
-
-	_ struct{} `type:"structure"`
 }
 
 // String returns the string representation
@@ -4838,10 +4838,10 @@ func (s Tag) GoString() string {
 // Represents the output from the AddTagsToResource, ListTagsOnResource, and
 // RemoveTagsFromResource actions.
 type TagListMessage struct {
+	_ struct{} `type:"structure"`
+
 	// A list of cost allocation tags as key-value pairs.
 	TagList []*Tag `locationNameList:"Tag" type:"list"`
-
-	_ struct{} `type:"structure"`
 }
 
 // String returns the string representation

--- a/service/elasticache/api.go
+++ b/service/elasticache/api.go
@@ -1320,11 +1320,7 @@ type AddTagsToResourceInput struct {
 	// pair. A tag key must be accompanied by a tag value.
 	Tags []*Tag `locationNameList:"Tag" type:"list" required:"true"`
 
-	metadataAddTagsToResourceInput `json:"-" xml:"-"`
-}
-
-type metadataAddTagsToResourceInput struct {
-	SDKShapeTraits bool `type:"structure"`
+	_ struct{} `type:"structure"`
 }
 
 // String returns the string representation
@@ -1351,11 +1347,7 @@ type AuthorizeCacheSecurityGroupIngressInput struct {
 	// AWS account number for this parameter.
 	EC2SecurityGroupOwnerId *string `type:"string" required:"true"`
 
-	metadataAuthorizeCacheSecurityGroupIngressInput `json:"-" xml:"-"`
-}
-
-type metadataAuthorizeCacheSecurityGroupIngressInput struct {
-	SDKShapeTraits bool `type:"structure"`
+	_ struct{} `type:"structure"`
 }
 
 // String returns the string representation
@@ -1374,11 +1366,7 @@ type AuthorizeCacheSecurityGroupIngressOutput struct {
 	//   AuthorizeCacheSecurityGroupIngress   CreateCacheSecurityGroup   RevokeCacheSecurityGroupIngress
 	CacheSecurityGroup *CacheSecurityGroup `type:"structure"`
 
-	metadataAuthorizeCacheSecurityGroupIngressOutput `json:"-" xml:"-"`
-}
-
-type metadataAuthorizeCacheSecurityGroupIngressOutput struct {
-	SDKShapeTraits bool `type:"structure"`
+	_ struct{} `type:"structure"`
 }
 
 // String returns the string representation
@@ -1396,11 +1384,7 @@ type AvailabilityZone struct {
 	// The name of the Availability Zone.
 	Name *string `type:"string"`
 
-	metadataAvailabilityZone `json:"-" xml:"-"`
-}
-
-type metadataAvailabilityZone struct {
-	SDKShapeTraits bool `type:"structure"`
+	_ struct{} `type:"structure"`
 }
 
 // String returns the string representation
@@ -1527,11 +1511,7 @@ type CacheCluster struct {
 	// Example: 05:00-09:00
 	SnapshotWindow *string `type:"string"`
 
-	metadataCacheCluster `json:"-" xml:"-"`
-}
-
-type metadataCacheCluster struct {
-	SDKShapeTraits bool `type:"structure"`
+	_ struct{} `type:"structure"`
 }
 
 // String returns the string representation
@@ -1561,11 +1541,7 @@ type CacheEngineVersion struct {
 	// The version number of the cache engine.
 	EngineVersion *string `type:"string"`
 
-	metadataCacheEngineVersion `json:"-" xml:"-"`
-}
-
-type metadataCacheEngineVersion struct {
-	SDKShapeTraits bool `type:"structure"`
+	_ struct{} `type:"structure"`
 }
 
 // String returns the string representation
@@ -1625,11 +1601,7 @@ type CacheNode struct {
 	// cluster.
 	SourceCacheNodeId *string `type:"string"`
 
-	metadataCacheNode `json:"-" xml:"-"`
-}
-
-type metadataCacheNode struct {
-	SDKShapeTraits bool `type:"structure"`
+	_ struct{} `type:"structure"`
 }
 
 // String returns the string representation
@@ -1672,11 +1644,7 @@ type CacheNodeTypeSpecificParameter struct {
 	// The source of the parameter value.
 	Source *string `type:"string"`
 
-	metadataCacheNodeTypeSpecificParameter `json:"-" xml:"-"`
-}
-
-type metadataCacheNodeTypeSpecificParameter struct {
-	SDKShapeTraits bool `type:"structure"`
+	_ struct{} `type:"structure"`
 }
 
 // String returns the string representation
@@ -1697,11 +1665,7 @@ type CacheNodeTypeSpecificValue struct {
 	// The value for the cache node type.
 	Value *string `type:"string"`
 
-	metadataCacheNodeTypeSpecificValue `json:"-" xml:"-"`
-}
-
-type metadataCacheNodeTypeSpecificValue struct {
-	SDKShapeTraits bool `type:"structure"`
+	_ struct{} `type:"structure"`
 }
 
 // String returns the string representation
@@ -1726,11 +1690,7 @@ type CacheParameterGroup struct {
 	// The description for this cache parameter group.
 	Description *string `type:"string"`
 
-	metadataCacheParameterGroup `json:"-" xml:"-"`
-}
-
-type metadataCacheParameterGroup struct {
-	SDKShapeTraits bool `type:"structure"`
+	_ struct{} `type:"structure"`
 }
 
 // String returns the string representation
@@ -1750,11 +1710,7 @@ type CacheParameterGroupNameMessage struct {
 	// The name of the cache parameter group.
 	CacheParameterGroupName *string `type:"string"`
 
-	metadataCacheParameterGroupNameMessage `json:"-" xml:"-"`
-}
-
-type metadataCacheParameterGroupNameMessage struct {
-	SDKShapeTraits bool `type:"structure"`
+	_ struct{} `type:"structure"`
 }
 
 // String returns the string representation
@@ -1779,11 +1735,7 @@ type CacheParameterGroupStatus struct {
 	// The status of parameter updates.
 	ParameterApplyStatus *string `type:"string"`
 
-	metadataCacheParameterGroupStatus `json:"-" xml:"-"`
-}
-
-type metadataCacheParameterGroupStatus struct {
-	SDKShapeTraits bool `type:"structure"`
+	_ struct{} `type:"structure"`
 }
 
 // String returns the string representation
@@ -1813,11 +1765,7 @@ type CacheSecurityGroup struct {
 	// The AWS account ID of the cache security group owner.
 	OwnerId *string `type:"string"`
 
-	metadataCacheSecurityGroup `json:"-" xml:"-"`
-}
-
-type metadataCacheSecurityGroup struct {
-	SDKShapeTraits bool `type:"structure"`
+	_ struct{} `type:"structure"`
 }
 
 // String returns the string representation
@@ -1840,11 +1788,7 @@ type CacheSecurityGroupMembership struct {
 	// to a cache cluster are modified.
 	Status *string `type:"string"`
 
-	metadataCacheSecurityGroupMembership `json:"-" xml:"-"`
-}
-
-type metadataCacheSecurityGroupMembership struct {
-	SDKShapeTraits bool `type:"structure"`
+	_ struct{} `type:"structure"`
 }
 
 // String returns the string representation
@@ -1874,11 +1818,7 @@ type CacheSubnetGroup struct {
 	// group.
 	VpcId *string `type:"string"`
 
-	metadataCacheSubnetGroup `json:"-" xml:"-"`
-}
-
-type metadataCacheSubnetGroup struct {
-	SDKShapeTraits bool `type:"structure"`
+	_ struct{} `type:"structure"`
 }
 
 // String returns the string representation
@@ -1899,11 +1839,7 @@ type CopySnapshotInput struct {
 	// A name for the copied snapshot.
 	TargetSnapshotName *string `type:"string" required:"true"`
 
-	metadataCopySnapshotInput `json:"-" xml:"-"`
-}
-
-type metadataCopySnapshotInput struct {
-	SDKShapeTraits bool `type:"structure"`
+	_ struct{} `type:"structure"`
 }
 
 // String returns the string representation
@@ -1921,11 +1857,7 @@ type CopySnapshotOutput struct {
 	// was taken.
 	Snapshot *Snapshot `type:"structure"`
 
-	metadataCopySnapshotOutput `json:"-" xml:"-"`
-}
-
-type metadataCopySnapshotOutput struct {
-	SDKShapeTraits bool `type:"structure"`
+	_ struct{} `type:"structure"`
 }
 
 // String returns the string representation
@@ -2130,11 +2062,7 @@ type CreateCacheClusterInput struct {
 	// pair. A tag key must be accompanied by a tag value.
 	Tags []*Tag `locationNameList:"Tag" type:"list"`
 
-	metadataCreateCacheClusterInput `json:"-" xml:"-"`
-}
-
-type metadataCreateCacheClusterInput struct {
-	SDKShapeTraits bool `type:"structure"`
+	_ struct{} `type:"structure"`
 }
 
 // String returns the string representation
@@ -2151,11 +2079,7 @@ type CreateCacheClusterOutput struct {
 	// Contains all of the attributes of a specific cache cluster.
 	CacheCluster *CacheCluster `type:"structure"`
 
-	metadataCreateCacheClusterOutput `json:"-" xml:"-"`
-}
-
-type metadataCreateCacheClusterOutput struct {
-	SDKShapeTraits bool `type:"structure"`
+	_ struct{} `type:"structure"`
 }
 
 // String returns the string representation
@@ -2182,11 +2106,7 @@ type CreateCacheParameterGroupInput struct {
 	// A user-specified description for the cache parameter group.
 	Description *string `type:"string" required:"true"`
 
-	metadataCreateCacheParameterGroupInput `json:"-" xml:"-"`
-}
-
-type metadataCreateCacheParameterGroupInput struct {
-	SDKShapeTraits bool `type:"structure"`
+	_ struct{} `type:"structure"`
 }
 
 // String returns the string representation
@@ -2203,11 +2123,7 @@ type CreateCacheParameterGroupOutput struct {
 	// Represents the output of a CreateCacheParameterGroup action.
 	CacheParameterGroup *CacheParameterGroup `type:"structure"`
 
-	metadataCreateCacheParameterGroupOutput `json:"-" xml:"-"`
-}
-
-type metadataCreateCacheParameterGroupOutput struct {
-	SDKShapeTraits bool `type:"structure"`
+	_ struct{} `type:"structure"`
 }
 
 // String returns the string representation
@@ -2234,11 +2150,7 @@ type CreateCacheSecurityGroupInput struct {
 	// A description for the cache security group.
 	Description *string `type:"string" required:"true"`
 
-	metadataCreateCacheSecurityGroupInput `json:"-" xml:"-"`
-}
-
-type metadataCreateCacheSecurityGroupInput struct {
-	SDKShapeTraits bool `type:"structure"`
+	_ struct{} `type:"structure"`
 }
 
 // String returns the string representation
@@ -2257,11 +2169,7 @@ type CreateCacheSecurityGroupOutput struct {
 	//   AuthorizeCacheSecurityGroupIngress   CreateCacheSecurityGroup   RevokeCacheSecurityGroupIngress
 	CacheSecurityGroup *CacheSecurityGroup `type:"structure"`
 
-	metadataCreateCacheSecurityGroupOutput `json:"-" xml:"-"`
-}
-
-type metadataCreateCacheSecurityGroupOutput struct {
-	SDKShapeTraits bool `type:"structure"`
+	_ struct{} `type:"structure"`
 }
 
 // String returns the string representation
@@ -2289,11 +2197,7 @@ type CreateCacheSubnetGroupInput struct {
 	// A list of VPC subnet IDs for the cache subnet group.
 	SubnetIds []*string `locationNameList:"SubnetIdentifier" type:"list" required:"true"`
 
-	metadataCreateCacheSubnetGroupInput `json:"-" xml:"-"`
-}
-
-type metadataCreateCacheSubnetGroupInput struct {
-	SDKShapeTraits bool `type:"structure"`
+	_ struct{} `type:"structure"`
 }
 
 // String returns the string representation
@@ -2312,11 +2216,7 @@ type CreateCacheSubnetGroupOutput struct {
 	//   CreateCacheSubnetGroup   ModifyCacheSubnetGroup
 	CacheSubnetGroup *CacheSubnetGroup `type:"structure"`
 
-	metadataCreateCacheSubnetGroupOutput `json:"-" xml:"-"`
-}
-
-type metadataCreateCacheSubnetGroupOutput struct {
-	SDKShapeTraits bool `type:"structure"`
+	_ struct{} `type:"structure"`
 }
 
 // String returns the string representation
@@ -2500,11 +2400,7 @@ type CreateReplicationGroupInput struct {
 	// pair. A tag key must be accompanied by a tag value.
 	Tags []*Tag `locationNameList:"Tag" type:"list"`
 
-	metadataCreateReplicationGroupInput `json:"-" xml:"-"`
-}
-
-type metadataCreateReplicationGroupInput struct {
-	SDKShapeTraits bool `type:"structure"`
+	_ struct{} `type:"structure"`
 }
 
 // String returns the string representation
@@ -2521,11 +2417,7 @@ type CreateReplicationGroupOutput struct {
 	// Contains all of the attributes of a specific replication group.
 	ReplicationGroup *ReplicationGroup `type:"structure"`
 
-	metadataCreateReplicationGroupOutput `json:"-" xml:"-"`
-}
-
-type metadataCreateReplicationGroupOutput struct {
-	SDKShapeTraits bool `type:"structure"`
+	_ struct{} `type:"structure"`
 }
 
 // String returns the string representation
@@ -2547,11 +2439,7 @@ type CreateSnapshotInput struct {
 	// A name for the snapshot being created.
 	SnapshotName *string `type:"string" required:"true"`
 
-	metadataCreateSnapshotInput `json:"-" xml:"-"`
-}
-
-type metadataCreateSnapshotInput struct {
-	SDKShapeTraits bool `type:"structure"`
+	_ struct{} `type:"structure"`
 }
 
 // String returns the string representation
@@ -2569,11 +2457,7 @@ type CreateSnapshotOutput struct {
 	// was taken.
 	Snapshot *Snapshot `type:"structure"`
 
-	metadataCreateSnapshotOutput `json:"-" xml:"-"`
-}
-
-type metadataCreateSnapshotOutput struct {
-	SDKShapeTraits bool `type:"structure"`
+	_ struct{} `type:"structure"`
 }
 
 // String returns the string representation
@@ -2597,11 +2481,7 @@ type DeleteCacheClusterInput struct {
 	// then deletes the cache cluster immediately afterward.
 	FinalSnapshotIdentifier *string `type:"string"`
 
-	metadataDeleteCacheClusterInput `json:"-" xml:"-"`
-}
-
-type metadataDeleteCacheClusterInput struct {
-	SDKShapeTraits bool `type:"structure"`
+	_ struct{} `type:"structure"`
 }
 
 // String returns the string representation
@@ -2618,11 +2498,7 @@ type DeleteCacheClusterOutput struct {
 	// Contains all of the attributes of a specific cache cluster.
 	CacheCluster *CacheCluster `type:"structure"`
 
-	metadataDeleteCacheClusterOutput `json:"-" xml:"-"`
-}
-
-type metadataDeleteCacheClusterOutput struct {
-	SDKShapeTraits bool `type:"structure"`
+	_ struct{} `type:"structure"`
 }
 
 // String returns the string representation
@@ -2643,11 +2519,7 @@ type DeleteCacheParameterGroupInput struct {
 	// clusters.
 	CacheParameterGroupName *string `type:"string" required:"true"`
 
-	metadataDeleteCacheParameterGroupInput `json:"-" xml:"-"`
-}
-
-type metadataDeleteCacheParameterGroupInput struct {
-	SDKShapeTraits bool `type:"structure"`
+	_ struct{} `type:"structure"`
 }
 
 // String returns the string representation
@@ -2661,11 +2533,7 @@ func (s DeleteCacheParameterGroupInput) GoString() string {
 }
 
 type DeleteCacheParameterGroupOutput struct {
-	metadataDeleteCacheParameterGroupOutput `json:"-" xml:"-"`
-}
-
-type metadataDeleteCacheParameterGroupOutput struct {
-	SDKShapeTraits bool `type:"structure"`
+	_ struct{} `type:"structure"`
 }
 
 // String returns the string representation
@@ -2685,11 +2553,7 @@ type DeleteCacheSecurityGroupInput struct {
 	// You cannot delete the default security group.
 	CacheSecurityGroupName *string `type:"string" required:"true"`
 
-	metadataDeleteCacheSecurityGroupInput `json:"-" xml:"-"`
-}
-
-type metadataDeleteCacheSecurityGroupInput struct {
-	SDKShapeTraits bool `type:"structure"`
+	_ struct{} `type:"structure"`
 }
 
 // String returns the string representation
@@ -2703,11 +2567,7 @@ func (s DeleteCacheSecurityGroupInput) GoString() string {
 }
 
 type DeleteCacheSecurityGroupOutput struct {
-	metadataDeleteCacheSecurityGroupOutput `json:"-" xml:"-"`
-}
-
-type metadataDeleteCacheSecurityGroupOutput struct {
-	SDKShapeTraits bool `type:"structure"`
+	_ struct{} `type:"structure"`
 }
 
 // String returns the string representation
@@ -2727,11 +2587,7 @@ type DeleteCacheSubnetGroupInput struct {
 	// Constraints: Must contain no more than 255 alphanumeric characters or hyphens.
 	CacheSubnetGroupName *string `type:"string" required:"true"`
 
-	metadataDeleteCacheSubnetGroupInput `json:"-" xml:"-"`
-}
-
-type metadataDeleteCacheSubnetGroupInput struct {
-	SDKShapeTraits bool `type:"structure"`
+	_ struct{} `type:"structure"`
 }
 
 // String returns the string representation
@@ -2745,11 +2601,7 @@ func (s DeleteCacheSubnetGroupInput) GoString() string {
 }
 
 type DeleteCacheSubnetGroupOutput struct {
-	metadataDeleteCacheSubnetGroupOutput `json:"-" xml:"-"`
-}
-
-type metadataDeleteCacheSubnetGroupOutput struct {
-	SDKShapeTraits bool `type:"structure"`
+	_ struct{} `type:"structure"`
 }
 
 // String returns the string representation
@@ -2778,11 +2630,7 @@ type DeleteReplicationGroupInput struct {
 	// node will be retained.
 	RetainPrimaryCluster *bool `type:"boolean"`
 
-	metadataDeleteReplicationGroupInput `json:"-" xml:"-"`
-}
-
-type metadataDeleteReplicationGroupInput struct {
-	SDKShapeTraits bool `type:"structure"`
+	_ struct{} `type:"structure"`
 }
 
 // String returns the string representation
@@ -2799,11 +2647,7 @@ type DeleteReplicationGroupOutput struct {
 	// Contains all of the attributes of a specific replication group.
 	ReplicationGroup *ReplicationGroup `type:"structure"`
 
-	metadataDeleteReplicationGroupOutput `json:"-" xml:"-"`
-}
-
-type metadataDeleteReplicationGroupOutput struct {
-	SDKShapeTraits bool `type:"structure"`
+	_ struct{} `type:"structure"`
 }
 
 // String returns the string representation
@@ -2821,11 +2665,7 @@ type DeleteSnapshotInput struct {
 	// The name of the snapshot to be deleted.
 	SnapshotName *string `type:"string" required:"true"`
 
-	metadataDeleteSnapshotInput `json:"-" xml:"-"`
-}
-
-type metadataDeleteSnapshotInput struct {
-	SDKShapeTraits bool `type:"structure"`
+	_ struct{} `type:"structure"`
 }
 
 // String returns the string representation
@@ -2843,11 +2683,7 @@ type DeleteSnapshotOutput struct {
 	// was taken.
 	Snapshot *Snapshot `type:"structure"`
 
-	metadataDeleteSnapshotOutput `json:"-" xml:"-"`
-}
-
-type metadataDeleteSnapshotOutput struct {
-	SDKShapeTraits bool `type:"structure"`
+	_ struct{} `type:"structure"`
 }
 
 // String returns the string representation
@@ -2885,11 +2721,7 @@ type DescribeCacheClustersInput struct {
 	// to retrieve information about the individual cache nodes.
 	ShowCacheNodeInfo *bool `type:"boolean"`
 
-	metadataDescribeCacheClustersInput `json:"-" xml:"-"`
-}
-
-type metadataDescribeCacheClustersInput struct {
-	SDKShapeTraits bool `type:"structure"`
+	_ struct{} `type:"structure"`
 }
 
 // String returns the string representation
@@ -2911,11 +2743,7 @@ type DescribeCacheClustersOutput struct {
 	// Provides an identifier to allow retrieval of paginated results.
 	Marker *string `type:"string"`
 
-	metadataDescribeCacheClustersOutput `json:"-" xml:"-"`
-}
-
-type metadataDescribeCacheClustersOutput struct {
-	SDKShapeTraits bool `type:"structure"`
+	_ struct{} `type:"structure"`
 }
 
 // String returns the string representation
@@ -2964,11 +2792,7 @@ type DescribeCacheEngineVersionsInput struct {
 	// Constraints: minimum 20; maximum 100.
 	MaxRecords *int64 `type:"integer"`
 
-	metadataDescribeCacheEngineVersionsInput `json:"-" xml:"-"`
-}
-
-type metadataDescribeCacheEngineVersionsInput struct {
-	SDKShapeTraits bool `type:"structure"`
+	_ struct{} `type:"structure"`
 }
 
 // String returns the string representation
@@ -2990,11 +2814,7 @@ type DescribeCacheEngineVersionsOutput struct {
 	// Provides an identifier to allow retrieval of paginated results.
 	Marker *string `type:"string"`
 
-	metadataDescribeCacheEngineVersionsOutput `json:"-" xml:"-"`
-}
-
-type metadataDescribeCacheEngineVersionsOutput struct {
-	SDKShapeTraits bool `type:"structure"`
+	_ struct{} `type:"structure"`
 }
 
 // String returns the string representation
@@ -3026,11 +2846,7 @@ type DescribeCacheParameterGroupsInput struct {
 	// Constraints: minimum 20; maximum 100.
 	MaxRecords *int64 `type:"integer"`
 
-	metadataDescribeCacheParameterGroupsInput `json:"-" xml:"-"`
-}
-
-type metadataDescribeCacheParameterGroupsInput struct {
-	SDKShapeTraits bool `type:"structure"`
+	_ struct{} `type:"structure"`
 }
 
 // String returns the string representation
@@ -3052,11 +2868,7 @@ type DescribeCacheParameterGroupsOutput struct {
 	// Provides an identifier to allow retrieval of paginated results.
 	Marker *string `type:"string"`
 
-	metadataDescribeCacheParameterGroupsOutput `json:"-" xml:"-"`
-}
-
-type metadataDescribeCacheParameterGroupsOutput struct {
-	SDKShapeTraits bool `type:"structure"`
+	_ struct{} `type:"structure"`
 }
 
 // String returns the string representation
@@ -3093,11 +2905,7 @@ type DescribeCacheParametersInput struct {
 	// Valid values: user | system | engine-default
 	Source *string `type:"string"`
 
-	metadataDescribeCacheParametersInput `json:"-" xml:"-"`
-}
-
-type metadataDescribeCacheParametersInput struct {
-	SDKShapeTraits bool `type:"structure"`
+	_ struct{} `type:"structure"`
 }
 
 // String returns the string representation
@@ -3122,11 +2930,7 @@ type DescribeCacheParametersOutput struct {
 	// A list of Parameter instances.
 	Parameters []*Parameter `locationNameList:"Parameter" type:"list"`
 
-	metadataDescribeCacheParametersOutput `json:"-" xml:"-"`
-}
-
-type metadataDescribeCacheParametersOutput struct {
-	SDKShapeTraits bool `type:"structure"`
+	_ struct{} `type:"structure"`
 }
 
 // String returns the string representation
@@ -3158,11 +2962,7 @@ type DescribeCacheSecurityGroupsInput struct {
 	// Constraints: minimum 20; maximum 100.
 	MaxRecords *int64 `type:"integer"`
 
-	metadataDescribeCacheSecurityGroupsInput `json:"-" xml:"-"`
-}
-
-type metadataDescribeCacheSecurityGroupsInput struct {
-	SDKShapeTraits bool `type:"structure"`
+	_ struct{} `type:"structure"`
 }
 
 // String returns the string representation
@@ -3184,11 +2984,7 @@ type DescribeCacheSecurityGroupsOutput struct {
 	// Provides an identifier to allow retrieval of paginated results.
 	Marker *string `type:"string"`
 
-	metadataDescribeCacheSecurityGroupsOutput `json:"-" xml:"-"`
-}
-
-type metadataDescribeCacheSecurityGroupsOutput struct {
-	SDKShapeTraits bool `type:"structure"`
+	_ struct{} `type:"structure"`
 }
 
 // String returns the string representation
@@ -3220,11 +3016,7 @@ type DescribeCacheSubnetGroupsInput struct {
 	// Constraints: minimum 20; maximum 100.
 	MaxRecords *int64 `type:"integer"`
 
-	metadataDescribeCacheSubnetGroupsInput `json:"-" xml:"-"`
-}
-
-type metadataDescribeCacheSubnetGroupsInput struct {
-	SDKShapeTraits bool `type:"structure"`
+	_ struct{} `type:"structure"`
 }
 
 // String returns the string representation
@@ -3246,11 +3038,7 @@ type DescribeCacheSubnetGroupsOutput struct {
 	// Provides an identifier to allow retrieval of paginated results.
 	Marker *string `type:"string"`
 
-	metadataDescribeCacheSubnetGroupsOutput `json:"-" xml:"-"`
-}
-
-type metadataDescribeCacheSubnetGroupsOutput struct {
-	SDKShapeTraits bool `type:"structure"`
+	_ struct{} `type:"structure"`
 }
 
 // String returns the string representation
@@ -3283,11 +3071,7 @@ type DescribeEngineDefaultParametersInput struct {
 	// Constraints: minimum 20; maximum 100.
 	MaxRecords *int64 `type:"integer"`
 
-	metadataDescribeEngineDefaultParametersInput `json:"-" xml:"-"`
-}
-
-type metadataDescribeEngineDefaultParametersInput struct {
-	SDKShapeTraits bool `type:"structure"`
+	_ struct{} `type:"structure"`
 }
 
 // String returns the string representation
@@ -3304,11 +3088,7 @@ type DescribeEngineDefaultParametersOutput struct {
 	// Represents the output of a DescribeEngineDefaultParameters action.
 	EngineDefaults *EngineDefaults `type:"structure"`
 
-	metadataDescribeEngineDefaultParametersOutput `json:"-" xml:"-"`
-}
-
-type metadataDescribeEngineDefaultParametersOutput struct {
-	SDKShapeTraits bool `type:"structure"`
+	_ struct{} `type:"structure"`
 }
 
 // String returns the string representation
@@ -3359,11 +3139,7 @@ type DescribeEventsInput struct {
 	// 8601 format.
 	StartTime *time.Time `type:"timestamp" timestampFormat:"iso8601"`
 
-	metadataDescribeEventsInput `json:"-" xml:"-"`
-}
-
-type metadataDescribeEventsInput struct {
-	SDKShapeTraits bool `type:"structure"`
+	_ struct{} `type:"structure"`
 }
 
 // String returns the string representation
@@ -3385,11 +3161,7 @@ type DescribeEventsOutput struct {
 	// Provides an identifier to allow retrieval of paginated results.
 	Marker *string `type:"string"`
 
-	metadataDescribeEventsOutput `json:"-" xml:"-"`
-}
-
-type metadataDescribeEventsOutput struct {
-	SDKShapeTraits bool `type:"structure"`
+	_ struct{} `type:"structure"`
 }
 
 // String returns the string representation
@@ -3425,11 +3197,7 @@ type DescribeReplicationGroupsInput struct {
 	// groups is returned.
 	ReplicationGroupId *string `type:"string"`
 
-	metadataDescribeReplicationGroupsInput `json:"-" xml:"-"`
-}
-
-type metadataDescribeReplicationGroupsInput struct {
-	SDKShapeTraits bool `type:"structure"`
+	_ struct{} `type:"structure"`
 }
 
 // String returns the string representation
@@ -3451,11 +3219,7 @@ type DescribeReplicationGroupsOutput struct {
 	// about one replication group.
 	ReplicationGroups []*ReplicationGroup `locationNameList:"ReplicationGroup" type:"list"`
 
-	metadataDescribeReplicationGroupsOutput `json:"-" xml:"-"`
-}
-
-type metadataDescribeReplicationGroupsOutput struct {
-	SDKShapeTraits bool `type:"structure"`
+	_ struct{} `type:"structure"`
 }
 
 // String returns the string representation
@@ -3530,11 +3294,7 @@ type DescribeReservedCacheNodesInput struct {
 	// reservations matching the specified offering identifier.
 	ReservedCacheNodesOfferingId *string `type:"string"`
 
-	metadataDescribeReservedCacheNodesInput `json:"-" xml:"-"`
-}
-
-type metadataDescribeReservedCacheNodesInput struct {
-	SDKShapeTraits bool `type:"structure"`
+	_ struct{} `type:"structure"`
 }
 
 // String returns the string representation
@@ -3607,11 +3367,7 @@ type DescribeReservedCacheNodesOfferingsInput struct {
 	// Example: 438012d3-4052-4cc7-b2e3-8d3372e0e706
 	ReservedCacheNodesOfferingId *string `type:"string"`
 
-	metadataDescribeReservedCacheNodesOfferingsInput `json:"-" xml:"-"`
-}
-
-type metadataDescribeReservedCacheNodesOfferingsInput struct {
-	SDKShapeTraits bool `type:"structure"`
+	_ struct{} `type:"structure"`
 }
 
 // String returns the string representation
@@ -3633,11 +3389,7 @@ type DescribeReservedCacheNodesOfferingsOutput struct {
 	// detailed information about one offering.
 	ReservedCacheNodesOfferings []*ReservedCacheNodesOffering `locationNameList:"ReservedCacheNodesOffering" type:"list"`
 
-	metadataDescribeReservedCacheNodesOfferingsOutput `json:"-" xml:"-"`
-}
-
-type metadataDescribeReservedCacheNodesOfferingsOutput struct {
-	SDKShapeTraits bool `type:"structure"`
+	_ struct{} `type:"structure"`
 }
 
 // String returns the string representation
@@ -3659,11 +3411,7 @@ type DescribeReservedCacheNodesOutput struct {
 	// information about one node.
 	ReservedCacheNodes []*ReservedCacheNode `locationNameList:"ReservedCacheNode" type:"list"`
 
-	metadataDescribeReservedCacheNodesOutput `json:"-" xml:"-"`
-}
-
-type metadataDescribeReservedCacheNodesOutput struct {
-	SDKShapeTraits bool `type:"structure"`
+	_ struct{} `type:"structure"`
 }
 
 // String returns the string representation
@@ -3706,11 +3454,7 @@ type DescribeSnapshotsInput struct {
 	// snapshots.
 	SnapshotSource *string `type:"string"`
 
-	metadataDescribeSnapshotsInput `json:"-" xml:"-"`
-}
-
-type metadataDescribeSnapshotsInput struct {
-	SDKShapeTraits bool `type:"structure"`
+	_ struct{} `type:"structure"`
 }
 
 // String returns the string representation
@@ -3734,11 +3478,7 @@ type DescribeSnapshotsOutput struct {
 	// about one snapshot.
 	Snapshots []*Snapshot `locationNameList:"Snapshot" type:"list"`
 
-	metadataDescribeSnapshotsOutput `json:"-" xml:"-"`
-}
-
-type metadataDescribeSnapshotsOutput struct {
-	SDKShapeTraits bool `type:"structure"`
+	_ struct{} `type:"structure"`
 }
 
 // String returns the string representation
@@ -3762,11 +3502,7 @@ type EC2SecurityGroup struct {
 	// The status of the Amazon EC2 security group.
 	Status *string `type:"string"`
 
-	metadataEC2SecurityGroup `json:"-" xml:"-"`
-}
-
-type metadataEC2SecurityGroup struct {
-	SDKShapeTraits bool `type:"structure"`
+	_ struct{} `type:"structure"`
 }
 
 // String returns the string representation
@@ -3788,11 +3524,7 @@ type Endpoint struct {
 	// The port number that the cache engine is listening on.
 	Port *int64 `type:"integer"`
 
-	metadataEndpoint `json:"-" xml:"-"`
-}
-
-type metadataEndpoint struct {
-	SDKShapeTraits bool `type:"structure"`
+	_ struct{} `type:"structure"`
 }
 
 // String returns the string representation
@@ -3821,11 +3553,7 @@ type EngineDefaults struct {
 	// Contains a list of engine default parameters.
 	Parameters []*Parameter `locationNameList:"Parameter" type:"list"`
 
-	metadataEngineDefaults `json:"-" xml:"-"`
-}
-
-type metadataEngineDefaults struct {
-	SDKShapeTraits bool `type:"structure"`
+	_ struct{} `type:"structure"`
 }
 
 // String returns the string representation
@@ -3857,11 +3585,7 @@ type Event struct {
 	// a security group, etc.
 	SourceType *string `type:"string" enum:"SourceType"`
 
-	metadataEvent `json:"-" xml:"-"`
-}
-
-type metadataEvent struct {
-	SDKShapeTraits bool `type:"structure"`
+	_ struct{} `type:"structure"`
 }
 
 // String returns the string representation
@@ -3880,11 +3604,7 @@ type ListTagsForResourceInput struct {
 	// arn:aws:elasticache:us-west-2:0123456789:cluster:myCluster.
 	ResourceName *string `type:"string" required:"true"`
 
-	metadataListTagsForResourceInput `json:"-" xml:"-"`
-}
-
-type metadataListTagsForResourceInput struct {
-	SDKShapeTraits bool `type:"structure"`
+	_ struct{} `type:"structure"`
 }
 
 // String returns the string representation
@@ -4077,11 +3797,7 @@ type ModifyCacheClusterInput struct {
 	// a daily snapshot of your cache cluster.
 	SnapshotWindow *string `type:"string"`
 
-	metadataModifyCacheClusterInput `json:"-" xml:"-"`
-}
-
-type metadataModifyCacheClusterInput struct {
-	SDKShapeTraits bool `type:"structure"`
+	_ struct{} `type:"structure"`
 }
 
 // String returns the string representation
@@ -4098,11 +3814,7 @@ type ModifyCacheClusterOutput struct {
 	// Contains all of the attributes of a specific cache cluster.
 	CacheCluster *CacheCluster `type:"structure"`
 
-	metadataModifyCacheClusterOutput `json:"-" xml:"-"`
-}
-
-type metadataModifyCacheClusterOutput struct {
-	SDKShapeTraits bool `type:"structure"`
+	_ struct{} `type:"structure"`
 }
 
 // String returns the string representation
@@ -4125,11 +3837,7 @@ type ModifyCacheParameterGroupInput struct {
 	// A maximum of 20 parameters may be modified per request.
 	ParameterNameValues []*ParameterNameValue `locationNameList:"ParameterNameValue" type:"list" required:"true"`
 
-	metadataModifyCacheParameterGroupInput `json:"-" xml:"-"`
-}
-
-type metadataModifyCacheParameterGroupInput struct {
-	SDKShapeTraits bool `type:"structure"`
+	_ struct{} `type:"structure"`
 }
 
 // String returns the string representation
@@ -4158,11 +3866,7 @@ type ModifyCacheSubnetGroupInput struct {
 	// The EC2 subnet IDs for the cache subnet group.
 	SubnetIds []*string `locationNameList:"SubnetIdentifier" type:"list"`
 
-	metadataModifyCacheSubnetGroupInput `json:"-" xml:"-"`
-}
-
-type metadataModifyCacheSubnetGroupInput struct {
-	SDKShapeTraits bool `type:"structure"`
+	_ struct{} `type:"structure"`
 }
 
 // String returns the string representation
@@ -4181,11 +3885,7 @@ type ModifyCacheSubnetGroupOutput struct {
 	//   CreateCacheSubnetGroup   ModifyCacheSubnetGroup
 	CacheSubnetGroup *CacheSubnetGroup `type:"structure"`
 
-	metadataModifyCacheSubnetGroupOutput `json:"-" xml:"-"`
-}
-
-type metadataModifyCacheSubnetGroupOutput struct {
-	SDKShapeTraits bool `type:"structure"`
+	_ struct{} `type:"structure"`
 }
 
 // String returns the string representation
@@ -4307,11 +4007,7 @@ type ModifyReplicationGroupInput struct {
 	// replication group.
 	SnapshottingClusterId *string `type:"string"`
 
-	metadataModifyReplicationGroupInput `json:"-" xml:"-"`
-}
-
-type metadataModifyReplicationGroupInput struct {
-	SDKShapeTraits bool `type:"structure"`
+	_ struct{} `type:"structure"`
 }
 
 // String returns the string representation
@@ -4328,11 +4024,7 @@ type ModifyReplicationGroupOutput struct {
 	// Contains all of the attributes of a specific replication group.
 	ReplicationGroup *ReplicationGroup `type:"structure"`
 
-	metadataModifyReplicationGroupOutput `json:"-" xml:"-"`
-}
-
-type metadataModifyReplicationGroupOutput struct {
-	SDKShapeTraits bool `type:"structure"`
+	_ struct{} `type:"structure"`
 }
 
 // String returns the string representation
@@ -4361,11 +4053,7 @@ type NodeGroup struct {
 	// The current state of this replication group - creating, available, etc.
 	Status *string `type:"string"`
 
-	metadataNodeGroup `json:"-" xml:"-"`
-}
-
-type metadataNodeGroup struct {
-	SDKShapeTraits bool `type:"structure"`
+	_ struct{} `type:"structure"`
 }
 
 // String returns the string representation
@@ -4397,11 +4085,7 @@ type NodeGroupMember struct {
 	// node.
 	ReadEndpoint *Endpoint `type:"structure"`
 
-	metadataNodeGroupMember `json:"-" xml:"-"`
-}
-
-type metadataNodeGroupMember struct {
-	SDKShapeTraits bool `type:"structure"`
+	_ struct{} `type:"structure"`
 }
 
 // String returns the string representation
@@ -4429,11 +4113,7 @@ type NodeSnapshot struct {
 	// obtained for the snapshot.
 	SnapshotCreateTime *time.Time `type:"timestamp" timestampFormat:"iso8601"`
 
-	metadataNodeSnapshot `json:"-" xml:"-"`
-}
-
-type metadataNodeSnapshot struct {
-	SDKShapeTraits bool `type:"structure"`
+	_ struct{} `type:"structure"`
 }
 
 // String returns the string representation
@@ -4456,11 +4136,7 @@ type NotificationConfiguration struct {
 	// The current state of the topic.
 	TopicStatus *string `type:"string"`
 
-	metadataNotificationConfiguration `json:"-" xml:"-"`
-}
-
-type metadataNotificationConfiguration struct {
-	SDKShapeTraits bool `type:"structure"`
+	_ struct{} `type:"structure"`
 }
 
 // String returns the string representation
@@ -4502,11 +4178,7 @@ type Parameter struct {
 	// The source of the parameter.
 	Source *string `type:"string"`
 
-	metadataParameter `json:"-" xml:"-"`
-}
-
-type metadataParameter struct {
-	SDKShapeTraits bool `type:"structure"`
+	_ struct{} `type:"structure"`
 }
 
 // String returns the string representation
@@ -4527,11 +4199,7 @@ type ParameterNameValue struct {
 	// The value of the parameter.
 	ParameterValue *string `type:"string"`
 
-	metadataParameterNameValue `json:"-" xml:"-"`
-}
-
-type metadataParameterNameValue struct {
-	SDKShapeTraits bool `type:"structure"`
+	_ struct{} `type:"structure"`
 }
 
 // String returns the string representation
@@ -4560,11 +4228,7 @@ type PendingModifiedValues struct {
 	// this value must be between 1 and 20.
 	NumCacheNodes *int64 `type:"integer"`
 
-	metadataPendingModifiedValues `json:"-" xml:"-"`
-}
-
-type metadataPendingModifiedValues struct {
-	SDKShapeTraits bool `type:"structure"`
+	_ struct{} `type:"structure"`
 }
 
 // String returns the string representation
@@ -4594,11 +4258,7 @@ type PurchaseReservedCacheNodesOfferingInput struct {
 	// Example: 438012d3-4052-4cc7-b2e3-8d3372e0e706
 	ReservedCacheNodesOfferingId *string `type:"string" required:"true"`
 
-	metadataPurchaseReservedCacheNodesOfferingInput `json:"-" xml:"-"`
-}
-
-type metadataPurchaseReservedCacheNodesOfferingInput struct {
-	SDKShapeTraits bool `type:"structure"`
+	_ struct{} `type:"structure"`
 }
 
 // String returns the string representation
@@ -4615,11 +4275,7 @@ type PurchaseReservedCacheNodesOfferingOutput struct {
 	// Represents the output of a PurchaseReservedCacheNodesOffering action.
 	ReservedCacheNode *ReservedCacheNode `type:"structure"`
 
-	metadataPurchaseReservedCacheNodesOfferingOutput `json:"-" xml:"-"`
-}
-
-type metadataPurchaseReservedCacheNodesOfferingOutput struct {
-	SDKShapeTraits bool `type:"structure"`
+	_ struct{} `type:"structure"`
 }
 
 // String returns the string representation
@@ -4642,11 +4298,7 @@ type RebootCacheClusterInput struct {
 	// node IDs.
 	CacheNodeIdsToReboot []*string `locationNameList:"CacheNodeId" type:"list" required:"true"`
 
-	metadataRebootCacheClusterInput `json:"-" xml:"-"`
-}
-
-type metadataRebootCacheClusterInput struct {
-	SDKShapeTraits bool `type:"structure"`
+	_ struct{} `type:"structure"`
 }
 
 // String returns the string representation
@@ -4663,11 +4315,7 @@ type RebootCacheClusterOutput struct {
 	// Contains all of the attributes of a specific cache cluster.
 	CacheCluster *CacheCluster `type:"structure"`
 
-	metadataRebootCacheClusterOutput `json:"-" xml:"-"`
-}
-
-type metadataRebootCacheClusterOutput struct {
-	SDKShapeTraits bool `type:"structure"`
+	_ struct{} `type:"structure"`
 }
 
 // String returns the string representation
@@ -4689,11 +4337,7 @@ type RecurringCharge struct {
 	// The frequency of the recurring charge.
 	RecurringChargeFrequency *string `type:"string"`
 
-	metadataRecurringCharge `json:"-" xml:"-"`
-}
-
-type metadataRecurringCharge struct {
-	SDKShapeTraits bool `type:"structure"`
+	_ struct{} `type:"structure"`
 }
 
 // String returns the string representation
@@ -4717,11 +4361,7 @@ type RemoveTagsFromResourceInput struct {
 	// the key name Region from the resource named by the ResourceName parameter.
 	TagKeys []*string `type:"list" required:"true"`
 
-	metadataRemoveTagsFromResourceInput `json:"-" xml:"-"`
-}
-
-type metadataRemoveTagsFromResourceInput struct {
-	SDKShapeTraits bool `type:"structure"`
+	_ struct{} `type:"structure"`
 }
 
 // String returns the string representation
@@ -4767,11 +4407,7 @@ type ReplicationGroup struct {
 	// The current state of this replication group - creating, available, etc.
 	Status *string `type:"string"`
 
-	metadataReplicationGroup `json:"-" xml:"-"`
-}
-
-type metadataReplicationGroup struct {
-	SDKShapeTraits bool `type:"structure"`
+	_ struct{} `type:"structure"`
 }
 
 // String returns the string representation
@@ -4798,11 +4434,7 @@ type ReplicationGroupPendingModifiedValues struct {
 	// was specified), or during the next maintenance window.
 	PrimaryClusterId *string `type:"string"`
 
-	metadataReplicationGroupPendingModifiedValues `json:"-" xml:"-"`
-}
-
-type metadataReplicationGroupPendingModifiedValues struct {
-	SDKShapeTraits bool `type:"structure"`
+	_ struct{} `type:"structure"`
 }
 
 // String returns the string representation
@@ -4871,11 +4503,7 @@ type ReservedCacheNode struct {
 	// The hourly price charged for this reserved cache node.
 	UsagePrice *float64 `type:"double"`
 
-	metadataReservedCacheNode `json:"-" xml:"-"`
-}
-
-type metadataReservedCacheNode struct {
-	SDKShapeTraits bool `type:"structure"`
+	_ struct{} `type:"structure"`
 }
 
 // String returns the string representation
@@ -4932,11 +4560,7 @@ type ReservedCacheNodesOffering struct {
 	// The hourly price charged for this offering.
 	UsagePrice *float64 `type:"double"`
 
-	metadataReservedCacheNodesOffering `json:"-" xml:"-"`
-}
-
-type metadataReservedCacheNodesOffering struct {
-	SDKShapeTraits bool `type:"structure"`
+	_ struct{} `type:"structure"`
 }
 
 // String returns the string representation
@@ -4964,11 +4588,7 @@ type ResetCacheParameterGroupInput struct {
 	// Valid values: true | false
 	ResetAllParameters *bool `type:"boolean"`
 
-	metadataResetCacheParameterGroupInput `json:"-" xml:"-"`
-}
-
-type metadataResetCacheParameterGroupInput struct {
-	SDKShapeTraits bool `type:"structure"`
+	_ struct{} `type:"structure"`
 }
 
 // String returns the string representation
@@ -4994,11 +4614,7 @@ type RevokeCacheSecurityGroupIngressInput struct {
 	// AWS account number for this parameter.
 	EC2SecurityGroupOwnerId *string `type:"string" required:"true"`
 
-	metadataRevokeCacheSecurityGroupIngressInput `json:"-" xml:"-"`
-}
-
-type metadataRevokeCacheSecurityGroupIngressInput struct {
-	SDKShapeTraits bool `type:"structure"`
+	_ struct{} `type:"structure"`
 }
 
 // String returns the string representation
@@ -5017,11 +4633,7 @@ type RevokeCacheSecurityGroupIngressOutput struct {
 	//   AuthorizeCacheSecurityGroupIngress   CreateCacheSecurityGroup   RevokeCacheSecurityGroupIngress
 	CacheSecurityGroup *CacheSecurityGroup `type:"structure"`
 
-	metadataRevokeCacheSecurityGroupIngressOutput `json:"-" xml:"-"`
-}
-
-type metadataRevokeCacheSecurityGroupIngressOutput struct {
-	SDKShapeTraits bool `type:"structure"`
+	_ struct{} `type:"structure"`
 }
 
 // String returns the string representation
@@ -5044,11 +4656,7 @@ type SecurityGroupMembership struct {
 	// to a cache cluster are modified.
 	Status *string `type:"string"`
 
-	metadataSecurityGroupMembership `json:"-" xml:"-"`
-}
-
-type metadataSecurityGroupMembership struct {
-	SDKShapeTraits bool `type:"structure"`
+	_ struct{} `type:"structure"`
 }
 
 // String returns the string representation
@@ -5168,11 +4776,7 @@ type Snapshot struct {
 	// group for the source cache cluster.
 	VpcId *string `type:"string"`
 
-	metadataSnapshot `json:"-" xml:"-"`
-}
-
-type metadataSnapshot struct {
-	SDKShapeTraits bool `type:"structure"`
+	_ struct{} `type:"structure"`
 }
 
 // String returns the string representation
@@ -5195,11 +4799,7 @@ type Subnet struct {
 	// The unique identifier for the subnet.
 	SubnetIdentifier *string `type:"string"`
 
-	metadataSubnet `json:"-" xml:"-"`
-}
-
-type metadataSubnet struct {
-	SDKShapeTraits bool `type:"structure"`
+	_ struct{} `type:"structure"`
 }
 
 // String returns the string representation
@@ -5222,11 +4822,7 @@ type Tag struct {
 	// The tag's value. May not be null.
 	Value *string `type:"string"`
 
-	metadataTag `json:"-" xml:"-"`
-}
-
-type metadataTag struct {
-	SDKShapeTraits bool `type:"structure"`
+	_ struct{} `type:"structure"`
 }
 
 // String returns the string representation
@@ -5245,11 +4841,7 @@ type TagListMessage struct {
 	// A list of cost allocation tags as key-value pairs.
 	TagList []*Tag `locationNameList:"Tag" type:"list"`
 
-	metadataTagListMessage `json:"-" xml:"-"`
-}
-
-type metadataTagListMessage struct {
-	SDKShapeTraits bool `type:"structure"`
+	_ struct{} `type:"structure"`
 }
 
 // String returns the string representation

--- a/service/elasticbeanstalk/api.go
+++ b/service/elasticbeanstalk/api.go
@@ -1034,11 +1034,7 @@ type AbortEnvironmentUpdateInput struct {
 	// you want to cancel.
 	EnvironmentName *string `min:"4" type:"string"`
 
-	metadataAbortEnvironmentUpdateInput `json:"-" xml:"-"`
-}
-
-type metadataAbortEnvironmentUpdateInput struct {
-	SDKShapeTraits bool `type:"structure"`
+	_ struct{} `type:"structure"`
 }
 
 // String returns the string representation
@@ -1052,11 +1048,7 @@ func (s AbortEnvironmentUpdateInput) GoString() string {
 }
 
 type AbortEnvironmentUpdateOutput struct {
-	metadataAbortEnvironmentUpdateOutput `json:"-" xml:"-"`
-}
-
-type metadataAbortEnvironmentUpdateOutput struct {
-	SDKShapeTraits bool `type:"structure"`
+	_ struct{} `type:"structure"`
 }
 
 // String returns the string representation
@@ -1089,11 +1081,7 @@ type ApplicationDescription struct {
 	// The names of the versions for this application.
 	Versions []*string `type:"list"`
 
-	metadataApplicationDescription `json:"-" xml:"-"`
-}
-
-type metadataApplicationDescription struct {
-	SDKShapeTraits bool `type:"structure"`
+	_ struct{} `type:"structure"`
 }
 
 // String returns the string representation
@@ -1111,11 +1099,7 @@ type ApplicationDescriptionMessage struct {
 	// The ApplicationDescription of the application.
 	Application *ApplicationDescription `type:"structure"`
 
-	metadataApplicationDescriptionMessage `json:"-" xml:"-"`
-}
-
-type metadataApplicationDescriptionMessage struct {
-	SDKShapeTraits bool `type:"structure"`
+	_ struct{} `type:"structure"`
 }
 
 // String returns the string representation
@@ -1147,11 +1131,7 @@ type ApplicationMetrics struct {
 	// in each type of status code response.
 	StatusCodes *StatusCodes `type:"structure"`
 
-	metadataApplicationMetrics `json:"-" xml:"-"`
-}
-
-type metadataApplicationMetrics struct {
-	SDKShapeTraits bool `type:"structure"`
+	_ struct{} `type:"structure"`
 }
 
 // String returns the string representation
@@ -1187,11 +1167,7 @@ type ApplicationVersionDescription struct {
 	// A label uniquely identifying the version for the associated application.
 	VersionLabel *string `min:"1" type:"string"`
 
-	metadataApplicationVersionDescription `json:"-" xml:"-"`
-}
-
-type metadataApplicationVersionDescription struct {
-	SDKShapeTraits bool `type:"structure"`
+	_ struct{} `type:"structure"`
 }
 
 // String returns the string representation
@@ -1209,11 +1185,7 @@ type ApplicationVersionDescriptionMessage struct {
 	// The ApplicationVersionDescription of the application version.
 	ApplicationVersion *ApplicationVersionDescription `type:"structure"`
 
-	metadataApplicationVersionDescriptionMessage `json:"-" xml:"-"`
-}
-
-type metadataApplicationVersionDescriptionMessage struct {
-	SDKShapeTraits bool `type:"structure"`
+	_ struct{} `type:"structure"`
 }
 
 // String returns the string representation
@@ -1231,11 +1203,7 @@ type AutoScalingGroup struct {
 	// The name of the AutoScalingGroup .
 	Name *string `type:"string"`
 
-	metadataAutoScalingGroup `json:"-" xml:"-"`
-}
-
-type metadataAutoScalingGroup struct {
-	SDKShapeTraits bool `type:"structure"`
+	_ struct{} `type:"structure"`
 }
 
 // String returns the string representation
@@ -1280,11 +1248,7 @@ type CPUUtilization struct {
 	// 10 seconds.
 	User *float64 `type:"double"`
 
-	metadataCPUUtilization `json:"-" xml:"-"`
-}
-
-type metadataCPUUtilization struct {
-	SDKShapeTraits bool `type:"structure"`
+	_ struct{} `type:"structure"`
 }
 
 // String returns the string representation
@@ -1302,11 +1266,7 @@ type CheckDNSAvailabilityInput struct {
 	// The prefix used when this CNAME is reserved.
 	CNAMEPrefix *string `min:"4" type:"string" required:"true"`
 
-	metadataCheckDNSAvailabilityInput `json:"-" xml:"-"`
-}
-
-type metadataCheckDNSAvailabilityInput struct {
-	SDKShapeTraits bool `type:"structure"`
+	_ struct{} `type:"structure"`
 }
 
 // String returns the string representation
@@ -1330,11 +1290,7 @@ type CheckDNSAvailabilityOutput struct {
 	// the provided prefix.
 	FullyQualifiedCNAME *string `min:"1" type:"string"`
 
-	metadataCheckDNSAvailabilityOutput `json:"-" xml:"-"`
-}
-
-type metadataCheckDNSAvailabilityOutput struct {
-	SDKShapeTraits bool `type:"structure"`
+	_ struct{} `type:"structure"`
 }
 
 // String returns the string representation
@@ -1365,11 +1321,7 @@ type ComposeEnvironmentsInput struct {
 	// to create.
 	VersionLabels []*string `type:"list"`
 
-	metadataComposeEnvironmentsInput `json:"-" xml:"-"`
-}
-
-type metadataComposeEnvironmentsInput struct {
-	SDKShapeTraits bool `type:"structure"`
+	_ struct{} `type:"structure"`
 }
 
 // String returns the string representation
@@ -1446,11 +1398,7 @@ type ConfigurationOptionDescription struct {
 	// false .   Json : Values for this option are a JSON representation of a ConfigDocument.
 	ValueType *string `type:"string" enum:"ConfigurationOptionValueType"`
 
-	metadataConfigurationOptionDescription `json:"-" xml:"-"`
-}
-
-type metadataConfigurationOptionDescription struct {
-	SDKShapeTraits bool `type:"structure"`
+	_ struct{} `type:"structure"`
 }
 
 // String returns the string representation
@@ -1480,11 +1428,7 @@ type ConfigurationOptionSetting struct {
 	// The current value for the configuration option.
 	Value *string `type:"string"`
 
-	metadataConfigurationOptionSetting `json:"-" xml:"-"`
-}
-
-type metadataConfigurationOptionSetting struct {
-	SDKShapeTraits bool `type:"structure"`
+	_ struct{} `type:"structure"`
 }
 
 // String returns the string representation
@@ -1535,11 +1479,7 @@ type ConfigurationSettingsDescription struct {
 	// set.
 	TemplateName *string `min:"1" type:"string"`
 
-	metadataConfigurationSettingsDescription `json:"-" xml:"-"`
-}
-
-type metadataConfigurationSettingsDescription struct {
-	SDKShapeTraits bool `type:"structure"`
+	_ struct{} `type:"structure"`
 }
 
 // String returns the string representation
@@ -1562,11 +1502,7 @@ type CreateApplicationInput struct {
 	// Describes the application.
 	Description *string `type:"string"`
 
-	metadataCreateApplicationInput `json:"-" xml:"-"`
-}
-
-type metadataCreateApplicationInput struct {
-	SDKShapeTraits bool `type:"structure"`
+	_ struct{} `type:"structure"`
 }
 
 // String returns the string representation
@@ -1623,11 +1559,7 @@ type CreateApplicationVersionInput struct {
 	// returns an InvalidParameterValue error.
 	VersionLabel *string `min:"1" type:"string" required:"true"`
 
-	metadataCreateApplicationVersionInput `json:"-" xml:"-"`
-}
-
-type metadataCreateApplicationVersionInput struct {
-	SDKShapeTraits bool `type:"structure"`
+	_ struct{} `type:"structure"`
 }
 
 // String returns the string representation
@@ -1696,11 +1628,7 @@ type CreateConfigurationTemplateInput struct {
 	// Elastic Beanstalk returns an InvalidParameterValue error.
 	TemplateName *string `min:"1" type:"string" required:"true"`
 
-	metadataCreateConfigurationTemplateInput `json:"-" xml:"-"`
-}
-
-type metadataCreateConfigurationTemplateInput struct {
-	SDKShapeTraits bool `type:"structure"`
+	_ struct{} `type:"structure"`
 }
 
 // String returns the string representation
@@ -1791,11 +1719,7 @@ type CreateEnvironmentInput struct {
 	// sample application in the container.
 	VersionLabel *string `min:"1" type:"string"`
 
-	metadataCreateEnvironmentInput `json:"-" xml:"-"`
-}
-
-type metadataCreateEnvironmentInput struct {
-	SDKShapeTraits bool `type:"structure"`
+	_ struct{} `type:"structure"`
 }
 
 // String returns the string representation
@@ -1809,11 +1733,7 @@ func (s CreateEnvironmentInput) GoString() string {
 }
 
 type CreateStorageLocationInput struct {
-	metadataCreateStorageLocationInput `json:"-" xml:"-"`
-}
-
-type metadataCreateStorageLocationInput struct {
-	SDKShapeTraits bool `type:"structure"`
+	_ struct{} `type:"structure"`
 }
 
 // String returns the string representation
@@ -1831,11 +1751,7 @@ type CreateStorageLocationOutput struct {
 	// The name of the Amazon S3 bucket created.
 	S3Bucket *string `type:"string"`
 
-	metadataCreateStorageLocationOutput `json:"-" xml:"-"`
-}
-
-type metadataCreateStorageLocationOutput struct {
-	SDKShapeTraits bool `type:"structure"`
+	_ struct{} `type:"structure"`
 }
 
 // String returns the string representation
@@ -1856,11 +1772,7 @@ type DeleteApplicationInput struct {
 	// the application.
 	TerminateEnvByForce *bool `type:"boolean"`
 
-	metadataDeleteApplicationInput `json:"-" xml:"-"`
-}
-
-type metadataDeleteApplicationInput struct {
-	SDKShapeTraits bool `type:"structure"`
+	_ struct{} `type:"structure"`
 }
 
 // String returns the string representation
@@ -1874,11 +1786,7 @@ func (s DeleteApplicationInput) GoString() string {
 }
 
 type DeleteApplicationOutput struct {
-	metadataDeleteApplicationOutput `json:"-" xml:"-"`
-}
-
-type metadataDeleteApplicationOutput struct {
-	SDKShapeTraits bool `type:"structure"`
+	_ struct{} `type:"structure"`
 }
 
 // String returns the string representation
@@ -1905,11 +1813,7 @@ type DeleteApplicationVersionInput struct {
 	// The label of the version to delete.
 	VersionLabel *string `min:"1" type:"string" required:"true"`
 
-	metadataDeleteApplicationVersionInput `json:"-" xml:"-"`
-}
-
-type metadataDeleteApplicationVersionInput struct {
-	SDKShapeTraits bool `type:"structure"`
+	_ struct{} `type:"structure"`
 }
 
 // String returns the string representation
@@ -1923,11 +1827,7 @@ func (s DeleteApplicationVersionInput) GoString() string {
 }
 
 type DeleteApplicationVersionOutput struct {
-	metadataDeleteApplicationVersionOutput `json:"-" xml:"-"`
-}
-
-type metadataDeleteApplicationVersionOutput struct {
-	SDKShapeTraits bool `type:"structure"`
+	_ struct{} `type:"structure"`
 }
 
 // String returns the string representation
@@ -1947,11 +1847,7 @@ type DeleteConfigurationTemplateInput struct {
 	// The name of the configuration template to delete.
 	TemplateName *string `min:"1" type:"string" required:"true"`
 
-	metadataDeleteConfigurationTemplateInput `json:"-" xml:"-"`
-}
-
-type metadataDeleteConfigurationTemplateInput struct {
-	SDKShapeTraits bool `type:"structure"`
+	_ struct{} `type:"structure"`
 }
 
 // String returns the string representation
@@ -1965,11 +1861,7 @@ func (s DeleteConfigurationTemplateInput) GoString() string {
 }
 
 type DeleteConfigurationTemplateOutput struct {
-	metadataDeleteConfigurationTemplateOutput `json:"-" xml:"-"`
-}
-
-type metadataDeleteConfigurationTemplateOutput struct {
-	SDKShapeTraits bool `type:"structure"`
+	_ struct{} `type:"structure"`
 }
 
 // String returns the string representation
@@ -1989,11 +1881,7 @@ type DeleteEnvironmentConfigurationInput struct {
 	// The name of the environment to delete the draft configuration from.
 	EnvironmentName *string `min:"4" type:"string" required:"true"`
 
-	metadataDeleteEnvironmentConfigurationInput `json:"-" xml:"-"`
-}
-
-type metadataDeleteEnvironmentConfigurationInput struct {
-	SDKShapeTraits bool `type:"structure"`
+	_ struct{} `type:"structure"`
 }
 
 // String returns the string representation
@@ -2007,11 +1895,7 @@ func (s DeleteEnvironmentConfigurationInput) GoString() string {
 }
 
 type DeleteEnvironmentConfigurationOutput struct {
-	metadataDeleteEnvironmentConfigurationOutput `json:"-" xml:"-"`
-}
-
-type metadataDeleteEnvironmentConfigurationOutput struct {
-	SDKShapeTraits bool `type:"structure"`
+	_ struct{} `type:"structure"`
 }
 
 // String returns the string representation
@@ -2034,11 +1918,7 @@ type DescribeApplicationVersionsInput struct {
 	// have the specified version labels.
 	VersionLabels []*string `type:"list"`
 
-	metadataDescribeApplicationVersionsInput `json:"-" xml:"-"`
-}
-
-type metadataDescribeApplicationVersionsInput struct {
-	SDKShapeTraits bool `type:"structure"`
+	_ struct{} `type:"structure"`
 }
 
 // String returns the string representation
@@ -2056,11 +1936,7 @@ type DescribeApplicationVersionsOutput struct {
 	// List of ApplicationVersionDescription objects sorted by order of creation.
 	ApplicationVersions []*ApplicationVersionDescription `type:"list"`
 
-	metadataDescribeApplicationVersionsOutput `json:"-" xml:"-"`
-}
-
-type metadataDescribeApplicationVersionsOutput struct {
-	SDKShapeTraits bool `type:"structure"`
+	_ struct{} `type:"structure"`
 }
 
 // String returns the string representation
@@ -2078,11 +1954,7 @@ type DescribeApplicationsInput struct {
 	// only include those with the specified names.
 	ApplicationNames []*string `type:"list"`
 
-	metadataDescribeApplicationsInput `json:"-" xml:"-"`
-}
-
-type metadataDescribeApplicationsInput struct {
-	SDKShapeTraits bool `type:"structure"`
+	_ struct{} `type:"structure"`
 }
 
 // String returns the string representation
@@ -2100,11 +1972,7 @@ type DescribeApplicationsOutput struct {
 	// This parameter contains a list of ApplicationDescription.
 	Applications []*ApplicationDescription `type:"list"`
 
-	metadataDescribeApplicationsOutput `json:"-" xml:"-"`
-}
-
-type metadataDescribeApplicationsOutput struct {
-	SDKShapeTraits bool `type:"structure"`
+	_ struct{} `type:"structure"`
 }
 
 // String returns the string representation
@@ -2137,11 +2005,7 @@ type DescribeConfigurationOptionsInput struct {
 	// to describe.
 	TemplateName *string `min:"1" type:"string"`
 
-	metadataDescribeConfigurationOptionsInput `json:"-" xml:"-"`
-}
-
-type metadataDescribeConfigurationOptionsInput struct {
-	SDKShapeTraits bool `type:"structure"`
+	_ struct{} `type:"structure"`
 }
 
 // String returns the string representation
@@ -2162,11 +2026,7 @@ type DescribeConfigurationOptionsOutput struct {
 	// The name of the solution stack these configuration options belong to.
 	SolutionStackName *string `type:"string"`
 
-	metadataDescribeConfigurationOptionsOutput `json:"-" xml:"-"`
-}
-
-type metadataDescribeConfigurationOptionsOutput struct {
-	SDKShapeTraits bool `type:"structure"`
+	_ struct{} `type:"structure"`
 }
 
 // String returns the string representation
@@ -2201,11 +2061,7 @@ type DescribeConfigurationSettingsInput struct {
 	// error.
 	TemplateName *string `min:"1" type:"string"`
 
-	metadataDescribeConfigurationSettingsInput `json:"-" xml:"-"`
-}
-
-type metadataDescribeConfigurationSettingsInput struct {
-	SDKShapeTraits bool `type:"structure"`
+	_ struct{} `type:"structure"`
 }
 
 // String returns the string representation
@@ -2223,11 +2079,7 @@ type DescribeConfigurationSettingsOutput struct {
 	// A list of ConfigurationSettingsDescription.
 	ConfigurationSettings []*ConfigurationSettingsDescription `type:"list"`
 
-	metadataDescribeConfigurationSettingsOutput `json:"-" xml:"-"`
-}
-
-type metadataDescribeConfigurationSettingsOutput struct {
-	SDKShapeTraits bool `type:"structure"`
+	_ struct{} `type:"structure"`
 }
 
 // String returns the string representation
@@ -2260,11 +2112,7 @@ type DescribeEnvironmentHealthInput struct {
 	// error.
 	EnvironmentName *string `min:"4" type:"string"`
 
-	metadataDescribeEnvironmentHealthInput `json:"-" xml:"-"`
-}
-
-type metadataDescribeEnvironmentHealthInput struct {
-	SDKShapeTraits bool `type:"structure"`
+	_ struct{} `type:"structure"`
 }
 
 // String returns the string representation
@@ -2306,11 +2154,7 @@ type DescribeEnvironmentHealthOutput struct {
 	// see Health Colors and Statuses (http://docs.aws.amazon.com/elasticbeanstalk/latest/dg/health-enhanced-status.html).
 	Status *string `type:"string" enum:"EnvironmentHealth"`
 
-	metadataDescribeEnvironmentHealthOutput `json:"-" xml:"-"`
-}
-
-type metadataDescribeEnvironmentHealthOutput struct {
-	SDKShapeTraits bool `type:"structure"`
+	_ struct{} `type:"structure"`
 }
 
 // String returns the string representation
@@ -2338,11 +2182,7 @@ type DescribeEnvironmentResourcesInput struct {
 	// error.
 	EnvironmentName *string `min:"4" type:"string"`
 
-	metadataDescribeEnvironmentResourcesInput `json:"-" xml:"-"`
-}
-
-type metadataDescribeEnvironmentResourcesInput struct {
-	SDKShapeTraits bool `type:"structure"`
+	_ struct{} `type:"structure"`
 }
 
 // String returns the string representation
@@ -2360,11 +2200,7 @@ type DescribeEnvironmentResourcesOutput struct {
 	// A list of EnvironmentResourceDescription.
 	EnvironmentResources *EnvironmentResourceDescription `type:"structure"`
 
-	metadataDescribeEnvironmentResourcesOutput `json:"-" xml:"-"`
-}
-
-type metadataDescribeEnvironmentResourcesOutput struct {
-	SDKShapeTraits bool `type:"structure"`
+	_ struct{} `type:"structure"`
 }
 
 // String returns the string representation
@@ -2406,11 +2242,7 @@ type DescribeEnvironmentsInput struct {
 	// include only those that are associated with this application version.
 	VersionLabel *string `min:"1" type:"string"`
 
-	metadataDescribeEnvironmentsInput `json:"-" xml:"-"`
-}
-
-type metadataDescribeEnvironmentsInput struct {
-	SDKShapeTraits bool `type:"structure"`
+	_ struct{} `type:"structure"`
 }
 
 // String returns the string representation
@@ -2467,11 +2299,7 @@ type DescribeEventsInput struct {
 	// those associated with this application version.
 	VersionLabel *string `min:"1" type:"string"`
 
-	metadataDescribeEventsInput `json:"-" xml:"-"`
-}
-
-type metadataDescribeEventsInput struct {
-	SDKShapeTraits bool `type:"structure"`
+	_ struct{} `type:"structure"`
 }
 
 // String returns the string representation
@@ -2493,11 +2321,7 @@ type DescribeEventsOutput struct {
 	// token in the next DescribeEvents call to get the next batch of events.
 	NextToken *string `type:"string"`
 
-	metadataDescribeEventsOutput `json:"-" xml:"-"`
-}
-
-type metadataDescribeEventsOutput struct {
-	SDKShapeTraits bool `type:"structure"`
+	_ struct{} `type:"structure"`
 }
 
 // String returns the string representation
@@ -2525,11 +2349,7 @@ type DescribeInstancesHealthInput struct {
 	// Specifies the next token of the request.
 	NextToken *string `min:"1" type:"string"`
 
-	metadataDescribeInstancesHealthInput `json:"-" xml:"-"`
-}
-
-type metadataDescribeInstancesHealthInput struct {
-	SDKShapeTraits bool `type:"structure"`
+	_ struct{} `type:"structure"`
 }
 
 // String returns the string representation
@@ -2553,11 +2373,7 @@ type DescribeInstancesHealthOutput struct {
 	// The date and time the information was last refreshed.
 	RefreshedAt *time.Time `type:"timestamp" timestampFormat:"iso8601"`
 
-	metadataDescribeInstancesHealthOutput `json:"-" xml:"-"`
-}
-
-type metadataDescribeInstancesHealthOutput struct {
-	SDKShapeTraits bool `type:"structure"`
+	_ struct{} `type:"structure"`
 }
 
 // String returns the string representation
@@ -2648,11 +2464,7 @@ type EnvironmentDescription struct {
 	// The application version deployed in this environment.
 	VersionLabel *string `min:"1" type:"string"`
 
-	metadataEnvironmentDescription `json:"-" xml:"-"`
-}
-
-type metadataEnvironmentDescription struct {
-	SDKShapeTraits bool `type:"structure"`
+	_ struct{} `type:"structure"`
 }
 
 // String returns the string representation
@@ -2670,11 +2482,7 @@ type EnvironmentDescriptionsMessage struct {
 	// Returns an EnvironmentDescription list.
 	Environments []*EnvironmentDescription `type:"list"`
 
-	metadataEnvironmentDescriptionsMessage `json:"-" xml:"-"`
-}
-
-type metadataEnvironmentDescriptionsMessage struct {
-	SDKShapeTraits bool `type:"structure"`
+	_ struct{} `type:"structure"`
 }
 
 // String returns the string representation
@@ -2701,11 +2509,7 @@ type EnvironmentInfoDescription struct {
 	// The time stamp when this information was retrieved.
 	SampleTimestamp *time.Time `type:"timestamp" timestampFormat:"iso8601"`
 
-	metadataEnvironmentInfoDescription `json:"-" xml:"-"`
-}
-
-type metadataEnvironmentInfoDescription struct {
-	SDKShapeTraits bool `type:"structure"`
+	_ struct{} `type:"structure"`
 }
 
 // String returns the string representation
@@ -2730,11 +2534,7 @@ type EnvironmentLink struct {
 	// The name of the link.
 	LinkName *string `type:"string"`
 
-	metadataEnvironmentLink `json:"-" xml:"-"`
-}
-
-type metadataEnvironmentLink struct {
-	SDKShapeTraits bool `type:"structure"`
+	_ struct{} `type:"structure"`
 }
 
 // String returns the string representation
@@ -2770,11 +2570,7 @@ type EnvironmentResourceDescription struct {
 	// The AutoScaling triggers in use by this environment.
 	Triggers []*Trigger `type:"list"`
 
-	metadataEnvironmentResourceDescription `json:"-" xml:"-"`
-}
-
-type metadataEnvironmentResourceDescription struct {
-	SDKShapeTraits bool `type:"structure"`
+	_ struct{} `type:"structure"`
 }
 
 // String returns the string representation
@@ -2793,11 +2589,7 @@ type EnvironmentResourcesDescription struct {
 	// Describes the LoadBalancer.
 	LoadBalancer *LoadBalancerDescription `type:"structure"`
 
-	metadataEnvironmentResourcesDescription `json:"-" xml:"-"`
-}
-
-type metadataEnvironmentResourcesDescription struct {
-	SDKShapeTraits bool `type:"structure"`
+	_ struct{} `type:"structure"`
 }
 
 // String returns the string representation
@@ -2821,11 +2613,7 @@ type EnvironmentTier struct {
 	// The version of this environment tier.
 	Version *string `type:"string"`
 
-	metadataEnvironmentTier `json:"-" xml:"-"`
-}
-
-type metadataEnvironmentTier struct {
-	SDKShapeTraits bool `type:"structure"`
+	_ struct{} `type:"structure"`
 }
 
 // String returns the string representation
@@ -2864,11 +2652,7 @@ type EventDescription struct {
 	// The release label for the application version associated with this event.
 	VersionLabel *string `min:"1" type:"string"`
 
-	metadataEventDescription `json:"-" xml:"-"`
-}
-
-type metadataEventDescription struct {
-	SDKShapeTraits bool `type:"structure"`
+	_ struct{} `type:"structure"`
 }
 
 // String returns the string representation
@@ -2886,11 +2670,7 @@ type Instance struct {
 	// The ID of the Amazon EC2 instance.
 	Id *string `type:"string"`
 
-	metadataInstance `json:"-" xml:"-"`
-}
-
-type metadataInstance struct {
-	SDKShapeTraits bool `type:"structure"`
+	_ struct{} `type:"structure"`
 }
 
 // String returns the string representation
@@ -2936,11 +2716,7 @@ type InstanceHealthSummary struct {
 	// or other issues for an instance or environment.
 	Warning *int64 `type:"integer"`
 
-	metadataInstanceHealthSummary `json:"-" xml:"-"`
-}
-
-type metadataInstanceHealthSummary struct {
-	SDKShapeTraits bool `type:"structure"`
+	_ struct{} `type:"structure"`
 }
 
 // String returns the string representation
@@ -2988,11 +2764,7 @@ type Latency struct {
 	// 10 seconds.
 	P999 *float64 `type:"double"`
 
-	metadataLatency `json:"-" xml:"-"`
-}
-
-type metadataLatency struct {
-	SDKShapeTraits bool `type:"structure"`
+	_ struct{} `type:"structure"`
 }
 
 // String returns the string representation
@@ -3010,11 +2782,7 @@ type LaunchConfiguration struct {
 	// The name of the launch configuration.
 	Name *string `type:"string"`
 
-	metadataLaunchConfiguration `json:"-" xml:"-"`
-}
-
-type metadataLaunchConfiguration struct {
-	SDKShapeTraits bool `type:"structure"`
+	_ struct{} `type:"structure"`
 }
 
 // String returns the string representation
@@ -3028,11 +2796,7 @@ func (s LaunchConfiguration) GoString() string {
 }
 
 type ListAvailableSolutionStacksInput struct {
-	metadataListAvailableSolutionStacksInput `json:"-" xml:"-"`
-}
-
-type metadataListAvailableSolutionStacksInput struct {
-	SDKShapeTraits bool `type:"structure"`
+	_ struct{} `type:"structure"`
 }
 
 // String returns the string representation
@@ -3053,11 +2817,7 @@ type ListAvailableSolutionStacksOutput struct {
 	// A list of available solution stacks.
 	SolutionStacks []*string `type:"list"`
 
-	metadataListAvailableSolutionStacksOutput `json:"-" xml:"-"`
-}
-
-type metadataListAvailableSolutionStacksOutput struct {
-	SDKShapeTraits bool `type:"structure"`
+	_ struct{} `type:"structure"`
 }
 
 // String returns the string representation
@@ -3078,11 +2838,7 @@ type Listener struct {
 	// The protocol that is used by the Listener.
 	Protocol *string `type:"string"`
 
-	metadataListener `json:"-" xml:"-"`
-}
-
-type metadataListener struct {
-	SDKShapeTraits bool `type:"structure"`
+	_ struct{} `type:"structure"`
 }
 
 // String returns the string representation
@@ -3100,11 +2856,7 @@ type LoadBalancer struct {
 	// The name of the LoadBalancer.
 	Name *string `type:"string"`
 
-	metadataLoadBalancer `json:"-" xml:"-"`
-}
-
-type metadataLoadBalancer struct {
-	SDKShapeTraits bool `type:"structure"`
+	_ struct{} `type:"structure"`
 }
 
 // String returns the string representation
@@ -3128,11 +2880,7 @@ type LoadBalancerDescription struct {
 	// The name of the LoadBalancer.
 	LoadBalancerName *string `type:"string"`
 
-	metadataLoadBalancerDescription `json:"-" xml:"-"`
-}
-
-type metadataLoadBalancerDescription struct {
-	SDKShapeTraits bool `type:"structure"`
+	_ struct{} `type:"structure"`
 }
 
 // String returns the string representation
@@ -3155,11 +2903,7 @@ type OptionRestrictionRegex struct {
 	// this restriction must match.
 	Pattern *string `type:"string"`
 
-	metadataOptionRestrictionRegex `json:"-" xml:"-"`
-}
-
-type metadataOptionRestrictionRegex struct {
-	SDKShapeTraits bool `type:"structure"`
+	_ struct{} `type:"structure"`
 }
 
 // String returns the string representation
@@ -3183,11 +2927,7 @@ type OptionSpecification struct {
 	// A unique resource name for a time-based scaling configuration option.
 	ResourceName *string `min:"1" type:"string"`
 
-	metadataOptionSpecification `json:"-" xml:"-"`
-}
-
-type metadataOptionSpecification struct {
-	SDKShapeTraits bool `type:"structure"`
+	_ struct{} `type:"structure"`
 }
 
 // String returns the string representation
@@ -3208,11 +2948,7 @@ type Queue struct {
 	// The URL of the queue.
 	URL *string `type:"string"`
 
-	metadataQueue `json:"-" xml:"-"`
-}
-
-type metadataQueue struct {
-	SDKShapeTraits bool `type:"structure"`
+	_ struct{} `type:"structure"`
 }
 
 // String returns the string representation
@@ -3240,11 +2976,7 @@ type RebuildEnvironmentInput struct {
 	// error.
 	EnvironmentName *string `min:"4" type:"string"`
 
-	metadataRebuildEnvironmentInput `json:"-" xml:"-"`
-}
-
-type metadataRebuildEnvironmentInput struct {
-	SDKShapeTraits bool `type:"structure"`
+	_ struct{} `type:"structure"`
 }
 
 // String returns the string representation
@@ -3258,11 +2990,7 @@ func (s RebuildEnvironmentInput) GoString() string {
 }
 
 type RebuildEnvironmentOutput struct {
-	metadataRebuildEnvironmentOutput `json:"-" xml:"-"`
-}
-
-type metadataRebuildEnvironmentOutput struct {
-	SDKShapeTraits bool `type:"structure"`
+	_ struct{} `type:"structure"`
 }
 
 // String returns the string representation
@@ -3299,11 +3027,7 @@ type RequestEnvironmentInfoInput struct {
 	// The type of information to request.
 	InfoType *string `type:"string" required:"true" enum:"EnvironmentInfoType"`
 
-	metadataRequestEnvironmentInfoInput `json:"-" xml:"-"`
-}
-
-type metadataRequestEnvironmentInfoInput struct {
-	SDKShapeTraits bool `type:"structure"`
+	_ struct{} `type:"structure"`
 }
 
 // String returns the string representation
@@ -3317,11 +3041,7 @@ func (s RequestEnvironmentInfoInput) GoString() string {
 }
 
 type RequestEnvironmentInfoOutput struct {
-	metadataRequestEnvironmentInfoOutput `json:"-" xml:"-"`
-}
-
-type metadataRequestEnvironmentInfoOutput struct {
-	SDKShapeTraits bool `type:"structure"`
+	_ struct{} `type:"structure"`
 }
 
 // String returns the string representation
@@ -3349,11 +3069,7 @@ type RestartAppServerInput struct {
 	// error.
 	EnvironmentName *string `min:"4" type:"string"`
 
-	metadataRestartAppServerInput `json:"-" xml:"-"`
-}
-
-type metadataRestartAppServerInput struct {
-	SDKShapeTraits bool `type:"structure"`
+	_ struct{} `type:"structure"`
 }
 
 // String returns the string representation
@@ -3367,11 +3083,7 @@ func (s RestartAppServerInput) GoString() string {
 }
 
 type RestartAppServerOutput struct {
-	metadataRestartAppServerOutput `json:"-" xml:"-"`
-}
-
-type metadataRestartAppServerOutput struct {
-	SDKShapeTraits bool `type:"structure"`
+	_ struct{} `type:"structure"`
 }
 
 // String returns the string representation
@@ -3406,11 +3118,7 @@ type RetrieveEnvironmentInfoInput struct {
 	// The type of information to retrieve.
 	InfoType *string `type:"string" required:"true" enum:"EnvironmentInfoType"`
 
-	metadataRetrieveEnvironmentInfoInput `json:"-" xml:"-"`
-}
-
-type metadataRetrieveEnvironmentInfoInput struct {
-	SDKShapeTraits bool `type:"structure"`
+	_ struct{} `type:"structure"`
 }
 
 // String returns the string representation
@@ -3428,11 +3136,7 @@ type RetrieveEnvironmentInfoOutput struct {
 	// The EnvironmentInfoDescription of the environment.
 	EnvironmentInfo []*EnvironmentInfoDescription `type:"list"`
 
-	metadataRetrieveEnvironmentInfoOutput `json:"-" xml:"-"`
-}
-
-type metadataRetrieveEnvironmentInfoOutput struct {
-	SDKShapeTraits bool `type:"structure"`
+	_ struct{} `type:"structure"`
 }
 
 // String returns the string representation
@@ -3453,11 +3157,7 @@ type S3Location struct {
 	// The Amazon S3 key where the data is located.
 	S3Key *string `type:"string"`
 
-	metadataS3Location `json:"-" xml:"-"`
-}
-
-type metadataS3Location struct {
-	SDKShapeTraits bool `type:"structure"`
+	_ struct{} `type:"structure"`
 }
 
 // String returns the string representation
@@ -3500,11 +3200,7 @@ type SingleInstanceHealth struct {
 	// running in the specified environment.
 	System *SystemStatus `type:"structure"`
 
-	metadataSingleInstanceHealth `json:"-" xml:"-"`
-}
-
-type metadataSingleInstanceHealth struct {
-	SDKShapeTraits bool `type:"structure"`
+	_ struct{} `type:"structure"`
 }
 
 // String returns the string representation
@@ -3525,11 +3221,7 @@ type SolutionStackDescription struct {
 	// The name of the solution stack.
 	SolutionStackName *string `type:"string"`
 
-	metadataSolutionStackDescription `json:"-" xml:"-"`
-}
-
-type metadataSolutionStackDescription struct {
-	SDKShapeTraits bool `type:"structure"`
+	_ struct{} `type:"structure"`
 }
 
 // String returns the string representation
@@ -3550,11 +3242,7 @@ type SourceConfiguration struct {
 	// The name of the configuration template.
 	TemplateName *string `min:"1" type:"string"`
 
-	metadataSourceConfiguration `json:"-" xml:"-"`
-}
-
-type metadataSourceConfiguration struct {
-	SDKShapeTraits bool `type:"structure"`
+	_ struct{} `type:"structure"`
 }
 
 // String returns the string representation
@@ -3587,11 +3275,7 @@ type StatusCodes struct {
 	// (500, 501, etc.) status code.
 	Status5xx *int64 `type:"integer"`
 
-	metadataStatusCodes `json:"-" xml:"-"`
-}
-
-type metadataStatusCodes struct {
-	SDKShapeTraits bool `type:"structure"`
+	_ struct{} `type:"structure"`
 }
 
 // String returns the string representation
@@ -3634,11 +3318,7 @@ type SwapEnvironmentCNAMEsInput struct {
 	// must specify the DestinationEnvironmentName.
 	SourceEnvironmentName *string `min:"4" type:"string"`
 
-	metadataSwapEnvironmentCNAMEsInput `json:"-" xml:"-"`
-}
-
-type metadataSwapEnvironmentCNAMEsInput struct {
-	SDKShapeTraits bool `type:"structure"`
+	_ struct{} `type:"structure"`
 }
 
 // String returns the string representation
@@ -3652,11 +3332,7 @@ func (s SwapEnvironmentCNAMEsInput) GoString() string {
 }
 
 type SwapEnvironmentCNAMEsOutput struct {
-	metadataSwapEnvironmentCNAMEsOutput `json:"-" xml:"-"`
-}
-
-type metadataSwapEnvironmentCNAMEsOutput struct {
-	SDKShapeTraits bool `type:"structure"`
+	_ struct{} `type:"structure"`
 }
 
 // String returns the string representation
@@ -3681,11 +3357,7 @@ type SystemStatus struct {
 	// see Operating System Metrics (http://docs.aws.amazon.com/elasticbeanstalk/latest/dg/health-enhanced-metrics.html#health-enhanced-metrics-os).
 	LoadAverage []*float64 `type:"list"`
 
-	metadataSystemStatus `json:"-" xml:"-"`
-}
-
-type metadataSystemStatus struct {
-	SDKShapeTraits bool `type:"structure"`
+	_ struct{} `type:"structure"`
 }
 
 // String returns the string representation
@@ -3706,11 +3378,7 @@ type Tag struct {
 	// The value of the tag.
 	Value *string `min:"1" type:"string"`
 
-	metadataTag `json:"-" xml:"-"`
-}
-
-type metadataTag struct {
-	SDKShapeTraits bool `type:"structure"`
+	_ struct{} `type:"structure"`
 }
 
 // String returns the string representation
@@ -3756,11 +3424,7 @@ type TerminateEnvironmentInput struct {
 	//  Valid Values: true | false
 	TerminateResources *bool `type:"boolean"`
 
-	metadataTerminateEnvironmentInput `json:"-" xml:"-"`
-}
-
-type metadataTerminateEnvironmentInput struct {
-	SDKShapeTraits bool `type:"structure"`
+	_ struct{} `type:"structure"`
 }
 
 // String returns the string representation
@@ -3778,11 +3442,7 @@ type Trigger struct {
 	// The name of the trigger.
 	Name *string `type:"string"`
 
-	metadataTrigger `json:"-" xml:"-"`
-}
-
-type metadataTrigger struct {
-	SDKShapeTraits bool `type:"structure"`
+	_ struct{} `type:"structure"`
 }
 
 // String returns the string representation
@@ -3805,11 +3465,7 @@ type UpdateApplicationInput struct {
 	// Default: If not specified, AWS Elastic Beanstalk does not update the description.
 	Description *string `type:"string"`
 
-	metadataUpdateApplicationInput `json:"-" xml:"-"`
-}
-
-type metadataUpdateApplicationInput struct {
-	SDKShapeTraits bool `type:"structure"`
+	_ struct{} `type:"structure"`
 }
 
 // String returns the string representation
@@ -3838,11 +3494,7 @@ type UpdateApplicationVersionInput struct {
 	// an InvalidParameterValue error.
 	VersionLabel *string `min:"1" type:"string" required:"true"`
 
-	metadataUpdateApplicationVersionInput `json:"-" xml:"-"`
-}
-
-type metadataUpdateApplicationVersionInput struct {
-	SDKShapeTraits bool `type:"structure"`
+	_ struct{} `type:"structure"`
 }
 
 // String returns the string representation
@@ -3882,11 +3534,7 @@ type UpdateConfigurationTemplateInput struct {
 	// returns an InvalidParameterValue error.
 	TemplateName *string `min:"1" type:"string" required:"true"`
 
-	metadataUpdateConfigurationTemplateInput `json:"-" xml:"-"`
-}
-
-type metadataUpdateConfigurationTemplateInput struct {
-	SDKShapeTraits bool `type:"structure"`
+	_ struct{} `type:"structure"`
 }
 
 // String returns the string representation
@@ -3961,11 +3609,7 @@ type UpdateEnvironmentInput struct {
 	// an InvalidParameterValue error.
 	VersionLabel *string `min:"1" type:"string"`
 
-	metadataUpdateEnvironmentInput `json:"-" xml:"-"`
-}
-
-type metadataUpdateEnvironmentInput struct {
-	SDKShapeTraits bool `type:"structure"`
+	_ struct{} `type:"structure"`
 }
 
 // String returns the string representation
@@ -3997,11 +3641,7 @@ type ValidateConfigurationSettingsInput struct {
 	//  Condition: You cannot specify both this and an environment name.
 	TemplateName *string `min:"1" type:"string"`
 
-	metadataValidateConfigurationSettingsInput `json:"-" xml:"-"`
-}
-
-type metadataValidateConfigurationSettingsInput struct {
-	SDKShapeTraits bool `type:"structure"`
+	_ struct{} `type:"structure"`
 }
 
 // String returns the string representation
@@ -4019,11 +3659,7 @@ type ValidateConfigurationSettingsOutput struct {
 	// A list of ValidationMessage.
 	Messages []*ValidationMessage `type:"list"`
 
-	metadataValidateConfigurationSettingsOutput `json:"-" xml:"-"`
-}
-
-type metadataValidateConfigurationSettingsOutput struct {
-	SDKShapeTraits bool `type:"structure"`
+	_ struct{} `type:"structure"`
 }
 
 // String returns the string representation
@@ -4052,11 +3688,7 @@ type ValidationMessage struct {
 	// into account.
 	Severity *string `type:"string" enum:"ValidationSeverity"`
 
-	metadataValidationMessage `json:"-" xml:"-"`
-}
-
-type metadataValidationMessage struct {
-	SDKShapeTraits bool `type:"structure"`
+	_ struct{} `type:"structure"`
 }
 
 // String returns the string representation

--- a/service/elasticbeanstalk/api.go
+++ b/service/elasticbeanstalk/api.go
@@ -1026,6 +1026,8 @@ func (c *ElasticBeanstalk) ValidateConfigurationSettings(input *ValidateConfigur
 }
 
 type AbortEnvironmentUpdateInput struct {
+	_ struct{} `type:"structure"`
+
 	// This specifies the ID of the environment with the in-progress update that
 	// you want to cancel.
 	EnvironmentId *string `type:"string"`
@@ -1033,8 +1035,6 @@ type AbortEnvironmentUpdateInput struct {
 	// This specifies the name of the environment with the in-progress update that
 	// you want to cancel.
 	EnvironmentName *string `min:"4" type:"string"`
-
-	_ struct{} `type:"structure"`
 }
 
 // String returns the string representation
@@ -1063,6 +1063,8 @@ func (s AbortEnvironmentUpdateOutput) GoString() string {
 
 // Describes the properties of an application.
 type ApplicationDescription struct {
+	_ struct{} `type:"structure"`
+
 	// The name of the application.
 	ApplicationName *string `min:"1" type:"string"`
 
@@ -1080,8 +1082,6 @@ type ApplicationDescription struct {
 
 	// The names of the versions for this application.
 	Versions []*string `type:"list"`
-
-	_ struct{} `type:"structure"`
 }
 
 // String returns the string representation
@@ -1096,10 +1096,10 @@ func (s ApplicationDescription) GoString() string {
 
 // Result message containing a single description of an application.
 type ApplicationDescriptionMessage struct {
+	_ struct{} `type:"structure"`
+
 	// The ApplicationDescription of the application.
 	Application *ApplicationDescription `type:"structure"`
-
-	_ struct{} `type:"structure"`
 }
 
 // String returns the string representation
@@ -1114,6 +1114,8 @@ func (s ApplicationDescriptionMessage) GoString() string {
 
 // Represents the application metrics for a specified environment.
 type ApplicationMetrics struct {
+	_ struct{} `type:"structure"`
+
 	// The amount of time that the metrics cover (usually 10 seconds). For example,
 	// you might have 5 requests (request_count) within the most recent time slice
 	// of 10 seconds (duration).
@@ -1130,8 +1132,6 @@ type ApplicationMetrics struct {
 	// Represents the percentage of requests over the last 10 seconds that resulted
 	// in each type of status code response.
 	StatusCodes *StatusCodes `type:"structure"`
-
-	_ struct{} `type:"structure"`
 }
 
 // String returns the string representation
@@ -1146,6 +1146,8 @@ func (s ApplicationMetrics) GoString() string {
 
 // Describes the properties of an application version.
 type ApplicationVersionDescription struct {
+	_ struct{} `type:"structure"`
+
 	// The name of the application associated with this release.
 	ApplicationName *string `min:"1" type:"string"`
 
@@ -1166,8 +1168,6 @@ type ApplicationVersionDescription struct {
 
 	// A label uniquely identifying the version for the associated application.
 	VersionLabel *string `min:"1" type:"string"`
-
-	_ struct{} `type:"structure"`
 }
 
 // String returns the string representation
@@ -1182,10 +1182,10 @@ func (s ApplicationVersionDescription) GoString() string {
 
 // Result message wrapping a single description of an application version.
 type ApplicationVersionDescriptionMessage struct {
+	_ struct{} `type:"structure"`
+
 	// The ApplicationVersionDescription of the application version.
 	ApplicationVersion *ApplicationVersionDescription `type:"structure"`
-
-	_ struct{} `type:"structure"`
 }
 
 // String returns the string representation
@@ -1200,10 +1200,10 @@ func (s ApplicationVersionDescriptionMessage) GoString() string {
 
 // Describes an Auto Scaling launch configuration.
 type AutoScalingGroup struct {
+	_ struct{} `type:"structure"`
+
 	// The name of the AutoScalingGroup .
 	Name *string `type:"string"`
-
-	_ struct{} `type:"structure"`
 }
 
 // String returns the string representation
@@ -1220,6 +1220,8 @@ func (s AutoScalingGroup) GoString() string {
 // to the AWS Elastic Beanstalk environment. Use the instanceId property to
 // specify the application instance for which you'd like to return data.
 type CPUUtilization struct {
+	_ struct{} `type:"structure"`
+
 	// Percentage of time that the CPU has spent in the I/O Wait state over the
 	// last 10 seconds.
 	IOWait *float64 `type:"double"`
@@ -1247,8 +1249,6 @@ type CPUUtilization struct {
 	// Percentage of time that the CPU has spent in the User state over the last
 	// 10 seconds.
 	User *float64 `type:"double"`
-
-	_ struct{} `type:"structure"`
 }
 
 // String returns the string representation
@@ -1263,10 +1263,10 @@ func (s CPUUtilization) GoString() string {
 
 // Results message indicating whether a CNAME is available.
 type CheckDNSAvailabilityInput struct {
+	_ struct{} `type:"structure"`
+
 	// The prefix used when this CNAME is reserved.
 	CNAMEPrefix *string `min:"4" type:"string" required:"true"`
-
-	_ struct{} `type:"structure"`
 }
 
 // String returns the string representation
@@ -1281,6 +1281,8 @@ func (s CheckDNSAvailabilityInput) GoString() string {
 
 // Indicates if the specified CNAME is available.
 type CheckDNSAvailabilityOutput struct {
+	_ struct{} `type:"structure"`
+
 	// Indicates if the specified CNAME is available:
 	//
 	//   true : The CNAME is available.   false : The CNAME is not available.
@@ -1289,8 +1291,6 @@ type CheckDNSAvailabilityOutput struct {
 	// The fully qualified CNAME to reserve when CreateEnvironment is called with
 	// the provided prefix.
 	FullyQualifiedCNAME *string `min:"1" type:"string"`
-
-	_ struct{} `type:"structure"`
 }
 
 // String returns the string representation
@@ -1304,6 +1304,8 @@ func (s CheckDNSAvailabilityOutput) GoString() string {
 }
 
 type ComposeEnvironmentsInput struct {
+	_ struct{} `type:"structure"`
+
 	// The name of the application to which the specified source bundles belong.
 	ApplicationName *string `min:"1" type:"string"`
 
@@ -1320,8 +1322,6 @@ type ComposeEnvironmentsInput struct {
 	// of the solution stack to use, and optionally can specify environment links
 	// to create.
 	VersionLabels []*string `type:"list"`
-
-	_ struct{} `type:"structure"`
 }
 
 // String returns the string representation
@@ -1336,6 +1336,8 @@ func (s ComposeEnvironmentsInput) GoString() string {
 
 // Describes the possible values for a configuration option.
 type ConfigurationOptionDescription struct {
+	_ struct{} `type:"structure"`
+
 	// An indication of which action is required if the value for this configuration
 	// option changes:
 	//
@@ -1397,8 +1399,6 @@ type ConfigurationOptionDescription struct {
 	// the possible values.   Boolean : Values for this option are either true or
 	// false .   Json : Values for this option are a JSON representation of a ConfigDocument.
 	ValueType *string `type:"string" enum:"ConfigurationOptionValueType"`
-
-	_ struct{} `type:"structure"`
 }
 
 // String returns the string representation
@@ -1416,6 +1416,8 @@ func (s ConfigurationOptionDescription) GoString() string {
 // (http://docs.aws.amazon.com/elasticbeanstalk/latest/dg/command-options.html)
 // in the AWS Elastic Beanstalk Developer Guide.
 type ConfigurationOptionSetting struct {
+	_ struct{} `type:"structure"`
+
 	// A unique namespace identifying the option's associated AWS resource.
 	Namespace *string `type:"string"`
 
@@ -1427,8 +1429,6 @@ type ConfigurationOptionSetting struct {
 
 	// The current value for the configuration option.
 	Value *string `type:"string"`
-
-	_ struct{} `type:"structure"`
 }
 
 // String returns the string representation
@@ -1443,6 +1443,8 @@ func (s ConfigurationOptionSetting) GoString() string {
 
 // Describes the settings for a configuration set.
 type ConfigurationSettingsDescription struct {
+	_ struct{} `type:"structure"`
+
 	// The name of the application associated with this configuration set.
 	ApplicationName *string `min:"1" type:"string"`
 
@@ -1478,8 +1480,6 @@ type ConfigurationSettingsDescription struct {
 	// If not null, the name of the configuration template for this configuration
 	// set.
 	TemplateName *string `min:"1" type:"string"`
-
-	_ struct{} `type:"structure"`
 }
 
 // String returns the string representation
@@ -1493,6 +1493,8 @@ func (s ConfigurationSettingsDescription) GoString() string {
 }
 
 type CreateApplicationInput struct {
+	_ struct{} `type:"structure"`
+
 	// The name of the application.
 	//
 	//  Constraint: This name must be unique within your account. If the specified
@@ -1501,8 +1503,6 @@ type CreateApplicationInput struct {
 
 	// Describes the application.
 	Description *string `type:"string"`
-
-	_ struct{} `type:"structure"`
 }
 
 // String returns the string representation
@@ -1516,6 +1516,8 @@ func (s CreateApplicationInput) GoString() string {
 }
 
 type CreateApplicationVersionInput struct {
+	_ struct{} `type:"structure"`
+
 	// The name of the application. If no application is found with this name, and
 	// AutoCreateApplication is false, returns an InvalidParameterValue error.
 	ApplicationName *string `min:"1" type:"string" required:"true"`
@@ -1558,8 +1560,6 @@ type CreateApplicationVersionInput struct {
 	// exists with this label for the specified application, AWS Elastic Beanstalk
 	// returns an InvalidParameterValue error.
 	VersionLabel *string `min:"1" type:"string" required:"true"`
-
-	_ struct{} `type:"structure"`
 }
 
 // String returns the string representation
@@ -1573,6 +1573,8 @@ func (s CreateApplicationVersionInput) GoString() string {
 }
 
 type CreateConfigurationTemplateInput struct {
+	_ struct{} `type:"structure"`
+
 	// The name of the application to associate with this configuration template.
 	// If no application is found with this name, AWS Elastic Beanstalk returns
 	// an InvalidParameterValue error.
@@ -1627,8 +1629,6 @@ type CreateConfigurationTemplateInput struct {
 	// Default: If a configuration template already exists with this name, AWS
 	// Elastic Beanstalk returns an InvalidParameterValue error.
 	TemplateName *string `min:"1" type:"string" required:"true"`
-
-	_ struct{} `type:"structure"`
 }
 
 // String returns the string representation
@@ -1642,6 +1642,8 @@ func (s CreateConfigurationTemplateInput) GoString() string {
 }
 
 type CreateEnvironmentInput struct {
+	_ struct{} `type:"structure"`
+
 	// The name of the application that contains the version to be deployed.
 	//
 	//  If no application is found with this name, CreateEnvironment returns an
@@ -1718,8 +1720,6 @@ type CreateEnvironmentInput struct {
 	//  Default: If not specified, AWS Elastic Beanstalk attempts to launch the
 	// sample application in the container.
 	VersionLabel *string `min:"1" type:"string"`
-
-	_ struct{} `type:"structure"`
 }
 
 // String returns the string representation
@@ -1748,10 +1748,10 @@ func (s CreateStorageLocationInput) GoString() string {
 
 // Results of a CreateStorageLocationResult call.
 type CreateStorageLocationOutput struct {
+	_ struct{} `type:"structure"`
+
 	// The name of the Amazon S3 bucket created.
 	S3Bucket *string `type:"string"`
-
-	_ struct{} `type:"structure"`
 }
 
 // String returns the string representation
@@ -1765,14 +1765,14 @@ func (s CreateStorageLocationOutput) GoString() string {
 }
 
 type DeleteApplicationInput struct {
+	_ struct{} `type:"structure"`
+
 	// The name of the application to delete.
 	ApplicationName *string `min:"1" type:"string" required:"true"`
 
 	// When set to true, running environments will be terminated before deleting
 	// the application.
 	TerminateEnvByForce *bool `type:"boolean"`
-
-	_ struct{} `type:"structure"`
 }
 
 // String returns the string representation
@@ -1800,6 +1800,8 @@ func (s DeleteApplicationOutput) GoString() string {
 }
 
 type DeleteApplicationVersionInput struct {
+	_ struct{} `type:"structure"`
+
 	// The name of the application to delete releases from.
 	ApplicationName *string `min:"1" type:"string" required:"true"`
 
@@ -1812,8 +1814,6 @@ type DeleteApplicationVersionInput struct {
 
 	// The label of the version to delete.
 	VersionLabel *string `min:"1" type:"string" required:"true"`
-
-	_ struct{} `type:"structure"`
 }
 
 // String returns the string representation
@@ -1841,13 +1841,13 @@ func (s DeleteApplicationVersionOutput) GoString() string {
 }
 
 type DeleteConfigurationTemplateInput struct {
+	_ struct{} `type:"structure"`
+
 	// The name of the application to delete the configuration template from.
 	ApplicationName *string `min:"1" type:"string" required:"true"`
 
 	// The name of the configuration template to delete.
 	TemplateName *string `min:"1" type:"string" required:"true"`
-
-	_ struct{} `type:"structure"`
 }
 
 // String returns the string representation
@@ -1875,13 +1875,13 @@ func (s DeleteConfigurationTemplateOutput) GoString() string {
 }
 
 type DeleteEnvironmentConfigurationInput struct {
+	_ struct{} `type:"structure"`
+
 	// The name of the application the environment is associated with.
 	ApplicationName *string `min:"1" type:"string" required:"true"`
 
 	// The name of the environment to delete the draft configuration from.
 	EnvironmentName *string `min:"4" type:"string" required:"true"`
-
-	_ struct{} `type:"structure"`
 }
 
 // String returns the string representation
@@ -1910,6 +1910,8 @@ func (s DeleteEnvironmentConfigurationOutput) GoString() string {
 
 // Result message containing a list of configuration descriptions.
 type DescribeApplicationVersionsInput struct {
+	_ struct{} `type:"structure"`
+
 	// If specified, AWS Elastic Beanstalk restricts the returned descriptions to
 	// only include ones that are associated with the specified application.
 	ApplicationName *string `min:"1" type:"string"`
@@ -1917,8 +1919,6 @@ type DescribeApplicationVersionsInput struct {
 	// If specified, restricts the returned descriptions to only include ones that
 	// have the specified version labels.
 	VersionLabels []*string `type:"list"`
-
-	_ struct{} `type:"structure"`
 }
 
 // String returns the string representation
@@ -1933,10 +1933,10 @@ func (s DescribeApplicationVersionsInput) GoString() string {
 
 // Result message wrapping a list of application version descriptions.
 type DescribeApplicationVersionsOutput struct {
+	_ struct{} `type:"structure"`
+
 	// List of ApplicationVersionDescription objects sorted by order of creation.
 	ApplicationVersions []*ApplicationVersionDescription `type:"list"`
-
-	_ struct{} `type:"structure"`
 }
 
 // String returns the string representation
@@ -1950,11 +1950,11 @@ func (s DescribeApplicationVersionsOutput) GoString() string {
 }
 
 type DescribeApplicationsInput struct {
+	_ struct{} `type:"structure"`
+
 	// If specified, AWS Elastic Beanstalk restricts the returned descriptions to
 	// only include those with the specified names.
 	ApplicationNames []*string `type:"list"`
-
-	_ struct{} `type:"structure"`
 }
 
 // String returns the string representation
@@ -1969,10 +1969,10 @@ func (s DescribeApplicationsInput) GoString() string {
 
 // Result message containing a list of application descriptions.
 type DescribeApplicationsOutput struct {
+	_ struct{} `type:"structure"`
+
 	// This parameter contains a list of ApplicationDescription.
 	Applications []*ApplicationDescription `type:"list"`
-
-	_ struct{} `type:"structure"`
 }
 
 // String returns the string representation
@@ -1987,6 +1987,8 @@ func (s DescribeApplicationsOutput) GoString() string {
 
 // Result message containig a list of application version descriptions.
 type DescribeConfigurationOptionsInput struct {
+	_ struct{} `type:"structure"`
+
 	// The name of the application associated with the configuration template or
 	// environment. Only needed if you want to describe the configuration options
 	// associated with either the configuration template or environment.
@@ -2004,8 +2006,6 @@ type DescribeConfigurationOptionsInput struct {
 	// The name of the configuration template whose configuration options you want
 	// to describe.
 	TemplateName *string `min:"1" type:"string"`
-
-	_ struct{} `type:"structure"`
 }
 
 // String returns the string representation
@@ -2020,13 +2020,13 @@ func (s DescribeConfigurationOptionsInput) GoString() string {
 
 // Describes the settings for a specified configuration set.
 type DescribeConfigurationOptionsOutput struct {
+	_ struct{} `type:"structure"`
+
 	// A list of ConfigurationOptionDescription.
 	Options []*ConfigurationOptionDescription `type:"list"`
 
 	// The name of the solution stack these configuration options belong to.
 	SolutionStackName *string `type:"string"`
-
-	_ struct{} `type:"structure"`
 }
 
 // String returns the string representation
@@ -2042,6 +2042,8 @@ func (s DescribeConfigurationOptionsOutput) GoString() string {
 // Result message containing all of the configuration settings for a specified
 // solution stack or configuration template.
 type DescribeConfigurationSettingsInput struct {
+	_ struct{} `type:"structure"`
+
 	// The application for the environment or configuration template.
 	ApplicationName *string `min:"1" type:"string" required:"true"`
 
@@ -2060,8 +2062,6 @@ type DescribeConfigurationSettingsInput struct {
 	// error. If you do not specify either, AWS Elastic Beanstalk returns a MissingRequiredParameter
 	// error.
 	TemplateName *string `min:"1" type:"string"`
-
-	_ struct{} `type:"structure"`
 }
 
 // String returns the string representation
@@ -2076,10 +2076,10 @@ func (s DescribeConfigurationSettingsInput) GoString() string {
 
 // The results from a request to change the configuration settings of an environment.
 type DescribeConfigurationSettingsOutput struct {
+	_ struct{} `type:"structure"`
+
 	// A list of ConfigurationSettingsDescription.
 	ConfigurationSettings []*ConfigurationSettingsDescription `type:"list"`
-
-	_ struct{} `type:"structure"`
 }
 
 // String returns the string representation
@@ -2094,6 +2094,8 @@ func (s DescribeConfigurationSettingsOutput) GoString() string {
 
 // See the example below to learn how to create a request body.
 type DescribeEnvironmentHealthInput struct {
+	_ struct{} `type:"structure"`
+
 	// Specifies the response elements you wish to receive. If no attribute names
 	// are specified, AWS Elastic Beanstalk only returns the name of the environment.
 	AttributeNames []*string `type:"list"`
@@ -2111,8 +2113,6 @@ type DescribeEnvironmentHealthInput struct {
 	// you do not specify either, AWS Elastic Beanstalk returns MissingRequiredParameter
 	// error.
 	EnvironmentName *string `min:"4" type:"string"`
-
-	_ struct{} `type:"structure"`
 }
 
 // String returns the string representation
@@ -2127,6 +2127,8 @@ func (s DescribeEnvironmentHealthInput) GoString() string {
 
 // See the example below for a sample response.
 type DescribeEnvironmentHealthOutput struct {
+	_ struct{} `type:"structure"`
+
 	// Represents the application metrics for a specified environment.
 	ApplicationMetrics *ApplicationMetrics `type:"structure"`
 
@@ -2153,8 +2155,6 @@ type DescribeEnvironmentHealthOutput struct {
 	// Returns the health status value of the environment. For more information,
 	// see Health Colors and Statuses (http://docs.aws.amazon.com/elasticbeanstalk/latest/dg/health-enhanced-status.html).
 	Status *string `type:"string" enum:"EnvironmentHealth"`
-
-	_ struct{} `type:"structure"`
 }
 
 // String returns the string representation
@@ -2168,6 +2168,8 @@ func (s DescribeEnvironmentHealthOutput) GoString() string {
 }
 
 type DescribeEnvironmentResourcesInput struct {
+	_ struct{} `type:"structure"`
+
 	// The ID of the environment to retrieve AWS resource usage data.
 	//
 	//  Condition: You must specify either this or an EnvironmentName, or both.
@@ -2181,8 +2183,6 @@ type DescribeEnvironmentResourcesInput struct {
 	// you do not specify either, AWS Elastic Beanstalk returns MissingRequiredParameter
 	// error.
 	EnvironmentName *string `min:"4" type:"string"`
-
-	_ struct{} `type:"structure"`
 }
 
 // String returns the string representation
@@ -2197,10 +2197,10 @@ func (s DescribeEnvironmentResourcesInput) GoString() string {
 
 // Result message containing a list of environment resource descriptions.
 type DescribeEnvironmentResourcesOutput struct {
+	_ struct{} `type:"structure"`
+
 	// A list of EnvironmentResourceDescription.
 	EnvironmentResources *EnvironmentResourceDescription `type:"structure"`
-
-	_ struct{} `type:"structure"`
 }
 
 // String returns the string representation
@@ -2214,6 +2214,8 @@ func (s DescribeEnvironmentResourcesOutput) GoString() string {
 }
 
 type DescribeEnvironmentsInput struct {
+	_ struct{} `type:"structure"`
+
 	// If specified, AWS Elastic Beanstalk restricts the returned descriptions to
 	// include only those that are associated with this application.
 	ApplicationName *string `min:"1" type:"string"`
@@ -2241,8 +2243,6 @@ type DescribeEnvironmentsInput struct {
 	// If specified, AWS Elastic Beanstalk restricts the returned descriptions to
 	// include only those that are associated with this application version.
 	VersionLabel *string `min:"1" type:"string"`
-
-	_ struct{} `type:"structure"`
 }
 
 // String returns the string representation
@@ -2256,6 +2256,8 @@ func (s DescribeEnvironmentsInput) GoString() string {
 }
 
 type DescribeEventsInput struct {
+	_ struct{} `type:"structure"`
+
 	// If specified, AWS Elastic Beanstalk restricts the returned descriptions to
 	// include only those associated with this application.
 	ApplicationName *string `min:"1" type:"string"`
@@ -2298,8 +2300,6 @@ type DescribeEventsInput struct {
 	// If specified, AWS Elastic Beanstalk restricts the returned descriptions to
 	// those associated with this application version.
 	VersionLabel *string `min:"1" type:"string"`
-
-	_ struct{} `type:"structure"`
 }
 
 // String returns the string representation
@@ -2314,14 +2314,14 @@ func (s DescribeEventsInput) GoString() string {
 
 // Result message wrapping a list of event descriptions.
 type DescribeEventsOutput struct {
+	_ struct{} `type:"structure"`
+
 	// A list of EventDescription.
 	Events []*EventDescription `type:"list"`
 
 	// If returned, this indicates that there are more results to obtain. Use this
 	// token in the next DescribeEvents call to get the next batch of events.
 	NextToken *string `type:"string"`
-
-	_ struct{} `type:"structure"`
 }
 
 // String returns the string representation
@@ -2336,6 +2336,8 @@ func (s DescribeEventsOutput) GoString() string {
 
 // See the example below to learn how to create a request body.
 type DescribeInstancesHealthInput struct {
+	_ struct{} `type:"structure"`
+
 	// Specifies the response elements you wish to receive. If no attribute names
 	// are specified, AWS Elastic Beanstalk only returns a list of instances.
 	AttributeNames []*string `type:"list"`
@@ -2348,8 +2350,6 @@ type DescribeInstancesHealthInput struct {
 
 	// Specifies the next token of the request.
 	NextToken *string `min:"1" type:"string"`
-
-	_ struct{} `type:"structure"`
 }
 
 // String returns the string representation
@@ -2364,6 +2364,8 @@ func (s DescribeInstancesHealthInput) GoString() string {
 
 // See the example below for a sample response.
 type DescribeInstancesHealthOutput struct {
+	_ struct{} `type:"structure"`
+
 	// Contains the response body with information about the health of the instance.
 	InstanceHealthList []*SingleInstanceHealth `type:"list"`
 
@@ -2372,8 +2374,6 @@ type DescribeInstancesHealthOutput struct {
 
 	// The date and time the information was last refreshed.
 	RefreshedAt *time.Time `type:"timestamp" timestampFormat:"iso8601"`
-
-	_ struct{} `type:"structure"`
 }
 
 // String returns the string representation
@@ -2388,6 +2388,8 @@ func (s DescribeInstancesHealthOutput) GoString() string {
 
 // Describes the properties of an environment.
 type EnvironmentDescription struct {
+	_ struct{} `type:"structure"`
+
 	// Indicates if there is an in-progress environment configuration update or
 	// application version deployment that you can cancel.
 	//
@@ -2463,8 +2465,6 @@ type EnvironmentDescription struct {
 
 	// The application version deployed in this environment.
 	VersionLabel *string `min:"1" type:"string"`
-
-	_ struct{} `type:"structure"`
 }
 
 // String returns the string representation
@@ -2479,10 +2479,10 @@ func (s EnvironmentDescription) GoString() string {
 
 // Result message containing a list of environment descriptions.
 type EnvironmentDescriptionsMessage struct {
+	_ struct{} `type:"structure"`
+
 	// Returns an EnvironmentDescription list.
 	Environments []*EnvironmentDescription `type:"list"`
-
-	_ struct{} `type:"structure"`
 }
 
 // String returns the string representation
@@ -2497,6 +2497,8 @@ func (s EnvironmentDescriptionsMessage) GoString() string {
 
 // The information retrieved from the Amazon EC2 instances.
 type EnvironmentInfoDescription struct {
+	_ struct{} `type:"structure"`
+
 	// The Amazon EC2 Instance ID for this information.
 	Ec2InstanceId *string `type:"string"`
 
@@ -2508,8 +2510,6 @@ type EnvironmentInfoDescription struct {
 
 	// The time stamp when this information was retrieved.
 	SampleTimestamp *time.Time `type:"timestamp" timestampFormat:"iso8601"`
-
-	_ struct{} `type:"structure"`
 }
 
 // String returns the string representation
@@ -2528,13 +2528,13 @@ func (s EnvironmentInfoDescription) GoString() string {
 // (http://docs.aws.amazon.com/elasticbeanstalk/latest/dg/environment-mgmt-compose.html#environment-mgmt-compose-envyaml)
 // for details.
 type EnvironmentLink struct {
+	_ struct{} `type:"structure"`
+
 	// The name of the linked environment (the dependency).
 	EnvironmentName *string `type:"string"`
 
 	// The name of the link.
 	LinkName *string `type:"string"`
-
-	_ struct{} `type:"structure"`
 }
 
 // String returns the string representation
@@ -2549,6 +2549,8 @@ func (s EnvironmentLink) GoString() string {
 
 // Describes the AWS resources in use by this environment. This data is live.
 type EnvironmentResourceDescription struct {
+	_ struct{} `type:"structure"`
+
 	// The AutoScalingGroups used by this environment.
 	AutoScalingGroups []*AutoScalingGroup `type:"list"`
 
@@ -2569,8 +2571,6 @@ type EnvironmentResourceDescription struct {
 
 	// The AutoScaling triggers in use by this environment.
 	Triggers []*Trigger `type:"list"`
-
-	_ struct{} `type:"structure"`
 }
 
 // String returns the string representation
@@ -2586,10 +2586,10 @@ func (s EnvironmentResourceDescription) GoString() string {
 // Describes the AWS resources in use by this environment. This data is not
 // live data.
 type EnvironmentResourcesDescription struct {
+	_ struct{} `type:"structure"`
+
 	// Describes the LoadBalancer.
 	LoadBalancer *LoadBalancerDescription `type:"structure"`
-
-	_ struct{} `type:"structure"`
 }
 
 // String returns the string representation
@@ -2604,6 +2604,8 @@ func (s EnvironmentResourcesDescription) GoString() string {
 
 // Describes the properties of an environment tier
 type EnvironmentTier struct {
+	_ struct{} `type:"structure"`
+
 	// The name of this environment tier.
 	Name *string `type:"string"`
 
@@ -2612,8 +2614,6 @@ type EnvironmentTier struct {
 
 	// The version of this environment tier.
 	Version *string `type:"string"`
-
-	_ struct{} `type:"structure"`
 }
 
 // String returns the string representation
@@ -2628,6 +2628,8 @@ func (s EnvironmentTier) GoString() string {
 
 // Describes an event.
 type EventDescription struct {
+	_ struct{} `type:"structure"`
+
 	// The application associated with the event.
 	ApplicationName *string `min:"1" type:"string"`
 
@@ -2651,8 +2653,6 @@ type EventDescription struct {
 
 	// The release label for the application version associated with this event.
 	VersionLabel *string `min:"1" type:"string"`
-
-	_ struct{} `type:"structure"`
 }
 
 // String returns the string representation
@@ -2667,10 +2667,10 @@ func (s EventDescription) GoString() string {
 
 // The description of an Amazon EC2 instance.
 type Instance struct {
+	_ struct{} `type:"structure"`
+
 	// The ID of the Amazon EC2 instance.
 	Id *string `type:"string"`
-
-	_ struct{} `type:"structure"`
 }
 
 // String returns the string representation
@@ -2686,6 +2686,8 @@ func (s Instance) GoString() string {
 // Represents summary information about the health of an instance. For more
 // information, see Health Colors and Statuses (http://docs.aws.amazon.com/elasticbeanstalk/latest/dg/health-enhanced-status.html).
 type InstanceHealthSummary struct {
+	_ struct{} `type:"structure"`
+
 	// Red. The health agent is reporting a high number of request failures or other
 	// issues for an instance or environment.
 	Degraded *int64 `type:"integer"`
@@ -2715,8 +2717,6 @@ type InstanceHealthSummary struct {
 	// Yellow. The health agent is reporting a moderate number of request failures
 	// or other issues for an instance or environment.
 	Warning *int64 `type:"integer"`
-
-	_ struct{} `type:"structure"`
 }
 
 // String returns the string representation
@@ -2732,6 +2732,8 @@ func (s InstanceHealthSummary) GoString() string {
 // Represents the average latency for the slowest X percent of requests over
 // the last 10 seconds.
 type Latency struct {
+	_ struct{} `type:"structure"`
+
 	// The average latency for the slowest 90 percent of requests over the last
 	// 10 seconds.
 	P10 *float64 `type:"double"`
@@ -2763,8 +2765,6 @@ type Latency struct {
 	// The average latency for the slowest 0.1 percent of requests over the last
 	// 10 seconds.
 	P999 *float64 `type:"double"`
-
-	_ struct{} `type:"structure"`
 }
 
 // String returns the string representation
@@ -2779,10 +2779,10 @@ func (s Latency) GoString() string {
 
 // Describes an Auto Scaling launch configuration.
 type LaunchConfiguration struct {
+	_ struct{} `type:"structure"`
+
 	// The name of the launch configuration.
 	Name *string `type:"string"`
-
-	_ struct{} `type:"structure"`
 }
 
 // String returns the string representation
@@ -2811,13 +2811,13 @@ func (s ListAvailableSolutionStacksInput) GoString() string {
 
 // A list of available AWS Elastic Beanstalk solution stacks.
 type ListAvailableSolutionStacksOutput struct {
+	_ struct{} `type:"structure"`
+
 	// A list of available solution stacks and their SolutionStackDescription.
 	SolutionStackDetails []*SolutionStackDescription `type:"list"`
 
 	// A list of available solution stacks.
 	SolutionStacks []*string `type:"list"`
-
-	_ struct{} `type:"structure"`
 }
 
 // String returns the string representation
@@ -2832,13 +2832,13 @@ func (s ListAvailableSolutionStacksOutput) GoString() string {
 
 // Describes the properties of a Listener for the LoadBalancer.
 type Listener struct {
+	_ struct{} `type:"structure"`
+
 	// The port that is used by the Listener.
 	Port *int64 `type:"integer"`
 
 	// The protocol that is used by the Listener.
 	Protocol *string `type:"string"`
-
-	_ struct{} `type:"structure"`
 }
 
 // String returns the string representation
@@ -2853,10 +2853,10 @@ func (s Listener) GoString() string {
 
 // Describes a LoadBalancer.
 type LoadBalancer struct {
+	_ struct{} `type:"structure"`
+
 	// The name of the LoadBalancer.
 	Name *string `type:"string"`
-
-	_ struct{} `type:"structure"`
 }
 
 // String returns the string representation
@@ -2871,6 +2871,8 @@ func (s LoadBalancer) GoString() string {
 
 // Describes the details of a LoadBalancer.
 type LoadBalancerDescription struct {
+	_ struct{} `type:"structure"`
+
 	// The domain name of the LoadBalancer.
 	Domain *string `type:"string"`
 
@@ -2879,8 +2881,6 @@ type LoadBalancerDescription struct {
 
 	// The name of the LoadBalancer.
 	LoadBalancerName *string `type:"string"`
-
-	_ struct{} `type:"structure"`
 }
 
 // String returns the string representation
@@ -2896,14 +2896,14 @@ func (s LoadBalancerDescription) GoString() string {
 // A regular expression representing a restriction on a string configuration
 // option value.
 type OptionRestrictionRegex struct {
+	_ struct{} `type:"structure"`
+
 	// A unique name representing this regular expression.
 	Label *string `type:"string"`
 
 	// The regular expression pattern that a string configuration option value with
 	// this restriction must match.
 	Pattern *string `type:"string"`
-
-	_ struct{} `type:"structure"`
 }
 
 // String returns the string representation
@@ -2918,6 +2918,8 @@ func (s OptionRestrictionRegex) GoString() string {
 
 // A specification identifying an individual configuration option.
 type OptionSpecification struct {
+	_ struct{} `type:"structure"`
+
 	// A unique namespace identifying the option's associated AWS resource.
 	Namespace *string `type:"string"`
 
@@ -2926,8 +2928,6 @@ type OptionSpecification struct {
 
 	// A unique resource name for a time-based scaling configuration option.
 	ResourceName *string `min:"1" type:"string"`
-
-	_ struct{} `type:"structure"`
 }
 
 // String returns the string representation
@@ -2942,13 +2942,13 @@ func (s OptionSpecification) GoString() string {
 
 // Describes a queue.
 type Queue struct {
+	_ struct{} `type:"structure"`
+
 	// The name of the queue.
 	Name *string `type:"string"`
 
 	// The URL of the queue.
 	URL *string `type:"string"`
-
-	_ struct{} `type:"structure"`
 }
 
 // String returns the string representation
@@ -2962,6 +2962,8 @@ func (s Queue) GoString() string {
 }
 
 type RebuildEnvironmentInput struct {
+	_ struct{} `type:"structure"`
+
 	// The ID of the environment to rebuild.
 	//
 	//  Condition: You must specify either this or an EnvironmentName, or both.
@@ -2975,8 +2977,6 @@ type RebuildEnvironmentInput struct {
 	// you do not specify either, AWS Elastic Beanstalk returns MissingRequiredParameter
 	// error.
 	EnvironmentName *string `min:"4" type:"string"`
-
-	_ struct{} `type:"structure"`
 }
 
 // String returns the string representation
@@ -3004,6 +3004,8 @@ func (s RebuildEnvironmentOutput) GoString() string {
 }
 
 type RequestEnvironmentInfoInput struct {
+	_ struct{} `type:"structure"`
+
 	// The ID of the environment of the requested data.
 	//
 	//  If no such environment is found, RequestEnvironmentInfo returns an InvalidParameterValue
@@ -3026,8 +3028,6 @@ type RequestEnvironmentInfoInput struct {
 
 	// The type of information to request.
 	InfoType *string `type:"string" required:"true" enum:"EnvironmentInfoType"`
-
-	_ struct{} `type:"structure"`
 }
 
 // String returns the string representation
@@ -3055,6 +3055,8 @@ func (s RequestEnvironmentInfoOutput) GoString() string {
 }
 
 type RestartAppServerInput struct {
+	_ struct{} `type:"structure"`
+
 	// The ID of the environment to restart the server for.
 	//
 	//  Condition: You must specify either this or an EnvironmentName, or both.
@@ -3068,8 +3070,6 @@ type RestartAppServerInput struct {
 	// you do not specify either, AWS Elastic Beanstalk returns MissingRequiredParameter
 	// error.
 	EnvironmentName *string `min:"4" type:"string"`
-
-	_ struct{} `type:"structure"`
 }
 
 // String returns the string representation
@@ -3097,6 +3097,8 @@ func (s RestartAppServerOutput) GoString() string {
 }
 
 type RetrieveEnvironmentInfoInput struct {
+	_ struct{} `type:"structure"`
+
 	// The ID of the data's environment.
 	//
 	//  If no such environment is found, returns an InvalidParameterValue error.
@@ -3117,8 +3119,6 @@ type RetrieveEnvironmentInfoInput struct {
 
 	// The type of information to retrieve.
 	InfoType *string `type:"string" required:"true" enum:"EnvironmentInfoType"`
-
-	_ struct{} `type:"structure"`
 }
 
 // String returns the string representation
@@ -3133,10 +3133,10 @@ func (s RetrieveEnvironmentInfoInput) GoString() string {
 
 // Result message containing a description of the requested environment info.
 type RetrieveEnvironmentInfoOutput struct {
+	_ struct{} `type:"structure"`
+
 	// The EnvironmentInfoDescription of the environment.
 	EnvironmentInfo []*EnvironmentInfoDescription `type:"list"`
-
-	_ struct{} `type:"structure"`
 }
 
 // String returns the string representation
@@ -3151,13 +3151,13 @@ func (s RetrieveEnvironmentInfoOutput) GoString() string {
 
 // A specification of a location in Amazon S3.
 type S3Location struct {
+	_ struct{} `type:"structure"`
+
 	// The Amazon S3 bucket where the data is located.
 	S3Bucket *string `type:"string"`
 
 	// The Amazon S3 key where the data is located.
 	S3Key *string `type:"string"`
-
-	_ struct{} `type:"structure"`
 }
 
 // String returns the string representation
@@ -3174,6 +3174,8 @@ func (s S3Location) GoString() string {
 // the AWS Elastic Beanstalk environment. Use the InstanceId property to specify
 // the application instance for which you'd like to return data.
 type SingleInstanceHealth struct {
+	_ struct{} `type:"structure"`
+
 	// Represents the application metrics for a specified environment.
 	ApplicationMetrics *ApplicationMetrics `type:"structure"`
 
@@ -3199,8 +3201,6 @@ type SingleInstanceHealth struct {
 	// Represents CPU utilization and load average information for applications
 	// running in the specified environment.
 	System *SystemStatus `type:"structure"`
-
-	_ struct{} `type:"structure"`
 }
 
 // String returns the string representation
@@ -3215,13 +3215,13 @@ func (s SingleInstanceHealth) GoString() string {
 
 // Describes the solution stack.
 type SolutionStackDescription struct {
+	_ struct{} `type:"structure"`
+
 	// The permitted file types allowed for a solution stack.
 	PermittedFileTypes []*string `type:"list"`
 
 	// The name of the solution stack.
 	SolutionStackName *string `type:"string"`
-
-	_ struct{} `type:"structure"`
 }
 
 // String returns the string representation
@@ -3236,13 +3236,13 @@ func (s SolutionStackDescription) GoString() string {
 
 // A specification for an environment configuration
 type SourceConfiguration struct {
+	_ struct{} `type:"structure"`
+
 	// The name of the application associated with the configuration.
 	ApplicationName *string `min:"1" type:"string"`
 
 	// The name of the configuration template.
 	TemplateName *string `min:"1" type:"string"`
-
-	_ struct{} `type:"structure"`
 }
 
 // String returns the string representation
@@ -3259,6 +3259,8 @@ func (s SourceConfiguration) GoString() string {
 // in each type of status code response. For more information, see Status Code
 // Definitions (http://www.w3.org/Protocols/rfc2616/rfc2616-sec10.html).
 type StatusCodes struct {
+	_ struct{} `type:"structure"`
+
 	// The percentage of requests over the last 10 seconds that resulted in a 2xx
 	// (200, 201, etc.) status code.
 	Status2xx *int64 `type:"integer"`
@@ -3274,8 +3276,6 @@ type StatusCodes struct {
 	// The percentage of requests over the last 10 seconds that resulted in a 5xx
 	// (500, 501, etc.) status code.
 	Status5xx *int64 `type:"integer"`
-
-	_ struct{} `type:"structure"`
 }
 
 // String returns the string representation
@@ -3290,6 +3290,8 @@ func (s StatusCodes) GoString() string {
 
 // Swaps the CNAMEs of two environments.
 type SwapEnvironmentCNAMEsInput struct {
+	_ struct{} `type:"structure"`
+
 	// The ID of the destination environment.
 	//
 	//  Condition: You must specify at least the DestinationEnvironmentID or the
@@ -3317,8 +3319,6 @@ type SwapEnvironmentCNAMEsInput struct {
 	// You may also specify both. If you specify the SourceEnvironmentName, you
 	// must specify the DestinationEnvironmentName.
 	SourceEnvironmentName *string `min:"4" type:"string"`
-
-	_ struct{} `type:"structure"`
 }
 
 // String returns the string representation
@@ -3348,6 +3348,8 @@ func (s SwapEnvironmentCNAMEsOutput) GoString() string {
 // Represents CPU utilization and load average information for applications
 // running in the specified environment.
 type SystemStatus struct {
+	_ struct{} `type:"structure"`
+
 	// Represents CPU utilization information from the specified instance that belongs
 	// to the AWS Elastic Beanstalk environment. Use the instanceId property to
 	// specify the application instance for which you'd like to return data.
@@ -3356,8 +3358,6 @@ type SystemStatus struct {
 	// Load average in the last 1-minute and 5-minute periods. For more information,
 	// see Operating System Metrics (http://docs.aws.amazon.com/elasticbeanstalk/latest/dg/health-enhanced-metrics.html#health-enhanced-metrics-os).
 	LoadAverage []*float64 `type:"list"`
-
-	_ struct{} `type:"structure"`
 }
 
 // String returns the string representation
@@ -3372,13 +3372,13 @@ func (s SystemStatus) GoString() string {
 
 // Describes a tag applied to a resource in an environment.
 type Tag struct {
+	_ struct{} `type:"structure"`
+
 	// The key of the tag.
 	Key *string `min:"1" type:"string"`
 
 	// The value of the tag.
 	Value *string `min:"1" type:"string"`
-
-	_ struct{} `type:"structure"`
 }
 
 // String returns the string representation
@@ -3392,6 +3392,8 @@ func (s Tag) GoString() string {
 }
 
 type TerminateEnvironmentInput struct {
+	_ struct{} `type:"structure"`
+
 	// The ID of the environment to terminate.
 	//
 	//  Condition: You must specify either this or an EnvironmentName, or both.
@@ -3423,8 +3425,6 @@ type TerminateEnvironmentInput struct {
 	//
 	//  Valid Values: true | false
 	TerminateResources *bool `type:"boolean"`
-
-	_ struct{} `type:"structure"`
 }
 
 // String returns the string representation
@@ -3439,10 +3439,10 @@ func (s TerminateEnvironmentInput) GoString() string {
 
 // Describes a trigger.
 type Trigger struct {
+	_ struct{} `type:"structure"`
+
 	// The name of the trigger.
 	Name *string `type:"string"`
-
-	_ struct{} `type:"structure"`
 }
 
 // String returns the string representation
@@ -3456,6 +3456,8 @@ func (s Trigger) GoString() string {
 }
 
 type UpdateApplicationInput struct {
+	_ struct{} `type:"structure"`
+
 	// The name of the application to update. If no such application is found, UpdateApplication
 	// returns an InvalidParameterValue error.
 	ApplicationName *string `min:"1" type:"string" required:"true"`
@@ -3464,8 +3466,6 @@ type UpdateApplicationInput struct {
 	//
 	// Default: If not specified, AWS Elastic Beanstalk does not update the description.
 	Description *string `type:"string"`
-
-	_ struct{} `type:"structure"`
 }
 
 // String returns the string representation
@@ -3479,6 +3479,8 @@ func (s UpdateApplicationInput) GoString() string {
 }
 
 type UpdateApplicationVersionInput struct {
+	_ struct{} `type:"structure"`
+
 	// The name of the application associated with this version.
 	//
 	//  If no application is found with this name, UpdateApplication returns an
@@ -3493,8 +3495,6 @@ type UpdateApplicationVersionInput struct {
 	//  If no application version is found with this label, UpdateApplication returns
 	// an InvalidParameterValue error.
 	VersionLabel *string `min:"1" type:"string" required:"true"`
-
-	_ struct{} `type:"structure"`
 }
 
 // String returns the string representation
@@ -3509,6 +3509,8 @@ func (s UpdateApplicationVersionInput) GoString() string {
 
 // The result message containing the options for the specified solution stack.
 type UpdateConfigurationTemplateInput struct {
+	_ struct{} `type:"structure"`
+
 	// The name of the application associated with the configuration template to
 	// update.
 	//
@@ -3533,8 +3535,6 @@ type UpdateConfigurationTemplateInput struct {
 	//  If no configuration template is found with this name, UpdateConfigurationTemplate
 	// returns an InvalidParameterValue error.
 	TemplateName *string `min:"1" type:"string" required:"true"`
-
-	_ struct{} `type:"structure"`
 }
 
 // String returns the string representation
@@ -3548,6 +3548,8 @@ func (s UpdateConfigurationTemplateInput) GoString() string {
 }
 
 type UpdateEnvironmentInput struct {
+	_ struct{} `type:"structure"`
+
 	// The name of the application with which the environment is associated.
 	ApplicationName *string `min:"1" type:"string"`
 
@@ -3608,8 +3610,6 @@ type UpdateEnvironmentInput struct {
 	// version to the environment. If no such application version is found, returns
 	// an InvalidParameterValue error.
 	VersionLabel *string `min:"1" type:"string"`
-
-	_ struct{} `type:"structure"`
 }
 
 // String returns the string representation
@@ -3624,6 +3624,8 @@ func (s UpdateEnvironmentInput) GoString() string {
 
 // A list of validation messages for a specified configuration template.
 type ValidateConfigurationSettingsInput struct {
+	_ struct{} `type:"structure"`
+
 	// The name of the application that the configuration template or environment
 	// belongs to.
 	ApplicationName *string `min:"1" type:"string" required:"true"`
@@ -3640,8 +3642,6 @@ type ValidateConfigurationSettingsInput struct {
 	//
 	//  Condition: You cannot specify both this and an environment name.
 	TemplateName *string `min:"1" type:"string"`
-
-	_ struct{} `type:"structure"`
 }
 
 // String returns the string representation
@@ -3656,10 +3656,10 @@ func (s ValidateConfigurationSettingsInput) GoString() string {
 
 // Provides a list of validation messages.
 type ValidateConfigurationSettingsOutput struct {
+	_ struct{} `type:"structure"`
+
 	// A list of ValidationMessage.
 	Messages []*ValidationMessage `type:"list"`
-
-	_ struct{} `type:"structure"`
 }
 
 // String returns the string representation
@@ -3674,6 +3674,8 @@ func (s ValidateConfigurationSettingsOutput) GoString() string {
 
 // An error or warning for a desired configuration option value.
 type ValidationMessage struct {
+	_ struct{} `type:"structure"`
+
 	// A message describing the error or warning.
 	Message *string `type:"string"`
 
@@ -3687,8 +3689,6 @@ type ValidationMessage struct {
 	// option.   warning: This message is providing information you should take
 	// into account.
 	Severity *string `type:"string" enum:"ValidationSeverity"`
-
-	_ struct{} `type:"structure"`
 }
 
 // String returns the string representation

--- a/service/elasticsearchservice/api.go
+++ b/service/elasticsearchservice/api.go
@@ -305,11 +305,7 @@ type AccessPoliciesStatus struct {
 	// for the status information that's included.
 	Status *OptionStatus `type:"structure" required:"true"`
 
-	metadataAccessPoliciesStatus `json:"-" xml:"-"`
-}
-
-type metadataAccessPoliciesStatus struct {
-	SDKShapeTraits bool `type:"structure"`
+	_ struct{} `type:"structure"`
 }
 
 // String returns the string representation
@@ -331,11 +327,7 @@ type AddTagsInput struct {
 	// List of Tag that need to be added for the Elasticsearch domain.
 	TagList []*Tag `type:"list" required:"true"`
 
-	metadataAddTagsInput `json:"-" xml:"-"`
-}
-
-type metadataAddTagsInput struct {
-	SDKShapeTraits bool `type:"structure"`
+	_ struct{} `type:"structure"`
 }
 
 // String returns the string representation
@@ -349,11 +341,7 @@ func (s AddTagsInput) GoString() string {
 }
 
 type AddTagsOutput struct {
-	metadataAddTagsOutput `json:"-" xml:"-"`
-}
-
-type metadataAddTagsOutput struct {
-	SDKShapeTraits bool `type:"structure"`
+	_ struct{} `type:"structure"`
 }
 
 // String returns the string representation
@@ -384,11 +372,7 @@ type AdvancedOptionsStatus struct {
 	// Elasticsearch domain.
 	Status *OptionStatus `type:"structure" required:"true"`
 
-	metadataAdvancedOptionsStatus `json:"-" xml:"-"`
-}
-
-type metadataAdvancedOptionsStatus struct {
-	SDKShapeTraits bool `type:"structure"`
+	_ struct{} `type:"structure"`
 }
 
 // String returns the string representation
@@ -428,11 +412,7 @@ type CreateElasticsearchDomainInput struct {
 	// value is 0 hours.
 	SnapshotOptions *SnapshotOptions `type:"structure"`
 
-	metadataCreateElasticsearchDomainInput `json:"-" xml:"-"`
-}
-
-type metadataCreateElasticsearchDomainInput struct {
-	SDKShapeTraits bool `type:"structure"`
+	_ struct{} `type:"structure"`
 }
 
 // String returns the string representation
@@ -451,11 +431,7 @@ type CreateElasticsearchDomainOutput struct {
 	// The status of the newly created Elasticsearch domain.
 	DomainStatus *ElasticsearchDomainStatus `type:"structure"`
 
-	metadataCreateElasticsearchDomainOutput `json:"-" xml:"-"`
-}
-
-type metadataCreateElasticsearchDomainOutput struct {
-	SDKShapeTraits bool `type:"structure"`
+	_ struct{} `type:"structure"`
 }
 
 // String returns the string representation
@@ -474,11 +450,7 @@ type DeleteElasticsearchDomainInput struct {
 	// The name of the Elasticsearch domain that you want to permanently delete.
 	DomainName *string `location:"uri" locationName:"DomainName" min:"3" type:"string" required:"true"`
 
-	metadataDeleteElasticsearchDomainInput `json:"-" xml:"-"`
-}
-
-type metadataDeleteElasticsearchDomainInput struct {
-	SDKShapeTraits bool `type:"structure"`
+	_ struct{} `type:"structure"`
 }
 
 // String returns the string representation
@@ -498,11 +470,7 @@ type DeleteElasticsearchDomainOutput struct {
 	// The status of the Elasticsearch domain being deleted.
 	DomainStatus *ElasticsearchDomainStatus `type:"structure"`
 
-	metadataDeleteElasticsearchDomainOutput `json:"-" xml:"-"`
-}
-
-type metadataDeleteElasticsearchDomainOutput struct {
-	SDKShapeTraits bool `type:"structure"`
+	_ struct{} `type:"structure"`
 }
 
 // String returns the string representation
@@ -521,11 +489,7 @@ type DescribeElasticsearchDomainConfigInput struct {
 	// The Elasticsearch domain that you want to get information about.
 	DomainName *string `location:"uri" locationName:"DomainName" min:"3" type:"string" required:"true"`
 
-	metadataDescribeElasticsearchDomainConfigInput `json:"-" xml:"-"`
-}
-
-type metadataDescribeElasticsearchDomainConfigInput struct {
-	SDKShapeTraits bool `type:"structure"`
+	_ struct{} `type:"structure"`
 }
 
 // String returns the string representation
@@ -545,11 +509,7 @@ type DescribeElasticsearchDomainConfigOutput struct {
 	// request.
 	DomainConfig *ElasticsearchDomainConfig `type:"structure" required:"true"`
 
-	metadataDescribeElasticsearchDomainConfigOutput `json:"-" xml:"-"`
-}
-
-type metadataDescribeElasticsearchDomainConfigOutput struct {
-	SDKShapeTraits bool `type:"structure"`
+	_ struct{} `type:"structure"`
 }
 
 // String returns the string representation
@@ -567,11 +527,7 @@ type DescribeElasticsearchDomainInput struct {
 	// The name of the Elasticsearch domain for which you want information.
 	DomainName *string `location:"uri" locationName:"DomainName" min:"3" type:"string" required:"true"`
 
-	metadataDescribeElasticsearchDomainInput `json:"-" xml:"-"`
-}
-
-type metadataDescribeElasticsearchDomainInput struct {
-	SDKShapeTraits bool `type:"structure"`
+	_ struct{} `type:"structure"`
 }
 
 // String returns the string representation
@@ -590,11 +546,7 @@ type DescribeElasticsearchDomainOutput struct {
 	// The current status of the Elasticsearch domain.
 	DomainStatus *ElasticsearchDomainStatus `type:"structure" required:"true"`
 
-	metadataDescribeElasticsearchDomainOutput `json:"-" xml:"-"`
-}
-
-type metadataDescribeElasticsearchDomainOutput struct {
-	SDKShapeTraits bool `type:"structure"`
+	_ struct{} `type:"structure"`
 }
 
 // String returns the string representation
@@ -613,11 +565,7 @@ type DescribeElasticsearchDomainsInput struct {
 	// The Elasticsearch domains for which you want information.
 	DomainNames []*string `type:"list" required:"true"`
 
-	metadataDescribeElasticsearchDomainsInput `json:"-" xml:"-"`
-}
-
-type metadataDescribeElasticsearchDomainsInput struct {
-	SDKShapeTraits bool `type:"structure"`
+	_ struct{} `type:"structure"`
 }
 
 // String returns the string representation
@@ -636,11 +584,7 @@ type DescribeElasticsearchDomainsOutput struct {
 	// The status of the domains requested in the DescribeElasticsearchDomains request.
 	DomainStatusList []*ElasticsearchDomainStatus `type:"list" required:"true"`
 
-	metadataDescribeElasticsearchDomainsOutput `json:"-" xml:"-"`
-}
-
-type metadataDescribeElasticsearchDomainsOutput struct {
-	SDKShapeTraits bool `type:"structure"`
+	_ struct{} `type:"structure"`
 }
 
 // String returns the string representation
@@ -657,11 +601,7 @@ type DomainInfo struct {
 	// Specifies the DomainName.
 	DomainName *string `min:"3" type:"string"`
 
-	metadataDomainInfo `json:"-" xml:"-"`
-}
-
-type metadataDomainInfo struct {
-	SDKShapeTraits bool `type:"structure"`
+	_ struct{} `type:"structure"`
 }
 
 // String returns the string representation
@@ -690,11 +630,7 @@ type EBSOptions struct {
 	// Specifies the volume type for EBS-based storage.
 	VolumeType *string `type:"string" enum:"VolumeType"`
 
-	metadataEBSOptions `json:"-" xml:"-"`
-}
-
-type metadataEBSOptions struct {
-	SDKShapeTraits bool `type:"structure"`
+	_ struct{} `type:"structure"`
 }
 
 // String returns the string representation
@@ -715,11 +651,7 @@ type EBSOptionsStatus struct {
 	// Specifies the status of the EBS options for the specified Elasticsearch domain.
 	Status *OptionStatus `type:"structure" required:"true"`
 
-	metadataEBSOptionsStatus `json:"-" xml:"-"`
-}
-
-type metadataEBSOptionsStatus struct {
-	SDKShapeTraits bool `type:"structure"`
+	_ struct{} `type:"structure"`
 }
 
 // String returns the string representation
@@ -757,11 +689,7 @@ type ElasticsearchClusterConfig struct {
 	// target="_blank) for more information.
 	ZoneAwarenessEnabled *bool `type:"boolean"`
 
-	metadataElasticsearchClusterConfig `json:"-" xml:"-"`
-}
-
-type metadataElasticsearchClusterConfig struct {
-	SDKShapeTraits bool `type:"structure"`
+	_ struct{} `type:"structure"`
 }
 
 // String returns the string representation
@@ -783,11 +711,7 @@ type ElasticsearchClusterConfigStatus struct {
 	// domain.
 	Status *OptionStatus `type:"structure" required:"true"`
 
-	metadataElasticsearchClusterConfigStatus `json:"-" xml:"-"`
-}
-
-type metadataElasticsearchClusterConfigStatus struct {
-	SDKShapeTraits bool `type:"structure"`
+	_ struct{} `type:"structure"`
 }
 
 // String returns the string representation
@@ -819,11 +743,7 @@ type ElasticsearchDomainConfig struct {
 	// Specifies the SnapshotOptions for the Elasticsearch domain.
 	SnapshotOptions *SnapshotOptionsStatus `type:"structure"`
 
-	metadataElasticsearchDomainConfig `json:"-" xml:"-"`
-}
-
-type metadataElasticsearchDomainConfig struct {
-	SDKShapeTraits bool `type:"structure"`
+	_ struct{} `type:"structure"`
 }
 
 // String returns the string representation
@@ -888,11 +808,7 @@ type ElasticsearchDomainStatus struct {
 	// Specifies the status of the SnapshotOptions
 	SnapshotOptions *SnapshotOptions `type:"structure"`
 
-	metadataElasticsearchDomainStatus `json:"-" xml:"-"`
-}
-
-type metadataElasticsearchDomainStatus struct {
-	SDKShapeTraits bool `type:"structure"`
+	_ struct{} `type:"structure"`
 }
 
 // String returns the string representation
@@ -906,11 +822,7 @@ func (s ElasticsearchDomainStatus) GoString() string {
 }
 
 type ListDomainNamesInput struct {
-	metadataListDomainNamesInput `json:"-" xml:"-"`
-}
-
-type metadataListDomainNamesInput struct {
-	SDKShapeTraits bool `type:"structure"`
+	_ struct{} `type:"structure"`
 }
 
 // String returns the string representation
@@ -929,11 +841,7 @@ type ListDomainNamesOutput struct {
 	// List of Elasticsearch domain names.
 	DomainNames []*DomainInfo `type:"list"`
 
-	metadataListDomainNamesOutput `json:"-" xml:"-"`
-}
-
-type metadataListDomainNamesOutput struct {
-	SDKShapeTraits bool `type:"structure"`
+	_ struct{} `type:"structure"`
 }
 
 // String returns the string representation
@@ -954,11 +862,7 @@ type ListTagsInput struct {
 	// that you want to view.
 	ARN *string `location:"querystring" locationName:"arn" type:"string" required:"true"`
 
-	metadataListTagsInput `json:"-" xml:"-"`
-}
-
-type metadataListTagsInput struct {
-	SDKShapeTraits bool `type:"structure"`
+	_ struct{} `type:"structure"`
 }
 
 // String returns the string representation
@@ -977,11 +881,7 @@ type ListTagsOutput struct {
 	// List of Tag for the requested Elasticsearch domain.
 	TagList []*Tag `type:"list"`
 
-	metadataListTagsOutput `json:"-" xml:"-"`
-}
-
-type metadataListTagsOutput struct {
-	SDKShapeTraits bool `type:"structure"`
+	_ struct{} `type:"structure"`
 }
 
 // String returns the string representation
@@ -1011,11 +911,7 @@ type OptionStatus struct {
 	// Specifies the latest version for the entity.
 	UpdateVersion *int64 `type:"integer"`
 
-	metadataOptionStatus `json:"-" xml:"-"`
-}
-
-type metadataOptionStatus struct {
-	SDKShapeTraits bool `type:"structure"`
+	_ struct{} `type:"structure"`
 }
 
 // String returns the string representation
@@ -1040,11 +936,7 @@ type RemoveTagsInput struct {
 	// domain.
 	TagKeys []*string `type:"list" required:"true"`
 
-	metadataRemoveTagsInput `json:"-" xml:"-"`
-}
-
-type metadataRemoveTagsInput struct {
-	SDKShapeTraits bool `type:"structure"`
+	_ struct{} `type:"structure"`
 }
 
 // String returns the string representation
@@ -1058,11 +950,7 @@ func (s RemoveTagsInput) GoString() string {
 }
 
 type RemoveTagsOutput struct {
-	metadataRemoveTagsOutput `json:"-" xml:"-"`
-}
-
-type metadataRemoveTagsOutput struct {
-	SDKShapeTraits bool `type:"structure"`
+	_ struct{} `type:"structure"`
 }
 
 // String returns the string representation
@@ -1082,11 +970,7 @@ type SnapshotOptions struct {
 	// snapshot of the specified Elasticsearch domain. Default value is 0 hours.
 	AutomatedSnapshotStartHour *int64 `type:"integer"`
 
-	metadataSnapshotOptions `json:"-" xml:"-"`
-}
-
-type metadataSnapshotOptions struct {
-	SDKShapeTraits bool `type:"structure"`
+	_ struct{} `type:"structure"`
 }
 
 // String returns the string representation
@@ -1107,11 +991,7 @@ type SnapshotOptionsStatus struct {
 	// Specifies the status of a daily automated snapshot.
 	Status *OptionStatus `type:"structure" required:"true"`
 
-	metadataSnapshotOptionsStatus `json:"-" xml:"-"`
-}
-
-type metadataSnapshotOptionsStatus struct {
-	SDKShapeTraits bool `type:"structure"`
+	_ struct{} `type:"structure"`
 }
 
 // String returns the string representation
@@ -1136,11 +1016,7 @@ type Tag struct {
 	// : Trinity
 	Value *string `type:"string" required:"true"`
 
-	metadataTag `json:"-" xml:"-"`
-}
-
-type metadataTag struct {
-	SDKShapeTraits bool `type:"structure"`
+	_ struct{} `type:"structure"`
 }
 
 // String returns the string representation
@@ -1178,11 +1054,7 @@ type UpdateElasticsearchDomainConfigInput struct {
 	// Default value is 0 hours.
 	SnapshotOptions *SnapshotOptions `type:"structure"`
 
-	metadataUpdateElasticsearchDomainConfigInput `json:"-" xml:"-"`
-}
-
-type metadataUpdateElasticsearchDomainConfigInput struct {
-	SDKShapeTraits bool `type:"structure"`
+	_ struct{} `type:"structure"`
 }
 
 // String returns the string representation
@@ -1201,11 +1073,7 @@ type UpdateElasticsearchDomainConfigOutput struct {
 	// The status of the updated Elasticsearch domain.
 	DomainConfig *ElasticsearchDomainConfig `type:"structure" required:"true"`
 
-	metadataUpdateElasticsearchDomainConfigOutput `json:"-" xml:"-"`
-}
-
-type metadataUpdateElasticsearchDomainConfigOutput struct {
-	SDKShapeTraits bool `type:"structure"`
+	_ struct{} `type:"structure"`
 }
 
 // String returns the string representation

--- a/service/elasticsearchservice/api.go
+++ b/service/elasticsearchservice/api.go
@@ -295,6 +295,8 @@ func (c *ElasticsearchService) UpdateElasticsearchDomainConfig(input *UpdateElas
 // The configured access rules for the domain's document and search endpoints,
 // and the current status of those rules.
 type AccessPoliciesStatus struct {
+	_ struct{} `type:"structure"`
+
 	// The access policy configured for the Elasticsearch domain. Access policies
 	// may be resource-based, IP-based, or IAM-based. See  Configuring Access Policies
 	// (http://docs.aws.amazon.com/elasticsearch-service/latest/developerguide/es-createupdatedomains.html#es-createdomain-configure-access-policies"
@@ -304,8 +306,6 @@ type AccessPoliciesStatus struct {
 	// The status of the access policy for the Elasticsearch domain. See OptionStatus
 	// for the status information that's included.
 	Status *OptionStatus `type:"structure" required:"true"`
-
-	_ struct{} `type:"structure"`
 }
 
 // String returns the string representation
@@ -321,13 +321,13 @@ func (s AccessPoliciesStatus) GoString() string {
 // Container for the parameters to the AddTags operation. Specify the tags that
 // you want to attach to the Elasticsearch domain.
 type AddTagsInput struct {
+	_ struct{} `type:"structure"`
+
 	// Specify the ARN for which you want to add the tags.
 	ARN *string `type:"string" required:"true"`
 
 	// List of Tag that need to be added for the Elasticsearch domain.
 	TagList []*Tag `type:"list" required:"true"`
-
-	_ struct{} `type:"structure"`
 }
 
 // String returns the string representation
@@ -364,6 +364,8 @@ func (s AddTagsOutput) GoString() string {
 // heap space that is allocated to field data. By default, this setting is unbounded.
 //  For more information, see Configuring Advanced Options (http://docs.aws.amazon.com/elasticsearch-service/latest/developerguide/es-createupdatedomains.html#es-createdomain-configure-advanced-options).
 type AdvancedOptionsStatus struct {
+	_ struct{} `type:"structure"`
+
 	// Specifies the status of advanced options for the specified Elasticsearch
 	// domain.
 	Options map[string]*string `type:"map" required:"true"`
@@ -371,8 +373,6 @@ type AdvancedOptionsStatus struct {
 	// Specifies the status of OptionStatus for advanced options for the specified
 	// Elasticsearch domain.
 	Status *OptionStatus `type:"structure" required:"true"`
-
-	_ struct{} `type:"structure"`
 }
 
 // String returns the string representation
@@ -386,6 +386,8 @@ func (s AdvancedOptionsStatus) GoString() string {
 }
 
 type CreateElasticsearchDomainInput struct {
+	_ struct{} `type:"structure"`
+
 	// IAM access policy as a JSON-formatted string.
 	AccessPolicies *string `type:"string"`
 
@@ -411,8 +413,6 @@ type CreateElasticsearchDomainInput struct {
 	// Option to set time, in UTC format, of the daily automated snapshot. Default
 	// value is 0 hours.
 	SnapshotOptions *SnapshotOptions `type:"structure"`
-
-	_ struct{} `type:"structure"`
 }
 
 // String returns the string representation
@@ -428,10 +428,10 @@ func (s CreateElasticsearchDomainInput) GoString() string {
 // The result of a CreateElasticsearchDomain operation. Contains the status
 // of the newly created Elasticsearch domain.
 type CreateElasticsearchDomainOutput struct {
+	_ struct{} `type:"structure"`
+
 	// The status of the newly created Elasticsearch domain.
 	DomainStatus *ElasticsearchDomainStatus `type:"structure"`
-
-	_ struct{} `type:"structure"`
 }
 
 // String returns the string representation
@@ -447,10 +447,10 @@ func (s CreateElasticsearchDomainOutput) GoString() string {
 // Container for the parameters to the DeleteElasticsearchDomain operation.
 // Specifies the name of the Elasticsearch domain that you want to delete.
 type DeleteElasticsearchDomainInput struct {
+	_ struct{} `type:"structure"`
+
 	// The name of the Elasticsearch domain that you want to permanently delete.
 	DomainName *string `location:"uri" locationName:"DomainName" min:"3" type:"string" required:"true"`
-
-	_ struct{} `type:"structure"`
 }
 
 // String returns the string representation
@@ -467,10 +467,10 @@ func (s DeleteElasticsearchDomainInput) GoString() string {
 // the pending deletion, or no status if the domain and all of its resources
 // have been deleted.
 type DeleteElasticsearchDomainOutput struct {
+	_ struct{} `type:"structure"`
+
 	// The status of the Elasticsearch domain being deleted.
 	DomainStatus *ElasticsearchDomainStatus `type:"structure"`
-
-	_ struct{} `type:"structure"`
 }
 
 // String returns the string representation
@@ -486,10 +486,10 @@ func (s DeleteElasticsearchDomainOutput) GoString() string {
 // Container for the parameters to the DescribeElasticsearchDomainConfig operation.
 // Specifies the domain name for which you want configuration information.
 type DescribeElasticsearchDomainConfigInput struct {
+	_ struct{} `type:"structure"`
+
 	// The Elasticsearch domain that you want to get information about.
 	DomainName *string `location:"uri" locationName:"DomainName" min:"3" type:"string" required:"true"`
-
-	_ struct{} `type:"structure"`
 }
 
 // String returns the string representation
@@ -505,11 +505,11 @@ func (s DescribeElasticsearchDomainConfigInput) GoString() string {
 // The result of a DescribeElasticsearchDomainConfig request. Contains the configuration
 // information of the requested domain.
 type DescribeElasticsearchDomainConfigOutput struct {
+	_ struct{} `type:"structure"`
+
 	// The configuration information of the domain requested in the DescribeElasticsearchDomainConfig
 	// request.
 	DomainConfig *ElasticsearchDomainConfig `type:"structure" required:"true"`
-
-	_ struct{} `type:"structure"`
 }
 
 // String returns the string representation
@@ -524,10 +524,10 @@ func (s DescribeElasticsearchDomainConfigOutput) GoString() string {
 
 // Container for the parameters to the DescribeElasticsearchDomain operation.
 type DescribeElasticsearchDomainInput struct {
+	_ struct{} `type:"structure"`
+
 	// The name of the Elasticsearch domain for which you want information.
 	DomainName *string `location:"uri" locationName:"DomainName" min:"3" type:"string" required:"true"`
-
-	_ struct{} `type:"structure"`
 }
 
 // String returns the string representation
@@ -543,10 +543,10 @@ func (s DescribeElasticsearchDomainInput) GoString() string {
 // The result of a DescribeElasticsearchDomain request. Contains the status
 // of the domain specified in the request.
 type DescribeElasticsearchDomainOutput struct {
+	_ struct{} `type:"structure"`
+
 	// The current status of the Elasticsearch domain.
 	DomainStatus *ElasticsearchDomainStatus `type:"structure" required:"true"`
-
-	_ struct{} `type:"structure"`
 }
 
 // String returns the string representation
@@ -562,10 +562,10 @@ func (s DescribeElasticsearchDomainOutput) GoString() string {
 // Container for the parameters to the DescribeElasticsearchDomains operation.
 // By default, the API returns the status of all Elasticsearch domains.
 type DescribeElasticsearchDomainsInput struct {
+	_ struct{} `type:"structure"`
+
 	// The Elasticsearch domains for which you want information.
 	DomainNames []*string `type:"list" required:"true"`
-
-	_ struct{} `type:"structure"`
 }
 
 // String returns the string representation
@@ -581,10 +581,10 @@ func (s DescribeElasticsearchDomainsInput) GoString() string {
 // The result of a DescribeElasticsearchDomains request. Contains the status
 // of the specified domains or all domains owned by the account.
 type DescribeElasticsearchDomainsOutput struct {
+	_ struct{} `type:"structure"`
+
 	// The status of the domains requested in the DescribeElasticsearchDomains request.
 	DomainStatusList []*ElasticsearchDomainStatus `type:"list" required:"true"`
-
-	_ struct{} `type:"structure"`
 }
 
 // String returns the string representation
@@ -598,10 +598,10 @@ func (s DescribeElasticsearchDomainsOutput) GoString() string {
 }
 
 type DomainInfo struct {
+	_ struct{} `type:"structure"`
+
 	// Specifies the DomainName.
 	DomainName *string `min:"3" type:"string"`
-
-	_ struct{} `type:"structure"`
 }
 
 // String returns the string representation
@@ -618,6 +618,8 @@ func (s DomainInfo) GoString() string {
 // For more information, see  Configuring EBS-based Storage (http://docs.aws.amazon.com/elasticsearch-service/latest/developerguide/es-createupdatedomains.html#es-createdomain-configure-ebs"
 // target="_blank).
 type EBSOptions struct {
+	_ struct{} `type:"structure"`
+
 	// Specifies whether EBS-based storage is enabled.
 	EBSEnabled *bool `type:"boolean"`
 
@@ -629,8 +631,6 @@ type EBSOptions struct {
 
 	// Specifies the volume type for EBS-based storage.
 	VolumeType *string `type:"string" enum:"VolumeType"`
-
-	_ struct{} `type:"structure"`
 }
 
 // String returns the string representation
@@ -645,13 +645,13 @@ func (s EBSOptions) GoString() string {
 
 // Status of the EBS options for the specified Elasticsearch domain.
 type EBSOptionsStatus struct {
+	_ struct{} `type:"structure"`
+
 	// Specifies the EBS options for the specified Elasticsearch domain.
 	Options *EBSOptions `type:"structure" required:"true"`
 
 	// Specifies the status of the EBS options for the specified Elasticsearch domain.
 	Status *OptionStatus `type:"structure" required:"true"`
-
-	_ struct{} `type:"structure"`
 }
 
 // String returns the string representation
@@ -667,6 +667,8 @@ func (s EBSOptionsStatus) GoString() string {
 // Specifies the configuration for the domain cluster, such as the type and
 // number of instances.
 type ElasticsearchClusterConfig struct {
+	_ struct{} `type:"structure"`
+
 	// Total number of dedicated master nodes, active and on standby, for the cluster.
 	DedicatedMasterCount *int64 `type:"integer"`
 
@@ -688,8 +690,6 @@ type ElasticsearchClusterConfig struct {
 	// Zone Awareness (http://docs.aws.amazon.com/elasticsearch-service/latest/developerguide/es-managedomains.html#es-managedomains-zoneawareness"
 	// target="_blank) for more information.
 	ZoneAwarenessEnabled *bool `type:"boolean"`
-
-	_ struct{} `type:"structure"`
 }
 
 // String returns the string representation
@@ -704,14 +704,14 @@ func (s ElasticsearchClusterConfig) GoString() string {
 
 // Specifies the configuration status for the specified Elasticsearch domain.
 type ElasticsearchClusterConfigStatus struct {
+	_ struct{} `type:"structure"`
+
 	// Specifies the cluster configuration for the specified Elasticsearch domain.
 	Options *ElasticsearchClusterConfig `type:"structure" required:"true"`
 
 	// Specifies the status of the configuration for the specified Elasticsearch
 	// domain.
 	Status *OptionStatus `type:"structure" required:"true"`
-
-	_ struct{} `type:"structure"`
 }
 
 // String returns the string representation
@@ -726,6 +726,8 @@ func (s ElasticsearchClusterConfigStatus) GoString() string {
 
 // The configuration of an Elasticsearch domain.
 type ElasticsearchDomainConfig struct {
+	_ struct{} `type:"structure"`
+
 	// IAM access policy as a JSON-formatted string.
 	AccessPolicies *AccessPoliciesStatus `type:"structure"`
 
@@ -742,8 +744,6 @@ type ElasticsearchDomainConfig struct {
 
 	// Specifies the SnapshotOptions for the Elasticsearch domain.
 	SnapshotOptions *SnapshotOptionsStatus `type:"structure"`
-
-	_ struct{} `type:"structure"`
 }
 
 // String returns the string representation
@@ -758,6 +758,8 @@ func (s ElasticsearchDomainConfig) GoString() string {
 
 // The current status of an Elasticsearch domain.
 type ElasticsearchDomainStatus struct {
+	_ struct{} `type:"structure"`
+
 	// The Amazon resource name (ARN) of an Elasticsearch domain. See Identifiers
 	// for IAM Entities (http://docs.aws.amazon.com/IAM/latest/UserGuide/index.html?Using_Identifiers.html"
 	// target="_blank) in Using AWS Identity and Access Management for more information.
@@ -807,8 +809,6 @@ type ElasticsearchDomainStatus struct {
 
 	// Specifies the status of the SnapshotOptions
 	SnapshotOptions *SnapshotOptions `type:"structure"`
-
-	_ struct{} `type:"structure"`
 }
 
 // String returns the string representation
@@ -838,10 +838,10 @@ func (s ListDomainNamesInput) GoString() string {
 // The result of a ListDomainNames operation. Contains the names of all Elasticsearch
 // domains owned by this account.
 type ListDomainNamesOutput struct {
+	_ struct{} `type:"structure"`
+
 	// List of Elasticsearch domain names.
 	DomainNames []*DomainInfo `type:"list"`
-
-	_ struct{} `type:"structure"`
 }
 
 // String returns the string representation
@@ -858,11 +858,11 @@ func (s ListDomainNamesOutput) GoString() string {
 // the Elasticsearch domain to which the tags are attached that you want to
 // view are attached.
 type ListTagsInput struct {
+	_ struct{} `type:"structure"`
+
 	// Specify the ARN for the Elasticsearch domain to which the tags are attached
 	// that you want to view.
 	ARN *string `location:"querystring" locationName:"arn" type:"string" required:"true"`
-
-	_ struct{} `type:"structure"`
 }
 
 // String returns the string representation
@@ -878,10 +878,10 @@ func (s ListTagsInput) GoString() string {
 // The result of a ListTags operation. Contains tags for all requested Elasticsearch
 // domains.
 type ListTagsOutput struct {
+	_ struct{} `type:"structure"`
+
 	// List of Tag for the requested Elasticsearch domain.
 	TagList []*Tag `type:"list"`
-
-	_ struct{} `type:"structure"`
 }
 
 // String returns the string representation
@@ -896,6 +896,8 @@ func (s ListTagsOutput) GoString() string {
 
 // Provides the current status of the entity.
 type OptionStatus struct {
+	_ struct{} `type:"structure"`
+
 	// Timestamp which tells the creation date for the entity.
 	CreationDate *time.Time `type:"timestamp" timestampFormat:"unix" required:"true"`
 
@@ -910,8 +912,6 @@ type OptionStatus struct {
 
 	// Specifies the latest version for the entity.
 	UpdateVersion *int64 `type:"integer"`
-
-	_ struct{} `type:"structure"`
 }
 
 // String returns the string representation
@@ -928,6 +928,8 @@ func (s OptionStatus) GoString() string {
 // for the Elasticsearch domain from which you want to remove the specified
 // TagKey.
 type RemoveTagsInput struct {
+	_ struct{} `type:"structure"`
+
 	// Specifies the ARN for the Elasticsearch domain from which you want to delete
 	// the specified tags.
 	ARN *string `type:"string" required:"true"`
@@ -935,8 +937,6 @@ type RemoveTagsInput struct {
 	// Specifies the TagKey list which you want to remove from the Elasticsearch
 	// domain.
 	TagKeys []*string `type:"list" required:"true"`
-
-	_ struct{} `type:"structure"`
 }
 
 // String returns the string representation
@@ -966,11 +966,11 @@ func (s RemoveTagsOutput) GoString() string {
 // Specifies the time, in UTC format, when the service takes a daily automated
 // snapshot of the specified Elasticsearch domain. Default value is 0 hours.
 type SnapshotOptions struct {
+	_ struct{} `type:"structure"`
+
 	// Specifies the time, in UTC format, when the service takes a daily automated
 	// snapshot of the specified Elasticsearch domain. Default value is 0 hours.
 	AutomatedSnapshotStartHour *int64 `type:"integer"`
-
-	_ struct{} `type:"structure"`
 }
 
 // String returns the string representation
@@ -985,13 +985,13 @@ func (s SnapshotOptions) GoString() string {
 
 // Status of a daily automated snapshot.
 type SnapshotOptionsStatus struct {
+	_ struct{} `type:"structure"`
+
 	// Specifies the daily snapshot options specified for the Elasticsearch domain.
 	Options *SnapshotOptions `type:"structure" required:"true"`
 
 	// Specifies the status of a daily automated snapshot.
 	Status *OptionStatus `type:"structure" required:"true"`
-
-	_ struct{} `type:"structure"`
 }
 
 // String returns the string representation
@@ -1006,6 +1006,8 @@ func (s SnapshotOptionsStatus) GoString() string {
 
 // Specifies a key value pair for a resource tag.
 type Tag struct {
+	_ struct{} `type:"structure"`
+
 	// Specifies the TagKey, the name of the tag. Tag keys must be unique for the
 	// Elasticsearch domain to which they are attached.
 	Key *string `min:"1" type:"string" required:"true"`
@@ -1015,8 +1017,6 @@ type Tag struct {
 	// you can have a key value pair in a tag set of project : Trinity and cost-center
 	// : Trinity
 	Value *string `type:"string" required:"true"`
-
-	_ struct{} `type:"structure"`
 }
 
 // String returns the string representation
@@ -1032,6 +1032,8 @@ func (s Tag) GoString() string {
 // Container for the parameters to the UpdateElasticsearchDomain operation.
 // Specifies the type and number of instances in the domain cluster.
 type UpdateElasticsearchDomainConfigInput struct {
+	_ struct{} `type:"structure"`
+
 	// IAM access policy as a JSON-formatted string.
 	AccessPolicies *string `type:"string"`
 
@@ -1053,8 +1055,6 @@ type UpdateElasticsearchDomainConfigInput struct {
 	// Option to set the time, in UTC format, for the daily automated snapshot.
 	// Default value is 0 hours.
 	SnapshotOptions *SnapshotOptions `type:"structure"`
-
-	_ struct{} `type:"structure"`
 }
 
 // String returns the string representation
@@ -1070,10 +1070,10 @@ func (s UpdateElasticsearchDomainConfigInput) GoString() string {
 // The result of an UpdateElasticsearchDomain request. Contains the status of
 // the Elasticsearch domain being updated.
 type UpdateElasticsearchDomainConfigOutput struct {
+	_ struct{} `type:"structure"`
+
 	// The status of the updated Elasticsearch domain.
 	DomainConfig *ElasticsearchDomainConfig `type:"structure" required:"true"`
-
-	_ struct{} `type:"structure"`
 }
 
 // String returns the string representation

--- a/service/elastictranscoder/api.go
+++ b/service/elastictranscoder/api.go
@@ -648,11 +648,7 @@ type Artwork struct {
 	// this option, Elastic Transcoder does not scale the art up.
 	SizingPolicy *string `type:"string"`
 
-	metadataArtwork `json:"-" xml:"-"`
-}
-
-type metadataArtwork struct {
-	SDKShapeTraits bool `type:"structure"`
+	_ struct{} `type:"structure"`
 }
 
 // String returns the string representation
@@ -715,11 +711,7 @@ type AudioCodecOptions struct {
 	// The supported value is Signed.
 	Signed *string `type:"string"`
 
-	metadataAudioCodecOptions `json:"-" xml:"-"`
-}
-
-type metadataAudioCodecOptions struct {
-	SDKShapeTraits bool `type:"structure"`
+	_ struct{} `type:"structure"`
 }
 
 // String returns the string representation
@@ -846,11 +838,7 @@ type AudioParameters struct {
 	// rate.
 	SampleRate *string `type:"string"`
 
-	metadataAudioParameters `json:"-" xml:"-"`
-}
-
-type metadataAudioParameters struct {
-	SDKShapeTraits bool `type:"structure"`
+	_ struct{} `type:"structure"`
 }
 
 // String returns the string representation
@@ -871,11 +859,7 @@ type CancelJobInput struct {
 	// Submitted, use the ListJobsByStatus API action.
 	Id *string `location:"uri" locationName:"Id" type:"string" required:"true"`
 
-	metadataCancelJobInput `json:"-" xml:"-"`
-}
-
-type metadataCancelJobInput struct {
-	SDKShapeTraits bool `type:"structure"`
+	_ struct{} `type:"structure"`
 }
 
 // String returns the string representation
@@ -891,11 +875,7 @@ func (s CancelJobInput) GoString() string {
 // The response body contains a JSON object. If the job is successfully canceled,
 // the value of Success is true.
 type CancelJobOutput struct {
-	metadataCancelJobOutput `json:"-" xml:"-"`
-}
-
-type metadataCancelJobOutput struct {
-	SDKShapeTraits bool `type:"structure"`
+	_ struct{} `type:"structure"`
 }
 
 // String returns the string representation
@@ -957,11 +937,7 @@ type CaptionFormat struct {
 	// (en), the name of the first caption file will be Sydney-en-sunrise00000.srt.
 	Pattern *string `type:"string"`
 
-	metadataCaptionFormat `json:"-" xml:"-"`
-}
-
-type metadataCaptionFormat struct {
-	SDKShapeTraits bool `type:"structure"`
+	_ struct{} `type:"structure"`
 }
 
 // String returns the string representation
@@ -1008,11 +984,7 @@ type CaptionSource struct {
 	// Specify the TimeOffset in the form [+-]SS.sss or [+-]HH:mm:SS.ss.
 	TimeOffset *string `type:"string"`
 
-	metadataCaptionSource `json:"-" xml:"-"`
-}
-
-type metadataCaptionSource struct {
-	SDKShapeTraits bool `type:"structure"`
+	_ struct{} `type:"structure"`
 }
 
 // String returns the string representation
@@ -1055,11 +1027,7 @@ type Captions struct {
 	//  MergePolicy cannot be null.
 	MergePolicy *string `type:"string"`
 
-	metadataCaptions `json:"-" xml:"-"`
-}
-
-type metadataCaptions struct {
-	SDKShapeTraits bool `type:"structure"`
+	_ struct{} `type:"structure"`
 }
 
 // String returns the string representation
@@ -1078,11 +1046,7 @@ type Clip struct {
 	// Settings that determine when a clip begins and how long it lasts.
 	TimeSpan *TimeSpan `type:"structure"`
 
-	metadataClip `json:"-" xml:"-"`
-}
-
-type metadataClip struct {
-	SDKShapeTraits bool `type:"structure"`
+	_ struct{} `type:"structure"`
 }
 
 // String returns the string representation
@@ -1133,11 +1097,7 @@ type CreateJobInput struct {
 	// will be returned in the same order in which you specify them.
 	UserMetadata map[string]*string `type:"map"`
 
-	metadataCreateJobInput `json:"-" xml:"-"`
-}
-
-type metadataCreateJobInput struct {
-	SDKShapeTraits bool `type:"structure"`
+	_ struct{} `type:"structure"`
 }
 
 // String returns the string representation
@@ -1290,11 +1250,7 @@ type CreateJobOutput struct {
 	// the current output.
 	Watermarks []*JobWatermark `type:"list"`
 
-	metadataCreateJobOutput `json:"-" xml:"-"`
-}
-
-type metadataCreateJobOutput struct {
-	SDKShapeTraits bool `type:"structure"`
+	_ struct{} `type:"structure"`
 }
 
 // String returns the string representation
@@ -1372,11 +1328,7 @@ type CreateJobPlaylist struct {
 	// output files associated with this playlist.
 	PlayReadyDrm *PlayReadyDrm `type:"structure"`
 
-	metadataCreateJobPlaylist `json:"-" xml:"-"`
-}
-
-type metadataCreateJobPlaylist struct {
-	SDKShapeTraits bool `type:"structure"`
+	_ struct{} `type:"structure"`
 }
 
 // String returns the string representation
@@ -1395,11 +1347,7 @@ type CreateJobResponse struct {
 	// is created.
 	Job *Job `type:"structure"`
 
-	metadataCreateJobResponse `json:"-" xml:"-"`
-}
-
-type metadataCreateJobResponse struct {
-	SDKShapeTraits bool `type:"structure"`
+	_ struct{} `type:"structure"`
 }
 
 // String returns the string representation
@@ -1565,11 +1513,7 @@ type CreatePipelineInput struct {
 	// Transcoder to assign to the thumbnails that it stores in your Amazon S3 bucket.
 	ThumbnailConfig *PipelineOutputConfig `type:"structure"`
 
-	metadataCreatePipelineInput `json:"-" xml:"-"`
-}
-
-type metadataCreatePipelineInput struct {
-	SDKShapeTraits bool `type:"structure"`
+	_ struct{} `type:"structure"`
 }
 
 // String returns the string representation
@@ -1597,11 +1541,7 @@ type CreatePipelineOutput struct {
 	// cross-regional charges.
 	Warnings []*Warning `type:"list"`
 
-	metadataCreatePipelineOutput `json:"-" xml:"-"`
-}
-
-type metadataCreatePipelineOutput struct {
-	SDKShapeTraits bool `type:"structure"`
+	_ struct{} `type:"structure"`
 }
 
 // String returns the string representation
@@ -1637,11 +1577,7 @@ type CreatePresetInput struct {
 	// A section of the request body that specifies the video parameters.
 	Video *VideoParameters `type:"structure"`
 
-	metadataCreatePresetInput `json:"-" xml:"-"`
-}
-
-type metadataCreatePresetInput struct {
-	SDKShapeTraits bool `type:"structure"`
+	_ struct{} `type:"structure"`
 }
 
 // String returns the string representation
@@ -1666,11 +1602,7 @@ type CreatePresetOutput struct {
 	// preset because the settings might produce acceptable output.
 	Warning *string `type:"string"`
 
-	metadataCreatePresetOutput `json:"-" xml:"-"`
-}
-
-type metadataCreatePresetOutput struct {
-	SDKShapeTraits bool `type:"structure"`
+	_ struct{} `type:"structure"`
 }
 
 // String returns the string representation
@@ -1688,11 +1620,7 @@ type DeletePipelineInput struct {
 	// The identifier of the pipeline that you want to delete.
 	Id *string `location:"uri" locationName:"Id" type:"string" required:"true"`
 
-	metadataDeletePipelineInput `json:"-" xml:"-"`
-}
-
-type metadataDeletePipelineInput struct {
-	SDKShapeTraits bool `type:"structure"`
+	_ struct{} `type:"structure"`
 }
 
 // String returns the string representation
@@ -1707,11 +1635,7 @@ func (s DeletePipelineInput) GoString() string {
 
 // The DeletePipelineResponse structure.
 type DeletePipelineOutput struct {
-	metadataDeletePipelineOutput `json:"-" xml:"-"`
-}
-
-type metadataDeletePipelineOutput struct {
-	SDKShapeTraits bool `type:"structure"`
+	_ struct{} `type:"structure"`
 }
 
 // String returns the string representation
@@ -1729,11 +1653,7 @@ type DeletePresetInput struct {
 	// The identifier of the preset for which you want to get detailed information.
 	Id *string `location:"uri" locationName:"Id" type:"string" required:"true"`
 
-	metadataDeletePresetInput `json:"-" xml:"-"`
-}
-
-type metadataDeletePresetInput struct {
-	SDKShapeTraits bool `type:"structure"`
+	_ struct{} `type:"structure"`
 }
 
 // String returns the string representation
@@ -1748,11 +1668,7 @@ func (s DeletePresetInput) GoString() string {
 
 // The DeletePresetResponse structure.
 type DeletePresetOutput struct {
-	metadataDeletePresetOutput `json:"-" xml:"-"`
-}
-
-type metadataDeletePresetOutput struct {
-	SDKShapeTraits bool `type:"structure"`
+	_ struct{} `type:"structure"`
 }
 
 // String returns the string representation
@@ -1783,11 +1699,7 @@ type DetectedProperties struct {
 	// The detected width of the input file, in pixels.
 	Width *int64 `type:"integer"`
 
-	metadataDetectedProperties `json:"-" xml:"-"`
-}
-
-type metadataDetectedProperties struct {
-	SDKShapeTraits bool `type:"structure"`
+	_ struct{} `type:"structure"`
 }
 
 // String returns the string representation
@@ -1865,11 +1777,7 @@ type Encryption struct {
 	// data.
 	Mode *string `type:"string"`
 
-	metadataEncryption `json:"-" xml:"-"`
-}
-
-type metadataEncryption struct {
-	SDKShapeTraits bool `type:"structure"`
+	_ struct{} `type:"structure"`
 }
 
 // String returns the string representation
@@ -1930,11 +1838,7 @@ type HlsContentProtection struct {
 	// tag in the output playlist.
 	Method *string `type:"string"`
 
-	metadataHlsContentProtection `json:"-" xml:"-"`
-}
-
-type metadataHlsContentProtection struct {
-	SDKShapeTraits bool `type:"structure"`
+	_ struct{} `type:"structure"`
 }
 
 // String returns the string representation
@@ -2021,11 +1925,7 @@ type Job struct {
 	// The following symbols: _.:/=+-%@
 	UserMetadata map[string]*string `type:"map"`
 
-	metadataJob `json:"-" xml:"-"`
-}
-
-type metadataJob struct {
-	SDKShapeTraits bool `type:"structure"`
+	_ struct{} `type:"structure"`
 }
 
 // String returns the string representation
@@ -2056,11 +1956,7 @@ type JobAlbumArt struct {
 	// file.
 	MergePolicy *string `type:"string"`
 
-	metadataJobAlbumArt `json:"-" xml:"-"`
-}
-
-type metadataJobAlbumArt struct {
-	SDKShapeTraits bool `type:"structure"`
+	_ struct{} `type:"structure"`
 }
 
 // String returns the string representation
@@ -2137,11 +2033,7 @@ type JobInput struct {
 	// detect the resolution of the input file.
 	Resolution *string `type:"string"`
 
-	metadataJobInput `json:"-" xml:"-"`
-}
-
-type metadataJobInput struct {
-	SDKShapeTraits bool `type:"structure"`
+	_ struct{} `type:"structure"`
 }
 
 // String returns the string representation
@@ -2356,11 +2248,7 @@ type JobOutput struct {
 	// Specifies the width of the output file in pixels.
 	Width *int64 `type:"integer"`
 
-	metadataJobOutput `json:"-" xml:"-"`
-}
-
-type metadataJobOutput struct {
-	SDKShapeTraits bool `type:"structure"`
+	_ struct{} `type:"structure"`
 }
 
 // String returns the string representation
@@ -2396,11 +2284,7 @@ type JobWatermark struct {
 	// Id tells Elastic Transcoder which settings to use.
 	PresetWatermarkId *string `min:"1" type:"string"`
 
-	metadataJobWatermark `json:"-" xml:"-"`
-}
-
-type metadataJobWatermark struct {
-	SDKShapeTraits bool `type:"structure"`
+	_ struct{} `type:"structure"`
 }
 
 // String returns the string representation
@@ -2426,11 +2310,7 @@ type ListJobsByPipelineInput struct {
 	// The ID of the pipeline for which you want to get job information.
 	PipelineId *string `location:"uri" locationName:"PipelineId" type:"string" required:"true"`
 
-	metadataListJobsByPipelineInput `json:"-" xml:"-"`
-}
-
-type metadataListJobsByPipelineInput struct {
-	SDKShapeTraits bool `type:"structure"`
+	_ struct{} `type:"structure"`
 }
 
 // String returns the string representation
@@ -2453,11 +2333,7 @@ type ListJobsByPipelineOutput struct {
 	// reached the last page of results, the value of NextPageToken is null.
 	NextPageToken *string `type:"string"`
 
-	metadataListJobsByPipelineOutput `json:"-" xml:"-"`
-}
-
-type metadataListJobsByPipelineOutput struct {
-	SDKShapeTraits bool `type:"structure"`
+	_ struct{} `type:"structure"`
 }
 
 // String returns the string representation
@@ -2485,11 +2361,7 @@ type ListJobsByStatusInput struct {
 	// Progressing, Complete, Canceled, or Error.
 	Status *string `location:"uri" locationName:"Status" type:"string" required:"true"`
 
-	metadataListJobsByStatusInput `json:"-" xml:"-"`
-}
-
-type metadataListJobsByStatusInput struct {
-	SDKShapeTraits bool `type:"structure"`
+	_ struct{} `type:"structure"`
 }
 
 // String returns the string representation
@@ -2512,11 +2384,7 @@ type ListJobsByStatusOutput struct {
 	// reached the last page of results, the value of NextPageToken is null.
 	NextPageToken *string `type:"string"`
 
-	metadataListJobsByStatusOutput `json:"-" xml:"-"`
-}
-
-type metadataListJobsByStatusOutput struct {
-	SDKShapeTraits bool `type:"structure"`
+	_ struct{} `type:"structure"`
 }
 
 // String returns the string representation
@@ -2540,11 +2408,7 @@ type ListPipelinesInput struct {
 	// in subsequent GET requests to get each successive page of results.
 	PageToken *string `location:"querystring" locationName:"PageToken" type:"string"`
 
-	metadataListPipelinesInput `json:"-" xml:"-"`
-}
-
-type metadataListPipelinesInput struct {
-	SDKShapeTraits bool `type:"structure"`
+	_ struct{} `type:"structure"`
 }
 
 // String returns the string representation
@@ -2567,11 +2431,7 @@ type ListPipelinesOutput struct {
 	// An array of Pipeline objects.
 	Pipelines []*Pipeline `type:"list"`
 
-	metadataListPipelinesOutput `json:"-" xml:"-"`
-}
-
-type metadataListPipelinesOutput struct {
-	SDKShapeTraits bool `type:"structure"`
+	_ struct{} `type:"structure"`
 }
 
 // String returns the string representation
@@ -2595,11 +2455,7 @@ type ListPresetsInput struct {
 	// in subsequent GET requests to get each successive page of results.
 	PageToken *string `location:"querystring" locationName:"PageToken" type:"string"`
 
-	metadataListPresetsInput `json:"-" xml:"-"`
-}
-
-type metadataListPresetsInput struct {
-	SDKShapeTraits bool `type:"structure"`
+	_ struct{} `type:"structure"`
 }
 
 // String returns the string representation
@@ -2622,11 +2478,7 @@ type ListPresetsOutput struct {
 	// An array of Preset objects.
 	Presets []*Preset `type:"list"`
 
-	metadataListPresetsOutput `json:"-" xml:"-"`
-}
-
-type metadataListPresetsOutput struct {
-	SDKShapeTraits bool `type:"structure"`
+	_ struct{} `type:"structure"`
 }
 
 // String returns the string representation
@@ -2661,11 +2513,7 @@ type Notifications struct {
 	// a warning condition.
 	Warning *string `type:"string"`
 
-	metadataNotifications `json:"-" xml:"-"`
-}
-
-type metadataNotifications struct {
-	SDKShapeTraits bool `type:"structure"`
+	_ struct{} `type:"structure"`
 }
 
 // String returns the string representation
@@ -2705,11 +2553,7 @@ type Permission struct {
 	// or LogDelivery.
 	GranteeType *string `type:"string"`
 
-	metadataPermission `json:"-" xml:"-"`
-}
-
-type metadataPermission struct {
-	SDKShapeTraits bool `type:"structure"`
+	_ struct{} `type:"structure"`
 }
 
 // String returns the string representation
@@ -2835,11 +2679,7 @@ type Pipeline struct {
 	// to the thumbnails that it stores in your Amazon S3 bucket.
 	ThumbnailConfig *PipelineOutputConfig `type:"structure"`
 
-	metadataPipeline `json:"-" xml:"-"`
-}
-
-type metadataPipeline struct {
-	SDKShapeTraits bool `type:"structure"`
+	_ struct{} `type:"structure"`
 }
 
 // String returns the string representation
@@ -2888,11 +2728,7 @@ type PipelineOutputConfig struct {
 	// in your Amazon S3 bucket.
 	StorageClass *string `type:"string"`
 
-	metadataPipelineOutputConfig `json:"-" xml:"-"`
-}
-
-type metadataPipelineOutputConfig struct {
-	SDKShapeTraits bool `type:"structure"`
+	_ struct{} `type:"structure"`
 }
 
 // String returns the string representation
@@ -2954,11 +2790,7 @@ type PlayReadyDrm struct {
 	// tags for HLS playlist outputs. An example URL looks like this: https://www.example.com/exampleKey/
 	LicenseAcquisitionUrl *string `min:"1" type:"string"`
 
-	metadataPlayReadyDrm `json:"-" xml:"-"`
-}
-
-type metadataPlayReadyDrm struct {
-	SDKShapeTraits bool `type:"structure"`
+	_ struct{} `type:"structure"`
 }
 
 // String returns the string representation
@@ -3046,11 +2878,7 @@ type Playlist struct {
 	// Information that further explains the status.
 	StatusDetail *string `type:"string"`
 
-	metadataPlaylist `json:"-" xml:"-"`
-}
-
-type metadataPlaylist struct {
-	SDKShapeTraits bool `type:"structure"`
+	_ struct{} `type:"structure"`
 }
 
 // String returns the string representation
@@ -3103,11 +2931,7 @@ type Preset struct {
 	// preset values.
 	Video *VideoParameters `type:"structure"`
 
-	metadataPreset `json:"-" xml:"-"`
-}
-
-type metadataPreset struct {
-	SDKShapeTraits bool `type:"structure"`
+	_ struct{} `type:"structure"`
 }
 
 // String returns the string representation
@@ -3246,11 +3070,7 @@ type PresetWatermark struct {
 	// offset calculation.
 	VerticalOffset *string `type:"string"`
 
-	metadataPresetWatermark `json:"-" xml:"-"`
-}
-
-type metadataPresetWatermark struct {
-	SDKShapeTraits bool `type:"structure"`
+	_ struct{} `type:"structure"`
 }
 
 // String returns the string representation
@@ -3268,11 +3088,7 @@ type ReadJobInput struct {
 	// The identifier of the job for which you want to get detailed information.
 	Id *string `location:"uri" locationName:"Id" type:"string" required:"true"`
 
-	metadataReadJobInput `json:"-" xml:"-"`
-}
-
-type metadataReadJobInput struct {
-	SDKShapeTraits bool `type:"structure"`
+	_ struct{} `type:"structure"`
 }
 
 // String returns the string representation
@@ -3290,11 +3106,7 @@ type ReadJobOutput struct {
 	// A section of the response body that provides information about the job.
 	Job *Job `type:"structure"`
 
-	metadataReadJobOutput `json:"-" xml:"-"`
-}
-
-type metadataReadJobOutput struct {
-	SDKShapeTraits bool `type:"structure"`
+	_ struct{} `type:"structure"`
 }
 
 // String returns the string representation
@@ -3312,11 +3124,7 @@ type ReadPipelineInput struct {
 	// The identifier of the pipeline to read.
 	Id *string `location:"uri" locationName:"Id" type:"string" required:"true"`
 
-	metadataReadPipelineInput `json:"-" xml:"-"`
-}
-
-type metadataReadPipelineInput struct {
-	SDKShapeTraits bool `type:"structure"`
+	_ struct{} `type:"structure"`
 }
 
 // String returns the string representation
@@ -3342,11 +3150,7 @@ type ReadPipelineOutput struct {
 	// cross-regional charges.
 	Warnings []*Warning `type:"list"`
 
-	metadataReadPipelineOutput `json:"-" xml:"-"`
-}
-
-type metadataReadPipelineOutput struct {
-	SDKShapeTraits bool `type:"structure"`
+	_ struct{} `type:"structure"`
 }
 
 // String returns the string representation
@@ -3364,11 +3168,7 @@ type ReadPresetInput struct {
 	// The identifier of the preset for which you want to get detailed information.
 	Id *string `location:"uri" locationName:"Id" type:"string" required:"true"`
 
-	metadataReadPresetInput `json:"-" xml:"-"`
-}
-
-type metadataReadPresetInput struct {
-	SDKShapeTraits bool `type:"structure"`
+	_ struct{} `type:"structure"`
 }
 
 // String returns the string representation
@@ -3386,11 +3186,7 @@ type ReadPresetOutput struct {
 	// A section of the response body that provides information about the preset.
 	Preset *Preset `type:"structure"`
 
-	metadataReadPresetOutput `json:"-" xml:"-"`
-}
-
-type metadataReadPresetOutput struct {
-	SDKShapeTraits bool `type:"structure"`
+	_ struct{} `type:"structure"`
 }
 
 // String returns the string representation
@@ -3421,11 +3217,7 @@ type TestRoleInput struct {
 	// that you want the action to send a test notification to.
 	Topics []*string `type:"list" required:"true"`
 
-	metadataTestRoleInput `json:"-" xml:"-"`
-}
-
-type metadataTestRoleInput struct {
-	SDKShapeTraits bool `type:"structure"`
+	_ struct{} `type:"structure"`
 }
 
 // String returns the string representation
@@ -3448,11 +3240,7 @@ type TestRoleOutput struct {
 	// is false.
 	Success *string `type:"string"`
 
-	metadataTestRoleOutput `json:"-" xml:"-"`
-}
-
-type metadataTestRoleOutput struct {
-	SDKShapeTraits bool `type:"structure"`
+	_ struct{} `type:"structure"`
 }
 
 // String returns the string representation
@@ -3540,11 +3328,7 @@ type Thumbnails struct {
 	// Transcoder does not scale thumbnails up.
 	SizingPolicy *string `type:"string"`
 
-	metadataThumbnails `json:"-" xml:"-"`
-}
-
-type metadataThumbnails struct {
-	SDKShapeTraits bool `type:"structure"`
+	_ struct{} `type:"structure"`
 }
 
 // String returns the string representation
@@ -3574,11 +3358,7 @@ type TimeSpan struct {
 	// value, Elastic Transcoder starts at the beginning of the input file.
 	StartTime *string `type:"string"`
 
-	metadataTimeSpan `json:"-" xml:"-"`
-}
-
-type metadataTimeSpan struct {
-	SDKShapeTraits bool `type:"structure"`
+	_ struct{} `type:"structure"`
 }
 
 // String returns the string representation
@@ -3602,11 +3382,7 @@ type Timing struct {
 	// The time the job was submitted to Elastic Transcoder, in epoch milliseconds.
 	SubmitTimeMillis *int64 `type:"long"`
 
-	metadataTiming `json:"-" xml:"-"`
-}
-
-type metadataTiming struct {
-	SDKShapeTraits bool `type:"structure"`
+	_ struct{} `type:"structure"`
 }
 
 // String returns the string representation
@@ -3743,11 +3519,7 @@ type UpdatePipelineInput struct {
 	// Transcoder to assign to the thumbnails that it stores in your Amazon S3 bucket.
 	ThumbnailConfig *PipelineOutputConfig `type:"structure"`
 
-	metadataUpdatePipelineInput `json:"-" xml:"-"`
-}
-
-type metadataUpdatePipelineInput struct {
-	SDKShapeTraits bool `type:"structure"`
+	_ struct{} `type:"structure"`
 }
 
 // String returns the string representation
@@ -3784,11 +3556,7 @@ type UpdatePipelineNotificationsInput struct {
 	// returned when you created the topic.
 	Notifications *Notifications `type:"structure" required:"true"`
 
-	metadataUpdatePipelineNotificationsInput `json:"-" xml:"-"`
-}
-
-type metadataUpdatePipelineNotificationsInput struct {
-	SDKShapeTraits bool `type:"structure"`
+	_ struct{} `type:"structure"`
 }
 
 // String returns the string representation
@@ -3806,11 +3574,7 @@ type UpdatePipelineNotificationsOutput struct {
 	// A section of the response body that provides information about the pipeline.
 	Pipeline *Pipeline `type:"structure"`
 
-	metadataUpdatePipelineNotificationsOutput `json:"-" xml:"-"`
-}
-
-type metadataUpdatePipelineNotificationsOutput struct {
-	SDKShapeTraits bool `type:"structure"`
+	_ struct{} `type:"structure"`
 }
 
 // String returns the string representation
@@ -3837,11 +3601,7 @@ type UpdatePipelineOutput struct {
 	// cross-regional charges.
 	Warnings []*Warning `type:"list"`
 
-	metadataUpdatePipelineOutput `json:"-" xml:"-"`
-}
-
-type metadataUpdatePipelineOutput struct {
-	SDKShapeTraits bool `type:"structure"`
+	_ struct{} `type:"structure"`
 }
 
 // String returns the string representation
@@ -3865,11 +3625,7 @@ type UpdatePipelineStatusInput struct {
 	// currently processing jobs.
 	Status *string `type:"string" required:"true"`
 
-	metadataUpdatePipelineStatusInput `json:"-" xml:"-"`
-}
-
-type metadataUpdatePipelineStatusInput struct {
-	SDKShapeTraits bool `type:"structure"`
+	_ struct{} `type:"structure"`
 }
 
 // String returns the string representation
@@ -3888,11 +3644,7 @@ type UpdatePipelineStatusOutput struct {
 	// A section of the response body that provides information about the pipeline.
 	Pipeline *Pipeline `type:"structure"`
 
-	metadataUpdatePipelineStatusOutput `json:"-" xml:"-"`
-}
-
-type metadataUpdatePipelineStatusOutput struct {
-	SDKShapeTraits bool `type:"structure"`
+	_ struct{} `type:"structure"`
 }
 
 // String returns the string representation
@@ -4202,11 +3954,7 @@ type VideoParameters struct {
 	// that have different dimensions.
 	Watermarks []*PresetWatermark `type:"list"`
 
-	metadataVideoParameters `json:"-" xml:"-"`
-}
-
-type metadataVideoParameters struct {
-	SDKShapeTraits bool `type:"structure"`
+	_ struct{} `type:"structure"`
 }
 
 // String returns the string representation
@@ -4235,11 +3983,7 @@ type Warning struct {
 	// Note: AWS KMS keys must be in the same region as the pipeline.
 	Message *string `type:"string"`
 
-	metadataWarning `json:"-" xml:"-"`
-}
-
-type metadataWarning struct {
-	SDKShapeTraits bool `type:"structure"`
+	_ struct{} `type:"structure"`
 }
 
 // String returns the string representation

--- a/service/elastictranscoder/api.go
+++ b/service/elastictranscoder/api.go
@@ -591,6 +591,8 @@ func (c *ElasticTranscoder) UpdatePipelineStatus(input *UpdatePipelineStatusInpu
 // To pass through existing artwork unchanged, set the Merge Policy to "Prepend",
 // "Append", or "Fallback", and use an empty Artwork array.
 type Artwork struct {
+	_ struct{} `type:"structure"`
+
 	// The format of album art, if any. Valid formats are .jpg and .png.
 	AlbumArtFormat *string `type:"string"`
 
@@ -647,8 +649,6 @@ type Artwork struct {
 	// of MaxWidth and MaxHeight without dropping below either value. If you specify
 	// this option, Elastic Transcoder does not scale the art up.
 	SizingPolicy *string `type:"string"`
-
-	_ struct{} `type:"structure"`
 }
 
 // String returns the string representation
@@ -663,6 +663,8 @@ func (s Artwork) GoString() string {
 
 // Options associated with your audio codec.
 type AudioCodecOptions struct {
+	_ struct{} `type:"structure"`
+
 	// You can only choose an audio bit depth when you specify flac or pcm for the
 	// value of Audio:Codec.
 	//
@@ -710,8 +712,6 @@ type AudioCodecOptions struct {
 	//
 	// The supported value is Signed.
 	Signed *string `type:"string"`
-
-	_ struct{} `type:"structure"`
 }
 
 // String returns the string representation
@@ -726,6 +726,8 @@ func (s AudioCodecOptions) GoString() string {
 
 // Parameters required for transcoding audio.
 type AudioParameters struct {
+	_ struct{} `type:"structure"`
+
 	// The method of organizing audio channels and tracks. Use Audio:Channels to
 	// specify the number of channels in your output, and Audio:AudioPackingMode
 	// to specify the number of tracks and their relation to the channels. If you
@@ -837,8 +839,6 @@ type AudioParameters struct {
 	// If you specify auto, Elastic Transcoder automatically detects the sample
 	// rate.
 	SampleRate *string `type:"string"`
-
-	_ struct{} `type:"structure"`
 }
 
 // String returns the string representation
@@ -853,13 +853,13 @@ func (s AudioParameters) GoString() string {
 
 // The CancelJobRequest structure.
 type CancelJobInput struct {
+	_ struct{} `type:"structure"`
+
 	// The identifier of the job that you want to cancel.
 	//
 	// To get a list of the jobs (including their jobId) that have a status of
 	// Submitted, use the ListJobsByStatus API action.
 	Id *string `location:"uri" locationName:"Id" type:"string" required:"true"`
-
-	_ struct{} `type:"structure"`
 }
 
 // String returns the string representation
@@ -891,6 +891,8 @@ func (s CancelJobOutput) GoString() string {
 // The file format of the output captions. If you leave this value blank, Elastic
 // Transcoder returns an error.
 type CaptionFormat struct {
+	_ struct{} `type:"structure"`
+
 	// The encryption settings, if any, that you want Elastic Transcoder to apply
 	// to your caption formats.
 	Encryption *Encryption `type:"structure"`
@@ -936,8 +938,6 @@ type CaptionFormat struct {
 	// "Sydney-{language}-sunrise", and the language of the captions is English
 	// (en), the name of the first caption file will be Sydney-en-sunrise00000.srt.
 	Pattern *string `type:"string"`
-
-	_ struct{} `type:"structure"`
 }
 
 // String returns the string representation
@@ -953,6 +953,8 @@ func (s CaptionFormat) GoString() string {
 // A source file for the input sidecar captions used during the transcoding
 // process.
 type CaptionSource struct {
+	_ struct{} `type:"structure"`
+
 	// The encryption settings, if any, that you want Elastic Transcoder to apply
 	// to your caption sources.
 	Encryption *Encryption `type:"structure"`
@@ -983,8 +985,6 @@ type CaptionSource struct {
 	//
 	// Specify the TimeOffset in the form [+-]SS.sss or [+-]HH:mm:SS.ss.
 	TimeOffset *string `type:"string"`
-
-	_ struct{} `type:"structure"`
 }
 
 // String returns the string representation
@@ -999,6 +999,8 @@ func (s CaptionSource) GoString() string {
 
 // The captions to be created, if any.
 type Captions struct {
+	_ struct{} `type:"structure"`
+
 	// The array of file formats for the output captions. If you leave this value
 	// blank, Elastic Transcoder returns an error.
 	CaptionFormats []*CaptionFormat `type:"list"`
@@ -1026,8 +1028,6 @@ type Captions struct {
 	//
 	//  MergePolicy cannot be null.
 	MergePolicy *string `type:"string"`
-
-	_ struct{} `type:"structure"`
 }
 
 // String returns the string representation
@@ -1043,10 +1043,10 @@ func (s Captions) GoString() string {
 // Settings for one clip in a composition. All jobs in a playlist must have
 // the same clip settings.
 type Clip struct {
+	_ struct{} `type:"structure"`
+
 	// Settings that determine when a clip begins and how long it lasts.
 	TimeSpan *TimeSpan `type:"structure"`
-
-	_ struct{} `type:"structure"`
 }
 
 // String returns the string representation
@@ -1061,6 +1061,8 @@ func (s Clip) GoString() string {
 
 // The CreateJobRequest structure.
 type CreateJobInput struct {
+	_ struct{} `type:"structure"`
+
 	// A section of the request body that provides information about the file that
 	// is being transcoded.
 	Input *JobInput `type:"structure" required:"true"`
@@ -1096,8 +1098,6 @@ type CreateJobInput struct {
 	// pairs per job. Elastic Transcoder does not guarantee that key/value pairs
 	// will be returned in the same order in which you specify them.
 	UserMetadata map[string]*string `type:"map"`
-
-	_ struct{} `type:"structure"`
 }
 
 // String returns the string representation
@@ -1112,6 +1112,8 @@ func (s CreateJobInput) GoString() string {
 
 // The CreateJobOutput structure.
 type CreateJobOutput struct {
+	_ struct{} `type:"structure"`
+
 	// Information about the album art that you want Elastic Transcoder to add to
 	// the file during transcoding. You can specify up to twenty album artworks
 	// for each output. Settings for each artwork must be defined in the job for
@@ -1249,8 +1251,6 @@ type CreateJobOutput struct {
 	// each output. Settings for each watermark must be defined in the preset for
 	// the current output.
 	Watermarks []*JobWatermark `type:"list"`
-
-	_ struct{} `type:"structure"`
 }
 
 // String returns the string representation
@@ -1265,6 +1265,8 @@ func (s CreateJobOutput) GoString() string {
 
 // Information about the master playlist.
 type CreateJobPlaylist struct {
+	_ struct{} `type:"structure"`
+
 	// The format of the output playlist. Valid formats include HLSv3, HLSv4, and
 	// Smooth.
 	Format *string `type:"string"`
@@ -1327,8 +1329,6 @@ type CreateJobPlaylist struct {
 	// The DRM settings, if any, that you want Elastic Transcoder to apply to the
 	// output files associated with this playlist.
 	PlayReadyDrm *PlayReadyDrm `type:"structure"`
-
-	_ struct{} `type:"structure"`
 }
 
 // String returns the string representation
@@ -1343,11 +1343,11 @@ func (s CreateJobPlaylist) GoString() string {
 
 // The CreateJobResponse structure.
 type CreateJobResponse struct {
+	_ struct{} `type:"structure"`
+
 	// A section of the response body that provides information about the job that
 	// is created.
 	Job *Job `type:"structure"`
-
-	_ struct{} `type:"structure"`
 }
 
 // String returns the string representation
@@ -1362,6 +1362,8 @@ func (s CreateJobResponse) GoString() string {
 
 // The CreatePipelineRequest structure.
 type CreatePipelineInput struct {
+	_ struct{} `type:"structure"`
+
 	// The AWS Key Management Service (AWS KMS) key that you want to use with this
 	// pipeline.
 	//
@@ -1512,8 +1514,6 @@ type CreatePipelineInput struct {
 	// Amazon S3 storage class, Standard or ReducedRedundancy, that you want Elastic
 	// Transcoder to assign to the thumbnails that it stores in your Amazon S3 bucket.
 	ThumbnailConfig *PipelineOutputConfig `type:"structure"`
-
-	_ struct{} `type:"structure"`
 }
 
 // String returns the string representation
@@ -1529,6 +1529,8 @@ func (s CreatePipelineInput) GoString() string {
 // When you create a pipeline, Elastic Transcoder returns the values that you
 // specified in the request.
 type CreatePipelineOutput struct {
+	_ struct{} `type:"structure"`
+
 	// A section of the response body that provides information about the pipeline
 	// that is created.
 	Pipeline *Pipeline `type:"structure"`
@@ -1540,8 +1542,6 @@ type CreatePipelineOutput struct {
 	// SNS notification topics, and AWS KMS key, reduces processing time and prevents
 	// cross-regional charges.
 	Warnings []*Warning `type:"list"`
-
-	_ struct{} `type:"structure"`
 }
 
 // String returns the string representation
@@ -1556,6 +1556,8 @@ func (s CreatePipelineOutput) GoString() string {
 
 // The CreatePresetRequest structure.
 type CreatePresetInput struct {
+	_ struct{} `type:"structure"`
+
 	// A section of the request body that specifies the audio parameters.
 	Audio *AudioParameters `type:"structure"`
 
@@ -1576,8 +1578,6 @@ type CreatePresetInput struct {
 
 	// A section of the request body that specifies the video parameters.
 	Video *VideoParameters `type:"structure"`
-
-	_ struct{} `type:"structure"`
 }
 
 // String returns the string representation
@@ -1592,6 +1592,8 @@ func (s CreatePresetInput) GoString() string {
 
 // The CreatePresetResponse structure.
 type CreatePresetOutput struct {
+	_ struct{} `type:"structure"`
+
 	// A section of the response body that provides information about the preset
 	// that is created.
 	Preset *Preset `type:"structure"`
@@ -1601,8 +1603,6 @@ type CreatePresetOutput struct {
 	// the preset settings don't meet the standard. Elastic Transcoder created the
 	// preset because the settings might produce acceptable output.
 	Warning *string `type:"string"`
-
-	_ struct{} `type:"structure"`
 }
 
 // String returns the string representation
@@ -1617,10 +1617,10 @@ func (s CreatePresetOutput) GoString() string {
 
 // The DeletePipelineRequest structure.
 type DeletePipelineInput struct {
+	_ struct{} `type:"structure"`
+
 	// The identifier of the pipeline that you want to delete.
 	Id *string `location:"uri" locationName:"Id" type:"string" required:"true"`
-
-	_ struct{} `type:"structure"`
 }
 
 // String returns the string representation
@@ -1650,10 +1650,10 @@ func (s DeletePipelineOutput) GoString() string {
 
 // The DeletePresetRequest structure.
 type DeletePresetInput struct {
+	_ struct{} `type:"structure"`
+
 	// The identifier of the preset for which you want to get detailed information.
 	Id *string `location:"uri" locationName:"Id" type:"string" required:"true"`
-
-	_ struct{} `type:"structure"`
 }
 
 // String returns the string representation
@@ -1684,6 +1684,8 @@ func (s DeletePresetOutput) GoString() string {
 // The detected properties of the input file. Elastic Transcoder identifies
 // these values from the input file.
 type DetectedProperties struct {
+	_ struct{} `type:"structure"`
+
 	// The detected duration of the input file, in milliseconds.
 	DurationMillis *int64 `type:"long"`
 
@@ -1698,8 +1700,6 @@ type DetectedProperties struct {
 
 	// The detected width of the input file, in pixels.
 	Width *int64 `type:"integer"`
-
-	_ struct{} `type:"structure"`
 }
 
 // String returns the string representation
@@ -1718,6 +1718,8 @@ func (s DetectedProperties) GoString() string {
 // otherwise you must specify the mode you want Elastic Transcoder to use to
 // encrypt your output files.
 type Encryption struct {
+	_ struct{} `type:"structure"`
+
 	// The series of random bits created by a random bit generator, unique for every
 	// encryption operation, that you used to encrypt your input files or that you
 	// want Elastic Transcoder to use to encrypt your output files. The initialization
@@ -1776,8 +1778,6 @@ type Encryption struct {
 	// your encryption keys. If you lose them, you won't be able to unencrypt your
 	// data.
 	Mode *string `type:"string"`
-
-	_ struct{} `type:"structure"`
 }
 
 // String returns the string representation
@@ -1793,6 +1793,8 @@ func (s Encryption) GoString() string {
 // The HLS content protection settings, if any, that you want Elastic Transcoder
 // to apply to your output files.
 type HlsContentProtection struct {
+	_ struct{} `type:"structure"`
+
 	// If Elastic Transcoder is generating your key for you, you must leave this
 	// field blank.
 	//
@@ -1837,8 +1839,6 @@ type HlsContentProtection struct {
 	// This value will be written into the method attribute of the EXT-X-KEY metadata
 	// tag in the output playlist.
 	Method *string `type:"string"`
-
-	_ struct{} `type:"structure"`
 }
 
 // String returns the string representation
@@ -1854,6 +1854,8 @@ func (s HlsContentProtection) GoString() string {
 // A section of the response body that provides information about the job that
 // is created.
 type Job struct {
+	_ struct{} `type:"structure"`
+
 	// The Amazon Resource Name (ARN) for the job.
 	Arn *string `type:"string"`
 
@@ -1924,8 +1926,6 @@ type Job struct {
 	//
 	// The following symbols: _.:/=+-%@
 	UserMetadata map[string]*string `type:"map"`
-
-	_ struct{} `type:"structure"`
 }
 
 // String returns the string representation
@@ -1940,6 +1940,8 @@ func (s Job) GoString() string {
 
 // The .jpg or .png file associated with an audio file.
 type JobAlbumArt struct {
+	_ struct{} `type:"structure"`
+
 	// The file to be used as album art. There can be multiple artworks associated
 	// with an audio file, to a maximum of 20. Valid formats are .jpg and .png
 	Artwork []*Artwork `type:"list"`
@@ -1955,8 +1957,6 @@ type JobAlbumArt struct {
 	// not contain artwork, Elastic Transcoder will use the specified album art
 	// file.
 	MergePolicy *string `type:"string"`
-
-	_ struct{} `type:"structure"`
 }
 
 // String returns the string representation
@@ -1971,6 +1971,8 @@ func (s JobAlbumArt) GoString() string {
 
 // Information about the file that you're transcoding.
 type JobInput struct {
+	_ struct{} `type:"structure"`
+
 	// The aspect ratio of the input file. If you want Elastic Transcoder to automatically
 	// detect the aspect ratio of the input file, specify auto. If you want to specify
 	// the aspect ratio for the output file, enter one of the following values:
@@ -2032,8 +2034,6 @@ type JobInput struct {
 	// This value must be auto, which causes Elastic Transcoder to automatically
 	// detect the resolution of the input file.
 	Resolution *string `type:"string"`
-
-	_ struct{} `type:"structure"`
 }
 
 // String returns the string representation
@@ -2051,6 +2051,8 @@ func (s JobInput) GoString() string {
 // object lists information about the first output. This duplicates the information
 // that is listed for the first output in the Outputs object.
 type JobOutput struct {
+	_ struct{} `type:"structure"`
+
 	// The album art to be associated with the output file, if any.
 	AlbumArt *JobAlbumArt `type:"structure"`
 
@@ -2247,8 +2249,6 @@ type JobOutput struct {
 
 	// Specifies the width of the output file in pixels.
 	Width *int64 `type:"integer"`
-
-	_ struct{} `type:"structure"`
 }
 
 // String returns the string representation
@@ -2264,6 +2264,8 @@ func (s JobOutput) GoString() string {
 // Watermarks can be in .png or .jpg format. If you want to display a watermark
 // that is not rectangular, use the .png format, which supports transparency.
 type JobWatermark struct {
+	_ struct{} `type:"structure"`
+
 	// The encryption settings, if any, that you want Elastic Transcoder to apply
 	// to your watermarks.
 	Encryption *Encryption `type:"structure"`
@@ -2283,8 +2285,6 @@ type JobWatermark struct {
 	// by Preset for the current output. In that preset, the value of Watermarks
 	// Id tells Elastic Transcoder which settings to use.
 	PresetWatermarkId *string `min:"1" type:"string"`
-
-	_ struct{} `type:"structure"`
 }
 
 // String returns the string representation
@@ -2299,6 +2299,8 @@ func (s JobWatermark) GoString() string {
 
 // The ListJobsByPipelineRequest structure.
 type ListJobsByPipelineInput struct {
+	_ struct{} `type:"structure"`
+
 	// To list jobs in chronological order by the date and time that they were submitted,
 	// enter true. To list jobs in reverse chronological order, enter false.
 	Ascending *string `location:"querystring" locationName:"Ascending" type:"string"`
@@ -2309,8 +2311,6 @@ type ListJobsByPipelineInput struct {
 
 	// The ID of the pipeline for which you want to get job information.
 	PipelineId *string `location:"uri" locationName:"PipelineId" type:"string" required:"true"`
-
-	_ struct{} `type:"structure"`
 }
 
 // String returns the string representation
@@ -2325,6 +2325,8 @@ func (s ListJobsByPipelineInput) GoString() string {
 
 // The ListJobsByPipelineResponse structure.
 type ListJobsByPipelineOutput struct {
+	_ struct{} `type:"structure"`
+
 	// An array of Job objects that are in the specified pipeline.
 	Jobs []*Job `type:"list"`
 
@@ -2332,8 +2334,6 @@ type ListJobsByPipelineOutput struct {
 	// if any. When the jobs in the specified pipeline fit on one page or when you've
 	// reached the last page of results, the value of NextPageToken is null.
 	NextPageToken *string `type:"string"`
-
-	_ struct{} `type:"structure"`
 }
 
 // String returns the string representation
@@ -2348,6 +2348,8 @@ func (s ListJobsByPipelineOutput) GoString() string {
 
 // The ListJobsByStatusRequest structure.
 type ListJobsByStatusInput struct {
+	_ struct{} `type:"structure"`
+
 	// To list jobs in chronological order by the date and time that they were submitted,
 	// enter true. To list jobs in reverse chronological order, enter false.
 	Ascending *string `location:"querystring" locationName:"Ascending" type:"string"`
@@ -2360,8 +2362,6 @@ type ListJobsByStatusInput struct {
 	// account that have a given status, specify the following status: Submitted,
 	// Progressing, Complete, Canceled, or Error.
 	Status *string `location:"uri" locationName:"Status" type:"string" required:"true"`
-
-	_ struct{} `type:"structure"`
 }
 
 // String returns the string representation
@@ -2376,6 +2376,8 @@ func (s ListJobsByStatusInput) GoString() string {
 
 // The ListJobsByStatusResponse structure.
 type ListJobsByStatusOutput struct {
+	_ struct{} `type:"structure"`
+
 	// An array of Job objects that have the specified status.
 	Jobs []*Job `type:"list"`
 
@@ -2383,8 +2385,6 @@ type ListJobsByStatusOutput struct {
 	// if any. When the jobs in the specified pipeline fit on one page or when you've
 	// reached the last page of results, the value of NextPageToken is null.
 	NextPageToken *string `type:"string"`
-
-	_ struct{} `type:"structure"`
 }
 
 // String returns the string representation
@@ -2399,6 +2399,8 @@ func (s ListJobsByStatusOutput) GoString() string {
 
 // The ListPipelineRequest structure.
 type ListPipelinesInput struct {
+	_ struct{} `type:"structure"`
+
 	// To list pipelines in chronological order by the date and time that they were
 	// created, enter true. To list pipelines in reverse chronological order, enter
 	// false.
@@ -2407,8 +2409,6 @@ type ListPipelinesInput struct {
 	// When Elastic Transcoder returns more than one page of results, use pageToken
 	// in subsequent GET requests to get each successive page of results.
 	PageToken *string `location:"querystring" locationName:"PageToken" type:"string"`
-
-	_ struct{} `type:"structure"`
 }
 
 // String returns the string representation
@@ -2423,6 +2423,8 @@ func (s ListPipelinesInput) GoString() string {
 
 // A list of the pipelines associated with the current AWS account.
 type ListPipelinesOutput struct {
+	_ struct{} `type:"structure"`
+
 	// A value that you use to access the second and subsequent pages of results,
 	// if any. When the pipelines fit on one page or when you've reached the last
 	// page of results, the value of NextPageToken is null.
@@ -2430,8 +2432,6 @@ type ListPipelinesOutput struct {
 
 	// An array of Pipeline objects.
 	Pipelines []*Pipeline `type:"list"`
-
-	_ struct{} `type:"structure"`
 }
 
 // String returns the string representation
@@ -2446,6 +2446,8 @@ func (s ListPipelinesOutput) GoString() string {
 
 // The ListPresetsRequest structure.
 type ListPresetsInput struct {
+	_ struct{} `type:"structure"`
+
 	// To list presets in chronological order by the date and time that they were
 	// created, enter true. To list presets in reverse chronological order, enter
 	// false.
@@ -2454,8 +2456,6 @@ type ListPresetsInput struct {
 	// When Elastic Transcoder returns more than one page of results, use pageToken
 	// in subsequent GET requests to get each successive page of results.
 	PageToken *string `location:"querystring" locationName:"PageToken" type:"string"`
-
-	_ struct{} `type:"structure"`
 }
 
 // String returns the string representation
@@ -2470,6 +2470,8 @@ func (s ListPresetsInput) GoString() string {
 
 // The ListPresetsResponse structure.
 type ListPresetsOutput struct {
+	_ struct{} `type:"structure"`
+
 	// A value that you use to access the second and subsequent pages of results,
 	// if any. When the presets fit on one page or when you've reached the last
 	// page of results, the value of NextPageToken is null.
@@ -2477,8 +2479,6 @@ type ListPresetsOutput struct {
 
 	// An array of Preset objects.
 	Presets []*Preset `type:"list"`
-
-	_ struct{} `type:"structure"`
 }
 
 // String returns the string representation
@@ -2497,6 +2497,8 @@ func (s ListPresetsOutput) GoString() string {
 // To receive notifications, you must also subscribe to the new topic in the
 // Amazon SNS console.
 type Notifications struct {
+	_ struct{} `type:"structure"`
+
 	// The Amazon SNS topic that you want to notify when Elastic Transcoder has
 	// finished processing the job.
 	Completed *string `type:"string"`
@@ -2512,8 +2514,6 @@ type Notifications struct {
 	// The Amazon SNS topic that you want to notify when Elastic Transcoder encounters
 	// a warning condition.
 	Warning *string `type:"string"`
-
-	_ struct{} `type:"structure"`
 }
 
 // String returns the string representation
@@ -2528,6 +2528,8 @@ func (s Notifications) GoString() string {
 
 // The Permission structure.
 type Permission struct {
+	_ struct{} `type:"structure"`
+
 	// The permission that you want to give to the AWS user that is listed in Grantee.
 	// Valid values include:   READ: The grantee can read the thumbnails and metadata
 	// for thumbnails that Elastic Transcoder adds to the Amazon S3 bucket.  READ_ACP:
@@ -2552,8 +2554,6 @@ type Permission struct {
 	//  Group: One of the following predefined Amazon S3 groups: AllUsers, AuthenticatedUsers,
 	// or LogDelivery.
 	GranteeType *string `type:"string"`
-
-	_ struct{} `type:"structure"`
 }
 
 // String returns the string representation
@@ -2568,6 +2568,8 @@ func (s Permission) GoString() string {
 
 // The pipeline (queue) that is used to manage jobs.
 type Pipeline struct {
+	_ struct{} `type:"structure"`
+
 	// The Amazon Resource Name (ARN) for the pipeline.
 	Arn *string `type:"string"`
 
@@ -2678,8 +2680,6 @@ type Pipeline struct {
 	// Standard or ReducedRedundancy, that you want Elastic Transcoder to assign
 	// to the thumbnails that it stores in your Amazon S3 bucket.
 	ThumbnailConfig *PipelineOutputConfig `type:"structure"`
-
-	_ struct{} `type:"structure"`
 }
 
 // String returns the string representation
@@ -2694,6 +2694,8 @@ func (s Pipeline) GoString() string {
 
 // The PipelineOutputConfig structure.
 type PipelineOutputConfig struct {
+	_ struct{} `type:"structure"`
+
 	// The Amazon S3 bucket in which you want Elastic Transcoder to save the transcoded
 	// files. Specify this value when all of the following are true:  You want to
 	// save transcoded files, thumbnails (if any), and playlists (if any) together
@@ -2727,8 +2729,6 @@ type PipelineOutputConfig struct {
 	// Elastic Transcoder to assign to the video files and playlists that it stores
 	// in your Amazon S3 bucket.
 	StorageClass *string `type:"string"`
-
-	_ struct{} `type:"structure"`
 }
 
 // String returns the string representation
@@ -2748,6 +2748,8 @@ func (s PipelineOutputConfig) GoString() string {
 //
 // If you use DRM for an HLSv3 playlist, your outputs must have a master playlist.
 type PlayReadyDrm struct {
+	_ struct{} `type:"structure"`
+
 	// The type of DRM, if any, that you want Elastic Transcoder to apply to the
 	// output files associated with this playlist.
 	Format *string `type:"string"`
@@ -2789,8 +2791,6 @@ type PlayReadyDrm struct {
 	// Smooth Streaming outputs, and in the EXT-X-DXDRM and EXT-XDXDRMINFO metadata
 	// tags for HLS playlist outputs. An example URL looks like this: https://www.example.com/exampleKey/
 	LicenseAcquisitionUrl *string `min:"1" type:"string"`
-
-	_ struct{} `type:"structure"`
 }
 
 // String returns the string representation
@@ -2809,6 +2809,8 @@ func (s PlayReadyDrm) GoString() string {
 // to create. We recommend that you create only one master playlist per output
 // format. The maximum number of master playlists in a job is 30.
 type Playlist struct {
+	_ struct{} `type:"structure"`
+
 	// The format of the output playlist. Valid formats include HLSv3, HLSv4, and
 	// Smooth.
 	Format *string `type:"string"`
@@ -2877,8 +2879,6 @@ type Playlist struct {
 
 	// Information that further explains the status.
 	StatusDetail *string `type:"string"`
-
-	_ struct{} `type:"structure"`
 }
 
 // String returns the string representation
@@ -2898,6 +2898,8 @@ func (s Playlist) GoString() string {
 // the default presets. You specify which preset you want to use when you create
 // a job.
 type Preset struct {
+	_ struct{} `type:"structure"`
+
 	// The Amazon Resource Name (ARN) for the preset.
 	Arn *string `type:"string"`
 
@@ -2930,8 +2932,6 @@ type Preset struct {
 	// A section of the response body that provides information about the video
 	// preset values.
 	Video *VideoParameters `type:"structure"`
-
-	_ struct{} `type:"structure"`
 }
 
 // String returns the string representation
@@ -2959,6 +2959,8 @@ func (s Preset) GoString() string {
 // in the preset, which allows you to use the same preset for up to four watermarks
 // that have different dimensions.
 type PresetWatermark struct {
+	_ struct{} `type:"structure"`
+
 	// The horizontal position of the watermark unless you specify a non-zero value
 	// for HorizontalOffset:   Left: The left edge of the watermark is aligned with
 	// the left border of the video.  Right: The right edge of the watermark is
@@ -3069,8 +3071,6 @@ type PresetWatermark struct {
 	// include the black bars that are added by Elastic Transcoder, if any, in the
 	// offset calculation.
 	VerticalOffset *string `type:"string"`
-
-	_ struct{} `type:"structure"`
 }
 
 // String returns the string representation
@@ -3085,10 +3085,10 @@ func (s PresetWatermark) GoString() string {
 
 // The ReadJobRequest structure.
 type ReadJobInput struct {
+	_ struct{} `type:"structure"`
+
 	// The identifier of the job for which you want to get detailed information.
 	Id *string `location:"uri" locationName:"Id" type:"string" required:"true"`
-
-	_ struct{} `type:"structure"`
 }
 
 // String returns the string representation
@@ -3103,10 +3103,10 @@ func (s ReadJobInput) GoString() string {
 
 // The ReadJobResponse structure.
 type ReadJobOutput struct {
+	_ struct{} `type:"structure"`
+
 	// A section of the response body that provides information about the job.
 	Job *Job `type:"structure"`
-
-	_ struct{} `type:"structure"`
 }
 
 // String returns the string representation
@@ -3121,10 +3121,10 @@ func (s ReadJobOutput) GoString() string {
 
 // The ReadPipelineRequest structure.
 type ReadPipelineInput struct {
+	_ struct{} `type:"structure"`
+
 	// The identifier of the pipeline to read.
 	Id *string `location:"uri" locationName:"Id" type:"string" required:"true"`
-
-	_ struct{} `type:"structure"`
 }
 
 // String returns the string representation
@@ -3139,6 +3139,8 @@ func (s ReadPipelineInput) GoString() string {
 
 // The ReadPipelineResponse structure.
 type ReadPipelineOutput struct {
+	_ struct{} `type:"structure"`
+
 	// A section of the response body that provides information about the pipeline.
 	Pipeline *Pipeline `type:"structure"`
 
@@ -3149,8 +3151,6 @@ type ReadPipelineOutput struct {
 	// SNS notification topics, and AWS KMS key, reduces processing time and prevents
 	// cross-regional charges.
 	Warnings []*Warning `type:"list"`
-
-	_ struct{} `type:"structure"`
 }
 
 // String returns the string representation
@@ -3165,10 +3165,10 @@ func (s ReadPipelineOutput) GoString() string {
 
 // The ReadPresetRequest structure.
 type ReadPresetInput struct {
+	_ struct{} `type:"structure"`
+
 	// The identifier of the preset for which you want to get detailed information.
 	Id *string `location:"uri" locationName:"Id" type:"string" required:"true"`
-
-	_ struct{} `type:"structure"`
 }
 
 // String returns the string representation
@@ -3183,10 +3183,10 @@ func (s ReadPresetInput) GoString() string {
 
 // The ReadPresetResponse structure.
 type ReadPresetOutput struct {
+	_ struct{} `type:"structure"`
+
 	// A section of the response body that provides information about the preset.
 	Preset *Preset `type:"structure"`
-
-	_ struct{} `type:"structure"`
 }
 
 // String returns the string representation
@@ -3201,6 +3201,8 @@ func (s ReadPresetOutput) GoString() string {
 
 // The TestRoleRequest structure.
 type TestRoleInput struct {
+	_ struct{} `type:"structure"`
+
 	// The Amazon S3 bucket that contains media files to be transcoded. The action
 	// attempts to read from this bucket.
 	InputBucket *string `type:"string" required:"true"`
@@ -3216,8 +3218,6 @@ type TestRoleInput struct {
 	// The ARNs of one or more Amazon Simple Notification Service (Amazon SNS) topics
 	// that you want the action to send a test notification to.
 	Topics []*string `type:"list" required:"true"`
-
-	_ struct{} `type:"structure"`
 }
 
 // String returns the string representation
@@ -3232,6 +3232,8 @@ func (s TestRoleInput) GoString() string {
 
 // The TestRoleResponse structure.
 type TestRoleOutput struct {
+	_ struct{} `type:"structure"`
+
 	// If the Success element contains false, this value is an array of one or more
 	// error messages that were generated during the test process.
 	Messages []*string `type:"list"`
@@ -3239,8 +3241,6 @@ type TestRoleOutput struct {
 	// If the operation is successful, this value is true; otherwise, the value
 	// is false.
 	Success *string `type:"string"`
-
-	_ struct{} `type:"structure"`
 }
 
 // String returns the string representation
@@ -3255,6 +3255,8 @@ func (s TestRoleOutput) GoString() string {
 
 // Thumbnails for videos.
 type Thumbnails struct {
+	_ struct{} `type:"structure"`
+
 	// To better control resolution and aspect ratio of thumbnails, we recommend
 	// that you use the values MaxWidth, MaxHeight, SizingPolicy, and PaddingPolicy
 	// instead of Resolution and AspectRatio. The two groups of settings are mutually
@@ -3327,8 +3329,6 @@ type Thumbnails struct {
 	// without dropping below either value. If you specify this option, Elastic
 	// Transcoder does not scale thumbnails up.
 	SizingPolicy *string `type:"string"`
-
-	_ struct{} `type:"structure"`
 }
 
 // String returns the string representation
@@ -3343,6 +3343,8 @@ func (s Thumbnails) GoString() string {
 
 // Settings that determine when a clip begins and how long it lasts.
 type TimeSpan struct {
+	_ struct{} `type:"structure"`
+
 	// The duration of the clip. The format can be either HH:mm:ss.SSS (maximum
 	// value: 23:59:59.999; SSS is thousandths of a second) or sssss.SSS (maximum
 	// value: 86399.999). If you don't specify a value, Elastic Transcoder creates
@@ -3357,8 +3359,6 @@ type TimeSpan struct {
 	// a second) or sssss.SSS (maximum value: 86399.999). If you don't specify a
 	// value, Elastic Transcoder starts at the beginning of the input file.
 	StartTime *string `type:"string"`
-
-	_ struct{} `type:"structure"`
 }
 
 // String returns the string representation
@@ -3373,6 +3373,8 @@ func (s TimeSpan) GoString() string {
 
 // Details about the timing of a job.
 type Timing struct {
+	_ struct{} `type:"structure"`
+
 	// The time the job finished transcoding, in epoch milliseconds.
 	FinishTimeMillis *int64 `type:"long"`
 
@@ -3381,8 +3383,6 @@ type Timing struct {
 
 	// The time the job was submitted to Elastic Transcoder, in epoch milliseconds.
 	SubmitTimeMillis *int64 `type:"long"`
-
-	_ struct{} `type:"structure"`
 }
 
 // String returns the string representation
@@ -3397,6 +3397,8 @@ func (s Timing) GoString() string {
 
 // The UpdatePipelineRequest structure.
 type UpdatePipelineInput struct {
+	_ struct{} `type:"structure"`
+
 	// The AWS Key Management Service (AWS KMS) key that you want to use with this
 	// pipeline.
 	//
@@ -3518,8 +3520,6 @@ type UpdatePipelineInput struct {
 	// Amazon S3 storage class, Standard or ReducedRedundancy, that you want Elastic
 	// Transcoder to assign to the thumbnails that it stores in your Amazon S3 bucket.
 	ThumbnailConfig *PipelineOutputConfig `type:"structure"`
-
-	_ struct{} `type:"structure"`
 }
 
 // String returns the string representation
@@ -3534,6 +3534,8 @@ func (s UpdatePipelineInput) GoString() string {
 
 // The UpdatePipelineNotificationsRequest structure.
 type UpdatePipelineNotificationsInput struct {
+	_ struct{} `type:"structure"`
+
 	// The identifier of the pipeline for which you want to change notification
 	// settings.
 	Id *string `location:"uri" locationName:"Id" type:"string" required:"true"`
@@ -3555,8 +3557,6 @@ type UpdatePipelineNotificationsInput struct {
 	// Transcoder encounters an error condition. This is the ARN that Amazon SNS
 	// returned when you created the topic.
 	Notifications *Notifications `type:"structure" required:"true"`
-
-	_ struct{} `type:"structure"`
 }
 
 // String returns the string representation
@@ -3571,10 +3571,10 @@ func (s UpdatePipelineNotificationsInput) GoString() string {
 
 // The UpdatePipelineNotificationsResponse structure.
 type UpdatePipelineNotificationsOutput struct {
+	_ struct{} `type:"structure"`
+
 	// A section of the response body that provides information about the pipeline.
 	Pipeline *Pipeline `type:"structure"`
-
-	_ struct{} `type:"structure"`
 }
 
 // String returns the string representation
@@ -3590,6 +3590,8 @@ func (s UpdatePipelineNotificationsOutput) GoString() string {
 // When you update a pipeline, Elastic Transcoder returns the values that you
 // specified in the request.
 type UpdatePipelineOutput struct {
+	_ struct{} `type:"structure"`
+
 	// The pipeline (queue) that is used to manage jobs.
 	Pipeline *Pipeline `type:"structure"`
 
@@ -3600,8 +3602,6 @@ type UpdatePipelineOutput struct {
 	// SNS notification topics, and AWS KMS key, reduces processing time and prevents
 	// cross-regional charges.
 	Warnings []*Warning `type:"list"`
-
-	_ struct{} `type:"structure"`
 }
 
 // String returns the string representation
@@ -3616,6 +3616,8 @@ func (s UpdatePipelineOutput) GoString() string {
 
 // The UpdatePipelineStatusRequest structure.
 type UpdatePipelineStatusInput struct {
+	_ struct{} `type:"structure"`
+
 	// The identifier of the pipeline to update.
 	Id *string `location:"uri" locationName:"Id" type:"string" required:"true"`
 
@@ -3624,8 +3626,6 @@ type UpdatePipelineStatusInput struct {
 	//   Active: The pipeline is processing jobs.  Paused: The pipeline is not
 	// currently processing jobs.
 	Status *string `type:"string" required:"true"`
-
-	_ struct{} `type:"structure"`
 }
 
 // String returns the string representation
@@ -3641,10 +3641,10 @@ func (s UpdatePipelineStatusInput) GoString() string {
 // When you update status for a pipeline, Elastic Transcoder returns the values
 // that you specified in the request.
 type UpdatePipelineStatusOutput struct {
+	_ struct{} `type:"structure"`
+
 	// A section of the response body that provides information about the pipeline.
 	Pipeline *Pipeline `type:"structure"`
-
-	_ struct{} `type:"structure"`
 }
 
 // String returns the string representation
@@ -3659,6 +3659,8 @@ func (s UpdatePipelineStatusOutput) GoString() string {
 
 // The VideoParameters structure.
 type VideoParameters struct {
+	_ struct{} `type:"structure"`
+
 	// To better control resolution and aspect ratio of output videos, we recommend
 	// that you use the values MaxWidth, MaxHeight, SizingPolicy, PaddingPolicy,
 	// and DisplayAspectRatio instead of Resolution and AspectRatio. The two groups
@@ -3953,8 +3955,6 @@ type VideoParameters struct {
 	// in the preset, which allows you to use the same preset for up to four watermarks
 	// that have different dimensions.
 	Watermarks []*PresetWatermark `type:"list"`
-
-	_ struct{} `type:"structure"`
 }
 
 // String returns the string representation
@@ -3974,6 +3974,8 @@ func (s VideoParameters) GoString() string {
 // SNS notification topics, and AWS KMS key, reduces processing time and prevents
 // cross-regional charges.
 type Warning struct {
+	_ struct{} `type:"structure"`
+
 	// The code of the cross-regional warning.
 	Code *string `type:"string"`
 
@@ -3982,8 +3984,6 @@ type Warning struct {
 	//
 	// Note: AWS KMS keys must be in the same region as the pipeline.
 	Message *string `type:"string"`
-
-	_ struct{} `type:"structure"`
 }
 
 // String returns the string representation

--- a/service/elb/api.go
+++ b/service/elb/api.go
@@ -986,11 +986,7 @@ type AccessLog struct {
 	// the root level of the bucket.
 	S3BucketPrefix *string `type:"string"`
 
-	metadataAccessLog `json:"-" xml:"-"`
-}
-
-type metadataAccessLog struct {
-	SDKShapeTraits bool `type:"structure"`
+	_ struct{} `type:"structure"`
 }
 
 // String returns the string representation
@@ -1010,11 +1006,7 @@ type AddTagsInput struct {
 	// The tags.
 	Tags []*Tag `min:"1" type:"list" required:"true"`
 
-	metadataAddTagsInput `json:"-" xml:"-"`
-}
-
-type metadataAddTagsInput struct {
-	SDKShapeTraits bool `type:"structure"`
+	_ struct{} `type:"structure"`
 }
 
 // String returns the string representation
@@ -1028,11 +1020,7 @@ func (s AddTagsInput) GoString() string {
 }
 
 type AddTagsOutput struct {
-	metadataAddTagsOutput `json:"-" xml:"-"`
-}
-
-type metadataAddTagsOutput struct {
-	SDKShapeTraits bool `type:"structure"`
+	_ struct{} `type:"structure"`
 }
 
 // String returns the string representation
@@ -1053,11 +1041,7 @@ type AdditionalAttribute struct {
 	// This parameter is reserved.
 	Value *string `type:"string"`
 
-	metadataAdditionalAttribute `json:"-" xml:"-"`
-}
-
-type metadataAdditionalAttribute struct {
-	SDKShapeTraits bool `type:"structure"`
+	_ struct{} `type:"structure"`
 }
 
 // String returns the string representation
@@ -1079,11 +1063,7 @@ type AppCookieStickinessPolicy struct {
 	// a set of policies for this load balancer.
 	PolicyName *string `type:"string"`
 
-	metadataAppCookieStickinessPolicy `json:"-" xml:"-"`
-}
-
-type metadataAppCookieStickinessPolicy struct {
-	SDKShapeTraits bool `type:"structure"`
+	_ struct{} `type:"structure"`
 }
 
 // String returns the string representation
@@ -1104,11 +1084,7 @@ type ApplySecurityGroupsToLoadBalancerInput struct {
 	// that you cannot specify the name of the security group.
 	SecurityGroups []*string `type:"list" required:"true"`
 
-	metadataApplySecurityGroupsToLoadBalancerInput `json:"-" xml:"-"`
-}
-
-type metadataApplySecurityGroupsToLoadBalancerInput struct {
-	SDKShapeTraits bool `type:"structure"`
+	_ struct{} `type:"structure"`
 }
 
 // String returns the string representation
@@ -1125,11 +1101,7 @@ type ApplySecurityGroupsToLoadBalancerOutput struct {
 	// The IDs of the security groups associated with the load balancer.
 	SecurityGroups []*string `type:"list"`
 
-	metadataApplySecurityGroupsToLoadBalancerOutput `json:"-" xml:"-"`
-}
-
-type metadataApplySecurityGroupsToLoadBalancerOutput struct {
-	SDKShapeTraits bool `type:"structure"`
+	_ struct{} `type:"structure"`
 }
 
 // String returns the string representation
@@ -1150,11 +1122,7 @@ type AttachLoadBalancerToSubnetsInput struct {
 	// subnet per Availability Zone.
 	Subnets []*string `type:"list" required:"true"`
 
-	metadataAttachLoadBalancerToSubnetsInput `json:"-" xml:"-"`
-}
-
-type metadataAttachLoadBalancerToSubnetsInput struct {
-	SDKShapeTraits bool `type:"structure"`
+	_ struct{} `type:"structure"`
 }
 
 // String returns the string representation
@@ -1171,11 +1139,7 @@ type AttachLoadBalancerToSubnetsOutput struct {
 	// The IDs of the subnets attached to the load balancer.
 	Subnets []*string `type:"list"`
 
-	metadataAttachLoadBalancerToSubnetsOutput `json:"-" xml:"-"`
-}
-
-type metadataAttachLoadBalancerToSubnetsOutput struct {
-	SDKShapeTraits bool `type:"structure"`
+	_ struct{} `type:"structure"`
 }
 
 // String returns the string representation
@@ -1196,11 +1160,7 @@ type BackendServerDescription struct {
 	// The names of the policies enabled for the back-end server.
 	PolicyNames []*string `type:"list"`
 
-	metadataBackendServerDescription `json:"-" xml:"-"`
-}
-
-type metadataBackendServerDescription struct {
-	SDKShapeTraits bool `type:"structure"`
+	_ struct{} `type:"structure"`
 }
 
 // String returns the string representation
@@ -1220,11 +1180,7 @@ type ConfigureHealthCheckInput struct {
 	// The name of the load balancer.
 	LoadBalancerName *string `type:"string" required:"true"`
 
-	metadataConfigureHealthCheckInput `json:"-" xml:"-"`
-}
-
-type metadataConfigureHealthCheckInput struct {
-	SDKShapeTraits bool `type:"structure"`
+	_ struct{} `type:"structure"`
 }
 
 // String returns the string representation
@@ -1241,11 +1197,7 @@ type ConfigureHealthCheckOutput struct {
 	// The updated health check.
 	HealthCheck *HealthCheck `type:"structure"`
 
-	metadataConfigureHealthCheckOutput `json:"-" xml:"-"`
-}
-
-type metadataConfigureHealthCheckOutput struct {
-	SDKShapeTraits bool `type:"structure"`
+	_ struct{} `type:"structure"`
 }
 
 // String returns the string representation
@@ -1267,11 +1219,7 @@ type ConnectionDraining struct {
 	// deregistering the instances.
 	Timeout *int64 `type:"integer"`
 
-	metadataConnectionDraining `json:"-" xml:"-"`
-}
-
-type metadataConnectionDraining struct {
-	SDKShapeTraits bool `type:"structure"`
+	_ struct{} `type:"structure"`
 }
 
 // String returns the string representation
@@ -1290,11 +1238,7 @@ type ConnectionSettings struct {
 	// has been sent over the connection) before it is closed by the load balancer.
 	IdleTimeout *int64 `min:"1" type:"integer" required:"true"`
 
-	metadataConnectionSettings `json:"-" xml:"-"`
-}
-
-type metadataConnectionSettings struct {
-	SDKShapeTraits bool `type:"structure"`
+	_ struct{} `type:"structure"`
 }
 
 // String returns the string representation
@@ -1319,11 +1263,7 @@ type CreateAppCookieStickinessPolicyInput struct {
 	// for this load balancer.
 	PolicyName *string `type:"string" required:"true"`
 
-	metadataCreateAppCookieStickinessPolicyInput `json:"-" xml:"-"`
-}
-
-type metadataCreateAppCookieStickinessPolicyInput struct {
-	SDKShapeTraits bool `type:"structure"`
+	_ struct{} `type:"structure"`
 }
 
 // String returns the string representation
@@ -1337,11 +1277,7 @@ func (s CreateAppCookieStickinessPolicyInput) GoString() string {
 }
 
 type CreateAppCookieStickinessPolicyOutput struct {
-	metadataCreateAppCookieStickinessPolicyOutput `json:"-" xml:"-"`
-}
-
-type metadataCreateAppCookieStickinessPolicyOutput struct {
-	SDKShapeTraits bool `type:"structure"`
+	_ struct{} `type:"structure"`
 }
 
 // String returns the string representation
@@ -1368,11 +1304,7 @@ type CreateLBCookieStickinessPolicyInput struct {
 	// for this load balancer.
 	PolicyName *string `type:"string" required:"true"`
 
-	metadataCreateLBCookieStickinessPolicyInput `json:"-" xml:"-"`
-}
-
-type metadataCreateLBCookieStickinessPolicyInput struct {
-	SDKShapeTraits bool `type:"structure"`
+	_ struct{} `type:"structure"`
 }
 
 // String returns the string representation
@@ -1386,11 +1318,7 @@ func (s CreateLBCookieStickinessPolicyInput) GoString() string {
 }
 
 type CreateLBCookieStickinessPolicyOutput struct {
-	metadataCreateLBCookieStickinessPolicyOutput `json:"-" xml:"-"`
-}
-
-type metadataCreateLBCookieStickinessPolicyOutput struct {
-	SDKShapeTraits bool `type:"structure"`
+	_ struct{} `type:"structure"`
 }
 
 // String returns the string representation
@@ -1451,11 +1379,7 @@ type CreateLoadBalancerInput struct {
 	// in the Elastic Load Balancing Developer Guide.
 	Tags []*Tag `min:"1" type:"list"`
 
-	metadataCreateLoadBalancerInput `json:"-" xml:"-"`
-}
-
-type metadataCreateLoadBalancerInput struct {
-	SDKShapeTraits bool `type:"structure"`
+	_ struct{} `type:"structure"`
 }
 
 // String returns the string representation
@@ -1475,11 +1399,7 @@ type CreateLoadBalancerListenersInput struct {
 	// The name of the load balancer.
 	LoadBalancerName *string `type:"string" required:"true"`
 
-	metadataCreateLoadBalancerListenersInput `json:"-" xml:"-"`
-}
-
-type metadataCreateLoadBalancerListenersInput struct {
-	SDKShapeTraits bool `type:"structure"`
+	_ struct{} `type:"structure"`
 }
 
 // String returns the string representation
@@ -1493,11 +1413,7 @@ func (s CreateLoadBalancerListenersInput) GoString() string {
 }
 
 type CreateLoadBalancerListenersOutput struct {
-	metadataCreateLoadBalancerListenersOutput `json:"-" xml:"-"`
-}
-
-type metadataCreateLoadBalancerListenersOutput struct {
-	SDKShapeTraits bool `type:"structure"`
+	_ struct{} `type:"structure"`
 }
 
 // String returns the string representation
@@ -1514,11 +1430,7 @@ type CreateLoadBalancerOutput struct {
 	// The DNS name of the load balancer.
 	DNSName *string `type:"string"`
 
-	metadataCreateLoadBalancerOutput `json:"-" xml:"-"`
-}
-
-type metadataCreateLoadBalancerOutput struct {
-	SDKShapeTraits bool `type:"structure"`
+	_ struct{} `type:"structure"`
 }
 
 // String returns the string representation
@@ -1545,11 +1457,7 @@ type CreateLoadBalancerPolicyInput struct {
 	// The name of the base policy type. To get the list of policy types, use DescribeLoadBalancerPolicyTypes.
 	PolicyTypeName *string `type:"string" required:"true"`
 
-	metadataCreateLoadBalancerPolicyInput `json:"-" xml:"-"`
-}
-
-type metadataCreateLoadBalancerPolicyInput struct {
-	SDKShapeTraits bool `type:"structure"`
+	_ struct{} `type:"structure"`
 }
 
 // String returns the string representation
@@ -1563,11 +1471,7 @@ func (s CreateLoadBalancerPolicyInput) GoString() string {
 }
 
 type CreateLoadBalancerPolicyOutput struct {
-	metadataCreateLoadBalancerPolicyOutput `json:"-" xml:"-"`
-}
-
-type metadataCreateLoadBalancerPolicyOutput struct {
-	SDKShapeTraits bool `type:"structure"`
+	_ struct{} `type:"structure"`
 }
 
 // String returns the string representation
@@ -1585,11 +1489,7 @@ type CrossZoneLoadBalancing struct {
 	// Specifies whether cross-zone load balancing is enabled for the load balancer.
 	Enabled *bool `type:"boolean" required:"true"`
 
-	metadataCrossZoneLoadBalancing `json:"-" xml:"-"`
-}
-
-type metadataCrossZoneLoadBalancing struct {
-	SDKShapeTraits bool `type:"structure"`
+	_ struct{} `type:"structure"`
 }
 
 // String returns the string representation
@@ -1606,11 +1506,7 @@ type DeleteLoadBalancerInput struct {
 	// The name of the load balancer.
 	LoadBalancerName *string `type:"string" required:"true"`
 
-	metadataDeleteLoadBalancerInput `json:"-" xml:"-"`
-}
-
-type metadataDeleteLoadBalancerInput struct {
-	SDKShapeTraits bool `type:"structure"`
+	_ struct{} `type:"structure"`
 }
 
 // String returns the string representation
@@ -1630,11 +1526,7 @@ type DeleteLoadBalancerListenersInput struct {
 	// The client port numbers of the listeners.
 	LoadBalancerPorts []*int64 `type:"list" required:"true"`
 
-	metadataDeleteLoadBalancerListenersInput `json:"-" xml:"-"`
-}
-
-type metadataDeleteLoadBalancerListenersInput struct {
-	SDKShapeTraits bool `type:"structure"`
+	_ struct{} `type:"structure"`
 }
 
 // String returns the string representation
@@ -1648,11 +1540,7 @@ func (s DeleteLoadBalancerListenersInput) GoString() string {
 }
 
 type DeleteLoadBalancerListenersOutput struct {
-	metadataDeleteLoadBalancerListenersOutput `json:"-" xml:"-"`
-}
-
-type metadataDeleteLoadBalancerListenersOutput struct {
-	SDKShapeTraits bool `type:"structure"`
+	_ struct{} `type:"structure"`
 }
 
 // String returns the string representation
@@ -1666,11 +1554,7 @@ func (s DeleteLoadBalancerListenersOutput) GoString() string {
 }
 
 type DeleteLoadBalancerOutput struct {
-	metadataDeleteLoadBalancerOutput `json:"-" xml:"-"`
-}
-
-type metadataDeleteLoadBalancerOutput struct {
-	SDKShapeTraits bool `type:"structure"`
+	_ struct{} `type:"structure"`
 }
 
 // String returns the string representation
@@ -1691,11 +1575,7 @@ type DeleteLoadBalancerPolicyInput struct {
 	// The name of the policy.
 	PolicyName *string `type:"string" required:"true"`
 
-	metadataDeleteLoadBalancerPolicyInput `json:"-" xml:"-"`
-}
-
-type metadataDeleteLoadBalancerPolicyInput struct {
-	SDKShapeTraits bool `type:"structure"`
+	_ struct{} `type:"structure"`
 }
 
 // String returns the string representation
@@ -1709,11 +1589,7 @@ func (s DeleteLoadBalancerPolicyInput) GoString() string {
 }
 
 type DeleteLoadBalancerPolicyOutput struct {
-	metadataDeleteLoadBalancerPolicyOutput `json:"-" xml:"-"`
-}
-
-type metadataDeleteLoadBalancerPolicyOutput struct {
-	SDKShapeTraits bool `type:"structure"`
+	_ struct{} `type:"structure"`
 }
 
 // String returns the string representation
@@ -1733,11 +1609,7 @@ type DeregisterInstancesFromLoadBalancerInput struct {
 	// The name of the load balancer.
 	LoadBalancerName *string `type:"string" required:"true"`
 
-	metadataDeregisterInstancesFromLoadBalancerInput `json:"-" xml:"-"`
-}
-
-type metadataDeregisterInstancesFromLoadBalancerInput struct {
-	SDKShapeTraits bool `type:"structure"`
+	_ struct{} `type:"structure"`
 }
 
 // String returns the string representation
@@ -1754,11 +1626,7 @@ type DeregisterInstancesFromLoadBalancerOutput struct {
 	// The remaining instances registered with the load balancer.
 	Instances []*Instance `type:"list"`
 
-	metadataDeregisterInstancesFromLoadBalancerOutput `json:"-" xml:"-"`
-}
-
-type metadataDeregisterInstancesFromLoadBalancerOutput struct {
-	SDKShapeTraits bool `type:"structure"`
+	_ struct{} `type:"structure"`
 }
 
 // String returns the string representation
@@ -1778,11 +1646,7 @@ type DescribeInstanceHealthInput struct {
 	// The name of the load balancer.
 	LoadBalancerName *string `type:"string" required:"true"`
 
-	metadataDescribeInstanceHealthInput `json:"-" xml:"-"`
-}
-
-type metadataDescribeInstanceHealthInput struct {
-	SDKShapeTraits bool `type:"structure"`
+	_ struct{} `type:"structure"`
 }
 
 // String returns the string representation
@@ -1799,11 +1663,7 @@ type DescribeInstanceHealthOutput struct {
 	// Information about the health of the instances.
 	InstanceStates []*InstanceState `type:"list"`
 
-	metadataDescribeInstanceHealthOutput `json:"-" xml:"-"`
-}
-
-type metadataDescribeInstanceHealthOutput struct {
-	SDKShapeTraits bool `type:"structure"`
+	_ struct{} `type:"structure"`
 }
 
 // String returns the string representation
@@ -1820,11 +1680,7 @@ type DescribeLoadBalancerAttributesInput struct {
 	// The name of the load balancer.
 	LoadBalancerName *string `type:"string" required:"true"`
 
-	metadataDescribeLoadBalancerAttributesInput `json:"-" xml:"-"`
-}
-
-type metadataDescribeLoadBalancerAttributesInput struct {
-	SDKShapeTraits bool `type:"structure"`
+	_ struct{} `type:"structure"`
 }
 
 // String returns the string representation
@@ -1841,11 +1697,7 @@ type DescribeLoadBalancerAttributesOutput struct {
 	// Information about the load balancer attributes.
 	LoadBalancerAttributes *LoadBalancerAttributes `type:"structure"`
 
-	metadataDescribeLoadBalancerAttributesOutput `json:"-" xml:"-"`
-}
-
-type metadataDescribeLoadBalancerAttributesOutput struct {
-	SDKShapeTraits bool `type:"structure"`
+	_ struct{} `type:"structure"`
 }
 
 // String returns the string representation
@@ -1865,11 +1717,7 @@ type DescribeLoadBalancerPoliciesInput struct {
 	// The names of the policies.
 	PolicyNames []*string `type:"list"`
 
-	metadataDescribeLoadBalancerPoliciesInput `json:"-" xml:"-"`
-}
-
-type metadataDescribeLoadBalancerPoliciesInput struct {
-	SDKShapeTraits bool `type:"structure"`
+	_ struct{} `type:"structure"`
 }
 
 // String returns the string representation
@@ -1886,11 +1734,7 @@ type DescribeLoadBalancerPoliciesOutput struct {
 	// Information about the policies.
 	PolicyDescriptions []*PolicyDescription `type:"list"`
 
-	metadataDescribeLoadBalancerPoliciesOutput `json:"-" xml:"-"`
-}
-
-type metadataDescribeLoadBalancerPoliciesOutput struct {
-	SDKShapeTraits bool `type:"structure"`
+	_ struct{} `type:"structure"`
 }
 
 // String returns the string representation
@@ -1908,11 +1752,7 @@ type DescribeLoadBalancerPolicyTypesInput struct {
 	// types defined by Elastic Load Balancing.
 	PolicyTypeNames []*string `type:"list"`
 
-	metadataDescribeLoadBalancerPolicyTypesInput `json:"-" xml:"-"`
-}
-
-type metadataDescribeLoadBalancerPolicyTypesInput struct {
-	SDKShapeTraits bool `type:"structure"`
+	_ struct{} `type:"structure"`
 }
 
 // String returns the string representation
@@ -1929,11 +1769,7 @@ type DescribeLoadBalancerPolicyTypesOutput struct {
 	// Information about the policy types.
 	PolicyTypeDescriptions []*PolicyTypeDescription `type:"list"`
 
-	metadataDescribeLoadBalancerPolicyTypesOutput `json:"-" xml:"-"`
-}
-
-type metadataDescribeLoadBalancerPolicyTypesOutput struct {
-	SDKShapeTraits bool `type:"structure"`
+	_ struct{} `type:"structure"`
 }
 
 // String returns the string representation
@@ -1958,11 +1794,7 @@ type DescribeLoadBalancersInput struct {
 	// 400). The default is 400.
 	PageSize *int64 `min:"1" type:"integer"`
 
-	metadataDescribeLoadBalancersInput `json:"-" xml:"-"`
-}
-
-type metadataDescribeLoadBalancersInput struct {
-	SDKShapeTraits bool `type:"structure"`
+	_ struct{} `type:"structure"`
 }
 
 // String returns the string representation
@@ -1983,11 +1815,7 @@ type DescribeLoadBalancersOutput struct {
 	// additional results, the string is empty.
 	NextMarker *string `type:"string"`
 
-	metadataDescribeLoadBalancersOutput `json:"-" xml:"-"`
-}
-
-type metadataDescribeLoadBalancersOutput struct {
-	SDKShapeTraits bool `type:"structure"`
+	_ struct{} `type:"structure"`
 }
 
 // String returns the string representation
@@ -2004,11 +1832,7 @@ type DescribeTagsInput struct {
 	// The names of the load balancers.
 	LoadBalancerNames []*string `min:"1" type:"list" required:"true"`
 
-	metadataDescribeTagsInput `json:"-" xml:"-"`
-}
-
-type metadataDescribeTagsInput struct {
-	SDKShapeTraits bool `type:"structure"`
+	_ struct{} `type:"structure"`
 }
 
 // String returns the string representation
@@ -2025,11 +1849,7 @@ type DescribeTagsOutput struct {
 	// Information about the tags.
 	TagDescriptions []*TagDescription `type:"list"`
 
-	metadataDescribeTagsOutput `json:"-" xml:"-"`
-}
-
-type metadataDescribeTagsOutput struct {
-	SDKShapeTraits bool `type:"structure"`
+	_ struct{} `type:"structure"`
 }
 
 // String returns the string representation
@@ -2049,11 +1869,7 @@ type DetachLoadBalancerFromSubnetsInput struct {
 	// The IDs of the subnets.
 	Subnets []*string `type:"list" required:"true"`
 
-	metadataDetachLoadBalancerFromSubnetsInput `json:"-" xml:"-"`
-}
-
-type metadataDetachLoadBalancerFromSubnetsInput struct {
-	SDKShapeTraits bool `type:"structure"`
+	_ struct{} `type:"structure"`
 }
 
 // String returns the string representation
@@ -2070,11 +1886,7 @@ type DetachLoadBalancerFromSubnetsOutput struct {
 	// The IDs of the remaining subnets for the load balancer.
 	Subnets []*string `type:"list"`
 
-	metadataDetachLoadBalancerFromSubnetsOutput `json:"-" xml:"-"`
-}
-
-type metadataDetachLoadBalancerFromSubnetsOutput struct {
-	SDKShapeTraits bool `type:"structure"`
+	_ struct{} `type:"structure"`
 }
 
 // String returns the string representation
@@ -2094,11 +1906,7 @@ type DisableAvailabilityZonesForLoadBalancerInput struct {
 	// The name of the load balancer.
 	LoadBalancerName *string `type:"string" required:"true"`
 
-	metadataDisableAvailabilityZonesForLoadBalancerInput `json:"-" xml:"-"`
-}
-
-type metadataDisableAvailabilityZonesForLoadBalancerInput struct {
-	SDKShapeTraits bool `type:"structure"`
+	_ struct{} `type:"structure"`
 }
 
 // String returns the string representation
@@ -2115,11 +1923,7 @@ type DisableAvailabilityZonesForLoadBalancerOutput struct {
 	// The remaining Availability Zones for the load balancer.
 	AvailabilityZones []*string `type:"list"`
 
-	metadataDisableAvailabilityZonesForLoadBalancerOutput `json:"-" xml:"-"`
-}
-
-type metadataDisableAvailabilityZonesForLoadBalancerOutput struct {
-	SDKShapeTraits bool `type:"structure"`
+	_ struct{} `type:"structure"`
 }
 
 // String returns the string representation
@@ -2139,11 +1943,7 @@ type EnableAvailabilityZonesForLoadBalancerInput struct {
 	// The name of the load balancer.
 	LoadBalancerName *string `type:"string" required:"true"`
 
-	metadataEnableAvailabilityZonesForLoadBalancerInput `json:"-" xml:"-"`
-}
-
-type metadataEnableAvailabilityZonesForLoadBalancerInput struct {
-	SDKShapeTraits bool `type:"structure"`
+	_ struct{} `type:"structure"`
 }
 
 // String returns the string representation
@@ -2160,11 +1960,7 @@ type EnableAvailabilityZonesForLoadBalancerOutput struct {
 	// The updated list of Availability Zones for the load balancer.
 	AvailabilityZones []*string `type:"list"`
 
-	metadataEnableAvailabilityZonesForLoadBalancerOutput `json:"-" xml:"-"`
-}
-
-type metadataEnableAvailabilityZonesForLoadBalancerOutput struct {
-	SDKShapeTraits bool `type:"structure"`
+	_ struct{} `type:"structure"`
 }
 
 // String returns the string representation
@@ -2217,11 +2013,7 @@ type HealthCheck struct {
 	// instance to the Unhealthy state.
 	UnhealthyThreshold *int64 `min:"2" type:"integer" required:"true"`
 
-	metadataHealthCheck `json:"-" xml:"-"`
-}
-
-type metadataHealthCheck struct {
-	SDKShapeTraits bool `type:"structure"`
+	_ struct{} `type:"structure"`
 }
 
 // String returns the string representation
@@ -2239,11 +2031,7 @@ type Instance struct {
 	// The ID of the instance.
 	InstanceId *string `type:"string"`
 
-	metadataInstance `json:"-" xml:"-"`
-}
-
-type metadataInstance struct {
-	SDKShapeTraits bool `type:"structure"`
+	_ struct{} `type:"structure"`
 }
 
 // String returns the string representation
@@ -2303,11 +2091,7 @@ type InstanceState struct {
 	// Valid values: InService | OutOfService | Unknown
 	State *string `type:"string"`
 
-	metadataInstanceState `json:"-" xml:"-"`
-}
-
-type metadataInstanceState struct {
-	SDKShapeTraits bool `type:"structure"`
+	_ struct{} `type:"structure"`
 }
 
 // String returns the string representation
@@ -2331,11 +2115,7 @@ type LBCookieStickinessPolicy struct {
 	// set of policies for this load balancer.
 	PolicyName *string `type:"string"`
 
-	metadataLBCookieStickinessPolicy `json:"-" xml:"-"`
-}
-
-type metadataLBCookieStickinessPolicy struct {
-	SDKShapeTraits bool `type:"structure"`
+	_ struct{} `type:"structure"`
 }
 
 // String returns the string representation
@@ -2382,11 +2162,7 @@ type Listener struct {
 	// The Amazon Resource Name (ARN) of the server certificate.
 	SSLCertificateId *string `type:"string"`
 
-	metadataListener `json:"-" xml:"-"`
-}
-
-type metadataListener struct {
-	SDKShapeTraits bool `type:"structure"`
+	_ struct{} `type:"structure"`
 }
 
 // String returns the string representation
@@ -2411,11 +2187,7 @@ type ListenerDescription struct {
 	// The policies. If there are no policies enabled, the list is empty.
 	PolicyNames []*string `type:"list"`
 
-	metadataListenerDescription `json:"-" xml:"-"`
-}
-
-type metadataListenerDescription struct {
-	SDKShapeTraits bool `type:"structure"`
+	_ struct{} `type:"structure"`
 }
 
 // String returns the string representation
@@ -2464,11 +2236,7 @@ type LoadBalancerAttributes struct {
 	// in the Elastic Load Balancing Developer Guide.
 	CrossZoneLoadBalancing *CrossZoneLoadBalancing `type:"structure"`
 
-	metadataLoadBalancerAttributes `json:"-" xml:"-"`
-}
-
-type metadataLoadBalancerAttributes struct {
-	SDKShapeTraits bool `type:"structure"`
+	_ struct{} `type:"structure"`
 }
 
 // String returns the string representation
@@ -2545,11 +2313,7 @@ type LoadBalancerDescription struct {
 	// The ID of the VPC for the load balancer.
 	VPCId *string `type:"string"`
 
-	metadataLoadBalancerDescription `json:"-" xml:"-"`
-}
-
-type metadataLoadBalancerDescription struct {
-	SDKShapeTraits bool `type:"structure"`
+	_ struct{} `type:"structure"`
 }
 
 // String returns the string representation
@@ -2569,11 +2333,7 @@ type ModifyLoadBalancerAttributesInput struct {
 	// The name of the load balancer.
 	LoadBalancerName *string `type:"string" required:"true"`
 
-	metadataModifyLoadBalancerAttributesInput `json:"-" xml:"-"`
-}
-
-type metadataModifyLoadBalancerAttributesInput struct {
-	SDKShapeTraits bool `type:"structure"`
+	_ struct{} `type:"structure"`
 }
 
 // String returns the string representation
@@ -2593,11 +2353,7 @@ type ModifyLoadBalancerAttributesOutput struct {
 	// The name of the load balancer.
 	LoadBalancerName *string `type:"string"`
 
-	metadataModifyLoadBalancerAttributesOutput `json:"-" xml:"-"`
-}
-
-type metadataModifyLoadBalancerAttributesOutput struct {
-	SDKShapeTraits bool `type:"structure"`
+	_ struct{} `type:"structure"`
 }
 
 // String returns the string representation
@@ -2621,11 +2377,7 @@ type Policies struct {
 	// The policies other than the stickiness policies.
 	OtherPolicies []*string `type:"list"`
 
-	metadataPolicies `json:"-" xml:"-"`
-}
-
-type metadataPolicies struct {
-	SDKShapeTraits bool `type:"structure"`
+	_ struct{} `type:"structure"`
 }
 
 // String returns the string representation
@@ -2646,11 +2398,7 @@ type PolicyAttribute struct {
 	// The value of the attribute.
 	AttributeValue *string `type:"string"`
 
-	metadataPolicyAttribute `json:"-" xml:"-"`
-}
-
-type metadataPolicyAttribute struct {
-	SDKShapeTraits bool `type:"structure"`
+	_ struct{} `type:"structure"`
 }
 
 // String returns the string representation
@@ -2671,11 +2419,7 @@ type PolicyAttributeDescription struct {
 	// The value of the attribute.
 	AttributeValue *string `type:"string"`
 
-	metadataPolicyAttributeDescription `json:"-" xml:"-"`
-}
-
-type metadataPolicyAttributeDescription struct {
-	SDKShapeTraits bool `type:"structure"`
+	_ struct{} `type:"structure"`
 }
 
 // String returns the string representation
@@ -2711,11 +2455,7 @@ type PolicyAttributeTypeDescription struct {
 	// A description of the attribute.
 	Description *string `type:"string"`
 
-	metadataPolicyAttributeTypeDescription `json:"-" xml:"-"`
-}
-
-type metadataPolicyAttributeTypeDescription struct {
-	SDKShapeTraits bool `type:"structure"`
+	_ struct{} `type:"structure"`
 }
 
 // String returns the string representation
@@ -2739,11 +2479,7 @@ type PolicyDescription struct {
 	// The name of the policy type.
 	PolicyTypeName *string `type:"string"`
 
-	metadataPolicyDescription `json:"-" xml:"-"`
-}
-
-type metadataPolicyDescription struct {
-	SDKShapeTraits bool `type:"structure"`
+	_ struct{} `type:"structure"`
 }
 
 // String returns the string representation
@@ -2768,11 +2504,7 @@ type PolicyTypeDescription struct {
 	// The name of the policy type.
 	PolicyTypeName *string `type:"string"`
 
-	metadataPolicyTypeDescription `json:"-" xml:"-"`
-}
-
-type metadataPolicyTypeDescription struct {
-	SDKShapeTraits bool `type:"structure"`
+	_ struct{} `type:"structure"`
 }
 
 // String returns the string representation
@@ -2792,11 +2524,7 @@ type RegisterInstancesWithLoadBalancerInput struct {
 	// The name of the load balancer.
 	LoadBalancerName *string `type:"string" required:"true"`
 
-	metadataRegisterInstancesWithLoadBalancerInput `json:"-" xml:"-"`
-}
-
-type metadataRegisterInstancesWithLoadBalancerInput struct {
-	SDKShapeTraits bool `type:"structure"`
+	_ struct{} `type:"structure"`
 }
 
 // String returns the string representation
@@ -2813,11 +2541,7 @@ type RegisterInstancesWithLoadBalancerOutput struct {
 	// The updated list of instances for the load balancer.
 	Instances []*Instance `type:"list"`
 
-	metadataRegisterInstancesWithLoadBalancerOutput `json:"-" xml:"-"`
-}
-
-type metadataRegisterInstancesWithLoadBalancerOutput struct {
-	SDKShapeTraits bool `type:"structure"`
+	_ struct{} `type:"structure"`
 }
 
 // String returns the string representation
@@ -2838,11 +2562,7 @@ type RemoveTagsInput struct {
 	// The list of tag keys to remove.
 	Tags []*TagKeyOnly `min:"1" type:"list" required:"true"`
 
-	metadataRemoveTagsInput `json:"-" xml:"-"`
-}
-
-type metadataRemoveTagsInput struct {
-	SDKShapeTraits bool `type:"structure"`
+	_ struct{} `type:"structure"`
 }
 
 // String returns the string representation
@@ -2856,11 +2576,7 @@ func (s RemoveTagsInput) GoString() string {
 }
 
 type RemoveTagsOutput struct {
-	metadataRemoveTagsOutput `json:"-" xml:"-"`
-}
-
-type metadataRemoveTagsOutput struct {
-	SDKShapeTraits bool `type:"structure"`
+	_ struct{} `type:"structure"`
 }
 
 // String returns the string representation
@@ -2883,11 +2599,7 @@ type SetLoadBalancerListenerSSLCertificateInput struct {
 	// The Amazon Resource Name (ARN) of the SSL certificate.
 	SSLCertificateId *string `type:"string" required:"true"`
 
-	metadataSetLoadBalancerListenerSSLCertificateInput `json:"-" xml:"-"`
-}
-
-type metadataSetLoadBalancerListenerSSLCertificateInput struct {
-	SDKShapeTraits bool `type:"structure"`
+	_ struct{} `type:"structure"`
 }
 
 // String returns the string representation
@@ -2901,11 +2613,7 @@ func (s SetLoadBalancerListenerSSLCertificateInput) GoString() string {
 }
 
 type SetLoadBalancerListenerSSLCertificateOutput struct {
-	metadataSetLoadBalancerListenerSSLCertificateOutput `json:"-" xml:"-"`
-}
-
-type metadataSetLoadBalancerListenerSSLCertificateOutput struct {
-	SDKShapeTraits bool `type:"structure"`
+	_ struct{} `type:"structure"`
 }
 
 // String returns the string representation
@@ -2929,11 +2637,7 @@ type SetLoadBalancerPoliciesForBackendServerInput struct {
 	// are removed from the back-end server.
 	PolicyNames []*string `type:"list" required:"true"`
 
-	metadataSetLoadBalancerPoliciesForBackendServerInput `json:"-" xml:"-"`
-}
-
-type metadataSetLoadBalancerPoliciesForBackendServerInput struct {
-	SDKShapeTraits bool `type:"structure"`
+	_ struct{} `type:"structure"`
 }
 
 // String returns the string representation
@@ -2947,11 +2651,7 @@ func (s SetLoadBalancerPoliciesForBackendServerInput) GoString() string {
 }
 
 type SetLoadBalancerPoliciesForBackendServerOutput struct {
-	metadataSetLoadBalancerPoliciesForBackendServerOutput `json:"-" xml:"-"`
-}
-
-type metadataSetLoadBalancerPoliciesForBackendServerOutput struct {
-	SDKShapeTraits bool `type:"structure"`
+	_ struct{} `type:"structure"`
 }
 
 // String returns the string representation
@@ -2975,11 +2675,7 @@ type SetLoadBalancerPoliciesOfListenerInput struct {
 	// from the listener.
 	PolicyNames []*string `type:"list" required:"true"`
 
-	metadataSetLoadBalancerPoliciesOfListenerInput `json:"-" xml:"-"`
-}
-
-type metadataSetLoadBalancerPoliciesOfListenerInput struct {
-	SDKShapeTraits bool `type:"structure"`
+	_ struct{} `type:"structure"`
 }
 
 // String returns the string representation
@@ -2993,11 +2689,7 @@ func (s SetLoadBalancerPoliciesOfListenerInput) GoString() string {
 }
 
 type SetLoadBalancerPoliciesOfListenerOutput struct {
-	metadataSetLoadBalancerPoliciesOfListenerOutput `json:"-" xml:"-"`
-}
-
-type metadataSetLoadBalancerPoliciesOfListenerOutput struct {
-	SDKShapeTraits bool `type:"structure"`
+	_ struct{} `type:"structure"`
 }
 
 // String returns the string representation
@@ -3018,11 +2710,7 @@ type SourceSecurityGroup struct {
 	// The owner of the security group.
 	OwnerAlias *string `type:"string"`
 
-	metadataSourceSecurityGroup `json:"-" xml:"-"`
-}
-
-type metadataSourceSecurityGroup struct {
-	SDKShapeTraits bool `type:"structure"`
+	_ struct{} `type:"structure"`
 }
 
 // String returns the string representation
@@ -3043,11 +2731,7 @@ type Tag struct {
 	// The value of the tag.
 	Value *string `type:"string"`
 
-	metadataTag `json:"-" xml:"-"`
-}
-
-type metadataTag struct {
-	SDKShapeTraits bool `type:"structure"`
+	_ struct{} `type:"structure"`
 }
 
 // String returns the string representation
@@ -3068,11 +2752,7 @@ type TagDescription struct {
 	// The tags.
 	Tags []*Tag `min:"1" type:"list"`
 
-	metadataTagDescription `json:"-" xml:"-"`
-}
-
-type metadataTagDescription struct {
-	SDKShapeTraits bool `type:"structure"`
+	_ struct{} `type:"structure"`
 }
 
 // String returns the string representation
@@ -3090,11 +2770,7 @@ type TagKeyOnly struct {
 	// The name of the key.
 	Key *string `min:"1" type:"string"`
 
-	metadataTagKeyOnly `json:"-" xml:"-"`
-}
-
-type metadataTagKeyOnly struct {
-	SDKShapeTraits bool `type:"structure"`
+	_ struct{} `type:"structure"`
 }
 
 // String returns the string representation

--- a/service/elb/api.go
+++ b/service/elb/api.go
@@ -969,6 +969,8 @@ func (c *ELB) SetLoadBalancerPoliciesOfListener(input *SetLoadBalancerPoliciesOf
 
 // Information about the AccessLog attribute.
 type AccessLog struct {
+	_ struct{} `type:"structure"`
+
 	// The interval for publishing the access logs. You can specify an interval
 	// of either 5 minutes or 60 minutes.
 	//
@@ -985,8 +987,6 @@ type AccessLog struct {
 	// my-bucket-prefix/prod. If the prefix is not provided, the log is placed at
 	// the root level of the bucket.
 	S3BucketPrefix *string `type:"string"`
-
-	_ struct{} `type:"structure"`
 }
 
 // String returns the string representation
@@ -1000,13 +1000,13 @@ func (s AccessLog) GoString() string {
 }
 
 type AddTagsInput struct {
+	_ struct{} `type:"structure"`
+
 	// The name of the load balancer. You can specify one load balancer only.
 	LoadBalancerNames []*string `type:"list" required:"true"`
 
 	// The tags.
 	Tags []*Tag `min:"1" type:"list" required:"true"`
-
-	_ struct{} `type:"structure"`
 }
 
 // String returns the string representation
@@ -1035,13 +1035,13 @@ func (s AddTagsOutput) GoString() string {
 
 // This data type is reserved.
 type AdditionalAttribute struct {
+	_ struct{} `type:"structure"`
+
 	// This parameter is reserved.
 	Key *string `type:"string"`
 
 	// This parameter is reserved.
 	Value *string `type:"string"`
-
-	_ struct{} `type:"structure"`
 }
 
 // String returns the string representation
@@ -1056,14 +1056,14 @@ func (s AdditionalAttribute) GoString() string {
 
 // Information about a policy for application-controlled session stickiness.
 type AppCookieStickinessPolicy struct {
+	_ struct{} `type:"structure"`
+
 	// The name of the application cookie used for stickiness.
 	CookieName *string `type:"string"`
 
 	// The mnemonic name for the policy being created. The name must be unique within
 	// a set of policies for this load balancer.
 	PolicyName *string `type:"string"`
-
-	_ struct{} `type:"structure"`
 }
 
 // String returns the string representation
@@ -1077,14 +1077,14 @@ func (s AppCookieStickinessPolicy) GoString() string {
 }
 
 type ApplySecurityGroupsToLoadBalancerInput struct {
+	_ struct{} `type:"structure"`
+
 	// The name of the load balancer.
 	LoadBalancerName *string `type:"string" required:"true"`
 
 	// The IDs of the security groups to associate with the load balancer. Note
 	// that you cannot specify the name of the security group.
 	SecurityGroups []*string `type:"list" required:"true"`
-
-	_ struct{} `type:"structure"`
 }
 
 // String returns the string representation
@@ -1098,10 +1098,10 @@ func (s ApplySecurityGroupsToLoadBalancerInput) GoString() string {
 }
 
 type ApplySecurityGroupsToLoadBalancerOutput struct {
+	_ struct{} `type:"structure"`
+
 	// The IDs of the security groups associated with the load balancer.
 	SecurityGroups []*string `type:"list"`
-
-	_ struct{} `type:"structure"`
 }
 
 // String returns the string representation
@@ -1115,14 +1115,14 @@ func (s ApplySecurityGroupsToLoadBalancerOutput) GoString() string {
 }
 
 type AttachLoadBalancerToSubnetsInput struct {
+	_ struct{} `type:"structure"`
+
 	// The name of the load balancer.
 	LoadBalancerName *string `type:"string" required:"true"`
 
 	// The IDs of the subnets to add for the load balancer. You can add only one
 	// subnet per Availability Zone.
 	Subnets []*string `type:"list" required:"true"`
-
-	_ struct{} `type:"structure"`
 }
 
 // String returns the string representation
@@ -1136,10 +1136,10 @@ func (s AttachLoadBalancerToSubnetsInput) GoString() string {
 }
 
 type AttachLoadBalancerToSubnetsOutput struct {
+	_ struct{} `type:"structure"`
+
 	// The IDs of the subnets attached to the load balancer.
 	Subnets []*string `type:"list"`
-
-	_ struct{} `type:"structure"`
 }
 
 // String returns the string representation
@@ -1154,13 +1154,13 @@ func (s AttachLoadBalancerToSubnetsOutput) GoString() string {
 
 // Information about the configuration of a back-end server.
 type BackendServerDescription struct {
+	_ struct{} `type:"structure"`
+
 	// The port on which the back-end server is listening.
 	InstancePort *int64 `min:"1" type:"integer"`
 
 	// The names of the policies enabled for the back-end server.
 	PolicyNames []*string `type:"list"`
-
-	_ struct{} `type:"structure"`
 }
 
 // String returns the string representation
@@ -1174,13 +1174,13 @@ func (s BackendServerDescription) GoString() string {
 }
 
 type ConfigureHealthCheckInput struct {
+	_ struct{} `type:"structure"`
+
 	// The configuration information for the new health check.
 	HealthCheck *HealthCheck `type:"structure" required:"true"`
 
 	// The name of the load balancer.
 	LoadBalancerName *string `type:"string" required:"true"`
-
-	_ struct{} `type:"structure"`
 }
 
 // String returns the string representation
@@ -1194,10 +1194,10 @@ func (s ConfigureHealthCheckInput) GoString() string {
 }
 
 type ConfigureHealthCheckOutput struct {
+	_ struct{} `type:"structure"`
+
 	// The updated health check.
 	HealthCheck *HealthCheck `type:"structure"`
-
-	_ struct{} `type:"structure"`
 }
 
 // String returns the string representation
@@ -1212,14 +1212,14 @@ func (s ConfigureHealthCheckOutput) GoString() string {
 
 // Information about the ConnectionDraining attribute.
 type ConnectionDraining struct {
+	_ struct{} `type:"structure"`
+
 	// Specifies whether connection draining is enabled for the load balancer.
 	Enabled *bool `type:"boolean" required:"true"`
 
 	// The maximum time, in seconds, to keep the existing connections open before
 	// deregistering the instances.
 	Timeout *int64 `type:"integer"`
-
-	_ struct{} `type:"structure"`
 }
 
 // String returns the string representation
@@ -1234,11 +1234,11 @@ func (s ConnectionDraining) GoString() string {
 
 // Information about the ConnectionSettings attribute.
 type ConnectionSettings struct {
+	_ struct{} `type:"structure"`
+
 	// The time, in seconds, that the connection is allowed to be idle (no data
 	// has been sent over the connection) before it is closed by the load balancer.
 	IdleTimeout *int64 `min:"1" type:"integer" required:"true"`
-
-	_ struct{} `type:"structure"`
 }
 
 // String returns the string representation
@@ -1252,6 +1252,8 @@ func (s ConnectionSettings) GoString() string {
 }
 
 type CreateAppCookieStickinessPolicyInput struct {
+	_ struct{} `type:"structure"`
+
 	// The name of the application cookie used for stickiness.
 	CookieName *string `type:"string" required:"true"`
 
@@ -1262,8 +1264,6 @@ type CreateAppCookieStickinessPolicyInput struct {
 	// characters and dashes (-). This name must be unique within the set of policies
 	// for this load balancer.
 	PolicyName *string `type:"string" required:"true"`
-
-	_ struct{} `type:"structure"`
 }
 
 // String returns the string representation
@@ -1291,6 +1291,8 @@ func (s CreateAppCookieStickinessPolicyOutput) GoString() string {
 }
 
 type CreateLBCookieStickinessPolicyInput struct {
+	_ struct{} `type:"structure"`
+
 	// The time period, in seconds, after which the cookie should be considered
 	// stale. If you do not specify this parameter, the sticky session lasts for
 	// the duration of the browser session.
@@ -1303,8 +1305,6 @@ type CreateLBCookieStickinessPolicyInput struct {
 	// characters and dashes (-). This name must be unique within the set of policies
 	// for this load balancer.
 	PolicyName *string `type:"string" required:"true"`
-
-	_ struct{} `type:"structure"`
 }
 
 // String returns the string representation
@@ -1332,6 +1332,8 @@ func (s CreateLBCookieStickinessPolicyOutput) GoString() string {
 }
 
 type CreateLoadBalancerInput struct {
+	_ struct{} `type:"structure"`
+
 	// One or more Availability Zones from the same region as the load balancer.
 	// Traffic is equally distributed across all specified Availability Zones.
 	//
@@ -1378,8 +1380,6 @@ type CreateLoadBalancerInput struct {
 	// For more information about tagging your load balancer, see Tagging (http://docs.aws.amazon.com/ElasticLoadBalancing/latest/DeveloperGuide/TerminologyandKeyConcepts.html#tagging-elb)
 	// in the Elastic Load Balancing Developer Guide.
 	Tags []*Tag `min:"1" type:"list"`
-
-	_ struct{} `type:"structure"`
 }
 
 // String returns the string representation
@@ -1393,13 +1393,13 @@ func (s CreateLoadBalancerInput) GoString() string {
 }
 
 type CreateLoadBalancerListenersInput struct {
+	_ struct{} `type:"structure"`
+
 	// The listeners.
 	Listeners []*Listener `type:"list" required:"true"`
 
 	// The name of the load balancer.
 	LoadBalancerName *string `type:"string" required:"true"`
-
-	_ struct{} `type:"structure"`
 }
 
 // String returns the string representation
@@ -1427,10 +1427,10 @@ func (s CreateLoadBalancerListenersOutput) GoString() string {
 }
 
 type CreateLoadBalancerOutput struct {
+	_ struct{} `type:"structure"`
+
 	// The DNS name of the load balancer.
 	DNSName *string `type:"string"`
-
-	_ struct{} `type:"structure"`
 }
 
 // String returns the string representation
@@ -1444,6 +1444,8 @@ func (s CreateLoadBalancerOutput) GoString() string {
 }
 
 type CreateLoadBalancerPolicyInput struct {
+	_ struct{} `type:"structure"`
+
 	// The name of the load balancer.
 	LoadBalancerName *string `type:"string" required:"true"`
 
@@ -1456,8 +1458,6 @@ type CreateLoadBalancerPolicyInput struct {
 
 	// The name of the base policy type. To get the list of policy types, use DescribeLoadBalancerPolicyTypes.
 	PolicyTypeName *string `type:"string" required:"true"`
-
-	_ struct{} `type:"structure"`
 }
 
 // String returns the string representation
@@ -1486,10 +1486,10 @@ func (s CreateLoadBalancerPolicyOutput) GoString() string {
 
 // Information about the CrossZoneLoadBalancing attribute.
 type CrossZoneLoadBalancing struct {
+	_ struct{} `type:"structure"`
+
 	// Specifies whether cross-zone load balancing is enabled for the load balancer.
 	Enabled *bool `type:"boolean" required:"true"`
-
-	_ struct{} `type:"structure"`
 }
 
 // String returns the string representation
@@ -1503,10 +1503,10 @@ func (s CrossZoneLoadBalancing) GoString() string {
 }
 
 type DeleteLoadBalancerInput struct {
+	_ struct{} `type:"structure"`
+
 	// The name of the load balancer.
 	LoadBalancerName *string `type:"string" required:"true"`
-
-	_ struct{} `type:"structure"`
 }
 
 // String returns the string representation
@@ -1520,13 +1520,13 @@ func (s DeleteLoadBalancerInput) GoString() string {
 }
 
 type DeleteLoadBalancerListenersInput struct {
+	_ struct{} `type:"structure"`
+
 	// The name of the load balancer.
 	LoadBalancerName *string `type:"string" required:"true"`
 
 	// The client port numbers of the listeners.
 	LoadBalancerPorts []*int64 `type:"list" required:"true"`
-
-	_ struct{} `type:"structure"`
 }
 
 // String returns the string representation
@@ -1569,13 +1569,13 @@ func (s DeleteLoadBalancerOutput) GoString() string {
 
 // =
 type DeleteLoadBalancerPolicyInput struct {
+	_ struct{} `type:"structure"`
+
 	// The name of the load balancer.
 	LoadBalancerName *string `type:"string" required:"true"`
 
 	// The name of the policy.
 	PolicyName *string `type:"string" required:"true"`
-
-	_ struct{} `type:"structure"`
 }
 
 // String returns the string representation
@@ -1603,13 +1603,13 @@ func (s DeleteLoadBalancerPolicyOutput) GoString() string {
 }
 
 type DeregisterInstancesFromLoadBalancerInput struct {
+	_ struct{} `type:"structure"`
+
 	// The IDs of the instances.
 	Instances []*Instance `type:"list" required:"true"`
 
 	// The name of the load balancer.
 	LoadBalancerName *string `type:"string" required:"true"`
-
-	_ struct{} `type:"structure"`
 }
 
 // String returns the string representation
@@ -1623,10 +1623,10 @@ func (s DeregisterInstancesFromLoadBalancerInput) GoString() string {
 }
 
 type DeregisterInstancesFromLoadBalancerOutput struct {
+	_ struct{} `type:"structure"`
+
 	// The remaining instances registered with the load balancer.
 	Instances []*Instance `type:"list"`
-
-	_ struct{} `type:"structure"`
 }
 
 // String returns the string representation
@@ -1640,13 +1640,13 @@ func (s DeregisterInstancesFromLoadBalancerOutput) GoString() string {
 }
 
 type DescribeInstanceHealthInput struct {
+	_ struct{} `type:"structure"`
+
 	// The IDs of the instances.
 	Instances []*Instance `type:"list"`
 
 	// The name of the load balancer.
 	LoadBalancerName *string `type:"string" required:"true"`
-
-	_ struct{} `type:"structure"`
 }
 
 // String returns the string representation
@@ -1660,10 +1660,10 @@ func (s DescribeInstanceHealthInput) GoString() string {
 }
 
 type DescribeInstanceHealthOutput struct {
+	_ struct{} `type:"structure"`
+
 	// Information about the health of the instances.
 	InstanceStates []*InstanceState `type:"list"`
-
-	_ struct{} `type:"structure"`
 }
 
 // String returns the string representation
@@ -1677,10 +1677,10 @@ func (s DescribeInstanceHealthOutput) GoString() string {
 }
 
 type DescribeLoadBalancerAttributesInput struct {
+	_ struct{} `type:"structure"`
+
 	// The name of the load balancer.
 	LoadBalancerName *string `type:"string" required:"true"`
-
-	_ struct{} `type:"structure"`
 }
 
 // String returns the string representation
@@ -1694,10 +1694,10 @@ func (s DescribeLoadBalancerAttributesInput) GoString() string {
 }
 
 type DescribeLoadBalancerAttributesOutput struct {
+	_ struct{} `type:"structure"`
+
 	// Information about the load balancer attributes.
 	LoadBalancerAttributes *LoadBalancerAttributes `type:"structure"`
-
-	_ struct{} `type:"structure"`
 }
 
 // String returns the string representation
@@ -1711,13 +1711,13 @@ func (s DescribeLoadBalancerAttributesOutput) GoString() string {
 }
 
 type DescribeLoadBalancerPoliciesInput struct {
+	_ struct{} `type:"structure"`
+
 	// The name of the load balancer.
 	LoadBalancerName *string `type:"string"`
 
 	// The names of the policies.
 	PolicyNames []*string `type:"list"`
-
-	_ struct{} `type:"structure"`
 }
 
 // String returns the string representation
@@ -1731,10 +1731,10 @@ func (s DescribeLoadBalancerPoliciesInput) GoString() string {
 }
 
 type DescribeLoadBalancerPoliciesOutput struct {
+	_ struct{} `type:"structure"`
+
 	// Information about the policies.
 	PolicyDescriptions []*PolicyDescription `type:"list"`
-
-	_ struct{} `type:"structure"`
 }
 
 // String returns the string representation
@@ -1748,11 +1748,11 @@ func (s DescribeLoadBalancerPoliciesOutput) GoString() string {
 }
 
 type DescribeLoadBalancerPolicyTypesInput struct {
+	_ struct{} `type:"structure"`
+
 	// The names of the policy types. If no names are specified, describes all policy
 	// types defined by Elastic Load Balancing.
 	PolicyTypeNames []*string `type:"list"`
-
-	_ struct{} `type:"structure"`
 }
 
 // String returns the string representation
@@ -1766,10 +1766,10 @@ func (s DescribeLoadBalancerPolicyTypesInput) GoString() string {
 }
 
 type DescribeLoadBalancerPolicyTypesOutput struct {
+	_ struct{} `type:"structure"`
+
 	// Information about the policy types.
 	PolicyTypeDescriptions []*PolicyTypeDescription `type:"list"`
-
-	_ struct{} `type:"structure"`
 }
 
 // String returns the string representation
@@ -1783,6 +1783,8 @@ func (s DescribeLoadBalancerPolicyTypesOutput) GoString() string {
 }
 
 type DescribeLoadBalancersInput struct {
+	_ struct{} `type:"structure"`
+
 	// The names of the load balancers.
 	LoadBalancerNames []*string `type:"list"`
 
@@ -1793,8 +1795,6 @@ type DescribeLoadBalancersInput struct {
 	// The maximum number of results to return with this call (a number from 1 to
 	// 400). The default is 400.
 	PageSize *int64 `min:"1" type:"integer"`
-
-	_ struct{} `type:"structure"`
 }
 
 // String returns the string representation
@@ -1808,14 +1808,14 @@ func (s DescribeLoadBalancersInput) GoString() string {
 }
 
 type DescribeLoadBalancersOutput struct {
+	_ struct{} `type:"structure"`
+
 	// Information about the load balancers.
 	LoadBalancerDescriptions []*LoadBalancerDescription `type:"list"`
 
 	// The marker to use when requesting the next set of results. If there are no
 	// additional results, the string is empty.
 	NextMarker *string `type:"string"`
-
-	_ struct{} `type:"structure"`
 }
 
 // String returns the string representation
@@ -1829,10 +1829,10 @@ func (s DescribeLoadBalancersOutput) GoString() string {
 }
 
 type DescribeTagsInput struct {
+	_ struct{} `type:"structure"`
+
 	// The names of the load balancers.
 	LoadBalancerNames []*string `min:"1" type:"list" required:"true"`
-
-	_ struct{} `type:"structure"`
 }
 
 // String returns the string representation
@@ -1846,10 +1846,10 @@ func (s DescribeTagsInput) GoString() string {
 }
 
 type DescribeTagsOutput struct {
+	_ struct{} `type:"structure"`
+
 	// Information about the tags.
 	TagDescriptions []*TagDescription `type:"list"`
-
-	_ struct{} `type:"structure"`
 }
 
 // String returns the string representation
@@ -1863,13 +1863,13 @@ func (s DescribeTagsOutput) GoString() string {
 }
 
 type DetachLoadBalancerFromSubnetsInput struct {
+	_ struct{} `type:"structure"`
+
 	// The name of the load balancer.
 	LoadBalancerName *string `type:"string" required:"true"`
 
 	// The IDs of the subnets.
 	Subnets []*string `type:"list" required:"true"`
-
-	_ struct{} `type:"structure"`
 }
 
 // String returns the string representation
@@ -1883,10 +1883,10 @@ func (s DetachLoadBalancerFromSubnetsInput) GoString() string {
 }
 
 type DetachLoadBalancerFromSubnetsOutput struct {
+	_ struct{} `type:"structure"`
+
 	// The IDs of the remaining subnets for the load balancer.
 	Subnets []*string `type:"list"`
-
-	_ struct{} `type:"structure"`
 }
 
 // String returns the string representation
@@ -1900,13 +1900,13 @@ func (s DetachLoadBalancerFromSubnetsOutput) GoString() string {
 }
 
 type DisableAvailabilityZonesForLoadBalancerInput struct {
+	_ struct{} `type:"structure"`
+
 	// The Availability Zones.
 	AvailabilityZones []*string `type:"list" required:"true"`
 
 	// The name of the load balancer.
 	LoadBalancerName *string `type:"string" required:"true"`
-
-	_ struct{} `type:"structure"`
 }
 
 // String returns the string representation
@@ -1920,10 +1920,10 @@ func (s DisableAvailabilityZonesForLoadBalancerInput) GoString() string {
 }
 
 type DisableAvailabilityZonesForLoadBalancerOutput struct {
+	_ struct{} `type:"structure"`
+
 	// The remaining Availability Zones for the load balancer.
 	AvailabilityZones []*string `type:"list"`
-
-	_ struct{} `type:"structure"`
 }
 
 // String returns the string representation
@@ -1937,13 +1937,13 @@ func (s DisableAvailabilityZonesForLoadBalancerOutput) GoString() string {
 }
 
 type EnableAvailabilityZonesForLoadBalancerInput struct {
+	_ struct{} `type:"structure"`
+
 	// The Availability Zones. These must be in the same region as the load balancer.
 	AvailabilityZones []*string `type:"list" required:"true"`
 
 	// The name of the load balancer.
 	LoadBalancerName *string `type:"string" required:"true"`
-
-	_ struct{} `type:"structure"`
 }
 
 // String returns the string representation
@@ -1957,10 +1957,10 @@ func (s EnableAvailabilityZonesForLoadBalancerInput) GoString() string {
 }
 
 type EnableAvailabilityZonesForLoadBalancerOutput struct {
+	_ struct{} `type:"structure"`
+
 	// The updated list of Availability Zones for the load balancer.
 	AvailabilityZones []*string `type:"list"`
-
-	_ struct{} `type:"structure"`
 }
 
 // String returns the string representation
@@ -1975,6 +1975,8 @@ func (s EnableAvailabilityZonesForLoadBalancerOutput) GoString() string {
 
 // Information about a health check.
 type HealthCheck struct {
+	_ struct{} `type:"structure"`
+
 	// The number of consecutive health checks successes required before moving
 	// the instance to the Healthy state.
 	HealthyThreshold *int64 `min:"2" type:"integer" required:"true"`
@@ -2012,8 +2014,6 @@ type HealthCheck struct {
 	// The number of consecutive health check failures required before moving the
 	// instance to the Unhealthy state.
 	UnhealthyThreshold *int64 `min:"2" type:"integer" required:"true"`
-
-	_ struct{} `type:"structure"`
 }
 
 // String returns the string representation
@@ -2028,10 +2028,10 @@ func (s HealthCheck) GoString() string {
 
 // The ID of a back-end instance.
 type Instance struct {
+	_ struct{} `type:"structure"`
+
 	// The ID of the instance.
 	InstanceId *string `type:"string"`
-
-	_ struct{} `type:"structure"`
 }
 
 // String returns the string representation
@@ -2046,6 +2046,8 @@ func (s Instance) GoString() string {
 
 // Information about the state of a back-end instance.
 type InstanceState struct {
+	_ struct{} `type:"structure"`
+
 	// A description of the instance state. This string can contain one or more
 	// of the following messages.
 	//
@@ -2090,8 +2092,6 @@ type InstanceState struct {
 	//
 	// Valid values: InService | OutOfService | Unknown
 	State *string `type:"string"`
-
-	_ struct{} `type:"structure"`
 }
 
 // String returns the string representation
@@ -2106,6 +2106,8 @@ func (s InstanceState) GoString() string {
 
 // Information about a policy for duration-based session stickiness.
 type LBCookieStickinessPolicy struct {
+	_ struct{} `type:"structure"`
+
 	// The time period, in seconds, after which the cookie should be considered
 	// stale. If this parameter is not specified, the stickiness session lasts for
 	// the duration of the browser session.
@@ -2114,8 +2116,6 @@ type LBCookieStickinessPolicy struct {
 	// The name for the policy being created. The name must be unique within the
 	// set of policies for this load balancer.
 	PolicyName *string `type:"string"`
-
-	_ struct{} `type:"structure"`
 }
 
 // String returns the string representation
@@ -2134,6 +2134,8 @@ func (s LBCookieStickinessPolicy) GoString() string {
 // Balancing, see Listener Configurations for Elastic Load Balancing (http://docs.aws.amazon.com/ElasticLoadBalancing/latest/DeveloperGuide/elb-listener-config.html)
 // in the Elastic Load Balancing Developer Guide.
 type Listener struct {
+	_ struct{} `type:"structure"`
+
 	// The port on which the instance is listening.
 	InstancePort *int64 `min:"1" type:"integer" required:"true"`
 
@@ -2161,8 +2163,6 @@ type Listener struct {
 
 	// The Amazon Resource Name (ARN) of the server certificate.
 	SSLCertificateId *string `type:"string"`
-
-	_ struct{} `type:"structure"`
 }
 
 // String returns the string representation
@@ -2177,6 +2177,8 @@ func (s Listener) GoString() string {
 
 // The policies enabled for a listener.
 type ListenerDescription struct {
+	_ struct{} `type:"structure"`
+
 	// Information about a listener.
 	//
 	// For information about the protocols and the ports supported by Elastic Load
@@ -2186,8 +2188,6 @@ type ListenerDescription struct {
 
 	// The policies. If there are no policies enabled, the list is empty.
 	PolicyNames []*string `type:"list"`
-
-	_ struct{} `type:"structure"`
 }
 
 // String returns the string representation
@@ -2202,6 +2202,8 @@ func (s ListenerDescription) GoString() string {
 
 // The attributes for a load balancer.
 type LoadBalancerAttributes struct {
+	_ struct{} `type:"structure"`
+
 	// If enabled, the load balancer captures detailed information of all requests
 	// and delivers the information to the Amazon S3 bucket that you specify.
 	//
@@ -2235,8 +2237,6 @@ type LoadBalancerAttributes struct {
 	// For more information, see Enable Cross-Zone Load Balancing (http://docs.aws.amazon.com/ElasticLoadBalancing/latest/DeveloperGuide/enable-disable-crosszone-lb.html)
 	// in the Elastic Load Balancing Developer Guide.
 	CrossZoneLoadBalancing *CrossZoneLoadBalancing `type:"structure"`
-
-	_ struct{} `type:"structure"`
 }
 
 // String returns the string representation
@@ -2251,6 +2251,8 @@ func (s LoadBalancerAttributes) GoString() string {
 
 // Information about a load balancer.
 type LoadBalancerDescription struct {
+	_ struct{} `type:"structure"`
+
 	// The Availability Zones for the load balancer.
 	AvailabilityZones []*string `type:"list"`
 
@@ -2312,8 +2314,6 @@ type LoadBalancerDescription struct {
 
 	// The ID of the VPC for the load balancer.
 	VPCId *string `type:"string"`
-
-	_ struct{} `type:"structure"`
 }
 
 // String returns the string representation
@@ -2327,13 +2327,13 @@ func (s LoadBalancerDescription) GoString() string {
 }
 
 type ModifyLoadBalancerAttributesInput struct {
+	_ struct{} `type:"structure"`
+
 	// The attributes of the load balancer.
 	LoadBalancerAttributes *LoadBalancerAttributes `type:"structure" required:"true"`
 
 	// The name of the load balancer.
 	LoadBalancerName *string `type:"string" required:"true"`
-
-	_ struct{} `type:"structure"`
 }
 
 // String returns the string representation
@@ -2347,13 +2347,13 @@ func (s ModifyLoadBalancerAttributesInput) GoString() string {
 }
 
 type ModifyLoadBalancerAttributesOutput struct {
+	_ struct{} `type:"structure"`
+
 	// The attributes for a load balancer.
 	LoadBalancerAttributes *LoadBalancerAttributes `type:"structure"`
 
 	// The name of the load balancer.
 	LoadBalancerName *string `type:"string"`
-
-	_ struct{} `type:"structure"`
 }
 
 // String returns the string representation
@@ -2368,6 +2368,8 @@ func (s ModifyLoadBalancerAttributesOutput) GoString() string {
 
 // The policies for a load balancer.
 type Policies struct {
+	_ struct{} `type:"structure"`
+
 	// The stickiness policies created using CreateAppCookieStickinessPolicy.
 	AppCookieStickinessPolicies []*AppCookieStickinessPolicy `type:"list"`
 
@@ -2376,8 +2378,6 @@ type Policies struct {
 
 	// The policies other than the stickiness policies.
 	OtherPolicies []*string `type:"list"`
-
-	_ struct{} `type:"structure"`
 }
 
 // String returns the string representation
@@ -2392,13 +2392,13 @@ func (s Policies) GoString() string {
 
 // Information about a policy attribute.
 type PolicyAttribute struct {
+	_ struct{} `type:"structure"`
+
 	// The name of the attribute.
 	AttributeName *string `type:"string"`
 
 	// The value of the attribute.
 	AttributeValue *string `type:"string"`
-
-	_ struct{} `type:"structure"`
 }
 
 // String returns the string representation
@@ -2413,13 +2413,13 @@ func (s PolicyAttribute) GoString() string {
 
 // Information about a policy attribute.
 type PolicyAttributeDescription struct {
+	_ struct{} `type:"structure"`
+
 	// The name of the attribute.
 	AttributeName *string `type:"string"`
 
 	// The value of the attribute.
 	AttributeValue *string `type:"string"`
-
-	_ struct{} `type:"structure"`
 }
 
 // String returns the string representation
@@ -2434,6 +2434,8 @@ func (s PolicyAttributeDescription) GoString() string {
 
 // Information about a policy attribute type.
 type PolicyAttributeTypeDescription struct {
+	_ struct{} `type:"structure"`
+
 	// The name of the attribute.
 	AttributeName *string `type:"string"`
 
@@ -2454,8 +2456,6 @@ type PolicyAttributeTypeDescription struct {
 
 	// A description of the attribute.
 	Description *string `type:"string"`
-
-	_ struct{} `type:"structure"`
 }
 
 // String returns the string representation
@@ -2470,6 +2470,8 @@ func (s PolicyAttributeTypeDescription) GoString() string {
 
 // Information about a policy.
 type PolicyDescription struct {
+	_ struct{} `type:"structure"`
+
 	// The policy attributes.
 	PolicyAttributeDescriptions []*PolicyAttributeDescription `type:"list"`
 
@@ -2478,8 +2480,6 @@ type PolicyDescription struct {
 
 	// The name of the policy type.
 	PolicyTypeName *string `type:"string"`
-
-	_ struct{} `type:"structure"`
 }
 
 // String returns the string representation
@@ -2494,6 +2494,8 @@ func (s PolicyDescription) GoString() string {
 
 // Information about a policy type.
 type PolicyTypeDescription struct {
+	_ struct{} `type:"structure"`
+
 	// A description of the policy type.
 	Description *string `type:"string"`
 
@@ -2503,8 +2505,6 @@ type PolicyTypeDescription struct {
 
 	// The name of the policy type.
 	PolicyTypeName *string `type:"string"`
-
-	_ struct{} `type:"structure"`
 }
 
 // String returns the string representation
@@ -2518,13 +2518,13 @@ func (s PolicyTypeDescription) GoString() string {
 }
 
 type RegisterInstancesWithLoadBalancerInput struct {
+	_ struct{} `type:"structure"`
+
 	// The IDs of the instances.
 	Instances []*Instance `type:"list" required:"true"`
 
 	// The name of the load balancer.
 	LoadBalancerName *string `type:"string" required:"true"`
-
-	_ struct{} `type:"structure"`
 }
 
 // String returns the string representation
@@ -2538,10 +2538,10 @@ func (s RegisterInstancesWithLoadBalancerInput) GoString() string {
 }
 
 type RegisterInstancesWithLoadBalancerOutput struct {
+	_ struct{} `type:"structure"`
+
 	// The updated list of instances for the load balancer.
 	Instances []*Instance `type:"list"`
-
-	_ struct{} `type:"structure"`
 }
 
 // String returns the string representation
@@ -2555,14 +2555,14 @@ func (s RegisterInstancesWithLoadBalancerOutput) GoString() string {
 }
 
 type RemoveTagsInput struct {
+	_ struct{} `type:"structure"`
+
 	// The name of the load balancer. You can specify a maximum of one load balancer
 	// name.
 	LoadBalancerNames []*string `type:"list" required:"true"`
 
 	// The list of tag keys to remove.
 	Tags []*TagKeyOnly `min:"1" type:"list" required:"true"`
-
-	_ struct{} `type:"structure"`
 }
 
 // String returns the string representation
@@ -2590,6 +2590,8 @@ func (s RemoveTagsOutput) GoString() string {
 }
 
 type SetLoadBalancerListenerSSLCertificateInput struct {
+	_ struct{} `type:"structure"`
+
 	// The name of the load balancer.
 	LoadBalancerName *string `type:"string" required:"true"`
 
@@ -2598,8 +2600,6 @@ type SetLoadBalancerListenerSSLCertificateInput struct {
 
 	// The Amazon Resource Name (ARN) of the SSL certificate.
 	SSLCertificateId *string `type:"string" required:"true"`
-
-	_ struct{} `type:"structure"`
 }
 
 // String returns the string representation
@@ -2627,6 +2627,8 @@ func (s SetLoadBalancerListenerSSLCertificateOutput) GoString() string {
 }
 
 type SetLoadBalancerPoliciesForBackendServerInput struct {
+	_ struct{} `type:"structure"`
+
 	// The port number associated with the back-end server.
 	InstancePort *int64 `type:"integer" required:"true"`
 
@@ -2636,8 +2638,6 @@ type SetLoadBalancerPoliciesForBackendServerInput struct {
 	// The names of the policies. If the list is empty, then all current polices
 	// are removed from the back-end server.
 	PolicyNames []*string `type:"list" required:"true"`
-
-	_ struct{} `type:"structure"`
 }
 
 // String returns the string representation
@@ -2665,6 +2665,8 @@ func (s SetLoadBalancerPoliciesForBackendServerOutput) GoString() string {
 }
 
 type SetLoadBalancerPoliciesOfListenerInput struct {
+	_ struct{} `type:"structure"`
+
 	// The name of the load balancer.
 	LoadBalancerName *string `type:"string" required:"true"`
 
@@ -2674,8 +2676,6 @@ type SetLoadBalancerPoliciesOfListenerInput struct {
 	// The names of the policies. If the list is empty, the current policy is removed
 	// from the listener.
 	PolicyNames []*string `type:"list" required:"true"`
-
-	_ struct{} `type:"structure"`
 }
 
 // String returns the string representation
@@ -2704,13 +2704,13 @@ func (s SetLoadBalancerPoliciesOfListenerOutput) GoString() string {
 
 // Information about a source security group.
 type SourceSecurityGroup struct {
+	_ struct{} `type:"structure"`
+
 	// The name of the security group.
 	GroupName *string `type:"string"`
 
 	// The owner of the security group.
 	OwnerAlias *string `type:"string"`
-
-	_ struct{} `type:"structure"`
 }
 
 // String returns the string representation
@@ -2725,13 +2725,13 @@ func (s SourceSecurityGroup) GoString() string {
 
 // Information about a tag.
 type Tag struct {
+	_ struct{} `type:"structure"`
+
 	// The key of the tag.
 	Key *string `min:"1" type:"string" required:"true"`
 
 	// The value of the tag.
 	Value *string `type:"string"`
-
-	_ struct{} `type:"structure"`
 }
 
 // String returns the string representation
@@ -2746,13 +2746,13 @@ func (s Tag) GoString() string {
 
 // The tags associated with a load balancer.
 type TagDescription struct {
+	_ struct{} `type:"structure"`
+
 	// The name of the load balancer.
 	LoadBalancerName *string `type:"string"`
 
 	// The tags.
 	Tags []*Tag `min:"1" type:"list"`
-
-	_ struct{} `type:"structure"`
 }
 
 // String returns the string representation
@@ -2767,10 +2767,10 @@ func (s TagDescription) GoString() string {
 
 // The key of a tag.
 type TagKeyOnly struct {
+	_ struct{} `type:"structure"`
+
 	// The name of the key.
 	Key *string `min:"1" type:"string"`
-
-	_ struct{} `type:"structure"`
 }
 
 // String returns the string representation

--- a/service/emr/api.go
+++ b/service/emr/api.go
@@ -652,13 +652,13 @@ func (c *EMR) TerminateJobFlows(input *TerminateJobFlowsInput) (*TerminateJobFlo
 
 // Input to an AddInstanceGroups call.
 type AddInstanceGroupsInput struct {
+	_ struct{} `type:"structure"`
+
 	// Instance Groups to add.
 	InstanceGroups []*InstanceGroupConfig `type:"list" required:"true"`
 
 	// Job flow in which to add the instance groups.
 	JobFlowId *string `type:"string" required:"true"`
-
-	_ struct{} `type:"structure"`
 }
 
 // String returns the string representation
@@ -673,13 +673,13 @@ func (s AddInstanceGroupsInput) GoString() string {
 
 // Output from an AddInstanceGroups call.
 type AddInstanceGroupsOutput struct {
+	_ struct{} `type:"structure"`
+
 	// Instance group IDs of the newly created instance groups.
 	InstanceGroupIds []*string `type:"list"`
 
 	// The job flow ID in which the instance groups are added.
 	JobFlowId *string `type:"string"`
-
-	_ struct{} `type:"structure"`
 }
 
 // String returns the string representation
@@ -694,14 +694,14 @@ func (s AddInstanceGroupsOutput) GoString() string {
 
 // The input argument to the AddJobFlowSteps operation.
 type AddJobFlowStepsInput struct {
+	_ struct{} `type:"structure"`
+
 	// A string that uniquely identifies the job flow. This identifier is returned
 	// by RunJobFlow and can also be obtained from ListClusters.
 	JobFlowId *string `type:"string" required:"true"`
 
 	// A list of StepConfig to be executed by the job flow.
 	Steps []*StepConfig `type:"list" required:"true"`
-
-	_ struct{} `type:"structure"`
 }
 
 // String returns the string representation
@@ -716,10 +716,10 @@ func (s AddJobFlowStepsInput) GoString() string {
 
 // The output for the AddJobFlowSteps operation.
 type AddJobFlowStepsOutput struct {
+	_ struct{} `type:"structure"`
+
 	// The identifiers of the list of steps added to the job flow.
 	StepIds []*string `type:"list"`
-
-	_ struct{} `type:"structure"`
 }
 
 // String returns the string representation
@@ -734,6 +734,8 @@ func (s AddJobFlowStepsOutput) GoString() string {
 
 // This input identifies a cluster and a list of tags to attach.
 type AddTagsInput struct {
+	_ struct{} `type:"structure"`
+
 	// The Amazon EMR resource identifier to which tags will be added. This value
 	// must be a cluster identifier.
 	ResourceId *string `type:"string" required:"true"`
@@ -743,8 +745,6 @@ type AddTagsInput struct {
 	// with a maximum of 128 characters, and an optional value string with a maximum
 	// of 256 characters.
 	Tags []*Tag `type:"list" required:"true"`
-
-	_ struct{} `type:"structure"`
 }
 
 // String returns the string representation
@@ -787,6 +787,8 @@ func (s AddTagsOutput) GoString() string {
 // accepted parameter is the application name. To pass arguments to applications,
 // you supply a configuration for each application.
 type Application struct {
+	_ struct{} `type:"structure"`
+
 	// This option is for advanced users only. This is meta information about third-party
 	// applications that third-party vendors use for testing purposes.
 	AdditionalInfo map[string]*string `type:"map"`
@@ -799,8 +801,6 @@ type Application struct {
 
 	// The version of the application.
 	Version *string `type:"string"`
-
-	_ struct{} `type:"structure"`
 }
 
 // String returns the string representation
@@ -815,13 +815,13 @@ func (s Application) GoString() string {
 
 // Configuration of a bootstrap action.
 type BootstrapActionConfig struct {
+	_ struct{} `type:"structure"`
+
 	// The name of the bootstrap action.
 	Name *string `type:"string" required:"true"`
 
 	// The script run by the bootstrap action.
 	ScriptBootstrapAction *ScriptBootstrapActionConfig `type:"structure" required:"true"`
-
-	_ struct{} `type:"structure"`
 }
 
 // String returns the string representation
@@ -836,10 +836,10 @@ func (s BootstrapActionConfig) GoString() string {
 
 // Reports the configuration of a bootstrap action in a job flow.
 type BootstrapActionDetail struct {
+	_ struct{} `type:"structure"`
+
 	// A description of the bootstrap action.
 	BootstrapActionConfig *BootstrapActionConfig `type:"structure"`
-
-	_ struct{} `type:"structure"`
 }
 
 // String returns the string representation
@@ -854,6 +854,8 @@ func (s BootstrapActionDetail) GoString() string {
 
 // The detailed description of the cluster.
 type Cluster struct {
+	_ struct{} `type:"structure"`
+
 	// The applications installed on this cluster.
 	Applications []*Application `type:"list"`
 
@@ -921,8 +923,6 @@ type Cluster struct {
 	// the cluster can view and manage it. This value can be changed using the SetVisibleToAllUsers
 	// action.
 	VisibleToAllUsers *bool `type:"boolean"`
-
-	_ struct{} `type:"structure"`
 }
 
 // String returns the string representation
@@ -937,13 +937,13 @@ func (s Cluster) GoString() string {
 
 // The reason that the cluster changed to its current state.
 type ClusterStateChangeReason struct {
+	_ struct{} `type:"structure"`
+
 	// The programmatic code for the state change reason.
 	Code *string `type:"string" enum:"ClusterStateChangeReasonCode"`
 
 	// The descriptive message for the state change reason.
 	Message *string `type:"string"`
-
-	_ struct{} `type:"structure"`
 }
 
 // String returns the string representation
@@ -958,6 +958,8 @@ func (s ClusterStateChangeReason) GoString() string {
 
 // The detailed status of the cluster.
 type ClusterStatus struct {
+	_ struct{} `type:"structure"`
+
 	// The current state of the cluster.
 	State *string `type:"string" enum:"ClusterState"`
 
@@ -967,8 +969,6 @@ type ClusterStatus struct {
 	// A timeline that represents the status of a cluster over the lifetime of the
 	// cluster.
 	Timeline *ClusterTimeline `type:"structure"`
-
-	_ struct{} `type:"structure"`
 }
 
 // String returns the string representation
@@ -983,6 +983,8 @@ func (s ClusterStatus) GoString() string {
 
 // The summary description of the cluster.
 type ClusterSummary struct {
+	_ struct{} `type:"structure"`
+
 	// The unique identifier for the cluster.
 	Id *string `type:"string"`
 
@@ -999,8 +1001,6 @@ type ClusterSummary struct {
 
 	// The details about the current status of the cluster.
 	Status *ClusterStatus `type:"structure"`
-
-	_ struct{} `type:"structure"`
 }
 
 // String returns the string representation
@@ -1015,6 +1015,8 @@ func (s ClusterSummary) GoString() string {
 
 // Represents the timeline of the cluster's lifecycle.
 type ClusterTimeline struct {
+	_ struct{} `type:"structure"`
+
 	// The creation date and time of the cluster.
 	CreationDateTime *time.Time `type:"timestamp" timestampFormat:"unix"`
 
@@ -1023,8 +1025,6 @@ type ClusterTimeline struct {
 
 	// The date and time when the cluster was ready to execute steps.
 	ReadyDateTime *time.Time `type:"timestamp" timestampFormat:"unix"`
-
-	_ struct{} `type:"structure"`
 }
 
 // String returns the string representation
@@ -1039,6 +1039,8 @@ func (s ClusterTimeline) GoString() string {
 
 // An entity describing an executable that runs on a cluster.
 type Command struct {
+	_ struct{} `type:"structure"`
+
 	// Arguments for Amazon EMR to pass to the command for execution.
 	Args []*string `type:"list"`
 
@@ -1047,8 +1049,6 @@ type Command struct {
 
 	// The Amazon S3 location of the command script.
 	ScriptPath *string `type:"string"`
-
-	_ struct{} `type:"structure"`
 }
 
 // String returns the string representation
@@ -1069,6 +1069,8 @@ func (s Command) GoString() string {
 // and a set of properties. Configurations can be nested, so a configuration
 // may have its own Configuration objects listed.
 type Configuration struct {
+	_ struct{} `type:"structure"`
+
 	// The classification of a configuration. For more information see, Amazon EMR
 	// Configurations (http://docs.aws.amazon.com/ElasticMapReduce/latest/API/EmrConfigurations.html).
 	Classification *string `type:"string"`
@@ -1078,8 +1080,6 @@ type Configuration struct {
 
 	// A set of properties supplied to the Configuration object.
 	Properties map[string]*string `type:"map"`
-
-	_ struct{} `type:"structure"`
 }
 
 // String returns the string representation
@@ -1094,10 +1094,10 @@ func (s Configuration) GoString() string {
 
 // This input determines which cluster to describe.
 type DescribeClusterInput struct {
+	_ struct{} `type:"structure"`
+
 	// The identifier of the cluster to describe.
 	ClusterId *string `type:"string" required:"true"`
-
-	_ struct{} `type:"structure"`
 }
 
 // String returns the string representation
@@ -1112,10 +1112,10 @@ func (s DescribeClusterInput) GoString() string {
 
 // This output contains the description of the cluster.
 type DescribeClusterOutput struct {
+	_ struct{} `type:"structure"`
+
 	// This output contains the details for the requested cluster.
 	Cluster *Cluster `type:"structure"`
-
-	_ struct{} `type:"structure"`
 }
 
 // String returns the string representation
@@ -1130,6 +1130,8 @@ func (s DescribeClusterOutput) GoString() string {
 
 // The input for the DescribeJobFlows operation.
 type DescribeJobFlowsInput struct {
+	_ struct{} `type:"structure"`
+
 	// Return only job flows created after this date and time.
 	CreatedAfter *time.Time `type:"timestamp" timestampFormat:"unix"`
 
@@ -1141,8 +1143,6 @@ type DescribeJobFlowsInput struct {
 
 	// Return only job flows whose state is contained in this list.
 	JobFlowStates []*string `type:"list"`
-
-	_ struct{} `type:"structure"`
 }
 
 // String returns the string representation
@@ -1157,10 +1157,10 @@ func (s DescribeJobFlowsInput) GoString() string {
 
 // The output for the DescribeJobFlows operation.
 type DescribeJobFlowsOutput struct {
+	_ struct{} `type:"structure"`
+
 	// A list of job flows matching the parameters supplied.
 	JobFlows []*JobFlowDetail `type:"list"`
-
-	_ struct{} `type:"structure"`
 }
 
 // String returns the string representation
@@ -1175,13 +1175,13 @@ func (s DescribeJobFlowsOutput) GoString() string {
 
 // This input determines which step to describe.
 type DescribeStepInput struct {
+	_ struct{} `type:"structure"`
+
 	// The identifier of the cluster with steps to describe.
 	ClusterId *string `type:"string" required:"true"`
 
 	// The identifier of the step to describe.
 	StepId *string `type:"string" required:"true"`
-
-	_ struct{} `type:"structure"`
 }
 
 // String returns the string representation
@@ -1196,10 +1196,10 @@ func (s DescribeStepInput) GoString() string {
 
 // This output contains the description of the cluster step.
 type DescribeStepOutput struct {
+	_ struct{} `type:"structure"`
+
 	// The step details for the requested step identifier.
 	Step *Step `type:"structure"`
-
-	_ struct{} `type:"structure"`
 }
 
 // String returns the string representation
@@ -1215,6 +1215,8 @@ func (s DescribeStepOutput) GoString() string {
 // Provides information about the EC2 instances in a cluster grouped by category.
 // For example, key name, subnet ID, IAM instance profile, and so on.
 type Ec2InstanceAttributes struct {
+	_ struct{} `type:"structure"`
+
 	// A list of additional Amazon EC2 security group IDs for the master node.
 	AdditionalMasterSecurityGroups []*string `type:"list"`
 
@@ -1249,8 +1251,6 @@ type Ec2InstanceAttributes struct {
 	// The IAM role that was specified when the job flow was launched. The EC2 instances
 	// of the job flow assume this role.
 	IamInstanceProfile *string `type:"string"`
-
-	_ struct{} `type:"structure"`
 }
 
 // String returns the string representation
@@ -1267,6 +1267,8 @@ func (s Ec2InstanceAttributes) GoString() string {
 // The main function submits a job for Hadoop to execute and waits for the job
 // to finish or fail.
 type HadoopJarStepConfig struct {
+	_ struct{} `type:"structure"`
+
 	// A list of command line arguments passed to the JAR file's main function when
 	// executed.
 	Args []*string `type:"list"`
@@ -1281,8 +1283,6 @@ type HadoopJarStepConfig struct {
 	// A list of Java properties that are set when the step runs. You can use these
 	// properties to pass key value pairs to your main function.
 	Properties []*KeyValue `type:"list"`
-
-	_ struct{} `type:"structure"`
 }
 
 // String returns the string representation
@@ -1299,6 +1299,8 @@ func (s HadoopJarStepConfig) GoString() string {
 // The main function submits a job for Hadoop to execute and waits for the job
 // to finish or fail.
 type HadoopStepConfig struct {
+	_ struct{} `type:"structure"`
+
 	// The list of command line arguments to pass to the JAR file's main function
 	// for execution.
 	Args []*string `type:"list"`
@@ -1313,8 +1315,6 @@ type HadoopStepConfig struct {
 	// The list of Java properties that are set when the step runs. You can use
 	// these properties to pass key value pairs to your main function.
 	Properties map[string]*string `type:"map"`
-
-	_ struct{} `type:"structure"`
 }
 
 // String returns the string representation
@@ -1329,6 +1329,8 @@ func (s HadoopStepConfig) GoString() string {
 
 // Represents an EC2 instance provisioned as part of cluster.
 type Instance struct {
+	_ struct{} `type:"structure"`
+
 	// The unique identifier of the instance in Amazon EC2.
 	Ec2InstanceId *string `type:"string"`
 
@@ -1349,8 +1351,6 @@ type Instance struct {
 
 	// The current status of the instance.
 	Status *InstanceStatus `type:"structure"`
-
-	_ struct{} `type:"structure"`
 }
 
 // String returns the string representation
@@ -1366,6 +1366,8 @@ func (s Instance) GoString() string {
 // This entity represents an instance group, which is a group of instances that
 // have common purpose. For example, CORE instance group is used for HDFS.
 type InstanceGroup struct {
+	_ struct{} `type:"structure"`
+
 	// The bid price for each EC2 instance in the instance group when launching
 	// nodes as Spot Instances, expressed in USD.
 	BidPrice *string `type:"string"`
@@ -1401,8 +1403,6 @@ type InstanceGroup struct {
 
 	// The current status of the instance group.
 	Status *InstanceGroupStatus `type:"structure"`
-
-	_ struct{} `type:"structure"`
 }
 
 // String returns the string representation
@@ -1417,6 +1417,8 @@ func (s InstanceGroup) GoString() string {
 
 // Configuration defining a new instance group.
 type InstanceGroupConfig struct {
+	_ struct{} `type:"structure"`
+
 	// Bid price for each Amazon EC2 instance in the instance group when launching
 	// nodes as Spot Instances, expressed in USD.
 	BidPrice *string `type:"string"`
@@ -1442,8 +1444,6 @@ type InstanceGroupConfig struct {
 
 	// Friendly name given to the instance group.
 	Name *string `type:"string"`
-
-	_ struct{} `type:"structure"`
 }
 
 // String returns the string representation
@@ -1458,6 +1458,8 @@ func (s InstanceGroupConfig) GoString() string {
 
 // Detailed information about an instance group.
 type InstanceGroupDetail struct {
+	_ struct{} `type:"structure"`
+
 	// Bid price for EC2 Instances when launching nodes as Spot Instances, expressed
 	// in USD.
 	BidPrice *string `type:"string"`
@@ -1501,8 +1503,6 @@ type InstanceGroupDetail struct {
 	// State of instance group. The following values are deprecated: STARTING, TERMINATED,
 	// and FAILED.
 	State *string `type:"string" required:"true" enum:"InstanceGroupState"`
-
-	_ struct{} `type:"structure"`
 }
 
 // String returns the string representation
@@ -1517,6 +1517,8 @@ func (s InstanceGroupDetail) GoString() string {
 
 // Modify an instance group size.
 type InstanceGroupModifyConfig struct {
+	_ struct{} `type:"structure"`
+
 	// The EC2 InstanceIds to terminate. For advanced users only. Once you terminate
 	// the instances, the instance group will not return to its original requested
 	// size.
@@ -1527,8 +1529,6 @@ type InstanceGroupModifyConfig struct {
 
 	// Unique ID of the instance group to expand or shrink.
 	InstanceGroupId *string `type:"string" required:"true"`
-
-	_ struct{} `type:"structure"`
 }
 
 // String returns the string representation
@@ -1543,13 +1543,13 @@ func (s InstanceGroupModifyConfig) GoString() string {
 
 // The status change reason details for the instance group.
 type InstanceGroupStateChangeReason struct {
+	_ struct{} `type:"structure"`
+
 	// The programmable code for the state change reason.
 	Code *string `type:"string" enum:"InstanceGroupStateChangeReasonCode"`
 
 	// The status change reason description.
 	Message *string `type:"string"`
-
-	_ struct{} `type:"structure"`
 }
 
 // String returns the string representation
@@ -1564,6 +1564,8 @@ func (s InstanceGroupStateChangeReason) GoString() string {
 
 // The details of the instance group status.
 type InstanceGroupStatus struct {
+	_ struct{} `type:"structure"`
+
 	// The current state of the instance group.
 	State *string `type:"string" enum:"InstanceGroupState"`
 
@@ -1572,8 +1574,6 @@ type InstanceGroupStatus struct {
 
 	// The timeline of the instance group status over time.
 	Timeline *InstanceGroupTimeline `type:"structure"`
-
-	_ struct{} `type:"structure"`
 }
 
 // String returns the string representation
@@ -1588,6 +1588,8 @@ func (s InstanceGroupStatus) GoString() string {
 
 // The timeline of the instance group lifecycle.
 type InstanceGroupTimeline struct {
+	_ struct{} `type:"structure"`
+
 	// The creation date and time of the instance group.
 	CreationDateTime *time.Time `type:"timestamp" timestampFormat:"unix"`
 
@@ -1596,8 +1598,6 @@ type InstanceGroupTimeline struct {
 
 	// The date and time when the instance group became ready to perform tasks.
 	ReadyDateTime *time.Time `type:"timestamp" timestampFormat:"unix"`
-
-	_ struct{} `type:"structure"`
 }
 
 // String returns the string representation
@@ -1612,13 +1612,13 @@ func (s InstanceGroupTimeline) GoString() string {
 
 // The details of the status change reason for the instance.
 type InstanceStateChangeReason struct {
+	_ struct{} `type:"structure"`
+
 	// The programmable code for the state change reason.
 	Code *string `type:"string" enum:"InstanceStateChangeReasonCode"`
 
 	// The status change reason description.
 	Message *string `type:"string"`
-
-	_ struct{} `type:"structure"`
 }
 
 // String returns the string representation
@@ -1633,6 +1633,8 @@ func (s InstanceStateChangeReason) GoString() string {
 
 // The instance status details.
 type InstanceStatus struct {
+	_ struct{} `type:"structure"`
+
 	// The current state of the instance.
 	State *string `type:"string" enum:"InstanceState"`
 
@@ -1641,8 +1643,6 @@ type InstanceStatus struct {
 
 	// The timeline of the instance status over time.
 	Timeline *InstanceTimeline `type:"structure"`
-
-	_ struct{} `type:"structure"`
 }
 
 // String returns the string representation
@@ -1657,6 +1657,8 @@ func (s InstanceStatus) GoString() string {
 
 // The timeline of the instance lifecycle.
 type InstanceTimeline struct {
+	_ struct{} `type:"structure"`
+
 	// The creation date and time of the instance.
 	CreationDateTime *time.Time `type:"timestamp" timestampFormat:"unix"`
 
@@ -1665,8 +1667,6 @@ type InstanceTimeline struct {
 
 	// The date and time when the instance was ready to perform tasks.
 	ReadyDateTime *time.Time `type:"timestamp" timestampFormat:"unix"`
-
-	_ struct{} `type:"structure"`
 }
 
 // String returns the string representation
@@ -1681,6 +1681,8 @@ func (s InstanceTimeline) GoString() string {
 
 // A description of a job flow.
 type JobFlowDetail struct {
+	_ struct{} `type:"structure"`
+
 	// The version of the AMI used to initialize Amazon EC2 instances in the job
 	// flow. For a list of AMI versions currently supported by Amazon ElasticMapReduce,
 	// go to AMI Versions Supported in Elastic MapReduce (http://docs.aws.amazon.com/ElasticMapReduce/latest/DeveloperGuide/EnvironmentConfig_AMIVersion.html#ami-versions-supported)
@@ -1728,8 +1730,6 @@ type JobFlowDetail struct {
 	// the job flow can view and manage it. This value can be changed using the
 	// SetVisibleToAllUsers action.
 	VisibleToAllUsers *bool `type:"boolean"`
-
-	_ struct{} `type:"structure"`
 }
 
 // String returns the string representation
@@ -1744,6 +1744,8 @@ func (s JobFlowDetail) GoString() string {
 
 // Describes the status of the job flow.
 type JobFlowExecutionStatusDetail struct {
+	_ struct{} `type:"structure"`
+
 	// The creation date and time of the job flow.
 	CreationDateTime *time.Time `type:"timestamp" timestampFormat:"unix" required:"true"`
 
@@ -1762,8 +1764,6 @@ type JobFlowExecutionStatusDetail struct {
 
 	// The state of the job flow.
 	State *string `type:"string" required:"true" enum:"JobFlowExecutionState"`
-
-	_ struct{} `type:"structure"`
 }
 
 // String returns the string representation
@@ -1781,6 +1781,8 @@ func (s JobFlowExecutionStatusDetail) GoString() string {
 // However, a valid alternative is to have MasterInstanceType, SlaveInstanceType,
 // and InstanceCount (all three must be present).
 type JobFlowInstancesConfig struct {
+	_ struct{} `type:"structure"`
+
 	// A list of additional Amazon EC2 security group IDs for the master node.
 	AdditionalMasterSecurityGroups []*string `type:"list"`
 
@@ -1839,8 +1841,6 @@ type JobFlowInstancesConfig struct {
 	// from being terminated by API call, user intervention, or in the event of
 	// a job flow error.
 	TerminationProtected *bool `type:"boolean"`
-
-	_ struct{} `type:"structure"`
 }
 
 // String returns the string representation
@@ -1855,6 +1855,8 @@ func (s JobFlowInstancesConfig) GoString() string {
 
 // Specify the type of Amazon EC2 instances to run the job flow on.
 type JobFlowInstancesDetail struct {
+	_ struct{} `type:"structure"`
+
 	// The name of an Amazon EC2 key pair that can be used to ssh to the master
 	// node of job flow.
 	Ec2KeyName *string `type:"string"`
@@ -1904,8 +1906,6 @@ type JobFlowInstancesDetail struct {
 	// termination by API calls, user intervention, or in the event of a job flow
 	// error.
 	TerminationProtected *bool `type:"boolean"`
-
-	_ struct{} `type:"structure"`
 }
 
 // String returns the string representation
@@ -1920,13 +1920,13 @@ func (s JobFlowInstancesDetail) GoString() string {
 
 // A key value pair.
 type KeyValue struct {
+	_ struct{} `type:"structure"`
+
 	// The unique identifier of a key value pair.
 	Key *string `type:"string"`
 
 	// The value part of the identified key.
 	Value *string `type:"string"`
-
-	_ struct{} `type:"structure"`
 }
 
 // String returns the string representation
@@ -1941,13 +1941,13 @@ func (s KeyValue) GoString() string {
 
 // This input determines which bootstrap actions to retrieve.
 type ListBootstrapActionsInput struct {
+	_ struct{} `type:"structure"`
+
 	// The cluster identifier for the bootstrap actions to list .
 	ClusterId *string `type:"string" required:"true"`
 
 	// The pagination token that indicates the next set of results to retrieve .
 	Marker *string `type:"string"`
-
-	_ struct{} `type:"structure"`
 }
 
 // String returns the string representation
@@ -1962,13 +1962,13 @@ func (s ListBootstrapActionsInput) GoString() string {
 
 // This output contains the boostrap actions detail .
 type ListBootstrapActionsOutput struct {
+	_ struct{} `type:"structure"`
+
 	// The bootstrap actions associated with the cluster .
 	BootstrapActions []*Command `type:"list"`
 
 	// The pagination token that indicates the next set of results to retrieve .
 	Marker *string `type:"string"`
-
-	_ struct{} `type:"structure"`
 }
 
 // String returns the string representation
@@ -1984,6 +1984,8 @@ func (s ListBootstrapActionsOutput) GoString() string {
 // This input determines how the ListClusters action filters the list of clusters
 // that it returns.
 type ListClustersInput struct {
+	_ struct{} `type:"structure"`
+
 	// The cluster state filters to apply when listing clusters.
 	ClusterStates []*string `type:"list"`
 
@@ -1995,8 +1997,6 @@ type ListClustersInput struct {
 
 	// The pagination token that indicates the next set of results to retrieve.
 	Marker *string `type:"string"`
-
-	_ struct{} `type:"structure"`
 }
 
 // String returns the string representation
@@ -2012,13 +2012,13 @@ func (s ListClustersInput) GoString() string {
 // This contains a ClusterSummaryList with the cluster details; for example,
 // the cluster IDs, names, and status.
 type ListClustersOutput struct {
+	_ struct{} `type:"structure"`
+
 	// The list of clusters for the account based on the given filters.
 	Clusters []*ClusterSummary `type:"list"`
 
 	// The pagination token that indicates the next set of results to retrieve.
 	Marker *string `type:"string"`
-
-	_ struct{} `type:"structure"`
 }
 
 // String returns the string representation
@@ -2033,13 +2033,13 @@ func (s ListClustersOutput) GoString() string {
 
 // This input determines which instance groups to retrieve.
 type ListInstanceGroupsInput struct {
+	_ struct{} `type:"structure"`
+
 	// The identifier of the cluster for which to list the instance groups.
 	ClusterId *string `type:"string" required:"true"`
 
 	// The pagination token that indicates the next set of results to retrieve.
 	Marker *string `type:"string"`
-
-	_ struct{} `type:"structure"`
 }
 
 // String returns the string representation
@@ -2054,13 +2054,13 @@ func (s ListInstanceGroupsInput) GoString() string {
 
 // This input determines which instance groups to retrieve.
 type ListInstanceGroupsOutput struct {
+	_ struct{} `type:"structure"`
+
 	// The list of instance groups for the cluster and given filters.
 	InstanceGroups []*InstanceGroup `type:"list"`
 
 	// The pagination token that indicates the next set of results to retrieve.
 	Marker *string `type:"string"`
-
-	_ struct{} `type:"structure"`
 }
 
 // String returns the string representation
@@ -2075,6 +2075,8 @@ func (s ListInstanceGroupsOutput) GoString() string {
 
 // This input determines which instances to list.
 type ListInstancesInput struct {
+	_ struct{} `type:"structure"`
+
 	// The identifier of the cluster for which to list the instances.
 	ClusterId *string `type:"string" required:"true"`
 
@@ -2086,8 +2088,6 @@ type ListInstancesInput struct {
 
 	// The pagination token that indicates the next set of results to retrieve.
 	Marker *string `type:"string"`
-
-	_ struct{} `type:"structure"`
 }
 
 // String returns the string representation
@@ -2102,13 +2102,13 @@ func (s ListInstancesInput) GoString() string {
 
 // This output contains the list of instances.
 type ListInstancesOutput struct {
+	_ struct{} `type:"structure"`
+
 	// The list of instances for the cluster and given filters.
 	Instances []*Instance `type:"list"`
 
 	// The pagination token that indicates the next set of results to retrieve.
 	Marker *string `type:"string"`
-
-	_ struct{} `type:"structure"`
 }
 
 // String returns the string representation
@@ -2123,6 +2123,8 @@ func (s ListInstancesOutput) GoString() string {
 
 // This input determines which steps to list.
 type ListStepsInput struct {
+	_ struct{} `type:"structure"`
+
 	// The identifier of the cluster for which to list the steps.
 	ClusterId *string `type:"string" required:"true"`
 
@@ -2134,8 +2136,6 @@ type ListStepsInput struct {
 
 	// The filter to limit the step list based on certain states.
 	StepStates []*string `type:"list"`
-
-	_ struct{} `type:"structure"`
 }
 
 // String returns the string representation
@@ -2150,13 +2150,13 @@ func (s ListStepsInput) GoString() string {
 
 // This output contains the list of steps.
 type ListStepsOutput struct {
+	_ struct{} `type:"structure"`
+
 	// The pagination token that indicates the next set of results to retrieve.
 	Marker *string `type:"string"`
 
 	// The filtered list of steps for the cluster.
 	Steps []*StepSummary `type:"list"`
-
-	_ struct{} `type:"structure"`
 }
 
 // String returns the string representation
@@ -2171,10 +2171,10 @@ func (s ListStepsOutput) GoString() string {
 
 // Change the size of some instance groups.
 type ModifyInstanceGroupsInput struct {
+	_ struct{} `type:"structure"`
+
 	// Instance groups to change.
 	InstanceGroups []*InstanceGroupModifyConfig `type:"list"`
-
-	_ struct{} `type:"structure"`
 }
 
 // String returns the string representation
@@ -2203,10 +2203,10 @@ func (s ModifyInstanceGroupsOutput) GoString() string {
 
 // The Amazon EC2 location for the job flow.
 type PlacementType struct {
+	_ struct{} `type:"structure"`
+
 	// The Amazon EC2 Availability Zone for the job flow.
 	AvailabilityZone *string `type:"string" required:"true"`
-
-	_ struct{} `type:"structure"`
 }
 
 // String returns the string representation
@@ -2221,14 +2221,14 @@ func (s PlacementType) GoString() string {
 
 // This input identifies a cluster and a list of tags to remove.
 type RemoveTagsInput struct {
+	_ struct{} `type:"structure"`
+
 	// The Amazon EMR resource identifier from which tags will be removed. This
 	// value must be a cluster identifier.
 	ResourceId *string `type:"string" required:"true"`
 
 	// A list of tag keys to remove from a resource.
 	TagKeys []*string `type:"list" required:"true"`
-
-	_ struct{} `type:"structure"`
 }
 
 // String returns the string representation
@@ -2258,6 +2258,8 @@ func (s RemoveTagsOutput) GoString() string {
 
 // Input to the RunJobFlow operation.
 type RunJobFlowInput struct {
+	_ struct{} `type:"structure"`
+
 	// A JSON string for selecting additional features.
 	AdditionalInfo *string `type:"string"`
 
@@ -2362,8 +2364,6 @@ type RunJobFlowInput struct {
 	// the job flow. If it is set to false, only the IAM user that created the job
 	// flow can view and manage it.
 	VisibleToAllUsers *bool `type:"boolean"`
-
-	_ struct{} `type:"structure"`
 }
 
 // String returns the string representation
@@ -2378,10 +2378,10 @@ func (s RunJobFlowInput) GoString() string {
 
 // The result of the RunJobFlow operation.
 type RunJobFlowOutput struct {
+	_ struct{} `type:"structure"`
+
 	// An unique identifier for the job flow.
 	JobFlowId *string `type:"string"`
-
-	_ struct{} `type:"structure"`
 }
 
 // String returns the string representation
@@ -2396,14 +2396,14 @@ func (s RunJobFlowOutput) GoString() string {
 
 // Configuration of the script to run during a bootstrap action.
 type ScriptBootstrapActionConfig struct {
+	_ struct{} `type:"structure"`
+
 	// A list of command line arguments to pass to the bootstrap action script.
 	Args []*string `type:"list"`
 
 	// Location of the script to run during a bootstrap action. Can be either a
 	// location in Amazon S3 or on a local file system.
 	Path *string `type:"string" required:"true"`
-
-	_ struct{} `type:"structure"`
 }
 
 // String returns the string representation
@@ -2418,6 +2418,8 @@ func (s ScriptBootstrapActionConfig) GoString() string {
 
 // The input argument to the TerminationProtection operation.
 type SetTerminationProtectionInput struct {
+	_ struct{} `type:"structure"`
+
 	// A list of strings that uniquely identify the job flows to protect. This identifier
 	// is returned by RunJobFlow and can also be obtained from DescribeJobFlows
 	// .
@@ -2427,8 +2429,6 @@ type SetTerminationProtectionInput struct {
 	// Amazon EC2 instances in the cluster from shutting down due to API calls,
 	// user intervention, or job-flow error.
 	TerminationProtected *bool `type:"boolean" required:"true"`
-
-	_ struct{} `type:"structure"`
 }
 
 // String returns the string representation
@@ -2457,6 +2457,8 @@ func (s SetTerminationProtectionOutput) GoString() string {
 
 // The input to the SetVisibleToAllUsers action.
 type SetVisibleToAllUsersInput struct {
+	_ struct{} `type:"structure"`
+
 	// Identifiers of the job flows to receive the new visibility setting.
 	JobFlowIds []*string `type:"list" required:"true"`
 
@@ -2466,8 +2468,6 @@ type SetVisibleToAllUsersInput struct {
 	// set, manage the job flows. If it is set to False, only the IAM user that
 	// created a job flow can view and manage it.
 	VisibleToAllUsers *bool `type:"boolean" required:"true"`
-
-	_ struct{} `type:"structure"`
 }
 
 // String returns the string representation
@@ -2496,6 +2496,8 @@ func (s SetVisibleToAllUsersOutput) GoString() string {
 
 // This represents a step in a cluster.
 type Step struct {
+	_ struct{} `type:"structure"`
+
 	// This specifies what action to take when the cluster step fails. Possible
 	// values are TERMINATE_CLUSTER, CANCEL_AND_WAIT, and CONTINUE.
 	ActionOnFailure *string `type:"string" enum:"ActionOnFailure"`
@@ -2511,8 +2513,6 @@ type Step struct {
 
 	// The current execution status details of the cluster step.
 	Status *StepStatus `type:"structure"`
-
-	_ struct{} `type:"structure"`
 }
 
 // String returns the string representation
@@ -2527,6 +2527,8 @@ func (s Step) GoString() string {
 
 // Specification of a job flow step.
 type StepConfig struct {
+	_ struct{} `type:"structure"`
+
 	// The action to take if the job flow step fails.
 	ActionOnFailure *string `type:"string" enum:"ActionOnFailure"`
 
@@ -2535,8 +2537,6 @@ type StepConfig struct {
 
 	// The name of the job flow step.
 	Name *string `type:"string" required:"true"`
-
-	_ struct{} `type:"structure"`
 }
 
 // String returns the string representation
@@ -2551,13 +2551,13 @@ func (s StepConfig) GoString() string {
 
 // Combines the execution state and configuration of a step.
 type StepDetail struct {
+	_ struct{} `type:"structure"`
+
 	// The description of the step status.
 	ExecutionStatusDetail *StepExecutionStatusDetail `type:"structure" required:"true"`
 
 	// The step configuration.
 	StepConfig *StepConfig `type:"structure" required:"true"`
-
-	_ struct{} `type:"structure"`
 }
 
 // String returns the string representation
@@ -2572,6 +2572,8 @@ func (s StepDetail) GoString() string {
 
 // The execution state of a step.
 type StepExecutionStatusDetail struct {
+	_ struct{} `type:"structure"`
+
 	// The creation date and time of the step.
 	CreationDateTime *time.Time `type:"timestamp" timestampFormat:"unix" required:"true"`
 
@@ -2586,8 +2588,6 @@ type StepExecutionStatusDetail struct {
 
 	// The state of the job flow step.
 	State *string `type:"string" required:"true" enum:"StepExecutionState"`
-
-	_ struct{} `type:"structure"`
 }
 
 // String returns the string representation
@@ -2602,14 +2602,14 @@ func (s StepExecutionStatusDetail) GoString() string {
 
 // The details of the step state change reason.
 type StepStateChangeReason struct {
+	_ struct{} `type:"structure"`
+
 	// The programmable code for the state change reason. Note: Currently, the service
 	// provides no code for the state change.
 	Code *string `type:"string" enum:"StepStateChangeReasonCode"`
 
 	// The descriptive message for the state change reason.
 	Message *string `type:"string"`
-
-	_ struct{} `type:"structure"`
 }
 
 // String returns the string representation
@@ -2624,6 +2624,8 @@ func (s StepStateChangeReason) GoString() string {
 
 // The execution status details of the cluster step.
 type StepStatus struct {
+	_ struct{} `type:"structure"`
+
 	// The execution state of the cluster step.
 	State *string `type:"string" enum:"StepState"`
 
@@ -2632,8 +2634,6 @@ type StepStatus struct {
 
 	// The timeline of the cluster step status over time.
 	Timeline *StepTimeline `type:"structure"`
-
-	_ struct{} `type:"structure"`
 }
 
 // String returns the string representation
@@ -2648,6 +2648,8 @@ func (s StepStatus) GoString() string {
 
 // The summary of the cluster step.
 type StepSummary struct {
+	_ struct{} `type:"structure"`
+
 	// This specifies what action to take when the cluster step fails. Possible
 	// values are TERMINATE_CLUSTER, CANCEL_AND_WAIT, and CONTINUE.
 	ActionOnFailure *string `type:"string" enum:"ActionOnFailure"`
@@ -2663,8 +2665,6 @@ type StepSummary struct {
 
 	// The current execution status details of the cluster step.
 	Status *StepStatus `type:"structure"`
-
-	_ struct{} `type:"structure"`
 }
 
 // String returns the string representation
@@ -2679,6 +2679,8 @@ func (s StepSummary) GoString() string {
 
 // The timeline of the cluster step lifecycle.
 type StepTimeline struct {
+	_ struct{} `type:"structure"`
+
 	// The date and time when the cluster step was created.
 	CreationDateTime *time.Time `type:"timestamp" timestampFormat:"unix"`
 
@@ -2687,8 +2689,6 @@ type StepTimeline struct {
 
 	// The date and time when the cluster step execution started.
 	StartDateTime *time.Time `type:"timestamp" timestampFormat:"unix"`
-
-	_ struct{} `type:"structure"`
 }
 
 // String returns the string representation
@@ -2705,13 +2705,13 @@ func (s StepTimeline) GoString() string {
 // EMR accepts these arguments and forwards them to the corresponding installation
 // script as bootstrap action arguments.
 type SupportedProductConfig struct {
+	_ struct{} `type:"structure"`
+
 	// The list of user-supplied arguments.
 	Args []*string `type:"list"`
 
 	// The name of the product configuration.
 	Name *string `type:"string"`
-
-	_ struct{} `type:"structure"`
 }
 
 // String returns the string representation
@@ -2730,6 +2730,8 @@ func (s SupportedProductConfig) GoString() string {
 // allocation costs. For more information, see Tagging Amazon EMR Resources
 // (http://docs.aws.amazon.com/ElasticMapReduce/latest/DeveloperGuide/emr-plan-tags.html).
 type Tag struct {
+	_ struct{} `type:"structure"`
+
 	// A user-defined key, which is the minimum required information for a valid
 	// tag. For more information, see Tagging Amazon EMR Resources (http://docs.aws.amazon.com/ElasticMapReduce/latest/DeveloperGuide/emr-plan-tags.html).
 	Key *string `type:"string"`
@@ -2737,8 +2739,6 @@ type Tag struct {
 	// A user-defined value, which is optional in a tag. For more information, see
 	// Tagging Amazon EMR Resources (http://docs.aws.amazon.com/ElasticMapReduce/latest/DeveloperGuide/emr-plan-tags.html).
 	Value *string `type:"string"`
-
-	_ struct{} `type:"structure"`
 }
 
 // String returns the string representation
@@ -2753,10 +2753,10 @@ func (s Tag) GoString() string {
 
 // Input to the TerminateJobFlows operation.
 type TerminateJobFlowsInput struct {
+	_ struct{} `type:"structure"`
+
 	// A list of job flows to be shutdown.
 	JobFlowIds []*string `type:"list" required:"true"`
-
-	_ struct{} `type:"structure"`
 }
 
 // String returns the string representation

--- a/service/emr/api.go
+++ b/service/emr/api.go
@@ -658,11 +658,7 @@ type AddInstanceGroupsInput struct {
 	// Job flow in which to add the instance groups.
 	JobFlowId *string `type:"string" required:"true"`
 
-	metadataAddInstanceGroupsInput `json:"-" xml:"-"`
-}
-
-type metadataAddInstanceGroupsInput struct {
-	SDKShapeTraits bool `type:"structure"`
+	_ struct{} `type:"structure"`
 }
 
 // String returns the string representation
@@ -683,11 +679,7 @@ type AddInstanceGroupsOutput struct {
 	// The job flow ID in which the instance groups are added.
 	JobFlowId *string `type:"string"`
 
-	metadataAddInstanceGroupsOutput `json:"-" xml:"-"`
-}
-
-type metadataAddInstanceGroupsOutput struct {
-	SDKShapeTraits bool `type:"structure"`
+	_ struct{} `type:"structure"`
 }
 
 // String returns the string representation
@@ -709,11 +701,7 @@ type AddJobFlowStepsInput struct {
 	// A list of StepConfig to be executed by the job flow.
 	Steps []*StepConfig `type:"list" required:"true"`
 
-	metadataAddJobFlowStepsInput `json:"-" xml:"-"`
-}
-
-type metadataAddJobFlowStepsInput struct {
-	SDKShapeTraits bool `type:"structure"`
+	_ struct{} `type:"structure"`
 }
 
 // String returns the string representation
@@ -731,11 +719,7 @@ type AddJobFlowStepsOutput struct {
 	// The identifiers of the list of steps added to the job flow.
 	StepIds []*string `type:"list"`
 
-	metadataAddJobFlowStepsOutput `json:"-" xml:"-"`
-}
-
-type metadataAddJobFlowStepsOutput struct {
-	SDKShapeTraits bool `type:"structure"`
+	_ struct{} `type:"structure"`
 }
 
 // String returns the string representation
@@ -760,11 +744,7 @@ type AddTagsInput struct {
 	// of 256 characters.
 	Tags []*Tag `type:"list" required:"true"`
 
-	metadataAddTagsInput `json:"-" xml:"-"`
-}
-
-type metadataAddTagsInput struct {
-	SDKShapeTraits bool `type:"structure"`
+	_ struct{} `type:"structure"`
 }
 
 // String returns the string representation
@@ -779,11 +759,7 @@ func (s AddTagsInput) GoString() string {
 
 // This output indicates the result of adding tags to a resource.
 type AddTagsOutput struct {
-	metadataAddTagsOutput `json:"-" xml:"-"`
-}
-
-type metadataAddTagsOutput struct {
-	SDKShapeTraits bool `type:"structure"`
+	_ struct{} `type:"structure"`
 }
 
 // String returns the string representation
@@ -824,11 +800,7 @@ type Application struct {
 	// The version of the application.
 	Version *string `type:"string"`
 
-	metadataApplication `json:"-" xml:"-"`
-}
-
-type metadataApplication struct {
-	SDKShapeTraits bool `type:"structure"`
+	_ struct{} `type:"structure"`
 }
 
 // String returns the string representation
@@ -849,11 +821,7 @@ type BootstrapActionConfig struct {
 	// The script run by the bootstrap action.
 	ScriptBootstrapAction *ScriptBootstrapActionConfig `type:"structure" required:"true"`
 
-	metadataBootstrapActionConfig `json:"-" xml:"-"`
-}
-
-type metadataBootstrapActionConfig struct {
-	SDKShapeTraits bool `type:"structure"`
+	_ struct{} `type:"structure"`
 }
 
 // String returns the string representation
@@ -871,11 +839,7 @@ type BootstrapActionDetail struct {
 	// A description of the bootstrap action.
 	BootstrapActionConfig *BootstrapActionConfig `type:"structure"`
 
-	metadataBootstrapActionDetail `json:"-" xml:"-"`
-}
-
-type metadataBootstrapActionDetail struct {
-	SDKShapeTraits bool `type:"structure"`
+	_ struct{} `type:"structure"`
 }
 
 // String returns the string representation
@@ -958,11 +922,7 @@ type Cluster struct {
 	// action.
 	VisibleToAllUsers *bool `type:"boolean"`
 
-	metadataCluster `json:"-" xml:"-"`
-}
-
-type metadataCluster struct {
-	SDKShapeTraits bool `type:"structure"`
+	_ struct{} `type:"structure"`
 }
 
 // String returns the string representation
@@ -983,11 +943,7 @@ type ClusterStateChangeReason struct {
 	// The descriptive message for the state change reason.
 	Message *string `type:"string"`
 
-	metadataClusterStateChangeReason `json:"-" xml:"-"`
-}
-
-type metadataClusterStateChangeReason struct {
-	SDKShapeTraits bool `type:"structure"`
+	_ struct{} `type:"structure"`
 }
 
 // String returns the string representation
@@ -1012,11 +968,7 @@ type ClusterStatus struct {
 	// cluster.
 	Timeline *ClusterTimeline `type:"structure"`
 
-	metadataClusterStatus `json:"-" xml:"-"`
-}
-
-type metadataClusterStatus struct {
-	SDKShapeTraits bool `type:"structure"`
+	_ struct{} `type:"structure"`
 }
 
 // String returns the string representation
@@ -1048,11 +1000,7 @@ type ClusterSummary struct {
 	// The details about the current status of the cluster.
 	Status *ClusterStatus `type:"structure"`
 
-	metadataClusterSummary `json:"-" xml:"-"`
-}
-
-type metadataClusterSummary struct {
-	SDKShapeTraits bool `type:"structure"`
+	_ struct{} `type:"structure"`
 }
 
 // String returns the string representation
@@ -1076,11 +1024,7 @@ type ClusterTimeline struct {
 	// The date and time when the cluster was ready to execute steps.
 	ReadyDateTime *time.Time `type:"timestamp" timestampFormat:"unix"`
 
-	metadataClusterTimeline `json:"-" xml:"-"`
-}
-
-type metadataClusterTimeline struct {
-	SDKShapeTraits bool `type:"structure"`
+	_ struct{} `type:"structure"`
 }
 
 // String returns the string representation
@@ -1104,11 +1048,7 @@ type Command struct {
 	// The Amazon S3 location of the command script.
 	ScriptPath *string `type:"string"`
 
-	metadataCommand `json:"-" xml:"-"`
-}
-
-type metadataCommand struct {
-	SDKShapeTraits bool `type:"structure"`
+	_ struct{} `type:"structure"`
 }
 
 // String returns the string representation
@@ -1139,11 +1079,7 @@ type Configuration struct {
 	// A set of properties supplied to the Configuration object.
 	Properties map[string]*string `type:"map"`
 
-	metadataConfiguration `json:"-" xml:"-"`
-}
-
-type metadataConfiguration struct {
-	SDKShapeTraits bool `type:"structure"`
+	_ struct{} `type:"structure"`
 }
 
 // String returns the string representation
@@ -1161,11 +1097,7 @@ type DescribeClusterInput struct {
 	// The identifier of the cluster to describe.
 	ClusterId *string `type:"string" required:"true"`
 
-	metadataDescribeClusterInput `json:"-" xml:"-"`
-}
-
-type metadataDescribeClusterInput struct {
-	SDKShapeTraits bool `type:"structure"`
+	_ struct{} `type:"structure"`
 }
 
 // String returns the string representation
@@ -1183,11 +1115,7 @@ type DescribeClusterOutput struct {
 	// This output contains the details for the requested cluster.
 	Cluster *Cluster `type:"structure"`
 
-	metadataDescribeClusterOutput `json:"-" xml:"-"`
-}
-
-type metadataDescribeClusterOutput struct {
-	SDKShapeTraits bool `type:"structure"`
+	_ struct{} `type:"structure"`
 }
 
 // String returns the string representation
@@ -1214,11 +1142,7 @@ type DescribeJobFlowsInput struct {
 	// Return only job flows whose state is contained in this list.
 	JobFlowStates []*string `type:"list"`
 
-	metadataDescribeJobFlowsInput `json:"-" xml:"-"`
-}
-
-type metadataDescribeJobFlowsInput struct {
-	SDKShapeTraits bool `type:"structure"`
+	_ struct{} `type:"structure"`
 }
 
 // String returns the string representation
@@ -1236,11 +1160,7 @@ type DescribeJobFlowsOutput struct {
 	// A list of job flows matching the parameters supplied.
 	JobFlows []*JobFlowDetail `type:"list"`
 
-	metadataDescribeJobFlowsOutput `json:"-" xml:"-"`
-}
-
-type metadataDescribeJobFlowsOutput struct {
-	SDKShapeTraits bool `type:"structure"`
+	_ struct{} `type:"structure"`
 }
 
 // String returns the string representation
@@ -1261,11 +1181,7 @@ type DescribeStepInput struct {
 	// The identifier of the step to describe.
 	StepId *string `type:"string" required:"true"`
 
-	metadataDescribeStepInput `json:"-" xml:"-"`
-}
-
-type metadataDescribeStepInput struct {
-	SDKShapeTraits bool `type:"structure"`
+	_ struct{} `type:"structure"`
 }
 
 // String returns the string representation
@@ -1283,11 +1199,7 @@ type DescribeStepOutput struct {
 	// The step details for the requested step identifier.
 	Step *Step `type:"structure"`
 
-	metadataDescribeStepOutput `json:"-" xml:"-"`
-}
-
-type metadataDescribeStepOutput struct {
-	SDKShapeTraits bool `type:"structure"`
+	_ struct{} `type:"structure"`
 }
 
 // String returns the string representation
@@ -1338,11 +1250,7 @@ type Ec2InstanceAttributes struct {
 	// of the job flow assume this role.
 	IamInstanceProfile *string `type:"string"`
 
-	metadataEc2InstanceAttributes `json:"-" xml:"-"`
-}
-
-type metadataEc2InstanceAttributes struct {
-	SDKShapeTraits bool `type:"structure"`
+	_ struct{} `type:"structure"`
 }
 
 // String returns the string representation
@@ -1374,11 +1282,7 @@ type HadoopJarStepConfig struct {
 	// properties to pass key value pairs to your main function.
 	Properties []*KeyValue `type:"list"`
 
-	metadataHadoopJarStepConfig `json:"-" xml:"-"`
-}
-
-type metadataHadoopJarStepConfig struct {
-	SDKShapeTraits bool `type:"structure"`
+	_ struct{} `type:"structure"`
 }
 
 // String returns the string representation
@@ -1410,11 +1314,7 @@ type HadoopStepConfig struct {
 	// these properties to pass key value pairs to your main function.
 	Properties map[string]*string `type:"map"`
 
-	metadataHadoopStepConfig `json:"-" xml:"-"`
-}
-
-type metadataHadoopStepConfig struct {
-	SDKShapeTraits bool `type:"structure"`
+	_ struct{} `type:"structure"`
 }
 
 // String returns the string representation
@@ -1450,11 +1350,7 @@ type Instance struct {
 	// The current status of the instance.
 	Status *InstanceStatus `type:"structure"`
 
-	metadataInstance `json:"-" xml:"-"`
-}
-
-type metadataInstance struct {
-	SDKShapeTraits bool `type:"structure"`
+	_ struct{} `type:"structure"`
 }
 
 // String returns the string representation
@@ -1506,11 +1402,7 @@ type InstanceGroup struct {
 	// The current status of the instance group.
 	Status *InstanceGroupStatus `type:"structure"`
 
-	metadataInstanceGroup `json:"-" xml:"-"`
-}
-
-type metadataInstanceGroup struct {
-	SDKShapeTraits bool `type:"structure"`
+	_ struct{} `type:"structure"`
 }
 
 // String returns the string representation
@@ -1551,11 +1443,7 @@ type InstanceGroupConfig struct {
 	// Friendly name given to the instance group.
 	Name *string `type:"string"`
 
-	metadataInstanceGroupConfig `json:"-" xml:"-"`
-}
-
-type metadataInstanceGroupConfig struct {
-	SDKShapeTraits bool `type:"structure"`
+	_ struct{} `type:"structure"`
 }
 
 // String returns the string representation
@@ -1614,11 +1502,7 @@ type InstanceGroupDetail struct {
 	// and FAILED.
 	State *string `type:"string" required:"true" enum:"InstanceGroupState"`
 
-	metadataInstanceGroupDetail `json:"-" xml:"-"`
-}
-
-type metadataInstanceGroupDetail struct {
-	SDKShapeTraits bool `type:"structure"`
+	_ struct{} `type:"structure"`
 }
 
 // String returns the string representation
@@ -1644,11 +1528,7 @@ type InstanceGroupModifyConfig struct {
 	// Unique ID of the instance group to expand or shrink.
 	InstanceGroupId *string `type:"string" required:"true"`
 
-	metadataInstanceGroupModifyConfig `json:"-" xml:"-"`
-}
-
-type metadataInstanceGroupModifyConfig struct {
-	SDKShapeTraits bool `type:"structure"`
+	_ struct{} `type:"structure"`
 }
 
 // String returns the string representation
@@ -1669,11 +1549,7 @@ type InstanceGroupStateChangeReason struct {
 	// The status change reason description.
 	Message *string `type:"string"`
 
-	metadataInstanceGroupStateChangeReason `json:"-" xml:"-"`
-}
-
-type metadataInstanceGroupStateChangeReason struct {
-	SDKShapeTraits bool `type:"structure"`
+	_ struct{} `type:"structure"`
 }
 
 // String returns the string representation
@@ -1697,11 +1573,7 @@ type InstanceGroupStatus struct {
 	// The timeline of the instance group status over time.
 	Timeline *InstanceGroupTimeline `type:"structure"`
 
-	metadataInstanceGroupStatus `json:"-" xml:"-"`
-}
-
-type metadataInstanceGroupStatus struct {
-	SDKShapeTraits bool `type:"structure"`
+	_ struct{} `type:"structure"`
 }
 
 // String returns the string representation
@@ -1725,11 +1597,7 @@ type InstanceGroupTimeline struct {
 	// The date and time when the instance group became ready to perform tasks.
 	ReadyDateTime *time.Time `type:"timestamp" timestampFormat:"unix"`
 
-	metadataInstanceGroupTimeline `json:"-" xml:"-"`
-}
-
-type metadataInstanceGroupTimeline struct {
-	SDKShapeTraits bool `type:"structure"`
+	_ struct{} `type:"structure"`
 }
 
 // String returns the string representation
@@ -1750,11 +1618,7 @@ type InstanceStateChangeReason struct {
 	// The status change reason description.
 	Message *string `type:"string"`
 
-	metadataInstanceStateChangeReason `json:"-" xml:"-"`
-}
-
-type metadataInstanceStateChangeReason struct {
-	SDKShapeTraits bool `type:"structure"`
+	_ struct{} `type:"structure"`
 }
 
 // String returns the string representation
@@ -1778,11 +1642,7 @@ type InstanceStatus struct {
 	// The timeline of the instance status over time.
 	Timeline *InstanceTimeline `type:"structure"`
 
-	metadataInstanceStatus `json:"-" xml:"-"`
-}
-
-type metadataInstanceStatus struct {
-	SDKShapeTraits bool `type:"structure"`
+	_ struct{} `type:"structure"`
 }
 
 // String returns the string representation
@@ -1806,11 +1666,7 @@ type InstanceTimeline struct {
 	// The date and time when the instance was ready to perform tasks.
 	ReadyDateTime *time.Time `type:"timestamp" timestampFormat:"unix"`
 
-	metadataInstanceTimeline `json:"-" xml:"-"`
-}
-
-type metadataInstanceTimeline struct {
-	SDKShapeTraits bool `type:"structure"`
+	_ struct{} `type:"structure"`
 }
 
 // String returns the string representation
@@ -1873,11 +1729,7 @@ type JobFlowDetail struct {
 	// SetVisibleToAllUsers action.
 	VisibleToAllUsers *bool `type:"boolean"`
 
-	metadataJobFlowDetail `json:"-" xml:"-"`
-}
-
-type metadataJobFlowDetail struct {
-	SDKShapeTraits bool `type:"structure"`
+	_ struct{} `type:"structure"`
 }
 
 // String returns the string representation
@@ -1911,11 +1763,7 @@ type JobFlowExecutionStatusDetail struct {
 	// The state of the job flow.
 	State *string `type:"string" required:"true" enum:"JobFlowExecutionState"`
 
-	metadataJobFlowExecutionStatusDetail `json:"-" xml:"-"`
-}
-
-type metadataJobFlowExecutionStatusDetail struct {
-	SDKShapeTraits bool `type:"structure"`
+	_ struct{} `type:"structure"`
 }
 
 // String returns the string representation
@@ -1992,11 +1840,7 @@ type JobFlowInstancesConfig struct {
 	// a job flow error.
 	TerminationProtected *bool `type:"boolean"`
 
-	metadataJobFlowInstancesConfig `json:"-" xml:"-"`
-}
-
-type metadataJobFlowInstancesConfig struct {
-	SDKShapeTraits bool `type:"structure"`
+	_ struct{} `type:"structure"`
 }
 
 // String returns the string representation
@@ -2061,11 +1905,7 @@ type JobFlowInstancesDetail struct {
 	// error.
 	TerminationProtected *bool `type:"boolean"`
 
-	metadataJobFlowInstancesDetail `json:"-" xml:"-"`
-}
-
-type metadataJobFlowInstancesDetail struct {
-	SDKShapeTraits bool `type:"structure"`
+	_ struct{} `type:"structure"`
 }
 
 // String returns the string representation
@@ -2086,11 +1926,7 @@ type KeyValue struct {
 	// The value part of the identified key.
 	Value *string `type:"string"`
 
-	metadataKeyValue `json:"-" xml:"-"`
-}
-
-type metadataKeyValue struct {
-	SDKShapeTraits bool `type:"structure"`
+	_ struct{} `type:"structure"`
 }
 
 // String returns the string representation
@@ -2111,11 +1947,7 @@ type ListBootstrapActionsInput struct {
 	// The pagination token that indicates the next set of results to retrieve .
 	Marker *string `type:"string"`
 
-	metadataListBootstrapActionsInput `json:"-" xml:"-"`
-}
-
-type metadataListBootstrapActionsInput struct {
-	SDKShapeTraits bool `type:"structure"`
+	_ struct{} `type:"structure"`
 }
 
 // String returns the string representation
@@ -2136,11 +1968,7 @@ type ListBootstrapActionsOutput struct {
 	// The pagination token that indicates the next set of results to retrieve .
 	Marker *string `type:"string"`
 
-	metadataListBootstrapActionsOutput `json:"-" xml:"-"`
-}
-
-type metadataListBootstrapActionsOutput struct {
-	SDKShapeTraits bool `type:"structure"`
+	_ struct{} `type:"structure"`
 }
 
 // String returns the string representation
@@ -2168,11 +1996,7 @@ type ListClustersInput struct {
 	// The pagination token that indicates the next set of results to retrieve.
 	Marker *string `type:"string"`
 
-	metadataListClustersInput `json:"-" xml:"-"`
-}
-
-type metadataListClustersInput struct {
-	SDKShapeTraits bool `type:"structure"`
+	_ struct{} `type:"structure"`
 }
 
 // String returns the string representation
@@ -2194,11 +2018,7 @@ type ListClustersOutput struct {
 	// The pagination token that indicates the next set of results to retrieve.
 	Marker *string `type:"string"`
 
-	metadataListClustersOutput `json:"-" xml:"-"`
-}
-
-type metadataListClustersOutput struct {
-	SDKShapeTraits bool `type:"structure"`
+	_ struct{} `type:"structure"`
 }
 
 // String returns the string representation
@@ -2219,11 +2039,7 @@ type ListInstanceGroupsInput struct {
 	// The pagination token that indicates the next set of results to retrieve.
 	Marker *string `type:"string"`
 
-	metadataListInstanceGroupsInput `json:"-" xml:"-"`
-}
-
-type metadataListInstanceGroupsInput struct {
-	SDKShapeTraits bool `type:"structure"`
+	_ struct{} `type:"structure"`
 }
 
 // String returns the string representation
@@ -2244,11 +2060,7 @@ type ListInstanceGroupsOutput struct {
 	// The pagination token that indicates the next set of results to retrieve.
 	Marker *string `type:"string"`
 
-	metadataListInstanceGroupsOutput `json:"-" xml:"-"`
-}
-
-type metadataListInstanceGroupsOutput struct {
-	SDKShapeTraits bool `type:"structure"`
+	_ struct{} `type:"structure"`
 }
 
 // String returns the string representation
@@ -2275,11 +2087,7 @@ type ListInstancesInput struct {
 	// The pagination token that indicates the next set of results to retrieve.
 	Marker *string `type:"string"`
 
-	metadataListInstancesInput `json:"-" xml:"-"`
-}
-
-type metadataListInstancesInput struct {
-	SDKShapeTraits bool `type:"structure"`
+	_ struct{} `type:"structure"`
 }
 
 // String returns the string representation
@@ -2300,11 +2108,7 @@ type ListInstancesOutput struct {
 	// The pagination token that indicates the next set of results to retrieve.
 	Marker *string `type:"string"`
 
-	metadataListInstancesOutput `json:"-" xml:"-"`
-}
-
-type metadataListInstancesOutput struct {
-	SDKShapeTraits bool `type:"structure"`
+	_ struct{} `type:"structure"`
 }
 
 // String returns the string representation
@@ -2331,11 +2135,7 @@ type ListStepsInput struct {
 	// The filter to limit the step list based on certain states.
 	StepStates []*string `type:"list"`
 
-	metadataListStepsInput `json:"-" xml:"-"`
-}
-
-type metadataListStepsInput struct {
-	SDKShapeTraits bool `type:"structure"`
+	_ struct{} `type:"structure"`
 }
 
 // String returns the string representation
@@ -2356,11 +2156,7 @@ type ListStepsOutput struct {
 	// The filtered list of steps for the cluster.
 	Steps []*StepSummary `type:"list"`
 
-	metadataListStepsOutput `json:"-" xml:"-"`
-}
-
-type metadataListStepsOutput struct {
-	SDKShapeTraits bool `type:"structure"`
+	_ struct{} `type:"structure"`
 }
 
 // String returns the string representation
@@ -2378,11 +2174,7 @@ type ModifyInstanceGroupsInput struct {
 	// Instance groups to change.
 	InstanceGroups []*InstanceGroupModifyConfig `type:"list"`
 
-	metadataModifyInstanceGroupsInput `json:"-" xml:"-"`
-}
-
-type metadataModifyInstanceGroupsInput struct {
-	SDKShapeTraits bool `type:"structure"`
+	_ struct{} `type:"structure"`
 }
 
 // String returns the string representation
@@ -2396,11 +2188,7 @@ func (s ModifyInstanceGroupsInput) GoString() string {
 }
 
 type ModifyInstanceGroupsOutput struct {
-	metadataModifyInstanceGroupsOutput `json:"-" xml:"-"`
-}
-
-type metadataModifyInstanceGroupsOutput struct {
-	SDKShapeTraits bool `type:"structure"`
+	_ struct{} `type:"structure"`
 }
 
 // String returns the string representation
@@ -2418,11 +2206,7 @@ type PlacementType struct {
 	// The Amazon EC2 Availability Zone for the job flow.
 	AvailabilityZone *string `type:"string" required:"true"`
 
-	metadataPlacementType `json:"-" xml:"-"`
-}
-
-type metadataPlacementType struct {
-	SDKShapeTraits bool `type:"structure"`
+	_ struct{} `type:"structure"`
 }
 
 // String returns the string representation
@@ -2444,11 +2228,7 @@ type RemoveTagsInput struct {
 	// A list of tag keys to remove from a resource.
 	TagKeys []*string `type:"list" required:"true"`
 
-	metadataRemoveTagsInput `json:"-" xml:"-"`
-}
-
-type metadataRemoveTagsInput struct {
-	SDKShapeTraits bool `type:"structure"`
+	_ struct{} `type:"structure"`
 }
 
 // String returns the string representation
@@ -2463,11 +2243,7 @@ func (s RemoveTagsInput) GoString() string {
 
 // This output indicates the result of removing tags from a resource.
 type RemoveTagsOutput struct {
-	metadataRemoveTagsOutput `json:"-" xml:"-"`
-}
-
-type metadataRemoveTagsOutput struct {
-	SDKShapeTraits bool `type:"structure"`
+	_ struct{} `type:"structure"`
 }
 
 // String returns the string representation
@@ -2587,11 +2363,7 @@ type RunJobFlowInput struct {
 	// flow can view and manage it.
 	VisibleToAllUsers *bool `type:"boolean"`
 
-	metadataRunJobFlowInput `json:"-" xml:"-"`
-}
-
-type metadataRunJobFlowInput struct {
-	SDKShapeTraits bool `type:"structure"`
+	_ struct{} `type:"structure"`
 }
 
 // String returns the string representation
@@ -2609,11 +2381,7 @@ type RunJobFlowOutput struct {
 	// An unique identifier for the job flow.
 	JobFlowId *string `type:"string"`
 
-	metadataRunJobFlowOutput `json:"-" xml:"-"`
-}
-
-type metadataRunJobFlowOutput struct {
-	SDKShapeTraits bool `type:"structure"`
+	_ struct{} `type:"structure"`
 }
 
 // String returns the string representation
@@ -2635,11 +2403,7 @@ type ScriptBootstrapActionConfig struct {
 	// location in Amazon S3 or on a local file system.
 	Path *string `type:"string" required:"true"`
 
-	metadataScriptBootstrapActionConfig `json:"-" xml:"-"`
-}
-
-type metadataScriptBootstrapActionConfig struct {
-	SDKShapeTraits bool `type:"structure"`
+	_ struct{} `type:"structure"`
 }
 
 // String returns the string representation
@@ -2664,11 +2428,7 @@ type SetTerminationProtectionInput struct {
 	// user intervention, or job-flow error.
 	TerminationProtected *bool `type:"boolean" required:"true"`
 
-	metadataSetTerminationProtectionInput `json:"-" xml:"-"`
-}
-
-type metadataSetTerminationProtectionInput struct {
-	SDKShapeTraits bool `type:"structure"`
+	_ struct{} `type:"structure"`
 }
 
 // String returns the string representation
@@ -2682,11 +2442,7 @@ func (s SetTerminationProtectionInput) GoString() string {
 }
 
 type SetTerminationProtectionOutput struct {
-	metadataSetTerminationProtectionOutput `json:"-" xml:"-"`
-}
-
-type metadataSetTerminationProtectionOutput struct {
-	SDKShapeTraits bool `type:"structure"`
+	_ struct{} `type:"structure"`
 }
 
 // String returns the string representation
@@ -2711,11 +2467,7 @@ type SetVisibleToAllUsersInput struct {
 	// created a job flow can view and manage it.
 	VisibleToAllUsers *bool `type:"boolean" required:"true"`
 
-	metadataSetVisibleToAllUsersInput `json:"-" xml:"-"`
-}
-
-type metadataSetVisibleToAllUsersInput struct {
-	SDKShapeTraits bool `type:"structure"`
+	_ struct{} `type:"structure"`
 }
 
 // String returns the string representation
@@ -2729,11 +2481,7 @@ func (s SetVisibleToAllUsersInput) GoString() string {
 }
 
 type SetVisibleToAllUsersOutput struct {
-	metadataSetVisibleToAllUsersOutput `json:"-" xml:"-"`
-}
-
-type metadataSetVisibleToAllUsersOutput struct {
-	SDKShapeTraits bool `type:"structure"`
+	_ struct{} `type:"structure"`
 }
 
 // String returns the string representation
@@ -2764,11 +2512,7 @@ type Step struct {
 	// The current execution status details of the cluster step.
 	Status *StepStatus `type:"structure"`
 
-	metadataStep `json:"-" xml:"-"`
-}
-
-type metadataStep struct {
-	SDKShapeTraits bool `type:"structure"`
+	_ struct{} `type:"structure"`
 }
 
 // String returns the string representation
@@ -2792,11 +2536,7 @@ type StepConfig struct {
 	// The name of the job flow step.
 	Name *string `type:"string" required:"true"`
 
-	metadataStepConfig `json:"-" xml:"-"`
-}
-
-type metadataStepConfig struct {
-	SDKShapeTraits bool `type:"structure"`
+	_ struct{} `type:"structure"`
 }
 
 // String returns the string representation
@@ -2817,11 +2557,7 @@ type StepDetail struct {
 	// The step configuration.
 	StepConfig *StepConfig `type:"structure" required:"true"`
 
-	metadataStepDetail `json:"-" xml:"-"`
-}
-
-type metadataStepDetail struct {
-	SDKShapeTraits bool `type:"structure"`
+	_ struct{} `type:"structure"`
 }
 
 // String returns the string representation
@@ -2851,11 +2587,7 @@ type StepExecutionStatusDetail struct {
 	// The state of the job flow step.
 	State *string `type:"string" required:"true" enum:"StepExecutionState"`
 
-	metadataStepExecutionStatusDetail `json:"-" xml:"-"`
-}
-
-type metadataStepExecutionStatusDetail struct {
-	SDKShapeTraits bool `type:"structure"`
+	_ struct{} `type:"structure"`
 }
 
 // String returns the string representation
@@ -2877,11 +2609,7 @@ type StepStateChangeReason struct {
 	// The descriptive message for the state change reason.
 	Message *string `type:"string"`
 
-	metadataStepStateChangeReason `json:"-" xml:"-"`
-}
-
-type metadataStepStateChangeReason struct {
-	SDKShapeTraits bool `type:"structure"`
+	_ struct{} `type:"structure"`
 }
 
 // String returns the string representation
@@ -2905,11 +2633,7 @@ type StepStatus struct {
 	// The timeline of the cluster step status over time.
 	Timeline *StepTimeline `type:"structure"`
 
-	metadataStepStatus `json:"-" xml:"-"`
-}
-
-type metadataStepStatus struct {
-	SDKShapeTraits bool `type:"structure"`
+	_ struct{} `type:"structure"`
 }
 
 // String returns the string representation
@@ -2940,11 +2664,7 @@ type StepSummary struct {
 	// The current execution status details of the cluster step.
 	Status *StepStatus `type:"structure"`
 
-	metadataStepSummary `json:"-" xml:"-"`
-}
-
-type metadataStepSummary struct {
-	SDKShapeTraits bool `type:"structure"`
+	_ struct{} `type:"structure"`
 }
 
 // String returns the string representation
@@ -2968,11 +2688,7 @@ type StepTimeline struct {
 	// The date and time when the cluster step execution started.
 	StartDateTime *time.Time `type:"timestamp" timestampFormat:"unix"`
 
-	metadataStepTimeline `json:"-" xml:"-"`
-}
-
-type metadataStepTimeline struct {
-	SDKShapeTraits bool `type:"structure"`
+	_ struct{} `type:"structure"`
 }
 
 // String returns the string representation
@@ -2995,11 +2711,7 @@ type SupportedProductConfig struct {
 	// The name of the product configuration.
 	Name *string `type:"string"`
 
-	metadataSupportedProductConfig `json:"-" xml:"-"`
-}
-
-type metadataSupportedProductConfig struct {
-	SDKShapeTraits bool `type:"structure"`
+	_ struct{} `type:"structure"`
 }
 
 // String returns the string representation
@@ -3026,11 +2738,7 @@ type Tag struct {
 	// Tagging Amazon EMR Resources (http://docs.aws.amazon.com/ElasticMapReduce/latest/DeveloperGuide/emr-plan-tags.html).
 	Value *string `type:"string"`
 
-	metadataTag `json:"-" xml:"-"`
-}
-
-type metadataTag struct {
-	SDKShapeTraits bool `type:"structure"`
+	_ struct{} `type:"structure"`
 }
 
 // String returns the string representation
@@ -3048,11 +2756,7 @@ type TerminateJobFlowsInput struct {
 	// A list of job flows to be shutdown.
 	JobFlowIds []*string `type:"list" required:"true"`
 
-	metadataTerminateJobFlowsInput `json:"-" xml:"-"`
-}
-
-type metadataTerminateJobFlowsInput struct {
-	SDKShapeTraits bool `type:"structure"`
+	_ struct{} `type:"structure"`
 }
 
 // String returns the string representation
@@ -3066,11 +2770,7 @@ func (s TerminateJobFlowsInput) GoString() string {
 }
 
 type TerminateJobFlowsOutput struct {
-	metadataTerminateJobFlowsOutput `json:"-" xml:"-"`
-}
-
-type metadataTerminateJobFlowsOutput struct {
-	SDKShapeTraits bool `type:"structure"`
+	_ struct{} `type:"structure"`
 }
 
 // String returns the string representation

--- a/service/firehose/api.go
+++ b/service/firehose/api.go
@@ -399,11 +399,7 @@ type BufferingHints struct {
 	// if you typically ingest data at 1 MB/sec set SizeInMBs to be 10 MB or higher.
 	SizeInMBs *int64 `min:"1" type:"integer"`
 
-	metadataBufferingHints `json:"-" xml:"-"`
-}
-
-type metadataBufferingHints struct {
-	SDKShapeTraits bool `type:"structure"`
+	_ struct{} `type:"structure"`
 }
 
 // String returns the string representation
@@ -446,11 +442,7 @@ type CopyCommand struct {
 	// The name of the target table. The table must already exist in the database.
 	DataTableName *string `min:"1" type:"string" required:"true"`
 
-	metadataCopyCommand `json:"-" xml:"-"`
-}
-
-type metadataCopyCommand struct {
-	SDKShapeTraits bool `type:"structure"`
+	_ struct{} `type:"structure"`
 }
 
 // String returns the string representation
@@ -476,11 +468,7 @@ type CreateDeliveryStreamInput struct {
 	// is specified (see restrictions listed above).
 	S3DestinationConfiguration *S3DestinationConfiguration `type:"structure"`
 
-	metadataCreateDeliveryStreamInput `json:"-" xml:"-"`
-}
-
-type metadataCreateDeliveryStreamInput struct {
-	SDKShapeTraits bool `type:"structure"`
+	_ struct{} `type:"structure"`
 }
 
 // String returns the string representation
@@ -498,11 +486,7 @@ type CreateDeliveryStreamOutput struct {
 	// The ARN of the delivery stream.
 	DeliveryStreamARN *string `type:"string"`
 
-	metadataCreateDeliveryStreamOutput `json:"-" xml:"-"`
-}
-
-type metadataCreateDeliveryStreamOutput struct {
-	SDKShapeTraits bool `type:"structure"`
+	_ struct{} `type:"structure"`
 }
 
 // String returns the string representation
@@ -520,11 +504,7 @@ type DeleteDeliveryStreamInput struct {
 	// The name of the delivery stream.
 	DeliveryStreamName *string `min:"1" type:"string" required:"true"`
 
-	metadataDeleteDeliveryStreamInput `json:"-" xml:"-"`
-}
-
-type metadataDeleteDeliveryStreamInput struct {
-	SDKShapeTraits bool `type:"structure"`
+	_ struct{} `type:"structure"`
 }
 
 // String returns the string representation
@@ -539,11 +519,7 @@ func (s DeleteDeliveryStreamInput) GoString() string {
 
 // Contains the output of DeleteDeliveryStream.
 type DeleteDeliveryStreamOutput struct {
-	metadataDeleteDeliveryStreamOutput `json:"-" xml:"-"`
-}
-
-type metadataDeleteDeliveryStreamOutput struct {
-	SDKShapeTraits bool `type:"structure"`
+	_ struct{} `type:"structure"`
 }
 
 // String returns the string representation
@@ -586,11 +562,7 @@ type DeliveryStreamDescription struct {
 	// stream.
 	VersionId *string `min:"1" type:"string" required:"true"`
 
-	metadataDeliveryStreamDescription `json:"-" xml:"-"`
-}
-
-type metadataDeliveryStreamDescription struct {
-	SDKShapeTraits bool `type:"structure"`
+	_ struct{} `type:"structure"`
 }
 
 // String returns the string representation
@@ -616,11 +588,7 @@ type DescribeDeliveryStreamInput struct {
 	// one destination per delivery stream.
 	Limit *int64 `min:"1" type:"integer"`
 
-	metadataDescribeDeliveryStreamInput `json:"-" xml:"-"`
-}
-
-type metadataDescribeDeliveryStreamInput struct {
-	SDKShapeTraits bool `type:"structure"`
+	_ struct{} `type:"structure"`
 }
 
 // String returns the string representation
@@ -638,11 +606,7 @@ type DescribeDeliveryStreamOutput struct {
 	// Information about the delivery stream.
 	DeliveryStreamDescription *DeliveryStreamDescription `type:"structure" required:"true"`
 
-	metadataDescribeDeliveryStreamOutput `json:"-" xml:"-"`
-}
-
-type metadataDescribeDeliveryStreamOutput struct {
-	SDKShapeTraits bool `type:"structure"`
+	_ struct{} `type:"structure"`
 }
 
 // String returns the string representation
@@ -666,11 +630,7 @@ type DestinationDescription struct {
 	// The Amazon S3 destination.
 	S3DestinationDescription *S3DestinationDescription `type:"structure"`
 
-	metadataDestinationDescription `json:"-" xml:"-"`
-}
-
-type metadataDestinationDescription struct {
-	SDKShapeTraits bool `type:"structure"`
+	_ struct{} `type:"structure"`
 }
 
 // String returns the string representation
@@ -692,11 +652,7 @@ type EncryptionConfiguration struct {
 	// is used.
 	NoEncryptionConfig *string `type:"string" enum:"NoEncryptionConfig"`
 
-	metadataEncryptionConfiguration `json:"-" xml:"-"`
-}
-
-type metadataEncryptionConfiguration struct {
-	SDKShapeTraits bool `type:"structure"`
+	_ struct{} `type:"structure"`
 }
 
 // String returns the string representation
@@ -715,11 +671,7 @@ type KMSEncryptionConfig struct {
 	// Amazon S3 bucket.
 	AWSKMSKeyARN *string `min:"1" type:"string" required:"true"`
 
-	metadataKMSEncryptionConfig `json:"-" xml:"-"`
-}
-
-type metadataKMSEncryptionConfig struct {
-	SDKShapeTraits bool `type:"structure"`
+	_ struct{} `type:"structure"`
 }
 
 // String returns the string representation
@@ -740,11 +692,7 @@ type ListDeliveryStreamsInput struct {
 	// The maximum number of delivery streams to list.
 	Limit *int64 `min:"1" type:"integer"`
 
-	metadataListDeliveryStreamsInput `json:"-" xml:"-"`
-}
-
-type metadataListDeliveryStreamsInput struct {
-	SDKShapeTraits bool `type:"structure"`
+	_ struct{} `type:"structure"`
 }
 
 // String returns the string representation
@@ -765,11 +713,7 @@ type ListDeliveryStreamsOutput struct {
 	// Indicates whether there are more delivery streams available to list.
 	HasMoreDeliveryStreams *bool `type:"boolean" required:"true"`
 
-	metadataListDeliveryStreamsOutput `json:"-" xml:"-"`
-}
-
-type metadataListDeliveryStreamsOutput struct {
-	SDKShapeTraits bool `type:"structure"`
+	_ struct{} `type:"structure"`
 }
 
 // String returns the string representation
@@ -790,11 +734,7 @@ type PutRecordBatchInput struct {
 	// One or more records.
 	Records []*Record `min:"1" type:"list" required:"true"`
 
-	metadataPutRecordBatchInput `json:"-" xml:"-"`
-}
-
-type metadataPutRecordBatchInput struct {
-	SDKShapeTraits bool `type:"structure"`
+	_ struct{} `type:"structure"`
 }
 
 // String returns the string representation
@@ -816,11 +756,7 @@ type PutRecordBatchOutput struct {
 	// the same index in which records were sent.
 	RequestResponses []*PutRecordBatchResponseEntry `min:"1" type:"list" required:"true"`
 
-	metadataPutRecordBatchOutput `json:"-" xml:"-"`
-}
-
-type metadataPutRecordBatchOutput struct {
-	SDKShapeTraits bool `type:"structure"`
+	_ struct{} `type:"structure"`
 }
 
 // String returns the string representation
@@ -847,11 +783,7 @@ type PutRecordBatchResponseEntry struct {
 	// The ID of the record.
 	RecordId *string `min:"1" type:"string"`
 
-	metadataPutRecordBatchResponseEntry `json:"-" xml:"-"`
-}
-
-type metadataPutRecordBatchResponseEntry struct {
-	SDKShapeTraits bool `type:"structure"`
+	_ struct{} `type:"structure"`
 }
 
 // String returns the string representation
@@ -872,11 +804,7 @@ type PutRecordInput struct {
 	// The record.
 	Record *Record `type:"structure" required:"true"`
 
-	metadataPutRecordInput `json:"-" xml:"-"`
-}
-
-type metadataPutRecordInput struct {
-	SDKShapeTraits bool `type:"structure"`
+	_ struct{} `type:"structure"`
 }
 
 // String returns the string representation
@@ -894,11 +822,7 @@ type PutRecordOutput struct {
 	// The ID of the record.
 	RecordId *string `min:"1" type:"string" required:"true"`
 
-	metadataPutRecordOutput `json:"-" xml:"-"`
-}
-
-type metadataPutRecordOutput struct {
-	SDKShapeTraits bool `type:"structure"`
+	_ struct{} `type:"structure"`
 }
 
 // String returns the string representation
@@ -917,11 +841,7 @@ type Record struct {
 	// size of the data blob, before base64-encoding, is 1,000 KB.
 	Data []byte `type:"blob" required:"true"`
 
-	metadataRecord `json:"-" xml:"-"`
-}
-
-type metadataRecord struct {
-	SDKShapeTraits bool `type:"structure"`
+	_ struct{} `type:"structure"`
 }
 
 // String returns the string representation
@@ -959,11 +879,7 @@ type RedshiftDestinationConfiguration struct {
 	// The name of the user.
 	Username *string `min:"1" type:"string" required:"true"`
 
-	metadataRedshiftDestinationConfiguration `json:"-" xml:"-"`
-}
-
-type metadataRedshiftDestinationConfiguration struct {
-	SDKShapeTraits bool `type:"structure"`
+	_ struct{} `type:"structure"`
 }
 
 // String returns the string representation
@@ -993,11 +909,7 @@ type RedshiftDestinationDescription struct {
 	// The name of the user.
 	Username *string `min:"1" type:"string" required:"true"`
 
-	metadataRedshiftDestinationDescription `json:"-" xml:"-"`
-}
-
-type metadataRedshiftDestinationDescription struct {
-	SDKShapeTraits bool `type:"structure"`
+	_ struct{} `type:"structure"`
 }
 
 // String returns the string representation
@@ -1034,11 +946,7 @@ type RedshiftDestinationUpdate struct {
 	// The name of the user.
 	Username *string `min:"1" type:"string"`
 
-	metadataRedshiftDestinationUpdate `json:"-" xml:"-"`
-}
-
-type metadataRedshiftDestinationUpdate struct {
-	SDKShapeTraits bool `type:"structure"`
+	_ struct{} `type:"structure"`
 }
 
 // String returns the string representation
@@ -1082,11 +990,7 @@ type S3DestinationConfiguration struct {
 	// The ARN of the AWS credentials.
 	RoleARN *string `min:"1" type:"string" required:"true"`
 
-	metadataS3DestinationConfiguration `json:"-" xml:"-"`
-}
-
-type metadataS3DestinationConfiguration struct {
-	SDKShapeTraits bool `type:"structure"`
+	_ struct{} `type:"structure"`
 }
 
 // String returns the string representation
@@ -1126,11 +1030,7 @@ type S3DestinationDescription struct {
 	// The ARN of the AWS credentials.
 	RoleARN *string `min:"1" type:"string" required:"true"`
 
-	metadataS3DestinationDescription `json:"-" xml:"-"`
-}
-
-type metadataS3DestinationDescription struct {
-	SDKShapeTraits bool `type:"structure"`
+	_ struct{} `type:"structure"`
 }
 
 // String returns the string representation
@@ -1174,11 +1074,7 @@ type S3DestinationUpdate struct {
 	// The ARN of the AWS credentials.
 	RoleARN *string `min:"1" type:"string"`
 
-	metadataS3DestinationUpdate `json:"-" xml:"-"`
-}
-
-type metadataS3DestinationUpdate struct {
-	SDKShapeTraits bool `type:"structure"`
+	_ struct{} `type:"structure"`
 }
 
 // String returns the string representation
@@ -1213,11 +1109,7 @@ type UpdateDestinationInput struct {
 	// Describes an update for a destination in Amazon S3.
 	S3DestinationUpdate *S3DestinationUpdate `type:"structure"`
 
-	metadataUpdateDestinationInput `json:"-" xml:"-"`
-}
-
-type metadataUpdateDestinationInput struct {
-	SDKShapeTraits bool `type:"structure"`
+	_ struct{} `type:"structure"`
 }
 
 // String returns the string representation
@@ -1232,11 +1124,7 @@ func (s UpdateDestinationInput) GoString() string {
 
 // Contains the output of UpdateDestination.
 type UpdateDestinationOutput struct {
-	metadataUpdateDestinationOutput `json:"-" xml:"-"`
-}
-
-type metadataUpdateDestinationOutput struct {
-	SDKShapeTraits bool `type:"structure"`
+	_ struct{} `type:"structure"`
 }
 
 // String returns the string representation

--- a/service/firehose/api.go
+++ b/service/firehose/api.go
@@ -387,6 +387,8 @@ func (c *Firehose) UpdateDestination(input *UpdateDestinationInput) (*UpdateDest
 
 // Describes the buffering to perform before delivering data to the destination.
 type BufferingHints struct {
+	_ struct{} `type:"structure"`
+
 	// Buffer incoming data for the specified period of time, in seconds, before
 	// delivering it to the destination. The default value is 300.
 	IntervalInSeconds *int64 `min:"60" type:"integer"`
@@ -398,8 +400,6 @@ type BufferingHints struct {
 	// you typically ingest into the delivery stream in 10 seconds. For example,
 	// if you typically ingest data at 1 MB/sec set SizeInMBs to be 10 MB or higher.
 	SizeInMBs *int64 `min:"1" type:"integer"`
-
-	_ struct{} `type:"structure"`
 }
 
 // String returns the string representation
@@ -414,6 +414,8 @@ func (s BufferingHints) GoString() string {
 
 // Describes a COPY command for Amazon Redshift.
 type CopyCommand struct {
+	_ struct{} `type:"structure"`
+
 	// Optional parameters to use with the Amazon Redshift COPY command. For more
 	// information, see the "Optional Parameters" section of Amazon Redshift COPY
 	// command (http://docs.aws.amazon.com/redshift/latest/dg/r_COPY.html). Some
@@ -441,8 +443,6 @@ type CopyCommand struct {
 
 	// The name of the target table. The table must already exist in the database.
 	DataTableName *string `min:"1" type:"string" required:"true"`
-
-	_ struct{} `type:"structure"`
 }
 
 // String returns the string representation
@@ -457,6 +457,8 @@ func (s CopyCommand) GoString() string {
 
 // Contains the parameters for CreateDeliveryStream.
 type CreateDeliveryStreamInput struct {
+	_ struct{} `type:"structure"`
+
 	// The name of the delivery stream.
 	DeliveryStreamName *string `min:"1" type:"string" required:"true"`
 
@@ -467,8 +469,6 @@ type CreateDeliveryStreamInput struct {
 	// The destination in Amazon S3. This value must be specified if RedshiftDestinationConfiguration
 	// is specified (see restrictions listed above).
 	S3DestinationConfiguration *S3DestinationConfiguration `type:"structure"`
-
-	_ struct{} `type:"structure"`
 }
 
 // String returns the string representation
@@ -483,10 +483,10 @@ func (s CreateDeliveryStreamInput) GoString() string {
 
 // Contains the output of CreateDeliveryStream.
 type CreateDeliveryStreamOutput struct {
+	_ struct{} `type:"structure"`
+
 	// The ARN of the delivery stream.
 	DeliveryStreamARN *string `type:"string"`
-
-	_ struct{} `type:"structure"`
 }
 
 // String returns the string representation
@@ -501,10 +501,10 @@ func (s CreateDeliveryStreamOutput) GoString() string {
 
 // Contains the parameters for DeleteDeliveryStream.
 type DeleteDeliveryStreamInput struct {
+	_ struct{} `type:"structure"`
+
 	// The name of the delivery stream.
 	DeliveryStreamName *string `min:"1" type:"string" required:"true"`
-
-	_ struct{} `type:"structure"`
 }
 
 // String returns the string representation
@@ -534,6 +534,8 @@ func (s DeleteDeliveryStreamOutput) GoString() string {
 
 // Contains information about a delivery stream.
 type DeliveryStreamDescription struct {
+	_ struct{} `type:"structure"`
+
 	// The date and time that the delivery stream was created.
 	CreateTimestamp *time.Time `type:"timestamp" timestampFormat:"unix"`
 
@@ -561,8 +563,6 @@ type DeliveryStreamDescription struct {
 	// service knows it is applying the changes to the correct version of the delivery
 	// stream.
 	VersionId *string `min:"1" type:"string" required:"true"`
-
-	_ struct{} `type:"structure"`
 }
 
 // String returns the string representation
@@ -577,6 +577,8 @@ func (s DeliveryStreamDescription) GoString() string {
 
 // Contains the parameters for DescribeDeliveryStream.
 type DescribeDeliveryStreamInput struct {
+	_ struct{} `type:"structure"`
+
 	// The name of the delivery stream.
 	DeliveryStreamName *string `min:"1" type:"string" required:"true"`
 
@@ -587,8 +589,6 @@ type DescribeDeliveryStreamInput struct {
 	// The limit on the number of destinations to return. Currently, you can have
 	// one destination per delivery stream.
 	Limit *int64 `min:"1" type:"integer"`
-
-	_ struct{} `type:"structure"`
 }
 
 // String returns the string representation
@@ -603,10 +603,10 @@ func (s DescribeDeliveryStreamInput) GoString() string {
 
 // Contains the output of DescribeDeliveryStream.
 type DescribeDeliveryStreamOutput struct {
+	_ struct{} `type:"structure"`
+
 	// Information about the delivery stream.
 	DeliveryStreamDescription *DeliveryStreamDescription `type:"structure" required:"true"`
-
-	_ struct{} `type:"structure"`
 }
 
 // String returns the string representation
@@ -621,6 +621,8 @@ func (s DescribeDeliveryStreamOutput) GoString() string {
 
 // Describes the destination for a delivery stream.
 type DestinationDescription struct {
+	_ struct{} `type:"structure"`
+
 	// The ID of the destination.
 	DestinationId *string `min:"1" type:"string" required:"true"`
 
@@ -629,8 +631,6 @@ type DestinationDescription struct {
 
 	// The Amazon S3 destination.
 	S3DestinationDescription *S3DestinationDescription `type:"structure"`
-
-	_ struct{} `type:"structure"`
 }
 
 // String returns the string representation
@@ -645,14 +645,14 @@ func (s DestinationDescription) GoString() string {
 
 // Describes the encryption for a destination in Amazon S3.
 type EncryptionConfiguration struct {
+	_ struct{} `type:"structure"`
+
 	// The encryption key.
 	KMSEncryptionConfig *KMSEncryptionConfig `type:"structure"`
 
 	// Specifically override existing encryption information to ensure no encryption
 	// is used.
 	NoEncryptionConfig *string `type:"string" enum:"NoEncryptionConfig"`
-
-	_ struct{} `type:"structure"`
 }
 
 // String returns the string representation
@@ -667,11 +667,11 @@ func (s EncryptionConfiguration) GoString() string {
 
 // Describes an encryption key for a destination in Amazon S3.
 type KMSEncryptionConfig struct {
+	_ struct{} `type:"structure"`
+
 	// The ARN of the encryption key. Must belong to the same region as the destination
 	// Amazon S3 bucket.
 	AWSKMSKeyARN *string `min:"1" type:"string" required:"true"`
-
-	_ struct{} `type:"structure"`
 }
 
 // String returns the string representation
@@ -686,13 +686,13 @@ func (s KMSEncryptionConfig) GoString() string {
 
 // Contains the parameters for ListDeliveryStreams.
 type ListDeliveryStreamsInput struct {
+	_ struct{} `type:"structure"`
+
 	// The name of the delivery stream to start the list with.
 	ExclusiveStartDeliveryStreamName *string `min:"1" type:"string"`
 
 	// The maximum number of delivery streams to list.
 	Limit *int64 `min:"1" type:"integer"`
-
-	_ struct{} `type:"structure"`
 }
 
 // String returns the string representation
@@ -707,13 +707,13 @@ func (s ListDeliveryStreamsInput) GoString() string {
 
 // Contains the output of ListDeliveryStreams.
 type ListDeliveryStreamsOutput struct {
+	_ struct{} `type:"structure"`
+
 	// The names of the delivery streams.
 	DeliveryStreamNames []*string `type:"list" required:"true"`
 
 	// Indicates whether there are more delivery streams available to list.
 	HasMoreDeliveryStreams *bool `type:"boolean" required:"true"`
-
-	_ struct{} `type:"structure"`
 }
 
 // String returns the string representation
@@ -728,13 +728,13 @@ func (s ListDeliveryStreamsOutput) GoString() string {
 
 // Contains the parameters for PutRecordBatch.
 type PutRecordBatchInput struct {
+	_ struct{} `type:"structure"`
+
 	// The name of the delivery stream.
 	DeliveryStreamName *string `min:"1" type:"string" required:"true"`
 
 	// One or more records.
 	Records []*Record `min:"1" type:"list" required:"true"`
-
-	_ struct{} `type:"structure"`
 }
 
 // String returns the string representation
@@ -749,14 +749,14 @@ func (s PutRecordBatchInput) GoString() string {
 
 // Contains the output of PutRecordBatch.
 type PutRecordBatchOutput struct {
+	_ struct{} `type:"structure"`
+
 	// The number of unsuccessfully written records.
 	FailedPutCount *int64 `type:"integer" required:"true"`
 
 	// The results for the individual records. The index of each element matches
 	// the same index in which records were sent.
 	RequestResponses []*PutRecordBatchResponseEntry `min:"1" type:"list" required:"true"`
-
-	_ struct{} `type:"structure"`
 }
 
 // String returns the string representation
@@ -774,6 +774,8 @@ func (s PutRecordBatchOutput) GoString() string {
 // a record ID. If the record fails to be added to your delivery stream, the
 // result includes an error code and an error message.
 type PutRecordBatchResponseEntry struct {
+	_ struct{} `type:"structure"`
+
 	// The error code for an individual record result.
 	ErrorCode *string `type:"string"`
 
@@ -782,8 +784,6 @@ type PutRecordBatchResponseEntry struct {
 
 	// The ID of the record.
 	RecordId *string `min:"1" type:"string"`
-
-	_ struct{} `type:"structure"`
 }
 
 // String returns the string representation
@@ -798,13 +798,13 @@ func (s PutRecordBatchResponseEntry) GoString() string {
 
 // Contains the parameters for PutRecord.
 type PutRecordInput struct {
+	_ struct{} `type:"structure"`
+
 	// The name of the delivery stream.
 	DeliveryStreamName *string `min:"1" type:"string" required:"true"`
 
 	// The record.
 	Record *Record `type:"structure" required:"true"`
-
-	_ struct{} `type:"structure"`
 }
 
 // String returns the string representation
@@ -819,10 +819,10 @@ func (s PutRecordInput) GoString() string {
 
 // Contains the output of PutRecord.
 type PutRecordOutput struct {
+	_ struct{} `type:"structure"`
+
 	// The ID of the record.
 	RecordId *string `min:"1" type:"string" required:"true"`
-
-	_ struct{} `type:"structure"`
 }
 
 // String returns the string representation
@@ -837,11 +837,11 @@ func (s PutRecordOutput) GoString() string {
 
 // The unit of data in a delivery stream.
 type Record struct {
+	_ struct{} `type:"structure"`
+
 	// The data blob, which is base64-encoded when the blob is serialized. The maximum
 	// size of the data blob, before base64-encoding, is 1,000 KB.
 	Data []byte `type:"blob" required:"true"`
-
-	_ struct{} `type:"structure"`
 }
 
 // String returns the string representation
@@ -856,6 +856,8 @@ func (s Record) GoString() string {
 
 // Describes the configuration of a destination in Amazon Redshift.
 type RedshiftDestinationConfiguration struct {
+	_ struct{} `type:"structure"`
+
 	// The database connection string.
 	ClusterJDBCURL *string `min:"1" type:"string" required:"true"`
 
@@ -878,8 +880,6 @@ type RedshiftDestinationConfiguration struct {
 
 	// The name of the user.
 	Username *string `min:"1" type:"string" required:"true"`
-
-	_ struct{} `type:"structure"`
 }
 
 // String returns the string representation
@@ -894,6 +894,8 @@ func (s RedshiftDestinationConfiguration) GoString() string {
 
 // Describes a destination in Amazon Redshift.
 type RedshiftDestinationDescription struct {
+	_ struct{} `type:"structure"`
+
 	// The database connection string.
 	ClusterJDBCURL *string `min:"1" type:"string" required:"true"`
 
@@ -908,8 +910,6 @@ type RedshiftDestinationDescription struct {
 
 	// The name of the user.
 	Username *string `min:"1" type:"string" required:"true"`
-
-	_ struct{} `type:"structure"`
 }
 
 // String returns the string representation
@@ -924,6 +924,8 @@ func (s RedshiftDestinationDescription) GoString() string {
 
 // Describes an update for a destination in Amazon Redshift.
 type RedshiftDestinationUpdate struct {
+	_ struct{} `type:"structure"`
+
 	// The database connection string.
 	ClusterJDBCURL *string `min:"1" type:"string"`
 
@@ -945,8 +947,6 @@ type RedshiftDestinationUpdate struct {
 
 	// The name of the user.
 	Username *string `min:"1" type:"string"`
-
-	_ struct{} `type:"structure"`
 }
 
 // String returns the string representation
@@ -961,6 +961,8 @@ func (s RedshiftDestinationUpdate) GoString() string {
 
 // Describes the configuration of a destination in Amazon S3.
 type S3DestinationConfiguration struct {
+	_ struct{} `type:"structure"`
+
 	// The ARN of the S3 bucket.
 	BucketARN *string `min:"1" type:"string" required:"true"`
 
@@ -989,8 +991,6 @@ type S3DestinationConfiguration struct {
 
 	// The ARN of the AWS credentials.
 	RoleARN *string `min:"1" type:"string" required:"true"`
-
-	_ struct{} `type:"structure"`
 }
 
 // String returns the string representation
@@ -1005,6 +1005,8 @@ func (s S3DestinationConfiguration) GoString() string {
 
 // Describes a destination in Amazon S3.
 type S3DestinationDescription struct {
+	_ struct{} `type:"structure"`
+
 	// The ARN of the S3 bucket.
 	BucketARN *string `min:"1" type:"string" required:"true"`
 
@@ -1029,8 +1031,6 @@ type S3DestinationDescription struct {
 
 	// The ARN of the AWS credentials.
 	RoleARN *string `min:"1" type:"string" required:"true"`
-
-	_ struct{} `type:"structure"`
 }
 
 // String returns the string representation
@@ -1045,6 +1045,8 @@ func (s S3DestinationDescription) GoString() string {
 
 // Describes an update for a destination in Amazon S3.
 type S3DestinationUpdate struct {
+	_ struct{} `type:"structure"`
+
 	// The ARN of the S3 bucket.
 	BucketARN *string `min:"1" type:"string"`
 
@@ -1073,8 +1075,6 @@ type S3DestinationUpdate struct {
 
 	// The ARN of the AWS credentials.
 	RoleARN *string `min:"1" type:"string"`
-
-	_ struct{} `type:"structure"`
 }
 
 // String returns the string representation
@@ -1089,6 +1089,8 @@ func (s S3DestinationUpdate) GoString() string {
 
 // Contains the parameters for UpdateDestination.
 type UpdateDestinationInput struct {
+	_ struct{} `type:"structure"`
+
 	// Obtain this value from the VersionId result of the DeliveryStreamDescription
 	// operation. This value is required, and helps the service to perform conditional
 	// operations. For example, if there is a interleaving update and this value
@@ -1108,8 +1110,6 @@ type UpdateDestinationInput struct {
 
 	// Describes an update for a destination in Amazon S3.
 	S3DestinationUpdate *S3DestinationUpdate `type:"structure"`
-
-	_ struct{} `type:"structure"`
 }
 
 // String returns the string representation

--- a/service/glacier/api.go
+++ b/service/glacier/api.go
@@ -1643,11 +1643,7 @@ type AbortMultipartUploadInput struct {
 	// The name of the vault.
 	VaultName *string `location:"uri" locationName:"vaultName" type:"string" required:"true"`
 
-	metadataAbortMultipartUploadInput `json:"-" xml:"-"`
-}
-
-type metadataAbortMultipartUploadInput struct {
-	SDKShapeTraits bool `type:"structure"`
+	_ struct{} `type:"structure"`
 }
 
 // String returns the string representation
@@ -1661,11 +1657,7 @@ func (s AbortMultipartUploadInput) GoString() string {
 }
 
 type AbortMultipartUploadOutput struct {
-	metadataAbortMultipartUploadOutput `json:"-" xml:"-"`
-}
-
-type metadataAbortMultipartUploadOutput struct {
-	SDKShapeTraits bool `type:"structure"`
+	_ struct{} `type:"structure"`
 }
 
 // String returns the string representation
@@ -1691,11 +1683,7 @@ type AbortVaultLockInput struct {
 	// The name of the vault.
 	VaultName *string `location:"uri" locationName:"vaultName" type:"string" required:"true"`
 
-	metadataAbortVaultLockInput `json:"-" xml:"-"`
-}
-
-type metadataAbortVaultLockInput struct {
-	SDKShapeTraits bool `type:"structure"`
+	_ struct{} `type:"structure"`
 }
 
 // String returns the string representation
@@ -1709,11 +1697,7 @@ func (s AbortVaultLockInput) GoString() string {
 }
 
 type AbortVaultLockOutput struct {
-	metadataAbortVaultLockOutput `json:"-" xml:"-"`
-}
-
-type metadataAbortVaultLockOutput struct {
-	SDKShapeTraits bool `type:"structure"`
+	_ struct{} `type:"structure"`
 }
 
 // String returns the string representation
@@ -1742,11 +1726,7 @@ type AddTagsToVaultInput struct {
 	// The name of the vault.
 	VaultName *string `location:"uri" locationName:"vaultName" type:"string" required:"true"`
 
-	metadataAddTagsToVaultInput `json:"-" xml:"-"`
-}
-
-type metadataAddTagsToVaultInput struct {
-	SDKShapeTraits bool `type:"structure"`
+	_ struct{} `type:"structure"`
 }
 
 // String returns the string representation
@@ -1760,11 +1740,7 @@ func (s AddTagsToVaultInput) GoString() string {
 }
 
 type AddTagsToVaultOutput struct {
-	metadataAddTagsToVaultOutput `json:"-" xml:"-"`
-}
-
-type metadataAddTagsToVaultOutput struct {
-	SDKShapeTraits bool `type:"structure"`
+	_ struct{} `type:"structure"`
 }
 
 // String returns the string representation
@@ -1792,11 +1768,7 @@ type ArchiveCreationOutput struct {
 	// The relative URI path of the newly added archive resource.
 	Location *string `location:"header" locationName:"Location" type:"string"`
 
-	metadataArchiveCreationOutput `json:"-" xml:"-"`
-}
-
-type metadataArchiveCreationOutput struct {
-	SDKShapeTraits bool `type:"structure"`
+	_ struct{} `type:"structure"`
 }
 
 // String returns the string representation
@@ -1838,11 +1810,7 @@ type CompleteMultipartUploadInput struct {
 	// The name of the vault.
 	VaultName *string `location:"uri" locationName:"vaultName" type:"string" required:"true"`
 
-	metadataCompleteMultipartUploadInput `json:"-" xml:"-"`
-}
-
-type metadataCompleteMultipartUploadInput struct {
-	SDKShapeTraits bool `type:"structure"`
+	_ struct{} `type:"structure"`
 }
 
 // String returns the string representation
@@ -1871,11 +1839,7 @@ type CompleteVaultLockInput struct {
 	// The name of the vault.
 	VaultName *string `location:"uri" locationName:"vaultName" type:"string" required:"true"`
 
-	metadataCompleteVaultLockInput `json:"-" xml:"-"`
-}
-
-type metadataCompleteVaultLockInput struct {
-	SDKShapeTraits bool `type:"structure"`
+	_ struct{} `type:"structure"`
 }
 
 // String returns the string representation
@@ -1889,11 +1853,7 @@ func (s CompleteVaultLockInput) GoString() string {
 }
 
 type CompleteVaultLockOutput struct {
-	metadataCompleteVaultLockOutput `json:"-" xml:"-"`
-}
-
-type metadataCompleteVaultLockOutput struct {
-	SDKShapeTraits bool `type:"structure"`
+	_ struct{} `type:"structure"`
 }
 
 // String returns the string representation
@@ -1919,11 +1879,7 @@ type CreateVaultInput struct {
 	// The name of the vault.
 	VaultName *string `location:"uri" locationName:"vaultName" type:"string" required:"true"`
 
-	metadataCreateVaultInput `json:"-" xml:"-"`
-}
-
-type metadataCreateVaultInput struct {
-	SDKShapeTraits bool `type:"structure"`
+	_ struct{} `type:"structure"`
 }
 
 // String returns the string representation
@@ -1941,11 +1897,7 @@ type CreateVaultOutput struct {
 	// The URI of the vault that was created.
 	Location *string `location:"header" locationName:"Location" type:"string"`
 
-	metadataCreateVaultOutput `json:"-" xml:"-"`
-}
-
-type metadataCreateVaultOutput struct {
-	SDKShapeTraits bool `type:"structure"`
+	_ struct{} `type:"structure"`
 }
 
 // String returns the string representation
@@ -1964,11 +1916,7 @@ type DataRetrievalPolicy struct {
 	// one rule, which contains a Strategy field and optionally a BytesPerHour field.
 	Rules []*DataRetrievalRule `type:"list"`
 
-	metadataDataRetrievalPolicy `json:"-" xml:"-"`
-}
-
-type metadataDataRetrievalPolicy struct {
-	SDKShapeTraits bool `type:"structure"`
+	_ struct{} `type:"structure"`
 }
 
 // String returns the string representation
@@ -1995,11 +1943,7 @@ type DataRetrievalRule struct {
 	// Valid values: BytesPerHour|FreeTier|None
 	Strategy *string `type:"string"`
 
-	metadataDataRetrievalRule `json:"-" xml:"-"`
-}
-
-type metadataDataRetrievalRule struct {
-	SDKShapeTraits bool `type:"structure"`
+	_ struct{} `type:"structure"`
 }
 
 // String returns the string representation
@@ -2027,11 +1971,7 @@ type DeleteArchiveInput struct {
 	// The name of the vault.
 	VaultName *string `location:"uri" locationName:"vaultName" type:"string" required:"true"`
 
-	metadataDeleteArchiveInput `json:"-" xml:"-"`
-}
-
-type metadataDeleteArchiveInput struct {
-	SDKShapeTraits bool `type:"structure"`
+	_ struct{} `type:"structure"`
 }
 
 // String returns the string representation
@@ -2045,11 +1985,7 @@ func (s DeleteArchiveInput) GoString() string {
 }
 
 type DeleteArchiveOutput struct {
-	metadataDeleteArchiveOutput `json:"-" xml:"-"`
-}
-
-type metadataDeleteArchiveOutput struct {
-	SDKShapeTraits bool `type:"structure"`
+	_ struct{} `type:"structure"`
 }
 
 // String returns the string representation
@@ -2074,11 +2010,7 @@ type DeleteVaultAccessPolicyInput struct {
 	// The name of the vault.
 	VaultName *string `location:"uri" locationName:"vaultName" type:"string" required:"true"`
 
-	metadataDeleteVaultAccessPolicyInput `json:"-" xml:"-"`
-}
-
-type metadataDeleteVaultAccessPolicyInput struct {
-	SDKShapeTraits bool `type:"structure"`
+	_ struct{} `type:"structure"`
 }
 
 // String returns the string representation
@@ -2092,11 +2024,7 @@ func (s DeleteVaultAccessPolicyInput) GoString() string {
 }
 
 type DeleteVaultAccessPolicyOutput struct {
-	metadataDeleteVaultAccessPolicyOutput `json:"-" xml:"-"`
-}
-
-type metadataDeleteVaultAccessPolicyOutput struct {
-	SDKShapeTraits bool `type:"structure"`
+	_ struct{} `type:"structure"`
 }
 
 // String returns the string representation
@@ -2121,11 +2049,7 @@ type DeleteVaultInput struct {
 	// The name of the vault.
 	VaultName *string `location:"uri" locationName:"vaultName" type:"string" required:"true"`
 
-	metadataDeleteVaultInput `json:"-" xml:"-"`
-}
-
-type metadataDeleteVaultInput struct {
-	SDKShapeTraits bool `type:"structure"`
+	_ struct{} `type:"structure"`
 }
 
 // String returns the string representation
@@ -2151,11 +2075,7 @@ type DeleteVaultNotificationsInput struct {
 	// The name of the vault.
 	VaultName *string `location:"uri" locationName:"vaultName" type:"string" required:"true"`
 
-	metadataDeleteVaultNotificationsInput `json:"-" xml:"-"`
-}
-
-type metadataDeleteVaultNotificationsInput struct {
-	SDKShapeTraits bool `type:"structure"`
+	_ struct{} `type:"structure"`
 }
 
 // String returns the string representation
@@ -2169,11 +2089,7 @@ func (s DeleteVaultNotificationsInput) GoString() string {
 }
 
 type DeleteVaultNotificationsOutput struct {
-	metadataDeleteVaultNotificationsOutput `json:"-" xml:"-"`
-}
-
-type metadataDeleteVaultNotificationsOutput struct {
-	SDKShapeTraits bool `type:"structure"`
+	_ struct{} `type:"structure"`
 }
 
 // String returns the string representation
@@ -2187,11 +2103,7 @@ func (s DeleteVaultNotificationsOutput) GoString() string {
 }
 
 type DeleteVaultOutput struct {
-	metadataDeleteVaultOutput `json:"-" xml:"-"`
-}
-
-type metadataDeleteVaultOutput struct {
-	SDKShapeTraits bool `type:"structure"`
+	_ struct{} `type:"structure"`
 }
 
 // String returns the string representation
@@ -2219,11 +2131,7 @@ type DescribeJobInput struct {
 	// The name of the vault.
 	VaultName *string `location:"uri" locationName:"vaultName" type:"string" required:"true"`
 
-	metadataDescribeJobInput `json:"-" xml:"-"`
-}
-
-type metadataDescribeJobInput struct {
-	SDKShapeTraits bool `type:"structure"`
+	_ struct{} `type:"structure"`
 }
 
 // String returns the string representation
@@ -2248,11 +2156,7 @@ type DescribeVaultInput struct {
 	// The name of the vault.
 	VaultName *string `location:"uri" locationName:"vaultName" type:"string" required:"true"`
 
-	metadataDescribeVaultInput `json:"-" xml:"-"`
-}
-
-type metadataDescribeVaultInput struct {
-	SDKShapeTraits bool `type:"structure"`
+	_ struct{} `type:"structure"`
 }
 
 // String returns the string representation
@@ -2291,11 +2195,7 @@ type DescribeVaultOutput struct {
 	// The name of the vault.
 	VaultName *string `type:"string"`
 
-	metadataDescribeVaultOutput `json:"-" xml:"-"`
-}
-
-type metadataDescribeVaultOutput struct {
-	SDKShapeTraits bool `type:"structure"`
+	_ struct{} `type:"structure"`
 }
 
 // String returns the string representation
@@ -2318,11 +2218,7 @@ type GetDataRetrievalPolicyInput struct {
 	// not include any hyphens (apos-apos) in the ID.
 	AccountId *string `location:"uri" locationName:"accountId" type:"string" required:"true"`
 
-	metadataGetDataRetrievalPolicyInput `json:"-" xml:"-"`
-}
-
-type metadataGetDataRetrievalPolicyInput struct {
-	SDKShapeTraits bool `type:"structure"`
+	_ struct{} `type:"structure"`
 }
 
 // String returns the string representation
@@ -2340,11 +2236,7 @@ type GetDataRetrievalPolicyOutput struct {
 	// Contains the returned data retrieval policy in JSON format.
 	Policy *DataRetrievalPolicy `type:"structure"`
 
-	metadataGetDataRetrievalPolicyOutput `json:"-" xml:"-"`
-}
-
-type metadataGetDataRetrievalPolicyOutput struct {
-	SDKShapeTraits bool `type:"structure"`
+	_ struct{} `type:"structure"`
 }
 
 // String returns the string representation
@@ -2377,11 +2269,7 @@ type GetJobOutputInput struct {
 	// The name of the vault.
 	VaultName *string `location:"uri" locationName:"vaultName" type:"string" required:"true"`
 
-	metadataGetJobOutputInput `json:"-" xml:"-"`
-}
-
-type metadataGetJobOutputInput struct {
-	SDKShapeTraits bool `type:"structure"`
+	_ struct{} `type:"structure"`
 }
 
 // String returns the string representation
@@ -2434,11 +2322,7 @@ type GetJobOutputOutput struct {
 	// a range was specified in the request.
 	Status *int64 `location:"statusCode" locationName:"status" type:"integer"`
 
-	metadataGetJobOutputOutput `json:"-" xml:"-"`
-}
-
-type metadataGetJobOutputOutput struct {
-	SDKShapeTraits bool `type:"structure" payload:"Body"`
+	_ struct{} `type:"structure" payload:"Body"`
 }
 
 // String returns the string representation
@@ -2463,11 +2347,7 @@ type GetVaultAccessPolicyInput struct {
 	// The name of the vault.
 	VaultName *string `location:"uri" locationName:"vaultName" type:"string" required:"true"`
 
-	metadataGetVaultAccessPolicyInput `json:"-" xml:"-"`
-}
-
-type metadataGetVaultAccessPolicyInput struct {
-	SDKShapeTraits bool `type:"structure"`
+	_ struct{} `type:"structure"`
 }
 
 // String returns the string representation
@@ -2485,11 +2365,7 @@ type GetVaultAccessPolicyOutput struct {
 	// Contains the returned vault access policy as a JSON string.
 	Policy *VaultAccessPolicy `locationName:"policy" type:"structure"`
 
-	metadataGetVaultAccessPolicyOutput `json:"-" xml:"-"`
-}
-
-type metadataGetVaultAccessPolicyOutput struct {
-	SDKShapeTraits bool `type:"structure" payload:"Policy"`
+	_ struct{} `type:"structure" payload:"Policy"`
 }
 
 // String returns the string representation
@@ -2514,11 +2390,7 @@ type GetVaultLockInput struct {
 	// The name of the vault.
 	VaultName *string `location:"uri" locationName:"vaultName" type:"string" required:"true"`
 
-	metadataGetVaultLockInput `json:"-" xml:"-"`
-}
-
-type metadataGetVaultLockInput struct {
-	SDKShapeTraits bool `type:"structure"`
+	_ struct{} `type:"structure"`
 }
 
 // String returns the string representation
@@ -2547,11 +2419,7 @@ type GetVaultLockOutput struct {
 	// The state of the vault lock. InProgress or Locked.
 	State *string `type:"string"`
 
-	metadataGetVaultLockOutput `json:"-" xml:"-"`
-}
-
-type metadataGetVaultLockOutput struct {
-	SDKShapeTraits bool `type:"structure"`
+	_ struct{} `type:"structure"`
 }
 
 // String returns the string representation
@@ -2577,11 +2445,7 @@ type GetVaultNotificationsInput struct {
 	// The name of the vault.
 	VaultName *string `location:"uri" locationName:"vaultName" type:"string" required:"true"`
 
-	metadataGetVaultNotificationsInput `json:"-" xml:"-"`
-}
-
-type metadataGetVaultNotificationsInput struct {
-	SDKShapeTraits bool `type:"structure"`
+	_ struct{} `type:"structure"`
 }
 
 // String returns the string representation
@@ -2599,11 +2463,7 @@ type GetVaultNotificationsOutput struct {
 	// Returns the notification configuration set on the vault.
 	VaultNotificationConfig *VaultNotificationConfig `locationName:"vaultNotificationConfig" type:"structure"`
 
-	metadataGetVaultNotificationsOutput `json:"-" xml:"-"`
-}
-
-type metadataGetVaultNotificationsOutput struct {
-	SDKShapeTraits bool `type:"structure" payload:"VaultNotificationConfig"`
+	_ struct{} `type:"structure" payload:"VaultNotificationConfig"`
 }
 
 // String returns the string representation
@@ -2631,11 +2491,7 @@ type InitiateJobInput struct {
 	// The name of the vault.
 	VaultName *string `location:"uri" locationName:"vaultName" type:"string" required:"true"`
 
-	metadataInitiateJobInput `json:"-" xml:"-"`
-}
-
-type metadataInitiateJobInput struct {
-	SDKShapeTraits bool `type:"structure" payload:"JobParameters"`
+	_ struct{} `type:"structure" payload:"JobParameters"`
 }
 
 // String returns the string representation
@@ -2656,11 +2512,7 @@ type InitiateJobOutput struct {
 	// The relative URI path of the job.
 	Location *string `location:"header" locationName:"Location" type:"string"`
 
-	metadataInitiateJobOutput `json:"-" xml:"-"`
-}
-
-type metadataInitiateJobOutput struct {
-	SDKShapeTraits bool `type:"structure"`
+	_ struct{} `type:"structure"`
 }
 
 // String returns the string representation
@@ -2697,11 +2549,7 @@ type InitiateMultipartUploadInput struct {
 	// The name of the vault.
 	VaultName *string `location:"uri" locationName:"vaultName" type:"string" required:"true"`
 
-	metadataInitiateMultipartUploadInput `json:"-" xml:"-"`
-}
-
-type metadataInitiateMultipartUploadInput struct {
-	SDKShapeTraits bool `type:"structure"`
+	_ struct{} `type:"structure"`
 }
 
 // String returns the string representation
@@ -2723,11 +2571,7 @@ type InitiateMultipartUploadOutput struct {
 	// location.
 	UploadId *string `location:"header" locationName:"x-amz-multipart-upload-id" type:"string"`
 
-	metadataInitiateMultipartUploadOutput `json:"-" xml:"-"`
-}
-
-type metadataInitiateMultipartUploadOutput struct {
-	SDKShapeTraits bool `type:"structure"`
+	_ struct{} `type:"structure"`
 }
 
 // String returns the string representation
@@ -2756,11 +2600,7 @@ type InitiateVaultLockInput struct {
 	// The name of the vault.
 	VaultName *string `location:"uri" locationName:"vaultName" type:"string" required:"true"`
 
-	metadataInitiateVaultLockInput `json:"-" xml:"-"`
-}
-
-type metadataInitiateVaultLockInput struct {
-	SDKShapeTraits bool `type:"structure" payload:"Policy"`
+	_ struct{} `type:"structure" payload:"Policy"`
 }
 
 // String returns the string representation
@@ -2778,11 +2618,7 @@ type InitiateVaultLockOutput struct {
 	// The lock ID, which is used to complete the vault locking process.
 	LockId *string `location:"header" locationName:"x-amz-lock-id" type:"string"`
 
-	metadataInitiateVaultLockOutput `json:"-" xml:"-"`
-}
-
-type metadataInitiateVaultLockOutput struct {
-	SDKShapeTraits bool `type:"structure"`
+	_ struct{} `type:"structure"`
 }
 
 // String returns the string representation
@@ -2824,11 +2660,7 @@ type InventoryRetrievalJobDescription struct {
 	// date format, for example, 2013-03-20T17:03:43Z.
 	StartDate *string `type:"string"`
 
-	metadataInventoryRetrievalJobDescription `json:"-" xml:"-"`
-}
-
-type metadataInventoryRetrievalJobDescription struct {
-	SDKShapeTraits bool `type:"structure"`
+	_ struct{} `type:"structure"`
 }
 
 // String returns the string representation
@@ -2863,11 +2695,7 @@ type InventoryRetrievalJobInput struct {
 	// date format, for example, 2013-03-20T17:03:43Z.
 	StartDate *string `type:"string"`
 
-	metadataInventoryRetrievalJobInput `json:"-" xml:"-"`
-}
-
-type metadataInventoryRetrievalJobInput struct {
-	SDKShapeTraits bool `type:"structure"`
+	_ struct{} `type:"structure"`
 }
 
 // String returns the string representation
@@ -2960,11 +2788,7 @@ type JobDescription struct {
 	// was requested.
 	VaultARN *string `type:"string"`
 
-	metadataJobDescription `json:"-" xml:"-"`
-}
-
-type metadataJobDescription struct {
-	SDKShapeTraits bool `type:"structure"`
+	_ struct{} `type:"structure"`
 }
 
 // String returns the string representation
@@ -3019,11 +2843,7 @@ type JobParameters struct {
 	// of a vault. Valid values are "archive-retrieval" and "inventory-retrieval".
 	Type *string `type:"string"`
 
-	metadataJobParameters `json:"-" xml:"-"`
-}
-
-type metadataJobParameters struct {
-	SDKShapeTraits bool `type:"structure"`
+	_ struct{} `type:"structure"`
 }
 
 // String returns the string representation
@@ -3065,11 +2885,7 @@ type ListJobsInput struct {
 	// The name of the vault.
 	VaultName *string `location:"uri" locationName:"vaultName" type:"string" required:"true"`
 
-	metadataListJobsInput `json:"-" xml:"-"`
-}
-
-type metadataListJobsInput struct {
-	SDKShapeTraits bool `type:"structure"`
+	_ struct{} `type:"structure"`
 }
 
 // String returns the string representation
@@ -3092,11 +2908,7 @@ type ListJobsOutput struct {
 	// list. If there are no more jobs, this value is null.
 	Marker *string `type:"string"`
 
-	metadataListJobsOutput `json:"-" xml:"-"`
-}
-
-type metadataListJobsOutput struct {
-	SDKShapeTraits bool `type:"structure"`
+	_ struct{} `type:"structure"`
 }
 
 // String returns the string representation
@@ -3133,11 +2945,7 @@ type ListMultipartUploadsInput struct {
 	// The name of the vault.
 	VaultName *string `location:"uri" locationName:"vaultName" type:"string" required:"true"`
 
-	metadataListMultipartUploadsInput `json:"-" xml:"-"`
-}
-
-type metadataListMultipartUploadsInput struct {
-	SDKShapeTraits bool `type:"structure"`
+	_ struct{} `type:"structure"`
 }
 
 // String returns the string representation
@@ -3160,11 +2968,7 @@ type ListMultipartUploadsOutput struct {
 	// A list of in-progress multipart uploads.
 	UploadsList []*UploadListElement `type:"list"`
 
-	metadataListMultipartUploadsOutput `json:"-" xml:"-"`
-}
-
-type metadataListMultipartUploadsOutput struct {
-	SDKShapeTraits bool `type:"structure"`
+	_ struct{} `type:"structure"`
 }
 
 // String returns the string representation
@@ -3204,11 +3008,7 @@ type ListPartsInput struct {
 	// The name of the vault.
 	VaultName *string `location:"uri" locationName:"vaultName" type:"string" required:"true"`
 
-	metadataListPartsInput `json:"-" xml:"-"`
-}
-
-type metadataListPartsInput struct {
-	SDKShapeTraits bool `type:"structure"`
+	_ struct{} `type:"structure"`
 }
 
 // String returns the string representation
@@ -3248,11 +3048,7 @@ type ListPartsOutput struct {
 	// was initiated.
 	VaultARN *string `type:"string"`
 
-	metadataListPartsOutput `json:"-" xml:"-"`
-}
-
-type metadataListPartsOutput struct {
-	SDKShapeTraits bool `type:"structure"`
+	_ struct{} `type:"structure"`
 }
 
 // String returns the string representation
@@ -3277,11 +3073,7 @@ type ListTagsForVaultInput struct {
 	// The name of the vault.
 	VaultName *string `location:"uri" locationName:"vaultName" type:"string" required:"true"`
 
-	metadataListTagsForVaultInput `json:"-" xml:"-"`
-}
-
-type metadataListTagsForVaultInput struct {
-	SDKShapeTraits bool `type:"structure"`
+	_ struct{} `type:"structure"`
 }
 
 // String returns the string representation
@@ -3299,11 +3091,7 @@ type ListTagsForVaultOutput struct {
 	// The tags attached to the vault. Each tag is composed of a key and a value.
 	Tags map[string]*string `type:"map"`
 
-	metadataListTagsForVaultOutput `json:"-" xml:"-"`
-}
-
-type metadataListTagsForVaultOutput struct {
-	SDKShapeTraits bool `type:"structure"`
+	_ struct{} `type:"structure"`
 }
 
 // String returns the string representation
@@ -3335,11 +3123,7 @@ type ListVaultsInput struct {
 	// the listing of vaults should begin.
 	Marker *string `location:"querystring" locationName:"marker" type:"string"`
 
-	metadataListVaultsInput `json:"-" xml:"-"`
-}
-
-type metadataListVaultsInput struct {
-	SDKShapeTraits bool `type:"structure"`
+	_ struct{} `type:"structure"`
 }
 
 // String returns the string representation
@@ -3361,11 +3145,7 @@ type ListVaultsOutput struct {
 	// List of vaults.
 	VaultList []*DescribeVaultOutput `type:"list"`
 
-	metadataListVaultsOutput `json:"-" xml:"-"`
-}
-
-type metadataListVaultsOutput struct {
-	SDKShapeTraits bool `type:"structure"`
+	_ struct{} `type:"structure"`
 }
 
 // String returns the string representation
@@ -3387,11 +3167,7 @@ type PartListElement struct {
 	// field is never null.
 	SHA256TreeHash *string `type:"string"`
 
-	metadataPartListElement `json:"-" xml:"-"`
-}
-
-type metadataPartListElement struct {
-	SDKShapeTraits bool `type:"structure"`
+	_ struct{} `type:"structure"`
 }
 
 // String returns the string representation
@@ -3419,11 +3195,7 @@ type RemoveTagsFromVaultInput struct {
 	// The name of the vault.
 	VaultName *string `location:"uri" locationName:"vaultName" type:"string" required:"true"`
 
-	metadataRemoveTagsFromVaultInput `json:"-" xml:"-"`
-}
-
-type metadataRemoveTagsFromVaultInput struct {
-	SDKShapeTraits bool `type:"structure"`
+	_ struct{} `type:"structure"`
 }
 
 // String returns the string representation
@@ -3437,11 +3209,7 @@ func (s RemoveTagsFromVaultInput) GoString() string {
 }
 
 type RemoveTagsFromVaultOutput struct {
-	metadataRemoveTagsFromVaultOutput `json:"-" xml:"-"`
-}
-
-type metadataRemoveTagsFromVaultOutput struct {
-	SDKShapeTraits bool `type:"structure"`
+	_ struct{} `type:"structure"`
 }
 
 // String returns the string representation
@@ -3467,11 +3235,7 @@ type SetDataRetrievalPolicyInput struct {
 	// The data retrieval policy in JSON format.
 	Policy *DataRetrievalPolicy `type:"structure"`
 
-	metadataSetDataRetrievalPolicyInput `json:"-" xml:"-"`
-}
-
-type metadataSetDataRetrievalPolicyInput struct {
-	SDKShapeTraits bool `type:"structure"`
+	_ struct{} `type:"structure"`
 }
 
 // String returns the string representation
@@ -3485,11 +3249,7 @@ func (s SetDataRetrievalPolicyInput) GoString() string {
 }
 
 type SetDataRetrievalPolicyOutput struct {
-	metadataSetDataRetrievalPolicyOutput `json:"-" xml:"-"`
-}
-
-type metadataSetDataRetrievalPolicyOutput struct {
-	SDKShapeTraits bool `type:"structure"`
+	_ struct{} `type:"structure"`
 }
 
 // String returns the string representation
@@ -3517,11 +3277,7 @@ type SetVaultAccessPolicyInput struct {
 	// The name of the vault.
 	VaultName *string `location:"uri" locationName:"vaultName" type:"string" required:"true"`
 
-	metadataSetVaultAccessPolicyInput `json:"-" xml:"-"`
-}
-
-type metadataSetVaultAccessPolicyInput struct {
-	SDKShapeTraits bool `type:"structure" payload:"Policy"`
+	_ struct{} `type:"structure" payload:"Policy"`
 }
 
 // String returns the string representation
@@ -3535,11 +3291,7 @@ func (s SetVaultAccessPolicyInput) GoString() string {
 }
 
 type SetVaultAccessPolicyOutput struct {
-	metadataSetVaultAccessPolicyOutput `json:"-" xml:"-"`
-}
-
-type metadataSetVaultAccessPolicyOutput struct {
-	SDKShapeTraits bool `type:"structure"`
+	_ struct{} `type:"structure"`
 }
 
 // String returns the string representation
@@ -3568,11 +3320,7 @@ type SetVaultNotificationsInput struct {
 	// Provides options for specifying notification configuration.
 	VaultNotificationConfig *VaultNotificationConfig `locationName:"vaultNotificationConfig" type:"structure"`
 
-	metadataSetVaultNotificationsInput `json:"-" xml:"-"`
-}
-
-type metadataSetVaultNotificationsInput struct {
-	SDKShapeTraits bool `type:"structure" payload:"VaultNotificationConfig"`
+	_ struct{} `type:"structure" payload:"VaultNotificationConfig"`
 }
 
 // String returns the string representation
@@ -3586,11 +3334,7 @@ func (s SetVaultNotificationsInput) GoString() string {
 }
 
 type SetVaultNotificationsOutput struct {
-	metadataSetVaultNotificationsOutput `json:"-" xml:"-"`
-}
-
-type metadataSetVaultNotificationsOutput struct {
-	SDKShapeTraits bool `type:"structure"`
+	_ struct{} `type:"structure"`
 }
 
 // String returns the string representation
@@ -3624,11 +3368,7 @@ type UploadArchiveInput struct {
 	// The name of the vault.
 	VaultName *string `location:"uri" locationName:"vaultName" type:"string" required:"true"`
 
-	metadataUploadArchiveInput `json:"-" xml:"-"`
-}
-
-type metadataUploadArchiveInput struct {
-	SDKShapeTraits bool `type:"structure" payload:"Body"`
+	_ struct{} `type:"structure" payload:"Body"`
 }
 
 // String returns the string representation
@@ -3661,11 +3401,7 @@ type UploadListElement struct {
 	// The Amazon Resource Name (ARN) of the vault that contains the archive.
 	VaultARN *string `type:"string"`
 
-	metadataUploadListElement `json:"-" xml:"-"`
-}
-
-type metadataUploadListElement struct {
-	SDKShapeTraits bool `type:"structure"`
+	_ struct{} `type:"structure"`
 }
 
 // String returns the string representation
@@ -3705,11 +3441,7 @@ type UploadMultipartPartInput struct {
 	// The name of the vault.
 	VaultName *string `location:"uri" locationName:"vaultName" type:"string" required:"true"`
 
-	metadataUploadMultipartPartInput `json:"-" xml:"-"`
-}
-
-type metadataUploadMultipartPartInput struct {
-	SDKShapeTraits bool `type:"structure" payload:"Body"`
+	_ struct{} `type:"structure" payload:"Body"`
 }
 
 // String returns the string representation
@@ -3727,11 +3459,7 @@ type UploadMultipartPartOutput struct {
 	// The SHA256 tree hash that Amazon Glacier computed for the uploaded part.
 	Checksum *string `location:"header" locationName:"x-amz-sha256-tree-hash" type:"string"`
 
-	metadataUploadMultipartPartOutput `json:"-" xml:"-"`
-}
-
-type metadataUploadMultipartPartOutput struct {
-	SDKShapeTraits bool `type:"structure"`
+	_ struct{} `type:"structure"`
 }
 
 // String returns the string representation
@@ -3749,11 +3477,7 @@ type VaultAccessPolicy struct {
 	// The vault access policy.
 	Policy *string `type:"string"`
 
-	metadataVaultAccessPolicy `json:"-" xml:"-"`
-}
-
-type metadataVaultAccessPolicy struct {
-	SDKShapeTraits bool `type:"structure"`
+	_ struct{} `type:"structure"`
 }
 
 // String returns the string representation
@@ -3771,11 +3495,7 @@ type VaultLockPolicy struct {
 	// The vault lock policy.
 	Policy *string `type:"string"`
 
-	metadataVaultLockPolicy `json:"-" xml:"-"`
-}
-
-type metadataVaultLockPolicy struct {
-	SDKShapeTraits bool `type:"structure"`
+	_ struct{} `type:"structure"`
 }
 
 // String returns the string representation
@@ -3798,11 +3518,7 @@ type VaultNotificationConfig struct {
 	// Name (ARN).
 	SNSTopic *string `type:"string"`
 
-	metadataVaultNotificationConfig `json:"-" xml:"-"`
-}
-
-type metadataVaultNotificationConfig struct {
-	SDKShapeTraits bool `type:"structure"`
+	_ struct{} `type:"structure"`
 }
 
 // String returns the string representation

--- a/service/glacier/api.go
+++ b/service/glacier/api.go
@@ -1630,6 +1630,8 @@ func (c *Glacier) UploadMultipartPart(input *UploadMultipartPartInput) (*UploadM
 // For conceptual information, go to Working with Archives in Amazon Glacier
 // (http://docs.aws.amazon.com/amazonglacier/latest/dev/working-with-archives.html).
 type AbortMultipartUploadInput struct {
+	_ struct{} `type:"structure"`
+
 	// The AccountId value is the AWS account ID of the account that owns the vault.
 	// You can either specify an AWS account ID or optionally a single apos-apos
 	// (hyphen), in which case Amazon Glacier uses the AWS account ID associated
@@ -1642,8 +1644,6 @@ type AbortMultipartUploadInput struct {
 
 	// The name of the vault.
 	VaultName *string `location:"uri" locationName:"vaultName" type:"string" required:"true"`
-
-	_ struct{} `type:"structure"`
 }
 
 // String returns the string representation
@@ -1672,6 +1672,8 @@ func (s AbortMultipartUploadOutput) GoString() string {
 
 // The input values for AbortVaultLock.
 type AbortVaultLockInput struct {
+	_ struct{} `type:"structure"`
+
 	// The AccountId value is the AWS account ID. This value must match the AWS
 	// account ID associated with the credentials used to sign the request. You
 	// can either specify an AWS account ID or optionally a single apos-apos (hyphen),
@@ -1682,8 +1684,6 @@ type AbortVaultLockInput struct {
 
 	// The name of the vault.
 	VaultName *string `location:"uri" locationName:"vaultName" type:"string" required:"true"`
-
-	_ struct{} `type:"structure"`
 }
 
 // String returns the string representation
@@ -1712,6 +1712,8 @@ func (s AbortVaultLockOutput) GoString() string {
 
 // The input values for AddTagsToVault.
 type AddTagsToVaultInput struct {
+	_ struct{} `type:"structure"`
+
 	// The AccountId value is the AWS account ID of the account that owns the vault.
 	// You can either specify an AWS account ID or optionally a single apos-apos
 	// (hyphen), in which case Amazon Glacier uses the AWS account ID associated
@@ -1725,8 +1727,6 @@ type AddTagsToVaultInput struct {
 
 	// The name of the vault.
 	VaultName *string `location:"uri" locationName:"vaultName" type:"string" required:"true"`
-
-	_ struct{} `type:"structure"`
 }
 
 // String returns the string representation
@@ -1759,6 +1759,8 @@ func (s AddTagsToVaultOutput) GoString() string {
 // For conceptual information, go to Working with Archives in Amazon Glacier
 // (http://docs.aws.amazon.com/amazonglacier/latest/dev/working-with-archives.html).
 type ArchiveCreationOutput struct {
+	_ struct{} `type:"structure"`
+
 	// The ID of the archive. This value is also included as part of the location.
 	ArchiveId *string `location:"header" locationName:"x-amz-archive-id" type:"string"`
 
@@ -1767,8 +1769,6 @@ type ArchiveCreationOutput struct {
 
 	// The relative URI path of the newly added archive resource.
 	Location *string `location:"header" locationName:"Location" type:"string"`
-
-	_ struct{} `type:"structure"`
 }
 
 // String returns the string representation
@@ -1787,6 +1787,8 @@ func (s ArchiveCreationOutput) GoString() string {
 // saving the archive to the vault, Amazon Glacier returns the URI path of the
 // newly created archive resource.
 type CompleteMultipartUploadInput struct {
+	_ struct{} `type:"structure"`
+
 	// The AccountId value is the AWS account ID of the account that owns the vault.
 	// You can either specify an AWS account ID or optionally a single apos-apos
 	// (hyphen), in which case Amazon Glacier uses the AWS account ID associated
@@ -1809,8 +1811,6 @@ type CompleteMultipartUploadInput struct {
 
 	// The name of the vault.
 	VaultName *string `location:"uri" locationName:"vaultName" type:"string" required:"true"`
-
-	_ struct{} `type:"structure"`
 }
 
 // String returns the string representation
@@ -1825,6 +1825,8 @@ func (s CompleteMultipartUploadInput) GoString() string {
 
 // The input values for CompleteVaultLock.
 type CompleteVaultLockInput struct {
+	_ struct{} `type:"structure"`
+
 	// The AccountId value is the AWS account ID. This value must match the AWS
 	// account ID associated with the credentials used to sign the request. You
 	// can either specify an AWS account ID or optionally a single apos-apos (hyphen),
@@ -1838,8 +1840,6 @@ type CompleteVaultLockInput struct {
 
 	// The name of the vault.
 	VaultName *string `location:"uri" locationName:"vaultName" type:"string" required:"true"`
-
-	_ struct{} `type:"structure"`
 }
 
 // String returns the string representation
@@ -1868,6 +1868,8 @@ func (s CompleteVaultLockOutput) GoString() string {
 
 // Provides options to create a vault.
 type CreateVaultInput struct {
+	_ struct{} `type:"structure"`
+
 	// The AccountId value is the AWS account ID. This value must match the AWS
 	// account ID associated with the credentials used to sign the request. You
 	// can either specify an AWS account ID or optionally a single apos-apos (hyphen),
@@ -1878,8 +1880,6 @@ type CreateVaultInput struct {
 
 	// The name of the vault.
 	VaultName *string `location:"uri" locationName:"vaultName" type:"string" required:"true"`
-
-	_ struct{} `type:"structure"`
 }
 
 // String returns the string representation
@@ -1894,10 +1894,10 @@ func (s CreateVaultInput) GoString() string {
 
 // Contains the Amazon Glacier response to your request.
 type CreateVaultOutput struct {
+	_ struct{} `type:"structure"`
+
 	// The URI of the vault that was created.
 	Location *string `location:"header" locationName:"Location" type:"string"`
-
-	_ struct{} `type:"structure"`
 }
 
 // String returns the string representation
@@ -1912,11 +1912,11 @@ func (s CreateVaultOutput) GoString() string {
 
 // Data retrieval policy.
 type DataRetrievalPolicy struct {
+	_ struct{} `type:"structure"`
+
 	// The policy rule. Although this is a list type, currently there must be only
 	// one rule, which contains a Strategy field and optionally a BytesPerHour field.
 	Rules []*DataRetrievalRule `type:"list"`
-
-	_ struct{} `type:"structure"`
 }
 
 // String returns the string representation
@@ -1931,6 +1931,8 @@ func (s DataRetrievalPolicy) GoString() string {
 
 // Data retrieval policy rule.
 type DataRetrievalRule struct {
+	_ struct{} `type:"structure"`
+
 	// The maximum number of bytes that can be retrieved in an hour.
 	//
 	// This field is required only if the value of the Strategy field is BytesPerHour.
@@ -1942,8 +1944,6 @@ type DataRetrievalRule struct {
 	//
 	// Valid values: BytesPerHour|FreeTier|None
 	Strategy *string `type:"string"`
-
-	_ struct{} `type:"structure"`
 }
 
 // String returns the string representation
@@ -1958,6 +1958,8 @@ func (s DataRetrievalRule) GoString() string {
 
 // Provides options for deleting an archive from an Amazon Glacier vault.
 type DeleteArchiveInput struct {
+	_ struct{} `type:"structure"`
+
 	// The AccountId value is the AWS account ID of the account that owns the vault.
 	// You can either specify an AWS account ID or optionally a single apos-apos
 	// (hyphen), in which case Amazon Glacier uses the AWS account ID associated
@@ -1970,8 +1972,6 @@ type DeleteArchiveInput struct {
 
 	// The name of the vault.
 	VaultName *string `location:"uri" locationName:"vaultName" type:"string" required:"true"`
-
-	_ struct{} `type:"structure"`
 }
 
 // String returns the string representation
@@ -2000,6 +2000,8 @@ func (s DeleteArchiveOutput) GoString() string {
 
 // DeleteVaultAccessPolicy input.
 type DeleteVaultAccessPolicyInput struct {
+	_ struct{} `type:"structure"`
+
 	// The AccountId value is the AWS account ID of the account that owns the vault.
 	// You can either specify an AWS account ID or optionally a single apos-apos
 	// (hyphen), in which case Amazon Glacier uses the AWS account ID associated
@@ -2009,8 +2011,6 @@ type DeleteVaultAccessPolicyInput struct {
 
 	// The name of the vault.
 	VaultName *string `location:"uri" locationName:"vaultName" type:"string" required:"true"`
-
-	_ struct{} `type:"structure"`
 }
 
 // String returns the string representation
@@ -2039,6 +2039,8 @@ func (s DeleteVaultAccessPolicyOutput) GoString() string {
 
 // Provides options for deleting a vault from Amazon Glacier.
 type DeleteVaultInput struct {
+	_ struct{} `type:"structure"`
+
 	// The AccountId value is the AWS account ID of the account that owns the vault.
 	// You can either specify an AWS account ID or optionally a single apos-apos
 	// (hyphen), in which case Amazon Glacier uses the AWS account ID associated
@@ -2048,8 +2050,6 @@ type DeleteVaultInput struct {
 
 	// The name of the vault.
 	VaultName *string `location:"uri" locationName:"vaultName" type:"string" required:"true"`
-
-	_ struct{} `type:"structure"`
 }
 
 // String returns the string representation
@@ -2065,6 +2065,8 @@ func (s DeleteVaultInput) GoString() string {
 // Provides options for deleting a vault notification configuration from an
 // Amazon Glacier vault.
 type DeleteVaultNotificationsInput struct {
+	_ struct{} `type:"structure"`
+
 	// The AccountId value is the AWS account ID of the account that owns the vault.
 	// You can either specify an AWS account ID or optionally a single apos-apos
 	// (hyphen), in which case Amazon Glacier uses the AWS account ID associated
@@ -2074,8 +2076,6 @@ type DeleteVaultNotificationsInput struct {
 
 	// The name of the vault.
 	VaultName *string `location:"uri" locationName:"vaultName" type:"string" required:"true"`
-
-	_ struct{} `type:"structure"`
 }
 
 // String returns the string representation
@@ -2118,6 +2118,8 @@ func (s DeleteVaultOutput) GoString() string {
 
 // Provides options for retrieving a job description.
 type DescribeJobInput struct {
+	_ struct{} `type:"structure"`
+
 	// The AccountId value is the AWS account ID of the account that owns the vault.
 	// You can either specify an AWS account ID or optionally a single apos-apos
 	// (hyphen), in which case Amazon Glacier uses the AWS account ID associated
@@ -2130,8 +2132,6 @@ type DescribeJobInput struct {
 
 	// The name of the vault.
 	VaultName *string `location:"uri" locationName:"vaultName" type:"string" required:"true"`
-
-	_ struct{} `type:"structure"`
 }
 
 // String returns the string representation
@@ -2146,6 +2146,8 @@ func (s DescribeJobInput) GoString() string {
 
 // Provides options for retrieving metadata for a specific vault in Amazon Glacier.
 type DescribeVaultInput struct {
+	_ struct{} `type:"structure"`
+
 	// The AccountId value is the AWS account ID of the account that owns the vault.
 	// You can either specify an AWS account ID or optionally a single apos-apos
 	// (hyphen), in which case Amazon Glacier uses the AWS account ID associated
@@ -2155,8 +2157,6 @@ type DescribeVaultInput struct {
 
 	// The name of the vault.
 	VaultName *string `location:"uri" locationName:"vaultName" type:"string" required:"true"`
-
-	_ struct{} `type:"structure"`
 }
 
 // String returns the string representation
@@ -2171,6 +2171,8 @@ func (s DescribeVaultInput) GoString() string {
 
 // Contains the Amazon Glacier response to your request.
 type DescribeVaultOutput struct {
+	_ struct{} `type:"structure"`
+
 	// The UTC date when the vault was created. A string representation of ISO 8601
 	// date format, for example, "2012-03-20T17:03:43.221Z".
 	CreationDate *string `type:"string"`
@@ -2194,8 +2196,6 @@ type DescribeVaultOutput struct {
 
 	// The name of the vault.
 	VaultName *string `type:"string"`
-
-	_ struct{} `type:"structure"`
 }
 
 // String returns the string representation
@@ -2210,6 +2210,8 @@ func (s DescribeVaultOutput) GoString() string {
 
 // Input for GetDataRetrievalPolicy.
 type GetDataRetrievalPolicyInput struct {
+	_ struct{} `type:"structure"`
+
 	// The AccountId value is the AWS account ID. This value must match the AWS
 	// account ID associated with the credentials used to sign the request. You
 	// can either specify an AWS account ID or optionally a single apos-apos (hyphen),
@@ -2217,8 +2219,6 @@ type GetDataRetrievalPolicyInput struct {
 	// credentials used to sign the request. If you specify your account ID, do
 	// not include any hyphens (apos-apos) in the ID.
 	AccountId *string `location:"uri" locationName:"accountId" type:"string" required:"true"`
-
-	_ struct{} `type:"structure"`
 }
 
 // String returns the string representation
@@ -2233,10 +2233,10 @@ func (s GetDataRetrievalPolicyInput) GoString() string {
 
 // Contains the Amazon Glacier response to the GetDataRetrievalPolicy request.
 type GetDataRetrievalPolicyOutput struct {
+	_ struct{} `type:"structure"`
+
 	// Contains the returned data retrieval policy in JSON format.
 	Policy *DataRetrievalPolicy `type:"structure"`
-
-	_ struct{} `type:"structure"`
 }
 
 // String returns the string representation
@@ -2251,6 +2251,8 @@ func (s GetDataRetrievalPolicyOutput) GoString() string {
 
 // Provides options for downloading output of an Amazon Glacier job.
 type GetJobOutputInput struct {
+	_ struct{} `type:"structure"`
+
 	// The AccountId value is the AWS account ID of the account that owns the vault.
 	// You can either specify an AWS account ID or optionally a single apos-apos
 	// (hyphen), in which case Amazon Glacier uses the AWS account ID associated
@@ -2268,8 +2270,6 @@ type GetJobOutputInput struct {
 
 	// The name of the vault.
 	VaultName *string `location:"uri" locationName:"vaultName" type:"string" required:"true"`
-
-	_ struct{} `type:"structure"`
 }
 
 // String returns the string representation
@@ -2284,6 +2284,8 @@ func (s GetJobOutputInput) GoString() string {
 
 // Contains the Amazon Glacier response to your request.
 type GetJobOutputOutput struct {
+	_ struct{} `type:"structure" payload:"Body"`
+
 	// Indicates the range units accepted. For more information, go to RFC2616 (http://www.w3.org/Protocols/rfc2616/rfc2616-sec14.html).
 	AcceptRanges *string `location:"header" locationName:"Accept-Ranges" type:"string"`
 
@@ -2321,8 +2323,6 @@ type GetJobOutputOutput struct {
 	// The HTTP response code for a job output request. The value depends on whether
 	// a range was specified in the request.
 	Status *int64 `location:"statusCode" locationName:"status" type:"integer"`
-
-	_ struct{} `type:"structure" payload:"Body"`
 }
 
 // String returns the string representation
@@ -2337,6 +2337,8 @@ func (s GetJobOutputOutput) GoString() string {
 
 // Input for GetVaultAccessPolicy.
 type GetVaultAccessPolicyInput struct {
+	_ struct{} `type:"structure"`
+
 	// The AccountId value is the AWS account ID of the account that owns the vault.
 	// You can either specify an AWS account ID or optionally a single apos-apos
 	// (hyphen), in which case Amazon Glacier uses the AWS account ID associated
@@ -2346,8 +2348,6 @@ type GetVaultAccessPolicyInput struct {
 
 	// The name of the vault.
 	VaultName *string `location:"uri" locationName:"vaultName" type:"string" required:"true"`
-
-	_ struct{} `type:"structure"`
 }
 
 // String returns the string representation
@@ -2362,10 +2362,10 @@ func (s GetVaultAccessPolicyInput) GoString() string {
 
 // Output for GetVaultAccessPolicy.
 type GetVaultAccessPolicyOutput struct {
+	_ struct{} `type:"structure" payload:"Policy"`
+
 	// Contains the returned vault access policy as a JSON string.
 	Policy *VaultAccessPolicy `locationName:"policy" type:"structure"`
-
-	_ struct{} `type:"structure" payload:"Policy"`
 }
 
 // String returns the string representation
@@ -2380,6 +2380,8 @@ func (s GetVaultAccessPolicyOutput) GoString() string {
 
 // The input values for GetVaultLock.
 type GetVaultLockInput struct {
+	_ struct{} `type:"structure"`
+
 	// The AccountId value is the AWS account ID of the account that owns the vault.
 	// You can either specify an AWS account ID or optionally a single apos-apos
 	// (hyphen), in which case Amazon Glacier uses the AWS account ID associated
@@ -2389,8 +2391,6 @@ type GetVaultLockInput struct {
 
 	// The name of the vault.
 	VaultName *string `location:"uri" locationName:"vaultName" type:"string" required:"true"`
-
-	_ struct{} `type:"structure"`
 }
 
 // String returns the string representation
@@ -2405,6 +2405,8 @@ func (s GetVaultLockInput) GoString() string {
 
 // Contains the Amazon Glacier response to your request.
 type GetVaultLockOutput struct {
+	_ struct{} `type:"structure"`
+
 	// The UTC date and time at which the vault lock was put into the InProgress
 	// state.
 	CreationDate *string `type:"string"`
@@ -2418,8 +2420,6 @@ type GetVaultLockOutput struct {
 
 	// The state of the vault lock. InProgress or Locked.
 	State *string `type:"string"`
-
-	_ struct{} `type:"structure"`
 }
 
 // String returns the string representation
@@ -2435,6 +2435,8 @@ func (s GetVaultLockOutput) GoString() string {
 // Provides options for retrieving the notification configuration set on an
 // Amazon Glacier vault.
 type GetVaultNotificationsInput struct {
+	_ struct{} `type:"structure"`
+
 	// The AccountId value is the AWS account ID of the account that owns the vault.
 	// You can either specify an AWS account ID or optionally a single apos-apos
 	// (hyphen), in which case Amazon Glacier uses the AWS account ID associated
@@ -2444,8 +2446,6 @@ type GetVaultNotificationsInput struct {
 
 	// The name of the vault.
 	VaultName *string `location:"uri" locationName:"vaultName" type:"string" required:"true"`
-
-	_ struct{} `type:"structure"`
 }
 
 // String returns the string representation
@@ -2460,10 +2460,10 @@ func (s GetVaultNotificationsInput) GoString() string {
 
 // Contains the Amazon Glacier response to your request.
 type GetVaultNotificationsOutput struct {
+	_ struct{} `type:"structure" payload:"VaultNotificationConfig"`
+
 	// Returns the notification configuration set on the vault.
 	VaultNotificationConfig *VaultNotificationConfig `locationName:"vaultNotificationConfig" type:"structure"`
-
-	_ struct{} `type:"structure" payload:"VaultNotificationConfig"`
 }
 
 // String returns the string representation
@@ -2478,6 +2478,8 @@ func (s GetVaultNotificationsOutput) GoString() string {
 
 // Provides options for initiating an Amazon Glacier job.
 type InitiateJobInput struct {
+	_ struct{} `type:"structure" payload:"JobParameters"`
+
 	// The AccountId value is the AWS account ID of the account that owns the vault.
 	// You can either specify an AWS account ID or optionally a single apos-apos
 	// (hyphen), in which case Amazon Glacier uses the AWS account ID associated
@@ -2490,8 +2492,6 @@ type InitiateJobInput struct {
 
 	// The name of the vault.
 	VaultName *string `location:"uri" locationName:"vaultName" type:"string" required:"true"`
-
-	_ struct{} `type:"structure" payload:"JobParameters"`
 }
 
 // String returns the string representation
@@ -2506,13 +2506,13 @@ func (s InitiateJobInput) GoString() string {
 
 // Contains the Amazon Glacier response to your request.
 type InitiateJobOutput struct {
+	_ struct{} `type:"structure"`
+
 	// The ID of the job.
 	JobId *string `location:"header" locationName:"x-amz-job-id" type:"string"`
 
 	// The relative URI path of the job.
 	Location *string `location:"header" locationName:"Location" type:"string"`
-
-	_ struct{} `type:"structure"`
 }
 
 // String returns the string representation
@@ -2527,6 +2527,8 @@ func (s InitiateJobOutput) GoString() string {
 
 // Provides options for initiating a multipart upload to an Amazon Glacier vault.
 type InitiateMultipartUploadInput struct {
+	_ struct{} `type:"structure"`
+
 	// The AccountId value is the AWS account ID of the account that owns the vault.
 	// You can either specify an AWS account ID or optionally a single apos-apos
 	// (hyphen), in which case Amazon Glacier uses the AWS account ID associated
@@ -2548,8 +2550,6 @@ type InitiateMultipartUploadInput struct {
 
 	// The name of the vault.
 	VaultName *string `location:"uri" locationName:"vaultName" type:"string" required:"true"`
-
-	_ struct{} `type:"structure"`
 }
 
 // String returns the string representation
@@ -2564,14 +2564,14 @@ func (s InitiateMultipartUploadInput) GoString() string {
 
 // The Amazon Glacier response to your request.
 type InitiateMultipartUploadOutput struct {
+	_ struct{} `type:"structure"`
+
 	// The relative URI path of the multipart upload ID Amazon Glacier created.
 	Location *string `location:"header" locationName:"Location" type:"string"`
 
 	// The ID of the multipart upload. This value is also included as part of the
 	// location.
 	UploadId *string `location:"header" locationName:"x-amz-multipart-upload-id" type:"string"`
-
-	_ struct{} `type:"structure"`
 }
 
 // String returns the string representation
@@ -2586,6 +2586,8 @@ func (s InitiateMultipartUploadOutput) GoString() string {
 
 // The input values for InitiateVaultLock.
 type InitiateVaultLockInput struct {
+	_ struct{} `type:"structure" payload:"Policy"`
+
 	// The AccountId value is the AWS account ID. This value must match the AWS
 	// account ID associated with the credentials used to sign the request. You
 	// can either specify an AWS account ID or optionally a single apos-apos (hyphen),
@@ -2599,8 +2601,6 @@ type InitiateVaultLockInput struct {
 
 	// The name of the vault.
 	VaultName *string `location:"uri" locationName:"vaultName" type:"string" required:"true"`
-
-	_ struct{} `type:"structure" payload:"Policy"`
 }
 
 // String returns the string representation
@@ -2615,10 +2615,10 @@ func (s InitiateVaultLockInput) GoString() string {
 
 // Contains the Amazon Glacier response to your request.
 type InitiateVaultLockOutput struct {
+	_ struct{} `type:"structure"`
+
 	// The lock ID, which is used to complete the vault locking process.
 	LockId *string `location:"header" locationName:"x-amz-lock-id" type:"string"`
-
-	_ struct{} `type:"structure"`
 }
 
 // String returns the string representation
@@ -2633,6 +2633,8 @@ func (s InitiateVaultLockOutput) GoString() string {
 
 // Describes the options for a range inventory retrieval job.
 type InventoryRetrievalJobDescription struct {
+	_ struct{} `type:"structure"`
+
 	// The end of the date range in UTC for vault inventory retrieval that includes
 	// archives created before this date. A string representation of ISO 8601 date
 	// format, for example, 2013-03-20T17:03:43Z.
@@ -2659,8 +2661,6 @@ type InventoryRetrievalJobDescription struct {
 	// archives created on or after this date. A string representation of ISO 8601
 	// date format, for example, 2013-03-20T17:03:43Z.
 	StartDate *string `type:"string"`
-
-	_ struct{} `type:"structure"`
 }
 
 // String returns the string representation
@@ -2675,6 +2675,8 @@ func (s InventoryRetrievalJobDescription) GoString() string {
 
 // Provides options for specifying a range inventory retrieval job.
 type InventoryRetrievalJobInput struct {
+	_ struct{} `type:"structure"`
+
 	// The end of the date range in UTC for vault inventory retrieval that includes
 	// archives created before this date. A string representation of ISO 8601 date
 	// format, for example, 2013-03-20T17:03:43Z.
@@ -2694,8 +2696,6 @@ type InventoryRetrievalJobInput struct {
 	// archives created on or after this date. A string representation of ISO 8601
 	// date format, for example, 2013-03-20T17:03:43Z.
 	StartDate *string `type:"string"`
-
-	_ struct{} `type:"structure"`
 }
 
 // String returns the string representation
@@ -2710,6 +2710,8 @@ func (s InventoryRetrievalJobInput) GoString() string {
 
 // Describes an Amazon Glacier job.
 type JobDescription struct {
+	_ struct{} `type:"structure"`
+
 	// The job type. It is either ArchiveRetrieval or InventoryRetrieval.
 	Action *string `type:"string" enum:"ActionCode"`
 
@@ -2787,8 +2789,6 @@ type JobDescription struct {
 	// The Amazon Resource Name (ARN) of the vault from which the archive retrieval
 	// was requested.
 	VaultARN *string `type:"string"`
-
-	_ struct{} `type:"structure"`
 }
 
 // String returns the string representation
@@ -2803,6 +2803,8 @@ func (s JobDescription) GoString() string {
 
 // Provides options for defining a job.
 type JobParameters struct {
+	_ struct{} `type:"structure"`
+
 	// The ID of the archive that you want to retrieve. This field is required only
 	// if Type is set to archive-retrieval. An error occurs if you specify this
 	// request parameter for an inventory retrieval job request.
@@ -2842,8 +2844,6 @@ type JobParameters struct {
 	// The job type. You can initiate a job to retrieve an archive or get an inventory
 	// of a vault. Valid values are "archive-retrieval" and "inventory-retrieval".
 	Type *string `type:"string"`
-
-	_ struct{} `type:"structure"`
 }
 
 // String returns the string representation
@@ -2858,6 +2858,8 @@ func (s JobParameters) GoString() string {
 
 // Provides options for retrieving a job list for an Amazon Glacier vault.
 type ListJobsInput struct {
+	_ struct{} `type:"structure"`
+
 	// The AccountId value is the AWS account ID of the account that owns the vault.
 	// You can either specify an AWS account ID or optionally a single apos-apos
 	// (hyphen), in which case Amazon Glacier uses the AWS account ID associated
@@ -2884,8 +2886,6 @@ type ListJobsInput struct {
 
 	// The name of the vault.
 	VaultName *string `location:"uri" locationName:"vaultName" type:"string" required:"true"`
-
-	_ struct{} `type:"structure"`
 }
 
 // String returns the string representation
@@ -2900,6 +2900,8 @@ func (s ListJobsInput) GoString() string {
 
 // Contains the Amazon Glacier response to your request.
 type ListJobsOutput struct {
+	_ struct{} `type:"structure"`
+
 	// A list of job objects. Each job object contains metadata describing the job.
 	JobList []*JobDescription `type:"list"`
 
@@ -2907,8 +2909,6 @@ type ListJobsOutput struct {
 	// You use this value in a new List Jobs request to obtain more jobs in the
 	// list. If there are no more jobs, this value is null.
 	Marker *string `type:"string"`
-
-	_ struct{} `type:"structure"`
 }
 
 // String returns the string representation
@@ -2924,6 +2924,8 @@ func (s ListJobsOutput) GoString() string {
 // Provides options for retrieving list of in-progress multipart uploads for
 // an Amazon Glacier vault.
 type ListMultipartUploadsInput struct {
+	_ struct{} `type:"structure"`
+
 	// The AccountId value is the AWS account ID of the account that owns the vault.
 	// You can either specify an AWS account ID or optionally a single apos-apos
 	// (hyphen), in which case Amazon Glacier uses the AWS account ID associated
@@ -2944,8 +2946,6 @@ type ListMultipartUploadsInput struct {
 
 	// The name of the vault.
 	VaultName *string `location:"uri" locationName:"vaultName" type:"string" required:"true"`
-
-	_ struct{} `type:"structure"`
 }
 
 // String returns the string representation
@@ -2960,6 +2960,8 @@ func (s ListMultipartUploadsInput) GoString() string {
 
 // Contains the Amazon Glacier response to your request.
 type ListMultipartUploadsOutput struct {
+	_ struct{} `type:"structure"`
+
 	// An opaque string that represents where to continue pagination of the results.
 	// You use the marker in a new List Multipart Uploads request to obtain more
 	// uploads in the list. If there are no more uploads, this value is null.
@@ -2967,8 +2969,6 @@ type ListMultipartUploadsOutput struct {
 
 	// A list of in-progress multipart uploads.
 	UploadsList []*UploadListElement `type:"list"`
-
-	_ struct{} `type:"structure"`
 }
 
 // String returns the string representation
@@ -2984,6 +2984,8 @@ func (s ListMultipartUploadsOutput) GoString() string {
 // Provides options for retrieving a list of parts of an archive that have been
 // uploaded in a specific multipart upload.
 type ListPartsInput struct {
+	_ struct{} `type:"structure"`
+
 	// The AccountId value is the AWS account ID of the account that owns the vault.
 	// You can either specify an AWS account ID or optionally a single apos-apos
 	// (hyphen), in which case Amazon Glacier uses the AWS account ID associated
@@ -3007,8 +3009,6 @@ type ListPartsInput struct {
 
 	// The name of the vault.
 	VaultName *string `location:"uri" locationName:"vaultName" type:"string" required:"true"`
-
-	_ struct{} `type:"structure"`
 }
 
 // String returns the string representation
@@ -3023,6 +3023,8 @@ func (s ListPartsInput) GoString() string {
 
 // Contains the Amazon Glacier response to your request.
 type ListPartsOutput struct {
+	_ struct{} `type:"structure"`
+
 	// The description of the archive that was specified in the Initiate Multipart
 	// Upload request.
 	ArchiveDescription *string `type:"string"`
@@ -3047,8 +3049,6 @@ type ListPartsOutput struct {
 	// The Amazon Resource Name (ARN) of the vault to which the multipart upload
 	// was initiated.
 	VaultARN *string `type:"string"`
-
-	_ struct{} `type:"structure"`
 }
 
 // String returns the string representation
@@ -3063,6 +3063,8 @@ func (s ListPartsOutput) GoString() string {
 
 // The input value for ListTagsForVaultInput.
 type ListTagsForVaultInput struct {
+	_ struct{} `type:"structure"`
+
 	// The AccountId value is the AWS account ID of the account that owns the vault.
 	// You can either specify an AWS account ID or optionally a single apos-apos
 	// (hyphen), in which case Amazon Glacier uses the AWS account ID associated
@@ -3072,8 +3074,6 @@ type ListTagsForVaultInput struct {
 
 	// The name of the vault.
 	VaultName *string `location:"uri" locationName:"vaultName" type:"string" required:"true"`
-
-	_ struct{} `type:"structure"`
 }
 
 // String returns the string representation
@@ -3088,10 +3088,10 @@ func (s ListTagsForVaultInput) GoString() string {
 
 // Contains the Amazon Glacier response to your request.
 type ListTagsForVaultOutput struct {
+	_ struct{} `type:"structure"`
+
 	// The tags attached to the vault. Each tag is composed of a key and a value.
 	Tags map[string]*string `type:"map"`
-
-	_ struct{} `type:"structure"`
 }
 
 // String returns the string representation
@@ -3107,6 +3107,8 @@ func (s ListTagsForVaultOutput) GoString() string {
 // Provides options to retrieve the vault list owned by the calling user's account.
 // The list provides metadata information for each vault.
 type ListVaultsInput struct {
+	_ struct{} `type:"structure"`
+
 	// The AccountId value is the AWS account ID. This value must match the AWS
 	// account ID associated with the credentials used to sign the request. You
 	// can either specify an AWS account ID or optionally a single apos-apos (hyphen),
@@ -3122,8 +3124,6 @@ type ListVaultsInput struct {
 	// A string used for pagination. The marker specifies the vault ARN after which
 	// the listing of vaults should begin.
 	Marker *string `location:"querystring" locationName:"marker" type:"string"`
-
-	_ struct{} `type:"structure"`
 }
 
 // String returns the string representation
@@ -3138,14 +3138,14 @@ func (s ListVaultsInput) GoString() string {
 
 // Contains the Amazon Glacier response to your request.
 type ListVaultsOutput struct {
+	_ struct{} `type:"structure"`
+
 	// The vault ARN at which to continue pagination of the results. You use the
 	// marker in another List Vaults request to obtain more vaults in the list.
 	Marker *string `type:"string"`
 
 	// List of vaults.
 	VaultList []*DescribeVaultOutput `type:"list"`
-
-	_ struct{} `type:"structure"`
 }
 
 // String returns the string representation
@@ -3160,14 +3160,14 @@ func (s ListVaultsOutput) GoString() string {
 
 // A list of the part sizes of the multipart upload.
 type PartListElement struct {
+	_ struct{} `type:"structure"`
+
 	// The byte range of a part, inclusive of the upper value of the range.
 	RangeInBytes *string `type:"string"`
 
 	// The SHA256 tree hash value that Amazon Glacier calculated for the part. This
 	// field is never null.
 	SHA256TreeHash *string `type:"string"`
-
-	_ struct{} `type:"structure"`
 }
 
 // String returns the string representation
@@ -3182,6 +3182,8 @@ func (s PartListElement) GoString() string {
 
 // The input value for RemoveTagsFromVaultInput.
 type RemoveTagsFromVaultInput struct {
+	_ struct{} `type:"structure"`
+
 	// The AccountId value is the AWS account ID of the account that owns the vault.
 	// You can either specify an AWS account ID or optionally a single apos-apos
 	// (hyphen), in which case Amazon Glacier uses the AWS account ID associated
@@ -3194,8 +3196,6 @@ type RemoveTagsFromVaultInput struct {
 
 	// The name of the vault.
 	VaultName *string `location:"uri" locationName:"vaultName" type:"string" required:"true"`
-
-	_ struct{} `type:"structure"`
 }
 
 // String returns the string representation
@@ -3224,6 +3224,8 @@ func (s RemoveTagsFromVaultOutput) GoString() string {
 
 // SetDataRetrievalPolicy input.
 type SetDataRetrievalPolicyInput struct {
+	_ struct{} `type:"structure"`
+
 	// The AccountId value is the AWS account ID. This value must match the AWS
 	// account ID associated with the credentials used to sign the request. You
 	// can either specify an AWS account ID or optionally a single apos-apos (hyphen),
@@ -3234,8 +3236,6 @@ type SetDataRetrievalPolicyInput struct {
 
 	// The data retrieval policy in JSON format.
 	Policy *DataRetrievalPolicy `type:"structure"`
-
-	_ struct{} `type:"structure"`
 }
 
 // String returns the string representation
@@ -3264,6 +3264,8 @@ func (s SetDataRetrievalPolicyOutput) GoString() string {
 
 // SetVaultAccessPolicy input.
 type SetVaultAccessPolicyInput struct {
+	_ struct{} `type:"structure" payload:"Policy"`
+
 	// The AccountId value is the AWS account ID of the account that owns the vault.
 	// You can either specify an AWS account ID or optionally a single apos-apos
 	// (hyphen), in which case Amazon Glacier uses the AWS account ID associated
@@ -3276,8 +3278,6 @@ type SetVaultAccessPolicyInput struct {
 
 	// The name of the vault.
 	VaultName *string `location:"uri" locationName:"vaultName" type:"string" required:"true"`
-
-	_ struct{} `type:"structure" payload:"Policy"`
 }
 
 // String returns the string representation
@@ -3307,6 +3307,8 @@ func (s SetVaultAccessPolicyOutput) GoString() string {
 // Provides options to configure notifications that will be sent when specific
 // events happen to a vault.
 type SetVaultNotificationsInput struct {
+	_ struct{} `type:"structure" payload:"VaultNotificationConfig"`
+
 	// The AccountId value is the AWS account ID of the account that owns the vault.
 	// You can either specify an AWS account ID or optionally a single apos-apos
 	// (hyphen), in which case Amazon Glacier uses the AWS account ID associated
@@ -3319,8 +3321,6 @@ type SetVaultNotificationsInput struct {
 
 	// Provides options for specifying notification configuration.
 	VaultNotificationConfig *VaultNotificationConfig `locationName:"vaultNotificationConfig" type:"structure"`
-
-	_ struct{} `type:"structure" payload:"VaultNotificationConfig"`
 }
 
 // String returns the string representation
@@ -3349,6 +3349,8 @@ func (s SetVaultNotificationsOutput) GoString() string {
 
 // Provides options to add an archive to a vault.
 type UploadArchiveInput struct {
+	_ struct{} `type:"structure" payload:"Body"`
+
 	// The AccountId value is the AWS account ID of the account that owns the vault.
 	// You can either specify an AWS account ID or optionally a single apos-apos
 	// (hyphen), in which case Amazon Glacier uses the AWS account ID associated
@@ -3367,8 +3369,6 @@ type UploadArchiveInput struct {
 
 	// The name of the vault.
 	VaultName *string `location:"uri" locationName:"vaultName" type:"string" required:"true"`
-
-	_ struct{} `type:"structure" payload:"Body"`
 }
 
 // String returns the string representation
@@ -3383,6 +3383,8 @@ func (s UploadArchiveInput) GoString() string {
 
 // A list of in-progress multipart uploads for a vault.
 type UploadListElement struct {
+	_ struct{} `type:"structure"`
+
 	// The description of the archive that was specified in the Initiate Multipart
 	// Upload request.
 	ArchiveDescription *string `type:"string"`
@@ -3400,8 +3402,6 @@ type UploadListElement struct {
 
 	// The Amazon Resource Name (ARN) of the vault that contains the archive.
 	VaultARN *string `type:"string"`
-
-	_ struct{} `type:"structure"`
 }
 
 // String returns the string representation
@@ -3416,6 +3416,8 @@ func (s UploadListElement) GoString() string {
 
 // Provides options to upload a part of an archive in a multipart upload operation.
 type UploadMultipartPartInput struct {
+	_ struct{} `type:"structure" payload:"Body"`
+
 	// The AccountId value is the AWS account ID of the account that owns the vault.
 	// You can either specify an AWS account ID or optionally a single apos-apos
 	// (hyphen), in which case Amazon Glacier uses the AWS account ID associated
@@ -3440,8 +3442,6 @@ type UploadMultipartPartInput struct {
 
 	// The name of the vault.
 	VaultName *string `location:"uri" locationName:"vaultName" type:"string" required:"true"`
-
-	_ struct{} `type:"structure" payload:"Body"`
 }
 
 // String returns the string representation
@@ -3456,10 +3456,10 @@ func (s UploadMultipartPartInput) GoString() string {
 
 // Contains the Amazon Glacier response to your request.
 type UploadMultipartPartOutput struct {
+	_ struct{} `type:"structure"`
+
 	// The SHA256 tree hash that Amazon Glacier computed for the uploaded part.
 	Checksum *string `location:"header" locationName:"x-amz-sha256-tree-hash" type:"string"`
-
-	_ struct{} `type:"structure"`
 }
 
 // String returns the string representation
@@ -3474,10 +3474,10 @@ func (s UploadMultipartPartOutput) GoString() string {
 
 // Contains the vault access policy.
 type VaultAccessPolicy struct {
+	_ struct{} `type:"structure"`
+
 	// The vault access policy.
 	Policy *string `type:"string"`
-
-	_ struct{} `type:"structure"`
 }
 
 // String returns the string representation
@@ -3492,10 +3492,10 @@ func (s VaultAccessPolicy) GoString() string {
 
 // Contains the vault lock policy.
 type VaultLockPolicy struct {
+	_ struct{} `type:"structure"`
+
 	// The vault lock policy.
 	Policy *string `type:"string"`
-
-	_ struct{} `type:"structure"`
 }
 
 // String returns the string representation
@@ -3510,6 +3510,8 @@ func (s VaultLockPolicy) GoString() string {
 
 // Represents a vault's notification configuration.
 type VaultNotificationConfig struct {
+	_ struct{} `type:"structure"`
+
 	// A list of one or more events for which Amazon Glacier will send a notification
 	// to the specified Amazon SNS topic.
 	Events []*string `type:"list"`
@@ -3517,8 +3519,6 @@ type VaultNotificationConfig struct {
 	// The Amazon Simple Notification Service (Amazon SNS) topic Amazon Resource
 	// Name (ARN).
 	SNSTopic *string `type:"string"`
-
-	_ struct{} `type:"structure"`
 }
 
 // String returns the string representation

--- a/service/iam/api.go
+++ b/service/iam/api.go
@@ -4178,6 +4178,8 @@ func (c *IAM) UploadSigningCertificate(input *UploadSigningCertificateInput) (*U
 // you cannot recover the secret access key later. If you lose a secret access
 // key, you must create a new access key.
 type AccessKey struct {
+	_ struct{} `type:"structure"`
+
 	// The ID for this access key.
 	AccessKeyId *string `min:"16" type:"string" required:"true"`
 
@@ -4193,8 +4195,6 @@ type AccessKey struct {
 
 	// The name of the IAM user that the access key is associated with.
 	UserName *string `min:"1" type:"string" required:"true"`
-
-	_ struct{} `type:"structure"`
 }
 
 // String returns the string representation
@@ -4212,6 +4212,8 @@ func (s AccessKey) GoString() string {
 // This data type is used as a response element in the GetAccessKeyLastUsed
 // action.
 type AccessKeyLastUsed struct {
+	_ struct{} `type:"structure"`
+
 	// The date and time, in ISO 8601 date-time format (http://www.iso.org/iso/iso8601),
 	// when the access key was most recently used. This field is null when:
 	//
@@ -4247,8 +4249,6 @@ type AccessKeyLastUsed struct {
 	//
 	//   There is no sign-in data associated with the user
 	ServiceName *string `type:"string" required:"true"`
-
-	_ struct{} `type:"structure"`
 }
 
 // String returns the string representation
@@ -4265,6 +4265,8 @@ func (s AccessKeyLastUsed) GoString() string {
 //
 // This data type is used as a response element in the ListAccessKeys action.
 type AccessKeyMetadata struct {
+	_ struct{} `type:"structure"`
+
 	// The ID for this access key.
 	AccessKeyId *string `min:"16" type:"string"`
 
@@ -4277,8 +4279,6 @@ type AccessKeyMetadata struct {
 
 	// The name of the IAM user that the key is associated with.
 	UserName *string `min:"1" type:"string"`
-
-	_ struct{} `type:"structure"`
 }
 
 // String returns the string representation
@@ -4292,6 +4292,8 @@ func (s AccessKeyMetadata) GoString() string {
 }
 
 type AddClientIDToOpenIDConnectProviderInput struct {
+	_ struct{} `type:"structure"`
+
 	// The client ID (also known as audience) to add to the IAM OpenID Connect provider.
 	ClientID *string `min:"1" type:"string" required:"true"`
 
@@ -4299,8 +4301,6 @@ type AddClientIDToOpenIDConnectProviderInput struct {
 	// to add the client ID to. You can get a list of OIDC provider ARNs by using
 	// the ListOpenIDConnectProviders action.
 	OpenIDConnectProviderArn *string `min:"20" type:"string" required:"true"`
-
-	_ struct{} `type:"structure"`
 }
 
 // String returns the string representation
@@ -4328,13 +4328,13 @@ func (s AddClientIDToOpenIDConnectProviderOutput) GoString() string {
 }
 
 type AddRoleToInstanceProfileInput struct {
+	_ struct{} `type:"structure"`
+
 	// The name of the instance profile to update.
 	InstanceProfileName *string `min:"1" type:"string" required:"true"`
 
 	// The name of the role to add.
 	RoleName *string `min:"1" type:"string" required:"true"`
-
-	_ struct{} `type:"structure"`
 }
 
 // String returns the string representation
@@ -4362,13 +4362,13 @@ func (s AddRoleToInstanceProfileOutput) GoString() string {
 }
 
 type AddUserToGroupInput struct {
+	_ struct{} `type:"structure"`
+
 	// The name of the group to update.
 	GroupName *string `min:"1" type:"string" required:"true"`
 
 	// The name of the user to add.
 	UserName *string `min:"1" type:"string" required:"true"`
-
-	_ struct{} `type:"structure"`
 }
 
 // String returns the string representation
@@ -4396,6 +4396,8 @@ func (s AddUserToGroupOutput) GoString() string {
 }
 
 type AttachGroupPolicyInput struct {
+	_ struct{} `type:"structure"`
+
 	// The name (friendly name, not ARN) of the group to attach the policy to.
 	GroupName *string `min:"1" type:"string" required:"true"`
 
@@ -4405,8 +4407,6 @@ type AttachGroupPolicyInput struct {
 	// AWS Service Namespaces (http://docs.aws.amazon.com/general/latest/gr/aws-arns-and-namespaces.html)
 	// in the AWS General Reference.
 	PolicyArn *string `min:"20" type:"string" required:"true"`
-
-	_ struct{} `type:"structure"`
 }
 
 // String returns the string representation
@@ -4434,6 +4434,8 @@ func (s AttachGroupPolicyOutput) GoString() string {
 }
 
 type AttachRolePolicyInput struct {
+	_ struct{} `type:"structure"`
+
 	// The Amazon Resource Name (ARN). ARNs are unique identifiers for AWS resources.
 	//
 	// For more information about ARNs, go to Amazon Resource Names (ARNs) and
@@ -4443,8 +4445,6 @@ type AttachRolePolicyInput struct {
 
 	// The name (friendly name, not ARN) of the role to attach the policy to.
 	RoleName *string `min:"1" type:"string" required:"true"`
-
-	_ struct{} `type:"structure"`
 }
 
 // String returns the string representation
@@ -4472,6 +4472,8 @@ func (s AttachRolePolicyOutput) GoString() string {
 }
 
 type AttachUserPolicyInput struct {
+	_ struct{} `type:"structure"`
+
 	// The Amazon Resource Name (ARN). ARNs are unique identifiers for AWS resources.
 	//
 	// For more information about ARNs, go to Amazon Resource Names (ARNs) and
@@ -4481,8 +4483,6 @@ type AttachUserPolicyInput struct {
 
 	// The name (friendly name, not ARN) of the user to attach the policy to.
 	UserName *string `min:"1" type:"string" required:"true"`
-
-	_ struct{} `type:"structure"`
 }
 
 // String returns the string representation
@@ -4520,6 +4520,8 @@ func (s AttachUserPolicyOutput) GoString() string {
 // Inline Policies (http://docs.aws.amazon.com/IAM/latest/UserGuide/policies-managed-vs-inline.html)
 // in the Using IAM guide.
 type AttachedPolicy struct {
+	_ struct{} `type:"structure"`
+
 	// The Amazon Resource Name (ARN). ARNs are unique identifiers for AWS resources.
 	//
 	// For more information about ARNs, go to Amazon Resource Names (ARNs) and
@@ -4529,8 +4531,6 @@ type AttachedPolicy struct {
 
 	// The friendly name of the attached policy.
 	PolicyName *string `min:"1" type:"string"`
-
-	_ struct{} `type:"structure"`
 }
 
 // String returns the string representation
@@ -4544,14 +4544,14 @@ func (s AttachedPolicy) GoString() string {
 }
 
 type ChangePasswordInput struct {
+	_ struct{} `type:"structure"`
+
 	// The new password. The new password must conform to the AWS account's password
 	// policy, if one exists.
 	NewPassword *string `min:"1" type:"string" required:"true"`
 
 	// The IAM user's current password.
 	OldPassword *string `min:"1" type:"string" required:"true"`
-
-	_ struct{} `type:"structure"`
 }
 
 // String returns the string representation
@@ -4585,6 +4585,8 @@ func (s ChangePasswordOutput) GoString() string {
 //
 // This data type is used as an input parameter to SimulatePolicy.
 type ContextEntry struct {
+	_ struct{} `type:"structure"`
+
 	// The full name of a condition context key, including the service prefix. For
 	// example, aws:SourceIp or s3:VersionId.
 	ContextKeyName *string `min:"5" type:"string"`
@@ -4597,8 +4599,6 @@ type ContextEntry struct {
 	// to provide to the simulation for use when the key is referenced by a Condition
 	// element in an input policy.
 	ContextKeyValues []*string `type:"list"`
-
-	_ struct{} `type:"structure"`
 }
 
 // String returns the string representation
@@ -4612,10 +4612,10 @@ func (s ContextEntry) GoString() string {
 }
 
 type CreateAccessKeyInput struct {
+	_ struct{} `type:"structure"`
+
 	// The user name that the new key will belong to.
 	UserName *string `min:"1" type:"string"`
-
-	_ struct{} `type:"structure"`
 }
 
 // String returns the string representation
@@ -4630,10 +4630,10 @@ func (s CreateAccessKeyInput) GoString() string {
 
 // Contains the response to a successful CreateAccessKey request.
 type CreateAccessKeyOutput struct {
+	_ struct{} `type:"structure"`
+
 	// Information about the access key.
 	AccessKey *AccessKey `type:"structure" required:"true"`
-
-	_ struct{} `type:"structure"`
 }
 
 // String returns the string representation
@@ -4647,10 +4647,10 @@ func (s CreateAccessKeyOutput) GoString() string {
 }
 
 type CreateAccountAliasInput struct {
+	_ struct{} `type:"structure"`
+
 	// The account alias to create.
 	AccountAlias *string `min:"3" type:"string" required:"true"`
-
-	_ struct{} `type:"structure"`
 }
 
 // String returns the string representation
@@ -4678,6 +4678,8 @@ func (s CreateAccountAliasOutput) GoString() string {
 }
 
 type CreateGroupInput struct {
+	_ struct{} `type:"structure"`
+
 	// The name of the group to create. Do not include the path in this value.
 	GroupName *string `min:"1" type:"string" required:"true"`
 
@@ -4688,8 +4690,6 @@ type CreateGroupInput struct {
 	// This parameter is optional. If it is not included, it defaults to a slash
 	// (/).
 	Path *string `min:"1" type:"string"`
-
-	_ struct{} `type:"structure"`
 }
 
 // String returns the string representation
@@ -4704,10 +4704,10 @@ func (s CreateGroupInput) GoString() string {
 
 // Contains the response to a successful CreateGroup request.
 type CreateGroupOutput struct {
+	_ struct{} `type:"structure"`
+
 	// Information about the group.
 	Group *Group `type:"structure" required:"true"`
-
-	_ struct{} `type:"structure"`
 }
 
 // String returns the string representation
@@ -4721,6 +4721,8 @@ func (s CreateGroupOutput) GoString() string {
 }
 
 type CreateInstanceProfileInput struct {
+	_ struct{} `type:"structure"`
+
 	// The name of the instance profile to create.
 	InstanceProfileName *string `min:"1" type:"string" required:"true"`
 
@@ -4731,8 +4733,6 @@ type CreateInstanceProfileInput struct {
 	// This parameter is optional. If it is not included, it defaults to a slash
 	// (/).
 	Path *string `min:"1" type:"string"`
-
-	_ struct{} `type:"structure"`
 }
 
 // String returns the string representation
@@ -4747,10 +4747,10 @@ func (s CreateInstanceProfileInput) GoString() string {
 
 // Contains the response to a successful CreateInstanceProfile request.
 type CreateInstanceProfileOutput struct {
+	_ struct{} `type:"structure"`
+
 	// Information about the instance profile.
 	InstanceProfile *InstanceProfile `type:"structure" required:"true"`
-
-	_ struct{} `type:"structure"`
 }
 
 // String returns the string representation
@@ -4764,6 +4764,8 @@ func (s CreateInstanceProfileOutput) GoString() string {
 }
 
 type CreateLoginProfileInput struct {
+	_ struct{} `type:"structure"`
+
 	// The new password for the user.
 	Password *string `min:"1" type:"string" required:"true"`
 
@@ -4772,8 +4774,6 @@ type CreateLoginProfileInput struct {
 
 	// The name of the user to create a password for.
 	UserName *string `min:"1" type:"string" required:"true"`
-
-	_ struct{} `type:"structure"`
 }
 
 // String returns the string representation
@@ -4788,10 +4788,10 @@ func (s CreateLoginProfileInput) GoString() string {
 
 // Contains the response to a successful CreateLoginProfile request.
 type CreateLoginProfileOutput struct {
+	_ struct{} `type:"structure"`
+
 	// The user name and password create date.
 	LoginProfile *LoginProfile `type:"structure" required:"true"`
-
-	_ struct{} `type:"structure"`
 }
 
 // String returns the string representation
@@ -4805,6 +4805,8 @@ func (s CreateLoginProfileOutput) GoString() string {
 }
 
 type CreateOpenIDConnectProviderInput struct {
+	_ struct{} `type:"structure"`
+
 	// A list of client IDs (also known as audiences). When a mobile or web app
 	// registers with an OpenID Connect provider, they establish a value that identifies
 	// the application. (This is the value that's sent as the client_id parameter
@@ -4849,8 +4851,6 @@ type CreateOpenIDConnectProviderInput struct {
 	// If you try to submit a URL that has already been used for an OpenID Connect
 	// provider in the AWS account, you will get an error.
 	Url *string `min:"1" type:"string" required:"true"`
-
-	_ struct{} `type:"structure"`
 }
 
 // String returns the string representation
@@ -4865,11 +4865,11 @@ func (s CreateOpenIDConnectProviderInput) GoString() string {
 
 // Contains the response to a successful CreateOpenIDConnectProvider request.
 type CreateOpenIDConnectProviderOutput struct {
+	_ struct{} `type:"structure"`
+
 	// The Amazon Resource Name (ARN) of the IAM OpenID Connect provider that was
 	// created. For more information, see OpenIDConnectProviderListEntry.
 	OpenIDConnectProviderArn *string `min:"20" type:"string"`
-
-	_ struct{} `type:"structure"`
 }
 
 // String returns the string representation
@@ -4883,6 +4883,8 @@ func (s CreateOpenIDConnectProviderOutput) GoString() string {
 }
 
 type CreatePolicyInput struct {
+	_ struct{} `type:"structure"`
+
 	// A friendly description of the policy.
 	//
 	// Typically used to store information about the permissions defined in the
@@ -4906,8 +4908,6 @@ type CreatePolicyInput struct {
 
 	// The name of the policy document.
 	PolicyName *string `min:"1" type:"string" required:"true"`
-
-	_ struct{} `type:"structure"`
 }
 
 // String returns the string representation
@@ -4922,10 +4922,10 @@ func (s CreatePolicyInput) GoString() string {
 
 // Contains the response to a successful CreatePolicy request.
 type CreatePolicyOutput struct {
+	_ struct{} `type:"structure"`
+
 	// Information about the policy.
 	Policy *Policy `type:"structure"`
-
-	_ struct{} `type:"structure"`
 }
 
 // String returns the string representation
@@ -4939,6 +4939,8 @@ func (s CreatePolicyOutput) GoString() string {
 }
 
 type CreatePolicyVersionInput struct {
+	_ struct{} `type:"structure"`
+
 	// The Amazon Resource Name (ARN). ARNs are unique identifiers for AWS resources.
 	//
 	// For more information about ARNs, go to Amazon Resource Names (ARNs) and
@@ -4959,8 +4961,6 @@ type CreatePolicyVersionInput struct {
 	// Policies (http://docs.aws.amazon.com/IAM/latest/UserGuide/policies-managed-versions.html)
 	// in the IAM User Guide.
 	SetAsDefault *bool `type:"boolean"`
-
-	_ struct{} `type:"structure"`
 }
 
 // String returns the string representation
@@ -4975,10 +4975,10 @@ func (s CreatePolicyVersionInput) GoString() string {
 
 // Contains the response to a successful CreatePolicyVersion request.
 type CreatePolicyVersionOutput struct {
+	_ struct{} `type:"structure"`
+
 	// Information about the policy version.
 	PolicyVersion *PolicyVersion `type:"structure"`
-
-	_ struct{} `type:"structure"`
 }
 
 // String returns the string representation
@@ -4992,6 +4992,8 @@ func (s CreatePolicyVersionOutput) GoString() string {
 }
 
 type CreateRoleInput struct {
+	_ struct{} `type:"structure"`
+
 	// The policy that grants an entity permission to assume the role.
 	AssumeRolePolicyDocument *string `min:"1" type:"string" required:"true"`
 
@@ -5005,8 +5007,6 @@ type CreateRoleInput struct {
 
 	// The name of the role to create.
 	RoleName *string `min:"1" type:"string" required:"true"`
-
-	_ struct{} `type:"structure"`
 }
 
 // String returns the string representation
@@ -5021,10 +5021,10 @@ func (s CreateRoleInput) GoString() string {
 
 // Contains the response to a successful CreateRole request.
 type CreateRoleOutput struct {
+	_ struct{} `type:"structure"`
+
 	// Information about the role.
 	Role *Role `type:"structure" required:"true"`
-
-	_ struct{} `type:"structure"`
 }
 
 // String returns the string representation
@@ -5038,6 +5038,8 @@ func (s CreateRoleOutput) GoString() string {
 }
 
 type CreateSAMLProviderInput struct {
+	_ struct{} `type:"structure"`
+
 	// The name of the provider to create.
 	Name *string `min:"1" type:"string" required:"true"`
 
@@ -5050,8 +5052,6 @@ type CreateSAMLProviderInput struct {
 	// For more information, see About SAML 2.0-based Federation (http://docs.aws.amazon.com/IAM/latest/UserGuide/id_roles_providers_saml.html)
 	// in the IAM User Guide
 	SAMLMetadataDocument *string `min:"1000" type:"string" required:"true"`
-
-	_ struct{} `type:"structure"`
 }
 
 // String returns the string representation
@@ -5066,10 +5066,10 @@ func (s CreateSAMLProviderInput) GoString() string {
 
 // Contains the response to a successful CreateSAMLProvider request.
 type CreateSAMLProviderOutput struct {
+	_ struct{} `type:"structure"`
+
 	// The Amazon Resource Name (ARN) of the SAML provider.
 	SAMLProviderArn *string `min:"20" type:"string"`
-
-	_ struct{} `type:"structure"`
 }
 
 // String returns the string representation
@@ -5083,6 +5083,8 @@ func (s CreateSAMLProviderOutput) GoString() string {
 }
 
 type CreateUserInput struct {
+	_ struct{} `type:"structure"`
+
 	// The path for the user name. For more information about paths, see IAM Identifiers
 	// (http://docs.aws.amazon.com/IAM/latest/UserGuide/Using_Identifiers.html)
 	// in the Using IAM guide.
@@ -5093,8 +5095,6 @@ type CreateUserInput struct {
 
 	// The name of the user to create.
 	UserName *string `min:"1" type:"string" required:"true"`
-
-	_ struct{} `type:"structure"`
 }
 
 // String returns the string representation
@@ -5109,10 +5109,10 @@ func (s CreateUserInput) GoString() string {
 
 // Contains the response to a successful CreateUser request.
 type CreateUserOutput struct {
+	_ struct{} `type:"structure"`
+
 	// Information about the user.
 	User *User `type:"structure"`
-
-	_ struct{} `type:"structure"`
 }
 
 // String returns the string representation
@@ -5126,6 +5126,8 @@ func (s CreateUserOutput) GoString() string {
 }
 
 type CreateVirtualMFADeviceInput struct {
+	_ struct{} `type:"structure"`
+
 	// The path for the virtual MFA device. For more information about paths, see
 	// IAM Identifiers (http://docs.aws.amazon.com/IAM/latest/UserGuide/Using_Identifiers.html)
 	// in the Using IAM guide.
@@ -5137,8 +5139,6 @@ type CreateVirtualMFADeviceInput struct {
 	// The name of the virtual MFA device. Use with path to uniquely identify a
 	// virtual MFA device.
 	VirtualMFADeviceName *string `min:"1" type:"string" required:"true"`
-
-	_ struct{} `type:"structure"`
 }
 
 // String returns the string representation
@@ -5153,10 +5153,10 @@ func (s CreateVirtualMFADeviceInput) GoString() string {
 
 // Contains the response to a successful CreateVirtualMFADevice request.
 type CreateVirtualMFADeviceOutput struct {
+	_ struct{} `type:"structure"`
+
 	// A newly created virtual MFA device.
 	VirtualMFADevice *VirtualMFADevice `type:"structure" required:"true"`
-
-	_ struct{} `type:"structure"`
 }
 
 // String returns the string representation
@@ -5170,14 +5170,14 @@ func (s CreateVirtualMFADeviceOutput) GoString() string {
 }
 
 type DeactivateMFADeviceInput struct {
+	_ struct{} `type:"structure"`
+
 	// The serial number that uniquely identifies the MFA device. For virtual MFA
 	// devices, the serial number is the device ARN.
 	SerialNumber *string `min:"9" type:"string" required:"true"`
 
 	// The name of the user whose MFA device you want to deactivate.
 	UserName *string `min:"1" type:"string" required:"true"`
-
-	_ struct{} `type:"structure"`
 }
 
 // String returns the string representation
@@ -5205,14 +5205,14 @@ func (s DeactivateMFADeviceOutput) GoString() string {
 }
 
 type DeleteAccessKeyInput struct {
+	_ struct{} `type:"structure"`
+
 	// The access key ID for the access key ID and secret access key you want to
 	// delete.
 	AccessKeyId *string `min:"16" type:"string" required:"true"`
 
 	// The name of the user whose key you want to delete.
 	UserName *string `min:"1" type:"string"`
-
-	_ struct{} `type:"structure"`
 }
 
 // String returns the string representation
@@ -5240,10 +5240,10 @@ func (s DeleteAccessKeyOutput) GoString() string {
 }
 
 type DeleteAccountAliasInput struct {
+	_ struct{} `type:"structure"`
+
 	// The name of the account alias to delete.
 	AccountAlias *string `min:"3" type:"string" required:"true"`
-
-	_ struct{} `type:"structure"`
 }
 
 // String returns the string representation
@@ -5299,10 +5299,10 @@ func (s DeleteAccountPasswordPolicyOutput) GoString() string {
 }
 
 type DeleteGroupInput struct {
+	_ struct{} `type:"structure"`
+
 	// The name of the group to delete.
 	GroupName *string `min:"1" type:"string" required:"true"`
-
-	_ struct{} `type:"structure"`
 }
 
 // String returns the string representation
@@ -5330,14 +5330,14 @@ func (s DeleteGroupOutput) GoString() string {
 }
 
 type DeleteGroupPolicyInput struct {
+	_ struct{} `type:"structure"`
+
 	// The name (friendly name, not ARN) identifying the group that the policy is
 	// embedded in.
 	GroupName *string `min:"1" type:"string" required:"true"`
 
 	// The name identifying the policy document to delete.
 	PolicyName *string `min:"1" type:"string" required:"true"`
-
-	_ struct{} `type:"structure"`
 }
 
 // String returns the string representation
@@ -5365,10 +5365,10 @@ func (s DeleteGroupPolicyOutput) GoString() string {
 }
 
 type DeleteInstanceProfileInput struct {
+	_ struct{} `type:"structure"`
+
 	// The name of the instance profile to delete.
 	InstanceProfileName *string `min:"1" type:"string" required:"true"`
-
-	_ struct{} `type:"structure"`
 }
 
 // String returns the string representation
@@ -5396,10 +5396,10 @@ func (s DeleteInstanceProfileOutput) GoString() string {
 }
 
 type DeleteLoginProfileInput struct {
+	_ struct{} `type:"structure"`
+
 	// The name of the user whose password you want to delete.
 	UserName *string `min:"1" type:"string" required:"true"`
-
-	_ struct{} `type:"structure"`
 }
 
 // String returns the string representation
@@ -5427,12 +5427,12 @@ func (s DeleteLoginProfileOutput) GoString() string {
 }
 
 type DeleteOpenIDConnectProviderInput struct {
+	_ struct{} `type:"structure"`
+
 	// The Amazon Resource Name (ARN) of the IAM OpenID Connect provider to delete.
 	// You can get a list of OpenID Connect provider ARNs by using the ListOpenIDConnectProviders
 	// action.
 	OpenIDConnectProviderArn *string `min:"20" type:"string" required:"true"`
-
-	_ struct{} `type:"structure"`
 }
 
 // String returns the string representation
@@ -5460,14 +5460,14 @@ func (s DeleteOpenIDConnectProviderOutput) GoString() string {
 }
 
 type DeletePolicyInput struct {
+	_ struct{} `type:"structure"`
+
 	// The Amazon Resource Name (ARN). ARNs are unique identifiers for AWS resources.
 	//
 	// For more information about ARNs, go to Amazon Resource Names (ARNs) and
 	// AWS Service Namespaces (http://docs.aws.amazon.com/general/latest/gr/aws-arns-and-namespaces.html)
 	// in the AWS General Reference.
 	PolicyArn *string `min:"20" type:"string" required:"true"`
-
-	_ struct{} `type:"structure"`
 }
 
 // String returns the string representation
@@ -5495,6 +5495,8 @@ func (s DeletePolicyOutput) GoString() string {
 }
 
 type DeletePolicyVersionInput struct {
+	_ struct{} `type:"structure"`
+
 	// The Amazon Resource Name (ARN). ARNs are unique identifiers for AWS resources.
 	//
 	// For more information about ARNs, go to Amazon Resource Names (ARNs) and
@@ -5508,8 +5510,6 @@ type DeletePolicyVersionInput struct {
 	// Policies (http://docs.aws.amazon.com/IAM/latest/UserGuide/policies-managed-versions.html)
 	// in the IAM User Guide.
 	VersionId *string `type:"string" required:"true"`
-
-	_ struct{} `type:"structure"`
 }
 
 // String returns the string representation
@@ -5537,10 +5537,10 @@ func (s DeletePolicyVersionOutput) GoString() string {
 }
 
 type DeleteRoleInput struct {
+	_ struct{} `type:"structure"`
+
 	// The name of the role to delete.
 	RoleName *string `min:"1" type:"string" required:"true"`
-
-	_ struct{} `type:"structure"`
 }
 
 // String returns the string representation
@@ -5568,14 +5568,14 @@ func (s DeleteRoleOutput) GoString() string {
 }
 
 type DeleteRolePolicyInput struct {
+	_ struct{} `type:"structure"`
+
 	// The name identifying the policy document to delete.
 	PolicyName *string `min:"1" type:"string" required:"true"`
 
 	// The name (friendly name, not ARN) identifying the role that the policy is
 	// embedded in.
 	RoleName *string `min:"1" type:"string" required:"true"`
-
-	_ struct{} `type:"structure"`
 }
 
 // String returns the string representation
@@ -5603,10 +5603,10 @@ func (s DeleteRolePolicyOutput) GoString() string {
 }
 
 type DeleteSAMLProviderInput struct {
+	_ struct{} `type:"structure"`
+
 	// The Amazon Resource Name (ARN) of the SAML provider to delete.
 	SAMLProviderArn *string `min:"20" type:"string" required:"true"`
-
-	_ struct{} `type:"structure"`
 }
 
 // String returns the string representation
@@ -5634,13 +5634,13 @@ func (s DeleteSAMLProviderOutput) GoString() string {
 }
 
 type DeleteSSHPublicKeyInput struct {
+	_ struct{} `type:"structure"`
+
 	// The unique identifier for the SSH public key.
 	SSHPublicKeyId *string `min:"20" type:"string" required:"true"`
 
 	// The name of the IAM user associated with the SSH public key.
 	UserName *string `min:"1" type:"string" required:"true"`
-
-	_ struct{} `type:"structure"`
 }
 
 // String returns the string representation
@@ -5668,10 +5668,10 @@ func (s DeleteSSHPublicKeyOutput) GoString() string {
 }
 
 type DeleteServerCertificateInput struct {
+	_ struct{} `type:"structure"`
+
 	// The name of the server certificate you want to delete.
 	ServerCertificateName *string `min:"1" type:"string" required:"true"`
-
-	_ struct{} `type:"structure"`
 }
 
 // String returns the string representation
@@ -5699,13 +5699,13 @@ func (s DeleteServerCertificateOutput) GoString() string {
 }
 
 type DeleteSigningCertificateInput struct {
+	_ struct{} `type:"structure"`
+
 	// The ID of the signing certificate to delete.
 	CertificateId *string `min:"24" type:"string" required:"true"`
 
 	// The name of the user the signing certificate belongs to.
 	UserName *string `min:"1" type:"string"`
-
-	_ struct{} `type:"structure"`
 }
 
 // String returns the string representation
@@ -5733,10 +5733,10 @@ func (s DeleteSigningCertificateOutput) GoString() string {
 }
 
 type DeleteUserInput struct {
+	_ struct{} `type:"structure"`
+
 	// The name of the user to delete.
 	UserName *string `min:"1" type:"string" required:"true"`
-
-	_ struct{} `type:"structure"`
 }
 
 // String returns the string representation
@@ -5764,14 +5764,14 @@ func (s DeleteUserOutput) GoString() string {
 }
 
 type DeleteUserPolicyInput struct {
+	_ struct{} `type:"structure"`
+
 	// The name identifying the policy document to delete.
 	PolicyName *string `min:"1" type:"string" required:"true"`
 
 	// The name (friendly name, not ARN) identifying the user that the policy is
 	// embedded in.
 	UserName *string `min:"1" type:"string" required:"true"`
-
-	_ struct{} `type:"structure"`
 }
 
 // String returns the string representation
@@ -5799,11 +5799,11 @@ func (s DeleteUserPolicyOutput) GoString() string {
 }
 
 type DeleteVirtualMFADeviceInput struct {
+	_ struct{} `type:"structure"`
+
 	// The serial number that uniquely identifies the MFA device. For virtual MFA
 	// devices, the serial number is the same as the ARN.
 	SerialNumber *string `min:"9" type:"string" required:"true"`
-
-	_ struct{} `type:"structure"`
 }
 
 // String returns the string representation
@@ -5831,6 +5831,8 @@ func (s DeleteVirtualMFADeviceOutput) GoString() string {
 }
 
 type DetachGroupPolicyInput struct {
+	_ struct{} `type:"structure"`
+
 	// The name (friendly name, not ARN) of the group to detach the policy from.
 	GroupName *string `min:"1" type:"string" required:"true"`
 
@@ -5840,8 +5842,6 @@ type DetachGroupPolicyInput struct {
 	// AWS Service Namespaces (http://docs.aws.amazon.com/general/latest/gr/aws-arns-and-namespaces.html)
 	// in the AWS General Reference.
 	PolicyArn *string `min:"20" type:"string" required:"true"`
-
-	_ struct{} `type:"structure"`
 }
 
 // String returns the string representation
@@ -5869,6 +5869,8 @@ func (s DetachGroupPolicyOutput) GoString() string {
 }
 
 type DetachRolePolicyInput struct {
+	_ struct{} `type:"structure"`
+
 	// The Amazon Resource Name (ARN). ARNs are unique identifiers for AWS resources.
 	//
 	// For more information about ARNs, go to Amazon Resource Names (ARNs) and
@@ -5878,8 +5880,6 @@ type DetachRolePolicyInput struct {
 
 	// The name (friendly name, not ARN) of the role to detach the policy from.
 	RoleName *string `min:"1" type:"string" required:"true"`
-
-	_ struct{} `type:"structure"`
 }
 
 // String returns the string representation
@@ -5907,6 +5907,8 @@ func (s DetachRolePolicyOutput) GoString() string {
 }
 
 type DetachUserPolicyInput struct {
+	_ struct{} `type:"structure"`
+
 	// The Amazon Resource Name (ARN). ARNs are unique identifiers for AWS resources.
 	//
 	// For more information about ARNs, go to Amazon Resource Names (ARNs) and
@@ -5916,8 +5918,6 @@ type DetachUserPolicyInput struct {
 
 	// The name (friendly name, not ARN) of the user to detach the policy from.
 	UserName *string `min:"1" type:"string" required:"true"`
-
-	_ struct{} `type:"structure"`
 }
 
 // String returns the string representation
@@ -5945,6 +5945,8 @@ func (s DetachUserPolicyOutput) GoString() string {
 }
 
 type EnableMFADeviceInput struct {
+	_ struct{} `type:"structure"`
+
 	// An authentication code emitted by the device.
 	AuthenticationCode1 *string `min:"6" type:"string" required:"true"`
 
@@ -5957,8 +5959,6 @@ type EnableMFADeviceInput struct {
 
 	// The name of the user for whom you want to enable the MFA device.
 	UserName *string `min:"1" type:"string" required:"true"`
-
-	_ struct{} `type:"structure"`
 }
 
 // String returns the string representation
@@ -5989,6 +5989,8 @@ func (s EnableMFADeviceOutput) GoString() string {
 //
 // This data type is used by the return parameter of SimulatePolicy.
 type EvaluationResult struct {
+	_ struct{} `type:"structure"`
+
 	// The name of the API action tested on the indicated resource.
 	EvalActionName *string `min:"3" type:"string" required:"true"`
 
@@ -6027,8 +6029,6 @@ type EvaluationResult struct {
 	// The individual results of the simulation of the API action specified in EvalActionName
 	// on each resource.
 	ResourceSpecificResults []*ResourceSpecificResult `type:"list"`
-
-	_ struct{} `type:"structure"`
 }
 
 // String returns the string representation
@@ -6057,13 +6057,13 @@ func (s GenerateCredentialReportInput) GoString() string {
 
 // Contains the response to a successful GenerateCredentialReport request.
 type GenerateCredentialReportOutput struct {
+	_ struct{} `type:"structure"`
+
 	// Information about the credential report.
 	Description *string `type:"string"`
 
 	// Information about the state of the credential report.
 	State *string `type:"string" enum:"ReportStateType"`
-
-	_ struct{} `type:"structure"`
 }
 
 // String returns the string representation
@@ -6077,10 +6077,10 @@ func (s GenerateCredentialReportOutput) GoString() string {
 }
 
 type GetAccessKeyLastUsedInput struct {
+	_ struct{} `type:"structure"`
+
 	// The identifier of an access key.
 	AccessKeyId *string `min:"16" type:"string" required:"true"`
-
-	_ struct{} `type:"structure"`
 }
 
 // String returns the string representation
@@ -6097,13 +6097,13 @@ func (s GetAccessKeyLastUsedInput) GoString() string {
 // also returned as a member of the AccessKeyMetaData structure returned by
 // the ListAccessKeys action.
 type GetAccessKeyLastUsedOutput struct {
+	_ struct{} `type:"structure"`
+
 	// Contains information about the last time the access key was used.
 	AccessKeyLastUsed *AccessKeyLastUsed `type:"structure"`
 
 	// The name of the AWS IAM user that owns this access key.
 	UserName *string `min:"1" type:"string"`
-
-	_ struct{} `type:"structure"`
 }
 
 // String returns the string representation
@@ -6117,6 +6117,8 @@ func (s GetAccessKeyLastUsedOutput) GoString() string {
 }
 
 type GetAccountAuthorizationDetailsInput struct {
+	_ struct{} `type:"structure"`
+
 	// A list of entity types (user, group, role, local managed policy, or AWS managed
 	// policy) for filtering the results.
 	Filter []*string `type:"list"`
@@ -6137,8 +6139,6 @@ type GetAccountAuthorizationDetailsInput struct {
 	// Marker contains a value to include in the subsequent call that tells the
 	// service where to continue from.
 	MaxItems *int64 `min:"1" type:"integer"`
-
-	_ struct{} `type:"structure"`
 }
 
 // String returns the string representation
@@ -6153,6 +6153,8 @@ func (s GetAccountAuthorizationDetailsInput) GoString() string {
 
 // Contains the response to a successful GetAccountAuthorizationDetails request.
 type GetAccountAuthorizationDetailsOutput struct {
+	_ struct{} `type:"structure"`
+
 	// A list containing information about IAM groups.
 	GroupDetailList []*GroupDetail `type:"list"`
 
@@ -6176,8 +6178,6 @@ type GetAccountAuthorizationDetailsOutput struct {
 
 	// A list containing information about IAM users.
 	UserDetailList []*UserDetail `type:"list"`
-
-	_ struct{} `type:"structure"`
 }
 
 // String returns the string representation
@@ -6206,13 +6206,13 @@ func (s GetAccountPasswordPolicyInput) GoString() string {
 
 // Contains the response to a successful GetAccountPasswordPolicy request.
 type GetAccountPasswordPolicyOutput struct {
+	_ struct{} `type:"structure"`
+
 	// Contains information about the account password policy.
 	//
 	//  This data type is used as a response element in the GetAccountPasswordPolicy
 	// action.
 	PasswordPolicy *PasswordPolicy `type:"structure" required:"true"`
-
-	_ struct{} `type:"structure"`
 }
 
 // String returns the string representation
@@ -6241,6 +6241,8 @@ func (s GetAccountSummaryInput) GoString() string {
 
 // Contains the response to a successful GetAccountSummary request.
 type GetAccountSummaryOutput struct {
+	_ struct{} `type:"structure"`
+
 	// A set of key value pairs containing information about IAM entity usage and
 	// IAM quotas.
 	//
@@ -6385,8 +6387,6 @@ type GetAccountSummaryOutput struct {
 	//
 	// The maximum number of policy versions allowed for each managed policy.
 	SummaryMap map[string]*int64 `type:"map"`
-
-	_ struct{} `type:"structure"`
 }
 
 // String returns the string representation
@@ -6400,12 +6400,12 @@ func (s GetAccountSummaryOutput) GoString() string {
 }
 
 type GetContextKeysForCustomPolicyInput struct {
+	_ struct{} `type:"structure"`
+
 	// A list of policies for which you want list of context keys used in Condition
 	// elements. Each document is specified as a string containing the complete,
 	// valid JSON text of an IAM policy.
 	PolicyInputList []*string `type:"list" required:"true"`
-
-	_ struct{} `type:"structure"`
 }
 
 // String returns the string representation
@@ -6421,11 +6421,11 @@ func (s GetContextKeysForCustomPolicyInput) GoString() string {
 // Contains the response to a successful GetContextKeysForPrincipalPolicy or
 // GetContextKeysForCustomPolicy request.
 type GetContextKeysForPolicyResponse struct {
+	_ struct{} `type:"structure"`
+
 	// The list of context keys that are used in the Condition elements of the input
 	// policies.
 	ContextKeyNames []*string `type:"list"`
-
-	_ struct{} `type:"structure"`
 }
 
 // String returns the string representation
@@ -6439,6 +6439,8 @@ func (s GetContextKeysForPolicyResponse) GoString() string {
 }
 
 type GetContextKeysForPrincipalPolicyInput struct {
+	_ struct{} `type:"structure"`
+
 	// A optional list of additional policies for which you want list of context
 	// keys used in Condition elements.
 	PolicyInputList []*string `type:"list"`
@@ -6451,8 +6453,6 @@ type GetContextKeysForPrincipalPolicyInput struct {
 	// Note that all parameters are shown in unencoded form here for clarity, but
 	// must be URL encoded to be included as a part of a real HTML request.
 	PolicySourceArn *string `min:"20" type:"string" required:"true"`
-
-	_ struct{} `type:"structure"`
 }
 
 // String returns the string representation
@@ -6481,6 +6481,8 @@ func (s GetCredentialReportInput) GoString() string {
 
 // Contains the response to a successful GetCredentialReport request.
 type GetCredentialReportOutput struct {
+	_ struct{} `type:"structure"`
+
 	// Contains the credential report. The report is Base64-encoded.
 	Content []byte `type:"blob"`
 
@@ -6490,8 +6492,6 @@ type GetCredentialReportOutput struct {
 
 	// The format (MIME type) of the credential report.
 	ReportFormat *string `type:"string" enum:"ReportFormatType"`
-
-	_ struct{} `type:"structure"`
 }
 
 // String returns the string representation
@@ -6505,6 +6505,8 @@ func (s GetCredentialReportOutput) GoString() string {
 }
 
 type GetGroupInput struct {
+	_ struct{} `type:"structure"`
+
 	// The name of the group.
 	GroupName *string `min:"1" type:"string" required:"true"`
 
@@ -6524,8 +6526,6 @@ type GetGroupInput struct {
 	// Marker contains a value to include in the subsequent call that tells the
 	// service where to continue from.
 	MaxItems *int64 `min:"1" type:"integer"`
-
-	_ struct{} `type:"structure"`
 }
 
 // String returns the string representation
@@ -6540,6 +6540,8 @@ func (s GetGroupInput) GoString() string {
 
 // Contains the response to a successful GetGroup request.
 type GetGroupOutput struct {
+	_ struct{} `type:"structure"`
+
 	// Information about the group.
 	Group *Group `type:"structure" required:"true"`
 
@@ -6557,8 +6559,6 @@ type GetGroupOutput struct {
 
 	// A list of users in the group.
 	Users []*User `type:"list" required:"true"`
-
-	_ struct{} `type:"structure"`
 }
 
 // String returns the string representation
@@ -6572,13 +6572,13 @@ func (s GetGroupOutput) GoString() string {
 }
 
 type GetGroupPolicyInput struct {
+	_ struct{} `type:"structure"`
+
 	// The name of the group the policy is associated with.
 	GroupName *string `min:"1" type:"string" required:"true"`
 
 	// The name of the policy document to get.
 	PolicyName *string `min:"1" type:"string" required:"true"`
-
-	_ struct{} `type:"structure"`
 }
 
 // String returns the string representation
@@ -6593,6 +6593,8 @@ func (s GetGroupPolicyInput) GoString() string {
 
 // Contains the response to a successful GetGroupPolicy request.
 type GetGroupPolicyOutput struct {
+	_ struct{} `type:"structure"`
+
 	// The group the policy is associated with.
 	GroupName *string `min:"1" type:"string" required:"true"`
 
@@ -6601,8 +6603,6 @@ type GetGroupPolicyOutput struct {
 
 	// The name of the policy.
 	PolicyName *string `min:"1" type:"string" required:"true"`
-
-	_ struct{} `type:"structure"`
 }
 
 // String returns the string representation
@@ -6616,10 +6616,10 @@ func (s GetGroupPolicyOutput) GoString() string {
 }
 
 type GetInstanceProfileInput struct {
+	_ struct{} `type:"structure"`
+
 	// The name of the instance profile to get information about.
 	InstanceProfileName *string `min:"1" type:"string" required:"true"`
-
-	_ struct{} `type:"structure"`
 }
 
 // String returns the string representation
@@ -6634,10 +6634,10 @@ func (s GetInstanceProfileInput) GoString() string {
 
 // Contains the response to a successful GetInstanceProfile request.
 type GetInstanceProfileOutput struct {
+	_ struct{} `type:"structure"`
+
 	// Information about the instance profile.
 	InstanceProfile *InstanceProfile `type:"structure" required:"true"`
-
-	_ struct{} `type:"structure"`
 }
 
 // String returns the string representation
@@ -6651,10 +6651,10 @@ func (s GetInstanceProfileOutput) GoString() string {
 }
 
 type GetLoginProfileInput struct {
+	_ struct{} `type:"structure"`
+
 	// The name of the user whose login profile you want to retrieve.
 	UserName *string `min:"1" type:"string" required:"true"`
-
-	_ struct{} `type:"structure"`
 }
 
 // String returns the string representation
@@ -6669,10 +6669,10 @@ func (s GetLoginProfileInput) GoString() string {
 
 // Contains the response to a successful GetLoginProfile request.
 type GetLoginProfileOutput struct {
+	_ struct{} `type:"structure"`
+
 	// The user name and password create date for the user.
 	LoginProfile *LoginProfile `type:"structure" required:"true"`
-
-	_ struct{} `type:"structure"`
 }
 
 // String returns the string representation
@@ -6686,12 +6686,12 @@ func (s GetLoginProfileOutput) GoString() string {
 }
 
 type GetOpenIDConnectProviderInput struct {
+	_ struct{} `type:"structure"`
+
 	// The Amazon Resource Name (ARN) of the IAM OpenID Connect (OIDC) provider
 	// to get information for. You can get a list of OIDC provider ARNs by using
 	// the ListOpenIDConnectProviders action.
 	OpenIDConnectProviderArn *string `min:"20" type:"string" required:"true"`
-
-	_ struct{} `type:"structure"`
 }
 
 // String returns the string representation
@@ -6706,6 +6706,8 @@ func (s GetOpenIDConnectProviderInput) GoString() string {
 
 // Contains the response to a successful GetOpenIDConnectProvider request.
 type GetOpenIDConnectProviderOutput struct {
+	_ struct{} `type:"structure"`
+
 	// A list of client IDs (also known as audiences) that are associated with the
 	// specified IAM OpenID Connect provider. For more information, see CreateOpenIDConnectProvider.
 	ClientIDList []*string `type:"list"`
@@ -6721,8 +6723,6 @@ type GetOpenIDConnectProviderOutput struct {
 	// The URL that the IAM OpenID Connect provider is associated with. For more
 	// information, see CreateOpenIDConnectProvider.
 	Url *string `min:"1" type:"string"`
-
-	_ struct{} `type:"structure"`
 }
 
 // String returns the string representation
@@ -6736,14 +6736,14 @@ func (s GetOpenIDConnectProviderOutput) GoString() string {
 }
 
 type GetPolicyInput struct {
+	_ struct{} `type:"structure"`
+
 	// The Amazon Resource Name (ARN). ARNs are unique identifiers for AWS resources.
 	//
 	// For more information about ARNs, go to Amazon Resource Names (ARNs) and
 	// AWS Service Namespaces (http://docs.aws.amazon.com/general/latest/gr/aws-arns-and-namespaces.html)
 	// in the AWS General Reference.
 	PolicyArn *string `min:"20" type:"string" required:"true"`
-
-	_ struct{} `type:"structure"`
 }
 
 // String returns the string representation
@@ -6758,10 +6758,10 @@ func (s GetPolicyInput) GoString() string {
 
 // Contains the response to a successful GetPolicy request.
 type GetPolicyOutput struct {
+	_ struct{} `type:"structure"`
+
 	// Information about the policy.
 	Policy *Policy `type:"structure"`
-
-	_ struct{} `type:"structure"`
 }
 
 // String returns the string representation
@@ -6775,6 +6775,8 @@ func (s GetPolicyOutput) GoString() string {
 }
 
 type GetPolicyVersionInput struct {
+	_ struct{} `type:"structure"`
+
 	// The Amazon Resource Name (ARN). ARNs are unique identifiers for AWS resources.
 	//
 	// For more information about ARNs, go to Amazon Resource Names (ARNs) and
@@ -6784,8 +6786,6 @@ type GetPolicyVersionInput struct {
 
 	// Identifies the policy version to retrieve.
 	VersionId *string `type:"string" required:"true"`
-
-	_ struct{} `type:"structure"`
 }
 
 // String returns the string representation
@@ -6800,14 +6800,14 @@ func (s GetPolicyVersionInput) GoString() string {
 
 // Contains the response to a successful GetPolicyVersion request.
 type GetPolicyVersionOutput struct {
+	_ struct{} `type:"structure"`
+
 	// Information about the policy version.
 	//
 	// For more information about managed policy versions, see Versioning for Managed
 	// Policies (http://docs.aws.amazon.com/IAM/latest/UserGuide/policies-managed-versions.html)
 	// in the IAM User Guide.
 	PolicyVersion *PolicyVersion `type:"structure"`
-
-	_ struct{} `type:"structure"`
 }
 
 // String returns the string representation
@@ -6821,10 +6821,10 @@ func (s GetPolicyVersionOutput) GoString() string {
 }
 
 type GetRoleInput struct {
+	_ struct{} `type:"structure"`
+
 	// The name of the role to get information about.
 	RoleName *string `min:"1" type:"string" required:"true"`
-
-	_ struct{} `type:"structure"`
 }
 
 // String returns the string representation
@@ -6839,10 +6839,10 @@ func (s GetRoleInput) GoString() string {
 
 // Contains the response to a successful GetRole request.
 type GetRoleOutput struct {
+	_ struct{} `type:"structure"`
+
 	// Information about the role.
 	Role *Role `type:"structure" required:"true"`
-
-	_ struct{} `type:"structure"`
 }
 
 // String returns the string representation
@@ -6856,13 +6856,13 @@ func (s GetRoleOutput) GoString() string {
 }
 
 type GetRolePolicyInput struct {
+	_ struct{} `type:"structure"`
+
 	// The name of the policy document to get.
 	PolicyName *string `min:"1" type:"string" required:"true"`
 
 	// The name of the role associated with the policy.
 	RoleName *string `min:"1" type:"string" required:"true"`
-
-	_ struct{} `type:"structure"`
 }
 
 // String returns the string representation
@@ -6877,6 +6877,8 @@ func (s GetRolePolicyInput) GoString() string {
 
 // Contains the response to a successful GetRolePolicy request.
 type GetRolePolicyOutput struct {
+	_ struct{} `type:"structure"`
+
 	// The policy document.
 	PolicyDocument *string `min:"1" type:"string" required:"true"`
 
@@ -6885,8 +6887,6 @@ type GetRolePolicyOutput struct {
 
 	// The role the policy is associated with.
 	RoleName *string `min:"1" type:"string" required:"true"`
-
-	_ struct{} `type:"structure"`
 }
 
 // String returns the string representation
@@ -6900,10 +6900,10 @@ func (s GetRolePolicyOutput) GoString() string {
 }
 
 type GetSAMLProviderInput struct {
+	_ struct{} `type:"structure"`
+
 	// The Amazon Resource Name (ARN) of the SAML provider to get information about.
 	SAMLProviderArn *string `min:"20" type:"string" required:"true"`
-
-	_ struct{} `type:"structure"`
 }
 
 // String returns the string representation
@@ -6918,6 +6918,8 @@ func (s GetSAMLProviderInput) GoString() string {
 
 // Contains the response to a successful GetSAMLProvider request.
 type GetSAMLProviderOutput struct {
+	_ struct{} `type:"structure"`
+
 	// The date and time when the SAML provider was created.
 	CreateDate *time.Time `type:"timestamp" timestampFormat:"iso8601"`
 
@@ -6926,8 +6928,6 @@ type GetSAMLProviderOutput struct {
 
 	// The expiration date and time for the SAML provider.
 	ValidUntil *time.Time `type:"timestamp" timestampFormat:"iso8601"`
-
-	_ struct{} `type:"structure"`
 }
 
 // String returns the string representation
@@ -6941,6 +6941,8 @@ func (s GetSAMLProviderOutput) GoString() string {
 }
 
 type GetSSHPublicKeyInput struct {
+	_ struct{} `type:"structure"`
+
 	// Specifies the public key encoding format to use in the response. To retrieve
 	// the public key in ssh-rsa format, use SSH. To retrieve the public key in
 	// PEM format, use PEM.
@@ -6951,8 +6953,6 @@ type GetSSHPublicKeyInput struct {
 
 	// The name of the IAM user associated with the SSH public key.
 	UserName *string `min:"1" type:"string" required:"true"`
-
-	_ struct{} `type:"structure"`
 }
 
 // String returns the string representation
@@ -6967,10 +6967,10 @@ func (s GetSSHPublicKeyInput) GoString() string {
 
 // Contains the response to a successful GetSSHPublicKey request.
 type GetSSHPublicKeyOutput struct {
+	_ struct{} `type:"structure"`
+
 	// Information about the SSH public key.
 	SSHPublicKey *SSHPublicKey `type:"structure"`
-
-	_ struct{} `type:"structure"`
 }
 
 // String returns the string representation
@@ -6984,10 +6984,10 @@ func (s GetSSHPublicKeyOutput) GoString() string {
 }
 
 type GetServerCertificateInput struct {
+	_ struct{} `type:"structure"`
+
 	// The name of the server certificate you want to retrieve information about.
 	ServerCertificateName *string `min:"1" type:"string" required:"true"`
-
-	_ struct{} `type:"structure"`
 }
 
 // String returns the string representation
@@ -7002,10 +7002,10 @@ func (s GetServerCertificateInput) GoString() string {
 
 // Contains the response to a successful GetServerCertificate request.
 type GetServerCertificateOutput struct {
+	_ struct{} `type:"structure"`
+
 	// Information about the server certificate.
 	ServerCertificate *ServerCertificate `type:"structure" required:"true"`
-
-	_ struct{} `type:"structure"`
 }
 
 // String returns the string representation
@@ -7019,13 +7019,13 @@ func (s GetServerCertificateOutput) GoString() string {
 }
 
 type GetUserInput struct {
+	_ struct{} `type:"structure"`
+
 	// The name of the user to get information about.
 	//
 	// This parameter is optional. If it is not included, it defaults to the user
 	// making the request.
 	UserName *string `min:"1" type:"string"`
-
-	_ struct{} `type:"structure"`
 }
 
 // String returns the string representation
@@ -7040,10 +7040,10 @@ func (s GetUserInput) GoString() string {
 
 // Contains the response to a successful GetUser request.
 type GetUserOutput struct {
+	_ struct{} `type:"structure"`
+
 	// Information about the user.
 	User *User `type:"structure" required:"true"`
-
-	_ struct{} `type:"structure"`
 }
 
 // String returns the string representation
@@ -7057,13 +7057,13 @@ func (s GetUserOutput) GoString() string {
 }
 
 type GetUserPolicyInput struct {
+	_ struct{} `type:"structure"`
+
 	// The name of the policy document to get.
 	PolicyName *string `min:"1" type:"string" required:"true"`
 
 	// The name of the user who the policy is associated with.
 	UserName *string `min:"1" type:"string" required:"true"`
-
-	_ struct{} `type:"structure"`
 }
 
 // String returns the string representation
@@ -7078,6 +7078,8 @@ func (s GetUserPolicyInput) GoString() string {
 
 // Contains the response to a successful GetUserPolicy request.
 type GetUserPolicyOutput struct {
+	_ struct{} `type:"structure"`
+
 	// The policy document.
 	PolicyDocument *string `min:"1" type:"string" required:"true"`
 
@@ -7086,8 +7088,6 @@ type GetUserPolicyOutput struct {
 
 	// The user the policy is associated with.
 	UserName *string `min:"1" type:"string" required:"true"`
-
-	_ struct{} `type:"structure"`
 }
 
 // String returns the string representation
@@ -7106,6 +7106,8 @@ func (s GetUserPolicyOutput) GoString() string {
 //
 //   CreateGroup   GetGroup   ListGroups
 type Group struct {
+	_ struct{} `type:"structure"`
+
 	// The Amazon Resource Name (ARN) specifying the group. For more information
 	// about ARNs and how to use them in policies, see IAM Identifiers (http://docs.aws.amazon.com/IAM/latest/UserGuide/Using_Identifiers.html)
 	// in the Using IAM guide.
@@ -7127,8 +7129,6 @@ type Group struct {
 	// (http://docs.aws.amazon.com/IAM/latest/UserGuide/Using_Identifiers.html)
 	// in the Using IAM guide.
 	Path *string `min:"1" type:"string" required:"true"`
-
-	_ struct{} `type:"structure"`
 }
 
 // String returns the string representation
@@ -7146,6 +7146,8 @@ func (s Group) GoString() string {
 // This data type is used as a response element in the GetAccountAuthorizationDetails
 // action.
 type GroupDetail struct {
+	_ struct{} `type:"structure"`
+
 	// The Amazon Resource Name (ARN). ARNs are unique identifiers for AWS resources.
 	//
 	// For more information about ARNs, go to Amazon Resource Names (ARNs) and
@@ -7175,8 +7177,6 @@ type GroupDetail struct {
 	// (http://docs.aws.amazon.com/IAM/latest/UserGuide/Using_Identifiers.html)
 	// in the Using IAM guide.
 	Path *string `min:"1" type:"string"`
-
-	_ struct{} `type:"structure"`
 }
 
 // String returns the string representation
@@ -7201,6 +7201,8 @@ func (s GroupDetail) GoString() string {
 //
 //    ListInstanceProfilesForRole
 type InstanceProfile struct {
+	_ struct{} `type:"structure"`
+
 	// The Amazon Resource Name (ARN) specifying the instance profile. For more
 	// information about ARNs and how to use them in policies, see IAM Identifiers
 	// (http://docs.aws.amazon.com/IAM/latest/UserGuide/Using_Identifiers.html)
@@ -7225,8 +7227,6 @@ type InstanceProfile struct {
 
 	// The role associated with the instance profile.
 	Roles []*Role `type:"list" required:"true"`
-
-	_ struct{} `type:"structure"`
 }
 
 // String returns the string representation
@@ -7240,6 +7240,8 @@ func (s InstanceProfile) GoString() string {
 }
 
 type ListAccessKeysInput struct {
+	_ struct{} `type:"structure"`
+
 	// Use this parameter only when paginating results and only after you receive
 	// a response indicating that the results are truncated. Set it to the value
 	// of the Marker element in the response that you received to indicate where
@@ -7259,8 +7261,6 @@ type ListAccessKeysInput struct {
 
 	// The name of the user.
 	UserName *string `min:"1" type:"string"`
-
-	_ struct{} `type:"structure"`
 }
 
 // String returns the string representation
@@ -7275,6 +7275,8 @@ func (s ListAccessKeysInput) GoString() string {
 
 // Contains the response to a successful ListAccessKeys request.
 type ListAccessKeysOutput struct {
+	_ struct{} `type:"structure"`
+
 	// A list of access key metadata.
 	AccessKeyMetadata []*AccessKeyMetadata `type:"list" required:"true"`
 
@@ -7289,8 +7291,6 @@ type ListAccessKeysOutput struct {
 	// When IsTruncated is true, this element is present and contains the value
 	// to use for the Marker parameter in a subsequent pagination request.
 	Marker *string `min:"1" type:"string"`
-
-	_ struct{} `type:"structure"`
 }
 
 // String returns the string representation
@@ -7304,6 +7304,8 @@ func (s ListAccessKeysOutput) GoString() string {
 }
 
 type ListAccountAliasesInput struct {
+	_ struct{} `type:"structure"`
+
 	// Use this parameter only when paginating results and only after you receive
 	// a response indicating that the results are truncated. Set it to the value
 	// of the Marker element in the response that you received to indicate where
@@ -7320,8 +7322,6 @@ type ListAccountAliasesInput struct {
 	// Marker contains a value to include in the subsequent call that tells the
 	// service where to continue from.
 	MaxItems *int64 `min:"1" type:"integer"`
-
-	_ struct{} `type:"structure"`
 }
 
 // String returns the string representation
@@ -7336,6 +7336,8 @@ func (s ListAccountAliasesInput) GoString() string {
 
 // Contains the response to a successful ListAccountAliases request.
 type ListAccountAliasesOutput struct {
+	_ struct{} `type:"structure"`
+
 	// A list of aliases associated with the account. AWS supports only one alias
 	// per account.
 	AccountAliases []*string `type:"list" required:"true"`
@@ -7351,8 +7353,6 @@ type ListAccountAliasesOutput struct {
 	// When IsTruncated is true, this element is present and contains the value
 	// to use for the Marker parameter in a subsequent pagination request.
 	Marker *string `min:"1" type:"string"`
-
-	_ struct{} `type:"structure"`
 }
 
 // String returns the string representation
@@ -7366,6 +7366,8 @@ func (s ListAccountAliasesOutput) GoString() string {
 }
 
 type ListAttachedGroupPoliciesInput struct {
+	_ struct{} `type:"structure"`
+
 	// The name (friendly name, not ARN) of the group to list attached policies
 	// for.
 	GroupName *string `min:"1" type:"string" required:"true"`
@@ -7390,8 +7392,6 @@ type ListAttachedGroupPoliciesInput struct {
 	// The path prefix for filtering the results. This parameter is optional. If
 	// it is not included, it defaults to a slash (/), listing all policies.
 	PathPrefix *string `type:"string"`
-
-	_ struct{} `type:"structure"`
 }
 
 // String returns the string representation
@@ -7406,6 +7406,8 @@ func (s ListAttachedGroupPoliciesInput) GoString() string {
 
 // Contains the response to a successful ListAttachedGroupPolicies request.
 type ListAttachedGroupPoliciesOutput struct {
+	_ struct{} `type:"structure"`
+
 	// A list of the attached policies.
 	AttachedPolicies []*AttachedPolicy `type:"list"`
 
@@ -7420,8 +7422,6 @@ type ListAttachedGroupPoliciesOutput struct {
 	// When IsTruncated is true, this element is present and contains the value
 	// to use for the Marker parameter in a subsequent pagination request.
 	Marker *string `min:"1" type:"string"`
-
-	_ struct{} `type:"structure"`
 }
 
 // String returns the string representation
@@ -7435,6 +7435,8 @@ func (s ListAttachedGroupPoliciesOutput) GoString() string {
 }
 
 type ListAttachedRolePoliciesInput struct {
+	_ struct{} `type:"structure"`
+
 	// Use this parameter only when paginating results and only after you receive
 	// a response indicating that the results are truncated. Set it to the value
 	// of the Marker element in the response that you received to indicate where
@@ -7458,8 +7460,6 @@ type ListAttachedRolePoliciesInput struct {
 
 	// The name (friendly name, not ARN) of the role to list attached policies for.
 	RoleName *string `min:"1" type:"string" required:"true"`
-
-	_ struct{} `type:"structure"`
 }
 
 // String returns the string representation
@@ -7474,6 +7474,8 @@ func (s ListAttachedRolePoliciesInput) GoString() string {
 
 // Contains the response to a successful ListAttachedRolePolicies request.
 type ListAttachedRolePoliciesOutput struct {
+	_ struct{} `type:"structure"`
+
 	// A list of the attached policies.
 	AttachedPolicies []*AttachedPolicy `type:"list"`
 
@@ -7488,8 +7490,6 @@ type ListAttachedRolePoliciesOutput struct {
 	// When IsTruncated is true, this element is present and contains the value
 	// to use for the Marker parameter in a subsequent pagination request.
 	Marker *string `min:"1" type:"string"`
-
-	_ struct{} `type:"structure"`
 }
 
 // String returns the string representation
@@ -7503,6 +7503,8 @@ func (s ListAttachedRolePoliciesOutput) GoString() string {
 }
 
 type ListAttachedUserPoliciesInput struct {
+	_ struct{} `type:"structure"`
+
 	// Use this parameter only when paginating results and only after you receive
 	// a response indicating that the results are truncated. Set it to the value
 	// of the Marker element in the response that you received to indicate where
@@ -7526,8 +7528,6 @@ type ListAttachedUserPoliciesInput struct {
 
 	// The name (friendly name, not ARN) of the user to list attached policies for.
 	UserName *string `min:"1" type:"string" required:"true"`
-
-	_ struct{} `type:"structure"`
 }
 
 // String returns the string representation
@@ -7542,6 +7542,8 @@ func (s ListAttachedUserPoliciesInput) GoString() string {
 
 // Contains the response to a successful ListAttachedUserPolicies request.
 type ListAttachedUserPoliciesOutput struct {
+	_ struct{} `type:"structure"`
+
 	// A list of the attached policies.
 	AttachedPolicies []*AttachedPolicy `type:"list"`
 
@@ -7556,8 +7558,6 @@ type ListAttachedUserPoliciesOutput struct {
 	// When IsTruncated is true, this element is present and contains the value
 	// to use for the Marker parameter in a subsequent pagination request.
 	Marker *string `min:"1" type:"string"`
-
-	_ struct{} `type:"structure"`
 }
 
 // String returns the string representation
@@ -7571,6 +7571,8 @@ func (s ListAttachedUserPoliciesOutput) GoString() string {
 }
 
 type ListEntitiesForPolicyInput struct {
+	_ struct{} `type:"structure"`
+
 	// The entity type to use for filtering the results.
 	//
 	// For example, when EntityFilter is Role, only the roles that are attached
@@ -7605,8 +7607,6 @@ type ListEntitiesForPolicyInput struct {
 	// AWS Service Namespaces (http://docs.aws.amazon.com/general/latest/gr/aws-arns-and-namespaces.html)
 	// in the AWS General Reference.
 	PolicyArn *string `min:"20" type:"string" required:"true"`
-
-	_ struct{} `type:"structure"`
 }
 
 // String returns the string representation
@@ -7621,6 +7621,8 @@ func (s ListEntitiesForPolicyInput) GoString() string {
 
 // Contains the response to a successful ListEntitiesForPolicy request.
 type ListEntitiesForPolicyOutput struct {
+	_ struct{} `type:"structure"`
+
 	// A flag that indicates whether there are more items to return. If your results
 	// were truncated, you can make a subsequent pagination request using the Marker
 	// request parameter to retrieve more items. Note that IAM might return fewer
@@ -7641,8 +7643,6 @@ type ListEntitiesForPolicyOutput struct {
 
 	// A list of users that the policy is attached to.
 	PolicyUsers []*PolicyUser `type:"list"`
-
-	_ struct{} `type:"structure"`
 }
 
 // String returns the string representation
@@ -7656,6 +7656,8 @@ func (s ListEntitiesForPolicyOutput) GoString() string {
 }
 
 type ListGroupPoliciesInput struct {
+	_ struct{} `type:"structure"`
+
 	// The name of the group to list policies for.
 	GroupName *string `min:"1" type:"string" required:"true"`
 
@@ -7675,8 +7677,6 @@ type ListGroupPoliciesInput struct {
 	// Marker contains a value to include in the subsequent call that tells the
 	// service where to continue from.
 	MaxItems *int64 `min:"1" type:"integer"`
-
-	_ struct{} `type:"structure"`
 }
 
 // String returns the string representation
@@ -7691,6 +7691,8 @@ func (s ListGroupPoliciesInput) GoString() string {
 
 // Contains the response to a successful ListGroupPolicies request.
 type ListGroupPoliciesOutput struct {
+	_ struct{} `type:"structure"`
+
 	// A flag that indicates whether there are more items to return. If your results
 	// were truncated, you can make a subsequent pagination request using the Marker
 	// request parameter to retrieve more items. Note that IAM might return fewer
@@ -7705,8 +7707,6 @@ type ListGroupPoliciesOutput struct {
 
 	// A list of policy names.
 	PolicyNames []*string `type:"list" required:"true"`
-
-	_ struct{} `type:"structure"`
 }
 
 // String returns the string representation
@@ -7720,6 +7720,8 @@ func (s ListGroupPoliciesOutput) GoString() string {
 }
 
 type ListGroupsForUserInput struct {
+	_ struct{} `type:"structure"`
+
 	// Use this parameter only when paginating results and only after you receive
 	// a response indicating that the results are truncated. Set it to the value
 	// of the Marker element in the response that you received to indicate where
@@ -7739,8 +7741,6 @@ type ListGroupsForUserInput struct {
 
 	// The name of the user to list groups for.
 	UserName *string `min:"1" type:"string" required:"true"`
-
-	_ struct{} `type:"structure"`
 }
 
 // String returns the string representation
@@ -7755,6 +7755,8 @@ func (s ListGroupsForUserInput) GoString() string {
 
 // Contains the response to a successful ListGroupsForUser request.
 type ListGroupsForUserOutput struct {
+	_ struct{} `type:"structure"`
+
 	// A list of groups.
 	Groups []*Group `type:"list" required:"true"`
 
@@ -7769,8 +7771,6 @@ type ListGroupsForUserOutput struct {
 	// When IsTruncated is true, this element is present and contains the value
 	// to use for the Marker parameter in a subsequent pagination request.
 	Marker *string `min:"1" type:"string"`
-
-	_ struct{} `type:"structure"`
 }
 
 // String returns the string representation
@@ -7784,6 +7784,8 @@ func (s ListGroupsForUserOutput) GoString() string {
 }
 
 type ListGroupsInput struct {
+	_ struct{} `type:"structure"`
+
 	// Use this parameter only when paginating results and only after you receive
 	// a response indicating that the results are truncated. Set it to the value
 	// of the Marker element in the response that you received to indicate where
@@ -7807,8 +7809,6 @@ type ListGroupsInput struct {
 	//  This parameter is optional. If it is not included, it defaults to a slash
 	// (/), listing all groups.
 	PathPrefix *string `min:"1" type:"string"`
-
-	_ struct{} `type:"structure"`
 }
 
 // String returns the string representation
@@ -7823,6 +7823,8 @@ func (s ListGroupsInput) GoString() string {
 
 // Contains the response to a successful ListGroups request.
 type ListGroupsOutput struct {
+	_ struct{} `type:"structure"`
+
 	// A list of groups.
 	Groups []*Group `type:"list" required:"true"`
 
@@ -7837,8 +7839,6 @@ type ListGroupsOutput struct {
 	// When IsTruncated is true, this element is present and contains the value
 	// to use for the Marker parameter in a subsequent pagination request.
 	Marker *string `min:"1" type:"string"`
-
-	_ struct{} `type:"structure"`
 }
 
 // String returns the string representation
@@ -7852,6 +7852,8 @@ func (s ListGroupsOutput) GoString() string {
 }
 
 type ListInstanceProfilesForRoleInput struct {
+	_ struct{} `type:"structure"`
+
 	// Use this parameter only when paginating results and only after you receive
 	// a response indicating that the results are truncated. Set it to the value
 	// of the Marker element in the response that you received to indicate where
@@ -7871,8 +7873,6 @@ type ListInstanceProfilesForRoleInput struct {
 
 	// The name of the role to list instance profiles for.
 	RoleName *string `min:"1" type:"string" required:"true"`
-
-	_ struct{} `type:"structure"`
 }
 
 // String returns the string representation
@@ -7887,6 +7887,8 @@ func (s ListInstanceProfilesForRoleInput) GoString() string {
 
 // Contains the response to a successful ListInstanceProfilesForRole request.
 type ListInstanceProfilesForRoleOutput struct {
+	_ struct{} `type:"structure"`
+
 	// A list of instance profiles.
 	InstanceProfiles []*InstanceProfile `type:"list" required:"true"`
 
@@ -7901,8 +7903,6 @@ type ListInstanceProfilesForRoleOutput struct {
 	// When IsTruncated is true, this element is present and contains the value
 	// to use for the Marker parameter in a subsequent pagination request.
 	Marker *string `min:"1" type:"string"`
-
-	_ struct{} `type:"structure"`
 }
 
 // String returns the string representation
@@ -7916,6 +7916,8 @@ func (s ListInstanceProfilesForRoleOutput) GoString() string {
 }
 
 type ListInstanceProfilesInput struct {
+	_ struct{} `type:"structure"`
+
 	// Use this parameter only when paginating results and only after you receive
 	// a response indicating that the results are truncated. Set it to the value
 	// of the Marker element in the response that you received to indicate where
@@ -7939,8 +7941,6 @@ type ListInstanceProfilesInput struct {
 	//  This parameter is optional. If it is not included, it defaults to a slash
 	// (/), listing all instance profiles.
 	PathPrefix *string `min:"1" type:"string"`
-
-	_ struct{} `type:"structure"`
 }
 
 // String returns the string representation
@@ -7955,6 +7955,8 @@ func (s ListInstanceProfilesInput) GoString() string {
 
 // Contains the response to a successful ListInstanceProfiles request.
 type ListInstanceProfilesOutput struct {
+	_ struct{} `type:"structure"`
+
 	// A list of instance profiles.
 	InstanceProfiles []*InstanceProfile `type:"list" required:"true"`
 
@@ -7969,8 +7971,6 @@ type ListInstanceProfilesOutput struct {
 	// When IsTruncated is true, this element is present and contains the value
 	// to use for the Marker parameter in a subsequent pagination request.
 	Marker *string `min:"1" type:"string"`
-
-	_ struct{} `type:"structure"`
 }
 
 // String returns the string representation
@@ -7984,6 +7984,8 @@ func (s ListInstanceProfilesOutput) GoString() string {
 }
 
 type ListMFADevicesInput struct {
+	_ struct{} `type:"structure"`
+
 	// Use this parameter only when paginating results and only after you receive
 	// a response indicating that the results are truncated. Set it to the value
 	// of the Marker element in the response that you received to indicate where
@@ -8003,8 +8005,6 @@ type ListMFADevicesInput struct {
 
 	// The name of the user whose MFA devices you want to list.
 	UserName *string `min:"1" type:"string"`
-
-	_ struct{} `type:"structure"`
 }
 
 // String returns the string representation
@@ -8019,6 +8019,8 @@ func (s ListMFADevicesInput) GoString() string {
 
 // Contains the response to a successful ListMFADevices request.
 type ListMFADevicesOutput struct {
+	_ struct{} `type:"structure"`
+
 	// A flag that indicates whether there are more items to return. If your results
 	// were truncated, you can make a subsequent pagination request using the Marker
 	// request parameter to retrieve more items. Note that IAM might return fewer
@@ -8033,8 +8035,6 @@ type ListMFADevicesOutput struct {
 	// When IsTruncated is true, this element is present and contains the value
 	// to use for the Marker parameter in a subsequent pagination request.
 	Marker *string `min:"1" type:"string"`
-
-	_ struct{} `type:"structure"`
 }
 
 // String returns the string representation
@@ -8063,10 +8063,10 @@ func (s ListOpenIDConnectProvidersInput) GoString() string {
 
 // Contains the response to a successful ListOpenIDConnectProviders request.
 type ListOpenIDConnectProvidersOutput struct {
+	_ struct{} `type:"structure"`
+
 	// The list of IAM OpenID Connect providers in the AWS account.
 	OpenIDConnectProviderList []*OpenIDConnectProviderListEntry `type:"list"`
-
-	_ struct{} `type:"structure"`
 }
 
 // String returns the string representation
@@ -8080,6 +8080,8 @@ func (s ListOpenIDConnectProvidersOutput) GoString() string {
 }
 
 type ListPoliciesInput struct {
+	_ struct{} `type:"structure"`
+
 	// Use this parameter only when paginating results and only after you receive
 	// a response indicating that the results are truncated. Set it to the value
 	// of the Marker element in the response that you received to indicate where
@@ -8116,8 +8118,6 @@ type ListPoliciesInput struct {
 	// This parameter is optional. If it is not included, or if it is set to All,
 	// all policies are returned.
 	Scope *string `type:"string" enum:"policyScopeType"`
-
-	_ struct{} `type:"structure"`
 }
 
 // String returns the string representation
@@ -8132,6 +8132,8 @@ func (s ListPoliciesInput) GoString() string {
 
 // Contains the response to a successful ListPolicies request.
 type ListPoliciesOutput struct {
+	_ struct{} `type:"structure"`
+
 	// A flag that indicates whether there are more items to return. If your results
 	// were truncated, you can make a subsequent pagination request using the Marker
 	// request parameter to retrieve more items. Note that IAM might return fewer
@@ -8146,8 +8148,6 @@ type ListPoliciesOutput struct {
 
 	// A list of policies.
 	Policies []*Policy `type:"list"`
-
-	_ struct{} `type:"structure"`
 }
 
 // String returns the string representation
@@ -8161,6 +8161,8 @@ func (s ListPoliciesOutput) GoString() string {
 }
 
 type ListPolicyVersionsInput struct {
+	_ struct{} `type:"structure"`
+
 	// Use this parameter only when paginating results and only after you receive
 	// a response indicating that the results are truncated. Set it to the value
 	// of the Marker element in the response that you received to indicate where
@@ -8184,8 +8186,6 @@ type ListPolicyVersionsInput struct {
 	// AWS Service Namespaces (http://docs.aws.amazon.com/general/latest/gr/aws-arns-and-namespaces.html)
 	// in the AWS General Reference.
 	PolicyArn *string `min:"20" type:"string" required:"true"`
-
-	_ struct{} `type:"structure"`
 }
 
 // String returns the string representation
@@ -8200,6 +8200,8 @@ func (s ListPolicyVersionsInput) GoString() string {
 
 // Contains the response to a successful ListPolicyVersions request.
 type ListPolicyVersionsOutput struct {
+	_ struct{} `type:"structure"`
+
 	// A flag that indicates whether there are more items to return. If your results
 	// were truncated, you can make a subsequent pagination request using the Marker
 	// request parameter to retrieve more items. Note that IAM might return fewer
@@ -8218,8 +8220,6 @@ type ListPolicyVersionsOutput struct {
 	// Policies (http://docs.aws.amazon.com/IAM/latest/UserGuide/policies-managed-versions.html)
 	// in the IAM User Guide.
 	Versions []*PolicyVersion `type:"list"`
-
-	_ struct{} `type:"structure"`
 }
 
 // String returns the string representation
@@ -8233,6 +8233,8 @@ func (s ListPolicyVersionsOutput) GoString() string {
 }
 
 type ListRolePoliciesInput struct {
+	_ struct{} `type:"structure"`
+
 	// Use this parameter only when paginating results and only after you receive
 	// a response indicating that the results are truncated. Set it to the value
 	// of the Marker element in the response that you received to indicate where
@@ -8252,8 +8254,6 @@ type ListRolePoliciesInput struct {
 
 	// The name of the role to list policies for.
 	RoleName *string `min:"1" type:"string" required:"true"`
-
-	_ struct{} `type:"structure"`
 }
 
 // String returns the string representation
@@ -8268,6 +8268,8 @@ func (s ListRolePoliciesInput) GoString() string {
 
 // Contains the response to a successful ListRolePolicies request.
 type ListRolePoliciesOutput struct {
+	_ struct{} `type:"structure"`
+
 	// A flag that indicates whether there are more items to return. If your results
 	// were truncated, you can make a subsequent pagination request using the Marker
 	// request parameter to retrieve more items. Note that IAM might return fewer
@@ -8282,8 +8284,6 @@ type ListRolePoliciesOutput struct {
 
 	// A list of policy names.
 	PolicyNames []*string `type:"list" required:"true"`
-
-	_ struct{} `type:"structure"`
 }
 
 // String returns the string representation
@@ -8297,6 +8297,8 @@ func (s ListRolePoliciesOutput) GoString() string {
 }
 
 type ListRolesInput struct {
+	_ struct{} `type:"structure"`
+
 	// Use this parameter only when paginating results and only after you receive
 	// a response indicating that the results are truncated. Set it to the value
 	// of the Marker element in the response that you received to indicate where
@@ -8320,8 +8322,6 @@ type ListRolesInput struct {
 	//  This parameter is optional. If it is not included, it defaults to a slash
 	// (/), listing all roles.
 	PathPrefix *string `min:"1" type:"string"`
-
-	_ struct{} `type:"structure"`
 }
 
 // String returns the string representation
@@ -8336,6 +8336,8 @@ func (s ListRolesInput) GoString() string {
 
 // Contains the response to a successful ListRoles request.
 type ListRolesOutput struct {
+	_ struct{} `type:"structure"`
+
 	// A flag that indicates whether there are more items to return. If your results
 	// were truncated, you can make a subsequent pagination request using the Marker
 	// request parameter to retrieve more items. Note that IAM might return fewer
@@ -8350,8 +8352,6 @@ type ListRolesOutput struct {
 
 	// A list of roles.
 	Roles []*Role `type:"list" required:"true"`
-
-	_ struct{} `type:"structure"`
 }
 
 // String returns the string representation
@@ -8380,10 +8380,10 @@ func (s ListSAMLProvidersInput) GoString() string {
 
 // Contains the response to a successful ListSAMLProviders request.
 type ListSAMLProvidersOutput struct {
+	_ struct{} `type:"structure"`
+
 	// The list of SAML providers for this account.
 	SAMLProviderList []*SAMLProviderListEntry `type:"list"`
-
-	_ struct{} `type:"structure"`
 }
 
 // String returns the string representation
@@ -8397,6 +8397,8 @@ func (s ListSAMLProvidersOutput) GoString() string {
 }
 
 type ListSSHPublicKeysInput struct {
+	_ struct{} `type:"structure"`
+
 	// Use this parameter only when paginating results and only after you receive
 	// a response indicating that the results are truncated. Set it to the value
 	// of the Marker element in the response that you received to indicate where
@@ -8418,8 +8420,6 @@ type ListSSHPublicKeysInput struct {
 	// the UserName field is determined implicitly based on the AWS access key used
 	// to sign the request.
 	UserName *string `min:"1" type:"string"`
-
-	_ struct{} `type:"structure"`
 }
 
 // String returns the string representation
@@ -8434,6 +8434,8 @@ func (s ListSSHPublicKeysInput) GoString() string {
 
 // Contains the response to a successful ListSSHPublicKeys request.
 type ListSSHPublicKeysOutput struct {
+	_ struct{} `type:"structure"`
+
 	// A flag that indicates whether there are more items to return. If your results
 	// were truncated, you can make a subsequent pagination request using the Marker
 	// request parameter to retrieve more items. Note that IAM might return fewer
@@ -8448,8 +8450,6 @@ type ListSSHPublicKeysOutput struct {
 
 	// A list of SSH public keys.
 	SSHPublicKeys []*SSHPublicKeyMetadata `type:"list"`
-
-	_ struct{} `type:"structure"`
 }
 
 // String returns the string representation
@@ -8463,6 +8463,8 @@ func (s ListSSHPublicKeysOutput) GoString() string {
 }
 
 type ListServerCertificatesInput struct {
+	_ struct{} `type:"structure"`
+
 	// Use this parameter only when paginating results and only after you receive
 	// a response indicating that the results are truncated. Set it to the value
 	// of the Marker element in the response that you received to indicate where
@@ -8486,8 +8488,6 @@ type ListServerCertificatesInput struct {
 	//  This parameter is optional. If it is not included, it defaults to a slash
 	// (/), listing all server certificates.
 	PathPrefix *string `min:"1" type:"string"`
-
-	_ struct{} `type:"structure"`
 }
 
 // String returns the string representation
@@ -8502,6 +8502,8 @@ func (s ListServerCertificatesInput) GoString() string {
 
 // Contains the response to a successful ListServerCertificates request.
 type ListServerCertificatesOutput struct {
+	_ struct{} `type:"structure"`
+
 	// A flag that indicates whether there are more items to return. If your results
 	// were truncated, you can make a subsequent pagination request using the Marker
 	// request parameter to retrieve more items. Note that IAM might return fewer
@@ -8516,8 +8518,6 @@ type ListServerCertificatesOutput struct {
 
 	// A list of server certificates.
 	ServerCertificateMetadataList []*ServerCertificateMetadata `type:"list" required:"true"`
-
-	_ struct{} `type:"structure"`
 }
 
 // String returns the string representation
@@ -8531,6 +8531,8 @@ func (s ListServerCertificatesOutput) GoString() string {
 }
 
 type ListSigningCertificatesInput struct {
+	_ struct{} `type:"structure"`
+
 	// Use this parameter only when paginating results and only after you receive
 	// a response indicating that the results are truncated. Set it to the value
 	// of the Marker element in the response that you received to indicate where
@@ -8550,8 +8552,6 @@ type ListSigningCertificatesInput struct {
 
 	// The name of the user.
 	UserName *string `min:"1" type:"string"`
-
-	_ struct{} `type:"structure"`
 }
 
 // String returns the string representation
@@ -8566,6 +8566,8 @@ func (s ListSigningCertificatesInput) GoString() string {
 
 // Contains the response to a successful ListSigningCertificates request.
 type ListSigningCertificatesOutput struct {
+	_ struct{} `type:"structure"`
+
 	// A list of the user's signing certificate information.
 	Certificates []*SigningCertificate `type:"list" required:"true"`
 
@@ -8580,8 +8582,6 @@ type ListSigningCertificatesOutput struct {
 	// When IsTruncated is true, this element is present and contains the value
 	// to use for the Marker parameter in a subsequent pagination request.
 	Marker *string `min:"1" type:"string"`
-
-	_ struct{} `type:"structure"`
 }
 
 // String returns the string representation
@@ -8595,6 +8595,8 @@ func (s ListSigningCertificatesOutput) GoString() string {
 }
 
 type ListUserPoliciesInput struct {
+	_ struct{} `type:"structure"`
+
 	// Use this parameter only when paginating results and only after you receive
 	// a response indicating that the results are truncated. Set it to the value
 	// of the Marker element in the response that you received to indicate where
@@ -8614,8 +8616,6 @@ type ListUserPoliciesInput struct {
 
 	// The name of the user to list policies for.
 	UserName *string `min:"1" type:"string" required:"true"`
-
-	_ struct{} `type:"structure"`
 }
 
 // String returns the string representation
@@ -8630,6 +8630,8 @@ func (s ListUserPoliciesInput) GoString() string {
 
 // Contains the response to a successful ListUserPolicies request.
 type ListUserPoliciesOutput struct {
+	_ struct{} `type:"structure"`
+
 	// A flag that indicates whether there are more items to return. If your results
 	// were truncated, you can make a subsequent pagination request using the Marker
 	// request parameter to retrieve more items. Note that IAM might return fewer
@@ -8644,8 +8646,6 @@ type ListUserPoliciesOutput struct {
 
 	// A list of policy names.
 	PolicyNames []*string `type:"list" required:"true"`
-
-	_ struct{} `type:"structure"`
 }
 
 // String returns the string representation
@@ -8659,6 +8659,8 @@ func (s ListUserPoliciesOutput) GoString() string {
 }
 
 type ListUsersInput struct {
+	_ struct{} `type:"structure"`
+
 	// Use this parameter only when paginating results and only after you receive
 	// a response indicating that the results are truncated. Set it to the value
 	// of the Marker element in the response that you received to indicate where
@@ -8682,8 +8684,6 @@ type ListUsersInput struct {
 	//  This parameter is optional. If it is not included, it defaults to a slash
 	// (/), listing all user names.
 	PathPrefix *string `min:"1" type:"string"`
-
-	_ struct{} `type:"structure"`
 }
 
 // String returns the string representation
@@ -8698,6 +8698,8 @@ func (s ListUsersInput) GoString() string {
 
 // Contains the response to a successful ListUsers request.
 type ListUsersOutput struct {
+	_ struct{} `type:"structure"`
+
 	// A flag that indicates whether there are more items to return. If your results
 	// were truncated, you can make a subsequent pagination request using the Marker
 	// request parameter to retrieve more items. Note that IAM might return fewer
@@ -8712,8 +8714,6 @@ type ListUsersOutput struct {
 
 	// A list of users.
 	Users []*User `type:"list" required:"true"`
-
-	_ struct{} `type:"structure"`
 }
 
 // String returns the string representation
@@ -8727,6 +8727,8 @@ func (s ListUsersOutput) GoString() string {
 }
 
 type ListVirtualMFADevicesInput struct {
+	_ struct{} `type:"structure"`
+
 	// The status (unassigned or assigned) of the devices to list. If you do not
 	// specify an AssignmentStatus, the action defaults to Any which lists both
 	// assigned and unassigned virtual MFA devices.
@@ -8748,8 +8750,6 @@ type ListVirtualMFADevicesInput struct {
 	// Marker contains a value to include in the subsequent call that tells the
 	// service where to continue from.
 	MaxItems *int64 `min:"1" type:"integer"`
-
-	_ struct{} `type:"structure"`
 }
 
 // String returns the string representation
@@ -8764,6 +8764,8 @@ func (s ListVirtualMFADevicesInput) GoString() string {
 
 // Contains the response to a successful ListVirtualMFADevices request.
 type ListVirtualMFADevicesOutput struct {
+	_ struct{} `type:"structure"`
+
 	// A flag that indicates whether there are more items to return. If your results
 	// were truncated, you can make a subsequent pagination request using the Marker
 	// request parameter to retrieve more items. Note that IAM might return fewer
@@ -8779,8 +8781,6 @@ type ListVirtualMFADevicesOutput struct {
 	// The list of virtual MFA devices in the current account that match the AssignmentStatus
 	// value that was passed in the request.
 	VirtualMFADevices []*VirtualMFADevice `type:"list" required:"true"`
-
-	_ struct{} `type:"structure"`
 }
 
 // String returns the string representation
@@ -8798,6 +8798,8 @@ func (s ListVirtualMFADevicesOutput) GoString() string {
 //  This data type is used as a response element in the CreateLoginProfile
 // and GetLoginProfile actions.
 type LoginProfile struct {
+	_ struct{} `type:"structure"`
+
 	// The date when the password for the user was created.
 	CreateDate *time.Time `type:"timestamp" timestampFormat:"iso8601" required:"true"`
 
@@ -8807,8 +8809,6 @@ type LoginProfile struct {
 	// The name of the user, which can be used for signing in to the AWS Management
 	// Console.
 	UserName *string `min:"1" type:"string" required:"true"`
-
-	_ struct{} `type:"structure"`
 }
 
 // String returns the string representation
@@ -8825,6 +8825,8 @@ func (s LoginProfile) GoString() string {
 //
 // This data type is used as a response element in the ListMFADevices action.
 type MFADevice struct {
+	_ struct{} `type:"structure"`
+
 	// The date when the MFA device was enabled for the user.
 	EnableDate *time.Time `type:"timestamp" timestampFormat:"iso8601" required:"true"`
 
@@ -8834,8 +8836,6 @@ type MFADevice struct {
 
 	// The user with whom the MFA device is associated.
 	UserName *string `min:"1" type:"string" required:"true"`
-
-	_ struct{} `type:"structure"`
 }
 
 // String returns the string representation
@@ -8859,6 +8859,8 @@ func (s MFADevice) GoString() string {
 // Policies (http://docs.aws.amazon.com/IAM/latest/UserGuide/policies-managed-vs-inline.html)
 // in the Using IAM guide.
 type ManagedPolicyDetail struct {
+	_ struct{} `type:"structure"`
+
 	// The Amazon Resource Name (ARN). ARNs are unique identifiers for AWS resources.
 	//
 	// For more information about ARNs, go to Amazon Resource Names (ARNs) and
@@ -8914,8 +8916,6 @@ type ManagedPolicyDetail struct {
 	// field contains the date and time when the most recent policy version was
 	// created.
 	UpdateDate *time.Time `type:"timestamp" timestampFormat:"iso8601"`
-
-	_ struct{} `type:"structure"`
 }
 
 // String returns the string representation
@@ -8930,14 +8930,14 @@ func (s ManagedPolicyDetail) GoString() string {
 
 // Contains the Amazon Resource Name (ARN) for an IAM OpenID Connect provider.
 type OpenIDConnectProviderListEntry struct {
+	_ struct{} `type:"structure"`
+
 	// The Amazon Resource Name (ARN). ARNs are unique identifiers for AWS resources.
 	//
 	// For more information about ARNs, go to Amazon Resource Names (ARNs) and
 	// AWS Service Namespaces (http://docs.aws.amazon.com/general/latest/gr/aws-arns-and-namespaces.html)
 	// in the AWS General Reference.
 	Arn *string `min:"20" type:"string"`
-
-	_ struct{} `type:"structure"`
 }
 
 // String returns the string representation
@@ -8955,6 +8955,8 @@ func (s OpenIDConnectProviderListEntry) GoString() string {
 //  This data type is used as a response element in the GetAccountPasswordPolicy
 // action.
 type PasswordPolicy struct {
+	_ struct{} `type:"structure"`
+
 	// Specifies whether IAM users are allowed to change their own password.
 	AllowUsersToChangePassword *bool `type:"boolean"`
 
@@ -8988,8 +8990,6 @@ type PasswordPolicy struct {
 
 	// Specifies whether to require uppercase characters for IAM user passwords.
 	RequireUppercaseCharacters *bool `type:"boolean"`
-
-	_ struct{} `type:"structure"`
 }
 
 // String returns the string representation
@@ -9011,6 +9011,8 @@ func (s PasswordPolicy) GoString() string {
 // Inline Policies (http://docs.aws.amazon.com/IAM/latest/UserGuide/policies-managed-vs-inline.html)
 // in the Using IAM guide.
 type Policy struct {
+	_ struct{} `type:"structure"`
+
 	// The Amazon Resource Name (ARN). ARNs are unique identifiers for AWS resources.
 	//
 	// For more information about ARNs, go to Amazon Resource Names (ARNs) and
@@ -9061,8 +9063,6 @@ type Policy struct {
 	// field contains the date and time when the most recent policy version was
 	// created.
 	UpdateDate *time.Time `type:"timestamp" timestampFormat:"iso8601"`
-
-	_ struct{} `type:"structure"`
 }
 
 // String returns the string representation
@@ -9080,13 +9080,13 @@ func (s Policy) GoString() string {
 // This data type is used as a response element in the GetAccountAuthorizationDetails
 // action.
 type PolicyDetail struct {
+	_ struct{} `type:"structure"`
+
 	// The policy document.
 	PolicyDocument *string `min:"1" type:"string"`
 
 	// The name of the policy.
 	PolicyName *string `min:"1" type:"string"`
-
-	_ struct{} `type:"structure"`
 }
 
 // String returns the string representation
@@ -9108,10 +9108,10 @@ func (s PolicyDetail) GoString() string {
 // Inline Policies (http://docs.aws.amazon.com/IAM/latest/UserGuide/policies-managed-vs-inline.html)
 // in the Using IAM guide.
 type PolicyGroup struct {
+	_ struct{} `type:"structure"`
+
 	// The name (friendly name, not ARN) identifying the group.
 	GroupName *string `min:"1" type:"string"`
-
-	_ struct{} `type:"structure"`
 }
 
 // String returns the string representation
@@ -9133,10 +9133,10 @@ func (s PolicyGroup) GoString() string {
 // Inline Policies (http://docs.aws.amazon.com/IAM/latest/UserGuide/policies-managed-vs-inline.html)
 // in the Using IAM guide.
 type PolicyRole struct {
+	_ struct{} `type:"structure"`
+
 	// The name (friendly name, not ARN) identifying the role.
 	RoleName *string `min:"1" type:"string"`
-
-	_ struct{} `type:"structure"`
 }
 
 // String returns the string representation
@@ -9158,10 +9158,10 @@ func (s PolicyRole) GoString() string {
 // Inline Policies (http://docs.aws.amazon.com/IAM/latest/UserGuide/policies-managed-vs-inline.html)
 // in the Using IAM guide.
 type PolicyUser struct {
+	_ struct{} `type:"structure"`
+
 	// The name (friendly name, not ARN) identifying the user.
 	UserName *string `min:"1" type:"string"`
-
-	_ struct{} `type:"structure"`
 }
 
 // String returns the string representation
@@ -9184,6 +9184,8 @@ func (s PolicyUser) GoString() string {
 // Inline Policies (http://docs.aws.amazon.com/IAM/latest/UserGuide/policies-managed-vs-inline.html)
 // in the Using IAM guide.
 type PolicyVersion struct {
+	_ struct{} `type:"structure"`
+
 	// The date and time, in ISO 8601 date-time format (http://www.iso.org/iso/iso8601),
 	// when the policy version was created.
 	CreateDate *time.Time `type:"timestamp" timestampFormat:"iso8601"`
@@ -9203,8 +9205,6 @@ type PolicyVersion struct {
 	// Policy version identifiers always begin with v (always lowercase). When
 	// a policy is created, the first policy version is v1.
 	VersionId *string `type:"string"`
-
-	_ struct{} `type:"structure"`
 }
 
 // String returns the string representation
@@ -9222,13 +9222,13 @@ func (s PolicyVersion) GoString() string {
 //
 // This data type is used as a member of the Statement type.
 type Position struct {
+	_ struct{} `type:"structure"`
+
 	// The column in the line containing the specified position in the document.
 	Column *int64 `type:"integer"`
 
 	// The line containing the specified position in the document.
 	Line *int64 `type:"integer"`
-
-	_ struct{} `type:"structure"`
 }
 
 // String returns the string representation
@@ -9242,6 +9242,8 @@ func (s Position) GoString() string {
 }
 
 type PutGroupPolicyInput struct {
+	_ struct{} `type:"structure"`
+
 	// The name of the group to associate the policy with.
 	GroupName *string `min:"1" type:"string" required:"true"`
 
@@ -9250,8 +9252,6 @@ type PutGroupPolicyInput struct {
 
 	// The name of the policy document.
 	PolicyName *string `min:"1" type:"string" required:"true"`
-
-	_ struct{} `type:"structure"`
 }
 
 // String returns the string representation
@@ -9279,6 +9279,8 @@ func (s PutGroupPolicyOutput) GoString() string {
 }
 
 type PutRolePolicyInput struct {
+	_ struct{} `type:"structure"`
+
 	// The policy document.
 	PolicyDocument *string `min:"1" type:"string" required:"true"`
 
@@ -9287,8 +9289,6 @@ type PutRolePolicyInput struct {
 
 	// The name of the role to associate the policy with.
 	RoleName *string `min:"1" type:"string" required:"true"`
-
-	_ struct{} `type:"structure"`
 }
 
 // String returns the string representation
@@ -9316,6 +9316,8 @@ func (s PutRolePolicyOutput) GoString() string {
 }
 
 type PutUserPolicyInput struct {
+	_ struct{} `type:"structure"`
+
 	// The policy document.
 	PolicyDocument *string `min:"1" type:"string" required:"true"`
 
@@ -9324,8 +9326,6 @@ type PutUserPolicyInput struct {
 
 	// The name of the user to associate the policy with.
 	UserName *string `min:"1" type:"string" required:"true"`
-
-	_ struct{} `type:"structure"`
 }
 
 // String returns the string representation
@@ -9353,6 +9353,8 @@ func (s PutUserPolicyOutput) GoString() string {
 }
 
 type RemoveClientIDFromOpenIDConnectProviderInput struct {
+	_ struct{} `type:"structure"`
+
 	// The client ID (also known as audience) to remove from the IAM OpenID Connect
 	// provider. For more information about client IDs, see CreateOpenIDConnectProvider.
 	ClientID *string `min:"1" type:"string" required:"true"`
@@ -9361,8 +9363,6 @@ type RemoveClientIDFromOpenIDConnectProviderInput struct {
 	// to remove the client ID from. You can get a list of OIDC provider ARNs by
 	// using the ListOpenIDConnectProviders action.
 	OpenIDConnectProviderArn *string `min:"20" type:"string" required:"true"`
-
-	_ struct{} `type:"structure"`
 }
 
 // String returns the string representation
@@ -9390,13 +9390,13 @@ func (s RemoveClientIDFromOpenIDConnectProviderOutput) GoString() string {
 }
 
 type RemoveRoleFromInstanceProfileInput struct {
+	_ struct{} `type:"structure"`
+
 	// The name of the instance profile to update.
 	InstanceProfileName *string `min:"1" type:"string" required:"true"`
 
 	// The name of the role to remove.
 	RoleName *string `min:"1" type:"string" required:"true"`
-
-	_ struct{} `type:"structure"`
 }
 
 // String returns the string representation
@@ -9424,13 +9424,13 @@ func (s RemoveRoleFromInstanceProfileOutput) GoString() string {
 }
 
 type RemoveUserFromGroupInput struct {
+	_ struct{} `type:"structure"`
+
 	// The name of the group to update.
 	GroupName *string `min:"1" type:"string" required:"true"`
 
 	// The name of the user to remove.
 	UserName *string `min:"1" type:"string" required:"true"`
-
-	_ struct{} `type:"structure"`
 }
 
 // String returns the string representation
@@ -9462,6 +9462,8 @@ func (s RemoveUserFromGroupOutput) GoString() string {
 //
 // This data type is used by a member of the EvaluationResult data type.
 type ResourceSpecificResult struct {
+	_ struct{} `type:"structure"`
+
 	// Additional details about the results of the evaluation decision. When there
 	// are both IAM policies and resource policies, this parameter explains how
 	// each set of policies contributes to the final evaluation decision. When simulating
@@ -9488,8 +9490,6 @@ type ResourceSpecificResult struct {
 	// keys used by a set of policies, you can call GetContextKeysForCustomPolicy
 	// or GetContextKeysForPrincipalPolicy.
 	MissingContextValues []*string `type:"list"`
-
-	_ struct{} `type:"structure"`
 }
 
 // String returns the string representation
@@ -9503,6 +9503,8 @@ func (s ResourceSpecificResult) GoString() string {
 }
 
 type ResyncMFADeviceInput struct {
+	_ struct{} `type:"structure"`
+
 	// An authentication code emitted by the device.
 	AuthenticationCode1 *string `min:"6" type:"string" required:"true"`
 
@@ -9514,8 +9516,6 @@ type ResyncMFADeviceInput struct {
 
 	// The name of the user whose MFA device you want to resynchronize.
 	UserName *string `min:"1" type:"string" required:"true"`
-
-	_ struct{} `type:"structure"`
 }
 
 // String returns the string representation
@@ -9552,6 +9552,8 @@ func (s ResyncMFADeviceOutput) GoString() string {
 //
 //    ListRoles
 type Role struct {
+	_ struct{} `type:"structure"`
+
 	// The Amazon Resource Name (ARN) specifying the role. For more information
 	// about ARNs and how to use them in policies, see IAM Identifiers (http://docs.aws.amazon.com/IAM/latest/UserGuide/Using_Identifiers.html)
 	// in the Using IAM guide.
@@ -9576,8 +9578,6 @@ type Role struct {
 
 	// The friendly name that identifies the role.
 	RoleName *string `min:"1" type:"string" required:"true"`
-
-	_ struct{} `type:"structure"`
 }
 
 // String returns the string representation
@@ -9595,6 +9595,8 @@ func (s Role) GoString() string {
 // This data type is used as a response element in the GetAccountAuthorizationDetails
 // action.
 type RoleDetail struct {
+	_ struct{} `type:"structure"`
+
 	// The Amazon Resource Name (ARN). ARNs are unique identifiers for AWS resources.
 	//
 	// For more information about ARNs, go to Amazon Resource Names (ARNs) and
@@ -9632,8 +9634,6 @@ type RoleDetail struct {
 	// A list of inline policies embedded in the role. These policies are the role's
 	// access (permissions) policies.
 	RolePolicyList []*PolicyDetail `type:"list"`
-
-	_ struct{} `type:"structure"`
 }
 
 // String returns the string representation
@@ -9648,6 +9648,8 @@ func (s RoleDetail) GoString() string {
 
 // Contains the list of SAML providers for this account.
 type SAMLProviderListEntry struct {
+	_ struct{} `type:"structure"`
+
 	// The Amazon Resource Name (ARN) of the SAML provider.
 	Arn *string `min:"20" type:"string"`
 
@@ -9656,8 +9658,6 @@ type SAMLProviderListEntry struct {
 
 	// The expiration date and time for the SAML provider.
 	ValidUntil *time.Time `type:"timestamp" timestampFormat:"iso8601"`
-
-	_ struct{} `type:"structure"`
 }
 
 // String returns the string representation
@@ -9675,6 +9675,8 @@ func (s SAMLProviderListEntry) GoString() string {
 // This data type is used as a response element in the GetSSHPublicKey and
 // UploadSSHPublicKey actions.
 type SSHPublicKey struct {
+	_ struct{} `type:"structure"`
+
 	// The MD5 message digest of the SSH public key.
 	Fingerprint *string `min:"48" type:"string" required:"true"`
 
@@ -9694,8 +9696,6 @@ type SSHPublicKey struct {
 
 	// The name of the IAM user associated with the SSH public key.
 	UserName *string `min:"1" type:"string" required:"true"`
-
-	_ struct{} `type:"structure"`
 }
 
 // String returns the string representation
@@ -9712,6 +9712,8 @@ func (s SSHPublicKey) GoString() string {
 //
 // This data type is used as a response element in the ListSSHPublicKeys action.
 type SSHPublicKeyMetadata struct {
+	_ struct{} `type:"structure"`
+
 	// The unique identifier for the SSH public key.
 	SSHPublicKeyId *string `min:"20" type:"string" required:"true"`
 
@@ -9725,8 +9727,6 @@ type SSHPublicKeyMetadata struct {
 
 	// The name of the IAM user associated with the SSH public key.
 	UserName *string `min:"1" type:"string" required:"true"`
-
-	_ struct{} `type:"structure"`
 }
 
 // String returns the string representation
@@ -9744,6 +9744,8 @@ func (s SSHPublicKeyMetadata) GoString() string {
 //  This data type is used as a response element in the GetServerCertificate
 // action.
 type ServerCertificate struct {
+	_ struct{} `type:"structure"`
+
 	// The contents of the public key certificate.
 	CertificateBody *string `min:"1" type:"string" required:"true"`
 
@@ -9753,8 +9755,6 @@ type ServerCertificate struct {
 	// The meta information of the server certificate, such as its name, path, ID,
 	// and ARN.
 	ServerCertificateMetadata *ServerCertificateMetadata `type:"structure" required:"true"`
-
-	_ struct{} `type:"structure"`
 }
 
 // String returns the string representation
@@ -9773,6 +9773,8 @@ func (s ServerCertificate) GoString() string {
 //  This data type is used as a response element in the UploadServerCertificate
 // and ListServerCertificates actions.
 type ServerCertificateMetadata struct {
+	_ struct{} `type:"structure"`
+
 	// The Amazon Resource Name (ARN) specifying the server certificate. For more
 	// information about ARNs and how to use them in policies, see IAM Identifiers
 	// (http://docs.aws.amazon.com/IAM/latest/UserGuide/Using_Identifiers.html)
@@ -9797,8 +9799,6 @@ type ServerCertificateMetadata struct {
 
 	// The date when the server certificate was uploaded.
 	UploadDate *time.Time `type:"timestamp" timestampFormat:"iso8601"`
-
-	_ struct{} `type:"structure"`
 }
 
 // String returns the string representation
@@ -9812,6 +9812,8 @@ func (s ServerCertificateMetadata) GoString() string {
 }
 
 type SetDefaultPolicyVersionInput struct {
+	_ struct{} `type:"structure"`
+
 	// The Amazon Resource Name (ARN). ARNs are unique identifiers for AWS resources.
 	//
 	// For more information about ARNs, go to Amazon Resource Names (ARNs) and
@@ -9825,8 +9827,6 @@ type SetDefaultPolicyVersionInput struct {
 	// Policies (http://docs.aws.amazon.com/IAM/latest/UserGuide/policies-managed-versions.html)
 	// in the IAM User Guide.
 	VersionId *string `type:"string" required:"true"`
-
-	_ struct{} `type:"structure"`
 }
 
 // String returns the string representation
@@ -9858,6 +9858,8 @@ func (s SetDefaultPolicyVersionOutput) GoString() string {
 // This data type is used as a response element in the UploadSigningCertificate
 // and ListSigningCertificates actions.
 type SigningCertificate struct {
+	_ struct{} `type:"structure"`
+
 	// The contents of the signing certificate.
 	CertificateBody *string `min:"1" type:"string" required:"true"`
 
@@ -9873,8 +9875,6 @@ type SigningCertificate struct {
 
 	// The name of the user the signing certificate is associated with.
 	UserName *string `min:"1" type:"string" required:"true"`
-
-	_ struct{} `type:"structure"`
 }
 
 // String returns the string representation
@@ -9888,6 +9888,8 @@ func (s SigningCertificate) GoString() string {
 }
 
 type SimulateCustomPolicyInput struct {
+	_ struct{} `type:"structure"`
+
 	// A list of names of API actions to evaluate in the simulation. Each action
 	// is evaluated against each resource. Each action must include the service
 	// identifier, such as iam:CreateUser.
@@ -10003,8 +10005,6 @@ type SimulateCustomPolicyInput struct {
 	// Each resource in the simulation is treated as if it had this policy attached.
 	// You can include only one resource-based policy in a simulation.
 	ResourcePolicy *string `min:"1" type:"string"`
-
-	_ struct{} `type:"structure"`
 }
 
 // String returns the string representation
@@ -10020,6 +10020,8 @@ func (s SimulateCustomPolicyInput) GoString() string {
 // Contains the response to a successful SimulatePrincipalPolicy or SimulateCustomPolicy
 // request.
 type SimulatePolicyResponse struct {
+	_ struct{} `type:"structure"`
+
 	// The results of the simulation.
 	EvaluationResults []*EvaluationResult `type:"list"`
 
@@ -10034,8 +10036,6 @@ type SimulatePolicyResponse struct {
 	// When IsTruncated is true, this element is present and contains the value
 	// to use for the Marker parameter in a subsequent pagination request.
 	Marker *string `min:"1" type:"string"`
-
-	_ struct{} `type:"structure"`
 }
 
 // String returns the string representation
@@ -10049,6 +10049,8 @@ func (s SimulatePolicyResponse) GoString() string {
 }
 
 type SimulatePrincipalPolicyInput struct {
+	_ struct{} `type:"structure"`
+
 	// A list of names of API actions to evaluate in the simulation. Each action
 	// is evaluated for each resource. Each action must include the service identifier,
 	// such as iam:CreateUser.
@@ -10170,8 +10172,6 @@ type SimulatePrincipalPolicyInput struct {
 	// Each resource in the simulation is treated as if it had this policy attached.
 	// You can include only one resource-based policy in a simulation.
 	ResourcePolicy *string `min:"1" type:"string"`
-
-	_ struct{} `type:"structure"`
 }
 
 // String returns the string representation
@@ -10190,6 +10190,8 @@ func (s SimulatePrincipalPolicyInput) GoString() string {
 // This data type is used by the MatchedStatements member of the EvaluationResult
 // type.
 type Statement struct {
+	_ struct{} `type:"structure"`
+
 	// The row and column of the end of a Statement in an IAM policy.
 	EndPosition *Position `type:"structure"`
 
@@ -10201,8 +10203,6 @@ type Statement struct {
 
 	// The row and column of the beginning of the Statement in an IAM policy.
 	StartPosition *Position `type:"structure"`
-
-	_ struct{} `type:"structure"`
 }
 
 // String returns the string representation
@@ -10216,6 +10216,8 @@ func (s Statement) GoString() string {
 }
 
 type UpdateAccessKeyInput struct {
+	_ struct{} `type:"structure"`
+
 	// The access key ID of the secret access key you want to update.
 	AccessKeyId *string `min:"16" type:"string" required:"true"`
 
@@ -10226,8 +10228,6 @@ type UpdateAccessKeyInput struct {
 
 	// The name of the user whose key you want to update.
 	UserName *string `min:"1" type:"string"`
-
-	_ struct{} `type:"structure"`
 }
 
 // String returns the string representation
@@ -10255,6 +10255,8 @@ func (s UpdateAccessKeyOutput) GoString() string {
 }
 
 type UpdateAccountPasswordPolicyInput struct {
+	_ struct{} `type:"structure"`
+
 	// Allows all IAM users in your account to use the AWS Management Console to
 	// change their own passwords. For more information, see Letting IAM Users Change
 	// Their Own Passwords (http://docs.aws.amazon.com/IAM/latest/UserGuide/HowToPwdIAMUser.html)
@@ -10311,8 +10313,6 @@ type UpdateAccountPasswordPolicyInput struct {
 	//
 	// Default value: false
 	RequireUppercaseCharacters *bool `type:"boolean"`
-
-	_ struct{} `type:"structure"`
 }
 
 // String returns the string representation
@@ -10340,13 +10340,13 @@ func (s UpdateAccountPasswordPolicyOutput) GoString() string {
 }
 
 type UpdateAssumeRolePolicyInput struct {
+	_ struct{} `type:"structure"`
+
 	// The policy that grants an entity permission to assume the role.
 	PolicyDocument *string `min:"1" type:"string" required:"true"`
 
 	// The name of the role to update.
 	RoleName *string `min:"1" type:"string" required:"true"`
-
-	_ struct{} `type:"structure"`
 }
 
 // String returns the string representation
@@ -10374,6 +10374,8 @@ func (s UpdateAssumeRolePolicyOutput) GoString() string {
 }
 
 type UpdateGroupInput struct {
+	_ struct{} `type:"structure"`
+
 	// Name of the group to update. If you're changing the name of the group, this
 	// is the original name.
 	GroupName *string `min:"1" type:"string" required:"true"`
@@ -10383,8 +10385,6 @@ type UpdateGroupInput struct {
 
 	// New path for the group. Only include this if changing the group's path.
 	NewPath *string `min:"1" type:"string"`
-
-	_ struct{} `type:"structure"`
 }
 
 // String returns the string representation
@@ -10412,6 +10412,8 @@ func (s UpdateGroupOutput) GoString() string {
 }
 
 type UpdateLoginProfileInput struct {
+	_ struct{} `type:"structure"`
+
 	// The new password for the specified user.
 	Password *string `min:"1" type:"string"`
 
@@ -10420,8 +10422,6 @@ type UpdateLoginProfileInput struct {
 
 	// The name of the user whose password you want to update.
 	UserName *string `min:"1" type:"string" required:"true"`
-
-	_ struct{} `type:"structure"`
 }
 
 // String returns the string representation
@@ -10449,6 +10449,8 @@ func (s UpdateLoginProfileOutput) GoString() string {
 }
 
 type UpdateOpenIDConnectProviderThumbprintInput struct {
+	_ struct{} `type:"structure"`
+
 	// The Amazon Resource Name (ARN) of the IAM OpenID Connect (OIDC) provider
 	// to update the thumbprint for. You can get a list of OIDC provider ARNs by
 	// using the ListOpenIDConnectProviders action.
@@ -10457,8 +10459,6 @@ type UpdateOpenIDConnectProviderThumbprintInput struct {
 	// A list of certificate thumbprints that are associated with the specified
 	// IAM OpenID Connect provider. For more information, see CreateOpenIDConnectProvider.
 	ThumbprintList []*string `type:"list" required:"true"`
-
-	_ struct{} `type:"structure"`
 }
 
 // String returns the string representation
@@ -10486,6 +10486,8 @@ func (s UpdateOpenIDConnectProviderThumbprintOutput) GoString() string {
 }
 
 type UpdateSAMLProviderInput struct {
+	_ struct{} `type:"structure"`
+
 	// An XML document generated by an identity provider (IdP) that supports SAML
 	// 2.0. The document includes the issuer's name, expiration information, and
 	// keys that can be used to validate the SAML authentication response (assertions)
@@ -10495,8 +10497,6 @@ type UpdateSAMLProviderInput struct {
 
 	// The Amazon Resource Name (ARN) of the SAML provider to update.
 	SAMLProviderArn *string `min:"20" type:"string" required:"true"`
-
-	_ struct{} `type:"structure"`
 }
 
 // String returns the string representation
@@ -10511,10 +10511,10 @@ func (s UpdateSAMLProviderInput) GoString() string {
 
 // Contains the response to a successful UpdateSAMLProvider request.
 type UpdateSAMLProviderOutput struct {
+	_ struct{} `type:"structure"`
+
 	// The Amazon Resource Name (ARN) of the SAML provider that was updated.
 	SAMLProviderArn *string `min:"20" type:"string"`
-
-	_ struct{} `type:"structure"`
 }
 
 // String returns the string representation
@@ -10528,6 +10528,8 @@ func (s UpdateSAMLProviderOutput) GoString() string {
 }
 
 type UpdateSSHPublicKeyInput struct {
+	_ struct{} `type:"structure"`
+
 	// The unique identifier for the SSH public key.
 	SSHPublicKeyId *string `min:"20" type:"string" required:"true"`
 
@@ -10538,8 +10540,6 @@ type UpdateSSHPublicKeyInput struct {
 
 	// The name of the IAM user associated with the SSH public key.
 	UserName *string `min:"1" type:"string" required:"true"`
-
-	_ struct{} `type:"structure"`
 }
 
 // String returns the string representation
@@ -10567,6 +10567,8 @@ func (s UpdateSSHPublicKeyOutput) GoString() string {
 }
 
 type UpdateServerCertificateInput struct {
+	_ struct{} `type:"structure"`
+
 	// The new path for the server certificate. Include this only if you are updating
 	// the server certificate's path.
 	NewPath *string `min:"1" type:"string"`
@@ -10578,8 +10580,6 @@ type UpdateServerCertificateInput struct {
 
 	// The name of the server certificate that you want to update.
 	ServerCertificateName *string `min:"1" type:"string" required:"true"`
-
-	_ struct{} `type:"structure"`
 }
 
 // String returns the string representation
@@ -10607,6 +10607,8 @@ func (s UpdateServerCertificateOutput) GoString() string {
 }
 
 type UpdateSigningCertificateInput struct {
+	_ struct{} `type:"structure"`
+
 	// The ID of the signing certificate you want to update.
 	CertificateId *string `min:"24" type:"string" required:"true"`
 
@@ -10617,8 +10619,6 @@ type UpdateSigningCertificateInput struct {
 
 	// The name of the user the signing certificate belongs to.
 	UserName *string `min:"1" type:"string"`
-
-	_ struct{} `type:"structure"`
 }
 
 // String returns the string representation
@@ -10646,6 +10646,8 @@ func (s UpdateSigningCertificateOutput) GoString() string {
 }
 
 type UpdateUserInput struct {
+	_ struct{} `type:"structure"`
+
 	// New path for the user. Include this parameter only if you're changing the
 	// user's path.
 	NewPath *string `min:"1" type:"string"`
@@ -10657,8 +10659,6 @@ type UpdateUserInput struct {
 	// Name of the user to update. If you're changing the name of the user, this
 	// is the original user name.
 	UserName *string `min:"1" type:"string" required:"true"`
-
-	_ struct{} `type:"structure"`
 }
 
 // String returns the string representation
@@ -10686,14 +10686,14 @@ func (s UpdateUserOutput) GoString() string {
 }
 
 type UploadSSHPublicKeyInput struct {
+	_ struct{} `type:"structure"`
+
 	// The SSH public key. The public key must be encoded in ssh-rsa format or PEM
 	// format.
 	SSHPublicKeyBody *string `min:"1" type:"string" required:"true"`
 
 	// The name of the IAM user to associate the SSH public key with.
 	UserName *string `min:"1" type:"string" required:"true"`
-
-	_ struct{} `type:"structure"`
 }
 
 // String returns the string representation
@@ -10708,10 +10708,10 @@ func (s UploadSSHPublicKeyInput) GoString() string {
 
 // Contains the response to a successful UploadSSHPublicKey request.
 type UploadSSHPublicKeyOutput struct {
+	_ struct{} `type:"structure"`
+
 	// Contains information about the SSH public key.
 	SSHPublicKey *SSHPublicKey `type:"structure"`
-
-	_ struct{} `type:"structure"`
 }
 
 // String returns the string representation
@@ -10725,6 +10725,8 @@ func (s UploadSSHPublicKeyOutput) GoString() string {
 }
 
 type UploadServerCertificateInput struct {
+	_ struct{} `type:"structure"`
+
 	// The contents of the public key certificate in PEM-encoded format.
 	CertificateBody *string `min:"1" type:"string" required:"true"`
 
@@ -10751,8 +10753,6 @@ type UploadServerCertificateInput struct {
 	// The name for the server certificate. Do not include the path in this value.
 	// The name of the certificate cannot contain any spaces.
 	ServerCertificateName *string `min:"1" type:"string" required:"true"`
-
-	_ struct{} `type:"structure"`
 }
 
 // String returns the string representation
@@ -10767,11 +10767,11 @@ func (s UploadServerCertificateInput) GoString() string {
 
 // Contains the response to a successful UploadServerCertificate request.
 type UploadServerCertificateOutput struct {
+	_ struct{} `type:"structure"`
+
 	// The meta information of the uploaded server certificate without its certificate
 	// body, certificate chain, and private key.
 	ServerCertificateMetadata *ServerCertificateMetadata `type:"structure"`
-
-	_ struct{} `type:"structure"`
 }
 
 // String returns the string representation
@@ -10785,13 +10785,13 @@ func (s UploadServerCertificateOutput) GoString() string {
 }
 
 type UploadSigningCertificateInput struct {
+	_ struct{} `type:"structure"`
+
 	// The contents of the signing certificate.
 	CertificateBody *string `min:"1" type:"string" required:"true"`
 
 	// The name of the user the signing certificate is for.
 	UserName *string `min:"1" type:"string"`
-
-	_ struct{} `type:"structure"`
 }
 
 // String returns the string representation
@@ -10806,10 +10806,10 @@ func (s UploadSigningCertificateInput) GoString() string {
 
 // Contains the response to a successful UploadSigningCertificate request.
 type UploadSigningCertificateOutput struct {
+	_ struct{} `type:"structure"`
+
 	// Information about the certificate.
 	Certificate *SigningCertificate `type:"structure" required:"true"`
-
-	_ struct{} `type:"structure"`
 }
 
 // String returns the string representation
@@ -10832,6 +10832,8 @@ func (s UploadSigningCertificateOutput) GoString() string {
 //
 //    ListUsers
 type User struct {
+	_ struct{} `type:"structure"`
+
 	// The Amazon Resource Name (ARN) that identifies the user. For more information
 	// about ARNs and how to use ARNs in policies, see IAM Identifiers (http://docs.aws.amazon.com/IAM/latest/UserGuide/Using_Identifiers.html)
 	// in the Using IAM guide.
@@ -10871,8 +10873,6 @@ type User struct {
 
 	// The friendly name identifying the user.
 	UserName *string `min:"1" type:"string" required:"true"`
-
-	_ struct{} `type:"structure"`
 }
 
 // String returns the string representation
@@ -10891,6 +10891,8 @@ func (s User) GoString() string {
 // This data type is used as a response element in the GetAccountAuthorizationDetails
 // action.
 type UserDetail struct {
+	_ struct{} `type:"structure"`
+
 	// The Amazon Resource Name (ARN). ARNs are unique identifiers for AWS resources.
 	//
 	// For more information about ARNs, go to Amazon Resource Names (ARNs) and
@@ -10923,8 +10925,6 @@ type UserDetail struct {
 
 	// A list of the inline policies embedded in the user.
 	UserPolicyList []*PolicyDetail `type:"list"`
-
-	_ struct{} `type:"structure"`
 }
 
 // String returns the string representation
@@ -10939,6 +10939,8 @@ func (s UserDetail) GoString() string {
 
 // Contains information about a virtual MFA device.
 type VirtualMFADevice struct {
+	_ struct{} `type:"structure"`
+
 	// The Base32 seed defined as specified in RFC3548 (http://www.ietf.org/rfc/rfc3548.txt).
 	// The Base32StringSeed is Base64-encoded.
 	Base32StringSeed []byte `type:"blob"`
@@ -10965,8 +10967,6 @@ type VirtualMFADevice struct {
 	//
 	//    ListUsers
 	User *User `type:"structure"`
-
-	_ struct{} `type:"structure"`
 }
 
 // String returns the string representation

--- a/service/iam/api.go
+++ b/service/iam/api.go
@@ -4194,11 +4194,7 @@ type AccessKey struct {
 	// The name of the IAM user that the access key is associated with.
 	UserName *string `min:"1" type:"string" required:"true"`
 
-	metadataAccessKey `json:"-" xml:"-"`
-}
-
-type metadataAccessKey struct {
-	SDKShapeTraits bool `type:"structure"`
+	_ struct{} `type:"structure"`
 }
 
 // String returns the string representation
@@ -4252,11 +4248,7 @@ type AccessKeyLastUsed struct {
 	//   There is no sign-in data associated with the user
 	ServiceName *string `type:"string" required:"true"`
 
-	metadataAccessKeyLastUsed `json:"-" xml:"-"`
-}
-
-type metadataAccessKeyLastUsed struct {
-	SDKShapeTraits bool `type:"structure"`
+	_ struct{} `type:"structure"`
 }
 
 // String returns the string representation
@@ -4286,11 +4278,7 @@ type AccessKeyMetadata struct {
 	// The name of the IAM user that the key is associated with.
 	UserName *string `min:"1" type:"string"`
 
-	metadataAccessKeyMetadata `json:"-" xml:"-"`
-}
-
-type metadataAccessKeyMetadata struct {
-	SDKShapeTraits bool `type:"structure"`
+	_ struct{} `type:"structure"`
 }
 
 // String returns the string representation
@@ -4312,11 +4300,7 @@ type AddClientIDToOpenIDConnectProviderInput struct {
 	// the ListOpenIDConnectProviders action.
 	OpenIDConnectProviderArn *string `min:"20" type:"string" required:"true"`
 
-	metadataAddClientIDToOpenIDConnectProviderInput `json:"-" xml:"-"`
-}
-
-type metadataAddClientIDToOpenIDConnectProviderInput struct {
-	SDKShapeTraits bool `type:"structure"`
+	_ struct{} `type:"structure"`
 }
 
 // String returns the string representation
@@ -4330,11 +4314,7 @@ func (s AddClientIDToOpenIDConnectProviderInput) GoString() string {
 }
 
 type AddClientIDToOpenIDConnectProviderOutput struct {
-	metadataAddClientIDToOpenIDConnectProviderOutput `json:"-" xml:"-"`
-}
-
-type metadataAddClientIDToOpenIDConnectProviderOutput struct {
-	SDKShapeTraits bool `type:"structure"`
+	_ struct{} `type:"structure"`
 }
 
 // String returns the string representation
@@ -4354,11 +4334,7 @@ type AddRoleToInstanceProfileInput struct {
 	// The name of the role to add.
 	RoleName *string `min:"1" type:"string" required:"true"`
 
-	metadataAddRoleToInstanceProfileInput `json:"-" xml:"-"`
-}
-
-type metadataAddRoleToInstanceProfileInput struct {
-	SDKShapeTraits bool `type:"structure"`
+	_ struct{} `type:"structure"`
 }
 
 // String returns the string representation
@@ -4372,11 +4348,7 @@ func (s AddRoleToInstanceProfileInput) GoString() string {
 }
 
 type AddRoleToInstanceProfileOutput struct {
-	metadataAddRoleToInstanceProfileOutput `json:"-" xml:"-"`
-}
-
-type metadataAddRoleToInstanceProfileOutput struct {
-	SDKShapeTraits bool `type:"structure"`
+	_ struct{} `type:"structure"`
 }
 
 // String returns the string representation
@@ -4396,11 +4368,7 @@ type AddUserToGroupInput struct {
 	// The name of the user to add.
 	UserName *string `min:"1" type:"string" required:"true"`
 
-	metadataAddUserToGroupInput `json:"-" xml:"-"`
-}
-
-type metadataAddUserToGroupInput struct {
-	SDKShapeTraits bool `type:"structure"`
+	_ struct{} `type:"structure"`
 }
 
 // String returns the string representation
@@ -4414,11 +4382,7 @@ func (s AddUserToGroupInput) GoString() string {
 }
 
 type AddUserToGroupOutput struct {
-	metadataAddUserToGroupOutput `json:"-" xml:"-"`
-}
-
-type metadataAddUserToGroupOutput struct {
-	SDKShapeTraits bool `type:"structure"`
+	_ struct{} `type:"structure"`
 }
 
 // String returns the string representation
@@ -4442,11 +4406,7 @@ type AttachGroupPolicyInput struct {
 	// in the AWS General Reference.
 	PolicyArn *string `min:"20" type:"string" required:"true"`
 
-	metadataAttachGroupPolicyInput `json:"-" xml:"-"`
-}
-
-type metadataAttachGroupPolicyInput struct {
-	SDKShapeTraits bool `type:"structure"`
+	_ struct{} `type:"structure"`
 }
 
 // String returns the string representation
@@ -4460,11 +4420,7 @@ func (s AttachGroupPolicyInput) GoString() string {
 }
 
 type AttachGroupPolicyOutput struct {
-	metadataAttachGroupPolicyOutput `json:"-" xml:"-"`
-}
-
-type metadataAttachGroupPolicyOutput struct {
-	SDKShapeTraits bool `type:"structure"`
+	_ struct{} `type:"structure"`
 }
 
 // String returns the string representation
@@ -4488,11 +4444,7 @@ type AttachRolePolicyInput struct {
 	// The name (friendly name, not ARN) of the role to attach the policy to.
 	RoleName *string `min:"1" type:"string" required:"true"`
 
-	metadataAttachRolePolicyInput `json:"-" xml:"-"`
-}
-
-type metadataAttachRolePolicyInput struct {
-	SDKShapeTraits bool `type:"structure"`
+	_ struct{} `type:"structure"`
 }
 
 // String returns the string representation
@@ -4506,11 +4458,7 @@ func (s AttachRolePolicyInput) GoString() string {
 }
 
 type AttachRolePolicyOutput struct {
-	metadataAttachRolePolicyOutput `json:"-" xml:"-"`
-}
-
-type metadataAttachRolePolicyOutput struct {
-	SDKShapeTraits bool `type:"structure"`
+	_ struct{} `type:"structure"`
 }
 
 // String returns the string representation
@@ -4534,11 +4482,7 @@ type AttachUserPolicyInput struct {
 	// The name (friendly name, not ARN) of the user to attach the policy to.
 	UserName *string `min:"1" type:"string" required:"true"`
 
-	metadataAttachUserPolicyInput `json:"-" xml:"-"`
-}
-
-type metadataAttachUserPolicyInput struct {
-	SDKShapeTraits bool `type:"structure"`
+	_ struct{} `type:"structure"`
 }
 
 // String returns the string representation
@@ -4552,11 +4496,7 @@ func (s AttachUserPolicyInput) GoString() string {
 }
 
 type AttachUserPolicyOutput struct {
-	metadataAttachUserPolicyOutput `json:"-" xml:"-"`
-}
-
-type metadataAttachUserPolicyOutput struct {
-	SDKShapeTraits bool `type:"structure"`
+	_ struct{} `type:"structure"`
 }
 
 // String returns the string representation
@@ -4590,11 +4530,7 @@ type AttachedPolicy struct {
 	// The friendly name of the attached policy.
 	PolicyName *string `min:"1" type:"string"`
 
-	metadataAttachedPolicy `json:"-" xml:"-"`
-}
-
-type metadataAttachedPolicy struct {
-	SDKShapeTraits bool `type:"structure"`
+	_ struct{} `type:"structure"`
 }
 
 // String returns the string representation
@@ -4615,11 +4551,7 @@ type ChangePasswordInput struct {
 	// The IAM user's current password.
 	OldPassword *string `min:"1" type:"string" required:"true"`
 
-	metadataChangePasswordInput `json:"-" xml:"-"`
-}
-
-type metadataChangePasswordInput struct {
-	SDKShapeTraits bool `type:"structure"`
+	_ struct{} `type:"structure"`
 }
 
 // String returns the string representation
@@ -4633,11 +4565,7 @@ func (s ChangePasswordInput) GoString() string {
 }
 
 type ChangePasswordOutput struct {
-	metadataChangePasswordOutput `json:"-" xml:"-"`
-}
-
-type metadataChangePasswordOutput struct {
-	SDKShapeTraits bool `type:"structure"`
+	_ struct{} `type:"structure"`
 }
 
 // String returns the string representation
@@ -4670,11 +4598,7 @@ type ContextEntry struct {
 	// element in an input policy.
 	ContextKeyValues []*string `type:"list"`
 
-	metadataContextEntry `json:"-" xml:"-"`
-}
-
-type metadataContextEntry struct {
-	SDKShapeTraits bool `type:"structure"`
+	_ struct{} `type:"structure"`
 }
 
 // String returns the string representation
@@ -4691,11 +4615,7 @@ type CreateAccessKeyInput struct {
 	// The user name that the new key will belong to.
 	UserName *string `min:"1" type:"string"`
 
-	metadataCreateAccessKeyInput `json:"-" xml:"-"`
-}
-
-type metadataCreateAccessKeyInput struct {
-	SDKShapeTraits bool `type:"structure"`
+	_ struct{} `type:"structure"`
 }
 
 // String returns the string representation
@@ -4713,11 +4633,7 @@ type CreateAccessKeyOutput struct {
 	// Information about the access key.
 	AccessKey *AccessKey `type:"structure" required:"true"`
 
-	metadataCreateAccessKeyOutput `json:"-" xml:"-"`
-}
-
-type metadataCreateAccessKeyOutput struct {
-	SDKShapeTraits bool `type:"structure"`
+	_ struct{} `type:"structure"`
 }
 
 // String returns the string representation
@@ -4734,11 +4650,7 @@ type CreateAccountAliasInput struct {
 	// The account alias to create.
 	AccountAlias *string `min:"3" type:"string" required:"true"`
 
-	metadataCreateAccountAliasInput `json:"-" xml:"-"`
-}
-
-type metadataCreateAccountAliasInput struct {
-	SDKShapeTraits bool `type:"structure"`
+	_ struct{} `type:"structure"`
 }
 
 // String returns the string representation
@@ -4752,11 +4664,7 @@ func (s CreateAccountAliasInput) GoString() string {
 }
 
 type CreateAccountAliasOutput struct {
-	metadataCreateAccountAliasOutput `json:"-" xml:"-"`
-}
-
-type metadataCreateAccountAliasOutput struct {
-	SDKShapeTraits bool `type:"structure"`
+	_ struct{} `type:"structure"`
 }
 
 // String returns the string representation
@@ -4781,11 +4689,7 @@ type CreateGroupInput struct {
 	// (/).
 	Path *string `min:"1" type:"string"`
 
-	metadataCreateGroupInput `json:"-" xml:"-"`
-}
-
-type metadataCreateGroupInput struct {
-	SDKShapeTraits bool `type:"structure"`
+	_ struct{} `type:"structure"`
 }
 
 // String returns the string representation
@@ -4803,11 +4707,7 @@ type CreateGroupOutput struct {
 	// Information about the group.
 	Group *Group `type:"structure" required:"true"`
 
-	metadataCreateGroupOutput `json:"-" xml:"-"`
-}
-
-type metadataCreateGroupOutput struct {
-	SDKShapeTraits bool `type:"structure"`
+	_ struct{} `type:"structure"`
 }
 
 // String returns the string representation
@@ -4832,11 +4732,7 @@ type CreateInstanceProfileInput struct {
 	// (/).
 	Path *string `min:"1" type:"string"`
 
-	metadataCreateInstanceProfileInput `json:"-" xml:"-"`
-}
-
-type metadataCreateInstanceProfileInput struct {
-	SDKShapeTraits bool `type:"structure"`
+	_ struct{} `type:"structure"`
 }
 
 // String returns the string representation
@@ -4854,11 +4750,7 @@ type CreateInstanceProfileOutput struct {
 	// Information about the instance profile.
 	InstanceProfile *InstanceProfile `type:"structure" required:"true"`
 
-	metadataCreateInstanceProfileOutput `json:"-" xml:"-"`
-}
-
-type metadataCreateInstanceProfileOutput struct {
-	SDKShapeTraits bool `type:"structure"`
+	_ struct{} `type:"structure"`
 }
 
 // String returns the string representation
@@ -4881,11 +4773,7 @@ type CreateLoginProfileInput struct {
 	// The name of the user to create a password for.
 	UserName *string `min:"1" type:"string" required:"true"`
 
-	metadataCreateLoginProfileInput `json:"-" xml:"-"`
-}
-
-type metadataCreateLoginProfileInput struct {
-	SDKShapeTraits bool `type:"structure"`
+	_ struct{} `type:"structure"`
 }
 
 // String returns the string representation
@@ -4903,11 +4791,7 @@ type CreateLoginProfileOutput struct {
 	// The user name and password create date.
 	LoginProfile *LoginProfile `type:"structure" required:"true"`
 
-	metadataCreateLoginProfileOutput `json:"-" xml:"-"`
-}
-
-type metadataCreateLoginProfileOutput struct {
-	SDKShapeTraits bool `type:"structure"`
+	_ struct{} `type:"structure"`
 }
 
 // String returns the string representation
@@ -4966,11 +4850,7 @@ type CreateOpenIDConnectProviderInput struct {
 	// provider in the AWS account, you will get an error.
 	Url *string `min:"1" type:"string" required:"true"`
 
-	metadataCreateOpenIDConnectProviderInput `json:"-" xml:"-"`
-}
-
-type metadataCreateOpenIDConnectProviderInput struct {
-	SDKShapeTraits bool `type:"structure"`
+	_ struct{} `type:"structure"`
 }
 
 // String returns the string representation
@@ -4989,11 +4869,7 @@ type CreateOpenIDConnectProviderOutput struct {
 	// created. For more information, see OpenIDConnectProviderListEntry.
 	OpenIDConnectProviderArn *string `min:"20" type:"string"`
 
-	metadataCreateOpenIDConnectProviderOutput `json:"-" xml:"-"`
-}
-
-type metadataCreateOpenIDConnectProviderOutput struct {
-	SDKShapeTraits bool `type:"structure"`
+	_ struct{} `type:"structure"`
 }
 
 // String returns the string representation
@@ -5031,11 +4907,7 @@ type CreatePolicyInput struct {
 	// The name of the policy document.
 	PolicyName *string `min:"1" type:"string" required:"true"`
 
-	metadataCreatePolicyInput `json:"-" xml:"-"`
-}
-
-type metadataCreatePolicyInput struct {
-	SDKShapeTraits bool `type:"structure"`
+	_ struct{} `type:"structure"`
 }
 
 // String returns the string representation
@@ -5053,11 +4925,7 @@ type CreatePolicyOutput struct {
 	// Information about the policy.
 	Policy *Policy `type:"structure"`
 
-	metadataCreatePolicyOutput `json:"-" xml:"-"`
-}
-
-type metadataCreatePolicyOutput struct {
-	SDKShapeTraits bool `type:"structure"`
+	_ struct{} `type:"structure"`
 }
 
 // String returns the string representation
@@ -5092,11 +4960,7 @@ type CreatePolicyVersionInput struct {
 	// in the IAM User Guide.
 	SetAsDefault *bool `type:"boolean"`
 
-	metadataCreatePolicyVersionInput `json:"-" xml:"-"`
-}
-
-type metadataCreatePolicyVersionInput struct {
-	SDKShapeTraits bool `type:"structure"`
+	_ struct{} `type:"structure"`
 }
 
 // String returns the string representation
@@ -5114,11 +4978,7 @@ type CreatePolicyVersionOutput struct {
 	// Information about the policy version.
 	PolicyVersion *PolicyVersion `type:"structure"`
 
-	metadataCreatePolicyVersionOutput `json:"-" xml:"-"`
-}
-
-type metadataCreatePolicyVersionOutput struct {
-	SDKShapeTraits bool `type:"structure"`
+	_ struct{} `type:"structure"`
 }
 
 // String returns the string representation
@@ -5146,11 +5006,7 @@ type CreateRoleInput struct {
 	// The name of the role to create.
 	RoleName *string `min:"1" type:"string" required:"true"`
 
-	metadataCreateRoleInput `json:"-" xml:"-"`
-}
-
-type metadataCreateRoleInput struct {
-	SDKShapeTraits bool `type:"structure"`
+	_ struct{} `type:"structure"`
 }
 
 // String returns the string representation
@@ -5168,11 +5024,7 @@ type CreateRoleOutput struct {
 	// Information about the role.
 	Role *Role `type:"structure" required:"true"`
 
-	metadataCreateRoleOutput `json:"-" xml:"-"`
-}
-
-type metadataCreateRoleOutput struct {
-	SDKShapeTraits bool `type:"structure"`
+	_ struct{} `type:"structure"`
 }
 
 // String returns the string representation
@@ -5199,11 +5051,7 @@ type CreateSAMLProviderInput struct {
 	// in the IAM User Guide
 	SAMLMetadataDocument *string `min:"1000" type:"string" required:"true"`
 
-	metadataCreateSAMLProviderInput `json:"-" xml:"-"`
-}
-
-type metadataCreateSAMLProviderInput struct {
-	SDKShapeTraits bool `type:"structure"`
+	_ struct{} `type:"structure"`
 }
 
 // String returns the string representation
@@ -5221,11 +5069,7 @@ type CreateSAMLProviderOutput struct {
 	// The Amazon Resource Name (ARN) of the SAML provider.
 	SAMLProviderArn *string `min:"20" type:"string"`
 
-	metadataCreateSAMLProviderOutput `json:"-" xml:"-"`
-}
-
-type metadataCreateSAMLProviderOutput struct {
-	SDKShapeTraits bool `type:"structure"`
+	_ struct{} `type:"structure"`
 }
 
 // String returns the string representation
@@ -5250,11 +5094,7 @@ type CreateUserInput struct {
 	// The name of the user to create.
 	UserName *string `min:"1" type:"string" required:"true"`
 
-	metadataCreateUserInput `json:"-" xml:"-"`
-}
-
-type metadataCreateUserInput struct {
-	SDKShapeTraits bool `type:"structure"`
+	_ struct{} `type:"structure"`
 }
 
 // String returns the string representation
@@ -5272,11 +5112,7 @@ type CreateUserOutput struct {
 	// Information about the user.
 	User *User `type:"structure"`
 
-	metadataCreateUserOutput `json:"-" xml:"-"`
-}
-
-type metadataCreateUserOutput struct {
-	SDKShapeTraits bool `type:"structure"`
+	_ struct{} `type:"structure"`
 }
 
 // String returns the string representation
@@ -5302,11 +5138,7 @@ type CreateVirtualMFADeviceInput struct {
 	// virtual MFA device.
 	VirtualMFADeviceName *string `min:"1" type:"string" required:"true"`
 
-	metadataCreateVirtualMFADeviceInput `json:"-" xml:"-"`
-}
-
-type metadataCreateVirtualMFADeviceInput struct {
-	SDKShapeTraits bool `type:"structure"`
+	_ struct{} `type:"structure"`
 }
 
 // String returns the string representation
@@ -5324,11 +5156,7 @@ type CreateVirtualMFADeviceOutput struct {
 	// A newly created virtual MFA device.
 	VirtualMFADevice *VirtualMFADevice `type:"structure" required:"true"`
 
-	metadataCreateVirtualMFADeviceOutput `json:"-" xml:"-"`
-}
-
-type metadataCreateVirtualMFADeviceOutput struct {
-	SDKShapeTraits bool `type:"structure"`
+	_ struct{} `type:"structure"`
 }
 
 // String returns the string representation
@@ -5349,11 +5177,7 @@ type DeactivateMFADeviceInput struct {
 	// The name of the user whose MFA device you want to deactivate.
 	UserName *string `min:"1" type:"string" required:"true"`
 
-	metadataDeactivateMFADeviceInput `json:"-" xml:"-"`
-}
-
-type metadataDeactivateMFADeviceInput struct {
-	SDKShapeTraits bool `type:"structure"`
+	_ struct{} `type:"structure"`
 }
 
 // String returns the string representation
@@ -5367,11 +5191,7 @@ func (s DeactivateMFADeviceInput) GoString() string {
 }
 
 type DeactivateMFADeviceOutput struct {
-	metadataDeactivateMFADeviceOutput `json:"-" xml:"-"`
-}
-
-type metadataDeactivateMFADeviceOutput struct {
-	SDKShapeTraits bool `type:"structure"`
+	_ struct{} `type:"structure"`
 }
 
 // String returns the string representation
@@ -5392,11 +5212,7 @@ type DeleteAccessKeyInput struct {
 	// The name of the user whose key you want to delete.
 	UserName *string `min:"1" type:"string"`
 
-	metadataDeleteAccessKeyInput `json:"-" xml:"-"`
-}
-
-type metadataDeleteAccessKeyInput struct {
-	SDKShapeTraits bool `type:"structure"`
+	_ struct{} `type:"structure"`
 }
 
 // String returns the string representation
@@ -5410,11 +5226,7 @@ func (s DeleteAccessKeyInput) GoString() string {
 }
 
 type DeleteAccessKeyOutput struct {
-	metadataDeleteAccessKeyOutput `json:"-" xml:"-"`
-}
-
-type metadataDeleteAccessKeyOutput struct {
-	SDKShapeTraits bool `type:"structure"`
+	_ struct{} `type:"structure"`
 }
 
 // String returns the string representation
@@ -5431,11 +5243,7 @@ type DeleteAccountAliasInput struct {
 	// The name of the account alias to delete.
 	AccountAlias *string `min:"3" type:"string" required:"true"`
 
-	metadataDeleteAccountAliasInput `json:"-" xml:"-"`
-}
-
-type metadataDeleteAccountAliasInput struct {
-	SDKShapeTraits bool `type:"structure"`
+	_ struct{} `type:"structure"`
 }
 
 // String returns the string representation
@@ -5449,11 +5257,7 @@ func (s DeleteAccountAliasInput) GoString() string {
 }
 
 type DeleteAccountAliasOutput struct {
-	metadataDeleteAccountAliasOutput `json:"-" xml:"-"`
-}
-
-type metadataDeleteAccountAliasOutput struct {
-	SDKShapeTraits bool `type:"structure"`
+	_ struct{} `type:"structure"`
 }
 
 // String returns the string representation
@@ -5467,11 +5271,7 @@ func (s DeleteAccountAliasOutput) GoString() string {
 }
 
 type DeleteAccountPasswordPolicyInput struct {
-	metadataDeleteAccountPasswordPolicyInput `json:"-" xml:"-"`
-}
-
-type metadataDeleteAccountPasswordPolicyInput struct {
-	SDKShapeTraits bool `type:"structure"`
+	_ struct{} `type:"structure"`
 }
 
 // String returns the string representation
@@ -5485,11 +5285,7 @@ func (s DeleteAccountPasswordPolicyInput) GoString() string {
 }
 
 type DeleteAccountPasswordPolicyOutput struct {
-	metadataDeleteAccountPasswordPolicyOutput `json:"-" xml:"-"`
-}
-
-type metadataDeleteAccountPasswordPolicyOutput struct {
-	SDKShapeTraits bool `type:"structure"`
+	_ struct{} `type:"structure"`
 }
 
 // String returns the string representation
@@ -5506,11 +5302,7 @@ type DeleteGroupInput struct {
 	// The name of the group to delete.
 	GroupName *string `min:"1" type:"string" required:"true"`
 
-	metadataDeleteGroupInput `json:"-" xml:"-"`
-}
-
-type metadataDeleteGroupInput struct {
-	SDKShapeTraits bool `type:"structure"`
+	_ struct{} `type:"structure"`
 }
 
 // String returns the string representation
@@ -5524,11 +5316,7 @@ func (s DeleteGroupInput) GoString() string {
 }
 
 type DeleteGroupOutput struct {
-	metadataDeleteGroupOutput `json:"-" xml:"-"`
-}
-
-type metadataDeleteGroupOutput struct {
-	SDKShapeTraits bool `type:"structure"`
+	_ struct{} `type:"structure"`
 }
 
 // String returns the string representation
@@ -5549,11 +5337,7 @@ type DeleteGroupPolicyInput struct {
 	// The name identifying the policy document to delete.
 	PolicyName *string `min:"1" type:"string" required:"true"`
 
-	metadataDeleteGroupPolicyInput `json:"-" xml:"-"`
-}
-
-type metadataDeleteGroupPolicyInput struct {
-	SDKShapeTraits bool `type:"structure"`
+	_ struct{} `type:"structure"`
 }
 
 // String returns the string representation
@@ -5567,11 +5351,7 @@ func (s DeleteGroupPolicyInput) GoString() string {
 }
 
 type DeleteGroupPolicyOutput struct {
-	metadataDeleteGroupPolicyOutput `json:"-" xml:"-"`
-}
-
-type metadataDeleteGroupPolicyOutput struct {
-	SDKShapeTraits bool `type:"structure"`
+	_ struct{} `type:"structure"`
 }
 
 // String returns the string representation
@@ -5588,11 +5368,7 @@ type DeleteInstanceProfileInput struct {
 	// The name of the instance profile to delete.
 	InstanceProfileName *string `min:"1" type:"string" required:"true"`
 
-	metadataDeleteInstanceProfileInput `json:"-" xml:"-"`
-}
-
-type metadataDeleteInstanceProfileInput struct {
-	SDKShapeTraits bool `type:"structure"`
+	_ struct{} `type:"structure"`
 }
 
 // String returns the string representation
@@ -5606,11 +5382,7 @@ func (s DeleteInstanceProfileInput) GoString() string {
 }
 
 type DeleteInstanceProfileOutput struct {
-	metadataDeleteInstanceProfileOutput `json:"-" xml:"-"`
-}
-
-type metadataDeleteInstanceProfileOutput struct {
-	SDKShapeTraits bool `type:"structure"`
+	_ struct{} `type:"structure"`
 }
 
 // String returns the string representation
@@ -5627,11 +5399,7 @@ type DeleteLoginProfileInput struct {
 	// The name of the user whose password you want to delete.
 	UserName *string `min:"1" type:"string" required:"true"`
 
-	metadataDeleteLoginProfileInput `json:"-" xml:"-"`
-}
-
-type metadataDeleteLoginProfileInput struct {
-	SDKShapeTraits bool `type:"structure"`
+	_ struct{} `type:"structure"`
 }
 
 // String returns the string representation
@@ -5645,11 +5413,7 @@ func (s DeleteLoginProfileInput) GoString() string {
 }
 
 type DeleteLoginProfileOutput struct {
-	metadataDeleteLoginProfileOutput `json:"-" xml:"-"`
-}
-
-type metadataDeleteLoginProfileOutput struct {
-	SDKShapeTraits bool `type:"structure"`
+	_ struct{} `type:"structure"`
 }
 
 // String returns the string representation
@@ -5668,11 +5432,7 @@ type DeleteOpenIDConnectProviderInput struct {
 	// action.
 	OpenIDConnectProviderArn *string `min:"20" type:"string" required:"true"`
 
-	metadataDeleteOpenIDConnectProviderInput `json:"-" xml:"-"`
-}
-
-type metadataDeleteOpenIDConnectProviderInput struct {
-	SDKShapeTraits bool `type:"structure"`
+	_ struct{} `type:"structure"`
 }
 
 // String returns the string representation
@@ -5686,11 +5446,7 @@ func (s DeleteOpenIDConnectProviderInput) GoString() string {
 }
 
 type DeleteOpenIDConnectProviderOutput struct {
-	metadataDeleteOpenIDConnectProviderOutput `json:"-" xml:"-"`
-}
-
-type metadataDeleteOpenIDConnectProviderOutput struct {
-	SDKShapeTraits bool `type:"structure"`
+	_ struct{} `type:"structure"`
 }
 
 // String returns the string representation
@@ -5711,11 +5467,7 @@ type DeletePolicyInput struct {
 	// in the AWS General Reference.
 	PolicyArn *string `min:"20" type:"string" required:"true"`
 
-	metadataDeletePolicyInput `json:"-" xml:"-"`
-}
-
-type metadataDeletePolicyInput struct {
-	SDKShapeTraits bool `type:"structure"`
+	_ struct{} `type:"structure"`
 }
 
 // String returns the string representation
@@ -5729,11 +5481,7 @@ func (s DeletePolicyInput) GoString() string {
 }
 
 type DeletePolicyOutput struct {
-	metadataDeletePolicyOutput `json:"-" xml:"-"`
-}
-
-type metadataDeletePolicyOutput struct {
-	SDKShapeTraits bool `type:"structure"`
+	_ struct{} `type:"structure"`
 }
 
 // String returns the string representation
@@ -5761,11 +5509,7 @@ type DeletePolicyVersionInput struct {
 	// in the IAM User Guide.
 	VersionId *string `type:"string" required:"true"`
 
-	metadataDeletePolicyVersionInput `json:"-" xml:"-"`
-}
-
-type metadataDeletePolicyVersionInput struct {
-	SDKShapeTraits bool `type:"structure"`
+	_ struct{} `type:"structure"`
 }
 
 // String returns the string representation
@@ -5779,11 +5523,7 @@ func (s DeletePolicyVersionInput) GoString() string {
 }
 
 type DeletePolicyVersionOutput struct {
-	metadataDeletePolicyVersionOutput `json:"-" xml:"-"`
-}
-
-type metadataDeletePolicyVersionOutput struct {
-	SDKShapeTraits bool `type:"structure"`
+	_ struct{} `type:"structure"`
 }
 
 // String returns the string representation
@@ -5800,11 +5540,7 @@ type DeleteRoleInput struct {
 	// The name of the role to delete.
 	RoleName *string `min:"1" type:"string" required:"true"`
 
-	metadataDeleteRoleInput `json:"-" xml:"-"`
-}
-
-type metadataDeleteRoleInput struct {
-	SDKShapeTraits bool `type:"structure"`
+	_ struct{} `type:"structure"`
 }
 
 // String returns the string representation
@@ -5818,11 +5554,7 @@ func (s DeleteRoleInput) GoString() string {
 }
 
 type DeleteRoleOutput struct {
-	metadataDeleteRoleOutput `json:"-" xml:"-"`
-}
-
-type metadataDeleteRoleOutput struct {
-	SDKShapeTraits bool `type:"structure"`
+	_ struct{} `type:"structure"`
 }
 
 // String returns the string representation
@@ -5843,11 +5575,7 @@ type DeleteRolePolicyInput struct {
 	// embedded in.
 	RoleName *string `min:"1" type:"string" required:"true"`
 
-	metadataDeleteRolePolicyInput `json:"-" xml:"-"`
-}
-
-type metadataDeleteRolePolicyInput struct {
-	SDKShapeTraits bool `type:"structure"`
+	_ struct{} `type:"structure"`
 }
 
 // String returns the string representation
@@ -5861,11 +5589,7 @@ func (s DeleteRolePolicyInput) GoString() string {
 }
 
 type DeleteRolePolicyOutput struct {
-	metadataDeleteRolePolicyOutput `json:"-" xml:"-"`
-}
-
-type metadataDeleteRolePolicyOutput struct {
-	SDKShapeTraits bool `type:"structure"`
+	_ struct{} `type:"structure"`
 }
 
 // String returns the string representation
@@ -5882,11 +5606,7 @@ type DeleteSAMLProviderInput struct {
 	// The Amazon Resource Name (ARN) of the SAML provider to delete.
 	SAMLProviderArn *string `min:"20" type:"string" required:"true"`
 
-	metadataDeleteSAMLProviderInput `json:"-" xml:"-"`
-}
-
-type metadataDeleteSAMLProviderInput struct {
-	SDKShapeTraits bool `type:"structure"`
+	_ struct{} `type:"structure"`
 }
 
 // String returns the string representation
@@ -5900,11 +5620,7 @@ func (s DeleteSAMLProviderInput) GoString() string {
 }
 
 type DeleteSAMLProviderOutput struct {
-	metadataDeleteSAMLProviderOutput `json:"-" xml:"-"`
-}
-
-type metadataDeleteSAMLProviderOutput struct {
-	SDKShapeTraits bool `type:"structure"`
+	_ struct{} `type:"structure"`
 }
 
 // String returns the string representation
@@ -5924,11 +5640,7 @@ type DeleteSSHPublicKeyInput struct {
 	// The name of the IAM user associated with the SSH public key.
 	UserName *string `min:"1" type:"string" required:"true"`
 
-	metadataDeleteSSHPublicKeyInput `json:"-" xml:"-"`
-}
-
-type metadataDeleteSSHPublicKeyInput struct {
-	SDKShapeTraits bool `type:"structure"`
+	_ struct{} `type:"structure"`
 }
 
 // String returns the string representation
@@ -5942,11 +5654,7 @@ func (s DeleteSSHPublicKeyInput) GoString() string {
 }
 
 type DeleteSSHPublicKeyOutput struct {
-	metadataDeleteSSHPublicKeyOutput `json:"-" xml:"-"`
-}
-
-type metadataDeleteSSHPublicKeyOutput struct {
-	SDKShapeTraits bool `type:"structure"`
+	_ struct{} `type:"structure"`
 }
 
 // String returns the string representation
@@ -5963,11 +5671,7 @@ type DeleteServerCertificateInput struct {
 	// The name of the server certificate you want to delete.
 	ServerCertificateName *string `min:"1" type:"string" required:"true"`
 
-	metadataDeleteServerCertificateInput `json:"-" xml:"-"`
-}
-
-type metadataDeleteServerCertificateInput struct {
-	SDKShapeTraits bool `type:"structure"`
+	_ struct{} `type:"structure"`
 }
 
 // String returns the string representation
@@ -5981,11 +5685,7 @@ func (s DeleteServerCertificateInput) GoString() string {
 }
 
 type DeleteServerCertificateOutput struct {
-	metadataDeleteServerCertificateOutput `json:"-" xml:"-"`
-}
-
-type metadataDeleteServerCertificateOutput struct {
-	SDKShapeTraits bool `type:"structure"`
+	_ struct{} `type:"structure"`
 }
 
 // String returns the string representation
@@ -6005,11 +5705,7 @@ type DeleteSigningCertificateInput struct {
 	// The name of the user the signing certificate belongs to.
 	UserName *string `min:"1" type:"string"`
 
-	metadataDeleteSigningCertificateInput `json:"-" xml:"-"`
-}
-
-type metadataDeleteSigningCertificateInput struct {
-	SDKShapeTraits bool `type:"structure"`
+	_ struct{} `type:"structure"`
 }
 
 // String returns the string representation
@@ -6023,11 +5719,7 @@ func (s DeleteSigningCertificateInput) GoString() string {
 }
 
 type DeleteSigningCertificateOutput struct {
-	metadataDeleteSigningCertificateOutput `json:"-" xml:"-"`
-}
-
-type metadataDeleteSigningCertificateOutput struct {
-	SDKShapeTraits bool `type:"structure"`
+	_ struct{} `type:"structure"`
 }
 
 // String returns the string representation
@@ -6044,11 +5736,7 @@ type DeleteUserInput struct {
 	// The name of the user to delete.
 	UserName *string `min:"1" type:"string" required:"true"`
 
-	metadataDeleteUserInput `json:"-" xml:"-"`
-}
-
-type metadataDeleteUserInput struct {
-	SDKShapeTraits bool `type:"structure"`
+	_ struct{} `type:"structure"`
 }
 
 // String returns the string representation
@@ -6062,11 +5750,7 @@ func (s DeleteUserInput) GoString() string {
 }
 
 type DeleteUserOutput struct {
-	metadataDeleteUserOutput `json:"-" xml:"-"`
-}
-
-type metadataDeleteUserOutput struct {
-	SDKShapeTraits bool `type:"structure"`
+	_ struct{} `type:"structure"`
 }
 
 // String returns the string representation
@@ -6087,11 +5771,7 @@ type DeleteUserPolicyInput struct {
 	// embedded in.
 	UserName *string `min:"1" type:"string" required:"true"`
 
-	metadataDeleteUserPolicyInput `json:"-" xml:"-"`
-}
-
-type metadataDeleteUserPolicyInput struct {
-	SDKShapeTraits bool `type:"structure"`
+	_ struct{} `type:"structure"`
 }
 
 // String returns the string representation
@@ -6105,11 +5785,7 @@ func (s DeleteUserPolicyInput) GoString() string {
 }
 
 type DeleteUserPolicyOutput struct {
-	metadataDeleteUserPolicyOutput `json:"-" xml:"-"`
-}
-
-type metadataDeleteUserPolicyOutput struct {
-	SDKShapeTraits bool `type:"structure"`
+	_ struct{} `type:"structure"`
 }
 
 // String returns the string representation
@@ -6127,11 +5803,7 @@ type DeleteVirtualMFADeviceInput struct {
 	// devices, the serial number is the same as the ARN.
 	SerialNumber *string `min:"9" type:"string" required:"true"`
 
-	metadataDeleteVirtualMFADeviceInput `json:"-" xml:"-"`
-}
-
-type metadataDeleteVirtualMFADeviceInput struct {
-	SDKShapeTraits bool `type:"structure"`
+	_ struct{} `type:"structure"`
 }
 
 // String returns the string representation
@@ -6145,11 +5817,7 @@ func (s DeleteVirtualMFADeviceInput) GoString() string {
 }
 
 type DeleteVirtualMFADeviceOutput struct {
-	metadataDeleteVirtualMFADeviceOutput `json:"-" xml:"-"`
-}
-
-type metadataDeleteVirtualMFADeviceOutput struct {
-	SDKShapeTraits bool `type:"structure"`
+	_ struct{} `type:"structure"`
 }
 
 // String returns the string representation
@@ -6173,11 +5841,7 @@ type DetachGroupPolicyInput struct {
 	// in the AWS General Reference.
 	PolicyArn *string `min:"20" type:"string" required:"true"`
 
-	metadataDetachGroupPolicyInput `json:"-" xml:"-"`
-}
-
-type metadataDetachGroupPolicyInput struct {
-	SDKShapeTraits bool `type:"structure"`
+	_ struct{} `type:"structure"`
 }
 
 // String returns the string representation
@@ -6191,11 +5855,7 @@ func (s DetachGroupPolicyInput) GoString() string {
 }
 
 type DetachGroupPolicyOutput struct {
-	metadataDetachGroupPolicyOutput `json:"-" xml:"-"`
-}
-
-type metadataDetachGroupPolicyOutput struct {
-	SDKShapeTraits bool `type:"structure"`
+	_ struct{} `type:"structure"`
 }
 
 // String returns the string representation
@@ -6219,11 +5879,7 @@ type DetachRolePolicyInput struct {
 	// The name (friendly name, not ARN) of the role to detach the policy from.
 	RoleName *string `min:"1" type:"string" required:"true"`
 
-	metadataDetachRolePolicyInput `json:"-" xml:"-"`
-}
-
-type metadataDetachRolePolicyInput struct {
-	SDKShapeTraits bool `type:"structure"`
+	_ struct{} `type:"structure"`
 }
 
 // String returns the string representation
@@ -6237,11 +5893,7 @@ func (s DetachRolePolicyInput) GoString() string {
 }
 
 type DetachRolePolicyOutput struct {
-	metadataDetachRolePolicyOutput `json:"-" xml:"-"`
-}
-
-type metadataDetachRolePolicyOutput struct {
-	SDKShapeTraits bool `type:"structure"`
+	_ struct{} `type:"structure"`
 }
 
 // String returns the string representation
@@ -6265,11 +5917,7 @@ type DetachUserPolicyInput struct {
 	// The name (friendly name, not ARN) of the user to detach the policy from.
 	UserName *string `min:"1" type:"string" required:"true"`
 
-	metadataDetachUserPolicyInput `json:"-" xml:"-"`
-}
-
-type metadataDetachUserPolicyInput struct {
-	SDKShapeTraits bool `type:"structure"`
+	_ struct{} `type:"structure"`
 }
 
 // String returns the string representation
@@ -6283,11 +5931,7 @@ func (s DetachUserPolicyInput) GoString() string {
 }
 
 type DetachUserPolicyOutput struct {
-	metadataDetachUserPolicyOutput `json:"-" xml:"-"`
-}
-
-type metadataDetachUserPolicyOutput struct {
-	SDKShapeTraits bool `type:"structure"`
+	_ struct{} `type:"structure"`
 }
 
 // String returns the string representation
@@ -6314,11 +5958,7 @@ type EnableMFADeviceInput struct {
 	// The name of the user for whom you want to enable the MFA device.
 	UserName *string `min:"1" type:"string" required:"true"`
 
-	metadataEnableMFADeviceInput `json:"-" xml:"-"`
-}
-
-type metadataEnableMFADeviceInput struct {
-	SDKShapeTraits bool `type:"structure"`
+	_ struct{} `type:"structure"`
 }
 
 // String returns the string representation
@@ -6332,11 +5972,7 @@ func (s EnableMFADeviceInput) GoString() string {
 }
 
 type EnableMFADeviceOutput struct {
-	metadataEnableMFADeviceOutput `json:"-" xml:"-"`
-}
-
-type metadataEnableMFADeviceOutput struct {
-	SDKShapeTraits bool `type:"structure"`
+	_ struct{} `type:"structure"`
 }
 
 // String returns the string representation
@@ -6392,11 +6028,7 @@ type EvaluationResult struct {
 	// on each resource.
 	ResourceSpecificResults []*ResourceSpecificResult `type:"list"`
 
-	metadataEvaluationResult `json:"-" xml:"-"`
-}
-
-type metadataEvaluationResult struct {
-	SDKShapeTraits bool `type:"structure"`
+	_ struct{} `type:"structure"`
 }
 
 // String returns the string representation
@@ -6410,11 +6042,7 @@ func (s EvaluationResult) GoString() string {
 }
 
 type GenerateCredentialReportInput struct {
-	metadataGenerateCredentialReportInput `json:"-" xml:"-"`
-}
-
-type metadataGenerateCredentialReportInput struct {
-	SDKShapeTraits bool `type:"structure"`
+	_ struct{} `type:"structure"`
 }
 
 // String returns the string representation
@@ -6435,11 +6063,7 @@ type GenerateCredentialReportOutput struct {
 	// Information about the state of the credential report.
 	State *string `type:"string" enum:"ReportStateType"`
 
-	metadataGenerateCredentialReportOutput `json:"-" xml:"-"`
-}
-
-type metadataGenerateCredentialReportOutput struct {
-	SDKShapeTraits bool `type:"structure"`
+	_ struct{} `type:"structure"`
 }
 
 // String returns the string representation
@@ -6456,11 +6080,7 @@ type GetAccessKeyLastUsedInput struct {
 	// The identifier of an access key.
 	AccessKeyId *string `min:"16" type:"string" required:"true"`
 
-	metadataGetAccessKeyLastUsedInput `json:"-" xml:"-"`
-}
-
-type metadataGetAccessKeyLastUsedInput struct {
-	SDKShapeTraits bool `type:"structure"`
+	_ struct{} `type:"structure"`
 }
 
 // String returns the string representation
@@ -6483,11 +6103,7 @@ type GetAccessKeyLastUsedOutput struct {
 	// The name of the AWS IAM user that owns this access key.
 	UserName *string `min:"1" type:"string"`
 
-	metadataGetAccessKeyLastUsedOutput `json:"-" xml:"-"`
-}
-
-type metadataGetAccessKeyLastUsedOutput struct {
-	SDKShapeTraits bool `type:"structure"`
+	_ struct{} `type:"structure"`
 }
 
 // String returns the string representation
@@ -6522,11 +6138,7 @@ type GetAccountAuthorizationDetailsInput struct {
 	// service where to continue from.
 	MaxItems *int64 `min:"1" type:"integer"`
 
-	metadataGetAccountAuthorizationDetailsInput `json:"-" xml:"-"`
-}
-
-type metadataGetAccountAuthorizationDetailsInput struct {
-	SDKShapeTraits bool `type:"structure"`
+	_ struct{} `type:"structure"`
 }
 
 // String returns the string representation
@@ -6565,11 +6177,7 @@ type GetAccountAuthorizationDetailsOutput struct {
 	// A list containing information about IAM users.
 	UserDetailList []*UserDetail `type:"list"`
 
-	metadataGetAccountAuthorizationDetailsOutput `json:"-" xml:"-"`
-}
-
-type metadataGetAccountAuthorizationDetailsOutput struct {
-	SDKShapeTraits bool `type:"structure"`
+	_ struct{} `type:"structure"`
 }
 
 // String returns the string representation
@@ -6583,11 +6191,7 @@ func (s GetAccountAuthorizationDetailsOutput) GoString() string {
 }
 
 type GetAccountPasswordPolicyInput struct {
-	metadataGetAccountPasswordPolicyInput `json:"-" xml:"-"`
-}
-
-type metadataGetAccountPasswordPolicyInput struct {
-	SDKShapeTraits bool `type:"structure"`
+	_ struct{} `type:"structure"`
 }
 
 // String returns the string representation
@@ -6608,11 +6212,7 @@ type GetAccountPasswordPolicyOutput struct {
 	// action.
 	PasswordPolicy *PasswordPolicy `type:"structure" required:"true"`
 
-	metadataGetAccountPasswordPolicyOutput `json:"-" xml:"-"`
-}
-
-type metadataGetAccountPasswordPolicyOutput struct {
-	SDKShapeTraits bool `type:"structure"`
+	_ struct{} `type:"structure"`
 }
 
 // String returns the string representation
@@ -6626,11 +6226,7 @@ func (s GetAccountPasswordPolicyOutput) GoString() string {
 }
 
 type GetAccountSummaryInput struct {
-	metadataGetAccountSummaryInput `json:"-" xml:"-"`
-}
-
-type metadataGetAccountSummaryInput struct {
-	SDKShapeTraits bool `type:"structure"`
+	_ struct{} `type:"structure"`
 }
 
 // String returns the string representation
@@ -6790,11 +6386,7 @@ type GetAccountSummaryOutput struct {
 	// The maximum number of policy versions allowed for each managed policy.
 	SummaryMap map[string]*int64 `type:"map"`
 
-	metadataGetAccountSummaryOutput `json:"-" xml:"-"`
-}
-
-type metadataGetAccountSummaryOutput struct {
-	SDKShapeTraits bool `type:"structure"`
+	_ struct{} `type:"structure"`
 }
 
 // String returns the string representation
@@ -6813,11 +6405,7 @@ type GetContextKeysForCustomPolicyInput struct {
 	// valid JSON text of an IAM policy.
 	PolicyInputList []*string `type:"list" required:"true"`
 
-	metadataGetContextKeysForCustomPolicyInput `json:"-" xml:"-"`
-}
-
-type metadataGetContextKeysForCustomPolicyInput struct {
-	SDKShapeTraits bool `type:"structure"`
+	_ struct{} `type:"structure"`
 }
 
 // String returns the string representation
@@ -6837,11 +6425,7 @@ type GetContextKeysForPolicyResponse struct {
 	// policies.
 	ContextKeyNames []*string `type:"list"`
 
-	metadataGetContextKeysForPolicyResponse `json:"-" xml:"-"`
-}
-
-type metadataGetContextKeysForPolicyResponse struct {
-	SDKShapeTraits bool `type:"structure"`
+	_ struct{} `type:"structure"`
 }
 
 // String returns the string representation
@@ -6868,11 +6452,7 @@ type GetContextKeysForPrincipalPolicyInput struct {
 	// must be URL encoded to be included as a part of a real HTML request.
 	PolicySourceArn *string `min:"20" type:"string" required:"true"`
 
-	metadataGetContextKeysForPrincipalPolicyInput `json:"-" xml:"-"`
-}
-
-type metadataGetContextKeysForPrincipalPolicyInput struct {
-	SDKShapeTraits bool `type:"structure"`
+	_ struct{} `type:"structure"`
 }
 
 // String returns the string representation
@@ -6886,11 +6466,7 @@ func (s GetContextKeysForPrincipalPolicyInput) GoString() string {
 }
 
 type GetCredentialReportInput struct {
-	metadataGetCredentialReportInput `json:"-" xml:"-"`
-}
-
-type metadataGetCredentialReportInput struct {
-	SDKShapeTraits bool `type:"structure"`
+	_ struct{} `type:"structure"`
 }
 
 // String returns the string representation
@@ -6915,11 +6491,7 @@ type GetCredentialReportOutput struct {
 	// The format (MIME type) of the credential report.
 	ReportFormat *string `type:"string" enum:"ReportFormatType"`
 
-	metadataGetCredentialReportOutput `json:"-" xml:"-"`
-}
-
-type metadataGetCredentialReportOutput struct {
-	SDKShapeTraits bool `type:"structure"`
+	_ struct{} `type:"structure"`
 }
 
 // String returns the string representation
@@ -6953,11 +6525,7 @@ type GetGroupInput struct {
 	// service where to continue from.
 	MaxItems *int64 `min:"1" type:"integer"`
 
-	metadataGetGroupInput `json:"-" xml:"-"`
-}
-
-type metadataGetGroupInput struct {
-	SDKShapeTraits bool `type:"structure"`
+	_ struct{} `type:"structure"`
 }
 
 // String returns the string representation
@@ -6990,11 +6558,7 @@ type GetGroupOutput struct {
 	// A list of users in the group.
 	Users []*User `type:"list" required:"true"`
 
-	metadataGetGroupOutput `json:"-" xml:"-"`
-}
-
-type metadataGetGroupOutput struct {
-	SDKShapeTraits bool `type:"structure"`
+	_ struct{} `type:"structure"`
 }
 
 // String returns the string representation
@@ -7014,11 +6578,7 @@ type GetGroupPolicyInput struct {
 	// The name of the policy document to get.
 	PolicyName *string `min:"1" type:"string" required:"true"`
 
-	metadataGetGroupPolicyInput `json:"-" xml:"-"`
-}
-
-type metadataGetGroupPolicyInput struct {
-	SDKShapeTraits bool `type:"structure"`
+	_ struct{} `type:"structure"`
 }
 
 // String returns the string representation
@@ -7042,11 +6602,7 @@ type GetGroupPolicyOutput struct {
 	// The name of the policy.
 	PolicyName *string `min:"1" type:"string" required:"true"`
 
-	metadataGetGroupPolicyOutput `json:"-" xml:"-"`
-}
-
-type metadataGetGroupPolicyOutput struct {
-	SDKShapeTraits bool `type:"structure"`
+	_ struct{} `type:"structure"`
 }
 
 // String returns the string representation
@@ -7063,11 +6619,7 @@ type GetInstanceProfileInput struct {
 	// The name of the instance profile to get information about.
 	InstanceProfileName *string `min:"1" type:"string" required:"true"`
 
-	metadataGetInstanceProfileInput `json:"-" xml:"-"`
-}
-
-type metadataGetInstanceProfileInput struct {
-	SDKShapeTraits bool `type:"structure"`
+	_ struct{} `type:"structure"`
 }
 
 // String returns the string representation
@@ -7085,11 +6637,7 @@ type GetInstanceProfileOutput struct {
 	// Information about the instance profile.
 	InstanceProfile *InstanceProfile `type:"structure" required:"true"`
 
-	metadataGetInstanceProfileOutput `json:"-" xml:"-"`
-}
-
-type metadataGetInstanceProfileOutput struct {
-	SDKShapeTraits bool `type:"structure"`
+	_ struct{} `type:"structure"`
 }
 
 // String returns the string representation
@@ -7106,11 +6654,7 @@ type GetLoginProfileInput struct {
 	// The name of the user whose login profile you want to retrieve.
 	UserName *string `min:"1" type:"string" required:"true"`
 
-	metadataGetLoginProfileInput `json:"-" xml:"-"`
-}
-
-type metadataGetLoginProfileInput struct {
-	SDKShapeTraits bool `type:"structure"`
+	_ struct{} `type:"structure"`
 }
 
 // String returns the string representation
@@ -7128,11 +6672,7 @@ type GetLoginProfileOutput struct {
 	// The user name and password create date for the user.
 	LoginProfile *LoginProfile `type:"structure" required:"true"`
 
-	metadataGetLoginProfileOutput `json:"-" xml:"-"`
-}
-
-type metadataGetLoginProfileOutput struct {
-	SDKShapeTraits bool `type:"structure"`
+	_ struct{} `type:"structure"`
 }
 
 // String returns the string representation
@@ -7151,11 +6691,7 @@ type GetOpenIDConnectProviderInput struct {
 	// the ListOpenIDConnectProviders action.
 	OpenIDConnectProviderArn *string `min:"20" type:"string" required:"true"`
 
-	metadataGetOpenIDConnectProviderInput `json:"-" xml:"-"`
-}
-
-type metadataGetOpenIDConnectProviderInput struct {
-	SDKShapeTraits bool `type:"structure"`
+	_ struct{} `type:"structure"`
 }
 
 // String returns the string representation
@@ -7186,11 +6722,7 @@ type GetOpenIDConnectProviderOutput struct {
 	// information, see CreateOpenIDConnectProvider.
 	Url *string `min:"1" type:"string"`
 
-	metadataGetOpenIDConnectProviderOutput `json:"-" xml:"-"`
-}
-
-type metadataGetOpenIDConnectProviderOutput struct {
-	SDKShapeTraits bool `type:"structure"`
+	_ struct{} `type:"structure"`
 }
 
 // String returns the string representation
@@ -7211,11 +6743,7 @@ type GetPolicyInput struct {
 	// in the AWS General Reference.
 	PolicyArn *string `min:"20" type:"string" required:"true"`
 
-	metadataGetPolicyInput `json:"-" xml:"-"`
-}
-
-type metadataGetPolicyInput struct {
-	SDKShapeTraits bool `type:"structure"`
+	_ struct{} `type:"structure"`
 }
 
 // String returns the string representation
@@ -7233,11 +6761,7 @@ type GetPolicyOutput struct {
 	// Information about the policy.
 	Policy *Policy `type:"structure"`
 
-	metadataGetPolicyOutput `json:"-" xml:"-"`
-}
-
-type metadataGetPolicyOutput struct {
-	SDKShapeTraits bool `type:"structure"`
+	_ struct{} `type:"structure"`
 }
 
 // String returns the string representation
@@ -7261,11 +6785,7 @@ type GetPolicyVersionInput struct {
 	// Identifies the policy version to retrieve.
 	VersionId *string `type:"string" required:"true"`
 
-	metadataGetPolicyVersionInput `json:"-" xml:"-"`
-}
-
-type metadataGetPolicyVersionInput struct {
-	SDKShapeTraits bool `type:"structure"`
+	_ struct{} `type:"structure"`
 }
 
 // String returns the string representation
@@ -7287,11 +6807,7 @@ type GetPolicyVersionOutput struct {
 	// in the IAM User Guide.
 	PolicyVersion *PolicyVersion `type:"structure"`
 
-	metadataGetPolicyVersionOutput `json:"-" xml:"-"`
-}
-
-type metadataGetPolicyVersionOutput struct {
-	SDKShapeTraits bool `type:"structure"`
+	_ struct{} `type:"structure"`
 }
 
 // String returns the string representation
@@ -7308,11 +6824,7 @@ type GetRoleInput struct {
 	// The name of the role to get information about.
 	RoleName *string `min:"1" type:"string" required:"true"`
 
-	metadataGetRoleInput `json:"-" xml:"-"`
-}
-
-type metadataGetRoleInput struct {
-	SDKShapeTraits bool `type:"structure"`
+	_ struct{} `type:"structure"`
 }
 
 // String returns the string representation
@@ -7330,11 +6842,7 @@ type GetRoleOutput struct {
 	// Information about the role.
 	Role *Role `type:"structure" required:"true"`
 
-	metadataGetRoleOutput `json:"-" xml:"-"`
-}
-
-type metadataGetRoleOutput struct {
-	SDKShapeTraits bool `type:"structure"`
+	_ struct{} `type:"structure"`
 }
 
 // String returns the string representation
@@ -7354,11 +6862,7 @@ type GetRolePolicyInput struct {
 	// The name of the role associated with the policy.
 	RoleName *string `min:"1" type:"string" required:"true"`
 
-	metadataGetRolePolicyInput `json:"-" xml:"-"`
-}
-
-type metadataGetRolePolicyInput struct {
-	SDKShapeTraits bool `type:"structure"`
+	_ struct{} `type:"structure"`
 }
 
 // String returns the string representation
@@ -7382,11 +6886,7 @@ type GetRolePolicyOutput struct {
 	// The role the policy is associated with.
 	RoleName *string `min:"1" type:"string" required:"true"`
 
-	metadataGetRolePolicyOutput `json:"-" xml:"-"`
-}
-
-type metadataGetRolePolicyOutput struct {
-	SDKShapeTraits bool `type:"structure"`
+	_ struct{} `type:"structure"`
 }
 
 // String returns the string representation
@@ -7403,11 +6903,7 @@ type GetSAMLProviderInput struct {
 	// The Amazon Resource Name (ARN) of the SAML provider to get information about.
 	SAMLProviderArn *string `min:"20" type:"string" required:"true"`
 
-	metadataGetSAMLProviderInput `json:"-" xml:"-"`
-}
-
-type metadataGetSAMLProviderInput struct {
-	SDKShapeTraits bool `type:"structure"`
+	_ struct{} `type:"structure"`
 }
 
 // String returns the string representation
@@ -7431,11 +6927,7 @@ type GetSAMLProviderOutput struct {
 	// The expiration date and time for the SAML provider.
 	ValidUntil *time.Time `type:"timestamp" timestampFormat:"iso8601"`
 
-	metadataGetSAMLProviderOutput `json:"-" xml:"-"`
-}
-
-type metadataGetSAMLProviderOutput struct {
-	SDKShapeTraits bool `type:"structure"`
+	_ struct{} `type:"structure"`
 }
 
 // String returns the string representation
@@ -7460,11 +6952,7 @@ type GetSSHPublicKeyInput struct {
 	// The name of the IAM user associated with the SSH public key.
 	UserName *string `min:"1" type:"string" required:"true"`
 
-	metadataGetSSHPublicKeyInput `json:"-" xml:"-"`
-}
-
-type metadataGetSSHPublicKeyInput struct {
-	SDKShapeTraits bool `type:"structure"`
+	_ struct{} `type:"structure"`
 }
 
 // String returns the string representation
@@ -7482,11 +6970,7 @@ type GetSSHPublicKeyOutput struct {
 	// Information about the SSH public key.
 	SSHPublicKey *SSHPublicKey `type:"structure"`
 
-	metadataGetSSHPublicKeyOutput `json:"-" xml:"-"`
-}
-
-type metadataGetSSHPublicKeyOutput struct {
-	SDKShapeTraits bool `type:"structure"`
+	_ struct{} `type:"structure"`
 }
 
 // String returns the string representation
@@ -7503,11 +6987,7 @@ type GetServerCertificateInput struct {
 	// The name of the server certificate you want to retrieve information about.
 	ServerCertificateName *string `min:"1" type:"string" required:"true"`
 
-	metadataGetServerCertificateInput `json:"-" xml:"-"`
-}
-
-type metadataGetServerCertificateInput struct {
-	SDKShapeTraits bool `type:"structure"`
+	_ struct{} `type:"structure"`
 }
 
 // String returns the string representation
@@ -7525,11 +7005,7 @@ type GetServerCertificateOutput struct {
 	// Information about the server certificate.
 	ServerCertificate *ServerCertificate `type:"structure" required:"true"`
 
-	metadataGetServerCertificateOutput `json:"-" xml:"-"`
-}
-
-type metadataGetServerCertificateOutput struct {
-	SDKShapeTraits bool `type:"structure"`
+	_ struct{} `type:"structure"`
 }
 
 // String returns the string representation
@@ -7549,11 +7025,7 @@ type GetUserInput struct {
 	// making the request.
 	UserName *string `min:"1" type:"string"`
 
-	metadataGetUserInput `json:"-" xml:"-"`
-}
-
-type metadataGetUserInput struct {
-	SDKShapeTraits bool `type:"structure"`
+	_ struct{} `type:"structure"`
 }
 
 // String returns the string representation
@@ -7571,11 +7043,7 @@ type GetUserOutput struct {
 	// Information about the user.
 	User *User `type:"structure" required:"true"`
 
-	metadataGetUserOutput `json:"-" xml:"-"`
-}
-
-type metadataGetUserOutput struct {
-	SDKShapeTraits bool `type:"structure"`
+	_ struct{} `type:"structure"`
 }
 
 // String returns the string representation
@@ -7595,11 +7063,7 @@ type GetUserPolicyInput struct {
 	// The name of the user who the policy is associated with.
 	UserName *string `min:"1" type:"string" required:"true"`
 
-	metadataGetUserPolicyInput `json:"-" xml:"-"`
-}
-
-type metadataGetUserPolicyInput struct {
-	SDKShapeTraits bool `type:"structure"`
+	_ struct{} `type:"structure"`
 }
 
 // String returns the string representation
@@ -7623,11 +7087,7 @@ type GetUserPolicyOutput struct {
 	// The user the policy is associated with.
 	UserName *string `min:"1" type:"string" required:"true"`
 
-	metadataGetUserPolicyOutput `json:"-" xml:"-"`
-}
-
-type metadataGetUserPolicyOutput struct {
-	SDKShapeTraits bool `type:"structure"`
+	_ struct{} `type:"structure"`
 }
 
 // String returns the string representation
@@ -7668,11 +7128,7 @@ type Group struct {
 	// in the Using IAM guide.
 	Path *string `min:"1" type:"string" required:"true"`
 
-	metadataGroup `json:"-" xml:"-"`
-}
-
-type metadataGroup struct {
-	SDKShapeTraits bool `type:"structure"`
+	_ struct{} `type:"structure"`
 }
 
 // String returns the string representation
@@ -7720,11 +7176,7 @@ type GroupDetail struct {
 	// in the Using IAM guide.
 	Path *string `min:"1" type:"string"`
 
-	metadataGroupDetail `json:"-" xml:"-"`
-}
-
-type metadataGroupDetail struct {
-	SDKShapeTraits bool `type:"structure"`
+	_ struct{} `type:"structure"`
 }
 
 // String returns the string representation
@@ -7774,11 +7226,7 @@ type InstanceProfile struct {
 	// The role associated with the instance profile.
 	Roles []*Role `type:"list" required:"true"`
 
-	metadataInstanceProfile `json:"-" xml:"-"`
-}
-
-type metadataInstanceProfile struct {
-	SDKShapeTraits bool `type:"structure"`
+	_ struct{} `type:"structure"`
 }
 
 // String returns the string representation
@@ -7812,11 +7260,7 @@ type ListAccessKeysInput struct {
 	// The name of the user.
 	UserName *string `min:"1" type:"string"`
 
-	metadataListAccessKeysInput `json:"-" xml:"-"`
-}
-
-type metadataListAccessKeysInput struct {
-	SDKShapeTraits bool `type:"structure"`
+	_ struct{} `type:"structure"`
 }
 
 // String returns the string representation
@@ -7846,11 +7290,7 @@ type ListAccessKeysOutput struct {
 	// to use for the Marker parameter in a subsequent pagination request.
 	Marker *string `min:"1" type:"string"`
 
-	metadataListAccessKeysOutput `json:"-" xml:"-"`
-}
-
-type metadataListAccessKeysOutput struct {
-	SDKShapeTraits bool `type:"structure"`
+	_ struct{} `type:"structure"`
 }
 
 // String returns the string representation
@@ -7881,11 +7321,7 @@ type ListAccountAliasesInput struct {
 	// service where to continue from.
 	MaxItems *int64 `min:"1" type:"integer"`
 
-	metadataListAccountAliasesInput `json:"-" xml:"-"`
-}
-
-type metadataListAccountAliasesInput struct {
-	SDKShapeTraits bool `type:"structure"`
+	_ struct{} `type:"structure"`
 }
 
 // String returns the string representation
@@ -7916,11 +7352,7 @@ type ListAccountAliasesOutput struct {
 	// to use for the Marker parameter in a subsequent pagination request.
 	Marker *string `min:"1" type:"string"`
 
-	metadataListAccountAliasesOutput `json:"-" xml:"-"`
-}
-
-type metadataListAccountAliasesOutput struct {
-	SDKShapeTraits bool `type:"structure"`
+	_ struct{} `type:"structure"`
 }
 
 // String returns the string representation
@@ -7959,11 +7391,7 @@ type ListAttachedGroupPoliciesInput struct {
 	// it is not included, it defaults to a slash (/), listing all policies.
 	PathPrefix *string `type:"string"`
 
-	metadataListAttachedGroupPoliciesInput `json:"-" xml:"-"`
-}
-
-type metadataListAttachedGroupPoliciesInput struct {
-	SDKShapeTraits bool `type:"structure"`
+	_ struct{} `type:"structure"`
 }
 
 // String returns the string representation
@@ -7993,11 +7421,7 @@ type ListAttachedGroupPoliciesOutput struct {
 	// to use for the Marker parameter in a subsequent pagination request.
 	Marker *string `min:"1" type:"string"`
 
-	metadataListAttachedGroupPoliciesOutput `json:"-" xml:"-"`
-}
-
-type metadataListAttachedGroupPoliciesOutput struct {
-	SDKShapeTraits bool `type:"structure"`
+	_ struct{} `type:"structure"`
 }
 
 // String returns the string representation
@@ -8035,11 +7459,7 @@ type ListAttachedRolePoliciesInput struct {
 	// The name (friendly name, not ARN) of the role to list attached policies for.
 	RoleName *string `min:"1" type:"string" required:"true"`
 
-	metadataListAttachedRolePoliciesInput `json:"-" xml:"-"`
-}
-
-type metadataListAttachedRolePoliciesInput struct {
-	SDKShapeTraits bool `type:"structure"`
+	_ struct{} `type:"structure"`
 }
 
 // String returns the string representation
@@ -8069,11 +7489,7 @@ type ListAttachedRolePoliciesOutput struct {
 	// to use for the Marker parameter in a subsequent pagination request.
 	Marker *string `min:"1" type:"string"`
 
-	metadataListAttachedRolePoliciesOutput `json:"-" xml:"-"`
-}
-
-type metadataListAttachedRolePoliciesOutput struct {
-	SDKShapeTraits bool `type:"structure"`
+	_ struct{} `type:"structure"`
 }
 
 // String returns the string representation
@@ -8111,11 +7527,7 @@ type ListAttachedUserPoliciesInput struct {
 	// The name (friendly name, not ARN) of the user to list attached policies for.
 	UserName *string `min:"1" type:"string" required:"true"`
 
-	metadataListAttachedUserPoliciesInput `json:"-" xml:"-"`
-}
-
-type metadataListAttachedUserPoliciesInput struct {
-	SDKShapeTraits bool `type:"structure"`
+	_ struct{} `type:"structure"`
 }
 
 // String returns the string representation
@@ -8145,11 +7557,7 @@ type ListAttachedUserPoliciesOutput struct {
 	// to use for the Marker parameter in a subsequent pagination request.
 	Marker *string `min:"1" type:"string"`
 
-	metadataListAttachedUserPoliciesOutput `json:"-" xml:"-"`
-}
-
-type metadataListAttachedUserPoliciesOutput struct {
-	SDKShapeTraits bool `type:"structure"`
+	_ struct{} `type:"structure"`
 }
 
 // String returns the string representation
@@ -8198,11 +7606,7 @@ type ListEntitiesForPolicyInput struct {
 	// in the AWS General Reference.
 	PolicyArn *string `min:"20" type:"string" required:"true"`
 
-	metadataListEntitiesForPolicyInput `json:"-" xml:"-"`
-}
-
-type metadataListEntitiesForPolicyInput struct {
-	SDKShapeTraits bool `type:"structure"`
+	_ struct{} `type:"structure"`
 }
 
 // String returns the string representation
@@ -8238,11 +7642,7 @@ type ListEntitiesForPolicyOutput struct {
 	// A list of users that the policy is attached to.
 	PolicyUsers []*PolicyUser `type:"list"`
 
-	metadataListEntitiesForPolicyOutput `json:"-" xml:"-"`
-}
-
-type metadataListEntitiesForPolicyOutput struct {
-	SDKShapeTraits bool `type:"structure"`
+	_ struct{} `type:"structure"`
 }
 
 // String returns the string representation
@@ -8276,11 +7676,7 @@ type ListGroupPoliciesInput struct {
 	// service where to continue from.
 	MaxItems *int64 `min:"1" type:"integer"`
 
-	metadataListGroupPoliciesInput `json:"-" xml:"-"`
-}
-
-type metadataListGroupPoliciesInput struct {
-	SDKShapeTraits bool `type:"structure"`
+	_ struct{} `type:"structure"`
 }
 
 // String returns the string representation
@@ -8310,11 +7706,7 @@ type ListGroupPoliciesOutput struct {
 	// A list of policy names.
 	PolicyNames []*string `type:"list" required:"true"`
 
-	metadataListGroupPoliciesOutput `json:"-" xml:"-"`
-}
-
-type metadataListGroupPoliciesOutput struct {
-	SDKShapeTraits bool `type:"structure"`
+	_ struct{} `type:"structure"`
 }
 
 // String returns the string representation
@@ -8348,11 +7740,7 @@ type ListGroupsForUserInput struct {
 	// The name of the user to list groups for.
 	UserName *string `min:"1" type:"string" required:"true"`
 
-	metadataListGroupsForUserInput `json:"-" xml:"-"`
-}
-
-type metadataListGroupsForUserInput struct {
-	SDKShapeTraits bool `type:"structure"`
+	_ struct{} `type:"structure"`
 }
 
 // String returns the string representation
@@ -8382,11 +7770,7 @@ type ListGroupsForUserOutput struct {
 	// to use for the Marker parameter in a subsequent pagination request.
 	Marker *string `min:"1" type:"string"`
 
-	metadataListGroupsForUserOutput `json:"-" xml:"-"`
-}
-
-type metadataListGroupsForUserOutput struct {
-	SDKShapeTraits bool `type:"structure"`
+	_ struct{} `type:"structure"`
 }
 
 // String returns the string representation
@@ -8424,11 +7808,7 @@ type ListGroupsInput struct {
 	// (/), listing all groups.
 	PathPrefix *string `min:"1" type:"string"`
 
-	metadataListGroupsInput `json:"-" xml:"-"`
-}
-
-type metadataListGroupsInput struct {
-	SDKShapeTraits bool `type:"structure"`
+	_ struct{} `type:"structure"`
 }
 
 // String returns the string representation
@@ -8458,11 +7838,7 @@ type ListGroupsOutput struct {
 	// to use for the Marker parameter in a subsequent pagination request.
 	Marker *string `min:"1" type:"string"`
 
-	metadataListGroupsOutput `json:"-" xml:"-"`
-}
-
-type metadataListGroupsOutput struct {
-	SDKShapeTraits bool `type:"structure"`
+	_ struct{} `type:"structure"`
 }
 
 // String returns the string representation
@@ -8496,11 +7872,7 @@ type ListInstanceProfilesForRoleInput struct {
 	// The name of the role to list instance profiles for.
 	RoleName *string `min:"1" type:"string" required:"true"`
 
-	metadataListInstanceProfilesForRoleInput `json:"-" xml:"-"`
-}
-
-type metadataListInstanceProfilesForRoleInput struct {
-	SDKShapeTraits bool `type:"structure"`
+	_ struct{} `type:"structure"`
 }
 
 // String returns the string representation
@@ -8530,11 +7902,7 @@ type ListInstanceProfilesForRoleOutput struct {
 	// to use for the Marker parameter in a subsequent pagination request.
 	Marker *string `min:"1" type:"string"`
 
-	metadataListInstanceProfilesForRoleOutput `json:"-" xml:"-"`
-}
-
-type metadataListInstanceProfilesForRoleOutput struct {
-	SDKShapeTraits bool `type:"structure"`
+	_ struct{} `type:"structure"`
 }
 
 // String returns the string representation
@@ -8572,11 +7940,7 @@ type ListInstanceProfilesInput struct {
 	// (/), listing all instance profiles.
 	PathPrefix *string `min:"1" type:"string"`
 
-	metadataListInstanceProfilesInput `json:"-" xml:"-"`
-}
-
-type metadataListInstanceProfilesInput struct {
-	SDKShapeTraits bool `type:"structure"`
+	_ struct{} `type:"structure"`
 }
 
 // String returns the string representation
@@ -8606,11 +7970,7 @@ type ListInstanceProfilesOutput struct {
 	// to use for the Marker parameter in a subsequent pagination request.
 	Marker *string `min:"1" type:"string"`
 
-	metadataListInstanceProfilesOutput `json:"-" xml:"-"`
-}
-
-type metadataListInstanceProfilesOutput struct {
-	SDKShapeTraits bool `type:"structure"`
+	_ struct{} `type:"structure"`
 }
 
 // String returns the string representation
@@ -8644,11 +8004,7 @@ type ListMFADevicesInput struct {
 	// The name of the user whose MFA devices you want to list.
 	UserName *string `min:"1" type:"string"`
 
-	metadataListMFADevicesInput `json:"-" xml:"-"`
-}
-
-type metadataListMFADevicesInput struct {
-	SDKShapeTraits bool `type:"structure"`
+	_ struct{} `type:"structure"`
 }
 
 // String returns the string representation
@@ -8678,11 +8034,7 @@ type ListMFADevicesOutput struct {
 	// to use for the Marker parameter in a subsequent pagination request.
 	Marker *string `min:"1" type:"string"`
 
-	metadataListMFADevicesOutput `json:"-" xml:"-"`
-}
-
-type metadataListMFADevicesOutput struct {
-	SDKShapeTraits bool `type:"structure"`
+	_ struct{} `type:"structure"`
 }
 
 // String returns the string representation
@@ -8696,11 +8048,7 @@ func (s ListMFADevicesOutput) GoString() string {
 }
 
 type ListOpenIDConnectProvidersInput struct {
-	metadataListOpenIDConnectProvidersInput `json:"-" xml:"-"`
-}
-
-type metadataListOpenIDConnectProvidersInput struct {
-	SDKShapeTraits bool `type:"structure"`
+	_ struct{} `type:"structure"`
 }
 
 // String returns the string representation
@@ -8718,11 +8066,7 @@ type ListOpenIDConnectProvidersOutput struct {
 	// The list of IAM OpenID Connect providers in the AWS account.
 	OpenIDConnectProviderList []*OpenIDConnectProviderListEntry `type:"list"`
 
-	metadataListOpenIDConnectProvidersOutput `json:"-" xml:"-"`
-}
-
-type metadataListOpenIDConnectProvidersOutput struct {
-	SDKShapeTraits bool `type:"structure"`
+	_ struct{} `type:"structure"`
 }
 
 // String returns the string representation
@@ -8773,11 +8117,7 @@ type ListPoliciesInput struct {
 	// all policies are returned.
 	Scope *string `type:"string" enum:"policyScopeType"`
 
-	metadataListPoliciesInput `json:"-" xml:"-"`
-}
-
-type metadataListPoliciesInput struct {
-	SDKShapeTraits bool `type:"structure"`
+	_ struct{} `type:"structure"`
 }
 
 // String returns the string representation
@@ -8807,11 +8147,7 @@ type ListPoliciesOutput struct {
 	// A list of policies.
 	Policies []*Policy `type:"list"`
 
-	metadataListPoliciesOutput `json:"-" xml:"-"`
-}
-
-type metadataListPoliciesOutput struct {
-	SDKShapeTraits bool `type:"structure"`
+	_ struct{} `type:"structure"`
 }
 
 // String returns the string representation
@@ -8849,11 +8185,7 @@ type ListPolicyVersionsInput struct {
 	// in the AWS General Reference.
 	PolicyArn *string `min:"20" type:"string" required:"true"`
 
-	metadataListPolicyVersionsInput `json:"-" xml:"-"`
-}
-
-type metadataListPolicyVersionsInput struct {
-	SDKShapeTraits bool `type:"structure"`
+	_ struct{} `type:"structure"`
 }
 
 // String returns the string representation
@@ -8887,11 +8219,7 @@ type ListPolicyVersionsOutput struct {
 	// in the IAM User Guide.
 	Versions []*PolicyVersion `type:"list"`
 
-	metadataListPolicyVersionsOutput `json:"-" xml:"-"`
-}
-
-type metadataListPolicyVersionsOutput struct {
-	SDKShapeTraits bool `type:"structure"`
+	_ struct{} `type:"structure"`
 }
 
 // String returns the string representation
@@ -8925,11 +8253,7 @@ type ListRolePoliciesInput struct {
 	// The name of the role to list policies for.
 	RoleName *string `min:"1" type:"string" required:"true"`
 
-	metadataListRolePoliciesInput `json:"-" xml:"-"`
-}
-
-type metadataListRolePoliciesInput struct {
-	SDKShapeTraits bool `type:"structure"`
+	_ struct{} `type:"structure"`
 }
 
 // String returns the string representation
@@ -8959,11 +8283,7 @@ type ListRolePoliciesOutput struct {
 	// A list of policy names.
 	PolicyNames []*string `type:"list" required:"true"`
 
-	metadataListRolePoliciesOutput `json:"-" xml:"-"`
-}
-
-type metadataListRolePoliciesOutput struct {
-	SDKShapeTraits bool `type:"structure"`
+	_ struct{} `type:"structure"`
 }
 
 // String returns the string representation
@@ -9001,11 +8321,7 @@ type ListRolesInput struct {
 	// (/), listing all roles.
 	PathPrefix *string `min:"1" type:"string"`
 
-	metadataListRolesInput `json:"-" xml:"-"`
-}
-
-type metadataListRolesInput struct {
-	SDKShapeTraits bool `type:"structure"`
+	_ struct{} `type:"structure"`
 }
 
 // String returns the string representation
@@ -9035,11 +8351,7 @@ type ListRolesOutput struct {
 	// A list of roles.
 	Roles []*Role `type:"list" required:"true"`
 
-	metadataListRolesOutput `json:"-" xml:"-"`
-}
-
-type metadataListRolesOutput struct {
-	SDKShapeTraits bool `type:"structure"`
+	_ struct{} `type:"structure"`
 }
 
 // String returns the string representation
@@ -9053,11 +8365,7 @@ func (s ListRolesOutput) GoString() string {
 }
 
 type ListSAMLProvidersInput struct {
-	metadataListSAMLProvidersInput `json:"-" xml:"-"`
-}
-
-type metadataListSAMLProvidersInput struct {
-	SDKShapeTraits bool `type:"structure"`
+	_ struct{} `type:"structure"`
 }
 
 // String returns the string representation
@@ -9075,11 +8383,7 @@ type ListSAMLProvidersOutput struct {
 	// The list of SAML providers for this account.
 	SAMLProviderList []*SAMLProviderListEntry `type:"list"`
 
-	metadataListSAMLProvidersOutput `json:"-" xml:"-"`
-}
-
-type metadataListSAMLProvidersOutput struct {
-	SDKShapeTraits bool `type:"structure"`
+	_ struct{} `type:"structure"`
 }
 
 // String returns the string representation
@@ -9115,11 +8419,7 @@ type ListSSHPublicKeysInput struct {
 	// to sign the request.
 	UserName *string `min:"1" type:"string"`
 
-	metadataListSSHPublicKeysInput `json:"-" xml:"-"`
-}
-
-type metadataListSSHPublicKeysInput struct {
-	SDKShapeTraits bool `type:"structure"`
+	_ struct{} `type:"structure"`
 }
 
 // String returns the string representation
@@ -9149,11 +8449,7 @@ type ListSSHPublicKeysOutput struct {
 	// A list of SSH public keys.
 	SSHPublicKeys []*SSHPublicKeyMetadata `type:"list"`
 
-	metadataListSSHPublicKeysOutput `json:"-" xml:"-"`
-}
-
-type metadataListSSHPublicKeysOutput struct {
-	SDKShapeTraits bool `type:"structure"`
+	_ struct{} `type:"structure"`
 }
 
 // String returns the string representation
@@ -9191,11 +8487,7 @@ type ListServerCertificatesInput struct {
 	// (/), listing all server certificates.
 	PathPrefix *string `min:"1" type:"string"`
 
-	metadataListServerCertificatesInput `json:"-" xml:"-"`
-}
-
-type metadataListServerCertificatesInput struct {
-	SDKShapeTraits bool `type:"structure"`
+	_ struct{} `type:"structure"`
 }
 
 // String returns the string representation
@@ -9225,11 +8517,7 @@ type ListServerCertificatesOutput struct {
 	// A list of server certificates.
 	ServerCertificateMetadataList []*ServerCertificateMetadata `type:"list" required:"true"`
 
-	metadataListServerCertificatesOutput `json:"-" xml:"-"`
-}
-
-type metadataListServerCertificatesOutput struct {
-	SDKShapeTraits bool `type:"structure"`
+	_ struct{} `type:"structure"`
 }
 
 // String returns the string representation
@@ -9263,11 +8551,7 @@ type ListSigningCertificatesInput struct {
 	// The name of the user.
 	UserName *string `min:"1" type:"string"`
 
-	metadataListSigningCertificatesInput `json:"-" xml:"-"`
-}
-
-type metadataListSigningCertificatesInput struct {
-	SDKShapeTraits bool `type:"structure"`
+	_ struct{} `type:"structure"`
 }
 
 // String returns the string representation
@@ -9297,11 +8581,7 @@ type ListSigningCertificatesOutput struct {
 	// to use for the Marker parameter in a subsequent pagination request.
 	Marker *string `min:"1" type:"string"`
 
-	metadataListSigningCertificatesOutput `json:"-" xml:"-"`
-}
-
-type metadataListSigningCertificatesOutput struct {
-	SDKShapeTraits bool `type:"structure"`
+	_ struct{} `type:"structure"`
 }
 
 // String returns the string representation
@@ -9335,11 +8615,7 @@ type ListUserPoliciesInput struct {
 	// The name of the user to list policies for.
 	UserName *string `min:"1" type:"string" required:"true"`
 
-	metadataListUserPoliciesInput `json:"-" xml:"-"`
-}
-
-type metadataListUserPoliciesInput struct {
-	SDKShapeTraits bool `type:"structure"`
+	_ struct{} `type:"structure"`
 }
 
 // String returns the string representation
@@ -9369,11 +8645,7 @@ type ListUserPoliciesOutput struct {
 	// A list of policy names.
 	PolicyNames []*string `type:"list" required:"true"`
 
-	metadataListUserPoliciesOutput `json:"-" xml:"-"`
-}
-
-type metadataListUserPoliciesOutput struct {
-	SDKShapeTraits bool `type:"structure"`
+	_ struct{} `type:"structure"`
 }
 
 // String returns the string representation
@@ -9411,11 +8683,7 @@ type ListUsersInput struct {
 	// (/), listing all user names.
 	PathPrefix *string `min:"1" type:"string"`
 
-	metadataListUsersInput `json:"-" xml:"-"`
-}
-
-type metadataListUsersInput struct {
-	SDKShapeTraits bool `type:"structure"`
+	_ struct{} `type:"structure"`
 }
 
 // String returns the string representation
@@ -9445,11 +8713,7 @@ type ListUsersOutput struct {
 	// A list of users.
 	Users []*User `type:"list" required:"true"`
 
-	metadataListUsersOutput `json:"-" xml:"-"`
-}
-
-type metadataListUsersOutput struct {
-	SDKShapeTraits bool `type:"structure"`
+	_ struct{} `type:"structure"`
 }
 
 // String returns the string representation
@@ -9485,11 +8749,7 @@ type ListVirtualMFADevicesInput struct {
 	// service where to continue from.
 	MaxItems *int64 `min:"1" type:"integer"`
 
-	metadataListVirtualMFADevicesInput `json:"-" xml:"-"`
-}
-
-type metadataListVirtualMFADevicesInput struct {
-	SDKShapeTraits bool `type:"structure"`
+	_ struct{} `type:"structure"`
 }
 
 // String returns the string representation
@@ -9520,11 +8780,7 @@ type ListVirtualMFADevicesOutput struct {
 	// value that was passed in the request.
 	VirtualMFADevices []*VirtualMFADevice `type:"list" required:"true"`
 
-	metadataListVirtualMFADevicesOutput `json:"-" xml:"-"`
-}
-
-type metadataListVirtualMFADevicesOutput struct {
-	SDKShapeTraits bool `type:"structure"`
+	_ struct{} `type:"structure"`
 }
 
 // String returns the string representation
@@ -9552,11 +8808,7 @@ type LoginProfile struct {
 	// Console.
 	UserName *string `min:"1" type:"string" required:"true"`
 
-	metadataLoginProfile `json:"-" xml:"-"`
-}
-
-type metadataLoginProfile struct {
-	SDKShapeTraits bool `type:"structure"`
+	_ struct{} `type:"structure"`
 }
 
 // String returns the string representation
@@ -9583,11 +8835,7 @@ type MFADevice struct {
 	// The user with whom the MFA device is associated.
 	UserName *string `min:"1" type:"string" required:"true"`
 
-	metadataMFADevice `json:"-" xml:"-"`
-}
-
-type metadataMFADevice struct {
-	SDKShapeTraits bool `type:"structure"`
+	_ struct{} `type:"structure"`
 }
 
 // String returns the string representation
@@ -9667,11 +8915,7 @@ type ManagedPolicyDetail struct {
 	// created.
 	UpdateDate *time.Time `type:"timestamp" timestampFormat:"iso8601"`
 
-	metadataManagedPolicyDetail `json:"-" xml:"-"`
-}
-
-type metadataManagedPolicyDetail struct {
-	SDKShapeTraits bool `type:"structure"`
+	_ struct{} `type:"structure"`
 }
 
 // String returns the string representation
@@ -9693,11 +8937,7 @@ type OpenIDConnectProviderListEntry struct {
 	// in the AWS General Reference.
 	Arn *string `min:"20" type:"string"`
 
-	metadataOpenIDConnectProviderListEntry `json:"-" xml:"-"`
-}
-
-type metadataOpenIDConnectProviderListEntry struct {
-	SDKShapeTraits bool `type:"structure"`
+	_ struct{} `type:"structure"`
 }
 
 // String returns the string representation
@@ -9749,11 +8989,7 @@ type PasswordPolicy struct {
 	// Specifies whether to require uppercase characters for IAM user passwords.
 	RequireUppercaseCharacters *bool `type:"boolean"`
 
-	metadataPasswordPolicy `json:"-" xml:"-"`
-}
-
-type metadataPasswordPolicy struct {
-	SDKShapeTraits bool `type:"structure"`
+	_ struct{} `type:"structure"`
 }
 
 // String returns the string representation
@@ -9826,11 +9062,7 @@ type Policy struct {
 	// created.
 	UpdateDate *time.Time `type:"timestamp" timestampFormat:"iso8601"`
 
-	metadataPolicy `json:"-" xml:"-"`
-}
-
-type metadataPolicy struct {
-	SDKShapeTraits bool `type:"structure"`
+	_ struct{} `type:"structure"`
 }
 
 // String returns the string representation
@@ -9854,11 +9086,7 @@ type PolicyDetail struct {
 	// The name of the policy.
 	PolicyName *string `min:"1" type:"string"`
 
-	metadataPolicyDetail `json:"-" xml:"-"`
-}
-
-type metadataPolicyDetail struct {
-	SDKShapeTraits bool `type:"structure"`
+	_ struct{} `type:"structure"`
 }
 
 // String returns the string representation
@@ -9883,11 +9111,7 @@ type PolicyGroup struct {
 	// The name (friendly name, not ARN) identifying the group.
 	GroupName *string `min:"1" type:"string"`
 
-	metadataPolicyGroup `json:"-" xml:"-"`
-}
-
-type metadataPolicyGroup struct {
-	SDKShapeTraits bool `type:"structure"`
+	_ struct{} `type:"structure"`
 }
 
 // String returns the string representation
@@ -9912,11 +9136,7 @@ type PolicyRole struct {
 	// The name (friendly name, not ARN) identifying the role.
 	RoleName *string `min:"1" type:"string"`
 
-	metadataPolicyRole `json:"-" xml:"-"`
-}
-
-type metadataPolicyRole struct {
-	SDKShapeTraits bool `type:"structure"`
+	_ struct{} `type:"structure"`
 }
 
 // String returns the string representation
@@ -9941,11 +9161,7 @@ type PolicyUser struct {
 	// The name (friendly name, not ARN) identifying the user.
 	UserName *string `min:"1" type:"string"`
 
-	metadataPolicyUser `json:"-" xml:"-"`
-}
-
-type metadataPolicyUser struct {
-	SDKShapeTraits bool `type:"structure"`
+	_ struct{} `type:"structure"`
 }
 
 // String returns the string representation
@@ -9988,11 +9204,7 @@ type PolicyVersion struct {
 	// a policy is created, the first policy version is v1.
 	VersionId *string `type:"string"`
 
-	metadataPolicyVersion `json:"-" xml:"-"`
-}
-
-type metadataPolicyVersion struct {
-	SDKShapeTraits bool `type:"structure"`
+	_ struct{} `type:"structure"`
 }
 
 // String returns the string representation
@@ -10016,11 +9228,7 @@ type Position struct {
 	// The line containing the specified position in the document.
 	Line *int64 `type:"integer"`
 
-	metadataPosition `json:"-" xml:"-"`
-}
-
-type metadataPosition struct {
-	SDKShapeTraits bool `type:"structure"`
+	_ struct{} `type:"structure"`
 }
 
 // String returns the string representation
@@ -10043,11 +9251,7 @@ type PutGroupPolicyInput struct {
 	// The name of the policy document.
 	PolicyName *string `min:"1" type:"string" required:"true"`
 
-	metadataPutGroupPolicyInput `json:"-" xml:"-"`
-}
-
-type metadataPutGroupPolicyInput struct {
-	SDKShapeTraits bool `type:"structure"`
+	_ struct{} `type:"structure"`
 }
 
 // String returns the string representation
@@ -10061,11 +9265,7 @@ func (s PutGroupPolicyInput) GoString() string {
 }
 
 type PutGroupPolicyOutput struct {
-	metadataPutGroupPolicyOutput `json:"-" xml:"-"`
-}
-
-type metadataPutGroupPolicyOutput struct {
-	SDKShapeTraits bool `type:"structure"`
+	_ struct{} `type:"structure"`
 }
 
 // String returns the string representation
@@ -10088,11 +9288,7 @@ type PutRolePolicyInput struct {
 	// The name of the role to associate the policy with.
 	RoleName *string `min:"1" type:"string" required:"true"`
 
-	metadataPutRolePolicyInput `json:"-" xml:"-"`
-}
-
-type metadataPutRolePolicyInput struct {
-	SDKShapeTraits bool `type:"structure"`
+	_ struct{} `type:"structure"`
 }
 
 // String returns the string representation
@@ -10106,11 +9302,7 @@ func (s PutRolePolicyInput) GoString() string {
 }
 
 type PutRolePolicyOutput struct {
-	metadataPutRolePolicyOutput `json:"-" xml:"-"`
-}
-
-type metadataPutRolePolicyOutput struct {
-	SDKShapeTraits bool `type:"structure"`
+	_ struct{} `type:"structure"`
 }
 
 // String returns the string representation
@@ -10133,11 +9325,7 @@ type PutUserPolicyInput struct {
 	// The name of the user to associate the policy with.
 	UserName *string `min:"1" type:"string" required:"true"`
 
-	metadataPutUserPolicyInput `json:"-" xml:"-"`
-}
-
-type metadataPutUserPolicyInput struct {
-	SDKShapeTraits bool `type:"structure"`
+	_ struct{} `type:"structure"`
 }
 
 // String returns the string representation
@@ -10151,11 +9339,7 @@ func (s PutUserPolicyInput) GoString() string {
 }
 
 type PutUserPolicyOutput struct {
-	metadataPutUserPolicyOutput `json:"-" xml:"-"`
-}
-
-type metadataPutUserPolicyOutput struct {
-	SDKShapeTraits bool `type:"structure"`
+	_ struct{} `type:"structure"`
 }
 
 // String returns the string representation
@@ -10178,11 +9362,7 @@ type RemoveClientIDFromOpenIDConnectProviderInput struct {
 	// using the ListOpenIDConnectProviders action.
 	OpenIDConnectProviderArn *string `min:"20" type:"string" required:"true"`
 
-	metadataRemoveClientIDFromOpenIDConnectProviderInput `json:"-" xml:"-"`
-}
-
-type metadataRemoveClientIDFromOpenIDConnectProviderInput struct {
-	SDKShapeTraits bool `type:"structure"`
+	_ struct{} `type:"structure"`
 }
 
 // String returns the string representation
@@ -10196,11 +9376,7 @@ func (s RemoveClientIDFromOpenIDConnectProviderInput) GoString() string {
 }
 
 type RemoveClientIDFromOpenIDConnectProviderOutput struct {
-	metadataRemoveClientIDFromOpenIDConnectProviderOutput `json:"-" xml:"-"`
-}
-
-type metadataRemoveClientIDFromOpenIDConnectProviderOutput struct {
-	SDKShapeTraits bool `type:"structure"`
+	_ struct{} `type:"structure"`
 }
 
 // String returns the string representation
@@ -10220,11 +9396,7 @@ type RemoveRoleFromInstanceProfileInput struct {
 	// The name of the role to remove.
 	RoleName *string `min:"1" type:"string" required:"true"`
 
-	metadataRemoveRoleFromInstanceProfileInput `json:"-" xml:"-"`
-}
-
-type metadataRemoveRoleFromInstanceProfileInput struct {
-	SDKShapeTraits bool `type:"structure"`
+	_ struct{} `type:"structure"`
 }
 
 // String returns the string representation
@@ -10238,11 +9410,7 @@ func (s RemoveRoleFromInstanceProfileInput) GoString() string {
 }
 
 type RemoveRoleFromInstanceProfileOutput struct {
-	metadataRemoveRoleFromInstanceProfileOutput `json:"-" xml:"-"`
-}
-
-type metadataRemoveRoleFromInstanceProfileOutput struct {
-	SDKShapeTraits bool `type:"structure"`
+	_ struct{} `type:"structure"`
 }
 
 // String returns the string representation
@@ -10262,11 +9430,7 @@ type RemoveUserFromGroupInput struct {
 	// The name of the user to remove.
 	UserName *string `min:"1" type:"string" required:"true"`
 
-	metadataRemoveUserFromGroupInput `json:"-" xml:"-"`
-}
-
-type metadataRemoveUserFromGroupInput struct {
-	SDKShapeTraits bool `type:"structure"`
+	_ struct{} `type:"structure"`
 }
 
 // String returns the string representation
@@ -10280,11 +9444,7 @@ func (s RemoveUserFromGroupInput) GoString() string {
 }
 
 type RemoveUserFromGroupOutput struct {
-	metadataRemoveUserFromGroupOutput `json:"-" xml:"-"`
-}
-
-type metadataRemoveUserFromGroupOutput struct {
-	SDKShapeTraits bool `type:"structure"`
+	_ struct{} `type:"structure"`
 }
 
 // String returns the string representation
@@ -10329,11 +9489,7 @@ type ResourceSpecificResult struct {
 	// or GetContextKeysForPrincipalPolicy.
 	MissingContextValues []*string `type:"list"`
 
-	metadataResourceSpecificResult `json:"-" xml:"-"`
-}
-
-type metadataResourceSpecificResult struct {
-	SDKShapeTraits bool `type:"structure"`
+	_ struct{} `type:"structure"`
 }
 
 // String returns the string representation
@@ -10359,11 +9515,7 @@ type ResyncMFADeviceInput struct {
 	// The name of the user whose MFA device you want to resynchronize.
 	UserName *string `min:"1" type:"string" required:"true"`
 
-	metadataResyncMFADeviceInput `json:"-" xml:"-"`
-}
-
-type metadataResyncMFADeviceInput struct {
-	SDKShapeTraits bool `type:"structure"`
+	_ struct{} `type:"structure"`
 }
 
 // String returns the string representation
@@ -10377,11 +9529,7 @@ func (s ResyncMFADeviceInput) GoString() string {
 }
 
 type ResyncMFADeviceOutput struct {
-	metadataResyncMFADeviceOutput `json:"-" xml:"-"`
-}
-
-type metadataResyncMFADeviceOutput struct {
-	SDKShapeTraits bool `type:"structure"`
+	_ struct{} `type:"structure"`
 }
 
 // String returns the string representation
@@ -10429,11 +9577,7 @@ type Role struct {
 	// The friendly name that identifies the role.
 	RoleName *string `min:"1" type:"string" required:"true"`
 
-	metadataRole `json:"-" xml:"-"`
-}
-
-type metadataRole struct {
-	SDKShapeTraits bool `type:"structure"`
+	_ struct{} `type:"structure"`
 }
 
 // String returns the string representation
@@ -10489,11 +9633,7 @@ type RoleDetail struct {
 	// access (permissions) policies.
 	RolePolicyList []*PolicyDetail `type:"list"`
 
-	metadataRoleDetail `json:"-" xml:"-"`
-}
-
-type metadataRoleDetail struct {
-	SDKShapeTraits bool `type:"structure"`
+	_ struct{} `type:"structure"`
 }
 
 // String returns the string representation
@@ -10517,11 +9657,7 @@ type SAMLProviderListEntry struct {
 	// The expiration date and time for the SAML provider.
 	ValidUntil *time.Time `type:"timestamp" timestampFormat:"iso8601"`
 
-	metadataSAMLProviderListEntry `json:"-" xml:"-"`
-}
-
-type metadataSAMLProviderListEntry struct {
-	SDKShapeTraits bool `type:"structure"`
+	_ struct{} `type:"structure"`
 }
 
 // String returns the string representation
@@ -10559,11 +9695,7 @@ type SSHPublicKey struct {
 	// The name of the IAM user associated with the SSH public key.
 	UserName *string `min:"1" type:"string" required:"true"`
 
-	metadataSSHPublicKey `json:"-" xml:"-"`
-}
-
-type metadataSSHPublicKey struct {
-	SDKShapeTraits bool `type:"structure"`
+	_ struct{} `type:"structure"`
 }
 
 // String returns the string representation
@@ -10594,11 +9726,7 @@ type SSHPublicKeyMetadata struct {
 	// The name of the IAM user associated with the SSH public key.
 	UserName *string `min:"1" type:"string" required:"true"`
 
-	metadataSSHPublicKeyMetadata `json:"-" xml:"-"`
-}
-
-type metadataSSHPublicKeyMetadata struct {
-	SDKShapeTraits bool `type:"structure"`
+	_ struct{} `type:"structure"`
 }
 
 // String returns the string representation
@@ -10626,11 +9754,7 @@ type ServerCertificate struct {
 	// and ARN.
 	ServerCertificateMetadata *ServerCertificateMetadata `type:"structure" required:"true"`
 
-	metadataServerCertificate `json:"-" xml:"-"`
-}
-
-type metadataServerCertificate struct {
-	SDKShapeTraits bool `type:"structure"`
+	_ struct{} `type:"structure"`
 }
 
 // String returns the string representation
@@ -10674,11 +9798,7 @@ type ServerCertificateMetadata struct {
 	// The date when the server certificate was uploaded.
 	UploadDate *time.Time `type:"timestamp" timestampFormat:"iso8601"`
 
-	metadataServerCertificateMetadata `json:"-" xml:"-"`
-}
-
-type metadataServerCertificateMetadata struct {
-	SDKShapeTraits bool `type:"structure"`
+	_ struct{} `type:"structure"`
 }
 
 // String returns the string representation
@@ -10706,11 +9826,7 @@ type SetDefaultPolicyVersionInput struct {
 	// in the IAM User Guide.
 	VersionId *string `type:"string" required:"true"`
 
-	metadataSetDefaultPolicyVersionInput `json:"-" xml:"-"`
-}
-
-type metadataSetDefaultPolicyVersionInput struct {
-	SDKShapeTraits bool `type:"structure"`
+	_ struct{} `type:"structure"`
 }
 
 // String returns the string representation
@@ -10724,11 +9840,7 @@ func (s SetDefaultPolicyVersionInput) GoString() string {
 }
 
 type SetDefaultPolicyVersionOutput struct {
-	metadataSetDefaultPolicyVersionOutput `json:"-" xml:"-"`
-}
-
-type metadataSetDefaultPolicyVersionOutput struct {
-	SDKShapeTraits bool `type:"structure"`
+	_ struct{} `type:"structure"`
 }
 
 // String returns the string representation
@@ -10762,11 +9874,7 @@ type SigningCertificate struct {
 	// The name of the user the signing certificate is associated with.
 	UserName *string `min:"1" type:"string" required:"true"`
 
-	metadataSigningCertificate `json:"-" xml:"-"`
-}
-
-type metadataSigningCertificate struct {
-	SDKShapeTraits bool `type:"structure"`
+	_ struct{} `type:"structure"`
 }
 
 // String returns the string representation
@@ -10896,11 +10004,7 @@ type SimulateCustomPolicyInput struct {
 	// You can include only one resource-based policy in a simulation.
 	ResourcePolicy *string `min:"1" type:"string"`
 
-	metadataSimulateCustomPolicyInput `json:"-" xml:"-"`
-}
-
-type metadataSimulateCustomPolicyInput struct {
-	SDKShapeTraits bool `type:"structure"`
+	_ struct{} `type:"structure"`
 }
 
 // String returns the string representation
@@ -10931,11 +10035,7 @@ type SimulatePolicyResponse struct {
 	// to use for the Marker parameter in a subsequent pagination request.
 	Marker *string `min:"1" type:"string"`
 
-	metadataSimulatePolicyResponse `json:"-" xml:"-"`
-}
-
-type metadataSimulatePolicyResponse struct {
-	SDKShapeTraits bool `type:"structure"`
+	_ struct{} `type:"structure"`
 }
 
 // String returns the string representation
@@ -11071,11 +10171,7 @@ type SimulatePrincipalPolicyInput struct {
 	// You can include only one resource-based policy in a simulation.
 	ResourcePolicy *string `min:"1" type:"string"`
 
-	metadataSimulatePrincipalPolicyInput `json:"-" xml:"-"`
-}
-
-type metadataSimulatePrincipalPolicyInput struct {
-	SDKShapeTraits bool `type:"structure"`
+	_ struct{} `type:"structure"`
 }
 
 // String returns the string representation
@@ -11106,11 +10202,7 @@ type Statement struct {
 	// The row and column of the beginning of the Statement in an IAM policy.
 	StartPosition *Position `type:"structure"`
 
-	metadataStatement `json:"-" xml:"-"`
-}
-
-type metadataStatement struct {
-	SDKShapeTraits bool `type:"structure"`
+	_ struct{} `type:"structure"`
 }
 
 // String returns the string representation
@@ -11135,11 +10227,7 @@ type UpdateAccessKeyInput struct {
 	// The name of the user whose key you want to update.
 	UserName *string `min:"1" type:"string"`
 
-	metadataUpdateAccessKeyInput `json:"-" xml:"-"`
-}
-
-type metadataUpdateAccessKeyInput struct {
-	SDKShapeTraits bool `type:"structure"`
+	_ struct{} `type:"structure"`
 }
 
 // String returns the string representation
@@ -11153,11 +10241,7 @@ func (s UpdateAccessKeyInput) GoString() string {
 }
 
 type UpdateAccessKeyOutput struct {
-	metadataUpdateAccessKeyOutput `json:"-" xml:"-"`
-}
-
-type metadataUpdateAccessKeyOutput struct {
-	SDKShapeTraits bool `type:"structure"`
+	_ struct{} `type:"structure"`
 }
 
 // String returns the string representation
@@ -11228,11 +10312,7 @@ type UpdateAccountPasswordPolicyInput struct {
 	// Default value: false
 	RequireUppercaseCharacters *bool `type:"boolean"`
 
-	metadataUpdateAccountPasswordPolicyInput `json:"-" xml:"-"`
-}
-
-type metadataUpdateAccountPasswordPolicyInput struct {
-	SDKShapeTraits bool `type:"structure"`
+	_ struct{} `type:"structure"`
 }
 
 // String returns the string representation
@@ -11246,11 +10326,7 @@ func (s UpdateAccountPasswordPolicyInput) GoString() string {
 }
 
 type UpdateAccountPasswordPolicyOutput struct {
-	metadataUpdateAccountPasswordPolicyOutput `json:"-" xml:"-"`
-}
-
-type metadataUpdateAccountPasswordPolicyOutput struct {
-	SDKShapeTraits bool `type:"structure"`
+	_ struct{} `type:"structure"`
 }
 
 // String returns the string representation
@@ -11270,11 +10346,7 @@ type UpdateAssumeRolePolicyInput struct {
 	// The name of the role to update.
 	RoleName *string `min:"1" type:"string" required:"true"`
 
-	metadataUpdateAssumeRolePolicyInput `json:"-" xml:"-"`
-}
-
-type metadataUpdateAssumeRolePolicyInput struct {
-	SDKShapeTraits bool `type:"structure"`
+	_ struct{} `type:"structure"`
 }
 
 // String returns the string representation
@@ -11288,11 +10360,7 @@ func (s UpdateAssumeRolePolicyInput) GoString() string {
 }
 
 type UpdateAssumeRolePolicyOutput struct {
-	metadataUpdateAssumeRolePolicyOutput `json:"-" xml:"-"`
-}
-
-type metadataUpdateAssumeRolePolicyOutput struct {
-	SDKShapeTraits bool `type:"structure"`
+	_ struct{} `type:"structure"`
 }
 
 // String returns the string representation
@@ -11316,11 +10384,7 @@ type UpdateGroupInput struct {
 	// New path for the group. Only include this if changing the group's path.
 	NewPath *string `min:"1" type:"string"`
 
-	metadataUpdateGroupInput `json:"-" xml:"-"`
-}
-
-type metadataUpdateGroupInput struct {
-	SDKShapeTraits bool `type:"structure"`
+	_ struct{} `type:"structure"`
 }
 
 // String returns the string representation
@@ -11334,11 +10398,7 @@ func (s UpdateGroupInput) GoString() string {
 }
 
 type UpdateGroupOutput struct {
-	metadataUpdateGroupOutput `json:"-" xml:"-"`
-}
-
-type metadataUpdateGroupOutput struct {
-	SDKShapeTraits bool `type:"structure"`
+	_ struct{} `type:"structure"`
 }
 
 // String returns the string representation
@@ -11361,11 +10421,7 @@ type UpdateLoginProfileInput struct {
 	// The name of the user whose password you want to update.
 	UserName *string `min:"1" type:"string" required:"true"`
 
-	metadataUpdateLoginProfileInput `json:"-" xml:"-"`
-}
-
-type metadataUpdateLoginProfileInput struct {
-	SDKShapeTraits bool `type:"structure"`
+	_ struct{} `type:"structure"`
 }
 
 // String returns the string representation
@@ -11379,11 +10435,7 @@ func (s UpdateLoginProfileInput) GoString() string {
 }
 
 type UpdateLoginProfileOutput struct {
-	metadataUpdateLoginProfileOutput `json:"-" xml:"-"`
-}
-
-type metadataUpdateLoginProfileOutput struct {
-	SDKShapeTraits bool `type:"structure"`
+	_ struct{} `type:"structure"`
 }
 
 // String returns the string representation
@@ -11406,11 +10458,7 @@ type UpdateOpenIDConnectProviderThumbprintInput struct {
 	// IAM OpenID Connect provider. For more information, see CreateOpenIDConnectProvider.
 	ThumbprintList []*string `type:"list" required:"true"`
 
-	metadataUpdateOpenIDConnectProviderThumbprintInput `json:"-" xml:"-"`
-}
-
-type metadataUpdateOpenIDConnectProviderThumbprintInput struct {
-	SDKShapeTraits bool `type:"structure"`
+	_ struct{} `type:"structure"`
 }
 
 // String returns the string representation
@@ -11424,11 +10472,7 @@ func (s UpdateOpenIDConnectProviderThumbprintInput) GoString() string {
 }
 
 type UpdateOpenIDConnectProviderThumbprintOutput struct {
-	metadataUpdateOpenIDConnectProviderThumbprintOutput `json:"-" xml:"-"`
-}
-
-type metadataUpdateOpenIDConnectProviderThumbprintOutput struct {
-	SDKShapeTraits bool `type:"structure"`
+	_ struct{} `type:"structure"`
 }
 
 // String returns the string representation
@@ -11452,11 +10496,7 @@ type UpdateSAMLProviderInput struct {
 	// The Amazon Resource Name (ARN) of the SAML provider to update.
 	SAMLProviderArn *string `min:"20" type:"string" required:"true"`
 
-	metadataUpdateSAMLProviderInput `json:"-" xml:"-"`
-}
-
-type metadataUpdateSAMLProviderInput struct {
-	SDKShapeTraits bool `type:"structure"`
+	_ struct{} `type:"structure"`
 }
 
 // String returns the string representation
@@ -11474,11 +10514,7 @@ type UpdateSAMLProviderOutput struct {
 	// The Amazon Resource Name (ARN) of the SAML provider that was updated.
 	SAMLProviderArn *string `min:"20" type:"string"`
 
-	metadataUpdateSAMLProviderOutput `json:"-" xml:"-"`
-}
-
-type metadataUpdateSAMLProviderOutput struct {
-	SDKShapeTraits bool `type:"structure"`
+	_ struct{} `type:"structure"`
 }
 
 // String returns the string representation
@@ -11503,11 +10539,7 @@ type UpdateSSHPublicKeyInput struct {
 	// The name of the IAM user associated with the SSH public key.
 	UserName *string `min:"1" type:"string" required:"true"`
 
-	metadataUpdateSSHPublicKeyInput `json:"-" xml:"-"`
-}
-
-type metadataUpdateSSHPublicKeyInput struct {
-	SDKShapeTraits bool `type:"structure"`
+	_ struct{} `type:"structure"`
 }
 
 // String returns the string representation
@@ -11521,11 +10553,7 @@ func (s UpdateSSHPublicKeyInput) GoString() string {
 }
 
 type UpdateSSHPublicKeyOutput struct {
-	metadataUpdateSSHPublicKeyOutput `json:"-" xml:"-"`
-}
-
-type metadataUpdateSSHPublicKeyOutput struct {
-	SDKShapeTraits bool `type:"structure"`
+	_ struct{} `type:"structure"`
 }
 
 // String returns the string representation
@@ -11551,11 +10579,7 @@ type UpdateServerCertificateInput struct {
 	// The name of the server certificate that you want to update.
 	ServerCertificateName *string `min:"1" type:"string" required:"true"`
 
-	metadataUpdateServerCertificateInput `json:"-" xml:"-"`
-}
-
-type metadataUpdateServerCertificateInput struct {
-	SDKShapeTraits bool `type:"structure"`
+	_ struct{} `type:"structure"`
 }
 
 // String returns the string representation
@@ -11569,11 +10593,7 @@ func (s UpdateServerCertificateInput) GoString() string {
 }
 
 type UpdateServerCertificateOutput struct {
-	metadataUpdateServerCertificateOutput `json:"-" xml:"-"`
-}
-
-type metadataUpdateServerCertificateOutput struct {
-	SDKShapeTraits bool `type:"structure"`
+	_ struct{} `type:"structure"`
 }
 
 // String returns the string representation
@@ -11598,11 +10618,7 @@ type UpdateSigningCertificateInput struct {
 	// The name of the user the signing certificate belongs to.
 	UserName *string `min:"1" type:"string"`
 
-	metadataUpdateSigningCertificateInput `json:"-" xml:"-"`
-}
-
-type metadataUpdateSigningCertificateInput struct {
-	SDKShapeTraits bool `type:"structure"`
+	_ struct{} `type:"structure"`
 }
 
 // String returns the string representation
@@ -11616,11 +10632,7 @@ func (s UpdateSigningCertificateInput) GoString() string {
 }
 
 type UpdateSigningCertificateOutput struct {
-	metadataUpdateSigningCertificateOutput `json:"-" xml:"-"`
-}
-
-type metadataUpdateSigningCertificateOutput struct {
-	SDKShapeTraits bool `type:"structure"`
+	_ struct{} `type:"structure"`
 }
 
 // String returns the string representation
@@ -11646,11 +10658,7 @@ type UpdateUserInput struct {
 	// is the original user name.
 	UserName *string `min:"1" type:"string" required:"true"`
 
-	metadataUpdateUserInput `json:"-" xml:"-"`
-}
-
-type metadataUpdateUserInput struct {
-	SDKShapeTraits bool `type:"structure"`
+	_ struct{} `type:"structure"`
 }
 
 // String returns the string representation
@@ -11664,11 +10672,7 @@ func (s UpdateUserInput) GoString() string {
 }
 
 type UpdateUserOutput struct {
-	metadataUpdateUserOutput `json:"-" xml:"-"`
-}
-
-type metadataUpdateUserOutput struct {
-	SDKShapeTraits bool `type:"structure"`
+	_ struct{} `type:"structure"`
 }
 
 // String returns the string representation
@@ -11689,11 +10693,7 @@ type UploadSSHPublicKeyInput struct {
 	// The name of the IAM user to associate the SSH public key with.
 	UserName *string `min:"1" type:"string" required:"true"`
 
-	metadataUploadSSHPublicKeyInput `json:"-" xml:"-"`
-}
-
-type metadataUploadSSHPublicKeyInput struct {
-	SDKShapeTraits bool `type:"structure"`
+	_ struct{} `type:"structure"`
 }
 
 // String returns the string representation
@@ -11711,11 +10711,7 @@ type UploadSSHPublicKeyOutput struct {
 	// Contains information about the SSH public key.
 	SSHPublicKey *SSHPublicKey `type:"structure"`
 
-	metadataUploadSSHPublicKeyOutput `json:"-" xml:"-"`
-}
-
-type metadataUploadSSHPublicKeyOutput struct {
-	SDKShapeTraits bool `type:"structure"`
+	_ struct{} `type:"structure"`
 }
 
 // String returns the string representation
@@ -11756,11 +10752,7 @@ type UploadServerCertificateInput struct {
 	// The name of the certificate cannot contain any spaces.
 	ServerCertificateName *string `min:"1" type:"string" required:"true"`
 
-	metadataUploadServerCertificateInput `json:"-" xml:"-"`
-}
-
-type metadataUploadServerCertificateInput struct {
-	SDKShapeTraits bool `type:"structure"`
+	_ struct{} `type:"structure"`
 }
 
 // String returns the string representation
@@ -11779,11 +10771,7 @@ type UploadServerCertificateOutput struct {
 	// body, certificate chain, and private key.
 	ServerCertificateMetadata *ServerCertificateMetadata `type:"structure"`
 
-	metadataUploadServerCertificateOutput `json:"-" xml:"-"`
-}
-
-type metadataUploadServerCertificateOutput struct {
-	SDKShapeTraits bool `type:"structure"`
+	_ struct{} `type:"structure"`
 }
 
 // String returns the string representation
@@ -11803,11 +10791,7 @@ type UploadSigningCertificateInput struct {
 	// The name of the user the signing certificate is for.
 	UserName *string `min:"1" type:"string"`
 
-	metadataUploadSigningCertificateInput `json:"-" xml:"-"`
-}
-
-type metadataUploadSigningCertificateInput struct {
-	SDKShapeTraits bool `type:"structure"`
+	_ struct{} `type:"structure"`
 }
 
 // String returns the string representation
@@ -11825,11 +10809,7 @@ type UploadSigningCertificateOutput struct {
 	// Information about the certificate.
 	Certificate *SigningCertificate `type:"structure" required:"true"`
 
-	metadataUploadSigningCertificateOutput `json:"-" xml:"-"`
-}
-
-type metadataUploadSigningCertificateOutput struct {
-	SDKShapeTraits bool `type:"structure"`
+	_ struct{} `type:"structure"`
 }
 
 // String returns the string representation
@@ -11892,11 +10872,7 @@ type User struct {
 	// The friendly name identifying the user.
 	UserName *string `min:"1" type:"string" required:"true"`
 
-	metadataUser `json:"-" xml:"-"`
-}
-
-type metadataUser struct {
-	SDKShapeTraits bool `type:"structure"`
+	_ struct{} `type:"structure"`
 }
 
 // String returns the string representation
@@ -11948,11 +10924,7 @@ type UserDetail struct {
 	// A list of the inline policies embedded in the user.
 	UserPolicyList []*PolicyDetail `type:"list"`
 
-	metadataUserDetail `json:"-" xml:"-"`
-}
-
-type metadataUserDetail struct {
-	SDKShapeTraits bool `type:"structure"`
+	_ struct{} `type:"structure"`
 }
 
 // String returns the string representation
@@ -11994,11 +10966,7 @@ type VirtualMFADevice struct {
 	//    ListUsers
 	User *User `type:"structure"`
 
-	metadataVirtualMFADevice `json:"-" xml:"-"`
-}
-
-type metadataVirtualMFADevice struct {
-	SDKShapeTraits bool `type:"structure"`
+	_ struct{} `type:"structure"`
 }
 
 // String returns the string representation

--- a/service/inspector/api.go
+++ b/service/inspector/api.go
@@ -1013,11 +1013,7 @@ type AddAttributesToFindingsInput struct {
 	// The ARNs specifying the findings that you want to assign attributes to.
 	FindingArns []*string `locationName:"findingArns" type:"list" required:"true"`
 
-	metadataAddAttributesToFindingsInput `json:"-" xml:"-"`
-}
-
-type metadataAddAttributesToFindingsInput struct {
-	SDKShapeTraits bool `type:"structure"`
+	_ struct{} `type:"structure"`
 }
 
 // String returns the string representation
@@ -1034,11 +1030,7 @@ type AddAttributesToFindingsOutput struct {
 	// Confirmation details of the action performed.
 	Message *string `locationName:"message" type:"string"`
 
-	metadataAddAttributesToFindingsOutput `json:"-" xml:"-"`
-}
-
-type metadataAddAttributesToFindingsOutput struct {
-	SDKShapeTraits bool `type:"structure"`
+	_ struct{} `type:"structure"`
 }
 
 // String returns the string representation
@@ -1079,11 +1071,7 @@ type Agent struct {
 	// The Inspector application data metrics collected by the agent.
 	Telemetry []*Telemetry `locationName:"telemetry" type:"list"`
 
-	metadataAgent `json:"-" xml:"-"`
-}
-
-type metadataAgent struct {
-	SDKShapeTraits bool `type:"structure"`
+	_ struct{} `type:"structure"`
 }
 
 // String returns the string representation
@@ -1105,11 +1093,7 @@ type AgentPreview struct {
 	// The autoscaling group for the EC2 instance where the agent is installed.
 	AutoScalingGroup *string `locationName:"autoScalingGroup" type:"string"`
 
-	metadataAgentPreview `json:"-" xml:"-"`
-}
-
-type metadataAgentPreview struct {
-	SDKShapeTraits bool `type:"structure"`
+	_ struct{} `type:"structure"`
 }
 
 // String returns the string representation
@@ -1130,11 +1114,7 @@ type AgentsFilter struct {
 	// data type.
 	AgentHealthList []*string `locationName:"agentHealthList" type:"list"`
 
-	metadataAgentsFilter `json:"-" xml:"-"`
-}
-
-type metadataAgentsFilter struct {
-	SDKShapeTraits bool `type:"structure"`
+	_ struct{} `type:"structure"`
 }
 
 // String returns the string representation
@@ -1161,11 +1141,7 @@ type Application struct {
 	// The ARN specifying the resource group that is associated with the application.
 	ResourceGroupArn *string `locationName:"resourceGroupArn" type:"string"`
 
-	metadataApplication `json:"-" xml:"-"`
-}
-
-type metadataApplication struct {
-	SDKShapeTraits bool `type:"structure"`
+	_ struct{} `type:"structure"`
 }
 
 // String returns the string representation
@@ -1185,11 +1161,7 @@ type ApplicationsFilter struct {
 	// the applicationName property of the Application data type.
 	ApplicationNamePatterns []*string `locationName:"applicationNamePatterns" type:"list"`
 
-	metadataApplicationsFilter `json:"-" xml:"-"`
-}
-
-type metadataApplicationsFilter struct {
-	SDKShapeTraits bool `type:"structure"`
+	_ struct{} `type:"structure"`
 }
 
 // String returns the string representation
@@ -1240,11 +1212,7 @@ type Assessment struct {
 	// The user-defined attributes that are assigned to every generated finding.
 	UserAttributesForFindings []*Attribute `locationName:"userAttributesForFindings" type:"list"`
 
-	metadataAssessment `json:"-" xml:"-"`
-}
-
-type metadataAssessment struct {
-	SDKShapeTraits bool `type:"structure"`
+	_ struct{} `type:"structure"`
 }
 
 // String returns the string representation
@@ -1290,11 +1258,7 @@ type AssessmentsFilter struct {
 	// values of the startTime property of the Assessment data type.
 	StartTimeRange *TimestampRange `locationName:"startTimeRange" type:"structure"`
 
-	metadataAssessmentsFilter `json:"-" xml:"-"`
-}
-
-type metadataAssessmentsFilter struct {
-	SDKShapeTraits bool `type:"structure"`
+	_ struct{} `type:"structure"`
 }
 
 // String returns the string representation
@@ -1314,11 +1278,7 @@ type AttachAssessmentAndRulesPackageInput struct {
 	// The ARN specifying the rules package that you want to attach to the assessment.
 	RulesPackageArn *string `locationName:"rulesPackageArn" type:"string" required:"true"`
 
-	metadataAttachAssessmentAndRulesPackageInput `json:"-" xml:"-"`
-}
-
-type metadataAttachAssessmentAndRulesPackageInput struct {
-	SDKShapeTraits bool `type:"structure"`
+	_ struct{} `type:"structure"`
 }
 
 // String returns the string representation
@@ -1335,11 +1295,7 @@ type AttachAssessmentAndRulesPackageOutput struct {
 	// Confirmation details of the action performed.
 	Message *string `locationName:"message" type:"string"`
 
-	metadataAttachAssessmentAndRulesPackageOutput `json:"-" xml:"-"`
-}
-
-type metadataAttachAssessmentAndRulesPackageOutput struct {
-	SDKShapeTraits bool `type:"structure"`
+	_ struct{} `type:"structure"`
 }
 
 // String returns the string representation
@@ -1361,11 +1317,7 @@ type Attribute struct {
 	// The value assigned to the attribute key.
 	Value *string `locationName:"value" type:"string"`
 
-	metadataAttribute `json:"-" xml:"-"`
-}
-
-type metadataAttribute struct {
-	SDKShapeTraits bool `type:"structure"`
+	_ struct{} `type:"structure"`
 }
 
 // String returns the string representation
@@ -1386,11 +1338,7 @@ type CreateApplicationInput struct {
 	// The ARN specifying the resource group that is used to create the application.
 	ResourceGroupArn *string `locationName:"resourceGroupArn" type:"string" required:"true"`
 
-	metadataCreateApplicationInput `json:"-" xml:"-"`
-}
-
-type metadataCreateApplicationInput struct {
-	SDKShapeTraits bool `type:"structure"`
+	_ struct{} `type:"structure"`
 }
 
 // String returns the string representation
@@ -1407,11 +1355,7 @@ type CreateApplicationOutput struct {
 	// The ARN specifying the application that is created.
 	ApplicationArn *string `locationName:"applicationArn" type:"string"`
 
-	metadataCreateApplicationOutput `json:"-" xml:"-"`
-}
-
-type metadataCreateApplicationOutput struct {
-	SDKShapeTraits bool `type:"structure"`
+	_ struct{} `type:"structure"`
 }
 
 // String returns the string representation
@@ -1441,11 +1385,7 @@ type CreateAssessmentInput struct {
 	// by running this assessment.
 	UserAttributesForFindings []*Attribute `locationName:"userAttributesForFindings" type:"list"`
 
-	metadataCreateAssessmentInput `json:"-" xml:"-"`
-}
-
-type metadataCreateAssessmentInput struct {
-	SDKShapeTraits bool `type:"structure"`
+	_ struct{} `type:"structure"`
 }
 
 // String returns the string representation
@@ -1462,11 +1402,7 @@ type CreateAssessmentOutput struct {
 	// The ARN specifying the assessment that is created.
 	AssessmentArn *string `locationName:"assessmentArn" type:"string"`
 
-	metadataCreateAssessmentOutput `json:"-" xml:"-"`
-}
-
-type metadataCreateAssessmentOutput struct {
-	SDKShapeTraits bool `type:"structure"`
+	_ struct{} `type:"structure"`
 }
 
 // String returns the string representation
@@ -1485,11 +1421,7 @@ type CreateResourceGroupInput struct {
 	// For example, [{ "key1" : ["Value1","Value2"]},{"Key2": ["Value3"]}]
 	ResourceGroupTags *string `locationName:"resourceGroupTags" type:"string" required:"true"`
 
-	metadataCreateResourceGroupInput `json:"-" xml:"-"`
-}
-
-type metadataCreateResourceGroupInput struct {
-	SDKShapeTraits bool `type:"structure"`
+	_ struct{} `type:"structure"`
 }
 
 // String returns the string representation
@@ -1506,11 +1438,7 @@ type CreateResourceGroupOutput struct {
 	// The ARN specifying the resource group that is created.
 	ResourceGroupArn *string `locationName:"resourceGroupArn" type:"string"`
 
-	metadataCreateResourceGroupOutput `json:"-" xml:"-"`
-}
-
-type metadataCreateResourceGroupOutput struct {
-	SDKShapeTraits bool `type:"structure"`
+	_ struct{} `type:"structure"`
 }
 
 // String returns the string representation
@@ -1527,11 +1455,7 @@ type DeleteApplicationInput struct {
 	// The ARN specifying the application that you want to delete.
 	ApplicationArn *string `locationName:"applicationArn" type:"string" required:"true"`
 
-	metadataDeleteApplicationInput `json:"-" xml:"-"`
-}
-
-type metadataDeleteApplicationInput struct {
-	SDKShapeTraits bool `type:"structure"`
+	_ struct{} `type:"structure"`
 }
 
 // String returns the string representation
@@ -1548,11 +1472,7 @@ type DeleteApplicationOutput struct {
 	// Confirmation details of the action performed.
 	Message *string `locationName:"message" type:"string"`
 
-	metadataDeleteApplicationOutput `json:"-" xml:"-"`
-}
-
-type metadataDeleteApplicationOutput struct {
-	SDKShapeTraits bool `type:"structure"`
+	_ struct{} `type:"structure"`
 }
 
 // String returns the string representation
@@ -1569,11 +1489,7 @@ type DeleteAssessmentInput struct {
 	// The ARN specifying the assessment that you want to delete.
 	AssessmentArn *string `locationName:"assessmentArn" type:"string" required:"true"`
 
-	metadataDeleteAssessmentInput `json:"-" xml:"-"`
-}
-
-type metadataDeleteAssessmentInput struct {
-	SDKShapeTraits bool `type:"structure"`
+	_ struct{} `type:"structure"`
 }
 
 // String returns the string representation
@@ -1590,11 +1506,7 @@ type DeleteAssessmentOutput struct {
 	// Confirmation details of the action performed.
 	Message *string `locationName:"message" type:"string"`
 
-	metadataDeleteAssessmentOutput `json:"-" xml:"-"`
-}
-
-type metadataDeleteAssessmentOutput struct {
-	SDKShapeTraits bool `type:"structure"`
+	_ struct{} `type:"structure"`
 }
 
 // String returns the string representation
@@ -1611,11 +1523,7 @@ type DeleteRunInput struct {
 	// The ARN specifying the assessment run that you want to delete.
 	RunArn *string `locationName:"runArn" type:"string" required:"true"`
 
-	metadataDeleteRunInput `json:"-" xml:"-"`
-}
-
-type metadataDeleteRunInput struct {
-	SDKShapeTraits bool `type:"structure"`
+	_ struct{} `type:"structure"`
 }
 
 // String returns the string representation
@@ -1632,11 +1540,7 @@ type DeleteRunOutput struct {
 	// Confirmation details of the action performed.
 	Message *string `locationName:"message" type:"string"`
 
-	metadataDeleteRunOutput `json:"-" xml:"-"`
-}
-
-type metadataDeleteRunOutput struct {
-	SDKShapeTraits bool `type:"structure"`
+	_ struct{} `type:"structure"`
 }
 
 // String returns the string representation
@@ -1653,11 +1557,7 @@ type DescribeApplicationInput struct {
 	// The ARN specifying the application that you want to describe.
 	ApplicationArn *string `locationName:"applicationArn" type:"string" required:"true"`
 
-	metadataDescribeApplicationInput `json:"-" xml:"-"`
-}
-
-type metadataDescribeApplicationInput struct {
-	SDKShapeTraits bool `type:"structure"`
+	_ struct{} `type:"structure"`
 }
 
 // String returns the string representation
@@ -1674,11 +1574,7 @@ type DescribeApplicationOutput struct {
 	// Information about the application.
 	Application *Application `locationName:"application" type:"structure"`
 
-	metadataDescribeApplicationOutput `json:"-" xml:"-"`
-}
-
-type metadataDescribeApplicationOutput struct {
-	SDKShapeTraits bool `type:"structure"`
+	_ struct{} `type:"structure"`
 }
 
 // String returns the string representation
@@ -1695,11 +1591,7 @@ type DescribeAssessmentInput struct {
 	// The ARN specifying the assessment that you want to describe.
 	AssessmentArn *string `locationName:"assessmentArn" type:"string" required:"true"`
 
-	metadataDescribeAssessmentInput `json:"-" xml:"-"`
-}
-
-type metadataDescribeAssessmentInput struct {
-	SDKShapeTraits bool `type:"structure"`
+	_ struct{} `type:"structure"`
 }
 
 // String returns the string representation
@@ -1716,11 +1608,7 @@ type DescribeAssessmentOutput struct {
 	// Information about the assessment.
 	Assessment *Assessment `locationName:"assessment" type:"structure"`
 
-	metadataDescribeAssessmentOutput `json:"-" xml:"-"`
-}
-
-type metadataDescribeAssessmentOutput struct {
-	SDKShapeTraits bool `type:"structure"`
+	_ struct{} `type:"structure"`
 }
 
 // String returns the string representation
@@ -1734,11 +1622,7 @@ func (s DescribeAssessmentOutput) GoString() string {
 }
 
 type DescribeCrossAccountAccessRoleInput struct {
-	metadataDescribeCrossAccountAccessRoleInput `json:"-" xml:"-"`
-}
-
-type metadataDescribeCrossAccountAccessRoleInput struct {
-	SDKShapeTraits bool `type:"structure"`
+	_ struct{} `type:"structure"`
 }
 
 // String returns the string representation
@@ -1759,11 +1643,7 @@ type DescribeCrossAccountAccessRoleOutput struct {
 	// attached to enable Inspector to access your AWS account.
 	Valid *bool `locationName:"valid" type:"boolean"`
 
-	metadataDescribeCrossAccountAccessRoleOutput `json:"-" xml:"-"`
-}
-
-type metadataDescribeCrossAccountAccessRoleOutput struct {
-	SDKShapeTraits bool `type:"structure"`
+	_ struct{} `type:"structure"`
 }
 
 // String returns the string representation
@@ -1780,11 +1660,7 @@ type DescribeFindingInput struct {
 	// The ARN specifying the finding that you want to describe.
 	FindingArn *string `locationName:"findingArn" type:"string" required:"true"`
 
-	metadataDescribeFindingInput `json:"-" xml:"-"`
-}
-
-type metadataDescribeFindingInput struct {
-	SDKShapeTraits bool `type:"structure"`
+	_ struct{} `type:"structure"`
 }
 
 // String returns the string representation
@@ -1801,11 +1677,7 @@ type DescribeFindingOutput struct {
 	// Information about the finding.
 	Finding *Finding `locationName:"finding" type:"structure"`
 
-	metadataDescribeFindingOutput `json:"-" xml:"-"`
-}
-
-type metadataDescribeFindingOutput struct {
-	SDKShapeTraits bool `type:"structure"`
+	_ struct{} `type:"structure"`
 }
 
 // String returns the string representation
@@ -1822,11 +1694,7 @@ type DescribeResourceGroupInput struct {
 	// The ARN specifying the resource group that you want to describe.
 	ResourceGroupArn *string `locationName:"resourceGroupArn" type:"string" required:"true"`
 
-	metadataDescribeResourceGroupInput `json:"-" xml:"-"`
-}
-
-type metadataDescribeResourceGroupInput struct {
-	SDKShapeTraits bool `type:"structure"`
+	_ struct{} `type:"structure"`
 }
 
 // String returns the string representation
@@ -1843,11 +1711,7 @@ type DescribeResourceGroupOutput struct {
 	// Information about the resource group.
 	ResourceGroup *ResourceGroup `locationName:"resourceGroup" type:"structure"`
 
-	metadataDescribeResourceGroupOutput `json:"-" xml:"-"`
-}
-
-type metadataDescribeResourceGroupOutput struct {
-	SDKShapeTraits bool `type:"structure"`
+	_ struct{} `type:"structure"`
 }
 
 // String returns the string representation
@@ -1864,11 +1728,7 @@ type DescribeRulesPackageInput struct {
 	// The ARN specifying the rules package that you want to describe.
 	RulesPackageArn *string `locationName:"rulesPackageArn" type:"string" required:"true"`
 
-	metadataDescribeRulesPackageInput `json:"-" xml:"-"`
-}
-
-type metadataDescribeRulesPackageInput struct {
-	SDKShapeTraits bool `type:"structure"`
+	_ struct{} `type:"structure"`
 }
 
 // String returns the string representation
@@ -1885,11 +1745,7 @@ type DescribeRulesPackageOutput struct {
 	// Information about the rules package.
 	RulesPackage *RulesPackage `locationName:"rulesPackage" type:"structure"`
 
-	metadataDescribeRulesPackageOutput `json:"-" xml:"-"`
-}
-
-type metadataDescribeRulesPackageOutput struct {
-	SDKShapeTraits bool `type:"structure"`
+	_ struct{} `type:"structure"`
 }
 
 // String returns the string representation
@@ -1906,11 +1762,7 @@ type DescribeRunInput struct {
 	// The ARN specifying the assessment run that you want to describe.
 	RunArn *string `locationName:"runArn" type:"string" required:"true"`
 
-	metadataDescribeRunInput `json:"-" xml:"-"`
-}
-
-type metadataDescribeRunInput struct {
-	SDKShapeTraits bool `type:"structure"`
+	_ struct{} `type:"structure"`
 }
 
 // String returns the string representation
@@ -1927,11 +1779,7 @@ type DescribeRunOutput struct {
 	// Information about the assessment run.
 	Run *Run `locationName:"run" type:"structure"`
 
-	metadataDescribeRunOutput `json:"-" xml:"-"`
-}
-
-type metadataDescribeRunOutput struct {
-	SDKShapeTraits bool `type:"structure"`
+	_ struct{} `type:"structure"`
 }
 
 // String returns the string representation
@@ -1951,11 +1799,7 @@ type DetachAssessmentAndRulesPackageInput struct {
 	// The ARN specifying the rules package that you want to detach from the assessment.
 	RulesPackageArn *string `locationName:"rulesPackageArn" type:"string" required:"true"`
 
-	metadataDetachAssessmentAndRulesPackageInput `json:"-" xml:"-"`
-}
-
-type metadataDetachAssessmentAndRulesPackageInput struct {
-	SDKShapeTraits bool `type:"structure"`
+	_ struct{} `type:"structure"`
 }
 
 // String returns the string representation
@@ -1972,11 +1816,7 @@ type DetachAssessmentAndRulesPackageOutput struct {
 	// Confirmation details of the action performed.
 	Message *string `locationName:"message" type:"string"`
 
-	metadataDetachAssessmentAndRulesPackageOutput `json:"-" xml:"-"`
-}
-
-type metadataDetachAssessmentAndRulesPackageOutput struct {
-	SDKShapeTraits bool `type:"structure"`
+	_ struct{} `type:"structure"`
 }
 
 // String returns the string representation
@@ -1998,11 +1838,7 @@ type DurationRange struct {
 	// The minimum value of the duration range. Must be greater than zero.
 	Minimum *int64 `locationName:"minimum" type:"integer"`
 
-	metadataDurationRange `json:"-" xml:"-"`
-}
-
-type metadataDurationRange struct {
-	SDKShapeTraits bool `type:"structure"`
+	_ struct{} `type:"structure"`
 }
 
 // String returns the string representation
@@ -2057,11 +1893,7 @@ type Finding struct {
 	// The user-defined attributes that are assigned to the finding.
 	UserAttributes []*Attribute `locationName:"userAttributes" type:"list"`
 
-	metadataFinding `json:"-" xml:"-"`
-}
-
-type metadataFinding struct {
-	SDKShapeTraits bool `type:"structure"`
+	_ struct{} `type:"structure"`
 }
 
 // String returns the string representation
@@ -2101,11 +1933,7 @@ type FindingsFilter struct {
 	// Finding data type.
 	UserAttributes []*Attribute `locationName:"userAttributes" type:"list"`
 
-	metadataFindingsFilter `json:"-" xml:"-"`
-}
-
-type metadataFindingsFilter struct {
-	SDKShapeTraits bool `type:"structure"`
+	_ struct{} `type:"structure"`
 }
 
 // String returns the string representation
@@ -2122,11 +1950,7 @@ type GetAssessmentTelemetryInput struct {
 	// The ARN specifying the assessment the telemetry of which you want to obtain.
 	AssessmentArn *string `locationName:"assessmentArn" type:"string" required:"true"`
 
-	metadataGetAssessmentTelemetryInput `json:"-" xml:"-"`
-}
-
-type metadataGetAssessmentTelemetryInput struct {
-	SDKShapeTraits bool `type:"structure"`
+	_ struct{} `type:"structure"`
 }
 
 // String returns the string representation
@@ -2143,11 +1967,7 @@ type GetAssessmentTelemetryOutput struct {
 	// Telemetry details.
 	Telemetry []*Telemetry `locationName:"telemetry" type:"list"`
 
-	metadataGetAssessmentTelemetryOutput `json:"-" xml:"-"`
-}
-
-type metadataGetAssessmentTelemetryOutput struct {
-	SDKShapeTraits bool `type:"structure"`
+	_ struct{} `type:"structure"`
 }
 
 // String returns the string representation
@@ -2179,11 +1999,7 @@ type ListApplicationsInput struct {
 	// from previous response to continue listing data.
 	NextToken *string `locationName:"nextToken" type:"string"`
 
-	metadataListApplicationsInput `json:"-" xml:"-"`
-}
-
-type metadataListApplicationsInput struct {
-	SDKShapeTraits bool `type:"structure"`
+	_ struct{} `type:"structure"`
 }
 
 // String returns the string representation
@@ -2206,11 +2022,7 @@ type ListApplicationsOutput struct {
 	// be listed, this parameter is set to 'null'.
 	NextToken *string `locationName:"nextToken" type:"string"`
 
-	metadataListApplicationsOutput `json:"-" xml:"-"`
-}
-
-type metadataListApplicationsOutput struct {
-	SDKShapeTraits bool `type:"structure"`
+	_ struct{} `type:"structure"`
 }
 
 // String returns the string representation
@@ -2245,11 +2057,7 @@ type ListAssessmentAgentsInput struct {
 	// of NextToken from previous response to continue listing data.
 	NextToken *string `locationName:"nextToken" type:"string"`
 
-	metadataListAssessmentAgentsInput `json:"-" xml:"-"`
-}
-
-type metadataListAssessmentAgentsInput struct {
-	SDKShapeTraits bool `type:"structure"`
+	_ struct{} `type:"structure"`
 }
 
 // String returns the string representation
@@ -2272,11 +2080,7 @@ type ListAssessmentAgentsOutput struct {
 	// be listed, this parameter is set to 'null'.
 	NextToken *string `locationName:"nextToken" type:"string"`
 
-	metadataListAssessmentAgentsOutput `json:"-" xml:"-"`
-}
-
-type metadataListAssessmentAgentsOutput struct {
-	SDKShapeTraits bool `type:"structure"`
+	_ struct{} `type:"structure"`
 }
 
 // String returns the string representation
@@ -2312,11 +2116,7 @@ type ListAssessmentsInput struct {
 	// from previous response to continue listing data.
 	NextToken *string `locationName:"nextToken" type:"string"`
 
-	metadataListAssessmentsInput `json:"-" xml:"-"`
-}
-
-type metadataListAssessmentsInput struct {
-	SDKShapeTraits bool `type:"structure"`
+	_ struct{} `type:"structure"`
 }
 
 // String returns the string representation
@@ -2339,11 +2139,7 @@ type ListAssessmentsOutput struct {
 	// be listed, this parameter is set to 'null'.
 	NextToken *string `locationName:"nextToken" type:"string"`
 
-	metadataListAssessmentsOutput `json:"-" xml:"-"`
-}
-
-type metadataListAssessmentsOutput struct {
-	SDKShapeTraits bool `type:"structure"`
+	_ struct{} `type:"structure"`
 }
 
 // String returns the string representation
@@ -2378,11 +2174,7 @@ type ListAttachedAssessmentsInput struct {
 	// The ARN specifying the rules package whose assessments you want to list.
 	RulesPackageArn *string `locationName:"rulesPackageArn" type:"string" required:"true"`
 
-	metadataListAttachedAssessmentsInput `json:"-" xml:"-"`
-}
-
-type metadataListAttachedAssessmentsInput struct {
-	SDKShapeTraits bool `type:"structure"`
+	_ struct{} `type:"structure"`
 }
 
 // String returns the string representation
@@ -2405,11 +2197,7 @@ type ListAttachedAssessmentsOutput struct {
 	// be listed, this parameter is set to 'null'.
 	NextToken *string `locationName:"nextToken" type:"string"`
 
-	metadataListAttachedAssessmentsOutput `json:"-" xml:"-"`
-}
-
-type metadataListAttachedAssessmentsOutput struct {
-	SDKShapeTraits bool `type:"structure"`
+	_ struct{} `type:"structure"`
 }
 
 // String returns the string representation
@@ -2436,11 +2224,7 @@ type ListAttachedRulesPackagesInput struct {
 	// of NextToken from previous response to continue listing data.
 	NextToken *string `locationName:"nextToken" type:"string"`
 
-	metadataListAttachedRulesPackagesInput `json:"-" xml:"-"`
-}
-
-type metadataListAttachedRulesPackagesInput struct {
-	SDKShapeTraits bool `type:"structure"`
+	_ struct{} `type:"structure"`
 }
 
 // String returns the string representation
@@ -2463,11 +2247,7 @@ type ListAttachedRulesPackagesOutput struct {
 	// A list of ARNs specifying the rules packages returned by the action.
 	RulesPackageArnList []*string `locationName:"rulesPackageArnList" type:"list"`
 
-	metadataListAttachedRulesPackagesOutput `json:"-" xml:"-"`
-}
-
-type metadataListAttachedRulesPackagesOutput struct {
-	SDKShapeTraits bool `type:"structure"`
+	_ struct{} `type:"structure"`
 }
 
 // String returns the string representation
@@ -2503,11 +2283,7 @@ type ListFindingsInput struct {
 	// to list.
 	RunArns []*string `locationName:"runArns" type:"list"`
 
-	metadataListFindingsInput `json:"-" xml:"-"`
-}
-
-type metadataListFindingsInput struct {
-	SDKShapeTraits bool `type:"structure"`
+	_ struct{} `type:"structure"`
 }
 
 // String returns the string representation
@@ -2530,11 +2306,7 @@ type ListFindingsOutput struct {
 	// be listed, this parameter is set to 'null'.
 	NextToken *string `locationName:"nextToken" type:"string"`
 
-	metadataListFindingsOutput `json:"-" xml:"-"`
-}
-
-type metadataListFindingsOutput struct {
-	SDKShapeTraits bool `type:"structure"`
+	_ struct{} `type:"structure"`
 }
 
 // String returns the string representation
@@ -2558,11 +2330,7 @@ type ListRulesPackagesInput struct {
 	// from previous response to continue listing data.
 	NextToken *string `locationName:"nextToken" type:"string"`
 
-	metadataListRulesPackagesInput `json:"-" xml:"-"`
-}
-
-type metadataListRulesPackagesInput struct {
-	SDKShapeTraits bool `type:"structure"`
+	_ struct{} `type:"structure"`
 }
 
 // String returns the string representation
@@ -2585,11 +2353,7 @@ type ListRulesPackagesOutput struct {
 	// The list of ARNs specifying the rules packages returned by the action.
 	RulesPackageArnList []*string `locationName:"rulesPackageArnList" type:"list"`
 
-	metadataListRulesPackagesOutput `json:"-" xml:"-"`
-}
-
-type metadataListRulesPackagesOutput struct {
-	SDKShapeTraits bool `type:"structure"`
+	_ struct{} `type:"structure"`
 }
 
 // String returns the string representation
@@ -2624,11 +2388,7 @@ type ListRunsInput struct {
 	// from previous response to continue listing data.
 	NextToken *string `locationName:"nextToken" type:"string"`
 
-	metadataListRunsInput `json:"-" xml:"-"`
-}
-
-type metadataListRunsInput struct {
-	SDKShapeTraits bool `type:"structure"`
+	_ struct{} `type:"structure"`
 }
 
 // String returns the string representation
@@ -2651,11 +2411,7 @@ type ListRunsOutput struct {
 	// A list of ARNs specifying the assessment runs returned by the action.
 	RunArnList []*string `locationName:"runArnList" type:"list"`
 
-	metadataListRunsOutput `json:"-" xml:"-"`
-}
-
-type metadataListRunsOutput struct {
-	SDKShapeTraits bool `type:"structure"`
+	_ struct{} `type:"structure"`
 }
 
 // String returns the string representation
@@ -2672,11 +2428,7 @@ type ListTagsForResourceInput struct {
 	// The ARN specifying the resource whose tags you want to list.
 	ResourceArn *string `locationName:"resourceArn" type:"string" required:"true"`
 
-	metadataListTagsForResourceInput `json:"-" xml:"-"`
-}
-
-type metadataListTagsForResourceInput struct {
-	SDKShapeTraits bool `type:"structure"`
+	_ struct{} `type:"structure"`
 }
 
 // String returns the string representation
@@ -2693,11 +2445,7 @@ type ListTagsForResourceOutput struct {
 	// A collection of key and value pairs.
 	TagList []*Tag `locationName:"tagList" type:"list"`
 
-	metadataListTagsForResourceOutput `json:"-" xml:"-"`
-}
-
-type metadataListTagsForResourceOutput struct {
-	SDKShapeTraits bool `type:"structure"`
+	_ struct{} `type:"structure"`
 }
 
 // String returns the string representation
@@ -2717,11 +2465,7 @@ type LocalizeTextInput struct {
 	// A list of textual identifiers.
 	LocalizedTexts []*LocalizedText `locationName:"localizedTexts" type:"list" required:"true"`
 
-	metadataLocalizeTextInput `json:"-" xml:"-"`
-}
-
-type metadataLocalizeTextInput struct {
-	SDKShapeTraits bool `type:"structure"`
+	_ struct{} `type:"structure"`
 }
 
 // String returns the string representation
@@ -2741,11 +2485,7 @@ type LocalizeTextOutput struct {
 	// The resulting list of user-readable texts.
 	Results []*string `locationName:"results" type:"list"`
 
-	metadataLocalizeTextOutput `json:"-" xml:"-"`
-}
-
-type metadataLocalizeTextOutput struct {
-	SDKShapeTraits bool `type:"structure"`
+	_ struct{} `type:"structure"`
 }
 
 // String returns the string representation
@@ -2767,11 +2507,7 @@ type LocalizedText struct {
 	// Values for the dynamic elements of the string specified by the textual identifier.
 	Parameters []*Parameter `locationName:"parameters" type:"list"`
 
-	metadataLocalizedText `json:"-" xml:"-"`
-}
-
-type metadataLocalizedText struct {
-	SDKShapeTraits bool `type:"structure"`
+	_ struct{} `type:"structure"`
 }
 
 // String returns the string representation
@@ -2792,11 +2528,7 @@ type LocalizedTextKey struct {
 	// Part of the module response source of the text.
 	Id *string `locationName:"id" type:"string"`
 
-	metadataLocalizedTextKey `json:"-" xml:"-"`
-}
-
-type metadataLocalizedTextKey struct {
-	SDKShapeTraits bool `type:"structure"`
+	_ struct{} `type:"structure"`
 }
 
 // String returns the string representation
@@ -2826,11 +2558,7 @@ type MessageTypeTelemetry struct {
 	// A specific type of behavioral data that is collected by the agent.
 	MessageType *string `locationName:"messageType" type:"string"`
 
-	metadataMessageTypeTelemetry `json:"-" xml:"-"`
-}
-
-type metadataMessageTypeTelemetry struct {
-	SDKShapeTraits bool `type:"structure"`
+	_ struct{} `type:"structure"`
 }
 
 // String returns the string representation
@@ -2851,11 +2579,7 @@ type Parameter struct {
 	// The value assigned to the variable that is being replaced.
 	Value *string `locationName:"value" type:"string"`
 
-	metadataParameter `json:"-" xml:"-"`
-}
-
-type metadataParameter struct {
-	SDKShapeTraits bool `type:"structure"`
+	_ struct{} `type:"structure"`
 }
 
 // String returns the string representation
@@ -2882,11 +2606,7 @@ type PreviewAgentsForResourceGroupInput struct {
 	// The ARN of the resource group that is used to create an application.
 	ResourceGroupArn *string `locationName:"resourceGroupArn" type:"string" required:"true"`
 
-	metadataPreviewAgentsForResourceGroupInput `json:"-" xml:"-"`
-}
-
-type metadataPreviewAgentsForResourceGroupInput struct {
-	SDKShapeTraits bool `type:"structure"`
+	_ struct{} `type:"structure"`
 }
 
 // String returns the string representation
@@ -2909,11 +2629,7 @@ type PreviewAgentsForResourceGroupOutput struct {
 	// be listed, this parameter is set to 'null'.
 	NextToken *string `locationName:"nextToken" type:"string"`
 
-	metadataPreviewAgentsForResourceGroupOutput `json:"-" xml:"-"`
-}
-
-type metadataPreviewAgentsForResourceGroupOutput struct {
-	SDKShapeTraits bool `type:"structure"`
+	_ struct{} `type:"structure"`
 }
 
 // String returns the string representation
@@ -2931,11 +2647,7 @@ type RegisterCrossAccountAccessRoleInput struct {
 	// the assessment.
 	RoleArn *string `locationName:"roleArn" type:"string" required:"true"`
 
-	metadataRegisterCrossAccountAccessRoleInput `json:"-" xml:"-"`
-}
-
-type metadataRegisterCrossAccountAccessRoleInput struct {
-	SDKShapeTraits bool `type:"structure"`
+	_ struct{} `type:"structure"`
 }
 
 // String returns the string representation
@@ -2952,11 +2664,7 @@ type RegisterCrossAccountAccessRoleOutput struct {
 	// Confirmation details of the action performed.
 	Message *string `locationName:"message" type:"string"`
 
-	metadataRegisterCrossAccountAccessRoleOutput `json:"-" xml:"-"`
-}
-
-type metadataRegisterCrossAccountAccessRoleOutput struct {
-	SDKShapeTraits bool `type:"structure"`
+	_ struct{} `type:"structure"`
 }
 
 // String returns the string representation
@@ -2976,11 +2684,7 @@ type RemoveAttributesFromFindingsInput struct {
 	// The ARNs specifying the findings that you want to remove attributes from.
 	FindingArns []*string `locationName:"findingArns" type:"list" required:"true"`
 
-	metadataRemoveAttributesFromFindingsInput `json:"-" xml:"-"`
-}
-
-type metadataRemoveAttributesFromFindingsInput struct {
-	SDKShapeTraits bool `type:"structure"`
+	_ struct{} `type:"structure"`
 }
 
 // String returns the string representation
@@ -2997,11 +2701,7 @@ type RemoveAttributesFromFindingsOutput struct {
 	// Confirmation details of the action performed.
 	Message *string `locationName:"message" type:"string"`
 
-	metadataRemoveAttributesFromFindingsOutput `json:"-" xml:"-"`
-}
-
-type metadataRemoveAttributesFromFindingsOutput struct {
-	SDKShapeTraits bool `type:"structure"`
+	_ struct{} `type:"structure"`
 }
 
 // String returns the string representation
@@ -3033,11 +2733,7 @@ type ResourceGroup struct {
 	// For example, [{ "key1" : ["Value1","Value2"]},{"Key2": ["Value3"]}]
 	ResourceGroupTags *string `locationName:"resourceGroupTags" type:"string"`
 
-	metadataResourceGroup `json:"-" xml:"-"`
-}
-
-type metadataResourceGroup struct {
-	SDKShapeTraits bool `type:"structure"`
+	_ struct{} `type:"structure"`
 }
 
 // String returns the string representation
@@ -3070,11 +2766,7 @@ type RulesPackage struct {
 	// The version id of the rules package.
 	Version *string `locationName:"version" type:"string"`
 
-	metadataRulesPackage `json:"-" xml:"-"`
-}
-
-type metadataRulesPackage struct {
-	SDKShapeTraits bool `type:"structure"`
+	_ struct{} `type:"structure"`
 }
 
 // String returns the string representation
@@ -3115,11 +2807,7 @@ type Run struct {
 	// EvaluatingPoliciesErrorCanRetry, Completed, Failed, TombStoned.
 	RunState *string `locationName:"runState" type:"string"`
 
-	metadataRun `json:"-" xml:"-"`
-}
-
-type metadataRun struct {
-	SDKShapeTraits bool `type:"structure"`
+	_ struct{} `type:"structure"`
 }
 
 // String returns the string representation
@@ -3139,11 +2827,7 @@ type RunAssessmentInput struct {
 	// A name specifying the run of the assessment.
 	RunName *string `locationName:"runName" type:"string" required:"true"`
 
-	metadataRunAssessmentInput `json:"-" xml:"-"`
-}
-
-type metadataRunAssessmentInput struct {
-	SDKShapeTraits bool `type:"structure"`
+	_ struct{} `type:"structure"`
 }
 
 // String returns the string representation
@@ -3160,11 +2844,7 @@ type RunAssessmentOutput struct {
 	// The ARN specifying the run of the assessment.
 	RunArn *string `locationName:"runArn" type:"string"`
 
-	metadataRunAssessmentOutput `json:"-" xml:"-"`
-}
-
-type metadataRunAssessmentOutput struct {
-	SDKShapeTraits bool `type:"structure"`
+	_ struct{} `type:"structure"`
 }
 
 // String returns the string representation
@@ -3204,11 +2884,7 @@ type RunsFilter struct {
 	// data type.
 	RunStates []*string `locationName:"runStates" type:"list"`
 
-	metadataRunsFilter `json:"-" xml:"-"`
-}
-
-type metadataRunsFilter struct {
-	SDKShapeTraits bool `type:"structure"`
+	_ struct{} `type:"structure"`
 }
 
 // String returns the string representation
@@ -3228,11 +2904,7 @@ type SetTagsForResourceInput struct {
 	// A collection of key and value pairs that you want to set to an assessment.
 	Tags []*Tag `locationName:"tags" type:"list"`
 
-	metadataSetTagsForResourceInput `json:"-" xml:"-"`
-}
-
-type metadataSetTagsForResourceInput struct {
-	SDKShapeTraits bool `type:"structure"`
+	_ struct{} `type:"structure"`
 }
 
 // String returns the string representation
@@ -3249,11 +2921,7 @@ type SetTagsForResourceOutput struct {
 	// Confirmation details of the action performed.
 	Message *string `locationName:"message" type:"string"`
 
-	metadataSetTagsForResourceOutput `json:"-" xml:"-"`
-}
-
-type metadataSetTagsForResourceOutput struct {
-	SDKShapeTraits bool `type:"structure"`
+	_ struct{} `type:"structure"`
 }
 
 // String returns the string representation
@@ -3271,11 +2939,7 @@ type StartDataCollectionInput struct {
 	// process.
 	AssessmentArn *string `locationName:"assessmentArn" type:"string" required:"true"`
 
-	metadataStartDataCollectionInput `json:"-" xml:"-"`
-}
-
-type metadataStartDataCollectionInput struct {
-	SDKShapeTraits bool `type:"structure"`
+	_ struct{} `type:"structure"`
 }
 
 // String returns the string representation
@@ -3292,11 +2956,7 @@ type StartDataCollectionOutput struct {
 	// Confirmation details of the action performed.
 	Message *string `locationName:"message" type:"string"`
 
-	metadataStartDataCollectionOutput `json:"-" xml:"-"`
-}
-
-type metadataStartDataCollectionOutput struct {
-	SDKShapeTraits bool `type:"structure"`
+	_ struct{} `type:"structure"`
 }
 
 // String returns the string representation
@@ -3314,11 +2974,7 @@ type StopDataCollectionInput struct {
 	// process.
 	AssessmentArn *string `locationName:"assessmentArn" type:"string" required:"true"`
 
-	metadataStopDataCollectionInput `json:"-" xml:"-"`
-}
-
-type metadataStopDataCollectionInput struct {
-	SDKShapeTraits bool `type:"structure"`
+	_ struct{} `type:"structure"`
 }
 
 // String returns the string representation
@@ -3335,11 +2991,7 @@ type StopDataCollectionOutput struct {
 	// Confirmation details of the action performed.
 	Message *string `locationName:"message" type:"string"`
 
-	metadataStopDataCollectionOutput `json:"-" xml:"-"`
-}
-
-type metadataStopDataCollectionOutput struct {
-	SDKShapeTraits bool `type:"structure"`
+	_ struct{} `type:"structure"`
 }
 
 // String returns the string representation
@@ -3363,11 +3015,7 @@ type Tag struct {
 	// The value assigned to a tag key.
 	Value *string `type:"string"`
 
-	metadataTag `json:"-" xml:"-"`
-}
-
-type metadataTag struct {
-	SDKShapeTraits bool `type:"structure"`
+	_ struct{} `type:"structure"`
 }
 
 // String returns the string representation
@@ -3393,11 +3041,7 @@ type Telemetry struct {
 	// that Inspector received from the agent.
 	Status *string `locationName:"status" type:"string"`
 
-	metadataTelemetry `json:"-" xml:"-"`
-}
-
-type metadataTelemetry struct {
-	SDKShapeTraits bool `type:"structure"`
+	_ struct{} `type:"structure"`
 }
 
 // String returns the string representation
@@ -3418,11 +3062,7 @@ type TimestampRange struct {
 	// The minimum value of the timestamp range.
 	Minimum *time.Time `locationName:"minimum" type:"timestamp" timestampFormat:"unix"`
 
-	metadataTimestampRange `json:"-" xml:"-"`
-}
-
-type metadataTimestampRange struct {
-	SDKShapeTraits bool `type:"structure"`
+	_ struct{} `type:"structure"`
 }
 
 // String returns the string representation
@@ -3445,11 +3085,7 @@ type UpdateApplicationInput struct {
 	// The resource group ARN that you want to update.
 	ResourceGroupArn *string `locationName:"resourceGroupArn" type:"string" required:"true"`
 
-	metadataUpdateApplicationInput `json:"-" xml:"-"`
-}
-
-type metadataUpdateApplicationInput struct {
-	SDKShapeTraits bool `type:"structure"`
+	_ struct{} `type:"structure"`
 }
 
 // String returns the string representation
@@ -3466,11 +3102,7 @@ type UpdateApplicationOutput struct {
 	// Confirmation details of the action performed.
 	Message *string `locationName:"message" type:"string"`
 
-	metadataUpdateApplicationOutput `json:"-" xml:"-"`
-}
-
-type metadataUpdateApplicationOutput struct {
-	SDKShapeTraits bool `type:"structure"`
+	_ struct{} `type:"structure"`
 }
 
 // String returns the string representation
@@ -3494,11 +3126,7 @@ type UpdateAssessmentInput struct {
 	// is 3600 seconds (one hour). The maximum value is 86400 seconds (one day).
 	DurationInSeconds *int64 `locationName:"durationInSeconds" type:"integer" required:"true"`
 
-	metadataUpdateAssessmentInput `json:"-" xml:"-"`
-}
-
-type metadataUpdateAssessmentInput struct {
-	SDKShapeTraits bool `type:"structure"`
+	_ struct{} `type:"structure"`
 }
 
 // String returns the string representation
@@ -3515,11 +3143,7 @@ type UpdateAssessmentOutput struct {
 	// Confirmation details of the action performed.
 	Message *string `locationName:"message" type:"string"`
 
-	metadataUpdateAssessmentOutput `json:"-" xml:"-"`
-}
-
-type metadataUpdateAssessmentOutput struct {
-	SDKShapeTraits bool `type:"structure"`
+	_ struct{} `type:"structure"`
 }
 
 // String returns the string representation

--- a/service/inspector/api.go
+++ b/service/inspector/api.go
@@ -1007,13 +1007,13 @@ func (c *Inspector) UpdateAssessment(input *UpdateAssessmentInput) (*UpdateAsses
 }
 
 type AddAttributesToFindingsInput struct {
+	_ struct{} `type:"structure"`
+
 	// The array of attributes that you want to assign to specified findings.
 	Attributes []*Attribute `locationName:"attributes" type:"list" required:"true"`
 
 	// The ARNs specifying the findings that you want to assign attributes to.
 	FindingArns []*string `locationName:"findingArns" type:"list" required:"true"`
-
-	_ struct{} `type:"structure"`
 }
 
 // String returns the string representation
@@ -1027,10 +1027,10 @@ func (s AddAttributesToFindingsInput) GoString() string {
 }
 
 type AddAttributesToFindingsOutput struct {
+	_ struct{} `type:"structure"`
+
 	// Confirmation details of the action performed.
 	Message *string `locationName:"message" type:"string"`
-
-	_ struct{} `type:"structure"`
 }
 
 // String returns the string representation
@@ -1046,6 +1046,8 @@ func (s AddAttributesToFindingsOutput) GoString() string {
 // Contains information about an Inspector agent. This data type is used as
 // a response element in the ListAssessmentAgents action.
 type Agent struct {
+	_ struct{} `type:"structure"`
+
 	// AWS account of the EC2 instance where the agent is installed.
 	AccountId *string `locationName:"accountId" type:"string"`
 
@@ -1070,8 +1072,6 @@ type Agent struct {
 
 	// The Inspector application data metrics collected by the agent.
 	Telemetry []*Telemetry `locationName:"telemetry" type:"list"`
-
-	_ struct{} `type:"structure"`
 }
 
 // String returns the string representation
@@ -1087,13 +1087,13 @@ func (s Agent) GoString() string {
 // This data type is used as a response element in the PreviewAgentsForResourceGroup
 // action.
 type AgentPreview struct {
+	_ struct{} `type:"structure"`
+
 	// The id of the EC2 instance where the agent is intalled.
 	AgentId *string `locationName:"agentId" type:"string"`
 
 	// The autoscaling group for the EC2 instance where the agent is installed.
 	AutoScalingGroup *string `locationName:"autoScalingGroup" type:"string"`
-
-	_ struct{} `type:"structure"`
 }
 
 // String returns the string representation
@@ -1109,12 +1109,12 @@ func (s AgentPreview) GoString() string {
 // This data type is used as a response element in the ListAssessmentAgents
 // action.
 type AgentsFilter struct {
+	_ struct{} `type:"structure"`
+
 	// For a record to match a filter, the value specified for this data type property
 	// must be the exact match of the value of the agentHealth property of the Agent
 	// data type.
 	AgentHealthList []*string `locationName:"agentHealthList" type:"list"`
-
-	_ struct{} `type:"structure"`
 }
 
 // String returns the string representation
@@ -1132,6 +1132,8 @@ func (s AgentsFilter) GoString() string {
 // This data type is used as the response element in the DescribeApplication
 // action.
 type Application struct {
+	_ struct{} `type:"structure"`
+
 	// The ARN specifying the Inspector application.
 	ApplicationArn *string `locationName:"applicationArn" type:"string"`
 
@@ -1140,8 +1142,6 @@ type Application struct {
 
 	// The ARN specifying the resource group that is associated with the application.
 	ResourceGroupArn *string `locationName:"resourceGroupArn" type:"string"`
-
-	_ struct{} `type:"structure"`
 }
 
 // String returns the string representation
@@ -1156,12 +1156,12 @@ func (s Application) GoString() string {
 
 // This data type is used as the request parameter in the ListApplications action.
 type ApplicationsFilter struct {
+	_ struct{} `type:"structure"`
+
 	// For a record to match a filter, an explicit value or a string containing
 	// a wildcard specified for this data type property must match the value of
 	// the applicationName property of the Application data type.
 	ApplicationNamePatterns []*string `locationName:"applicationNamePatterns" type:"list"`
-
-	_ struct{} `type:"structure"`
 }
 
 // String returns the string representation
@@ -1179,6 +1179,8 @@ func (s ApplicationsFilter) GoString() string {
 // This data type is used as the response element in the DescribeAssessment
 // action.
 type Assessment struct {
+	_ struct{} `type:"structure"`
+
 	// The ARN of the application that corresponds to this assessment.
 	ApplicationArn *string `locationName:"applicationArn" type:"string"`
 
@@ -1211,8 +1213,6 @@ type Assessment struct {
 
 	// The user-defined attributes that are assigned to every generated finding.
 	UserAttributesForFindings []*Attribute `locationName:"userAttributesForFindings" type:"list"`
-
-	_ struct{} `type:"structure"`
 }
 
 // String returns the string representation
@@ -1228,6 +1228,8 @@ func (s Assessment) GoString() string {
 // This data type is used as the request parameter in the ListAssessments and
 // ListAttachedAssessments actions.
 type AssessmentsFilter struct {
+	_ struct{} `type:"structure"`
+
 	// For a record to match a filter, an explicit value or a string containing
 	// a wildcard specified for this data type property must match the value of
 	// the assessmentName property of the Assessment data type.
@@ -1257,8 +1259,6 @@ type AssessmentsFilter struct {
 	// must inclusively match any value between the specified minimum and maximum
 	// values of the startTime property of the Assessment data type.
 	StartTimeRange *TimestampRange `locationName:"startTimeRange" type:"structure"`
-
-	_ struct{} `type:"structure"`
 }
 
 // String returns the string representation
@@ -1272,13 +1272,13 @@ func (s AssessmentsFilter) GoString() string {
 }
 
 type AttachAssessmentAndRulesPackageInput struct {
+	_ struct{} `type:"structure"`
+
 	// The ARN specifying the assessment to which you want to attach a rules package.
 	AssessmentArn *string `locationName:"assessmentArn" type:"string" required:"true"`
 
 	// The ARN specifying the rules package that you want to attach to the assessment.
 	RulesPackageArn *string `locationName:"rulesPackageArn" type:"string" required:"true"`
-
-	_ struct{} `type:"structure"`
 }
 
 // String returns the string representation
@@ -1292,10 +1292,10 @@ func (s AttachAssessmentAndRulesPackageInput) GoString() string {
 }
 
 type AttachAssessmentAndRulesPackageOutput struct {
+	_ struct{} `type:"structure"`
+
 	// Confirmation details of the action performed.
 	Message *string `locationName:"message" type:"string"`
-
-	_ struct{} `type:"structure"`
 }
 
 // String returns the string representation
@@ -1311,13 +1311,13 @@ func (s AttachAssessmentAndRulesPackageOutput) GoString() string {
 // This data type is used as a response element in the AddAttributesToFindings
 // action and a request parameter in the CreateAssessment action.
 type Attribute struct {
+	_ struct{} `type:"structure"`
+
 	// The attribute key.
 	Key *string `locationName:"key" type:"string"`
 
 	// The value assigned to the attribute key.
 	Value *string `locationName:"value" type:"string"`
-
-	_ struct{} `type:"structure"`
 }
 
 // String returns the string representation
@@ -1331,14 +1331,14 @@ func (s Attribute) GoString() string {
 }
 
 type CreateApplicationInput struct {
+	_ struct{} `type:"structure"`
+
 	// The user-defined name identifying the application that you want to create.
 	// The name must be unique within the AWS account.
 	ApplicationName *string `locationName:"applicationName" type:"string" required:"true"`
 
 	// The ARN specifying the resource group that is used to create the application.
 	ResourceGroupArn *string `locationName:"resourceGroupArn" type:"string" required:"true"`
-
-	_ struct{} `type:"structure"`
 }
 
 // String returns the string representation
@@ -1352,10 +1352,10 @@ func (s CreateApplicationInput) GoString() string {
 }
 
 type CreateApplicationOutput struct {
+	_ struct{} `type:"structure"`
+
 	// The ARN specifying the application that is created.
 	ApplicationArn *string `locationName:"applicationArn" type:"string"`
-
-	_ struct{} `type:"structure"`
 }
 
 // String returns the string representation
@@ -1369,6 +1369,8 @@ func (s CreateApplicationOutput) GoString() string {
 }
 
 type CreateAssessmentInput struct {
+	_ struct{} `type:"structure"`
+
 	// The ARN specifying the application for which you want to create an assessment.
 	ApplicationArn *string `locationName:"applicationArn" type:"string" required:"true"`
 
@@ -1384,8 +1386,6 @@ type CreateAssessmentInput struct {
 	// The user-defined attributes that are assigned to every finding generated
 	// by running this assessment.
 	UserAttributesForFindings []*Attribute `locationName:"userAttributesForFindings" type:"list"`
-
-	_ struct{} `type:"structure"`
 }
 
 // String returns the string representation
@@ -1399,10 +1399,10 @@ func (s CreateAssessmentInput) GoString() string {
 }
 
 type CreateAssessmentOutput struct {
+	_ struct{} `type:"structure"`
+
 	// The ARN specifying the assessment that is created.
 	AssessmentArn *string `locationName:"assessmentArn" type:"string"`
-
-	_ struct{} `type:"structure"`
 }
 
 // String returns the string representation
@@ -1416,12 +1416,12 @@ func (s CreateAssessmentOutput) GoString() string {
 }
 
 type CreateResourceGroupInput struct {
+	_ struct{} `type:"structure"`
+
 	// A collection of keys and an array of possible values in JSON format.
 	//
 	// For example, [{ "key1" : ["Value1","Value2"]},{"Key2": ["Value3"]}]
 	ResourceGroupTags *string `locationName:"resourceGroupTags" type:"string" required:"true"`
-
-	_ struct{} `type:"structure"`
 }
 
 // String returns the string representation
@@ -1435,10 +1435,10 @@ func (s CreateResourceGroupInput) GoString() string {
 }
 
 type CreateResourceGroupOutput struct {
+	_ struct{} `type:"structure"`
+
 	// The ARN specifying the resource group that is created.
 	ResourceGroupArn *string `locationName:"resourceGroupArn" type:"string"`
-
-	_ struct{} `type:"structure"`
 }
 
 // String returns the string representation
@@ -1452,10 +1452,10 @@ func (s CreateResourceGroupOutput) GoString() string {
 }
 
 type DeleteApplicationInput struct {
+	_ struct{} `type:"structure"`
+
 	// The ARN specifying the application that you want to delete.
 	ApplicationArn *string `locationName:"applicationArn" type:"string" required:"true"`
-
-	_ struct{} `type:"structure"`
 }
 
 // String returns the string representation
@@ -1469,10 +1469,10 @@ func (s DeleteApplicationInput) GoString() string {
 }
 
 type DeleteApplicationOutput struct {
+	_ struct{} `type:"structure"`
+
 	// Confirmation details of the action performed.
 	Message *string `locationName:"message" type:"string"`
-
-	_ struct{} `type:"structure"`
 }
 
 // String returns the string representation
@@ -1486,10 +1486,10 @@ func (s DeleteApplicationOutput) GoString() string {
 }
 
 type DeleteAssessmentInput struct {
+	_ struct{} `type:"structure"`
+
 	// The ARN specifying the assessment that you want to delete.
 	AssessmentArn *string `locationName:"assessmentArn" type:"string" required:"true"`
-
-	_ struct{} `type:"structure"`
 }
 
 // String returns the string representation
@@ -1503,10 +1503,10 @@ func (s DeleteAssessmentInput) GoString() string {
 }
 
 type DeleteAssessmentOutput struct {
+	_ struct{} `type:"structure"`
+
 	// Confirmation details of the action performed.
 	Message *string `locationName:"message" type:"string"`
-
-	_ struct{} `type:"structure"`
 }
 
 // String returns the string representation
@@ -1520,10 +1520,10 @@ func (s DeleteAssessmentOutput) GoString() string {
 }
 
 type DeleteRunInput struct {
+	_ struct{} `type:"structure"`
+
 	// The ARN specifying the assessment run that you want to delete.
 	RunArn *string `locationName:"runArn" type:"string" required:"true"`
-
-	_ struct{} `type:"structure"`
 }
 
 // String returns the string representation
@@ -1537,10 +1537,10 @@ func (s DeleteRunInput) GoString() string {
 }
 
 type DeleteRunOutput struct {
+	_ struct{} `type:"structure"`
+
 	// Confirmation details of the action performed.
 	Message *string `locationName:"message" type:"string"`
-
-	_ struct{} `type:"structure"`
 }
 
 // String returns the string representation
@@ -1554,10 +1554,10 @@ func (s DeleteRunOutput) GoString() string {
 }
 
 type DescribeApplicationInput struct {
+	_ struct{} `type:"structure"`
+
 	// The ARN specifying the application that you want to describe.
 	ApplicationArn *string `locationName:"applicationArn" type:"string" required:"true"`
-
-	_ struct{} `type:"structure"`
 }
 
 // String returns the string representation
@@ -1571,10 +1571,10 @@ func (s DescribeApplicationInput) GoString() string {
 }
 
 type DescribeApplicationOutput struct {
+	_ struct{} `type:"structure"`
+
 	// Information about the application.
 	Application *Application `locationName:"application" type:"structure"`
-
-	_ struct{} `type:"structure"`
 }
 
 // String returns the string representation
@@ -1588,10 +1588,10 @@ func (s DescribeApplicationOutput) GoString() string {
 }
 
 type DescribeAssessmentInput struct {
+	_ struct{} `type:"structure"`
+
 	// The ARN specifying the assessment that you want to describe.
 	AssessmentArn *string `locationName:"assessmentArn" type:"string" required:"true"`
-
-	_ struct{} `type:"structure"`
 }
 
 // String returns the string representation
@@ -1605,10 +1605,10 @@ func (s DescribeAssessmentInput) GoString() string {
 }
 
 type DescribeAssessmentOutput struct {
+	_ struct{} `type:"structure"`
+
 	// Information about the assessment.
 	Assessment *Assessment `locationName:"assessment" type:"structure"`
-
-	_ struct{} `type:"structure"`
 }
 
 // String returns the string representation
@@ -1636,14 +1636,14 @@ func (s DescribeCrossAccountAccessRoleInput) GoString() string {
 }
 
 type DescribeCrossAccountAccessRoleOutput struct {
+	_ struct{} `type:"structure"`
+
 	// The ARN specifying the IAM role that Inspector uses to access your AWS account.
 	RoleArn *string `locationName:"roleArn" type:"string"`
 
 	// A Boolean value that specifies whether the IAM role has the necessary policies
 	// attached to enable Inspector to access your AWS account.
 	Valid *bool `locationName:"valid" type:"boolean"`
-
-	_ struct{} `type:"structure"`
 }
 
 // String returns the string representation
@@ -1657,10 +1657,10 @@ func (s DescribeCrossAccountAccessRoleOutput) GoString() string {
 }
 
 type DescribeFindingInput struct {
+	_ struct{} `type:"structure"`
+
 	// The ARN specifying the finding that you want to describe.
 	FindingArn *string `locationName:"findingArn" type:"string" required:"true"`
-
-	_ struct{} `type:"structure"`
 }
 
 // String returns the string representation
@@ -1674,10 +1674,10 @@ func (s DescribeFindingInput) GoString() string {
 }
 
 type DescribeFindingOutput struct {
+	_ struct{} `type:"structure"`
+
 	// Information about the finding.
 	Finding *Finding `locationName:"finding" type:"structure"`
-
-	_ struct{} `type:"structure"`
 }
 
 // String returns the string representation
@@ -1691,10 +1691,10 @@ func (s DescribeFindingOutput) GoString() string {
 }
 
 type DescribeResourceGroupInput struct {
+	_ struct{} `type:"structure"`
+
 	// The ARN specifying the resource group that you want to describe.
 	ResourceGroupArn *string `locationName:"resourceGroupArn" type:"string" required:"true"`
-
-	_ struct{} `type:"structure"`
 }
 
 // String returns the string representation
@@ -1708,10 +1708,10 @@ func (s DescribeResourceGroupInput) GoString() string {
 }
 
 type DescribeResourceGroupOutput struct {
+	_ struct{} `type:"structure"`
+
 	// Information about the resource group.
 	ResourceGroup *ResourceGroup `locationName:"resourceGroup" type:"structure"`
-
-	_ struct{} `type:"structure"`
 }
 
 // String returns the string representation
@@ -1725,10 +1725,10 @@ func (s DescribeResourceGroupOutput) GoString() string {
 }
 
 type DescribeRulesPackageInput struct {
+	_ struct{} `type:"structure"`
+
 	// The ARN specifying the rules package that you want to describe.
 	RulesPackageArn *string `locationName:"rulesPackageArn" type:"string" required:"true"`
-
-	_ struct{} `type:"structure"`
 }
 
 // String returns the string representation
@@ -1742,10 +1742,10 @@ func (s DescribeRulesPackageInput) GoString() string {
 }
 
 type DescribeRulesPackageOutput struct {
+	_ struct{} `type:"structure"`
+
 	// Information about the rules package.
 	RulesPackage *RulesPackage `locationName:"rulesPackage" type:"structure"`
-
-	_ struct{} `type:"structure"`
 }
 
 // String returns the string representation
@@ -1759,10 +1759,10 @@ func (s DescribeRulesPackageOutput) GoString() string {
 }
 
 type DescribeRunInput struct {
+	_ struct{} `type:"structure"`
+
 	// The ARN specifying the assessment run that you want to describe.
 	RunArn *string `locationName:"runArn" type:"string" required:"true"`
-
-	_ struct{} `type:"structure"`
 }
 
 // String returns the string representation
@@ -1776,10 +1776,10 @@ func (s DescribeRunInput) GoString() string {
 }
 
 type DescribeRunOutput struct {
+	_ struct{} `type:"structure"`
+
 	// Information about the assessment run.
 	Run *Run `locationName:"run" type:"structure"`
-
-	_ struct{} `type:"structure"`
 }
 
 // String returns the string representation
@@ -1793,13 +1793,13 @@ func (s DescribeRunOutput) GoString() string {
 }
 
 type DetachAssessmentAndRulesPackageInput struct {
+	_ struct{} `type:"structure"`
+
 	// The ARN specifying the assessment from which you want to detach a rules package.
 	AssessmentArn *string `locationName:"assessmentArn" type:"string" required:"true"`
 
 	// The ARN specifying the rules package that you want to detach from the assessment.
 	RulesPackageArn *string `locationName:"rulesPackageArn" type:"string" required:"true"`
-
-	_ struct{} `type:"structure"`
 }
 
 // String returns the string representation
@@ -1813,10 +1813,10 @@ func (s DetachAssessmentAndRulesPackageInput) GoString() string {
 }
 
 type DetachAssessmentAndRulesPackageOutput struct {
+	_ struct{} `type:"structure"`
+
 	// Confirmation details of the action performed.
 	Message *string `locationName:"message" type:"string"`
-
-	_ struct{} `type:"structure"`
 }
 
 // String returns the string representation
@@ -1831,14 +1831,14 @@ func (s DetachAssessmentAndRulesPackageOutput) GoString() string {
 
 // This data type is used in the AssessmentsFilter data type.
 type DurationRange struct {
+	_ struct{} `type:"structure"`
+
 	// The maximum value of the duration range. Must be less than or equal to 604800
 	// seconds (1 week).
 	Maximum *int64 `locationName:"maximum" type:"integer"`
 
 	// The minimum value of the duration range. Must be greater than zero.
 	Minimum *int64 `locationName:"minimum" type:"integer"`
-
-	_ struct{} `type:"structure"`
 }
 
 // String returns the string representation
@@ -1855,6 +1855,8 @@ func (s DurationRange) GoString() string {
 //
 // This data type is used as the response element in the DescribeFinding action.
 type Finding struct {
+	_ struct{} `type:"structure"`
+
 	// The EC2 instance ID where the agent is installed that is used during the
 	// assessment that generates the finding.
 	AgentId *string `locationName:"agentId" type:"string"`
@@ -1892,8 +1894,6 @@ type Finding struct {
 
 	// The user-defined attributes that are assigned to the finding.
 	UserAttributes []*Attribute `locationName:"userAttributes" type:"list"`
-
-	_ struct{} `type:"structure"`
 }
 
 // String returns the string representation
@@ -1908,6 +1908,8 @@ func (s Finding) GoString() string {
 
 // This data type is used as a request parameter in the ListFindings action.
 type FindingsFilter struct {
+	_ struct{} `type:"structure"`
+
 	// For a record to match a filter, the value specified for this data type property
 	// must be the exact match of the value of the attributes property of the Finding
 	// data type.
@@ -1932,8 +1934,6 @@ type FindingsFilter struct {
 	// must be the exact match of the value of the userAttributes property of the
 	// Finding data type.
 	UserAttributes []*Attribute `locationName:"userAttributes" type:"list"`
-
-	_ struct{} `type:"structure"`
 }
 
 // String returns the string representation
@@ -1947,10 +1947,10 @@ func (s FindingsFilter) GoString() string {
 }
 
 type GetAssessmentTelemetryInput struct {
+	_ struct{} `type:"structure"`
+
 	// The ARN specifying the assessment the telemetry of which you want to obtain.
 	AssessmentArn *string `locationName:"assessmentArn" type:"string" required:"true"`
-
-	_ struct{} `type:"structure"`
 }
 
 // String returns the string representation
@@ -1964,10 +1964,10 @@ func (s GetAssessmentTelemetryInput) GoString() string {
 }
 
 type GetAssessmentTelemetryOutput struct {
+	_ struct{} `type:"structure"`
+
 	// Telemetry details.
 	Telemetry []*Telemetry `locationName:"telemetry" type:"list"`
-
-	_ struct{} `type:"structure"`
 }
 
 // String returns the string representation
@@ -1981,6 +1981,8 @@ func (s GetAssessmentTelemetryOutput) GoString() string {
 }
 
 type ListApplicationsInput struct {
+	_ struct{} `type:"structure"`
+
 	// You can use this parameter to specify a subset of data to be included in
 	// the action's response.
 	//
@@ -1998,8 +2000,6 @@ type ListApplicationsInput struct {
 	// calls to the action fill nextToken in the request with the value of NextToken
 	// from previous response to continue listing data.
 	NextToken *string `locationName:"nextToken" type:"string"`
-
-	_ struct{} `type:"structure"`
 }
 
 // String returns the string representation
@@ -2013,6 +2013,8 @@ func (s ListApplicationsInput) GoString() string {
 }
 
 type ListApplicationsOutput struct {
+	_ struct{} `type:"structure"`
+
 	// A list of ARNs specifying the applications returned by the action.
 	ApplicationArnList []*string `locationName:"applicationArnList" type:"list"`
 
@@ -2021,8 +2023,6 @@ type ListApplicationsOutput struct {
 	// parameter in a subsequent pagination request. If there is no more data to
 	// be listed, this parameter is set to 'null'.
 	NextToken *string `locationName:"nextToken" type:"string"`
-
-	_ struct{} `type:"structure"`
 }
 
 // String returns the string representation
@@ -2036,6 +2036,8 @@ func (s ListApplicationsOutput) GoString() string {
 }
 
 type ListAssessmentAgentsInput struct {
+	_ struct{} `type:"structure"`
+
 	// The ARN specifying the assessment whose agents you want to list.
 	AssessmentArn *string `locationName:"assessmentArn" type:"string" required:"true"`
 
@@ -2056,8 +2058,6 @@ type ListAssessmentAgentsInput struct {
 	// Subsequent calls to the action fill nextToken in the request with the value
 	// of NextToken from previous response to continue listing data.
 	NextToken *string `locationName:"nextToken" type:"string"`
-
-	_ struct{} `type:"structure"`
 }
 
 // String returns the string representation
@@ -2071,6 +2071,8 @@ func (s ListAssessmentAgentsInput) GoString() string {
 }
 
 type ListAssessmentAgentsOutput struct {
+	_ struct{} `type:"structure"`
+
 	// A list of ARNs specifying the agents returned by the action.
 	AgentList []*Agent `locationName:"agentList" type:"list"`
 
@@ -2079,8 +2081,6 @@ type ListAssessmentAgentsOutput struct {
 	// parameter in a subsequent pagination request. If there is no more data to
 	// be listed, this parameter is set to 'null'.
 	NextToken *string `locationName:"nextToken" type:"string"`
-
-	_ struct{} `type:"structure"`
 }
 
 // String returns the string representation
@@ -2094,6 +2094,8 @@ func (s ListAssessmentAgentsOutput) GoString() string {
 }
 
 type ListAssessmentsInput struct {
+	_ struct{} `type:"structure"`
+
 	// A list of ARNs specifying the applications the assessments of which you want
 	// to list.
 	ApplicationArns []*string `locationName:"applicationArns" type:"list"`
@@ -2115,8 +2117,6 @@ type ListAssessmentsInput struct {
 	// calls to the action fill nextToken in the request with the value of NextToken
 	// from previous response to continue listing data.
 	NextToken *string `locationName:"nextToken" type:"string"`
-
-	_ struct{} `type:"structure"`
 }
 
 // String returns the string representation
@@ -2130,6 +2130,8 @@ func (s ListAssessmentsInput) GoString() string {
 }
 
 type ListAssessmentsOutput struct {
+	_ struct{} `type:"structure"`
+
 	// A list of ARNs specifying the assessments returned by the action.
 	AssessmentArnList []*string `locationName:"assessmentArnList" type:"list"`
 
@@ -2138,8 +2140,6 @@ type ListAssessmentsOutput struct {
 	// parameter in a subsequent pagination request. If there is no more data to
 	// be listed, this parameter is set to 'null'.
 	NextToken *string `locationName:"nextToken" type:"string"`
-
-	_ struct{} `type:"structure"`
 }
 
 // String returns the string representation
@@ -2153,6 +2153,8 @@ func (s ListAssessmentsOutput) GoString() string {
 }
 
 type ListAttachedAssessmentsInput struct {
+	_ struct{} `type:"structure"`
+
 	// You can use this parameter to specify a subset of data to be included in
 	// the action's response.
 	//
@@ -2173,8 +2175,6 @@ type ListAttachedAssessmentsInput struct {
 
 	// The ARN specifying the rules package whose assessments you want to list.
 	RulesPackageArn *string `locationName:"rulesPackageArn" type:"string" required:"true"`
-
-	_ struct{} `type:"structure"`
 }
 
 // String returns the string representation
@@ -2188,6 +2188,8 @@ func (s ListAttachedAssessmentsInput) GoString() string {
 }
 
 type ListAttachedAssessmentsOutput struct {
+	_ struct{} `type:"structure"`
+
 	// A list of ARNs specifying the assessments returned by the action.
 	AssessmentArnList []*string `locationName:"assessmentArnList" type:"list"`
 
@@ -2196,8 +2198,6 @@ type ListAttachedAssessmentsOutput struct {
 	// parameter in a subsequent pagination request. If there is no more data to
 	// be listed, this parameter is set to 'null'.
 	NextToken *string `locationName:"nextToken" type:"string"`
-
-	_ struct{} `type:"structure"`
 }
 
 // String returns the string representation
@@ -2211,6 +2211,8 @@ func (s ListAttachedAssessmentsOutput) GoString() string {
 }
 
 type ListAttachedRulesPackagesInput struct {
+	_ struct{} `type:"structure"`
+
 	// The ARN specifying the assessment whose rules packages you want to list.
 	AssessmentArn *string `locationName:"assessmentArn" type:"string" required:"true"`
 
@@ -2223,8 +2225,6 @@ type ListAttachedRulesPackagesInput struct {
 	// Subsequent calls to the action fill nextToken in the request with the value
 	// of NextToken from previous response to continue listing data.
 	NextToken *string `locationName:"nextToken" type:"string"`
-
-	_ struct{} `type:"structure"`
 }
 
 // String returns the string representation
@@ -2238,6 +2238,8 @@ func (s ListAttachedRulesPackagesInput) GoString() string {
 }
 
 type ListAttachedRulesPackagesOutput struct {
+	_ struct{} `type:"structure"`
+
 	// When a response is generated, if there is more data to be listed, this parameter
 	// is present in the response and contains the value to use for the nextToken
 	// parameter in a subsequent pagination request. If there is no more data to
@@ -2246,8 +2248,6 @@ type ListAttachedRulesPackagesOutput struct {
 
 	// A list of ARNs specifying the rules packages returned by the action.
 	RulesPackageArnList []*string `locationName:"rulesPackageArnList" type:"list"`
-
-	_ struct{} `type:"structure"`
 }
 
 // String returns the string representation
@@ -2261,6 +2261,8 @@ func (s ListAttachedRulesPackagesOutput) GoString() string {
 }
 
 type ListFindingsInput struct {
+	_ struct{} `type:"structure"`
+
 	// You can use this parameter to specify a subset of data to be included in
 	// the action's response.
 	//
@@ -2282,8 +2284,6 @@ type ListFindingsInput struct {
 	// The ARNs of the assessment runs that generate the findings that you want
 	// to list.
 	RunArns []*string `locationName:"runArns" type:"list"`
-
-	_ struct{} `type:"structure"`
 }
 
 // String returns the string representation
@@ -2297,6 +2297,8 @@ func (s ListFindingsInput) GoString() string {
 }
 
 type ListFindingsOutput struct {
+	_ struct{} `type:"structure"`
+
 	// A list of ARNs specifying the findings returned by the action.
 	FindingArnList []*string `locationName:"findingArnList" type:"list"`
 
@@ -2305,8 +2307,6 @@ type ListFindingsOutput struct {
 	// parameter in a subsequent pagination request. If there is no more data to
 	// be listed, this parameter is set to 'null'.
 	NextToken *string `locationName:"nextToken" type:"string"`
-
-	_ struct{} `type:"structure"`
 }
 
 // String returns the string representation
@@ -2320,6 +2320,8 @@ func (s ListFindingsOutput) GoString() string {
 }
 
 type ListRulesPackagesInput struct {
+	_ struct{} `type:"structure"`
+
 	// You can use this parameter to indicate the maximum number of items you want
 	// in the response. The default value is 10. The maximum value is 500.
 	MaxResults *int64 `locationName:"maxResults" type:"integer"`
@@ -2329,8 +2331,6 @@ type ListRulesPackagesInput struct {
 	// calls to the action fill nextToken in the request with the value of NextToken
 	// from previous response to continue listing data.
 	NextToken *string `locationName:"nextToken" type:"string"`
-
-	_ struct{} `type:"structure"`
 }
 
 // String returns the string representation
@@ -2344,6 +2344,8 @@ func (s ListRulesPackagesInput) GoString() string {
 }
 
 type ListRulesPackagesOutput struct {
+	_ struct{} `type:"structure"`
+
 	// When a response is generated, if there is more data to be listed, this parameter
 	// is present in the response and contains the value to use for the nextToken
 	// parameter in a subsequent pagination request. If there is no more data to
@@ -2352,8 +2354,6 @@ type ListRulesPackagesOutput struct {
 
 	// The list of ARNs specifying the rules packages returned by the action.
 	RulesPackageArnList []*string `locationName:"rulesPackageArnList" type:"list"`
-
-	_ struct{} `type:"structure"`
 }
 
 // String returns the string representation
@@ -2367,6 +2367,8 @@ func (s ListRulesPackagesOutput) GoString() string {
 }
 
 type ListRunsInput struct {
+	_ struct{} `type:"structure"`
+
 	// The ARNs specifying the assessments whose runs you want to list.
 	AssessmentArns []*string `locationName:"assessmentArns" type:"list"`
 
@@ -2387,8 +2389,6 @@ type ListRunsInput struct {
 	// calls to the action fill nextToken in the request with the value of NextToken
 	// from previous response to continue listing data.
 	NextToken *string `locationName:"nextToken" type:"string"`
-
-	_ struct{} `type:"structure"`
 }
 
 // String returns the string representation
@@ -2402,6 +2402,8 @@ func (s ListRunsInput) GoString() string {
 }
 
 type ListRunsOutput struct {
+	_ struct{} `type:"structure"`
+
 	// When a response is generated, if there is more data to be listed, this parameter
 	// is present in the response and contains the value to use for the nextToken
 	// parameter in a subsequent pagination request. If there is no more data to
@@ -2410,8 +2412,6 @@ type ListRunsOutput struct {
 
 	// A list of ARNs specifying the assessment runs returned by the action.
 	RunArnList []*string `locationName:"runArnList" type:"list"`
-
-	_ struct{} `type:"structure"`
 }
 
 // String returns the string representation
@@ -2425,10 +2425,10 @@ func (s ListRunsOutput) GoString() string {
 }
 
 type ListTagsForResourceInput struct {
+	_ struct{} `type:"structure"`
+
 	// The ARN specifying the resource whose tags you want to list.
 	ResourceArn *string `locationName:"resourceArn" type:"string" required:"true"`
-
-	_ struct{} `type:"structure"`
 }
 
 // String returns the string representation
@@ -2442,10 +2442,10 @@ func (s ListTagsForResourceInput) GoString() string {
 }
 
 type ListTagsForResourceOutput struct {
+	_ struct{} `type:"structure"`
+
 	// A collection of key and value pairs.
 	TagList []*Tag `locationName:"tagList" type:"list"`
-
-	_ struct{} `type:"structure"`
 }
 
 // String returns the string representation
@@ -2459,13 +2459,13 @@ func (s ListTagsForResourceOutput) GoString() string {
 }
 
 type LocalizeTextInput struct {
+	_ struct{} `type:"structure"`
+
 	// The locale that you want to translate a textual identifier into.
 	Locale *string `locationName:"locale" type:"string" required:"true"`
 
 	// A list of textual identifiers.
 	LocalizedTexts []*LocalizedText `locationName:"localizedTexts" type:"list" required:"true"`
-
-	_ struct{} `type:"structure"`
 }
 
 // String returns the string representation
@@ -2479,13 +2479,13 @@ func (s LocalizeTextInput) GoString() string {
 }
 
 type LocalizeTextOutput struct {
+	_ struct{} `type:"structure"`
+
 	// Confirmation details of the action performed.
 	Message *string `locationName:"message" type:"string"`
 
 	// The resulting list of user-readable texts.
 	Results []*string `locationName:"results" type:"list"`
-
-	_ struct{} `type:"structure"`
 }
 
 // String returns the string representation
@@ -2501,13 +2501,13 @@ func (s LocalizeTextOutput) GoString() string {
 // The textual identifier. This data type is used as the request parameter in
 // the LocalizeText action.
 type LocalizedText struct {
+	_ struct{} `type:"structure"`
+
 	// The facility and id properties of the LocalizedTextKey data type.
 	Key *LocalizedTextKey `locationName:"key" type:"structure"`
 
 	// Values for the dynamic elements of the string specified by the textual identifier.
 	Parameters []*Parameter `locationName:"parameters" type:"list"`
-
-	_ struct{} `type:"structure"`
 }
 
 // String returns the string representation
@@ -2522,13 +2522,13 @@ func (s LocalizedText) GoString() string {
 
 // This data type is used in the LocalizedText data type.
 type LocalizedTextKey struct {
+	_ struct{} `type:"structure"`
+
 	// The module response source of the text.
 	Facility *string `locationName:"facility" type:"string"`
 
 	// Part of the module response source of the text.
 	Id *string `locationName:"id" type:"string"`
-
-	_ struct{} `type:"structure"`
 }
 
 // String returns the string representation
@@ -2547,6 +2547,8 @@ func (s LocalizedTextKey) GoString() string {
 // on your EC2 instances during an assessment and passed to the Inspector service
 // for analysis.
 type MessageTypeTelemetry struct {
+	_ struct{} `type:"structure"`
+
 	// The number of times that the behavioral data is collected by the agent during
 	// an assessment.
 	Count *int64 `locationName:"count" type:"long"`
@@ -2557,8 +2559,6 @@ type MessageTypeTelemetry struct {
 
 	// A specific type of behavioral data that is collected by the agent.
 	MessageType *string `locationName:"messageType" type:"string"`
-
-	_ struct{} `type:"structure"`
 }
 
 // String returns the string representation
@@ -2573,13 +2573,13 @@ func (s MessageTypeTelemetry) GoString() string {
 
 // This data type is used in the LocalizedText data type.
 type Parameter struct {
+	_ struct{} `type:"structure"`
+
 	// The name of the variable that is being replaced.
 	Name *string `locationName:"name" type:"string"`
 
 	// The value assigned to the variable that is being replaced.
 	Value *string `locationName:"value" type:"string"`
-
-	_ struct{} `type:"structure"`
 }
 
 // String returns the string representation
@@ -2593,6 +2593,8 @@ func (s Parameter) GoString() string {
 }
 
 type PreviewAgentsForResourceGroupInput struct {
+	_ struct{} `type:"structure"`
+
 	// You can use this parameter to indicate the maximum number of items you want
 	// in the response. The default value is 10. The maximum value is 500.
 	MaxResults *int64 `locationName:"maxResults" type:"integer"`
@@ -2605,8 +2607,6 @@ type PreviewAgentsForResourceGroupInput struct {
 
 	// The ARN of the resource group that is used to create an application.
 	ResourceGroupArn *string `locationName:"resourceGroupArn" type:"string" required:"true"`
-
-	_ struct{} `type:"structure"`
 }
 
 // String returns the string representation
@@ -2620,6 +2620,8 @@ func (s PreviewAgentsForResourceGroupInput) GoString() string {
 }
 
 type PreviewAgentsForResourceGroupOutput struct {
+	_ struct{} `type:"structure"`
+
 	// The resulting list of agents.
 	AgentPreviewList []*AgentPreview `locationName:"agentPreviewList" type:"list"`
 
@@ -2628,8 +2630,6 @@ type PreviewAgentsForResourceGroupOutput struct {
 	// parameter in a subsequent pagination request. If there is no more data to
 	// be listed, this parameter is set to 'null'.
 	NextToken *string `locationName:"nextToken" type:"string"`
-
-	_ struct{} `type:"structure"`
 }
 
 // String returns the string representation
@@ -2643,11 +2643,11 @@ func (s PreviewAgentsForResourceGroupOutput) GoString() string {
 }
 
 type RegisterCrossAccountAccessRoleInput struct {
+	_ struct{} `type:"structure"`
+
 	// The ARN of the IAM role that Inspector uses to list your EC2 instances during
 	// the assessment.
 	RoleArn *string `locationName:"roleArn" type:"string" required:"true"`
-
-	_ struct{} `type:"structure"`
 }
 
 // String returns the string representation
@@ -2661,10 +2661,10 @@ func (s RegisterCrossAccountAccessRoleInput) GoString() string {
 }
 
 type RegisterCrossAccountAccessRoleOutput struct {
+	_ struct{} `type:"structure"`
+
 	// Confirmation details of the action performed.
 	Message *string `locationName:"message" type:"string"`
-
-	_ struct{} `type:"structure"`
 }
 
 // String returns the string representation
@@ -2678,13 +2678,13 @@ func (s RegisterCrossAccountAccessRoleOutput) GoString() string {
 }
 
 type RemoveAttributesFromFindingsInput struct {
+	_ struct{} `type:"structure"`
+
 	// The array of attribute keys that you want to remove from specified findings.
 	AttributeKeys []*string `locationName:"attributeKeys" type:"list" required:"true"`
 
 	// The ARNs specifying the findings that you want to remove attributes from.
 	FindingArns []*string `locationName:"findingArns" type:"list" required:"true"`
-
-	_ struct{} `type:"structure"`
 }
 
 // String returns the string representation
@@ -2698,10 +2698,10 @@ func (s RemoveAttributesFromFindingsInput) GoString() string {
 }
 
 type RemoveAttributesFromFindingsOutput struct {
+	_ struct{} `type:"structure"`
+
 	// Confirmation details of the action performed.
 	Message *string `locationName:"message" type:"string"`
-
-	_ struct{} `type:"structure"`
 }
 
 // String returns the string representation
@@ -2721,6 +2721,8 @@ func (s RemoveAttributesFromFindingsOutput) GoString() string {
 // This data type is used as the response element in the DescribeResourceGroup
 // action.
 type ResourceGroup struct {
+	_ struct{} `type:"structure"`
+
 	// The ARN of the resource group.
 	ResourceGroupArn *string `locationName:"resourceGroupArn" type:"string"`
 
@@ -2732,8 +2734,6 @@ type ResourceGroup struct {
 	//
 	// For example, [{ "key1" : ["Value1","Value2"]},{"Key2": ["Value3"]}]
 	ResourceGroupTags *string `locationName:"resourceGroupTags" type:"string"`
-
-	_ struct{} `type:"structure"`
 }
 
 // String returns the string representation
@@ -2751,6 +2751,8 @@ func (s ResourceGroup) GoString() string {
 // This data type is used as the response element in the DescribeRulesPackage
 // action.
 type RulesPackage struct {
+	_ struct{} `type:"structure"`
+
 	// The description of the rules package.
 	Description *LocalizedText `locationName:"description" type:"structure"`
 
@@ -2765,8 +2767,6 @@ type RulesPackage struct {
 
 	// The version id of the rules package.
 	Version *string `locationName:"version" type:"string"`
-
-	_ struct{} `type:"structure"`
 }
 
 // String returns the string representation
@@ -2783,6 +2783,8 @@ func (s RulesPackage) GoString() string {
 //
 // This data type is used as the response element in the DescribeRun action.
 type Run struct {
+	_ struct{} `type:"structure"`
+
 	// The ARN of the assessment that is associated with the run.
 	AssessmentArn *string `locationName:"assessmentArn" type:"string"`
 
@@ -2806,8 +2808,6 @@ type Run struct {
 	// The state of the run. Values can be set to DataCollectionComplete, EvaluatingPolicies,
 	// EvaluatingPoliciesErrorCanRetry, Completed, Failed, TombStoned.
 	RunState *string `locationName:"runState" type:"string"`
-
-	_ struct{} `type:"structure"`
 }
 
 // String returns the string representation
@@ -2821,13 +2821,13 @@ func (s Run) GoString() string {
 }
 
 type RunAssessmentInput struct {
+	_ struct{} `type:"structure"`
+
 	// The ARN of the assessment that you want to run.
 	AssessmentArn *string `locationName:"assessmentArn" type:"string" required:"true"`
 
 	// A name specifying the run of the assessment.
 	RunName *string `locationName:"runName" type:"string" required:"true"`
-
-	_ struct{} `type:"structure"`
 }
 
 // String returns the string representation
@@ -2841,10 +2841,10 @@ func (s RunAssessmentInput) GoString() string {
 }
 
 type RunAssessmentOutput struct {
+	_ struct{} `type:"structure"`
+
 	// The ARN specifying the run of the assessment.
 	RunArn *string `locationName:"runArn" type:"string"`
-
-	_ struct{} `type:"structure"`
 }
 
 // String returns the string representation
@@ -2859,6 +2859,8 @@ func (s RunAssessmentOutput) GoString() string {
 
 // This data type is used as the request parameter in the ListRuns action.
 type RunsFilter struct {
+	_ struct{} `type:"structure"`
+
 	// For a record to match a filter, the value specified for this data type property
 	// must inclusively match any value between the specified minimum and maximum
 	// values of the completionTime property of the Run data type.
@@ -2883,8 +2885,6 @@ type RunsFilter struct {
 	// must be the exact match of the value of the runState property of the Run
 	// data type.
 	RunStates []*string `locationName:"runStates" type:"list"`
-
-	_ struct{} `type:"structure"`
 }
 
 // String returns the string representation
@@ -2898,13 +2898,13 @@ func (s RunsFilter) GoString() string {
 }
 
 type SetTagsForResourceInput struct {
+	_ struct{} `type:"structure"`
+
 	// The ARN of the assessment that you want to set tags to.
 	ResourceArn *string `locationName:"resourceArn" type:"string" required:"true"`
 
 	// A collection of key and value pairs that you want to set to an assessment.
 	Tags []*Tag `locationName:"tags" type:"list"`
-
-	_ struct{} `type:"structure"`
 }
 
 // String returns the string representation
@@ -2918,10 +2918,10 @@ func (s SetTagsForResourceInput) GoString() string {
 }
 
 type SetTagsForResourceOutput struct {
+	_ struct{} `type:"structure"`
+
 	// Confirmation details of the action performed.
 	Message *string `locationName:"message" type:"string"`
-
-	_ struct{} `type:"structure"`
 }
 
 // String returns the string representation
@@ -2935,11 +2935,11 @@ func (s SetTagsForResourceOutput) GoString() string {
 }
 
 type StartDataCollectionInput struct {
+	_ struct{} `type:"structure"`
+
 	// The ARN of the assessment for which you want to start the data collection
 	// process.
 	AssessmentArn *string `locationName:"assessmentArn" type:"string" required:"true"`
-
-	_ struct{} `type:"structure"`
 }
 
 // String returns the string representation
@@ -2953,10 +2953,10 @@ func (s StartDataCollectionInput) GoString() string {
 }
 
 type StartDataCollectionOutput struct {
+	_ struct{} `type:"structure"`
+
 	// Confirmation details of the action performed.
 	Message *string `locationName:"message" type:"string"`
-
-	_ struct{} `type:"structure"`
 }
 
 // String returns the string representation
@@ -2970,11 +2970,11 @@ func (s StartDataCollectionOutput) GoString() string {
 }
 
 type StopDataCollectionInput struct {
+	_ struct{} `type:"structure"`
+
 	// The ARN of the assessment for which you want to stop the data collection
 	// process.
 	AssessmentArn *string `locationName:"assessmentArn" type:"string" required:"true"`
-
-	_ struct{} `type:"structure"`
 }
 
 // String returns the string representation
@@ -2988,10 +2988,10 @@ func (s StopDataCollectionInput) GoString() string {
 }
 
 type StopDataCollectionOutput struct {
+	_ struct{} `type:"structure"`
+
 	// Confirmation details of the action performed.
 	Message *string `locationName:"message" type:"string"`
-
-	_ struct{} `type:"structure"`
 }
 
 // String returns the string representation
@@ -3009,13 +3009,13 @@ func (s StopDataCollectionOutput) GoString() string {
 // This data type is used as a request parameter in the SetTagsForResource
 // action and a response element in the ListTagsForResource action.
 type Tag struct {
+	_ struct{} `type:"structure"`
+
 	// The tag key.
 	Key *string `type:"string"`
 
 	// The value assigned to a tag key.
 	Value *string `type:"string"`
-
-	_ struct{} `type:"structure"`
 }
 
 // String returns the string representation
@@ -3034,14 +3034,14 @@ func (s Tag) GoString() string {
 // This data type is used as the response element in the GetAssessmentTelemetry
 // action.
 type Telemetry struct {
+	_ struct{} `type:"structure"`
+
 	// Counts of individual metrics received by Inspector from the agent.
 	MessageTypeTelemetries []*MessageTypeTelemetry `locationName:"messageTypeTelemetries" type:"list"`
 
 	// The category of the individual metrics that together constitute the telemetry
 	// that Inspector received from the agent.
 	Status *string `locationName:"status" type:"string"`
-
-	_ struct{} `type:"structure"`
 }
 
 // String returns the string representation
@@ -3056,13 +3056,13 @@ func (s Telemetry) GoString() string {
 
 // This data type is used in the AssessmentsFilter and RunsFilter data types.
 type TimestampRange struct {
+	_ struct{} `type:"structure"`
+
 	// The maximum value of the timestamp range.
 	Maximum *time.Time `locationName:"maximum" type:"timestamp" timestampFormat:"unix"`
 
 	// The minimum value of the timestamp range.
 	Minimum *time.Time `locationName:"minimum" type:"timestamp" timestampFormat:"unix"`
-
-	_ struct{} `type:"structure"`
 }
 
 // String returns the string representation
@@ -3076,6 +3076,8 @@ func (s TimestampRange) GoString() string {
 }
 
 type UpdateApplicationInput struct {
+	_ struct{} `type:"structure"`
+
 	// Application ARN that you want to update.
 	ApplicationArn *string `locationName:"applicationArn" type:"string" required:"true"`
 
@@ -3084,8 +3086,6 @@ type UpdateApplicationInput struct {
 
 	// The resource group ARN that you want to update.
 	ResourceGroupArn *string `locationName:"resourceGroupArn" type:"string" required:"true"`
-
-	_ struct{} `type:"structure"`
 }
 
 // String returns the string representation
@@ -3099,10 +3099,10 @@ func (s UpdateApplicationInput) GoString() string {
 }
 
 type UpdateApplicationOutput struct {
+	_ struct{} `type:"structure"`
+
 	// Confirmation details of the action performed.
 	Message *string `locationName:"message" type:"string"`
-
-	_ struct{} `type:"structure"`
 }
 
 // String returns the string representation
@@ -3116,6 +3116,8 @@ func (s UpdateApplicationOutput) GoString() string {
 }
 
 type UpdateAssessmentInput struct {
+	_ struct{} `type:"structure"`
+
 	// Asessment ARN that you want to update.
 	AssessmentArn *string `locationName:"assessmentArn" type:"string" required:"true"`
 
@@ -3125,8 +3127,6 @@ type UpdateAssessmentInput struct {
 	// Assessment duration in seconds that you want to update. The default value
 	// is 3600 seconds (one hour). The maximum value is 86400 seconds (one day).
 	DurationInSeconds *int64 `locationName:"durationInSeconds" type:"integer" required:"true"`
-
-	_ struct{} `type:"structure"`
 }
 
 // String returns the string representation
@@ -3140,10 +3140,10 @@ func (s UpdateAssessmentInput) GoString() string {
 }
 
 type UpdateAssessmentOutput struct {
+	_ struct{} `type:"structure"`
+
 	// Confirmation details of the action performed.
 	Message *string `locationName:"message" type:"string"`
-
-	_ struct{} `type:"structure"`
 }
 
 // String returns the string representation

--- a/service/iot/api.go
+++ b/service/iot/api.go
@@ -1158,11 +1158,7 @@ type AcceptCertificateTransferInput struct {
 	// Specifies whether the certificate is active.
 	SetAsActive *bool `location:"querystring" locationName:"setAsActive" type:"boolean"`
 
-	metadataAcceptCertificateTransferInput `json:"-" xml:"-"`
-}
-
-type metadataAcceptCertificateTransferInput struct {
-	SDKShapeTraits bool `type:"structure"`
+	_ struct{} `type:"structure"`
 }
 
 // String returns the string representation
@@ -1176,11 +1172,7 @@ func (s AcceptCertificateTransferInput) GoString() string {
 }
 
 type AcceptCertificateTransferOutput struct {
-	metadataAcceptCertificateTransferOutput `json:"-" xml:"-"`
-}
-
-type metadataAcceptCertificateTransferOutput struct {
-	SDKShapeTraits bool `type:"structure"`
+	_ struct{} `type:"structure"`
 }
 
 // String returns the string representation
@@ -1218,11 +1210,7 @@ type Action struct {
 	// Publish to an SQS queue.
 	Sqs *SqsAction `locationName:"sqs" type:"structure"`
 
-	metadataAction `json:"-" xml:"-"`
-}
-
-type metadataAction struct {
-	SDKShapeTraits bool `type:"structure"`
+	_ struct{} `type:"structure"`
 }
 
 // String returns the string representation
@@ -1244,11 +1232,7 @@ type AttachPrincipalPolicyInput struct {
 	// operation) or a Cognito ID.
 	Principal *string `location:"header" locationName:"x-amzn-iot-principal" type:"string" required:"true"`
 
-	metadataAttachPrincipalPolicyInput `json:"-" xml:"-"`
-}
-
-type metadataAttachPrincipalPolicyInput struct {
-	SDKShapeTraits bool `type:"structure"`
+	_ struct{} `type:"structure"`
 }
 
 // String returns the string representation
@@ -1262,11 +1246,7 @@ func (s AttachPrincipalPolicyInput) GoString() string {
 }
 
 type AttachPrincipalPolicyOutput struct {
-	metadataAttachPrincipalPolicyOutput `json:"-" xml:"-"`
-}
-
-type metadataAttachPrincipalPolicyOutput struct {
-	SDKShapeTraits bool `type:"structure"`
+	_ struct{} `type:"structure"`
 }
 
 // String returns the string representation
@@ -1287,11 +1267,7 @@ type AttachThingPrincipalInput struct {
 	// The name of the thing.
 	ThingName *string `location:"uri" locationName:"thingName" min:"1" type:"string" required:"true"`
 
-	metadataAttachThingPrincipalInput `json:"-" xml:"-"`
-}
-
-type metadataAttachThingPrincipalInput struct {
-	SDKShapeTraits bool `type:"structure"`
+	_ struct{} `type:"structure"`
 }
 
 // String returns the string representation
@@ -1306,11 +1282,7 @@ func (s AttachThingPrincipalInput) GoString() string {
 
 // The output from the AttachThingPrincipal operation.
 type AttachThingPrincipalOutput struct {
-	metadataAttachThingPrincipalOutput `json:"-" xml:"-"`
-}
-
-type metadataAttachThingPrincipalOutput struct {
-	SDKShapeTraits bool `type:"structure"`
+	_ struct{} `type:"structure"`
 }
 
 // String returns the string representation
@@ -1332,11 +1304,7 @@ type AttributePayload struct {
 	// For example: {\"attributes\":{\"string1\":\"string2\”}}
 	Attributes map[string]*string `locationName:"attributes" type:"map"`
 
-	metadataAttributePayload `json:"-" xml:"-"`
-}
-
-type metadataAttributePayload struct {
-	SDKShapeTraits bool `type:"structure"`
+	_ struct{} `type:"structure"`
 }
 
 // String returns the string representation
@@ -1354,11 +1322,7 @@ type CancelCertificateTransferInput struct {
 	// The ID of the certificate.
 	CertificateId *string `location:"uri" locationName:"certificateId" min:"64" type:"string" required:"true"`
 
-	metadataCancelCertificateTransferInput `json:"-" xml:"-"`
-}
-
-type metadataCancelCertificateTransferInput struct {
-	SDKShapeTraits bool `type:"structure"`
+	_ struct{} `type:"structure"`
 }
 
 // String returns the string representation
@@ -1372,11 +1336,7 @@ func (s CancelCertificateTransferInput) GoString() string {
 }
 
 type CancelCertificateTransferOutput struct {
-	metadataCancelCertificateTransferOutput `json:"-" xml:"-"`
-}
-
-type metadataCancelCertificateTransferOutput struct {
-	SDKShapeTraits bool `type:"structure"`
+	_ struct{} `type:"structure"`
 }
 
 // String returns the string representation
@@ -1403,11 +1363,7 @@ type Certificate struct {
 	// The status of the certificate.
 	Status *string `locationName:"status" type:"string" enum:"CertificateStatus"`
 
-	metadataCertificate `json:"-" xml:"-"`
-}
-
-type metadataCertificate struct {
-	SDKShapeTraits bool `type:"structure"`
+	_ struct{} `type:"structure"`
 }
 
 // String returns the string representation
@@ -1443,11 +1399,7 @@ type CertificateDescription struct {
 	// The status of the certificate.
 	Status *string `locationName:"status" type:"string" enum:"CertificateStatus"`
 
-	metadataCertificateDescription `json:"-" xml:"-"`
-}
-
-type metadataCertificateDescription struct {
-	SDKShapeTraits bool `type:"structure"`
+	_ struct{} `type:"structure"`
 }
 
 // String returns the string representation
@@ -1468,11 +1420,7 @@ type CreateCertificateFromCsrInput struct {
 	// Specifies whether the certificate is active.
 	SetAsActive *bool `location:"querystring" locationName:"setAsActive" type:"boolean"`
 
-	metadataCreateCertificateFromCsrInput `json:"-" xml:"-"`
-}
-
-type metadataCreateCertificateFromCsrInput struct {
-	SDKShapeTraits bool `type:"structure"`
+	_ struct{} `type:"structure"`
 }
 
 // String returns the string representation
@@ -1498,11 +1446,7 @@ type CreateCertificateFromCsrOutput struct {
 	// The certificate data, in PEM format.
 	CertificatePem *string `locationName:"certificatePem" type:"string"`
 
-	metadataCreateCertificateFromCsrOutput `json:"-" xml:"-"`
-}
-
-type metadataCreateCertificateFromCsrOutput struct {
-	SDKShapeTraits bool `type:"structure"`
+	_ struct{} `type:"structure"`
 }
 
 // String returns the string representation
@@ -1520,11 +1464,7 @@ type CreateKeysAndCertificateInput struct {
 	// Specifies whether the certificate is active.
 	SetAsActive *bool `location:"querystring" locationName:"setAsActive" type:"boolean"`
 
-	metadataCreateKeysAndCertificateInput `json:"-" xml:"-"`
-}
-
-type metadataCreateKeysAndCertificateInput struct {
-	SDKShapeTraits bool `type:"structure"`
+	_ struct{} `type:"structure"`
 }
 
 // String returns the string representation
@@ -1552,11 +1492,7 @@ type CreateKeysAndCertificateOutput struct {
 	// The generated key pair.
 	KeyPair *KeyPair `locationName:"keyPair" type:"structure"`
 
-	metadataCreateKeysAndCertificateOutput `json:"-" xml:"-"`
-}
-
-type metadataCreateKeysAndCertificateOutput struct {
-	SDKShapeTraits bool `type:"structure"`
+	_ struct{} `type:"structure"`
 }
 
 // String returns the string representation
@@ -1578,11 +1514,7 @@ type CreatePolicyInput struct {
 	// The policy name.
 	PolicyName *string `location:"uri" locationName:"policyName" min:"1" type:"string" required:"true"`
 
-	metadataCreatePolicyInput `json:"-" xml:"-"`
-}
-
-type metadataCreatePolicyInput struct {
-	SDKShapeTraits bool `type:"structure"`
+	_ struct{} `type:"structure"`
 }
 
 // String returns the string representation
@@ -1609,11 +1541,7 @@ type CreatePolicyOutput struct {
 	// The policy version ID.
 	PolicyVersionId *string `locationName:"policyVersionId" type:"string"`
 
-	metadataCreatePolicyOutput `json:"-" xml:"-"`
-}
-
-type metadataCreatePolicyOutput struct {
-	SDKShapeTraits bool `type:"structure"`
+	_ struct{} `type:"structure"`
 }
 
 // String returns the string representation
@@ -1637,11 +1565,7 @@ type CreatePolicyVersionInput struct {
 	// Specifies whether the policy version is set as the default.
 	SetAsDefault *bool `location:"querystring" locationName:"setAsDefault" type:"boolean"`
 
-	metadataCreatePolicyVersionInput `json:"-" xml:"-"`
-}
-
-type metadataCreatePolicyVersionInput struct {
-	SDKShapeTraits bool `type:"structure"`
+	_ struct{} `type:"structure"`
 }
 
 // String returns the string representation
@@ -1668,11 +1592,7 @@ type CreatePolicyVersionOutput struct {
 	// The policy version ID.
 	PolicyVersionId *string `locationName:"policyVersionId" type:"string"`
 
-	metadataCreatePolicyVersionOutput `json:"-" xml:"-"`
-}
-
-type metadataCreatePolicyVersionOutput struct {
-	SDKShapeTraits bool `type:"structure"`
+	_ struct{} `type:"structure"`
 }
 
 // String returns the string representation
@@ -1694,11 +1614,7 @@ type CreateThingInput struct {
 	// The name of the thing.
 	ThingName *string `location:"uri" locationName:"thingName" min:"1" type:"string" required:"true"`
 
-	metadataCreateThingInput `json:"-" xml:"-"`
-}
-
-type metadataCreateThingInput struct {
-	SDKShapeTraits bool `type:"structure"`
+	_ struct{} `type:"structure"`
 }
 
 // String returns the string representation
@@ -1719,11 +1635,7 @@ type CreateThingOutput struct {
 	// The name of the thing.
 	ThingName *string `locationName:"thingName" min:"1" type:"string"`
 
-	metadataCreateThingOutput `json:"-" xml:"-"`
-}
-
-type metadataCreateThingOutput struct {
-	SDKShapeTraits bool `type:"structure"`
+	_ struct{} `type:"structure"`
 }
 
 // String returns the string representation
@@ -1744,11 +1656,7 @@ type CreateTopicRuleInput struct {
 	// The rule payload.
 	TopicRulePayload *TopicRulePayload `locationName:"topicRulePayload" type:"structure" required:"true"`
 
-	metadataCreateTopicRuleInput `json:"-" xml:"-"`
-}
-
-type metadataCreateTopicRuleInput struct {
-	SDKShapeTraits bool `type:"structure" payload:"TopicRulePayload"`
+	_ struct{} `type:"structure" payload:"TopicRulePayload"`
 }
 
 // String returns the string representation
@@ -1762,11 +1670,7 @@ func (s CreateTopicRuleInput) GoString() string {
 }
 
 type CreateTopicRuleOutput struct {
-	metadataCreateTopicRuleOutput `json:"-" xml:"-"`
-}
-
-type metadataCreateTopicRuleOutput struct {
-	SDKShapeTraits bool `type:"structure"`
+	_ struct{} `type:"structure"`
 }
 
 // String returns the string representation
@@ -1784,11 +1688,7 @@ type DeleteCertificateInput struct {
 	// The ID of the certificate.
 	CertificateId *string `location:"uri" locationName:"certificateId" min:"64" type:"string" required:"true"`
 
-	metadataDeleteCertificateInput `json:"-" xml:"-"`
-}
-
-type metadataDeleteCertificateInput struct {
-	SDKShapeTraits bool `type:"structure"`
+	_ struct{} `type:"structure"`
 }
 
 // String returns the string representation
@@ -1802,11 +1702,7 @@ func (s DeleteCertificateInput) GoString() string {
 }
 
 type DeleteCertificateOutput struct {
-	metadataDeleteCertificateOutput `json:"-" xml:"-"`
-}
-
-type metadataDeleteCertificateOutput struct {
-	SDKShapeTraits bool `type:"structure"`
+	_ struct{} `type:"structure"`
 }
 
 // String returns the string representation
@@ -1824,11 +1720,7 @@ type DeletePolicyInput struct {
 	// The name of the policy to delete.
 	PolicyName *string `location:"uri" locationName:"policyName" min:"1" type:"string" required:"true"`
 
-	metadataDeletePolicyInput `json:"-" xml:"-"`
-}
-
-type metadataDeletePolicyInput struct {
-	SDKShapeTraits bool `type:"structure"`
+	_ struct{} `type:"structure"`
 }
 
 // String returns the string representation
@@ -1842,11 +1734,7 @@ func (s DeletePolicyInput) GoString() string {
 }
 
 type DeletePolicyOutput struct {
-	metadataDeletePolicyOutput `json:"-" xml:"-"`
-}
-
-type metadataDeletePolicyOutput struct {
-	SDKShapeTraits bool `type:"structure"`
+	_ struct{} `type:"structure"`
 }
 
 // String returns the string representation
@@ -1867,11 +1755,7 @@ type DeletePolicyVersionInput struct {
 	// The policy version ID.
 	PolicyVersionId *string `location:"uri" locationName:"policyVersionId" type:"string" required:"true"`
 
-	metadataDeletePolicyVersionInput `json:"-" xml:"-"`
-}
-
-type metadataDeletePolicyVersionInput struct {
-	SDKShapeTraits bool `type:"structure"`
+	_ struct{} `type:"structure"`
 }
 
 // String returns the string representation
@@ -1885,11 +1769,7 @@ func (s DeletePolicyVersionInput) GoString() string {
 }
 
 type DeletePolicyVersionOutput struct {
-	metadataDeletePolicyVersionOutput `json:"-" xml:"-"`
-}
-
-type metadataDeletePolicyVersionOutput struct {
-	SDKShapeTraits bool `type:"structure"`
+	_ struct{} `type:"structure"`
 }
 
 // String returns the string representation
@@ -1907,11 +1787,7 @@ type DeleteThingInput struct {
 	// The thing name.
 	ThingName *string `location:"uri" locationName:"thingName" min:"1" type:"string" required:"true"`
 
-	metadataDeleteThingInput `json:"-" xml:"-"`
-}
-
-type metadataDeleteThingInput struct {
-	SDKShapeTraits bool `type:"structure"`
+	_ struct{} `type:"structure"`
 }
 
 // String returns the string representation
@@ -1926,11 +1802,7 @@ func (s DeleteThingInput) GoString() string {
 
 // The output of the DeleteThing operation.
 type DeleteThingOutput struct {
-	metadataDeleteThingOutput `json:"-" xml:"-"`
-}
-
-type metadataDeleteThingOutput struct {
-	SDKShapeTraits bool `type:"structure"`
+	_ struct{} `type:"structure"`
 }
 
 // String returns the string representation
@@ -1948,11 +1820,7 @@ type DeleteTopicRuleInput struct {
 	// The name of the rule.
 	RuleName *string `location:"uri" locationName:"ruleName" min:"1" type:"string" required:"true"`
 
-	metadataDeleteTopicRuleInput `json:"-" xml:"-"`
-}
-
-type metadataDeleteTopicRuleInput struct {
-	SDKShapeTraits bool `type:"structure"`
+	_ struct{} `type:"structure"`
 }
 
 // String returns the string representation
@@ -1966,11 +1834,7 @@ func (s DeleteTopicRuleInput) GoString() string {
 }
 
 type DeleteTopicRuleOutput struct {
-	metadataDeleteTopicRuleOutput `json:"-" xml:"-"`
-}
-
-type metadataDeleteTopicRuleOutput struct {
-	SDKShapeTraits bool `type:"structure"`
+	_ struct{} `type:"structure"`
 }
 
 // String returns the string representation
@@ -1988,11 +1852,7 @@ type DescribeCertificateInput struct {
 	// The ID of the certificate.
 	CertificateId *string `location:"uri" locationName:"certificateId" min:"64" type:"string" required:"true"`
 
-	metadataDescribeCertificateInput `json:"-" xml:"-"`
-}
-
-type metadataDescribeCertificateInput struct {
-	SDKShapeTraits bool `type:"structure"`
+	_ struct{} `type:"structure"`
 }
 
 // String returns the string representation
@@ -2010,11 +1870,7 @@ type DescribeCertificateOutput struct {
 	// The description of the certificate.
 	CertificateDescription *CertificateDescription `locationName:"certificateDescription" type:"structure"`
 
-	metadataDescribeCertificateOutput `json:"-" xml:"-"`
-}
-
-type metadataDescribeCertificateOutput struct {
-	SDKShapeTraits bool `type:"structure"`
+	_ struct{} `type:"structure"`
 }
 
 // String returns the string representation
@@ -2029,11 +1885,7 @@ func (s DescribeCertificateOutput) GoString() string {
 
 // The input for the DescribeEndpoint operation.
 type DescribeEndpointInput struct {
-	metadataDescribeEndpointInput `json:"-" xml:"-"`
-}
-
-type metadataDescribeEndpointInput struct {
-	SDKShapeTraits bool `type:"structure"`
+	_ struct{} `type:"structure"`
 }
 
 // String returns the string representation
@@ -2051,11 +1903,7 @@ type DescribeEndpointOutput struct {
 	// The address.
 	EndpointAddress *string `locationName:"endpointAddress" type:"string"`
 
-	metadataDescribeEndpointOutput `json:"-" xml:"-"`
-}
-
-type metadataDescribeEndpointOutput struct {
-	SDKShapeTraits bool `type:"structure"`
+	_ struct{} `type:"structure"`
 }
 
 // String returns the string representation
@@ -2073,11 +1921,7 @@ type DescribeThingInput struct {
 	// The name of the thing.
 	ThingName *string `location:"uri" locationName:"thingName" min:"1" type:"string" required:"true"`
 
-	metadataDescribeThingInput `json:"-" xml:"-"`
-}
-
-type metadataDescribeThingInput struct {
-	SDKShapeTraits bool `type:"structure"`
+	_ struct{} `type:"structure"`
 }
 
 // String returns the string representation
@@ -2104,11 +1948,7 @@ type DescribeThingOutput struct {
 	// The name of the thing.
 	ThingName *string `locationName:"thingName" min:"1" type:"string"`
 
-	metadataDescribeThingOutput `json:"-" xml:"-"`
-}
-
-type metadataDescribeThingOutput struct {
-	SDKShapeTraits bool `type:"structure"`
+	_ struct{} `type:"structure"`
 }
 
 // String returns the string representation
@@ -2132,11 +1972,7 @@ type DetachPrincipalPolicyInput struct {
 	// is a Cognito identity specify the identity ID.
 	Principal *string `location:"header" locationName:"x-amzn-iot-principal" type:"string" required:"true"`
 
-	metadataDetachPrincipalPolicyInput `json:"-" xml:"-"`
-}
-
-type metadataDetachPrincipalPolicyInput struct {
-	SDKShapeTraits bool `type:"structure"`
+	_ struct{} `type:"structure"`
 }
 
 // String returns the string representation
@@ -2150,11 +1986,7 @@ func (s DetachPrincipalPolicyInput) GoString() string {
 }
 
 type DetachPrincipalPolicyOutput struct {
-	metadataDetachPrincipalPolicyOutput `json:"-" xml:"-"`
-}
-
-type metadataDetachPrincipalPolicyOutput struct {
-	SDKShapeTraits bool `type:"structure"`
+	_ struct{} `type:"structure"`
 }
 
 // String returns the string representation
@@ -2175,11 +2007,7 @@ type DetachThingPrincipalInput struct {
 	// The name of the thing.
 	ThingName *string `location:"uri" locationName:"thingName" min:"1" type:"string" required:"true"`
 
-	metadataDetachThingPrincipalInput `json:"-" xml:"-"`
-}
-
-type metadataDetachThingPrincipalInput struct {
-	SDKShapeTraits bool `type:"structure"`
+	_ struct{} `type:"structure"`
 }
 
 // String returns the string representation
@@ -2194,11 +2022,7 @@ func (s DetachThingPrincipalInput) GoString() string {
 
 // The output from the DetachThingPrincipal operation.
 type DetachThingPrincipalOutput struct {
-	metadataDetachThingPrincipalOutput `json:"-" xml:"-"`
-}
-
-type metadataDetachThingPrincipalOutput struct {
-	SDKShapeTraits bool `type:"structure"`
+	_ struct{} `type:"structure"`
 }
 
 // String returns the string representation
@@ -2250,11 +2074,7 @@ type DynamoDBAction struct {
 	// The name of the DynamoDB table.
 	TableName *string `locationName:"tableName" type:"string" required:"true"`
 
-	metadataDynamoDBAction `json:"-" xml:"-"`
-}
-
-type metadataDynamoDBAction struct {
-	SDKShapeTraits bool `type:"structure"`
+	_ struct{} `type:"structure"`
 }
 
 // String returns the string representation
@@ -2272,11 +2092,7 @@ type FirehoseAction struct {
 
 	RoleArn *string `locationName:"roleArn" type:"string" required:"true"`
 
-	metadataFirehoseAction `json:"-" xml:"-"`
-}
-
-type metadataFirehoseAction struct {
-	SDKShapeTraits bool `type:"structure"`
+	_ struct{} `type:"structure"`
 }
 
 // String returns the string representation
@@ -2291,11 +2107,7 @@ func (s FirehoseAction) GoString() string {
 
 // The input for the GetLoggingOptions operation.
 type GetLoggingOptionsInput struct {
-	metadataGetLoggingOptionsInput `json:"-" xml:"-"`
-}
-
-type metadataGetLoggingOptionsInput struct {
-	SDKShapeTraits bool `type:"structure"`
+	_ struct{} `type:"structure"`
 }
 
 // String returns the string representation
@@ -2316,11 +2128,7 @@ type GetLoggingOptionsOutput struct {
 	// The ARN of the IAM role that grants access.
 	RoleArn *string `locationName:"roleArn" type:"string"`
 
-	metadataGetLoggingOptionsOutput `json:"-" xml:"-"`
-}
-
-type metadataGetLoggingOptionsOutput struct {
-	SDKShapeTraits bool `type:"structure"`
+	_ struct{} `type:"structure"`
 }
 
 // String returns the string representation
@@ -2338,11 +2146,7 @@ type GetPolicyInput struct {
 	// The name of the policy.
 	PolicyName *string `location:"uri" locationName:"policyName" min:"1" type:"string" required:"true"`
 
-	metadataGetPolicyInput `json:"-" xml:"-"`
-}
-
-type metadataGetPolicyInput struct {
-	SDKShapeTraits bool `type:"structure"`
+	_ struct{} `type:"structure"`
 }
 
 // String returns the string representation
@@ -2369,11 +2173,7 @@ type GetPolicyOutput struct {
 	// The policy name.
 	PolicyName *string `locationName:"policyName" min:"1" type:"string"`
 
-	metadataGetPolicyOutput `json:"-" xml:"-"`
-}
-
-type metadataGetPolicyOutput struct {
-	SDKShapeTraits bool `type:"structure"`
+	_ struct{} `type:"structure"`
 }
 
 // String returns the string representation
@@ -2394,11 +2194,7 @@ type GetPolicyVersionInput struct {
 	// The policy version ID.
 	PolicyVersionId *string `location:"uri" locationName:"policyVersionId" type:"string" required:"true"`
 
-	metadataGetPolicyVersionInput `json:"-" xml:"-"`
-}
-
-type metadataGetPolicyVersionInput struct {
-	SDKShapeTraits bool `type:"structure"`
+	_ struct{} `type:"structure"`
 }
 
 // String returns the string representation
@@ -2428,11 +2224,7 @@ type GetPolicyVersionOutput struct {
 	// The policy version ID.
 	PolicyVersionId *string `locationName:"policyVersionId" type:"string"`
 
-	metadataGetPolicyVersionOutput `json:"-" xml:"-"`
-}
-
-type metadataGetPolicyVersionOutput struct {
-	SDKShapeTraits bool `type:"structure"`
+	_ struct{} `type:"structure"`
 }
 
 // String returns the string representation
@@ -2450,11 +2242,7 @@ type GetTopicRuleInput struct {
 	// The name of the rule.
 	RuleName *string `location:"uri" locationName:"ruleName" min:"1" type:"string" required:"true"`
 
-	metadataGetTopicRuleInput `json:"-" xml:"-"`
-}
-
-type metadataGetTopicRuleInput struct {
-	SDKShapeTraits bool `type:"structure"`
+	_ struct{} `type:"structure"`
 }
 
 // String returns the string representation
@@ -2472,11 +2260,7 @@ type GetTopicRuleOutput struct {
 	// The rule.
 	Rule *TopicRule `locationName:"rule" type:"structure"`
 
-	metadataGetTopicRuleOutput `json:"-" xml:"-"`
-}
-
-type metadataGetTopicRuleOutput struct {
-	SDKShapeTraits bool `type:"structure"`
+	_ struct{} `type:"structure"`
 }
 
 // String returns the string representation
@@ -2497,11 +2281,7 @@ type KeyPair struct {
 	// The public key.
 	PublicKey *string `min:"1" type:"string"`
 
-	metadataKeyPair `json:"-" xml:"-"`
-}
-
-type metadataKeyPair struct {
-	SDKShapeTraits bool `type:"structure"`
+	_ struct{} `type:"structure"`
 }
 
 // String returns the string representation
@@ -2525,11 +2305,7 @@ type KinesisAction struct {
 	// The name of the Kinesis stream.
 	StreamName *string `locationName:"streamName" type:"string" required:"true"`
 
-	metadataKinesisAction `json:"-" xml:"-"`
-}
-
-type metadataKinesisAction struct {
-	SDKShapeTraits bool `type:"structure"`
+	_ struct{} `type:"structure"`
 }
 
 // String returns the string representation
@@ -2547,11 +2323,7 @@ type LambdaAction struct {
 	// The ARN of the Lambda function.
 	FunctionArn *string `locationName:"functionArn" type:"string" required:"true"`
 
-	metadataLambdaAction `json:"-" xml:"-"`
-}
-
-type metadataLambdaAction struct {
-	SDKShapeTraits bool `type:"structure"`
+	_ struct{} `type:"structure"`
 }
 
 // String returns the string representation
@@ -2576,11 +2348,7 @@ type ListCertificatesInput struct {
 	// The result page size.
 	PageSize *int64 `location:"querystring" locationName:"pageSize" min:"1" type:"integer"`
 
-	metadataListCertificatesInput `json:"-" xml:"-"`
-}
-
-type metadataListCertificatesInput struct {
-	SDKShapeTraits bool `type:"structure"`
+	_ struct{} `type:"structure"`
 }
 
 // String returns the string representation
@@ -2602,11 +2370,7 @@ type ListCertificatesOutput struct {
 	// results.
 	NextMarker *string `locationName:"nextMarker" type:"string"`
 
-	metadataListCertificatesOutput `json:"-" xml:"-"`
-}
-
-type metadataListCertificatesOutput struct {
-	SDKShapeTraits bool `type:"structure"`
+	_ struct{} `type:"structure"`
 }
 
 // String returns the string representation
@@ -2631,11 +2395,7 @@ type ListPoliciesInput struct {
 	// The result page size.
 	PageSize *int64 `location:"querystring" locationName:"pageSize" min:"1" type:"integer"`
 
-	metadataListPoliciesInput `json:"-" xml:"-"`
-}
-
-type metadataListPoliciesInput struct {
-	SDKShapeTraits bool `type:"structure"`
+	_ struct{} `type:"structure"`
 }
 
 // String returns the string representation
@@ -2657,11 +2417,7 @@ type ListPoliciesOutput struct {
 	// The descriptions of the policies.
 	Policies []*Policy `locationName:"policies" type:"list"`
 
-	metadataListPoliciesOutput `json:"-" xml:"-"`
-}
-
-type metadataListPoliciesOutput struct {
-	SDKShapeTraits bool `type:"structure"`
+	_ struct{} `type:"structure"`
 }
 
 // String returns the string representation
@@ -2679,11 +2435,7 @@ type ListPolicyVersionsInput struct {
 	// The policy name.
 	PolicyName *string `location:"uri" locationName:"policyName" min:"1" type:"string" required:"true"`
 
-	metadataListPolicyVersionsInput `json:"-" xml:"-"`
-}
-
-type metadataListPolicyVersionsInput struct {
-	SDKShapeTraits bool `type:"structure"`
+	_ struct{} `type:"structure"`
 }
 
 // String returns the string representation
@@ -2701,11 +2453,7 @@ type ListPolicyVersionsOutput struct {
 	// The policy versions.
 	PolicyVersions []*PolicyVersion `locationName:"policyVersions" type:"list"`
 
-	metadataListPolicyVersionsOutput `json:"-" xml:"-"`
-}
-
-type metadataListPolicyVersionsOutput struct {
-	SDKShapeTraits bool `type:"structure"`
+	_ struct{} `type:"structure"`
 }
 
 // String returns the string representation
@@ -2733,11 +2481,7 @@ type ListPrincipalPoliciesInput struct {
 	// The principal.
 	Principal *string `location:"header" locationName:"x-amzn-iot-principal" type:"string" required:"true"`
 
-	metadataListPrincipalPoliciesInput `json:"-" xml:"-"`
-}
-
-type metadataListPrincipalPoliciesInput struct {
-	SDKShapeTraits bool `type:"structure"`
+	_ struct{} `type:"structure"`
 }
 
 // String returns the string representation
@@ -2759,11 +2503,7 @@ type ListPrincipalPoliciesOutput struct {
 	// The policies.
 	Policies []*Policy `locationName:"policies" type:"list"`
 
-	metadataListPrincipalPoliciesOutput `json:"-" xml:"-"`
-}
-
-type metadataListPrincipalPoliciesOutput struct {
-	SDKShapeTraits bool `type:"structure"`
+	_ struct{} `type:"structure"`
 }
 
 // String returns the string representation
@@ -2785,11 +2525,7 @@ type ListPrincipalThingsInput struct {
 	// The principal.
 	Principal *string `location:"header" locationName:"x-amzn-principal" type:"string" required:"true"`
 
-	metadataListPrincipalThingsInput `json:"-" xml:"-"`
-}
-
-type metadataListPrincipalThingsInput struct {
-	SDKShapeTraits bool `type:"structure"`
+	_ struct{} `type:"structure"`
 }
 
 // String returns the string representation
@@ -2810,11 +2546,7 @@ type ListPrincipalThingsOutput struct {
 	// The things.
 	Things []*string `locationName:"things" type:"list"`
 
-	metadataListPrincipalThingsOutput `json:"-" xml:"-"`
-}
-
-type metadataListPrincipalThingsOutput struct {
-	SDKShapeTraits bool `type:"structure"`
+	_ struct{} `type:"structure"`
 }
 
 // String returns the string representation
@@ -2832,11 +2564,7 @@ type ListThingPrincipalsInput struct {
 	// The name of the thing.
 	ThingName *string `location:"uri" locationName:"thingName" min:"1" type:"string" required:"true"`
 
-	metadataListThingPrincipalsInput `json:"-" xml:"-"`
-}
-
-type metadataListThingPrincipalsInput struct {
-	SDKShapeTraits bool `type:"structure"`
+	_ struct{} `type:"structure"`
 }
 
 // String returns the string representation
@@ -2854,11 +2582,7 @@ type ListThingPrincipalsOutput struct {
 	// The principals.
 	Principals []*string `locationName:"principals" type:"list"`
 
-	metadataListThingPrincipalsOutput `json:"-" xml:"-"`
-}
-
-type metadataListThingPrincipalsOutput struct {
-	SDKShapeTraits bool `type:"structure"`
+	_ struct{} `type:"structure"`
 }
 
 // String returns the string representation
@@ -2885,11 +2609,7 @@ type ListThingsInput struct {
 	// The token for the next value.
 	NextToken *string `location:"querystring" locationName:"nextToken" type:"string"`
 
-	metadataListThingsInput `json:"-" xml:"-"`
-}
-
-type metadataListThingsInput struct {
-	SDKShapeTraits bool `type:"structure"`
+	_ struct{} `type:"structure"`
 }
 
 // String returns the string representation
@@ -2910,11 +2630,7 @@ type ListThingsOutput struct {
 	// The things.
 	Things []*ThingAttribute `locationName:"things" type:"list"`
 
-	metadataListThingsOutput `json:"-" xml:"-"`
-}
-
-type metadataListThingsOutput struct {
-	SDKShapeTraits bool `type:"structure"`
+	_ struct{} `type:"structure"`
 }
 
 // String returns the string representation
@@ -2941,11 +2657,7 @@ type ListTopicRulesInput struct {
 	// The topic.
 	Topic *string `location:"querystring" locationName:"topic" type:"string"`
 
-	metadataListTopicRulesInput `json:"-" xml:"-"`
-}
-
-type metadataListTopicRulesInput struct {
-	SDKShapeTraits bool `type:"structure"`
+	_ struct{} `type:"structure"`
 }
 
 // String returns the string representation
@@ -2966,11 +2678,7 @@ type ListTopicRulesOutput struct {
 	// The rules.
 	Rules []*TopicRuleListItem `locationName:"rules" type:"list"`
 
-	metadataListTopicRulesOutput `json:"-" xml:"-"`
-}
-
-type metadataListTopicRulesOutput struct {
-	SDKShapeTraits bool `type:"structure"`
+	_ struct{} `type:"structure"`
 }
 
 // String returns the string representation
@@ -2991,11 +2699,7 @@ type LoggingOptionsPayload struct {
 	// The ARN of the IAM role that grants access.
 	RoleArn *string `locationName:"roleArn" type:"string" required:"true"`
 
-	metadataLoggingOptionsPayload `json:"-" xml:"-"`
-}
-
-type metadataLoggingOptionsPayload struct {
-	SDKShapeTraits bool `type:"structure"`
+	_ struct{} `type:"structure"`
 }
 
 // String returns the string representation
@@ -3016,11 +2720,7 @@ type Policy struct {
 	// The policy name.
 	PolicyName *string `locationName:"policyName" min:"1" type:"string"`
 
-	metadataPolicy `json:"-" xml:"-"`
-}
-
-type metadataPolicy struct {
-	SDKShapeTraits bool `type:"structure"`
+	_ struct{} `type:"structure"`
 }
 
 // String returns the string representation
@@ -3044,11 +2744,7 @@ type PolicyVersion struct {
 	// The policy version ID.
 	VersionId *string `locationName:"versionId" type:"string"`
 
-	metadataPolicyVersion `json:"-" xml:"-"`
-}
-
-type metadataPolicyVersion struct {
-	SDKShapeTraits bool `type:"structure"`
+	_ struct{} `type:"structure"`
 }
 
 // String returns the string representation
@@ -3066,11 +2762,7 @@ type RejectCertificateTransferInput struct {
 	// The ID of the certificate.
 	CertificateId *string `location:"uri" locationName:"certificateId" min:"64" type:"string" required:"true"`
 
-	metadataRejectCertificateTransferInput `json:"-" xml:"-"`
-}
-
-type metadataRejectCertificateTransferInput struct {
-	SDKShapeTraits bool `type:"structure"`
+	_ struct{} `type:"structure"`
 }
 
 // String returns the string representation
@@ -3084,11 +2776,7 @@ func (s RejectCertificateTransferInput) GoString() string {
 }
 
 type RejectCertificateTransferOutput struct {
-	metadataRejectCertificateTransferOutput `json:"-" xml:"-"`
-}
-
-type metadataRejectCertificateTransferOutput struct {
-	SDKShapeTraits bool `type:"structure"`
+	_ struct{} `type:"structure"`
 }
 
 // String returns the string representation
@@ -3109,11 +2797,7 @@ type ReplaceTopicRuleInput struct {
 	// The rule payload.
 	TopicRulePayload *TopicRulePayload `locationName:"topicRulePayload" type:"structure" required:"true"`
 
-	metadataReplaceTopicRuleInput `json:"-" xml:"-"`
-}
-
-type metadataReplaceTopicRuleInput struct {
-	SDKShapeTraits bool `type:"structure" payload:"TopicRulePayload"`
+	_ struct{} `type:"structure" payload:"TopicRulePayload"`
 }
 
 // String returns the string representation
@@ -3127,11 +2811,7 @@ func (s ReplaceTopicRuleInput) GoString() string {
 }
 
 type ReplaceTopicRuleOutput struct {
-	metadataReplaceTopicRuleOutput `json:"-" xml:"-"`
-}
-
-type metadataReplaceTopicRuleOutput struct {
-	SDKShapeTraits bool `type:"structure"`
+	_ struct{} `type:"structure"`
 }
 
 // String returns the string representation
@@ -3152,11 +2832,7 @@ type RepublishAction struct {
 	// The name of the MQTT topic.
 	Topic *string `locationName:"topic" type:"string" required:"true"`
 
-	metadataRepublishAction `json:"-" xml:"-"`
-}
-
-type metadataRepublishAction struct {
-	SDKShapeTraits bool `type:"structure"`
+	_ struct{} `type:"structure"`
 }
 
 // String returns the string representation
@@ -3180,11 +2856,7 @@ type S3Action struct {
 	// The ARN of the IAM role that grants access.
 	RoleArn *string `locationName:"roleArn" type:"string" required:"true"`
 
-	metadataS3Action `json:"-" xml:"-"`
-}
-
-type metadataS3Action struct {
-	SDKShapeTraits bool `type:"structure"`
+	_ struct{} `type:"structure"`
 }
 
 // String returns the string representation
@@ -3205,11 +2877,7 @@ type SetDefaultPolicyVersionInput struct {
 	// The policy version ID.
 	PolicyVersionId *string `location:"uri" locationName:"policyVersionId" type:"string" required:"true"`
 
-	metadataSetDefaultPolicyVersionInput `json:"-" xml:"-"`
-}
-
-type metadataSetDefaultPolicyVersionInput struct {
-	SDKShapeTraits bool `type:"structure"`
+	_ struct{} `type:"structure"`
 }
 
 // String returns the string representation
@@ -3223,11 +2891,7 @@ func (s SetDefaultPolicyVersionInput) GoString() string {
 }
 
 type SetDefaultPolicyVersionOutput struct {
-	metadataSetDefaultPolicyVersionOutput `json:"-" xml:"-"`
-}
-
-type metadataSetDefaultPolicyVersionOutput struct {
-	SDKShapeTraits bool `type:"structure"`
+	_ struct{} `type:"structure"`
 }
 
 // String returns the string representation
@@ -3245,11 +2909,7 @@ type SetLoggingOptionsInput struct {
 	// The logging options payload.
 	LoggingOptionsPayload *LoggingOptionsPayload `locationName:"loggingOptionsPayload" type:"structure"`
 
-	metadataSetLoggingOptionsInput `json:"-" xml:"-"`
-}
-
-type metadataSetLoggingOptionsInput struct {
-	SDKShapeTraits bool `type:"structure" payload:"LoggingOptionsPayload"`
+	_ struct{} `type:"structure" payload:"LoggingOptionsPayload"`
 }
 
 // String returns the string representation
@@ -3263,11 +2923,7 @@ func (s SetLoggingOptionsInput) GoString() string {
 }
 
 type SetLoggingOptionsOutput struct {
-	metadataSetLoggingOptionsOutput `json:"-" xml:"-"`
-}
-
-type metadataSetLoggingOptionsOutput struct {
-	SDKShapeTraits bool `type:"structure"`
+	_ struct{} `type:"structure"`
 }
 
 // String returns the string representation
@@ -3288,11 +2944,7 @@ type SnsAction struct {
 	// The ARN of the SNS topic.
 	TargetArn *string `locationName:"targetArn" type:"string" required:"true"`
 
-	metadataSnsAction `json:"-" xml:"-"`
-}
-
-type metadataSnsAction struct {
-	SDKShapeTraits bool `type:"structure"`
+	_ struct{} `type:"structure"`
 }
 
 // String returns the string representation
@@ -3316,11 +2968,7 @@ type SqsAction struct {
 	// Specifies whether to use Base64 encoding.
 	UseBase64 *bool `locationName:"useBase64" type:"boolean"`
 
-	metadataSqsAction `json:"-" xml:"-"`
-}
-
-type metadataSqsAction struct {
-	SDKShapeTraits bool `type:"structure"`
+	_ struct{} `type:"structure"`
 }
 
 // String returns the string representation
@@ -3341,11 +2989,7 @@ type ThingAttribute struct {
 	// The name of the thing.
 	ThingName *string `locationName:"thingName" min:"1" type:"string"`
 
-	metadataThingAttribute `json:"-" xml:"-"`
-}
-
-type metadataThingAttribute struct {
-	SDKShapeTraits bool `type:"structure"`
+	_ struct{} `type:"structure"`
 }
 
 // String returns the string representation
@@ -3379,11 +3023,7 @@ type TopicRule struct {
 	// lines, be sure to escape the newline characters properly.
 	Sql *string `locationName:"sql" type:"string"`
 
-	metadataTopicRule `json:"-" xml:"-"`
-}
-
-type metadataTopicRule struct {
-	SDKShapeTraits bool `type:"structure"`
+	_ struct{} `type:"structure"`
 }
 
 // String returns the string representation
@@ -3410,11 +3050,7 @@ type TopicRuleListItem struct {
 	// The pattern for the topic names that apply.
 	TopicPattern *string `locationName:"topicPattern" type:"string"`
 
-	metadataTopicRuleListItem `json:"-" xml:"-"`
-}
-
-type metadataTopicRuleListItem struct {
-	SDKShapeTraits bool `type:"structure"`
+	_ struct{} `type:"structure"`
 }
 
 // String returns the string representation
@@ -3443,11 +3079,7 @@ type TopicRulePayload struct {
 	// in the AWS IoT Developer Guide.
 	Sql *string `locationName:"sql" type:"string" required:"true"`
 
-	metadataTopicRulePayload `json:"-" xml:"-"`
-}
-
-type metadataTopicRulePayload struct {
-	SDKShapeTraits bool `type:"structure"`
+	_ struct{} `type:"structure"`
 }
 
 // String returns the string representation
@@ -3468,11 +3100,7 @@ type TransferCertificateInput struct {
 	// The AWS account.
 	TargetAwsAccount *string `location:"querystring" locationName:"targetAwsAccount" type:"string" required:"true"`
 
-	metadataTransferCertificateInput `json:"-" xml:"-"`
-}
-
-type metadataTransferCertificateInput struct {
-	SDKShapeTraits bool `type:"structure"`
+	_ struct{} `type:"structure"`
 }
 
 // String returns the string representation
@@ -3490,11 +3118,7 @@ type TransferCertificateOutput struct {
 	// The ARN of the certificate.
 	TransferredCertificateArn *string `locationName:"transferredCertificateArn" type:"string"`
 
-	metadataTransferCertificateOutput `json:"-" xml:"-"`
-}
-
-type metadataTransferCertificateOutput struct {
-	SDKShapeTraits bool `type:"structure"`
+	_ struct{} `type:"structure"`
 }
 
 // String returns the string representation
@@ -3515,11 +3139,7 @@ type UpdateCertificateInput struct {
 	// The new status.
 	NewStatus *string `location:"querystring" locationName:"newStatus" type:"string" required:"true" enum:"CertificateStatus"`
 
-	metadataUpdateCertificateInput `json:"-" xml:"-"`
-}
-
-type metadataUpdateCertificateInput struct {
-	SDKShapeTraits bool `type:"structure"`
+	_ struct{} `type:"structure"`
 }
 
 // String returns the string representation
@@ -3533,11 +3153,7 @@ func (s UpdateCertificateInput) GoString() string {
 }
 
 type UpdateCertificateOutput struct {
-	metadataUpdateCertificateOutput `json:"-" xml:"-"`
-}
-
-type metadataUpdateCertificateOutput struct {
-	SDKShapeTraits bool `type:"structure"`
+	_ struct{} `type:"structure"`
 }
 
 // String returns the string representation
@@ -3560,11 +3176,7 @@ type UpdateThingInput struct {
 	// The thing name.
 	ThingName *string `location:"uri" locationName:"thingName" min:"1" type:"string" required:"true"`
 
-	metadataUpdateThingInput `json:"-" xml:"-"`
-}
-
-type metadataUpdateThingInput struct {
-	SDKShapeTraits bool `type:"structure"`
+	_ struct{} `type:"structure"`
 }
 
 // String returns the string representation
@@ -3579,11 +3191,7 @@ func (s UpdateThingInput) GoString() string {
 
 // The output from the UpdateThing operation.
 type UpdateThingOutput struct {
-	metadataUpdateThingOutput `json:"-" xml:"-"`
-}
-
-type metadataUpdateThingOutput struct {
-	SDKShapeTraits bool `type:"structure"`
+	_ struct{} `type:"structure"`
 }
 
 // String returns the string representation

--- a/service/iot/api.go
+++ b/service/iot/api.go
@@ -1152,13 +1152,13 @@ func (c *IoT) UpdateThing(input *UpdateThingInput) (*UpdateThingOutput, error) {
 
 // The input for the AcceptCertificateTransfer operation.
 type AcceptCertificateTransferInput struct {
+	_ struct{} `type:"structure"`
+
 	// The ID of the certificate.
 	CertificateId *string `location:"uri" locationName:"certificateId" min:"64" type:"string" required:"true"`
 
 	// Specifies whether the certificate is active.
 	SetAsActive *bool `location:"querystring" locationName:"setAsActive" type:"boolean"`
-
-	_ struct{} `type:"structure"`
 }
 
 // String returns the string representation
@@ -1187,6 +1187,8 @@ func (s AcceptCertificateTransferOutput) GoString() string {
 
 // Describes the actions associated with a rule.
 type Action struct {
+	_ struct{} `type:"structure"`
+
 	// Write to a DynamoDB table.
 	DynamoDB *DynamoDBAction `locationName:"dynamoDB" type:"structure"`
 
@@ -1209,8 +1211,6 @@ type Action struct {
 
 	// Publish to an SQS queue.
 	Sqs *SqsAction `locationName:"sqs" type:"structure"`
-
-	_ struct{} `type:"structure"`
 }
 
 // String returns the string representation
@@ -1225,14 +1225,14 @@ func (s Action) GoString() string {
 
 // The input for the AttachPrincipalPolicy operation.
 type AttachPrincipalPolicyInput struct {
+	_ struct{} `type:"structure"`
+
 	// The policy name.
 	PolicyName *string `location:"uri" locationName:"policyName" min:"1" type:"string" required:"true"`
 
 	// The principal which can be a certificate ARN (as returned from the CreateCertificate
 	// operation) or a Cognito ID.
 	Principal *string `location:"header" locationName:"x-amzn-iot-principal" type:"string" required:"true"`
-
-	_ struct{} `type:"structure"`
 }
 
 // String returns the string representation
@@ -1261,13 +1261,13 @@ func (s AttachPrincipalPolicyOutput) GoString() string {
 
 // The input for the AttachThingPrincipal operation.
 type AttachThingPrincipalInput struct {
+	_ struct{} `type:"structure"`
+
 	// The principal (certificate or other credential).
 	Principal *string `location:"header" locationName:"x-amzn-principal" type:"string" required:"true"`
 
 	// The name of the thing.
 	ThingName *string `location:"uri" locationName:"thingName" min:"1" type:"string" required:"true"`
-
-	_ struct{} `type:"structure"`
 }
 
 // String returns the string representation
@@ -1299,12 +1299,12 @@ func (s AttachThingPrincipalOutput) GoString() string {
 //
 // For example: {\"attributes\":{\"string1\":\"string2\”}}
 type AttributePayload struct {
+	_ struct{} `type:"structure"`
+
 	// A JSON string containing up to three key-value pair in JSON format.
 	//
 	// For example: {\"attributes\":{\"string1\":\"string2\”}}
 	Attributes map[string]*string `locationName:"attributes" type:"map"`
-
-	_ struct{} `type:"structure"`
 }
 
 // String returns the string representation
@@ -1319,10 +1319,10 @@ func (s AttributePayload) GoString() string {
 
 // The input for the CancelCertificateTransfer operation.
 type CancelCertificateTransferInput struct {
+	_ struct{} `type:"structure"`
+
 	// The ID of the certificate.
 	CertificateId *string `location:"uri" locationName:"certificateId" min:"64" type:"string" required:"true"`
-
-	_ struct{} `type:"structure"`
 }
 
 // String returns the string representation
@@ -1351,6 +1351,8 @@ func (s CancelCertificateTransferOutput) GoString() string {
 
 // Information about a certificate.
 type Certificate struct {
+	_ struct{} `type:"structure"`
+
 	// The ARN of the certificate.
 	CertificateArn *string `locationName:"certificateArn" type:"string"`
 
@@ -1362,8 +1364,6 @@ type Certificate struct {
 
 	// The status of the certificate.
 	Status *string `locationName:"status" type:"string" enum:"CertificateStatus"`
-
-	_ struct{} `type:"structure"`
 }
 
 // String returns the string representation
@@ -1378,6 +1378,8 @@ func (s Certificate) GoString() string {
 
 // Describes a certificate.
 type CertificateDescription struct {
+	_ struct{} `type:"structure"`
+
 	// The ARN of the certificate.
 	CertificateArn *string `locationName:"certificateArn" type:"string"`
 
@@ -1398,8 +1400,6 @@ type CertificateDescription struct {
 
 	// The status of the certificate.
 	Status *string `locationName:"status" type:"string" enum:"CertificateStatus"`
-
-	_ struct{} `type:"structure"`
 }
 
 // String returns the string representation
@@ -1414,13 +1414,13 @@ func (s CertificateDescription) GoString() string {
 
 // The input for the CreateCertificateFromCsr operation.
 type CreateCertificateFromCsrInput struct {
+	_ struct{} `type:"structure"`
+
 	// The certificate signing request (CSR).
 	CertificateSigningRequest *string `locationName:"certificateSigningRequest" min:"1" type:"string" required:"true"`
 
 	// Specifies whether the certificate is active.
 	SetAsActive *bool `location:"querystring" locationName:"setAsActive" type:"boolean"`
-
-	_ struct{} `type:"structure"`
 }
 
 // String returns the string representation
@@ -1435,6 +1435,8 @@ func (s CreateCertificateFromCsrInput) GoString() string {
 
 // The output from the CreateCertificateFromCsr operation.
 type CreateCertificateFromCsrOutput struct {
+	_ struct{} `type:"structure"`
+
 	// The Amazon Resource Name (ARN) of the certificate. You can use the ARN as
 	// a principal for policy operations.
 	CertificateArn *string `locationName:"certificateArn" type:"string"`
@@ -1445,8 +1447,6 @@ type CreateCertificateFromCsrOutput struct {
 
 	// The certificate data, in PEM format.
 	CertificatePem *string `locationName:"certificatePem" type:"string"`
-
-	_ struct{} `type:"structure"`
 }
 
 // String returns the string representation
@@ -1461,10 +1461,10 @@ func (s CreateCertificateFromCsrOutput) GoString() string {
 
 // The input for the CreateKeysAndCertificate operation.
 type CreateKeysAndCertificateInput struct {
+	_ struct{} `type:"structure"`
+
 	// Specifies whether the certificate is active.
 	SetAsActive *bool `location:"querystring" locationName:"setAsActive" type:"boolean"`
-
-	_ struct{} `type:"structure"`
 }
 
 // String returns the string representation
@@ -1479,6 +1479,8 @@ func (s CreateKeysAndCertificateInput) GoString() string {
 
 // The output of the CreateKeysAndCertificate operation.
 type CreateKeysAndCertificateOutput struct {
+	_ struct{} `type:"structure"`
+
 	// The ARN of the certificate.
 	CertificateArn *string `locationName:"certificateArn" type:"string"`
 
@@ -1491,8 +1493,6 @@ type CreateKeysAndCertificateOutput struct {
 
 	// The generated key pair.
 	KeyPair *KeyPair `locationName:"keyPair" type:"structure"`
-
-	_ struct{} `type:"structure"`
 }
 
 // String returns the string representation
@@ -1507,14 +1507,14 @@ func (s CreateKeysAndCertificateOutput) GoString() string {
 
 // The input for the CreatePolicy operation.
 type CreatePolicyInput struct {
+	_ struct{} `type:"structure"`
+
 	// The JSON document that describes the policy. The length of the policyDocument
 	// must be a minimum length of 1, with a maximum length of 2048, excluding whitespace.
 	PolicyDocument *string `locationName:"policyDocument" type:"string" required:"true"`
 
 	// The policy name.
 	PolicyName *string `location:"uri" locationName:"policyName" min:"1" type:"string" required:"true"`
-
-	_ struct{} `type:"structure"`
 }
 
 // String returns the string representation
@@ -1529,6 +1529,8 @@ func (s CreatePolicyInput) GoString() string {
 
 // The output from the CreatePolicy operation.
 type CreatePolicyOutput struct {
+	_ struct{} `type:"structure"`
+
 	// The policy ARN.
 	PolicyArn *string `locationName:"policyArn" type:"string"`
 
@@ -1540,8 +1542,6 @@ type CreatePolicyOutput struct {
 
 	// The policy version ID.
 	PolicyVersionId *string `locationName:"policyVersionId" type:"string"`
-
-	_ struct{} `type:"structure"`
 }
 
 // String returns the string representation
@@ -1556,6 +1556,8 @@ func (s CreatePolicyOutput) GoString() string {
 
 // The input for the CreatePolicyVersion operation.
 type CreatePolicyVersionInput struct {
+	_ struct{} `type:"structure"`
+
 	// The JSON document that describes the policy.
 	PolicyDocument *string `locationName:"policyDocument" type:"string" required:"true"`
 
@@ -1564,8 +1566,6 @@ type CreatePolicyVersionInput struct {
 
 	// Specifies whether the policy version is set as the default.
 	SetAsDefault *bool `location:"querystring" locationName:"setAsDefault" type:"boolean"`
-
-	_ struct{} `type:"structure"`
 }
 
 // String returns the string representation
@@ -1580,6 +1580,8 @@ func (s CreatePolicyVersionInput) GoString() string {
 
 // The output of the CreatePolicyVersion operation.
 type CreatePolicyVersionOutput struct {
+	_ struct{} `type:"structure"`
+
 	// Specifies whether the policy version is the default.
 	IsDefaultVersion *bool `locationName:"isDefaultVersion" type:"boolean"`
 
@@ -1591,8 +1593,6 @@ type CreatePolicyVersionOutput struct {
 
 	// The policy version ID.
 	PolicyVersionId *string `locationName:"policyVersionId" type:"string"`
-
-	_ struct{} `type:"structure"`
 }
 
 // String returns the string representation
@@ -1607,14 +1607,14 @@ func (s CreatePolicyVersionOutput) GoString() string {
 
 // The input for the CreateThing operation.
 type CreateThingInput struct {
+	_ struct{} `type:"structure"`
+
 	// The attribute payload. Which consists of up to 3 name/value pairs in a JSON
 	// document. For example: {\"attributes\":{\"string1\":\"string2\”}}
 	AttributePayload *AttributePayload `locationName:"attributePayload" type:"structure"`
 
 	// The name of the thing.
 	ThingName *string `location:"uri" locationName:"thingName" min:"1" type:"string" required:"true"`
-
-	_ struct{} `type:"structure"`
 }
 
 // String returns the string representation
@@ -1629,13 +1629,13 @@ func (s CreateThingInput) GoString() string {
 
 // The output of the CreateThing operation.
 type CreateThingOutput struct {
+	_ struct{} `type:"structure"`
+
 	// The thing ARN.
 	ThingArn *string `locationName:"thingArn" type:"string"`
 
 	// The name of the thing.
 	ThingName *string `locationName:"thingName" min:"1" type:"string"`
-
-	_ struct{} `type:"structure"`
 }
 
 // String returns the string representation
@@ -1650,13 +1650,13 @@ func (s CreateThingOutput) GoString() string {
 
 // The input for the CreateTopicRule operation.
 type CreateTopicRuleInput struct {
+	_ struct{} `type:"structure" payload:"TopicRulePayload"`
+
 	// The name of the rule.
 	RuleName *string `location:"uri" locationName:"ruleName" min:"1" type:"string" required:"true"`
 
 	// The rule payload.
 	TopicRulePayload *TopicRulePayload `locationName:"topicRulePayload" type:"structure" required:"true"`
-
-	_ struct{} `type:"structure" payload:"TopicRulePayload"`
 }
 
 // String returns the string representation
@@ -1685,10 +1685,10 @@ func (s CreateTopicRuleOutput) GoString() string {
 
 // The input for the DeleteCertificate operation.
 type DeleteCertificateInput struct {
+	_ struct{} `type:"structure"`
+
 	// The ID of the certificate.
 	CertificateId *string `location:"uri" locationName:"certificateId" min:"64" type:"string" required:"true"`
-
-	_ struct{} `type:"structure"`
 }
 
 // String returns the string representation
@@ -1717,10 +1717,10 @@ func (s DeleteCertificateOutput) GoString() string {
 
 // The input for the DeletePolicy operation.
 type DeletePolicyInput struct {
+	_ struct{} `type:"structure"`
+
 	// The name of the policy to delete.
 	PolicyName *string `location:"uri" locationName:"policyName" min:"1" type:"string" required:"true"`
-
-	_ struct{} `type:"structure"`
 }
 
 // String returns the string representation
@@ -1749,13 +1749,13 @@ func (s DeletePolicyOutput) GoString() string {
 
 // The input for the DeletePolicyVersion operation.
 type DeletePolicyVersionInput struct {
+	_ struct{} `type:"structure"`
+
 	// The name of the policy.
 	PolicyName *string `location:"uri" locationName:"policyName" min:"1" type:"string" required:"true"`
 
 	// The policy version ID.
 	PolicyVersionId *string `location:"uri" locationName:"policyVersionId" type:"string" required:"true"`
-
-	_ struct{} `type:"structure"`
 }
 
 // String returns the string representation
@@ -1784,10 +1784,10 @@ func (s DeletePolicyVersionOutput) GoString() string {
 
 // The input for the DeleteThing operation.
 type DeleteThingInput struct {
+	_ struct{} `type:"structure"`
+
 	// The thing name.
 	ThingName *string `location:"uri" locationName:"thingName" min:"1" type:"string" required:"true"`
-
-	_ struct{} `type:"structure"`
 }
 
 // String returns the string representation
@@ -1817,10 +1817,10 @@ func (s DeleteThingOutput) GoString() string {
 
 // The input for the DeleteTopicRule operation.
 type DeleteTopicRuleInput struct {
+	_ struct{} `type:"structure"`
+
 	// The name of the rule.
 	RuleName *string `location:"uri" locationName:"ruleName" min:"1" type:"string" required:"true"`
-
-	_ struct{} `type:"structure"`
 }
 
 // String returns the string representation
@@ -1849,10 +1849,10 @@ func (s DeleteTopicRuleOutput) GoString() string {
 
 // The input for the DescribeCertificate operation.
 type DescribeCertificateInput struct {
+	_ struct{} `type:"structure"`
+
 	// The ID of the certificate.
 	CertificateId *string `location:"uri" locationName:"certificateId" min:"64" type:"string" required:"true"`
-
-	_ struct{} `type:"structure"`
 }
 
 // String returns the string representation
@@ -1867,10 +1867,10 @@ func (s DescribeCertificateInput) GoString() string {
 
 // The output of the DescribeCertificate operation.
 type DescribeCertificateOutput struct {
+	_ struct{} `type:"structure"`
+
 	// The description of the certificate.
 	CertificateDescription *CertificateDescription `locationName:"certificateDescription" type:"structure"`
-
-	_ struct{} `type:"structure"`
 }
 
 // String returns the string representation
@@ -1900,10 +1900,10 @@ func (s DescribeEndpointInput) GoString() string {
 
 // The output from the DescribeEndpoint operation.
 type DescribeEndpointOutput struct {
+	_ struct{} `type:"structure"`
+
 	// The address.
 	EndpointAddress *string `locationName:"endpointAddress" type:"string"`
-
-	_ struct{} `type:"structure"`
 }
 
 // String returns the string representation
@@ -1918,10 +1918,10 @@ func (s DescribeEndpointOutput) GoString() string {
 
 // The input for the DescribeThing operation.
 type DescribeThingInput struct {
+	_ struct{} `type:"structure"`
+
 	// The name of the thing.
 	ThingName *string `location:"uri" locationName:"thingName" min:"1" type:"string" required:"true"`
-
-	_ struct{} `type:"structure"`
 }
 
 // String returns the string representation
@@ -1936,6 +1936,8 @@ func (s DescribeThingInput) GoString() string {
 
 // The output from the DescribeThing operation.
 type DescribeThingOutput struct {
+	_ struct{} `type:"structure"`
+
 	// The attributes which are name/value pairs in JSON format. For example:
 	//
 	// {\"attributes\":{\"some-name1\":\"some-value1\”}, {\"some-name2\":\"some-value2\”},
@@ -1947,8 +1949,6 @@ type DescribeThingOutput struct {
 
 	// The name of the thing.
 	ThingName *string `locationName:"thingName" min:"1" type:"string"`
-
-	_ struct{} `type:"structure"`
 }
 
 // String returns the string representation
@@ -1963,6 +1963,8 @@ func (s DescribeThingOutput) GoString() string {
 
 // The input for the DetachPrincipalPolicy operation.
 type DetachPrincipalPolicyInput struct {
+	_ struct{} `type:"structure"`
+
 	// The name of the policy to detach.
 	PolicyName *string `location:"uri" locationName:"policyName" min:"1" type:"string" required:"true"`
 
@@ -1971,8 +1973,6 @@ type DetachPrincipalPolicyInput struct {
 	// If the principal is a certificate, specify the certificate ARN. If the principal
 	// is a Cognito identity specify the identity ID.
 	Principal *string `location:"header" locationName:"x-amzn-iot-principal" type:"string" required:"true"`
-
-	_ struct{} `type:"structure"`
 }
 
 // String returns the string representation
@@ -2001,13 +2001,13 @@ func (s DetachPrincipalPolicyOutput) GoString() string {
 
 // The input for the DetachThingPrincipal operation.
 type DetachThingPrincipalInput struct {
+	_ struct{} `type:"structure"`
+
 	// The principal.
 	Principal *string `location:"header" locationName:"x-amzn-principal" type:"string" required:"true"`
 
 	// The name of the thing.
 	ThingName *string `location:"uri" locationName:"thingName" min:"1" type:"string" required:"true"`
-
-	_ struct{} `type:"structure"`
 }
 
 // String returns the string representation
@@ -2053,6 +2053,8 @@ func (s DetachThingPrincipalOutput) GoString() string {
 //
 // "rangeKeyValue": "${timestamp()}"
 type DynamoDBAction struct {
+	_ struct{} `type:"structure"`
+
 	// The hash key name.
 	HashKeyField *string `locationName:"hashKeyField" type:"string" required:"true"`
 
@@ -2073,8 +2075,6 @@ type DynamoDBAction struct {
 
 	// The name of the DynamoDB table.
 	TableName *string `locationName:"tableName" type:"string" required:"true"`
-
-	_ struct{} `type:"structure"`
 }
 
 // String returns the string representation
@@ -2088,11 +2088,11 @@ func (s DynamoDBAction) GoString() string {
 }
 
 type FirehoseAction struct {
+	_ struct{} `type:"structure"`
+
 	DeliveryStreamName *string `locationName:"deliveryStreamName" type:"string" required:"true"`
 
 	RoleArn *string `locationName:"roleArn" type:"string" required:"true"`
-
-	_ struct{} `type:"structure"`
 }
 
 // String returns the string representation
@@ -2122,13 +2122,13 @@ func (s GetLoggingOptionsInput) GoString() string {
 
 // The output from the GetLoggingOptions operation.
 type GetLoggingOptionsOutput struct {
+	_ struct{} `type:"structure"`
+
 	// The logging level.
 	LogLevel *string `locationName:"logLevel" type:"string" enum:"LogLevel"`
 
 	// The ARN of the IAM role that grants access.
 	RoleArn *string `locationName:"roleArn" type:"string"`
-
-	_ struct{} `type:"structure"`
 }
 
 // String returns the string representation
@@ -2143,10 +2143,10 @@ func (s GetLoggingOptionsOutput) GoString() string {
 
 // The input for the GetPolicy operation.
 type GetPolicyInput struct {
+	_ struct{} `type:"structure"`
+
 	// The name of the policy.
 	PolicyName *string `location:"uri" locationName:"policyName" min:"1" type:"string" required:"true"`
-
-	_ struct{} `type:"structure"`
 }
 
 // String returns the string representation
@@ -2161,6 +2161,8 @@ func (s GetPolicyInput) GoString() string {
 
 // The output from the GetPolicy operation.
 type GetPolicyOutput struct {
+	_ struct{} `type:"structure"`
+
 	// The default policy version ID.
 	DefaultVersionId *string `locationName:"defaultVersionId" type:"string"`
 
@@ -2172,8 +2174,6 @@ type GetPolicyOutput struct {
 
 	// The policy name.
 	PolicyName *string `locationName:"policyName" min:"1" type:"string"`
-
-	_ struct{} `type:"structure"`
 }
 
 // String returns the string representation
@@ -2188,13 +2188,13 @@ func (s GetPolicyOutput) GoString() string {
 
 // The input for the GetPolicyVersion operation.
 type GetPolicyVersionInput struct {
+	_ struct{} `type:"structure"`
+
 	// The name of the policy.
 	PolicyName *string `location:"uri" locationName:"policyName" min:"1" type:"string" required:"true"`
 
 	// The policy version ID.
 	PolicyVersionId *string `location:"uri" locationName:"policyVersionId" type:"string" required:"true"`
-
-	_ struct{} `type:"structure"`
 }
 
 // String returns the string representation
@@ -2209,6 +2209,8 @@ func (s GetPolicyVersionInput) GoString() string {
 
 // The output from the GetPolicyVersion operation.
 type GetPolicyVersionOutput struct {
+	_ struct{} `type:"structure"`
+
 	// Specifies whether the policy version is the default.
 	IsDefaultVersion *bool `locationName:"isDefaultVersion" type:"boolean"`
 
@@ -2223,8 +2225,6 @@ type GetPolicyVersionOutput struct {
 
 	// The policy version ID.
 	PolicyVersionId *string `locationName:"policyVersionId" type:"string"`
-
-	_ struct{} `type:"structure"`
 }
 
 // String returns the string representation
@@ -2239,10 +2239,10 @@ func (s GetPolicyVersionOutput) GoString() string {
 
 // The input for the GetTopicRule operation.
 type GetTopicRuleInput struct {
+	_ struct{} `type:"structure"`
+
 	// The name of the rule.
 	RuleName *string `location:"uri" locationName:"ruleName" min:"1" type:"string" required:"true"`
-
-	_ struct{} `type:"structure"`
 }
 
 // String returns the string representation
@@ -2257,10 +2257,10 @@ func (s GetTopicRuleInput) GoString() string {
 
 // The output from the GetTopicRule operation.
 type GetTopicRuleOutput struct {
+	_ struct{} `type:"structure"`
+
 	// The rule.
 	Rule *TopicRule `locationName:"rule" type:"structure"`
-
-	_ struct{} `type:"structure"`
 }
 
 // String returns the string representation
@@ -2275,13 +2275,13 @@ func (s GetTopicRuleOutput) GoString() string {
 
 // Describes a key pair.
 type KeyPair struct {
+	_ struct{} `type:"structure"`
+
 	// The private key.
 	PrivateKey *string `min:"1" type:"string"`
 
 	// The public key.
 	PublicKey *string `min:"1" type:"string"`
-
-	_ struct{} `type:"structure"`
 }
 
 // String returns the string representation
@@ -2296,6 +2296,8 @@ func (s KeyPair) GoString() string {
 
 // Describes an action to write data to an Amazon Kinesis stream.
 type KinesisAction struct {
+	_ struct{} `type:"structure"`
+
 	// The partition key.
 	PartitionKey *string `locationName:"partitionKey" type:"string"`
 
@@ -2304,8 +2306,6 @@ type KinesisAction struct {
 
 	// The name of the Kinesis stream.
 	StreamName *string `locationName:"streamName" type:"string" required:"true"`
-
-	_ struct{} `type:"structure"`
 }
 
 // String returns the string representation
@@ -2320,10 +2320,10 @@ func (s KinesisAction) GoString() string {
 
 // Describes an action to invoke a Lamdba function.
 type LambdaAction struct {
+	_ struct{} `type:"structure"`
+
 	// The ARN of the Lambda function.
 	FunctionArn *string `locationName:"functionArn" type:"string" required:"true"`
-
-	_ struct{} `type:"structure"`
 }
 
 // String returns the string representation
@@ -2338,6 +2338,8 @@ func (s LambdaAction) GoString() string {
 
 // The input for the ListCertificates operation.
 type ListCertificatesInput struct {
+	_ struct{} `type:"structure"`
+
 	// Specifies the order for results. If True, the results are returned in ascending
 	// order, based on the creation date.
 	AscendingOrder *bool `location:"querystring" locationName:"isAscendingOrder" type:"boolean"`
@@ -2347,8 +2349,6 @@ type ListCertificatesInput struct {
 
 	// The result page size.
 	PageSize *int64 `location:"querystring" locationName:"pageSize" min:"1" type:"integer"`
-
-	_ struct{} `type:"structure"`
 }
 
 // String returns the string representation
@@ -2363,14 +2363,14 @@ func (s ListCertificatesInput) GoString() string {
 
 // The output of the ListCertificates operation.
 type ListCertificatesOutput struct {
+	_ struct{} `type:"structure"`
+
 	// The descriptions of the certificates.
 	Certificates []*Certificate `locationName:"certificates" type:"list"`
 
 	// The marker for the next set of results, or null if there are no additional
 	// results.
 	NextMarker *string `locationName:"nextMarker" type:"string"`
-
-	_ struct{} `type:"structure"`
 }
 
 // String returns the string representation
@@ -2385,6 +2385,8 @@ func (s ListCertificatesOutput) GoString() string {
 
 // The input for the ListPolicies operation.
 type ListPoliciesInput struct {
+	_ struct{} `type:"structure"`
+
 	// Specifies the order for results. If true, the results are returned in ascending
 	// creation order.
 	AscendingOrder *bool `location:"querystring" locationName:"isAscendingOrder" type:"boolean"`
@@ -2394,8 +2396,6 @@ type ListPoliciesInput struct {
 
 	// The result page size.
 	PageSize *int64 `location:"querystring" locationName:"pageSize" min:"1" type:"integer"`
-
-	_ struct{} `type:"structure"`
 }
 
 // String returns the string representation
@@ -2410,14 +2410,14 @@ func (s ListPoliciesInput) GoString() string {
 
 // The output from the ListPolicies operation.
 type ListPoliciesOutput struct {
+	_ struct{} `type:"structure"`
+
 	// The marker for the next set of results, or null if there are no additional
 	// results.
 	NextMarker *string `locationName:"nextMarker" type:"string"`
 
 	// The descriptions of the policies.
 	Policies []*Policy `locationName:"policies" type:"list"`
-
-	_ struct{} `type:"structure"`
 }
 
 // String returns the string representation
@@ -2432,10 +2432,10 @@ func (s ListPoliciesOutput) GoString() string {
 
 // The input for the ListPolicyVersions operation.
 type ListPolicyVersionsInput struct {
+	_ struct{} `type:"structure"`
+
 	// The policy name.
 	PolicyName *string `location:"uri" locationName:"policyName" min:"1" type:"string" required:"true"`
-
-	_ struct{} `type:"structure"`
 }
 
 // String returns the string representation
@@ -2450,10 +2450,10 @@ func (s ListPolicyVersionsInput) GoString() string {
 
 // The output from the ListPolicyVersions operation.
 type ListPolicyVersionsOutput struct {
+	_ struct{} `type:"structure"`
+
 	// The policy versions.
 	PolicyVersions []*PolicyVersion `locationName:"policyVersions" type:"list"`
-
-	_ struct{} `type:"structure"`
 }
 
 // String returns the string representation
@@ -2468,6 +2468,8 @@ func (s ListPolicyVersionsOutput) GoString() string {
 
 // The input for the ListPrincipalPolicies operation.
 type ListPrincipalPoliciesInput struct {
+	_ struct{} `type:"structure"`
+
 	// Specifies the order for results. If true, results are returned in ascending
 	// creation order.
 	AscendingOrder *bool `location:"querystring" locationName:"isAscendingOrder" type:"boolean"`
@@ -2480,8 +2482,6 @@ type ListPrincipalPoliciesInput struct {
 
 	// The principal.
 	Principal *string `location:"header" locationName:"x-amzn-iot-principal" type:"string" required:"true"`
-
-	_ struct{} `type:"structure"`
 }
 
 // String returns the string representation
@@ -2496,14 +2496,14 @@ func (s ListPrincipalPoliciesInput) GoString() string {
 
 // The output from the ListPrincipalPolicies operation.
 type ListPrincipalPoliciesOutput struct {
+	_ struct{} `type:"structure"`
+
 	// The marker for the next set of results, or null if there are no additional
 	// results.
 	NextMarker *string `locationName:"nextMarker" type:"string"`
 
 	// The policies.
 	Policies []*Policy `locationName:"policies" type:"list"`
-
-	_ struct{} `type:"structure"`
 }
 
 // String returns the string representation
@@ -2518,14 +2518,14 @@ func (s ListPrincipalPoliciesOutput) GoString() string {
 
 // The input for the ListPrincipalThings operation.
 type ListPrincipalThingsInput struct {
+	_ struct{} `type:"structure"`
+
 	MaxResults *int64 `location:"querystring" locationName:"maxResults" min:"1" type:"integer"`
 
 	NextToken *string `location:"querystring" locationName:"nextToken" type:"string"`
 
 	// The principal.
 	Principal *string `location:"header" locationName:"x-amzn-principal" type:"string" required:"true"`
-
-	_ struct{} `type:"structure"`
 }
 
 // String returns the string representation
@@ -2540,13 +2540,13 @@ func (s ListPrincipalThingsInput) GoString() string {
 
 // The output from the ListPrincipalThings operation.
 type ListPrincipalThingsOutput struct {
+	_ struct{} `type:"structure"`
+
 	// A token used to retrieve the next value.
 	NextToken *string `locationName:"nextToken" type:"string"`
 
 	// The things.
 	Things []*string `locationName:"things" type:"list"`
-
-	_ struct{} `type:"structure"`
 }
 
 // String returns the string representation
@@ -2561,10 +2561,10 @@ func (s ListPrincipalThingsOutput) GoString() string {
 
 // The input for the ListThingPrincipal operation.
 type ListThingPrincipalsInput struct {
+	_ struct{} `type:"structure"`
+
 	// The name of the thing.
 	ThingName *string `location:"uri" locationName:"thingName" min:"1" type:"string" required:"true"`
-
-	_ struct{} `type:"structure"`
 }
 
 // String returns the string representation
@@ -2579,10 +2579,10 @@ func (s ListThingPrincipalsInput) GoString() string {
 
 // The output from the ListThingPrincipals operation.
 type ListThingPrincipalsOutput struct {
+	_ struct{} `type:"structure"`
+
 	// The principals.
 	Principals []*string `locationName:"principals" type:"list"`
-
-	_ struct{} `type:"structure"`
 }
 
 // String returns the string representation
@@ -2597,6 +2597,8 @@ func (s ListThingPrincipalsOutput) GoString() string {
 
 // The input for the ListThings operation.
 type ListThingsInput struct {
+	_ struct{} `type:"structure"`
+
 	// The attribute name.
 	AttributeName *string `location:"querystring" locationName:"attributeName" type:"string"`
 
@@ -2608,8 +2610,6 @@ type ListThingsInput struct {
 
 	// The token for the next value.
 	NextToken *string `location:"querystring" locationName:"nextToken" type:"string"`
-
-	_ struct{} `type:"structure"`
 }
 
 // String returns the string representation
@@ -2624,13 +2624,13 @@ func (s ListThingsInput) GoString() string {
 
 // The output from the ListThings operation.
 type ListThingsOutput struct {
+	_ struct{} `type:"structure"`
+
 	// A token used to retrieve the next value.
 	NextToken *string `locationName:"nextToken" type:"string"`
 
 	// The things.
 	Things []*ThingAttribute `locationName:"things" type:"list"`
-
-	_ struct{} `type:"structure"`
 }
 
 // String returns the string representation
@@ -2645,6 +2645,8 @@ func (s ListThingsOutput) GoString() string {
 
 // The input for the ListTopicRules operation.
 type ListTopicRulesInput struct {
+	_ struct{} `type:"structure"`
+
 	// The maximum number of results to return.
 	MaxResults *int64 `location:"querystring" locationName:"maxResults" min:"1" type:"integer"`
 
@@ -2656,8 +2658,6 @@ type ListTopicRulesInput struct {
 
 	// The topic.
 	Topic *string `location:"querystring" locationName:"topic" type:"string"`
-
-	_ struct{} `type:"structure"`
 }
 
 // String returns the string representation
@@ -2672,13 +2672,13 @@ func (s ListTopicRulesInput) GoString() string {
 
 // The output from the ListTopicRules operation.
 type ListTopicRulesOutput struct {
+	_ struct{} `type:"structure"`
+
 	// A token used to retrieve the next value.
 	NextToken *string `locationName:"nextToken" type:"string"`
 
 	// The rules.
 	Rules []*TopicRuleListItem `locationName:"rules" type:"list"`
-
-	_ struct{} `type:"structure"`
 }
 
 // String returns the string representation
@@ -2693,13 +2693,13 @@ func (s ListTopicRulesOutput) GoString() string {
 
 // Describes the logging options payload.
 type LoggingOptionsPayload struct {
+	_ struct{} `type:"structure"`
+
 	// The logging level.
 	LogLevel *string `locationName:"logLevel" type:"string" enum:"LogLevel"`
 
 	// The ARN of the IAM role that grants access.
 	RoleArn *string `locationName:"roleArn" type:"string" required:"true"`
-
-	_ struct{} `type:"structure"`
 }
 
 // String returns the string representation
@@ -2714,13 +2714,13 @@ func (s LoggingOptionsPayload) GoString() string {
 
 // Describes an AWS IoT policy.
 type Policy struct {
+	_ struct{} `type:"structure"`
+
 	// The policy ARN.
 	PolicyArn *string `locationName:"policyArn" type:"string"`
 
 	// The policy name.
 	PolicyName *string `locationName:"policyName" min:"1" type:"string"`
-
-	_ struct{} `type:"structure"`
 }
 
 // String returns the string representation
@@ -2735,6 +2735,8 @@ func (s Policy) GoString() string {
 
 // Describes a policy version.
 type PolicyVersion struct {
+	_ struct{} `type:"structure"`
+
 	// The date and time the policy was created.
 	CreateDate *time.Time `locationName:"createDate" type:"timestamp" timestampFormat:"unix"`
 
@@ -2743,8 +2745,6 @@ type PolicyVersion struct {
 
 	// The policy version ID.
 	VersionId *string `locationName:"versionId" type:"string"`
-
-	_ struct{} `type:"structure"`
 }
 
 // String returns the string representation
@@ -2759,10 +2759,10 @@ func (s PolicyVersion) GoString() string {
 
 // The input for the RejectCertificateTransfer operation.
 type RejectCertificateTransferInput struct {
+	_ struct{} `type:"structure"`
+
 	// The ID of the certificate.
 	CertificateId *string `location:"uri" locationName:"certificateId" min:"64" type:"string" required:"true"`
-
-	_ struct{} `type:"structure"`
 }
 
 // String returns the string representation
@@ -2791,13 +2791,13 @@ func (s RejectCertificateTransferOutput) GoString() string {
 
 // The input for the ReplaceTopicRule operation.
 type ReplaceTopicRuleInput struct {
+	_ struct{} `type:"structure" payload:"TopicRulePayload"`
+
 	// The name of the rule.
 	RuleName *string `location:"uri" locationName:"ruleName" min:"1" type:"string" required:"true"`
 
 	// The rule payload.
 	TopicRulePayload *TopicRulePayload `locationName:"topicRulePayload" type:"structure" required:"true"`
-
-	_ struct{} `type:"structure" payload:"TopicRulePayload"`
 }
 
 // String returns the string representation
@@ -2826,13 +2826,13 @@ func (s ReplaceTopicRuleOutput) GoString() string {
 
 // Describes an action to republish to another topic.
 type RepublishAction struct {
+	_ struct{} `type:"structure"`
+
 	// The ARN of the IAM role that grants access.
 	RoleArn *string `locationName:"roleArn" type:"string" required:"true"`
 
 	// The name of the MQTT topic.
 	Topic *string `locationName:"topic" type:"string" required:"true"`
-
-	_ struct{} `type:"structure"`
 }
 
 // String returns the string representation
@@ -2847,6 +2847,8 @@ func (s RepublishAction) GoString() string {
 
 // Describes an action to write data to an Amazon S3 bucket.
 type S3Action struct {
+	_ struct{} `type:"structure"`
+
 	// The S3 bucket.
 	BucketName *string `locationName:"bucketName" type:"string" required:"true"`
 
@@ -2855,8 +2857,6 @@ type S3Action struct {
 
 	// The ARN of the IAM role that grants access.
 	RoleArn *string `locationName:"roleArn" type:"string" required:"true"`
-
-	_ struct{} `type:"structure"`
 }
 
 // String returns the string representation
@@ -2871,13 +2871,13 @@ func (s S3Action) GoString() string {
 
 // The input for the SetDefaultPolicyVersion operation.
 type SetDefaultPolicyVersionInput struct {
+	_ struct{} `type:"structure"`
+
 	// The policy name.
 	PolicyName *string `location:"uri" locationName:"policyName" min:"1" type:"string" required:"true"`
 
 	// The policy version ID.
 	PolicyVersionId *string `location:"uri" locationName:"policyVersionId" type:"string" required:"true"`
-
-	_ struct{} `type:"structure"`
 }
 
 // String returns the string representation
@@ -2906,10 +2906,10 @@ func (s SetDefaultPolicyVersionOutput) GoString() string {
 
 // The input for the SetLoggingOptions operation.
 type SetLoggingOptionsInput struct {
+	_ struct{} `type:"structure" payload:"LoggingOptionsPayload"`
+
 	// The logging options payload.
 	LoggingOptionsPayload *LoggingOptionsPayload `locationName:"loggingOptionsPayload" type:"structure"`
-
-	_ struct{} `type:"structure" payload:"LoggingOptionsPayload"`
 }
 
 // String returns the string representation
@@ -2938,13 +2938,13 @@ func (s SetLoggingOptionsOutput) GoString() string {
 
 // Describes an action to publish to an Amazon SNS topic.
 type SnsAction struct {
+	_ struct{} `type:"structure"`
+
 	// The ARN of the IAM role that grants access.
 	RoleArn *string `locationName:"roleArn" type:"string" required:"true"`
 
 	// The ARN of the SNS topic.
 	TargetArn *string `locationName:"targetArn" type:"string" required:"true"`
-
-	_ struct{} `type:"structure"`
 }
 
 // String returns the string representation
@@ -2959,6 +2959,8 @@ func (s SnsAction) GoString() string {
 
 // Describes an action to publish data to an SQS queue.
 type SqsAction struct {
+	_ struct{} `type:"structure"`
+
 	// The URL of the Amazon SQS queue.
 	QueueUrl *string `locationName:"queueUrl" type:"string" required:"true"`
 
@@ -2967,8 +2969,6 @@ type SqsAction struct {
 
 	// Specifies whether to use Base64 encoding.
 	UseBase64 *bool `locationName:"useBase64" type:"boolean"`
-
-	_ struct{} `type:"structure"`
 }
 
 // String returns the string representation
@@ -2983,13 +2983,13 @@ func (s SqsAction) GoString() string {
 
 // Describes a thing attribute.
 type ThingAttribute struct {
+	_ struct{} `type:"structure"`
+
 	// The attributes.
 	Attributes map[string]*string `locationName:"attributes" type:"map"`
 
 	// The name of the thing.
 	ThingName *string `locationName:"thingName" min:"1" type:"string"`
-
-	_ struct{} `type:"structure"`
 }
 
 // String returns the string representation
@@ -3004,6 +3004,8 @@ func (s ThingAttribute) GoString() string {
 
 // Describes a rule.
 type TopicRule struct {
+	_ struct{} `type:"structure"`
+
 	// The actions associated with the rule.
 	Actions []*Action `locationName:"actions" type:"list"`
 
@@ -3022,8 +3024,6 @@ type TopicRule struct {
 	// The SQL statement used to query the topic. When using a SQL query with multiple
 	// lines, be sure to escape the newline characters properly.
 	Sql *string `locationName:"sql" type:"string"`
-
-	_ struct{} `type:"structure"`
 }
 
 // String returns the string representation
@@ -3038,6 +3038,8 @@ func (s TopicRule) GoString() string {
 
 // Describes a rule.
 type TopicRuleListItem struct {
+	_ struct{} `type:"structure"`
+
 	// The date and time the rule was created.
 	CreatedAt *time.Time `locationName:"createdAt" type:"timestamp" timestampFormat:"unix"`
 
@@ -3049,8 +3051,6 @@ type TopicRuleListItem struct {
 
 	// The pattern for the topic names that apply.
 	TopicPattern *string `locationName:"topicPattern" type:"string"`
-
-	_ struct{} `type:"structure"`
 }
 
 // String returns the string representation
@@ -3065,6 +3065,8 @@ func (s TopicRuleListItem) GoString() string {
 
 // Describes a rule.
 type TopicRulePayload struct {
+	_ struct{} `type:"structure"`
+
 	// The actions associated with the rule.
 	Actions []*Action `locationName:"actions" type:"list" required:"true"`
 
@@ -3078,8 +3080,6 @@ type TopicRulePayload struct {
 	// IoT SQL Reference (http://docs.aws.amazon.com/iot/latest/developerguide/iot-rules.html#aws-iot-sql-reference)
 	// in the AWS IoT Developer Guide.
 	Sql *string `locationName:"sql" type:"string" required:"true"`
-
-	_ struct{} `type:"structure"`
 }
 
 // String returns the string representation
@@ -3094,13 +3094,13 @@ func (s TopicRulePayload) GoString() string {
 
 // The input for the TransferCertificate operation.
 type TransferCertificateInput struct {
+	_ struct{} `type:"structure"`
+
 	// The ID of the certificate.
 	CertificateId *string `location:"uri" locationName:"certificateId" min:"64" type:"string" required:"true"`
 
 	// The AWS account.
 	TargetAwsAccount *string `location:"querystring" locationName:"targetAwsAccount" type:"string" required:"true"`
-
-	_ struct{} `type:"structure"`
 }
 
 // String returns the string representation
@@ -3115,10 +3115,10 @@ func (s TransferCertificateInput) GoString() string {
 
 // The output from the TransferCertificate operation.
 type TransferCertificateOutput struct {
+	_ struct{} `type:"structure"`
+
 	// The ARN of the certificate.
 	TransferredCertificateArn *string `locationName:"transferredCertificateArn" type:"string"`
-
-	_ struct{} `type:"structure"`
 }
 
 // String returns the string representation
@@ -3133,13 +3133,13 @@ func (s TransferCertificateOutput) GoString() string {
 
 // The input for the UpdateCertificate operation.
 type UpdateCertificateInput struct {
+	_ struct{} `type:"structure"`
+
 	// The ID of the certificate.
 	CertificateId *string `location:"uri" locationName:"certificateId" min:"64" type:"string" required:"true"`
 
 	// The new status.
 	NewStatus *string `location:"querystring" locationName:"newStatus" type:"string" required:"true" enum:"CertificateStatus"`
-
-	_ struct{} `type:"structure"`
 }
 
 // String returns the string representation
@@ -3168,6 +3168,8 @@ func (s UpdateCertificateOutput) GoString() string {
 
 // The input for the UpdateThing operation.
 type UpdateThingInput struct {
+	_ struct{} `type:"structure"`
+
 	// The attribute payload, a JSON string containing up to three key-value pairs.
 	//
 	// For example: {\"attributes\":{\"string1\":\"string2\”}}
@@ -3175,8 +3177,6 @@ type UpdateThingInput struct {
 
 	// The thing name.
 	ThingName *string `location:"uri" locationName:"thingName" min:"1" type:"string" required:"true"`
-
-	_ struct{} `type:"structure"`
 }
 
 // String returns the string representation

--- a/service/iotdataplane/api.go
+++ b/service/iotdataplane/api.go
@@ -133,11 +133,7 @@ type DeleteThingShadowInput struct {
 	// The name of the thing.
 	ThingName *string `location:"uri" locationName:"thingName" min:"1" type:"string" required:"true"`
 
-	metadataDeleteThingShadowInput `json:"-" xml:"-"`
-}
-
-type metadataDeleteThingShadowInput struct {
-	SDKShapeTraits bool `type:"structure"`
+	_ struct{} `type:"structure"`
 }
 
 // String returns the string representation
@@ -155,11 +151,7 @@ type DeleteThingShadowOutput struct {
 	// The state information, in JSON format.
 	Payload []byte `locationName:"payload" type:"blob" required:"true"`
 
-	metadataDeleteThingShadowOutput `json:"-" xml:"-"`
-}
-
-type metadataDeleteThingShadowOutput struct {
-	SDKShapeTraits bool `type:"structure" payload:"Payload"`
+	_ struct{} `type:"structure" payload:"Payload"`
 }
 
 // String returns the string representation
@@ -177,11 +169,7 @@ type GetThingShadowInput struct {
 	// The name of the thing.
 	ThingName *string `location:"uri" locationName:"thingName" min:"1" type:"string" required:"true"`
 
-	metadataGetThingShadowInput `json:"-" xml:"-"`
-}
-
-type metadataGetThingShadowInput struct {
-	SDKShapeTraits bool `type:"structure"`
+	_ struct{} `type:"structure"`
 }
 
 // String returns the string representation
@@ -199,11 +187,7 @@ type GetThingShadowOutput struct {
 	// The state information, in JSON format.
 	Payload []byte `locationName:"payload" type:"blob"`
 
-	metadataGetThingShadowOutput `json:"-" xml:"-"`
-}
-
-type metadataGetThingShadowOutput struct {
-	SDKShapeTraits bool `type:"structure" payload:"Payload"`
+	_ struct{} `type:"structure" payload:"Payload"`
 }
 
 // String returns the string representation
@@ -227,11 +211,7 @@ type PublishInput struct {
 	// The name of the MQTT topic.
 	Topic *string `location:"uri" locationName:"topic" type:"string" required:"true"`
 
-	metadataPublishInput `json:"-" xml:"-"`
-}
-
-type metadataPublishInput struct {
-	SDKShapeTraits bool `type:"structure" payload:"Payload"`
+	_ struct{} `type:"structure" payload:"Payload"`
 }
 
 // String returns the string representation
@@ -245,11 +225,7 @@ func (s PublishInput) GoString() string {
 }
 
 type PublishOutput struct {
-	metadataPublishOutput `json:"-" xml:"-"`
-}
-
-type metadataPublishOutput struct {
-	SDKShapeTraits bool `type:"structure"`
+	_ struct{} `type:"structure"`
 }
 
 // String returns the string representation
@@ -270,11 +246,7 @@ type UpdateThingShadowInput struct {
 	// The name of the thing.
 	ThingName *string `location:"uri" locationName:"thingName" min:"1" type:"string" required:"true"`
 
-	metadataUpdateThingShadowInput `json:"-" xml:"-"`
-}
-
-type metadataUpdateThingShadowInput struct {
-	SDKShapeTraits bool `type:"structure" payload:"Payload"`
+	_ struct{} `type:"structure" payload:"Payload"`
 }
 
 // String returns the string representation
@@ -292,11 +264,7 @@ type UpdateThingShadowOutput struct {
 	// The state information, in JSON format.
 	Payload []byte `locationName:"payload" type:"blob"`
 
-	metadataUpdateThingShadowOutput `json:"-" xml:"-"`
-}
-
-type metadataUpdateThingShadowOutput struct {
-	SDKShapeTraits bool `type:"structure" payload:"Payload"`
+	_ struct{} `type:"structure" payload:"Payload"`
 }
 
 // String returns the string representation

--- a/service/iotdataplane/api.go
+++ b/service/iotdataplane/api.go
@@ -130,10 +130,10 @@ func (c *IoTDataPlane) UpdateThingShadow(input *UpdateThingShadowInput) (*Update
 
 // The input for the DeleteThingShadow operation.
 type DeleteThingShadowInput struct {
+	_ struct{} `type:"structure"`
+
 	// The name of the thing.
 	ThingName *string `location:"uri" locationName:"thingName" min:"1" type:"string" required:"true"`
-
-	_ struct{} `type:"structure"`
 }
 
 // String returns the string representation
@@ -148,10 +148,10 @@ func (s DeleteThingShadowInput) GoString() string {
 
 // The output from the DeleteThingShadow operation.
 type DeleteThingShadowOutput struct {
+	_ struct{} `type:"structure" payload:"Payload"`
+
 	// The state information, in JSON format.
 	Payload []byte `locationName:"payload" type:"blob" required:"true"`
-
-	_ struct{} `type:"structure" payload:"Payload"`
 }
 
 // String returns the string representation
@@ -166,10 +166,10 @@ func (s DeleteThingShadowOutput) GoString() string {
 
 // The input for the GetThingShadow operation.
 type GetThingShadowInput struct {
+	_ struct{} `type:"structure"`
+
 	// The name of the thing.
 	ThingName *string `location:"uri" locationName:"thingName" min:"1" type:"string" required:"true"`
-
-	_ struct{} `type:"structure"`
 }
 
 // String returns the string representation
@@ -184,10 +184,10 @@ func (s GetThingShadowInput) GoString() string {
 
 // The output from the GetThingShadow operation.
 type GetThingShadowOutput struct {
+	_ struct{} `type:"structure" payload:"Payload"`
+
 	// The state information, in JSON format.
 	Payload []byte `locationName:"payload" type:"blob"`
-
-	_ struct{} `type:"structure" payload:"Payload"`
 }
 
 // String returns the string representation
@@ -202,6 +202,8 @@ func (s GetThingShadowOutput) GoString() string {
 
 // The input for the Publish operation.
 type PublishInput struct {
+	_ struct{} `type:"structure" payload:"Payload"`
+
 	// The state information, in JSON format.
 	Payload []byte `locationName:"payload" type:"blob"`
 
@@ -210,8 +212,6 @@ type PublishInput struct {
 
 	// The name of the MQTT topic.
 	Topic *string `location:"uri" locationName:"topic" type:"string" required:"true"`
-
-	_ struct{} `type:"structure" payload:"Payload"`
 }
 
 // String returns the string representation
@@ -240,13 +240,13 @@ func (s PublishOutput) GoString() string {
 
 // The input for the UpdateThingShadow operation.
 type UpdateThingShadowInput struct {
+	_ struct{} `type:"structure" payload:"Payload"`
+
 	// The state information, in JSON format.
 	Payload []byte `locationName:"payload" type:"blob" required:"true"`
 
 	// The name of the thing.
 	ThingName *string `location:"uri" locationName:"thingName" min:"1" type:"string" required:"true"`
-
-	_ struct{} `type:"structure" payload:"Payload"`
 }
 
 // String returns the string representation
@@ -261,10 +261,10 @@ func (s UpdateThingShadowInput) GoString() string {
 
 // The output from the UpdateThingShadow operation.
 type UpdateThingShadowOutput struct {
+	_ struct{} `type:"structure" payload:"Payload"`
+
 	// The state information, in JSON format.
 	Payload []byte `locationName:"payload" type:"blob"`
-
-	_ struct{} `type:"structure" payload:"Payload"`
 }
 
 // String returns the string representation

--- a/service/kinesis/api.go
+++ b/service/kinesis/api.go
@@ -825,11 +825,7 @@ type AddTagsToStreamInput struct {
 	// The set of key-value pairs to use to create the tags.
 	Tags map[string]*string `min:"1" type:"map" required:"true"`
 
-	metadataAddTagsToStreamInput `json:"-" xml:"-"`
-}
-
-type metadataAddTagsToStreamInput struct {
-	SDKShapeTraits bool `type:"structure"`
+	_ struct{} `type:"structure"`
 }
 
 // String returns the string representation
@@ -843,11 +839,7 @@ func (s AddTagsToStreamInput) GoString() string {
 }
 
 type AddTagsToStreamOutput struct {
-	metadataAddTagsToStreamOutput `json:"-" xml:"-"`
-}
-
-type metadataAddTagsToStreamOutput struct {
-	SDKShapeTraits bool `type:"structure"`
+	_ struct{} `type:"structure"`
 }
 
 // String returns the string representation
@@ -876,11 +868,7 @@ type CreateStreamInput struct {
 	// have the same name.
 	StreamName *string `min:"1" type:"string" required:"true"`
 
-	metadataCreateStreamInput `json:"-" xml:"-"`
-}
-
-type metadataCreateStreamInput struct {
-	SDKShapeTraits bool `type:"structure"`
+	_ struct{} `type:"structure"`
 }
 
 // String returns the string representation
@@ -894,11 +882,7 @@ func (s CreateStreamInput) GoString() string {
 }
 
 type CreateStreamOutput struct {
-	metadataCreateStreamOutput `json:"-" xml:"-"`
-}
-
-type metadataCreateStreamOutput struct {
-	SDKShapeTraits bool `type:"structure"`
+	_ struct{} `type:"structure"`
 }
 
 // String returns the string representation
@@ -920,11 +904,7 @@ type DecreaseStreamRetentionPeriodInput struct {
 	// The name of the stream to modify.
 	StreamName *string `min:"1" type:"string" required:"true"`
 
-	metadataDecreaseStreamRetentionPeriodInput `json:"-" xml:"-"`
-}
-
-type metadataDecreaseStreamRetentionPeriodInput struct {
-	SDKShapeTraits bool `type:"structure"`
+	_ struct{} `type:"structure"`
 }
 
 // String returns the string representation
@@ -938,11 +918,7 @@ func (s DecreaseStreamRetentionPeriodInput) GoString() string {
 }
 
 type DecreaseStreamRetentionPeriodOutput struct {
-	metadataDecreaseStreamRetentionPeriodOutput `json:"-" xml:"-"`
-}
-
-type metadataDecreaseStreamRetentionPeriodOutput struct {
-	SDKShapeTraits bool `type:"structure"`
+	_ struct{} `type:"structure"`
 }
 
 // String returns the string representation
@@ -960,11 +936,7 @@ type DeleteStreamInput struct {
 	// The name of the stream to delete.
 	StreamName *string `min:"1" type:"string" required:"true"`
 
-	metadataDeleteStreamInput `json:"-" xml:"-"`
-}
-
-type metadataDeleteStreamInput struct {
-	SDKShapeTraits bool `type:"structure"`
+	_ struct{} `type:"structure"`
 }
 
 // String returns the string representation
@@ -978,11 +950,7 @@ func (s DeleteStreamInput) GoString() string {
 }
 
 type DeleteStreamOutput struct {
-	metadataDeleteStreamOutput `json:"-" xml:"-"`
-}
-
-type metadataDeleteStreamOutput struct {
-	SDKShapeTraits bool `type:"structure"`
+	_ struct{} `type:"structure"`
 }
 
 // String returns the string representation
@@ -1006,11 +974,7 @@ type DescribeStreamInput struct {
 	// The name of the stream to describe.
 	StreamName *string `min:"1" type:"string" required:"true"`
 
-	metadataDescribeStreamInput `json:"-" xml:"-"`
-}
-
-type metadataDescribeStreamInput struct {
-	SDKShapeTraits bool `type:"structure"`
+	_ struct{} `type:"structure"`
 }
 
 // String returns the string representation
@@ -1029,11 +993,7 @@ type DescribeStreamOutput struct {
 	// that comprise the stream, and states whether there are more shards available.
 	StreamDescription *StreamDescription `type:"structure" required:"true"`
 
-	metadataDescribeStreamOutput `json:"-" xml:"-"`
-}
-
-type metadataDescribeStreamOutput struct {
-	SDKShapeTraits bool `type:"structure"`
+	_ struct{} `type:"structure"`
 }
 
 // String returns the string representation
@@ -1057,11 +1017,7 @@ type GetRecordsInput struct {
 	// number of a data record in the shard.
 	ShardIterator *string `min:"1" type:"string" required:"true"`
 
-	metadataGetRecordsInput `json:"-" xml:"-"`
-}
-
-type metadataGetRecordsInput struct {
-	SDKShapeTraits bool `type:"structure"`
+	_ struct{} `type:"structure"`
 }
 
 // String returns the string representation
@@ -1090,11 +1046,7 @@ type GetRecordsOutput struct {
 	// The data records retrieved from the shard.
 	Records []*Record `type:"list" required:"true"`
 
-	metadataGetRecordsOutput `json:"-" xml:"-"`
-}
-
-type metadataGetRecordsOutput struct {
-	SDKShapeTraits bool `type:"structure"`
+	_ struct{} `type:"structure"`
 }
 
 // String returns the string representation
@@ -1133,11 +1085,7 @@ type GetShardIteratorInput struct {
 	// The name of the stream.
 	StreamName *string `min:"1" type:"string" required:"true"`
 
-	metadataGetShardIteratorInput `json:"-" xml:"-"`
-}
-
-type metadataGetShardIteratorInput struct {
-	SDKShapeTraits bool `type:"structure"`
+	_ struct{} `type:"structure"`
 }
 
 // String returns the string representation
@@ -1157,11 +1105,7 @@ type GetShardIteratorOutput struct {
 	// record in a shard.
 	ShardIterator *string `min:"1" type:"string"`
 
-	metadataGetShardIteratorOutput `json:"-" xml:"-"`
-}
-
-type metadataGetShardIteratorOutput struct {
-	SDKShapeTraits bool `type:"structure"`
+	_ struct{} `type:"structure"`
 }
 
 // String returns the string representation
@@ -1183,11 +1127,7 @@ type HashKeyRange struct {
 	// The starting hash key of the hash key range.
 	StartingHashKey *string `type:"string" required:"true"`
 
-	metadataHashKeyRange `json:"-" xml:"-"`
-}
-
-type metadataHashKeyRange struct {
-	SDKShapeTraits bool `type:"structure"`
+	_ struct{} `type:"structure"`
 }
 
 // String returns the string representation
@@ -1209,11 +1149,7 @@ type IncreaseStreamRetentionPeriodInput struct {
 	// The name of the stream to modify.
 	StreamName *string `min:"1" type:"string" required:"true"`
 
-	metadataIncreaseStreamRetentionPeriodInput `json:"-" xml:"-"`
-}
-
-type metadataIncreaseStreamRetentionPeriodInput struct {
-	SDKShapeTraits bool `type:"structure"`
+	_ struct{} `type:"structure"`
 }
 
 // String returns the string representation
@@ -1227,11 +1163,7 @@ func (s IncreaseStreamRetentionPeriodInput) GoString() string {
 }
 
 type IncreaseStreamRetentionPeriodOutput struct {
-	metadataIncreaseStreamRetentionPeriodOutput `json:"-" xml:"-"`
-}
-
-type metadataIncreaseStreamRetentionPeriodOutput struct {
-	SDKShapeTraits bool `type:"structure"`
+	_ struct{} `type:"structure"`
 }
 
 // String returns the string representation
@@ -1252,11 +1184,7 @@ type ListStreamsInput struct {
 	// The maximum number of streams to list.
 	Limit *int64 `min:"1" type:"integer"`
 
-	metadataListStreamsInput `json:"-" xml:"-"`
-}
-
-type metadataListStreamsInput struct {
-	SDKShapeTraits bool `type:"structure"`
+	_ struct{} `type:"structure"`
 }
 
 // String returns the string representation
@@ -1278,11 +1206,7 @@ type ListStreamsOutput struct {
 	// the ListStreams request.
 	StreamNames []*string `type:"list" required:"true"`
 
-	metadataListStreamsOutput `json:"-" xml:"-"`
-}
-
-type metadataListStreamsOutput struct {
-	SDKShapeTraits bool `type:"structure"`
+	_ struct{} `type:"structure"`
 }
 
 // String returns the string representation
@@ -1309,11 +1233,7 @@ type ListTagsForStreamInput struct {
 	// The name of the stream.
 	StreamName *string `min:"1" type:"string" required:"true"`
 
-	metadataListTagsForStreamInput `json:"-" xml:"-"`
-}
-
-type metadataListTagsForStreamInput struct {
-	SDKShapeTraits bool `type:"structure"`
+	_ struct{} `type:"structure"`
 }
 
 // String returns the string representation
@@ -1336,11 +1256,7 @@ type ListTagsForStreamOutput struct {
 	// ExclusiveStartTagKey and up to the specified Limit.
 	Tags []*Tag `type:"list" required:"true"`
 
-	metadataListTagsForStreamOutput `json:"-" xml:"-"`
-}
-
-type metadataListTagsForStreamOutput struct {
-	SDKShapeTraits bool `type:"structure"`
+	_ struct{} `type:"structure"`
 }
 
 // String returns the string representation
@@ -1364,11 +1280,7 @@ type MergeShardsInput struct {
 	// The name of the stream for the merge.
 	StreamName *string `min:"1" type:"string" required:"true"`
 
-	metadataMergeShardsInput `json:"-" xml:"-"`
-}
-
-type metadataMergeShardsInput struct {
-	SDKShapeTraits bool `type:"structure"`
+	_ struct{} `type:"structure"`
 }
 
 // String returns the string representation
@@ -1382,11 +1294,7 @@ func (s MergeShardsInput) GoString() string {
 }
 
 type MergeShardsOutput struct {
-	metadataMergeShardsOutput `json:"-" xml:"-"`
-}
-
-type metadataMergeShardsOutput struct {
-	SDKShapeTraits bool `type:"structure"`
+	_ struct{} `type:"structure"`
 }
 
 // String returns the string representation
@@ -1431,11 +1339,7 @@ type PutRecordInput struct {
 	// The name of the stream to put the data record into.
 	StreamName *string `min:"1" type:"string" required:"true"`
 
-	metadataPutRecordInput `json:"-" xml:"-"`
-}
-
-type metadataPutRecordInput struct {
-	SDKShapeTraits bool `type:"structure"`
+	_ struct{} `type:"structure"`
 }
 
 // String returns the string representation
@@ -1459,11 +1363,7 @@ type PutRecordOutput struct {
 	// The shard ID of the shard where the data record was placed.
 	ShardId *string `min:"1" type:"string" required:"true"`
 
-	metadataPutRecordOutput `json:"-" xml:"-"`
-}
-
-type metadataPutRecordOutput struct {
-	SDKShapeTraits bool `type:"structure"`
+	_ struct{} `type:"structure"`
 }
 
 // String returns the string representation
@@ -1484,11 +1384,7 @@ type PutRecordsInput struct {
 	// The stream name associated with the request.
 	StreamName *string `min:"1" type:"string" required:"true"`
 
-	metadataPutRecordsInput `json:"-" xml:"-"`
-}
-
-type metadataPutRecordsInput struct {
-	SDKShapeTraits bool `type:"structure"`
+	_ struct{} `type:"structure"`
 }
 
 // String returns the string representation
@@ -1513,11 +1409,7 @@ type PutRecordsOutput struct {
 	// ErrorCode and ErrorMessage in the result.
 	Records []*PutRecordsResultEntry `min:"1" type:"list" required:"true"`
 
-	metadataPutRecordsOutput `json:"-" xml:"-"`
-}
-
-type metadataPutRecordsOutput struct {
-	SDKShapeTraits bool `type:"structure"`
+	_ struct{} `type:"structure"`
 }
 
 // String returns the string representation
@@ -1552,11 +1444,7 @@ type PutRecordsRequestEntry struct {
 	// within the stream.
 	PartitionKey *string `min:"1" type:"string" required:"true"`
 
-	metadataPutRecordsRequestEntry `json:"-" xml:"-"`
-}
-
-type metadataPutRecordsRequestEntry struct {
-	SDKShapeTraits bool `type:"structure"`
+	_ struct{} `type:"structure"`
 }
 
 // String returns the string representation
@@ -1591,11 +1479,7 @@ type PutRecordsResultEntry struct {
 	// The shard ID for an individual record result.
 	ShardId *string `min:"1" type:"string"`
 
-	metadataPutRecordsResultEntry `json:"-" xml:"-"`
-}
-
-type metadataPutRecordsResultEntry struct {
-	SDKShapeTraits bool `type:"structure"`
+	_ struct{} `type:"structure"`
 }
 
 // String returns the string representation
@@ -1627,11 +1511,7 @@ type Record struct {
 	// The unique identifier of the record in the stream.
 	SequenceNumber *string `type:"string" required:"true"`
 
-	metadataRecord `json:"-" xml:"-"`
-}
-
-type metadataRecord struct {
-	SDKShapeTraits bool `type:"structure"`
+	_ struct{} `type:"structure"`
 }
 
 // String returns the string representation
@@ -1652,11 +1532,7 @@ type RemoveTagsFromStreamInput struct {
 	// A list of tag keys. Each corresponding tag is removed from the stream.
 	TagKeys []*string `min:"1" type:"list" required:"true"`
 
-	metadataRemoveTagsFromStreamInput `json:"-" xml:"-"`
-}
-
-type metadataRemoveTagsFromStreamInput struct {
-	SDKShapeTraits bool `type:"structure"`
+	_ struct{} `type:"structure"`
 }
 
 // String returns the string representation
@@ -1670,11 +1546,7 @@ func (s RemoveTagsFromStreamInput) GoString() string {
 }
 
 type RemoveTagsFromStreamOutput struct {
-	metadataRemoveTagsFromStreamOutput `json:"-" xml:"-"`
-}
-
-type metadataRemoveTagsFromStreamOutput struct {
-	SDKShapeTraits bool `type:"structure"`
+	_ struct{} `type:"structure"`
 }
 
 // String returns the string representation
@@ -1696,11 +1568,7 @@ type SequenceNumberRange struct {
 	// The starting sequence number for the range.
 	StartingSequenceNumber *string `type:"string" required:"true"`
 
-	metadataSequenceNumberRange `json:"-" xml:"-"`
-}
-
-type metadataSequenceNumberRange struct {
-	SDKShapeTraits bool `type:"structure"`
+	_ struct{} `type:"structure"`
 }
 
 // String returns the string representation
@@ -1731,11 +1599,7 @@ type Shard struct {
 	// The unique identifier of the shard within the Amazon Kinesis stream.
 	ShardId *string `min:"1" type:"string" required:"true"`
 
-	metadataShard `json:"-" xml:"-"`
-}
-
-type metadataShard struct {
-	SDKShapeTraits bool `type:"structure"`
+	_ struct{} `type:"structure"`
 }
 
 // String returns the string representation
@@ -1765,11 +1629,7 @@ type SplitShardInput struct {
 	// The name of the stream for the shard split.
 	StreamName *string `min:"1" type:"string" required:"true"`
 
-	metadataSplitShardInput `json:"-" xml:"-"`
-}
-
-type metadataSplitShardInput struct {
-	SDKShapeTraits bool `type:"structure"`
+	_ struct{} `type:"structure"`
 }
 
 // String returns the string representation
@@ -1783,11 +1643,7 @@ func (s SplitShardInput) GoString() string {
 }
 
 type SplitShardOutput struct {
-	metadataSplitShardOutput `json:"-" xml:"-"`
-}
-
-type metadataSplitShardOutput struct {
-	SDKShapeTraits bool `type:"structure"`
+	_ struct{} `type:"structure"`
 }
 
 // String returns the string representation
@@ -1831,11 +1687,7 @@ type StreamDescription struct {
 	// the UPDATING state.
 	StreamStatus *string `type:"string" required:"true" enum:"StreamStatus"`
 
-	metadataStreamDescription `json:"-" xml:"-"`
-}
-
-type metadataStreamDescription struct {
-	SDKShapeTraits bool `type:"structure"`
+	_ struct{} `type:"structure"`
 }
 
 // String returns the string representation
@@ -1859,11 +1711,7 @@ type Tag struct {
 	// space, _ . / = + - % @
 	Value *string `type:"string"`
 
-	metadataTag `json:"-" xml:"-"`
-}
-
-type metadataTag struct {
-	SDKShapeTraits bool `type:"structure"`
+	_ struct{} `type:"structure"`
 }
 
 // String returns the string representation

--- a/service/kinesis/api.go
+++ b/service/kinesis/api.go
@@ -819,13 +819,13 @@ func (c *Kinesis) SplitShard(input *SplitShardInput) (*SplitShardOutput, error) 
 
 // Represents the input for AddTagsToStream.
 type AddTagsToStreamInput struct {
+	_ struct{} `type:"structure"`
+
 	// The name of the stream.
 	StreamName *string `min:"1" type:"string" required:"true"`
 
 	// The set of key-value pairs to use to create the tags.
 	Tags map[string]*string `min:"1" type:"map" required:"true"`
-
-	_ struct{} `type:"structure"`
 }
 
 // String returns the string representation
@@ -854,6 +854,8 @@ func (s AddTagsToStreamOutput) GoString() string {
 
 // Represents the input for CreateStream.
 type CreateStreamInput struct {
+	_ struct{} `type:"structure"`
+
 	// The number of shards that the stream will use. The throughput of the stream
 	// is a function of the number of shards; more shards are required for greater
 	// provisioned throughput.
@@ -867,8 +869,6 @@ type CreateStreamInput struct {
 	// and two streams in the same AWS account, but in two different regions, can
 	// have the same name.
 	StreamName *string `min:"1" type:"string" required:"true"`
-
-	_ struct{} `type:"structure"`
 }
 
 // String returns the string representation
@@ -897,14 +897,14 @@ func (s CreateStreamOutput) GoString() string {
 
 // Represents the input for DecreaseStreamRetentionPeriod.
 type DecreaseStreamRetentionPeriodInput struct {
+	_ struct{} `type:"structure"`
+
 	// The new retention period of the stream, in hours. Must be less than the current
 	// retention period.
 	RetentionPeriodHours *int64 `min:"24" type:"integer" required:"true"`
 
 	// The name of the stream to modify.
 	StreamName *string `min:"1" type:"string" required:"true"`
-
-	_ struct{} `type:"structure"`
 }
 
 // String returns the string representation
@@ -933,10 +933,10 @@ func (s DecreaseStreamRetentionPeriodOutput) GoString() string {
 
 // Represents the input for DeleteStream.
 type DeleteStreamInput struct {
+	_ struct{} `type:"structure"`
+
 	// The name of the stream to delete.
 	StreamName *string `min:"1" type:"string" required:"true"`
-
-	_ struct{} `type:"structure"`
 }
 
 // String returns the string representation
@@ -965,6 +965,8 @@ func (s DeleteStreamOutput) GoString() string {
 
 // Represents the input for DescribeStream.
 type DescribeStreamInput struct {
+	_ struct{} `type:"structure"`
+
 	// The shard ID of the shard to start with.
 	ExclusiveStartShardId *string `min:"1" type:"string"`
 
@@ -973,8 +975,6 @@ type DescribeStreamInput struct {
 
 	// The name of the stream to describe.
 	StreamName *string `min:"1" type:"string" required:"true"`
-
-	_ struct{} `type:"structure"`
 }
 
 // String returns the string representation
@@ -989,11 +989,11 @@ func (s DescribeStreamInput) GoString() string {
 
 // Represents the output for DescribeStream.
 type DescribeStreamOutput struct {
+	_ struct{} `type:"structure"`
+
 	// The current status of the stream, the stream ARN, an array of shard objects
 	// that comprise the stream, and states whether there are more shards available.
 	StreamDescription *StreamDescription `type:"structure" required:"true"`
-
-	_ struct{} `type:"structure"`
 }
 
 // String returns the string representation
@@ -1008,6 +1008,8 @@ func (s DescribeStreamOutput) GoString() string {
 
 // Represents the input for GetRecords.
 type GetRecordsInput struct {
+	_ struct{} `type:"structure"`
+
 	// The maximum number of records to return. Specify a value of up to 10,000.
 	// If you specify a value that is greater than 10,000, GetRecords throws InvalidArgumentException.
 	Limit *int64 `min:"1" type:"integer"`
@@ -1016,8 +1018,6 @@ type GetRecordsInput struct {
 	// data records. A shard iterator specifies this position using the sequence
 	// number of a data record in the shard.
 	ShardIterator *string `min:"1" type:"string" required:"true"`
-
-	_ struct{} `type:"structure"`
 }
 
 // String returns the string representation
@@ -1032,6 +1032,8 @@ func (s GetRecordsInput) GoString() string {
 
 // Represents the output for GetRecords.
 type GetRecordsOutput struct {
+	_ struct{} `type:"structure"`
+
 	// The number of milliseconds the GetRecords response is from the tip of the
 	// stream, indicating how far behind current time the consumer is. A value of
 	// zero indicates record processing is caught up, and there are no new records
@@ -1045,8 +1047,6 @@ type GetRecordsOutput struct {
 
 	// The data records retrieved from the shard.
 	Records []*Record `type:"list" required:"true"`
-
-	_ struct{} `type:"structure"`
 }
 
 // String returns the string representation
@@ -1061,6 +1061,8 @@ func (s GetRecordsOutput) GoString() string {
 
 // Represents the input for GetShardIterator.
 type GetShardIteratorInput struct {
+	_ struct{} `type:"structure"`
+
 	// The shard ID of the shard to get the iterator for.
 	ShardId *string `min:"1" type:"string" required:"true"`
 
@@ -1084,8 +1086,6 @@ type GetShardIteratorInput struct {
 
 	// The name of the stream.
 	StreamName *string `min:"1" type:"string" required:"true"`
-
-	_ struct{} `type:"structure"`
 }
 
 // String returns the string representation
@@ -1100,12 +1100,12 @@ func (s GetShardIteratorInput) GoString() string {
 
 // Represents the output for GetShardIterator.
 type GetShardIteratorOutput struct {
+	_ struct{} `type:"structure"`
+
 	// The position in the shard from which to start reading data records sequentially.
 	// A shard iterator specifies this position using the sequence number of a data
 	// record in a shard.
 	ShardIterator *string `min:"1" type:"string"`
-
-	_ struct{} `type:"structure"`
 }
 
 // String returns the string representation
@@ -1121,13 +1121,13 @@ func (s GetShardIteratorOutput) GoString() string {
 // The range of possible hash key values for the shard, which is a set of ordered
 // contiguous positive integers.
 type HashKeyRange struct {
+	_ struct{} `type:"structure"`
+
 	// The ending hash key of the hash key range.
 	EndingHashKey *string `type:"string" required:"true"`
 
 	// The starting hash key of the hash key range.
 	StartingHashKey *string `type:"string" required:"true"`
-
-	_ struct{} `type:"structure"`
 }
 
 // String returns the string representation
@@ -1142,14 +1142,14 @@ func (s HashKeyRange) GoString() string {
 
 // Represents the input for IncreaseStreamRetentionPeriod.
 type IncreaseStreamRetentionPeriodInput struct {
+	_ struct{} `type:"structure"`
+
 	// The new retention period of the stream, in hours. Must be more than the current
 	// retention period.
 	RetentionPeriodHours *int64 `min:"24" type:"integer" required:"true"`
 
 	// The name of the stream to modify.
 	StreamName *string `min:"1" type:"string" required:"true"`
-
-	_ struct{} `type:"structure"`
 }
 
 // String returns the string representation
@@ -1178,13 +1178,13 @@ func (s IncreaseStreamRetentionPeriodOutput) GoString() string {
 
 // Represents the input for ListStreams.
 type ListStreamsInput struct {
+	_ struct{} `type:"structure"`
+
 	// The name of the stream to start the list with.
 	ExclusiveStartStreamName *string `min:"1" type:"string"`
 
 	// The maximum number of streams to list.
 	Limit *int64 `min:"1" type:"integer"`
-
-	_ struct{} `type:"structure"`
 }
 
 // String returns the string representation
@@ -1199,14 +1199,14 @@ func (s ListStreamsInput) GoString() string {
 
 // Represents the output for ListStreams.
 type ListStreamsOutput struct {
+	_ struct{} `type:"structure"`
+
 	// If set to true, there are more streams available to list.
 	HasMoreStreams *bool `type:"boolean" required:"true"`
 
 	// The names of the streams that are associated with the AWS account making
 	// the ListStreams request.
 	StreamNames []*string `type:"list" required:"true"`
-
-	_ struct{} `type:"structure"`
 }
 
 // String returns the string representation
@@ -1221,6 +1221,8 @@ func (s ListStreamsOutput) GoString() string {
 
 // Represents the input for ListTagsForStream.
 type ListTagsForStreamInput struct {
+	_ struct{} `type:"structure"`
+
 	// The key to use as the starting point for the list of tags. If this parameter
 	// is set, ListTagsForStream gets all tags that occur after ExclusiveStartTagKey.
 	ExclusiveStartTagKey *string `min:"1" type:"string"`
@@ -1232,8 +1234,6 @@ type ListTagsForStreamInput struct {
 
 	// The name of the stream.
 	StreamName *string `min:"1" type:"string" required:"true"`
-
-	_ struct{} `type:"structure"`
 }
 
 // String returns the string representation
@@ -1248,6 +1248,8 @@ func (s ListTagsForStreamInput) GoString() string {
 
 // Represents the output for ListTagsForStream.
 type ListTagsForStreamOutput struct {
+	_ struct{} `type:"structure"`
+
 	// If set to true, more tags are available. To request additional tags, set
 	// ExclusiveStartTagKey to the key of the last tag returned.
 	HasMoreTags *bool `type:"boolean" required:"true"`
@@ -1255,8 +1257,6 @@ type ListTagsForStreamOutput struct {
 	// A list of tags associated with StreamName, starting with the first tag after
 	// ExclusiveStartTagKey and up to the specified Limit.
 	Tags []*Tag `type:"list" required:"true"`
-
-	_ struct{} `type:"structure"`
 }
 
 // String returns the string representation
@@ -1271,6 +1271,8 @@ func (s ListTagsForStreamOutput) GoString() string {
 
 // Represents the input for MergeShards.
 type MergeShardsInput struct {
+	_ struct{} `type:"structure"`
+
 	// The shard ID of the adjacent shard for the merge.
 	AdjacentShardToMerge *string `min:"1" type:"string" required:"true"`
 
@@ -1279,8 +1281,6 @@ type MergeShardsInput struct {
 
 	// The name of the stream for the merge.
 	StreamName *string `min:"1" type:"string" required:"true"`
-
-	_ struct{} `type:"structure"`
 }
 
 // String returns the string representation
@@ -1309,6 +1309,8 @@ func (s MergeShardsOutput) GoString() string {
 
 // Represents the input for PutRecord.
 type PutRecordInput struct {
+	_ struct{} `type:"structure"`
+
 	// The data blob to put into the record, which is base64-encoded when the blob
 	// is serialized. When the data blob (the payload before base64-encoding) is
 	// added to the partition key size, the total size must not exceed the maximum
@@ -1338,8 +1340,6 @@ type PutRecordInput struct {
 
 	// The name of the stream to put the data record into.
 	StreamName *string `min:"1" type:"string" required:"true"`
-
-	_ struct{} `type:"structure"`
 }
 
 // String returns the string representation
@@ -1354,6 +1354,8 @@ func (s PutRecordInput) GoString() string {
 
 // Represents the output for PutRecord.
 type PutRecordOutput struct {
+	_ struct{} `type:"structure"`
+
 	// The sequence number identifier that was assigned to the put data record.
 	// The sequence number for the record is unique across all records in the stream.
 	// A sequence number is the identifier associated with every record put into
@@ -1362,8 +1364,6 @@ type PutRecordOutput struct {
 
 	// The shard ID of the shard where the data record was placed.
 	ShardId *string `min:"1" type:"string" required:"true"`
-
-	_ struct{} `type:"structure"`
 }
 
 // String returns the string representation
@@ -1378,13 +1378,13 @@ func (s PutRecordOutput) GoString() string {
 
 // A PutRecords request.
 type PutRecordsInput struct {
+	_ struct{} `type:"structure"`
+
 	// The records associated with the request.
 	Records []*PutRecordsRequestEntry `min:"1" type:"list" required:"true"`
 
 	// The stream name associated with the request.
 	StreamName *string `min:"1" type:"string" required:"true"`
-
-	_ struct{} `type:"structure"`
 }
 
 // String returns the string representation
@@ -1399,6 +1399,8 @@ func (s PutRecordsInput) GoString() string {
 
 // PutRecords results.
 type PutRecordsOutput struct {
+	_ struct{} `type:"structure"`
+
 	// The number of unsuccessfully processed records in a PutRecords request.
 	FailedRecordCount *int64 `min:"1" type:"integer"`
 
@@ -1408,8 +1410,6 @@ type PutRecordsOutput struct {
 	// result. A record that fails to be added to your Amazon Kinesis stream includes
 	// ErrorCode and ErrorMessage in the result.
 	Records []*PutRecordsResultEntry `min:"1" type:"list" required:"true"`
-
-	_ struct{} `type:"structure"`
 }
 
 // String returns the string representation
@@ -1424,6 +1424,8 @@ func (s PutRecordsOutput) GoString() string {
 
 // Represents the output for PutRecords.
 type PutRecordsRequestEntry struct {
+	_ struct{} `type:"structure"`
+
 	// The data blob to put into the record, which is base64-encoded when the blob
 	// is serialized. When the data blob (the payload before base64-encoding) is
 	// added to the partition key size, the total size must not exceed the maximum
@@ -1443,8 +1445,6 @@ type PutRecordsRequestEntry struct {
 	// mechanism, all data records with the same partition key map to the same shard
 	// within the stream.
 	PartitionKey *string `min:"1" type:"string" required:"true"`
-
-	_ struct{} `type:"structure"`
 }
 
 // String returns the string representation
@@ -1463,6 +1463,8 @@ func (s PutRecordsRequestEntry) GoString() string {
 // to your Amazon Kinesis stream includes ErrorCode and ErrorMessage in the
 // result.
 type PutRecordsResultEntry struct {
+	_ struct{} `type:"structure"`
+
 	// The error code for an individual record result. ErrorCodes can be either
 	// ProvisionedThroughputExceededException or InternalFailure.
 	ErrorCode *string `type:"string"`
@@ -1478,8 +1480,6 @@ type PutRecordsResultEntry struct {
 
 	// The shard ID for an individual record result.
 	ShardId *string `min:"1" type:"string"`
-
-	_ struct{} `type:"structure"`
 }
 
 // String returns the string representation
@@ -1495,6 +1495,8 @@ func (s PutRecordsResultEntry) GoString() string {
 // The unit of data of the Amazon Kinesis stream, which is composed of a sequence
 // number, a partition key, and a data blob.
 type Record struct {
+	_ struct{} `type:"structure"`
+
 	// The approximate time that the record was inserted into the stream.
 	ApproximateArrivalTimestamp *time.Time `type:"timestamp" timestampFormat:"unix"`
 
@@ -1510,8 +1512,6 @@ type Record struct {
 
 	// The unique identifier of the record in the stream.
 	SequenceNumber *string `type:"string" required:"true"`
-
-	_ struct{} `type:"structure"`
 }
 
 // String returns the string representation
@@ -1526,13 +1526,13 @@ func (s Record) GoString() string {
 
 // Represents the input for RemoveTagsFromStream.
 type RemoveTagsFromStreamInput struct {
+	_ struct{} `type:"structure"`
+
 	// The name of the stream.
 	StreamName *string `min:"1" type:"string" required:"true"`
 
 	// A list of tag keys. Each corresponding tag is removed from the stream.
 	TagKeys []*string `min:"1" type:"list" required:"true"`
-
-	_ struct{} `type:"structure"`
 }
 
 // String returns the string representation
@@ -1561,14 +1561,14 @@ func (s RemoveTagsFromStreamOutput) GoString() string {
 
 // The range of possible sequence numbers for the shard.
 type SequenceNumberRange struct {
+	_ struct{} `type:"structure"`
+
 	// The ending sequence number for the range. Shards that are in the OPEN state
 	// have an ending sequence number of null.
 	EndingSequenceNumber *string `type:"string"`
 
 	// The starting sequence number for the range.
 	StartingSequenceNumber *string `type:"string" required:"true"`
-
-	_ struct{} `type:"structure"`
 }
 
 // String returns the string representation
@@ -1583,6 +1583,8 @@ func (s SequenceNumberRange) GoString() string {
 
 // A uniquely identified group of data records in an Amazon Kinesis stream.
 type Shard struct {
+	_ struct{} `type:"structure"`
+
 	// The shard Id of the shard adjacent to the shard's parent.
 	AdjacentParentShardId *string `min:"1" type:"string"`
 
@@ -1598,8 +1600,6 @@ type Shard struct {
 
 	// The unique identifier of the shard within the Amazon Kinesis stream.
 	ShardId *string `min:"1" type:"string" required:"true"`
-
-	_ struct{} `type:"structure"`
 }
 
 // String returns the string representation
@@ -1614,6 +1614,8 @@ func (s Shard) GoString() string {
 
 // Represents the input for SplitShard.
 type SplitShardInput struct {
+	_ struct{} `type:"structure"`
+
 	// A hash key value for the starting hash key of one of the child shards created
 	// by the split. The hash key range for a given shard constitutes a set of ordered
 	// contiguous positive integers. The value for NewStartingHashKey must be in
@@ -1628,8 +1630,6 @@ type SplitShardInput struct {
 
 	// The name of the stream for the shard split.
 	StreamName *string `min:"1" type:"string" required:"true"`
-
-	_ struct{} `type:"structure"`
 }
 
 // String returns the string representation
@@ -1658,6 +1658,8 @@ func (s SplitShardOutput) GoString() string {
 
 // Represents the output for DescribeStream.
 type StreamDescription struct {
+	_ struct{} `type:"structure"`
+
 	// If set to true, more shards in the stream are available to describe.
 	HasMoreShards *bool `type:"boolean" required:"true"`
 
@@ -1686,8 +1688,6 @@ type StreamDescription struct {
 	// split. Read and write operations continue to work while the stream is in
 	// the UPDATING state.
 	StreamStatus *string `type:"string" required:"true" enum:"StreamStatus"`
-
-	_ struct{} `type:"structure"`
 }
 
 // String returns the string representation
@@ -1702,6 +1702,8 @@ func (s StreamDescription) GoString() string {
 
 // Metadata assigned to the stream, consisting of a key-value pair.
 type Tag struct {
+	_ struct{} `type:"structure"`
+
 	// A unique identifier for the tag. Maximum length: 128 characters. Valid characters:
 	// Unicode letters, digits, white space, _ . / = + - % @
 	Key *string `min:"1" type:"string" required:"true"`
@@ -1710,8 +1712,6 @@ type Tag struct {
 	// length: 256 characters. Valid characters: Unicode letters, digits, white
 	// space, _ . / = + - % @
 	Value *string `type:"string"`
-
-	_ struct{} `type:"structure"`
 }
 
 // String returns the string representation

--- a/service/kms/api.go
+++ b/service/kms/api.go
@@ -1000,11 +1000,7 @@ type AliasListEntry struct {
 	// String that contains the key identifier pointed to by the alias.
 	TargetKeyId *string `min:"1" type:"string"`
 
-	metadataAliasListEntry `json:"-" xml:"-"`
-}
-
-type metadataAliasListEntry struct {
-	SDKShapeTraits bool `type:"structure"`
+	_ struct{} `type:"structure"`
 }
 
 // String returns the string representation
@@ -1030,11 +1026,7 @@ type CancelKeyDeletionInput struct {
 	// DescribeKey.
 	KeyId *string `min:"1" type:"string" required:"true"`
 
-	metadataCancelKeyDeletionInput `json:"-" xml:"-"`
-}
-
-type metadataCancelKeyDeletionInput struct {
-	SDKShapeTraits bool `type:"structure"`
+	_ struct{} `type:"structure"`
 }
 
 // String returns the string representation
@@ -1051,11 +1043,7 @@ type CancelKeyDeletionOutput struct {
 	// The unique identifier of the master key for which deletion is canceled.
 	KeyId *string `min:"1" type:"string"`
 
-	metadataCancelKeyDeletionOutput `json:"-" xml:"-"`
-}
-
-type metadataCancelKeyDeletionOutput struct {
-	SDKShapeTraits bool `type:"structure"`
+	_ struct{} `type:"structure"`
 }
 
 // String returns the string representation
@@ -1080,11 +1068,7 @@ type CreateAliasInput struct {
 	// Globally Unique Key ID Example - 12345678-1234-1234-1234-123456789012
 	TargetKeyId *string `min:"1" type:"string" required:"true"`
 
-	metadataCreateAliasInput `json:"-" xml:"-"`
-}
-
-type metadataCreateAliasInput struct {
-	SDKShapeTraits bool `type:"structure"`
+	_ struct{} `type:"structure"`
 }
 
 // String returns the string representation
@@ -1098,11 +1082,7 @@ func (s CreateAliasInput) GoString() string {
 }
 
 type CreateAliasOutput struct {
-	metadataCreateAliasOutput `json:"-" xml:"-"`
-}
-
-type metadataCreateAliasOutput struct {
-	SDKShapeTraits bool `type:"structure"`
+	_ struct{} `type:"structure"`
 }
 
 // String returns the string representation
@@ -1179,11 +1159,7 @@ type CreateGrantInput struct {
 	// in the Example ARNs section of the AWS General Reference.
 	RetiringPrincipal *string `min:"1" type:"string"`
 
-	metadataCreateGrantInput `json:"-" xml:"-"`
-}
-
-type metadataCreateGrantInput struct {
-	SDKShapeTraits bool `type:"structure"`
+	_ struct{} `type:"structure"`
 }
 
 // String returns the string representation
@@ -1208,11 +1184,7 @@ type CreateGrantOutput struct {
 	// in the AWS Key Management Service Developer Guide.
 	GrantToken *string `min:"1" type:"string"`
 
-	metadataCreateGrantOutput `json:"-" xml:"-"`
-}
-
-type metadataCreateGrantOutput struct {
-	SDKShapeTraits bool `type:"structure"`
+	_ struct{} `type:"structure"`
 }
 
 // String returns the string representation
@@ -1238,11 +1210,7 @@ type CreateKeyInput struct {
 	// The key is the root of trust. The policy size limit is 32 KiB (32768 bytes).
 	Policy *string `min:"1" type:"string"`
 
-	metadataCreateKeyInput `json:"-" xml:"-"`
-}
-
-type metadataCreateKeyInput struct {
-	SDKShapeTraits bool `type:"structure"`
+	_ struct{} `type:"structure"`
 }
 
 // String returns the string representation
@@ -1259,11 +1227,7 @@ type CreateKeyOutput struct {
 	// Metadata associated with the key.
 	KeyMetadata *KeyMetadata `type:"structure"`
 
-	metadataCreateKeyOutput `json:"-" xml:"-"`
-}
-
-type metadataCreateKeyOutput struct {
-	SDKShapeTraits bool `type:"structure"`
+	_ struct{} `type:"structure"`
 }
 
 // String returns the string representation
@@ -1291,11 +1255,7 @@ type DecryptInput struct {
 	// in the AWS Key Management Service Developer Guide.
 	GrantTokens []*string `type:"list"`
 
-	metadataDecryptInput `json:"-" xml:"-"`
-}
-
-type metadataDecryptInput struct {
-	SDKShapeTraits bool `type:"structure"`
+	_ struct{} `type:"structure"`
 }
 
 // String returns the string representation
@@ -1317,11 +1277,7 @@ type DecryptOutput struct {
 	// master key is not available or if you didn't have permission to use it.
 	Plaintext []byte `min:"1" type:"blob"`
 
-	metadataDecryptOutput `json:"-" xml:"-"`
-}
-
-type metadataDecryptOutput struct {
-	SDKShapeTraits bool `type:"structure"`
+	_ struct{} `type:"structure"`
 }
 
 // String returns the string representation
@@ -1339,11 +1295,7 @@ type DeleteAliasInput struct {
 	// by a forward slash (alias/). Aliases that begin with "alias/AWS" are reserved.
 	AliasName *string `min:"1" type:"string" required:"true"`
 
-	metadataDeleteAliasInput `json:"-" xml:"-"`
-}
-
-type metadataDeleteAliasInput struct {
-	SDKShapeTraits bool `type:"structure"`
+	_ struct{} `type:"structure"`
 }
 
 // String returns the string representation
@@ -1357,11 +1309,7 @@ func (s DeleteAliasInput) GoString() string {
 }
 
 type DeleteAliasOutput struct {
-	metadataDeleteAliasOutput `json:"-" xml:"-"`
-}
-
-type metadataDeleteAliasOutput struct {
-	SDKShapeTraits bool `type:"structure"`
+	_ struct{} `type:"structure"`
 }
 
 // String returns the string representation
@@ -1389,11 +1337,7 @@ type DescribeKeyInput struct {
 	// Name Example - alias/MyAliasName
 	KeyId *string `min:"1" type:"string" required:"true"`
 
-	metadataDescribeKeyInput `json:"-" xml:"-"`
-}
-
-type metadataDescribeKeyInput struct {
-	SDKShapeTraits bool `type:"structure"`
+	_ struct{} `type:"structure"`
 }
 
 // String returns the string representation
@@ -1410,11 +1354,7 @@ type DescribeKeyOutput struct {
 	// Metadata associated with the key.
 	KeyMetadata *KeyMetadata `type:"structure"`
 
-	metadataDescribeKeyOutput `json:"-" xml:"-"`
-}
-
-type metadataDescribeKeyOutput struct {
-	SDKShapeTraits bool `type:"structure"`
+	_ struct{} `type:"structure"`
 }
 
 // String returns the string representation
@@ -1434,11 +1374,7 @@ type DisableKeyInput struct {
 	// Globally Unique Key ID Example - 12345678-1234-1234-1234-123456789012
 	KeyId *string `min:"1" type:"string" required:"true"`
 
-	metadataDisableKeyInput `json:"-" xml:"-"`
-}
-
-type metadataDisableKeyInput struct {
-	SDKShapeTraits bool `type:"structure"`
+	_ struct{} `type:"structure"`
 }
 
 // String returns the string representation
@@ -1452,11 +1388,7 @@ func (s DisableKeyInput) GoString() string {
 }
 
 type DisableKeyOutput struct {
-	metadataDisableKeyOutput `json:"-" xml:"-"`
-}
-
-type metadataDisableKeyOutput struct {
-	SDKShapeTraits bool `type:"structure"`
+	_ struct{} `type:"structure"`
 }
 
 // String returns the string representation
@@ -1476,11 +1408,7 @@ type DisableKeyRotationInput struct {
 	// Globally Unique Key ID Example - 12345678-1234-1234-1234-123456789012
 	KeyId *string `min:"1" type:"string" required:"true"`
 
-	metadataDisableKeyRotationInput `json:"-" xml:"-"`
-}
-
-type metadataDisableKeyRotationInput struct {
-	SDKShapeTraits bool `type:"structure"`
+	_ struct{} `type:"structure"`
 }
 
 // String returns the string representation
@@ -1494,11 +1422,7 @@ func (s DisableKeyRotationInput) GoString() string {
 }
 
 type DisableKeyRotationOutput struct {
-	metadataDisableKeyRotationOutput `json:"-" xml:"-"`
-}
-
-type metadataDisableKeyRotationOutput struct {
-	SDKShapeTraits bool `type:"structure"`
+	_ struct{} `type:"structure"`
 }
 
 // String returns the string representation
@@ -1518,11 +1442,7 @@ type EnableKeyInput struct {
 	// Globally Unique Key ID Example - 12345678-1234-1234-1234-123456789012
 	KeyId *string `min:"1" type:"string" required:"true"`
 
-	metadataEnableKeyInput `json:"-" xml:"-"`
-}
-
-type metadataEnableKeyInput struct {
-	SDKShapeTraits bool `type:"structure"`
+	_ struct{} `type:"structure"`
 }
 
 // String returns the string representation
@@ -1536,11 +1456,7 @@ func (s EnableKeyInput) GoString() string {
 }
 
 type EnableKeyOutput struct {
-	metadataEnableKeyOutput `json:"-" xml:"-"`
-}
-
-type metadataEnableKeyOutput struct {
-	SDKShapeTraits bool `type:"structure"`
+	_ struct{} `type:"structure"`
 }
 
 // String returns the string representation
@@ -1560,11 +1476,7 @@ type EnableKeyRotationInput struct {
 	// Globally Unique Key ID Example - 12345678-1234-1234-1234-123456789012
 	KeyId *string `min:"1" type:"string" required:"true"`
 
-	metadataEnableKeyRotationInput `json:"-" xml:"-"`
-}
-
-type metadataEnableKeyRotationInput struct {
-	SDKShapeTraits bool `type:"structure"`
+	_ struct{} `type:"structure"`
 }
 
 // String returns the string representation
@@ -1578,11 +1490,7 @@ func (s EnableKeyRotationInput) GoString() string {
 }
 
 type EnableKeyRotationOutput struct {
-	metadataEnableKeyRotationOutput `json:"-" xml:"-"`
-}
-
-type metadataEnableKeyRotationOutput struct {
-	SDKShapeTraits bool `type:"structure"`
+	_ struct{} `type:"structure"`
 }
 
 // String returns the string representation
@@ -1619,11 +1527,7 @@ type EncryptInput struct {
 	// Data to be encrypted.
 	Plaintext []byte `min:"1" type:"blob" required:"true"`
 
-	metadataEncryptInput `json:"-" xml:"-"`
-}
-
-type metadataEncryptInput struct {
-	SDKShapeTraits bool `type:"structure"`
+	_ struct{} `type:"structure"`
 }
 
 // String returns the string representation
@@ -1644,11 +1548,7 @@ type EncryptOutput struct {
 	// The ID of the key used during encryption.
 	KeyId *string `min:"1" type:"string"`
 
-	metadataEncryptOutput `json:"-" xml:"-"`
-}
-
-type metadataEncryptOutput struct {
-	SDKShapeTraits bool `type:"structure"`
+	_ struct{} `type:"structure"`
 }
 
 // String returns the string representation
@@ -1690,11 +1590,7 @@ type GenerateDataKeyInput struct {
 	// use the KeySpec parameter instead.
 	NumberOfBytes *int64 `min:"1" type:"integer"`
 
-	metadataGenerateDataKeyInput `json:"-" xml:"-"`
-}
-
-type metadataGenerateDataKeyInput struct {
-	SDKShapeTraits bool `type:"structure"`
+	_ struct{} `type:"structure"`
 }
 
 // String returns the string representation
@@ -1726,11 +1622,7 @@ type GenerateDataKeyOutput struct {
 	// and then remove it from memory as soon as possible.
 	Plaintext []byte `min:"1" type:"blob"`
 
-	metadataGenerateDataKeyOutput `json:"-" xml:"-"`
-}
-
-type metadataGenerateDataKeyOutput struct {
-	SDKShapeTraits bool `type:"structure"`
+	_ struct{} `type:"structure"`
 }
 
 // String returns the string representation
@@ -1771,11 +1663,7 @@ type GenerateDataKeyWithoutPlaintextInput struct {
 	// instead.
 	NumberOfBytes *int64 `min:"1" type:"integer"`
 
-	metadataGenerateDataKeyWithoutPlaintextInput `json:"-" xml:"-"`
-}
-
-type metadataGenerateDataKeyWithoutPlaintextInput struct {
-	SDKShapeTraits bool `type:"structure"`
+	_ struct{} `type:"structure"`
 }
 
 // String returns the string representation
@@ -1800,11 +1688,7 @@ type GenerateDataKeyWithoutPlaintextOutput struct {
 	// copy of the data key.
 	KeyId *string `min:"1" type:"string"`
 
-	metadataGenerateDataKeyWithoutPlaintextOutput `json:"-" xml:"-"`
-}
-
-type metadataGenerateDataKeyWithoutPlaintextOutput struct {
-	SDKShapeTraits bool `type:"structure"`
+	_ struct{} `type:"structure"`
 }
 
 // String returns the string representation
@@ -1822,11 +1706,7 @@ type GenerateRandomInput struct {
 	// 128, 256, 512, 1024 and so on. The current limit is 1024 bytes.
 	NumberOfBytes *int64 `min:"1" type:"integer"`
 
-	metadataGenerateRandomInput `json:"-" xml:"-"`
-}
-
-type metadataGenerateRandomInput struct {
-	SDKShapeTraits bool `type:"structure"`
+	_ struct{} `type:"structure"`
 }
 
 // String returns the string representation
@@ -1843,11 +1723,7 @@ type GenerateRandomOutput struct {
 	// Plaintext that contains the unpredictable byte string.
 	Plaintext []byte `min:"1" type:"blob"`
 
-	metadataGenerateRandomOutput `json:"-" xml:"-"`
-}
-
-type metadataGenerateRandomOutput struct {
-	SDKShapeTraits bool `type:"structure"`
+	_ struct{} `type:"structure"`
 }
 
 // String returns the string representation
@@ -1871,11 +1747,7 @@ type GetKeyPolicyInput struct {
 	// Policy names can be discovered by calling ListKeyPolicies.
 	PolicyName *string `min:"1" type:"string" required:"true"`
 
-	metadataGetKeyPolicyInput `json:"-" xml:"-"`
-}
-
-type metadataGetKeyPolicyInput struct {
-	SDKShapeTraits bool `type:"structure"`
+	_ struct{} `type:"structure"`
 }
 
 // String returns the string representation
@@ -1892,11 +1764,7 @@ type GetKeyPolicyOutput struct {
 	// A policy document in JSON format.
 	Policy *string `min:"1" type:"string"`
 
-	metadataGetKeyPolicyOutput `json:"-" xml:"-"`
-}
-
-type metadataGetKeyPolicyOutput struct {
-	SDKShapeTraits bool `type:"structure"`
+	_ struct{} `type:"structure"`
 }
 
 // String returns the string representation
@@ -1916,11 +1784,7 @@ type GetKeyRotationStatusInput struct {
 	// Globally Unique Key ID Example - 12345678-1234-1234-1234-123456789012
 	KeyId *string `min:"1" type:"string" required:"true"`
 
-	metadataGetKeyRotationStatusInput `json:"-" xml:"-"`
-}
-
-type metadataGetKeyRotationStatusInput struct {
-	SDKShapeTraits bool `type:"structure"`
+	_ struct{} `type:"structure"`
 }
 
 // String returns the string representation
@@ -1937,11 +1801,7 @@ type GetKeyRotationStatusOutput struct {
 	// A Boolean value that specifies whether key rotation is enabled.
 	KeyRotationEnabled *bool `type:"boolean"`
 
-	metadataGetKeyRotationStatusOutput `json:"-" xml:"-"`
-}
-
-type metadataGetKeyRotationStatusOutput struct {
-	SDKShapeTraits bool `type:"structure"`
+	_ struct{} `type:"structure"`
 }
 
 // String returns the string representation
@@ -1976,11 +1836,7 @@ type GrantConstraints struct {
 	// the operation. Otherwise, the operation is not allowed.
 	EncryptionContextSubset map[string]*string `type:"map"`
 
-	metadataGrantConstraints `json:"-" xml:"-"`
-}
-
-type metadataGrantConstraints struct {
-	SDKShapeTraits bool `type:"structure"`
+	_ struct{} `type:"structure"`
 }
 
 // String returns the string representation
@@ -2024,11 +1880,7 @@ type GrantListEntry struct {
 	// The principal that can retire the grant.
 	RetiringPrincipal *string `min:"1" type:"string"`
 
-	metadataGrantListEntry `json:"-" xml:"-"`
-}
-
-type metadataGrantListEntry struct {
-	SDKShapeTraits bool `type:"structure"`
+	_ struct{} `type:"structure"`
 }
 
 // String returns the string representation
@@ -2049,11 +1901,7 @@ type KeyListEntry struct {
 	// Unique identifier of the key.
 	KeyId *string `min:"1" type:"string"`
 
-	metadataKeyListEntry `json:"-" xml:"-"`
-}
-
-type metadataKeyListEntry struct {
-	SDKShapeTraits bool `type:"structure"`
+	_ struct{} `type:"structure"`
 }
 
 // String returns the string representation
@@ -2109,11 +1957,7 @@ type KeyMetadata struct {
 	// the Encrypt and Decrypt operations.
 	KeyUsage *string `type:"string" enum:"KeyUsageType"`
 
-	metadataKeyMetadata `json:"-" xml:"-"`
-}
-
-type metadataKeyMetadata struct {
-	SDKShapeTraits bool `type:"structure"`
+	_ struct{} `type:"structure"`
 }
 
 // String returns the string representation
@@ -2140,11 +1984,7 @@ type ListAliasesInput struct {
 	// the value of NextMarker from the response you just received.
 	Marker *string `min:"1" type:"string"`
 
-	metadataListAliasesInput `json:"-" xml:"-"`
-}
-
-type metadataListAliasesInput struct {
-	SDKShapeTraits bool `type:"structure"`
+	_ struct{} `type:"structure"`
 }
 
 // String returns the string representation
@@ -2170,11 +2010,7 @@ type ListAliasesOutput struct {
 	// request to retrieve more items in the list.
 	Truncated *bool `type:"boolean"`
 
-	metadataListAliasesOutput `json:"-" xml:"-"`
-}
-
-type metadataListAliasesOutput struct {
-	SDKShapeTraits bool `type:"structure"`
+	_ struct{} `type:"structure"`
 }
 
 // String returns the string representation
@@ -2207,11 +2043,7 @@ type ListGrantsInput struct {
 	// the value of NextMarker from the response you just received.
 	Marker *string `min:"1" type:"string"`
 
-	metadataListGrantsInput `json:"-" xml:"-"`
-}
-
-type metadataListGrantsInput struct {
-	SDKShapeTraits bool `type:"structure"`
+	_ struct{} `type:"structure"`
 }
 
 // String returns the string representation
@@ -2237,11 +2069,7 @@ type ListGrantsResponse struct {
 	// request to retrieve more items in the list.
 	Truncated *bool `type:"boolean"`
 
-	metadataListGrantsResponse `json:"-" xml:"-"`
-}
-
-type metadataListGrantsResponse struct {
-	SDKShapeTraits bool `type:"structure"`
+	_ struct{} `type:"structure"`
 }
 
 // String returns the string representation
@@ -2278,11 +2106,7 @@ type ListKeyPoliciesInput struct {
 	// the value of NextMarker from the response you just received.
 	Marker *string `min:"1" type:"string"`
 
-	metadataListKeyPoliciesInput `json:"-" xml:"-"`
-}
-
-type metadataListKeyPoliciesInput struct {
-	SDKShapeTraits bool `type:"structure"`
+	_ struct{} `type:"structure"`
 }
 
 // String returns the string representation
@@ -2309,11 +2133,7 @@ type ListKeyPoliciesOutput struct {
 	// request to retrieve more items in the list.
 	Truncated *bool `type:"boolean"`
 
-	metadataListKeyPoliciesOutput `json:"-" xml:"-"`
-}
-
-type metadataListKeyPoliciesOutput struct {
-	SDKShapeTraits bool `type:"structure"`
+	_ struct{} `type:"structure"`
 }
 
 // String returns the string representation
@@ -2340,11 +2160,7 @@ type ListKeysInput struct {
 	// the value of NextMarker from the response you just received.
 	Marker *string `min:"1" type:"string"`
 
-	metadataListKeysInput `json:"-" xml:"-"`
-}
-
-type metadataListKeysInput struct {
-	SDKShapeTraits bool `type:"structure"`
+	_ struct{} `type:"structure"`
 }
 
 // String returns the string representation
@@ -2370,11 +2186,7 @@ type ListKeysOutput struct {
 	// request to retrieve more items in the list.
 	Truncated *bool `type:"boolean"`
 
-	metadataListKeysOutput `json:"-" xml:"-"`
-}
-
-type metadataListKeysOutput struct {
-	SDKShapeTraits bool `type:"structure"`
+	_ struct{} `type:"structure"`
 }
 
 // String returns the string representation
@@ -2411,11 +2223,7 @@ type ListRetirableGrantsInput struct {
 	// in the Example ARNs section of the Amazon Web Services General Reference.
 	RetiringPrincipal *string `min:"1" type:"string" required:"true"`
 
-	metadataListRetirableGrantsInput `json:"-" xml:"-"`
-}
-
-type metadataListRetirableGrantsInput struct {
-	SDKShapeTraits bool `type:"structure"`
+	_ struct{} `type:"structure"`
 }
 
 // String returns the string representation
@@ -2444,11 +2252,7 @@ type PutKeyPolicyInput struct {
 	// "default".
 	PolicyName *string `min:"1" type:"string" required:"true"`
 
-	metadataPutKeyPolicyInput `json:"-" xml:"-"`
-}
-
-type metadataPutKeyPolicyInput struct {
-	SDKShapeTraits bool `type:"structure"`
+	_ struct{} `type:"structure"`
 }
 
 // String returns the string representation
@@ -2462,11 +2266,7 @@ func (s PutKeyPolicyInput) GoString() string {
 }
 
 type PutKeyPolicyOutput struct {
-	metadataPutKeyPolicyOutput `json:"-" xml:"-"`
-}
-
-type metadataPutKeyPolicyOutput struct {
-	SDKShapeTraits bool `type:"structure"`
+	_ struct{} `type:"structure"`
 }
 
 // String returns the string representation
@@ -2505,11 +2305,7 @@ type ReEncryptInput struct {
 	// CiphertextBlob parameter.
 	SourceEncryptionContext map[string]*string `type:"map"`
 
-	metadataReEncryptInput `json:"-" xml:"-"`
-}
-
-type metadataReEncryptInput struct {
-	SDKShapeTraits bool `type:"structure"`
+	_ struct{} `type:"structure"`
 }
 
 // String returns the string representation
@@ -2533,11 +2329,7 @@ type ReEncryptOutput struct {
 	// Unique identifier of the key used to originally encrypt the data.
 	SourceKeyId *string `min:"1" type:"string"`
 
-	metadataReEncryptOutput `json:"-" xml:"-"`
-}
-
-type metadataReEncryptOutput struct {
-	SDKShapeTraits bool `type:"structure"`
+	_ struct{} `type:"structure"`
 }
 
 // String returns the string representation
@@ -2564,11 +2356,7 @@ type RetireGrantInput struct {
 	// Globally Unique Key ID Example - 12345678-1234-1234-1234-123456789012
 	KeyId *string `min:"1" type:"string"`
 
-	metadataRetireGrantInput `json:"-" xml:"-"`
-}
-
-type metadataRetireGrantInput struct {
-	SDKShapeTraits bool `type:"structure"`
+	_ struct{} `type:"structure"`
 }
 
 // String returns the string representation
@@ -2582,11 +2370,7 @@ func (s RetireGrantInput) GoString() string {
 }
 
 type RetireGrantOutput struct {
-	metadataRetireGrantOutput `json:"-" xml:"-"`
-}
-
-type metadataRetireGrantOutput struct {
-	SDKShapeTraits bool `type:"structure"`
+	_ struct{} `type:"structure"`
 }
 
 // String returns the string representation
@@ -2609,11 +2393,7 @@ type RevokeGrantInput struct {
 	// Globally Unique Key ID Example - 12345678-1234-1234-1234-123456789012
 	KeyId *string `min:"1" type:"string" required:"true"`
 
-	metadataRevokeGrantInput `json:"-" xml:"-"`
-}
-
-type metadataRevokeGrantInput struct {
-	SDKShapeTraits bool `type:"structure"`
+	_ struct{} `type:"structure"`
 }
 
 // String returns the string representation
@@ -2627,11 +2407,7 @@ func (s RevokeGrantInput) GoString() string {
 }
 
 type RevokeGrantOutput struct {
-	metadataRevokeGrantOutput `json:"-" xml:"-"`
-}
-
-type metadataRevokeGrantOutput struct {
-	SDKShapeTraits bool `type:"structure"`
+	_ struct{} `type:"structure"`
 }
 
 // String returns the string representation
@@ -2663,11 +2439,7 @@ type ScheduleKeyDeletionInput struct {
 	// 30, inclusive. If you do not include a value, it defaults to 30.
 	PendingWindowInDays *int64 `min:"1" type:"integer"`
 
-	metadataScheduleKeyDeletionInput `json:"-" xml:"-"`
-}
-
-type metadataScheduleKeyDeletionInput struct {
-	SDKShapeTraits bool `type:"structure"`
+	_ struct{} `type:"structure"`
 }
 
 // String returns the string representation
@@ -2688,11 +2460,7 @@ type ScheduleKeyDeletionOutput struct {
 	// is scheduled.
 	KeyId *string `min:"1" type:"string"`
 
-	metadataScheduleKeyDeletionOutput `json:"-" xml:"-"`
-}
-
-type metadataScheduleKeyDeletionOutput struct {
-	SDKShapeTraits bool `type:"structure"`
+	_ struct{} `type:"structure"`
 }
 
 // String returns the string representation
@@ -2720,11 +2488,7 @@ type UpdateAliasInput struct {
 	// TargetKeyId.
 	TargetKeyId *string `min:"1" type:"string" required:"true"`
 
-	metadataUpdateAliasInput `json:"-" xml:"-"`
-}
-
-type metadataUpdateAliasInput struct {
-	SDKShapeTraits bool `type:"structure"`
+	_ struct{} `type:"structure"`
 }
 
 // String returns the string representation
@@ -2738,11 +2502,7 @@ func (s UpdateAliasInput) GoString() string {
 }
 
 type UpdateAliasOutput struct {
-	metadataUpdateAliasOutput `json:"-" xml:"-"`
-}
-
-type metadataUpdateAliasOutput struct {
-	SDKShapeTraits bool `type:"structure"`
+	_ struct{} `type:"structure"`
 }
 
 // String returns the string representation
@@ -2765,11 +2525,7 @@ type UpdateKeyDescriptionInput struct {
 	// Globally Unique Key ID Example - 12345678-1234-1234-1234-123456789012
 	KeyId *string `min:"1" type:"string" required:"true"`
 
-	metadataUpdateKeyDescriptionInput `json:"-" xml:"-"`
-}
-
-type metadataUpdateKeyDescriptionInput struct {
-	SDKShapeTraits bool `type:"structure"`
+	_ struct{} `type:"structure"`
 }
 
 // String returns the string representation
@@ -2783,11 +2539,7 @@ func (s UpdateKeyDescriptionInput) GoString() string {
 }
 
 type UpdateKeyDescriptionOutput struct {
-	metadataUpdateKeyDescriptionOutput `json:"-" xml:"-"`
-}
-
-type metadataUpdateKeyDescriptionOutput struct {
-	SDKShapeTraits bool `type:"structure"`
+	_ struct{} `type:"structure"`
 }
 
 // String returns the string representation

--- a/service/kms/api.go
+++ b/service/kms/api.go
@@ -991,6 +991,8 @@ func (c *KMS) UpdateKeyDescription(input *UpdateKeyDescriptionInput) (*UpdateKey
 
 // Contains information about an alias.
 type AliasListEntry struct {
+	_ struct{} `type:"structure"`
+
 	// String that contains the key ARN.
 	AliasArn *string `min:"20" type:"string"`
 
@@ -999,8 +1001,6 @@ type AliasListEntry struct {
 
 	// String that contains the key identifier pointed to by the alias.
 	TargetKeyId *string `min:"1" type:"string"`
-
-	_ struct{} `type:"structure"`
 }
 
 // String returns the string representation
@@ -1014,6 +1014,8 @@ func (s AliasListEntry) GoString() string {
 }
 
 type CancelKeyDeletionInput struct {
+	_ struct{} `type:"structure"`
+
 	// The unique identifier for the customer master key (CMK) for which to cancel
 	// deletion.
 	//
@@ -1025,8 +1027,6 @@ type CancelKeyDeletionInput struct {
 	// To obtain the unique key ID and key ARN for a given CMK, use ListKeys or
 	// DescribeKey.
 	KeyId *string `min:"1" type:"string" required:"true"`
-
-	_ struct{} `type:"structure"`
 }
 
 // String returns the string representation
@@ -1040,10 +1040,10 @@ func (s CancelKeyDeletionInput) GoString() string {
 }
 
 type CancelKeyDeletionOutput struct {
+	_ struct{} `type:"structure"`
+
 	// The unique identifier of the master key for which deletion is canceled.
 	KeyId *string `min:"1" type:"string"`
-
-	_ struct{} `type:"structure"`
 }
 
 // String returns the string representation
@@ -1057,6 +1057,8 @@ func (s CancelKeyDeletionOutput) GoString() string {
 }
 
 type CreateAliasInput struct {
+	_ struct{} `type:"structure"`
+
 	// String that contains the display name. The name must start with the word
 	// "alias" followed by a forward slash (alias/). Aliases that begin with "alias/AWS"
 	// are reserved.
@@ -1067,8 +1069,6 @@ type CreateAliasInput struct {
 	// specified ARN to a key.  Key ARN Example - arn:aws:kms:us-east-1:123456789012:key/12345678-1234-1234-1234-123456789012
 	// Globally Unique Key ID Example - 12345678-1234-1234-1234-123456789012
 	TargetKeyId *string `min:"1" type:"string" required:"true"`
-
-	_ struct{} `type:"structure"`
 }
 
 // String returns the string representation
@@ -1096,6 +1096,8 @@ func (s CreateAliasOutput) GoString() string {
 }
 
 type CreateGrantInput struct {
+	_ struct{} `type:"structure"`
+
 	// The conditions under which the operations permitted by the grant are allowed.
 	//
 	// You can use this value to allow the operations permitted by the grant only
@@ -1158,8 +1160,6 @@ type CreateGrantInput struct {
 	// (IAM) (http://docs.aws.amazon.com/general/latest/gr/aws-arns-and-namespaces.html#arn-syntax-iam)
 	// in the Example ARNs section of the AWS General Reference.
 	RetiringPrincipal *string `min:"1" type:"string"`
-
-	_ struct{} `type:"structure"`
 }
 
 // String returns the string representation
@@ -1173,6 +1173,8 @@ func (s CreateGrantInput) GoString() string {
 }
 
 type CreateGrantOutput struct {
+	_ struct{} `type:"structure"`
+
 	// The unique identifier for the grant.
 	//
 	// You can use the GrantId in a subsequent RetireGrant or RevokeGrant operation.
@@ -1183,8 +1185,6 @@ type CreateGrantOutput struct {
 	// For more information about using grant tokens, see Grant Tokens (http://docs.aws.amazon.com/kms/latest/developerguide/concepts.html#grant_token)
 	// in the AWS Key Management Service Developer Guide.
 	GrantToken *string `min:"1" type:"string"`
-
-	_ struct{} `type:"structure"`
 }
 
 // String returns the string representation
@@ -1198,6 +1198,8 @@ func (s CreateGrantOutput) GoString() string {
 }
 
 type CreateKeyInput struct {
+	_ struct{} `type:"structure"`
+
 	// Description of the key. We recommend that you choose a description that helps
 	// your customer decide whether the key is appropriate for a task.
 	Description *string `type:"string"`
@@ -1209,8 +1211,6 @@ type CreateKeyInput struct {
 	// Policy to attach to the key. This is required and delegates back to the account.
 	// The key is the root of trust. The policy size limit is 32 KiB (32768 bytes).
 	Policy *string `min:"1" type:"string"`
-
-	_ struct{} `type:"structure"`
 }
 
 // String returns the string representation
@@ -1224,10 +1224,10 @@ func (s CreateKeyInput) GoString() string {
 }
 
 type CreateKeyOutput struct {
+	_ struct{} `type:"structure"`
+
 	// Metadata associated with the key.
 	KeyMetadata *KeyMetadata `type:"structure"`
-
-	_ struct{} `type:"structure"`
 }
 
 // String returns the string representation
@@ -1241,6 +1241,8 @@ func (s CreateKeyOutput) GoString() string {
 }
 
 type DecryptInput struct {
+	_ struct{} `type:"structure"`
+
 	// Ciphertext to be decrypted. The blob includes metadata.
 	CiphertextBlob []byte `min:"1" type:"blob" required:"true"`
 
@@ -1254,8 +1256,6 @@ type DecryptInput struct {
 	// For more information, go to Grant Tokens (http://docs.aws.amazon.com/kms/latest/developerguide/concepts.html#grant_token)
 	// in the AWS Key Management Service Developer Guide.
 	GrantTokens []*string `type:"list"`
-
-	_ struct{} `type:"structure"`
 }
 
 // String returns the string representation
@@ -1269,6 +1269,8 @@ func (s DecryptInput) GoString() string {
 }
 
 type DecryptOutput struct {
+	_ struct{} `type:"structure"`
+
 	// ARN of the key used to perform the decryption. This value is returned if
 	// no errors are encountered during the operation.
 	KeyId *string `min:"1" type:"string"`
@@ -1276,8 +1278,6 @@ type DecryptOutput struct {
 	// Decrypted plaintext data. This value may not be returned if the customer
 	// master key is not available or if you didn't have permission to use it.
 	Plaintext []byte `min:"1" type:"blob"`
-
-	_ struct{} `type:"structure"`
 }
 
 // String returns the string representation
@@ -1291,11 +1291,11 @@ func (s DecryptOutput) GoString() string {
 }
 
 type DeleteAliasInput struct {
+	_ struct{} `type:"structure"`
+
 	// The alias to be deleted. The name must start with the word "alias" followed
 	// by a forward slash (alias/). Aliases that begin with "alias/AWS" are reserved.
 	AliasName *string `min:"1" type:"string" required:"true"`
-
-	_ struct{} `type:"structure"`
 }
 
 // String returns the string representation
@@ -1323,6 +1323,8 @@ func (s DeleteAliasOutput) GoString() string {
 }
 
 type DescribeKeyInput struct {
+	_ struct{} `type:"structure"`
+
 	// A list of grant tokens.
 	//
 	// For more information, go to Grant Tokens (http://docs.aws.amazon.com/kms/latest/developerguide/concepts.html#grant_token)
@@ -1336,8 +1338,6 @@ type DescribeKeyInput struct {
 	// Globally Unique Key ID Example - 12345678-1234-1234-1234-123456789012 Alias
 	// Name Example - alias/MyAliasName
 	KeyId *string `min:"1" type:"string" required:"true"`
-
-	_ struct{} `type:"structure"`
 }
 
 // String returns the string representation
@@ -1351,10 +1351,10 @@ func (s DescribeKeyInput) GoString() string {
 }
 
 type DescribeKeyOutput struct {
+	_ struct{} `type:"structure"`
+
 	// Metadata associated with the key.
 	KeyMetadata *KeyMetadata `type:"structure"`
-
-	_ struct{} `type:"structure"`
 }
 
 // String returns the string representation
@@ -1368,13 +1368,13 @@ func (s DescribeKeyOutput) GoString() string {
 }
 
 type DisableKeyInput struct {
+	_ struct{} `type:"structure"`
+
 	// A unique identifier for the customer master key. This value can be a globally
 	// unique identifier or the fully specified ARN to a key.  Key ARN Example -
 	// arn:aws:kms:us-east-1:123456789012:key/12345678-1234-1234-1234-123456789012
 	// Globally Unique Key ID Example - 12345678-1234-1234-1234-123456789012
 	KeyId *string `min:"1" type:"string" required:"true"`
-
-	_ struct{} `type:"structure"`
 }
 
 // String returns the string representation
@@ -1402,13 +1402,13 @@ func (s DisableKeyOutput) GoString() string {
 }
 
 type DisableKeyRotationInput struct {
+	_ struct{} `type:"structure"`
+
 	// A unique identifier for the customer master key. This value can be a globally
 	// unique identifier or the fully specified ARN to a key.  Key ARN Example -
 	// arn:aws:kms:us-east-1:123456789012:key/12345678-1234-1234-1234-123456789012
 	// Globally Unique Key ID Example - 12345678-1234-1234-1234-123456789012
 	KeyId *string `min:"1" type:"string" required:"true"`
-
-	_ struct{} `type:"structure"`
 }
 
 // String returns the string representation
@@ -1436,13 +1436,13 @@ func (s DisableKeyRotationOutput) GoString() string {
 }
 
 type EnableKeyInput struct {
+	_ struct{} `type:"structure"`
+
 	// A unique identifier for the customer master key. This value can be a globally
 	// unique identifier or the fully specified ARN to a key.  Key ARN Example -
 	// arn:aws:kms:us-east-1:123456789012:key/12345678-1234-1234-1234-123456789012
 	// Globally Unique Key ID Example - 12345678-1234-1234-1234-123456789012
 	KeyId *string `min:"1" type:"string" required:"true"`
-
-	_ struct{} `type:"structure"`
 }
 
 // String returns the string representation
@@ -1470,13 +1470,13 @@ func (s EnableKeyOutput) GoString() string {
 }
 
 type EnableKeyRotationInput struct {
+	_ struct{} `type:"structure"`
+
 	// A unique identifier for the customer master key. This value can be a globally
 	// unique identifier or the fully specified ARN to a key.  Key ARN Example -
 	// arn:aws:kms:us-east-1:123456789012:key/12345678-1234-1234-1234-123456789012
 	// Globally Unique Key ID Example - 12345678-1234-1234-1234-123456789012
 	KeyId *string `min:"1" type:"string" required:"true"`
-
-	_ struct{} `type:"structure"`
 }
 
 // String returns the string representation
@@ -1504,6 +1504,8 @@ func (s EnableKeyRotationOutput) GoString() string {
 }
 
 type EncryptInput struct {
+	_ struct{} `type:"structure"`
+
 	// Name/value pair that specifies the encryption context to be used for authenticated
 	// encryption. If used here, the same value must be supplied to the Decrypt
 	// API or decryption will fail. For more information, see Encryption Context
@@ -1526,8 +1528,6 @@ type EncryptInput struct {
 
 	// Data to be encrypted.
 	Plaintext []byte `min:"1" type:"blob" required:"true"`
-
-	_ struct{} `type:"structure"`
 }
 
 // String returns the string representation
@@ -1541,14 +1541,14 @@ func (s EncryptInput) GoString() string {
 }
 
 type EncryptOutput struct {
+	_ struct{} `type:"structure"`
+
 	// The encrypted plaintext. If you are using the CLI, the value is Base64 encoded.
 	// Otherwise, it is not encoded.
 	CiphertextBlob []byte `min:"1" type:"blob"`
 
 	// The ID of the key used during encryption.
 	KeyId *string `min:"1" type:"string"`
-
-	_ struct{} `type:"structure"`
 }
 
 // String returns the string representation
@@ -1562,6 +1562,8 @@ func (s EncryptOutput) GoString() string {
 }
 
 type GenerateDataKeyInput struct {
+	_ struct{} `type:"structure"`
+
 	// Name/value pair that contains additional data to be authenticated during
 	// the encryption and decryption processes that use the key. This value is logged
 	// by AWS CloudTrail to provide context around the data encrypted by the key.
@@ -1589,8 +1591,6 @@ type GenerateDataKeyInput struct {
 	// 128, 256, 512, and 1024. 1024 is the current limit. We recommend that you
 	// use the KeySpec parameter instead.
 	NumberOfBytes *int64 `min:"1" type:"integer"`
-
-	_ struct{} `type:"structure"`
 }
 
 // String returns the string representation
@@ -1604,6 +1604,8 @@ func (s GenerateDataKeyInput) GoString() string {
 }
 
 type GenerateDataKeyOutput struct {
+	_ struct{} `type:"structure"`
+
 	// Ciphertext that contains the encrypted data key. You must store the blob
 	// and enough information to reconstruct the encryption context so that the
 	// data encrypted by using the key can later be decrypted. You must provide
@@ -1621,8 +1623,6 @@ type GenerateDataKeyOutput struct {
 	// Plaintext that contains the data key. Use this for encryption and decryption
 	// and then remove it from memory as soon as possible.
 	Plaintext []byte `min:"1" type:"blob"`
-
-	_ struct{} `type:"structure"`
 }
 
 // String returns the string representation
@@ -1636,6 +1636,8 @@ func (s GenerateDataKeyOutput) GoString() string {
 }
 
 type GenerateDataKeyWithoutPlaintextInput struct {
+	_ struct{} `type:"structure"`
+
 	// Name:value pair that contains additional data to be authenticated during
 	// the encryption and decryption processes.
 	EncryptionContext map[string]*string `type:"map"`
@@ -1662,8 +1664,6 @@ type GenerateDataKeyWithoutPlaintextInput struct {
 	// 128, 256, 512, 1024 and so on. We recommend that you use the KeySpec parameter
 	// instead.
 	NumberOfBytes *int64 `min:"1" type:"integer"`
-
-	_ struct{} `type:"structure"`
 }
 
 // String returns the string representation
@@ -1677,6 +1677,8 @@ func (s GenerateDataKeyWithoutPlaintextInput) GoString() string {
 }
 
 type GenerateDataKeyWithoutPlaintextOutput struct {
+	_ struct{} `type:"structure"`
+
 	// Ciphertext that contains the wrapped data key. You must store the blob and
 	// encryption context so that the key can be used in a future decrypt operation.
 	//
@@ -1687,8 +1689,6 @@ type GenerateDataKeyWithoutPlaintextOutput struct {
 	// System generated unique identifier of the key to be used to decrypt the encrypted
 	// copy of the data key.
 	KeyId *string `min:"1" type:"string"`
-
-	_ struct{} `type:"structure"`
 }
 
 // String returns the string representation
@@ -1702,11 +1702,11 @@ func (s GenerateDataKeyWithoutPlaintextOutput) GoString() string {
 }
 
 type GenerateRandomInput struct {
+	_ struct{} `type:"structure"`
+
 	// Integer that contains the number of bytes to generate. Common values are
 	// 128, 256, 512, 1024 and so on. The current limit is 1024 bytes.
 	NumberOfBytes *int64 `min:"1" type:"integer"`
-
-	_ struct{} `type:"structure"`
 }
 
 // String returns the string representation
@@ -1720,10 +1720,10 @@ func (s GenerateRandomInput) GoString() string {
 }
 
 type GenerateRandomOutput struct {
+	_ struct{} `type:"structure"`
+
 	// Plaintext that contains the unpredictable byte string.
 	Plaintext []byte `min:"1" type:"blob"`
-
-	_ struct{} `type:"structure"`
 }
 
 // String returns the string representation
@@ -1737,6 +1737,8 @@ func (s GenerateRandomOutput) GoString() string {
 }
 
 type GetKeyPolicyInput struct {
+	_ struct{} `type:"structure"`
+
 	// A unique identifier for the customer master key. This value can be a globally
 	// unique identifier or the fully specified ARN to a key.  Key ARN Example -
 	// arn:aws:kms:us-east-1:123456789012:key/12345678-1234-1234-1234-123456789012
@@ -1746,8 +1748,6 @@ type GetKeyPolicyInput struct {
 	// String that contains the name of the policy. Currently, this must be "default".
 	// Policy names can be discovered by calling ListKeyPolicies.
 	PolicyName *string `min:"1" type:"string" required:"true"`
-
-	_ struct{} `type:"structure"`
 }
 
 // String returns the string representation
@@ -1761,10 +1761,10 @@ func (s GetKeyPolicyInput) GoString() string {
 }
 
 type GetKeyPolicyOutput struct {
+	_ struct{} `type:"structure"`
+
 	// A policy document in JSON format.
 	Policy *string `min:"1" type:"string"`
-
-	_ struct{} `type:"structure"`
 }
 
 // String returns the string representation
@@ -1778,13 +1778,13 @@ func (s GetKeyPolicyOutput) GoString() string {
 }
 
 type GetKeyRotationStatusInput struct {
+	_ struct{} `type:"structure"`
+
 	// A unique identifier for the customer master key. This value can be a globally
 	// unique identifier or the fully specified ARN to a key.  Key ARN Example -
 	// arn:aws:kms:us-east-1:123456789012:key/12345678-1234-1234-1234-123456789012
 	// Globally Unique Key ID Example - 12345678-1234-1234-1234-123456789012
 	KeyId *string `min:"1" type:"string" required:"true"`
-
-	_ struct{} `type:"structure"`
 }
 
 // String returns the string representation
@@ -1798,10 +1798,10 @@ func (s GetKeyRotationStatusInput) GoString() string {
 }
 
 type GetKeyRotationStatusOutput struct {
+	_ struct{} `type:"structure"`
+
 	// A Boolean value that specifies whether key rotation is enabled.
 	KeyRotationEnabled *bool `type:"boolean"`
-
-	_ struct{} `type:"structure"`
 }
 
 // String returns the string representation
@@ -1822,6 +1822,8 @@ func (s GetKeyRotationStatusOutput) GoString() string {
 // about encryption context, see Encryption Context (http://docs.aws.amazon.com/kms/latest/developerguide/encrypt-context.html)
 // in the AWS Key Management Service Developer Guide.
 type GrantConstraints struct {
+	_ struct{} `type:"structure"`
+
 	// Contains a list of key-value pairs that must be present in the encryption
 	// context of a subsequent operation permitted by the grant. When a subsequent
 	// operation permitted by the grant includes an encryption context that matches
@@ -1835,8 +1837,6 @@ type GrantConstraints struct {
 	// context that matches this list or is a subset of this list, the grant allows
 	// the operation. Otherwise, the operation is not allowed.
 	EncryptionContextSubset map[string]*string `type:"map"`
-
-	_ struct{} `type:"structure"`
 }
 
 // String returns the string representation
@@ -1851,6 +1851,8 @@ func (s GrantConstraints) GoString() string {
 
 // Contains information about an entry in a list of grants.
 type GrantListEntry struct {
+	_ struct{} `type:"structure"`
+
 	// The conditions under which the grant's operations are allowed.
 	Constraints *GrantConstraints `type:"structure"`
 
@@ -1879,8 +1881,6 @@ type GrantListEntry struct {
 
 	// The principal that can retire the grant.
 	RetiringPrincipal *string `min:"1" type:"string"`
-
-	_ struct{} `type:"structure"`
 }
 
 // String returns the string representation
@@ -1895,13 +1895,13 @@ func (s GrantListEntry) GoString() string {
 
 // Contains information about each entry in the key list.
 type KeyListEntry struct {
+	_ struct{} `type:"structure"`
+
 	// ARN of the key.
 	KeyArn *string `min:"20" type:"string"`
 
 	// Unique identifier of the key.
 	KeyId *string `min:"1" type:"string"`
-
-	_ struct{} `type:"structure"`
 }
 
 // String returns the string representation
@@ -1919,6 +1919,8 @@ func (s KeyListEntry) GoString() string {
 // This data type is used as a response element for the CreateKey and DescribeKey
 // operations.
 type KeyMetadata struct {
+	_ struct{} `type:"structure"`
+
 	// The twelve-digit account ID of the AWS account that owns the key.
 	AWSAccountId *string `type:"string"`
 
@@ -1956,8 +1958,6 @@ type KeyMetadata struct {
 	// only allowed value is ENCRYPT_DECRYPT, which means you can use the key for
 	// the Encrypt and Decrypt operations.
 	KeyUsage *string `type:"string" enum:"KeyUsageType"`
-
-	_ struct{} `type:"structure"`
 }
 
 // String returns the string representation
@@ -1971,6 +1971,8 @@ func (s KeyMetadata) GoString() string {
 }
 
 type ListAliasesInput struct {
+	_ struct{} `type:"structure"`
+
 	// When paginating results, specify the maximum number of items to return in
 	// the response. If additional items exist beyond the number you specify, the
 	// Truncated element in the response is set to true.
@@ -1983,8 +1985,6 @@ type ListAliasesInput struct {
 	// request after you've received a response with truncated results. Set it to
 	// the value of NextMarker from the response you just received.
 	Marker *string `min:"1" type:"string"`
-
-	_ struct{} `type:"structure"`
 }
 
 // String returns the string representation
@@ -1998,6 +1998,8 @@ func (s ListAliasesInput) GoString() string {
 }
 
 type ListAliasesOutput struct {
+	_ struct{} `type:"structure"`
+
 	// A list of key aliases in the user's account.
 	Aliases []*AliasListEntry `type:"list"`
 
@@ -2009,8 +2011,6 @@ type ListAliasesOutput struct {
 	// were truncated, you can use the Marker parameter to make a subsequent pagination
 	// request to retrieve more items in the list.
 	Truncated *bool `type:"boolean"`
-
-	_ struct{} `type:"structure"`
 }
 
 // String returns the string representation
@@ -2024,6 +2024,8 @@ func (s ListAliasesOutput) GoString() string {
 }
 
 type ListGrantsInput struct {
+	_ struct{} `type:"structure"`
+
 	// A unique identifier for the customer master key. This value can be a globally
 	// unique identifier or the fully specified ARN to a key.  Key ARN Example -
 	// arn:aws:kms:us-east-1:123456789012:key/12345678-1234-1234-1234-123456789012
@@ -2042,8 +2044,6 @@ type ListGrantsInput struct {
 	// request after you've received a response with truncated results. Set it to
 	// the value of NextMarker from the response you just received.
 	Marker *string `min:"1" type:"string"`
-
-	_ struct{} `type:"structure"`
 }
 
 // String returns the string representation
@@ -2057,6 +2057,8 @@ func (s ListGrantsInput) GoString() string {
 }
 
 type ListGrantsResponse struct {
+	_ struct{} `type:"structure"`
+
 	// A list of grants.
 	Grants []*GrantListEntry `type:"list"`
 
@@ -2068,8 +2070,6 @@ type ListGrantsResponse struct {
 	// were truncated, you can use the Marker parameter to make a subsequent pagination
 	// request to retrieve more items in the list.
 	Truncated *bool `type:"boolean"`
-
-	_ struct{} `type:"structure"`
 }
 
 // String returns the string representation
@@ -2083,6 +2083,8 @@ func (s ListGrantsResponse) GoString() string {
 }
 
 type ListKeyPoliciesInput struct {
+	_ struct{} `type:"structure"`
+
 	// A unique identifier for the customer master key. This value can be a globally
 	// unique identifier, a fully specified ARN to either an alias or a key, or
 	// an alias name prefixed by "alias/".  Key ARN Example - arn:aws:kms:us-east-1:123456789012:key/12345678-1234-1234-1234-123456789012
@@ -2105,8 +2107,6 @@ type ListKeyPoliciesInput struct {
 	// request after you've received a response with truncated results. Set it to
 	// the value of NextMarker from the response you just received.
 	Marker *string `min:"1" type:"string"`
-
-	_ struct{} `type:"structure"`
 }
 
 // String returns the string representation
@@ -2120,6 +2120,8 @@ func (s ListKeyPoliciesInput) GoString() string {
 }
 
 type ListKeyPoliciesOutput struct {
+	_ struct{} `type:"structure"`
+
 	// When Truncated is true, this value is present and contains the value to use
 	// for the Marker parameter in a subsequent pagination request.
 	NextMarker *string `min:"1" type:"string"`
@@ -2132,8 +2134,6 @@ type ListKeyPoliciesOutput struct {
 	// were truncated, you can use the Marker parameter to make a subsequent pagination
 	// request to retrieve more items in the list.
 	Truncated *bool `type:"boolean"`
-
-	_ struct{} `type:"structure"`
 }
 
 // String returns the string representation
@@ -2147,6 +2147,8 @@ func (s ListKeyPoliciesOutput) GoString() string {
 }
 
 type ListKeysInput struct {
+	_ struct{} `type:"structure"`
+
 	// When paginating results, specify the maximum number of items to return in
 	// the response. If additional items exist beyond the number you specify, the
 	// Truncated element in the response is set to true.
@@ -2159,8 +2161,6 @@ type ListKeysInput struct {
 	// request after you've received a response with truncated results. Set it to
 	// the value of NextMarker from the response you just received.
 	Marker *string `min:"1" type:"string"`
-
-	_ struct{} `type:"structure"`
 }
 
 // String returns the string representation
@@ -2174,6 +2174,8 @@ func (s ListKeysInput) GoString() string {
 }
 
 type ListKeysOutput struct {
+	_ struct{} `type:"structure"`
+
 	// A list of keys.
 	Keys []*KeyListEntry `type:"list"`
 
@@ -2185,8 +2187,6 @@ type ListKeysOutput struct {
 	// were truncated, you can use the Marker parameter to make a subsequent pagination
 	// request to retrieve more items in the list.
 	Truncated *bool `type:"boolean"`
-
-	_ struct{} `type:"structure"`
 }
 
 // String returns the string representation
@@ -2200,6 +2200,8 @@ func (s ListKeysOutput) GoString() string {
 }
 
 type ListRetirableGrantsInput struct {
+	_ struct{} `type:"structure"`
+
 	// When paginating results, specify the maximum number of items to return in
 	// the response. If additional items exist beyond the number you specify, the
 	// Truncated element in the response is set to true.
@@ -2222,8 +2224,6 @@ type ListRetirableGrantsInput struct {
 	// (http://docs.aws.amazon.com/general/latest/gr/aws-arns-and-namespaces.html#arn-syntax-iam)
 	// in the Example ARNs section of the Amazon Web Services General Reference.
 	RetiringPrincipal *string `min:"1" type:"string" required:"true"`
-
-	_ struct{} `type:"structure"`
 }
 
 // String returns the string representation
@@ -2237,6 +2237,8 @@ func (s ListRetirableGrantsInput) GoString() string {
 }
 
 type PutKeyPolicyInput struct {
+	_ struct{} `type:"structure"`
+
 	// A unique identifier for the customer master key. This value can be a globally
 	// unique identifier or the fully specified ARN to a key.  Key ARN Example -
 	// arn:aws:kms:us-east-1:123456789012:key/12345678-1234-1234-1234-123456789012
@@ -2251,8 +2253,6 @@ type PutKeyPolicyInput struct {
 	// Name of the policy to be attached. Currently, the only supported name is
 	// "default".
 	PolicyName *string `min:"1" type:"string" required:"true"`
-
-	_ struct{} `type:"structure"`
 }
 
 // String returns the string representation
@@ -2280,6 +2280,8 @@ func (s PutKeyPolicyOutput) GoString() string {
 }
 
 type ReEncryptInput struct {
+	_ struct{} `type:"structure"`
+
 	// Ciphertext of the data to re-encrypt.
 	CiphertextBlob []byte `min:"1" type:"blob" required:"true"`
 
@@ -2304,8 +2306,6 @@ type ReEncryptInput struct {
 	// Encryption context used to encrypt and decrypt the data specified in the
 	// CiphertextBlob parameter.
 	SourceEncryptionContext map[string]*string `type:"map"`
-
-	_ struct{} `type:"structure"`
 }
 
 // String returns the string representation
@@ -2319,6 +2319,8 @@ func (s ReEncryptInput) GoString() string {
 }
 
 type ReEncryptOutput struct {
+	_ struct{} `type:"structure"`
+
 	// The re-encrypted data. If you are using the CLI, the value is Base64 encoded.
 	// Otherwise, it is not encoded.
 	CiphertextBlob []byte `min:"1" type:"blob"`
@@ -2328,8 +2330,6 @@ type ReEncryptOutput struct {
 
 	// Unique identifier of the key used to originally encrypt the data.
 	SourceKeyId *string `min:"1" type:"string"`
-
-	_ struct{} `type:"structure"`
 }
 
 // String returns the string representation
@@ -2343,6 +2343,8 @@ func (s ReEncryptOutput) GoString() string {
 }
 
 type RetireGrantInput struct {
+	_ struct{} `type:"structure"`
+
 	// Unique identifier of the grant to be retired. The grant ID is returned by
 	// the CreateGrant function.  Grant ID Example - 0123456789012345678901234567890123456789012345678901234567890123
 	GrantId *string `min:"1" type:"string"`
@@ -2355,8 +2357,6 @@ type RetireGrantInput struct {
 	// the key.  Key ARN Example - arn:aws:kms:us-east-1:123456789012:key/12345678-1234-1234-1234-123456789012
 	// Globally Unique Key ID Example - 12345678-1234-1234-1234-123456789012
 	KeyId *string `min:"1" type:"string"`
-
-	_ struct{} `type:"structure"`
 }
 
 // String returns the string representation
@@ -2384,6 +2384,8 @@ func (s RetireGrantOutput) GoString() string {
 }
 
 type RevokeGrantInput struct {
+	_ struct{} `type:"structure"`
+
 	// Identifier of the grant to be revoked.
 	GrantId *string `min:"1" type:"string" required:"true"`
 
@@ -2392,8 +2394,6 @@ type RevokeGrantInput struct {
 	// to a key.  Key ARN Example - arn:aws:kms:us-east-1:123456789012:key/12345678-1234-1234-1234-123456789012
 	// Globally Unique Key ID Example - 12345678-1234-1234-1234-123456789012
 	KeyId *string `min:"1" type:"string" required:"true"`
-
-	_ struct{} `type:"structure"`
 }
 
 // String returns the string representation
@@ -2421,6 +2421,8 @@ func (s RevokeGrantOutput) GoString() string {
 }
 
 type ScheduleKeyDeletionInput struct {
+	_ struct{} `type:"structure"`
+
 	// The unique identifier for the customer master key (CMK) to delete.
 	//
 	// To specify this value, use the unique key ID or the Amazon Resource Name
@@ -2438,8 +2440,6 @@ type ScheduleKeyDeletionInput struct {
 	// This value is optional. If you include a value, it must be between 7 and
 	// 30, inclusive. If you do not include a value, it defaults to 30.
 	PendingWindowInDays *int64 `min:"1" type:"integer"`
-
-	_ struct{} `type:"structure"`
 }
 
 // String returns the string representation
@@ -2453,14 +2453,14 @@ func (s ScheduleKeyDeletionInput) GoString() string {
 }
 
 type ScheduleKeyDeletionOutput struct {
+	_ struct{} `type:"structure"`
+
 	// The date and time after which AWS KMS deletes the customer master key (CMK).
 	DeletionDate *time.Time `type:"timestamp" timestampFormat:"unix"`
 
 	// The unique identifier of the customer master key (CMK) for which deletion
 	// is scheduled.
 	KeyId *string `min:"1" type:"string"`
-
-	_ struct{} `type:"structure"`
 }
 
 // String returns the string representation
@@ -2474,6 +2474,8 @@ func (s ScheduleKeyDeletionOutput) GoString() string {
 }
 
 type UpdateAliasInput struct {
+	_ struct{} `type:"structure"`
+
 	// String that contains the name of the alias to be modified. The name must
 	// start with the word "alias" followed by a forward slash (alias/). Aliases
 	// that begin with "alias/aws" are reserved.
@@ -2487,8 +2489,6 @@ type UpdateAliasInput struct {
 	// You can call ListAliases to verify that the alias is mapped to the correct
 	// TargetKeyId.
 	TargetKeyId *string `min:"1" type:"string" required:"true"`
-
-	_ struct{} `type:"structure"`
 }
 
 // String returns the string representation
@@ -2516,6 +2516,8 @@ func (s UpdateAliasOutput) GoString() string {
 }
 
 type UpdateKeyDescriptionInput struct {
+	_ struct{} `type:"structure"`
+
 	// New description for the key.
 	Description *string `type:"string" required:"true"`
 
@@ -2524,8 +2526,6 @@ type UpdateKeyDescriptionInput struct {
 	// arn:aws:kms:us-east-1:123456789012:key/12345678-1234-1234-1234-123456789012
 	// Globally Unique Key ID Example - 12345678-1234-1234-1234-123456789012
 	KeyId *string `min:"1" type:"string" required:"true"`
-
-	_ struct{} `type:"structure"`
 }
 
 // String returns the string representation

--- a/service/lambda/api.go
+++ b/service/lambda/api.go
@@ -851,6 +851,8 @@ func (c *Lambda) UpdateFunctionConfiguration(input *UpdateFunctionConfigurationI
 }
 
 type AddPermissionInput struct {
+	_ struct{} `type:"structure"`
+
 	// The AWS Lambda action you want to allow in this statement. Each Lambda action
 	// is a string starting with "lambda:" followed by the API name (see Operations).
 	// For example, "lambda:CreateFunction". You can use wildcard ("lambda:*") to
@@ -915,8 +917,6 @@ type AddPermissionInput struct {
 
 	// A unique statement identifier.
 	StatementId *string `min:"1" type:"string" required:"true"`
-
-	_ struct{} `type:"structure"`
 }
 
 // String returns the string representation
@@ -930,11 +930,11 @@ func (s AddPermissionInput) GoString() string {
 }
 
 type AddPermissionOutput struct {
+	_ struct{} `type:"structure"`
+
 	// The permission statement you specified in the request. The response returns
 	// the same as a string using "\" as an escape character in the JSON.
 	Statement *string `type:"string"`
-
-	_ struct{} `type:"structure"`
 }
 
 // String returns the string representation
@@ -949,6 +949,8 @@ func (s AddPermissionOutput) GoString() string {
 
 // Provides configuration information about a Lambda function version alias.
 type AliasConfiguration struct {
+	_ struct{} `type:"structure"`
+
 	// Lambda function ARN that is qualified using alias name as the suffix. For
 	// example, if you create an alias "BETA" pointing to a helloworld function
 	// version, the ARN is arn:aws:lambda:aws-regions:acct-id:function:helloworld:BETA.
@@ -962,8 +964,6 @@ type AliasConfiguration struct {
 
 	// Alias name.
 	Name *string `min:"1" type:"string"`
-
-	_ struct{} `type:"structure"`
 }
 
 // String returns the string representation
@@ -977,6 +977,8 @@ func (s AliasConfiguration) GoString() string {
 }
 
 type CreateAliasInput struct {
+	_ struct{} `type:"structure"`
+
 	// Description of the alias.
 	Description *string `type:"string"`
 
@@ -988,8 +990,6 @@ type CreateAliasInput struct {
 
 	// Name for the alias your creating.
 	Name *string `min:"1" type:"string" required:"true"`
-
-	_ struct{} `type:"structure"`
 }
 
 // String returns the string representation
@@ -1003,6 +1003,8 @@ func (s CreateAliasInput) GoString() string {
 }
 
 type CreateEventSourceMappingInput struct {
+	_ struct{} `type:"structure"`
+
 	// The largest number of records that AWS Lambda will retrieve from your event
 	// source at the time of invoking your function. Your function receives an event
 	// with all the retrieved records. The default is 100 records.
@@ -1033,8 +1035,6 @@ type CreateEventSourceMappingInput struct {
 	// information, go to ShardIteratorType (http://docs.aws.amazon.com/kinesis/latest/APIReference/API_GetShardIterator.html#Kinesis-GetShardIterator-request-ShardIteratorType)
 	// in the Amazon Kinesis API Reference.
 	StartingPosition *string `type:"string" required:"true" enum:"EventSourcePosition"`
-
-	_ struct{} `type:"structure"`
 }
 
 // String returns the string representation
@@ -1048,6 +1048,8 @@ func (s CreateEventSourceMappingInput) GoString() string {
 }
 
 type CreateFunctionInput struct {
+	_ struct{} `type:"structure"`
+
 	// The code for the Lambda function.
 	Code *FunctionCode `type:"structure" required:"true"`
 
@@ -1097,8 +1099,6 @@ type CreateFunctionInput struct {
 	// Because the execution time has cost implications, we recommend you set this
 	// value based on your expected execution time. The default is 3 seconds.
 	Timeout *int64 `min:"1" type:"integer"`
-
-	_ struct{} `type:"structure"`
 }
 
 // String returns the string representation
@@ -1112,13 +1112,13 @@ func (s CreateFunctionInput) GoString() string {
 }
 
 type DeleteAliasInput struct {
+	_ struct{} `type:"structure"`
+
 	// The Lambda function name for which the alias is created.
 	FunctionName *string `location:"uri" locationName:"FunctionName" min:"1" type:"string" required:"true"`
 
 	// Name of the alias to delete.
 	Name *string `location:"uri" locationName:"Name" min:"1" type:"string" required:"true"`
-
-	_ struct{} `type:"structure"`
 }
 
 // String returns the string representation
@@ -1146,10 +1146,10 @@ func (s DeleteAliasOutput) GoString() string {
 }
 
 type DeleteEventSourceMappingInput struct {
+	_ struct{} `type:"structure"`
+
 	// The event source mapping ID.
 	UUID *string `location:"uri" locationName:"UUID" type:"string" required:"true"`
-
-	_ struct{} `type:"structure"`
 }
 
 // String returns the string representation
@@ -1163,6 +1163,8 @@ func (s DeleteEventSourceMappingInput) GoString() string {
 }
 
 type DeleteFunctionInput struct {
+	_ struct{} `type:"structure"`
+
 	// The Lambda function to delete.
 	//
 	//  You can specify an unqualified function name (for example, "Thumbnail")
@@ -1187,8 +1189,6 @@ type DeleteFunctionInput struct {
 	// If you don't specify this parameter, AWS Lambda will delete the function,
 	// including all its versions and aliases.
 	Qualifier *string `location:"querystring" locationName:"Qualifier" min:"1" type:"string"`
-
-	_ struct{} `type:"structure"`
 }
 
 // String returns the string representation
@@ -1217,6 +1217,8 @@ func (s DeleteFunctionOutput) GoString() string {
 
 // Describes mapping between an Amazon Kinesis stream and a Lambda function.
 type EventSourceMappingConfiguration struct {
+	_ struct{} `type:"structure"`
+
 	// The largest number of records that AWS Lambda will retrieve from your event
 	// source at the time of invoking your function. Your function receives an event
 	// with all the retrieved records.
@@ -1245,8 +1247,6 @@ type EventSourceMappingConfiguration struct {
 
 	// The AWS Lambda assigned opaque identifier for the mapping.
 	UUID *string `type:"string"`
-
-	_ struct{} `type:"structure"`
 }
 
 // String returns the string representation
@@ -1261,6 +1261,8 @@ func (s EventSourceMappingConfiguration) GoString() string {
 
 // The code for the Lambda function.
 type FunctionCode struct {
+	_ struct{} `type:"structure"`
+
 	// Amazon S3 bucket name where the .zip file containing your deployment package
 	// is stored. This bucket must reside in the same AWS region where you are creating
 	// the Lambda function.
@@ -1276,8 +1278,6 @@ type FunctionCode struct {
 	// about creating a .zip file, go to Execution Permissions (http://docs.aws.amazon.com/lambda/latest/dg/intro-permission-model.html#lambda-intro-execution-role.html)
 	// in the AWS Lambda Developer Guide.
 	ZipFile []byte `type:"blob"`
-
-	_ struct{} `type:"structure"`
 }
 
 // String returns the string representation
@@ -1292,14 +1292,14 @@ func (s FunctionCode) GoString() string {
 
 // The object for the Lambda function location.
 type FunctionCodeLocation struct {
+	_ struct{} `type:"structure"`
+
 	// The presigned URL you can use to download the function's .zip file that you
 	// previously uploaded. The URL is valid for up to 10 minutes.
 	Location *string `type:"string"`
 
 	// The repository from which you can download the function.
 	RepositoryType *string `type:"string"`
-
-	_ struct{} `type:"structure"`
 }
 
 // String returns the string representation
@@ -1314,6 +1314,8 @@ func (s FunctionCodeLocation) GoString() string {
 
 // A complex type that describes function metadata.
 type FunctionConfiguration struct {
+	_ struct{} `type:"structure"`
+
 	// It is the SHA256 hash of your function deployment package.
 	CodeSha256 *string `type:"string"`
 
@@ -1353,8 +1355,6 @@ type FunctionConfiguration struct {
 
 	// The version of the Lambda function.
 	Version *string `min:"1" type:"string"`
-
-	_ struct{} `type:"structure"`
 }
 
 // String returns the string representation
@@ -1368,6 +1368,8 @@ func (s FunctionConfiguration) GoString() string {
 }
 
 type GetAliasInput struct {
+	_ struct{} `type:"structure"`
+
 	// Function name for which the alias is created. An alias is a subresource that
 	// exists only in the context of an existing Lambda function. So you must specify
 	// the function name.
@@ -1375,8 +1377,6 @@ type GetAliasInput struct {
 
 	// Name of the alias for which you want to retrieve information.
 	Name *string `location:"uri" locationName:"Name" min:"1" type:"string" required:"true"`
-
-	_ struct{} `type:"structure"`
 }
 
 // String returns the string representation
@@ -1390,10 +1390,10 @@ func (s GetAliasInput) GoString() string {
 }
 
 type GetEventSourceMappingInput struct {
+	_ struct{} `type:"structure"`
+
 	// The AWS Lambda assigned ID of the event source mapping.
 	UUID *string `location:"uri" locationName:"UUID" type:"string" required:"true"`
-
-	_ struct{} `type:"structure"`
 }
 
 // String returns the string representation
@@ -1407,6 +1407,8 @@ func (s GetEventSourceMappingInput) GoString() string {
 }
 
 type GetFunctionConfigurationInput struct {
+	_ struct{} `type:"structure"`
+
 	// The name of the Lambda function for which you want to retrieve the configuration
 	// information.
 	//
@@ -1427,8 +1429,6 @@ type GetFunctionConfigurationInput struct {
 	// If you don't specify this parameter, the API uses unqualified function ARN,
 	// and returns information about the $LATEST function version.
 	Qualifier *string `location:"querystring" locationName:"Qualifier" min:"1" type:"string"`
-
-	_ struct{} `type:"structure"`
 }
 
 // String returns the string representation
@@ -1442,6 +1442,8 @@ func (s GetFunctionConfigurationInput) GoString() string {
 }
 
 type GetFunctionInput struct {
+	_ struct{} `type:"structure"`
+
 	// The Lambda function name.
 	//
 	//  You can specify an unqualified function name (for example, "Thumbnail")
@@ -1460,8 +1462,6 @@ type GetFunctionInput struct {
 	// this parameter, the API uses unqualified function ARN and returns information
 	// about the $LATEST version of the Lambda function.
 	Qualifier *string `location:"querystring" locationName:"Qualifier" min:"1" type:"string"`
-
-	_ struct{} `type:"structure"`
 }
 
 // String returns the string representation
@@ -1476,13 +1476,13 @@ func (s GetFunctionInput) GoString() string {
 
 // This response contains the object for the Lambda function location (see API_FunctionCodeLocation
 type GetFunctionOutput struct {
+	_ struct{} `type:"structure"`
+
 	// The object for the Lambda function location.
 	Code *FunctionCodeLocation `type:"structure"`
 
 	// A complex type that describes function metadata.
 	Configuration *FunctionConfiguration `type:"structure"`
-
-	_ struct{} `type:"structure"`
 }
 
 // String returns the string representation
@@ -1496,6 +1496,8 @@ func (s GetFunctionOutput) GoString() string {
 }
 
 type GetPolicyInput struct {
+	_ struct{} `type:"structure"`
+
 	// Function name whose resource policy you want to retrieve.
 	//
 	//  You can specify an unqualified function name (for example, "Thumbnail")
@@ -1511,8 +1513,6 @@ type GetPolicyInput struct {
 	// with the specific ARN. If you don't provide this parameter, the API will
 	// return permissions that apply to the unqualified function ARN.
 	Qualifier *string `min:"1" type:"string"`
-
-	_ struct{} `type:"structure"`
 }
 
 // String returns the string representation
@@ -1526,11 +1526,11 @@ func (s GetPolicyInput) GoString() string {
 }
 
 type GetPolicyOutput struct {
+	_ struct{} `type:"structure"`
+
 	// The resource policy associated with the specified function. The response
 	// returns the same as a string using "\" as an escape character in the JSON.
 	Policy *string `type:"string"`
-
-	_ struct{} `type:"structure"`
 }
 
 // String returns the string representation
@@ -1544,13 +1544,13 @@ func (s GetPolicyOutput) GoString() string {
 }
 
 type InvokeAsyncInput struct {
+	_ struct{} `type:"structure" payload:"InvokeArgs"`
+
 	// The Lambda function name.
 	FunctionName *string `location:"uri" locationName:"FunctionName" min:"1" type:"string" required:"true"`
 
 	// JSON that you want to provide to your Lambda function as input.
 	InvokeArgs io.ReadSeeker `type:"blob" required:"true"`
-
-	_ struct{} `type:"structure" payload:"InvokeArgs"`
 }
 
 // String returns the string representation
@@ -1565,10 +1565,10 @@ func (s InvokeAsyncInput) GoString() string {
 
 // Upon success, it returns empty response. Otherwise, throws an exception.
 type InvokeAsyncOutput struct {
+	_ struct{} `type:"structure"`
+
 	// It will be 202 upon success.
 	Status *int64 `location:"statusCode" type:"integer"`
-
-	_ struct{} `type:"structure"`
 }
 
 // String returns the string representation
@@ -1582,6 +1582,8 @@ func (s InvokeAsyncOutput) GoString() string {
 }
 
 type InvokeInput struct {
+	_ struct{} `type:"structure" payload:"Payload"`
+
 	// Using the ClientContext you can pass client-specific information to the Lambda
 	// function you are invoking. You can then process the client information in
 	// your Lambda function as you choose through the context variable. For an example
@@ -1628,8 +1630,6 @@ type InvokeInput struct {
 	// If you don't provide this parameter, then the API uses unqualified function
 	// ARN which results in invocation of the $LATEST version.
 	Qualifier *string `location:"querystring" locationName:"Qualifier" min:"1" type:"string"`
-
-	_ struct{} `type:"structure" payload:"Payload"`
 }
 
 // String returns the string representation
@@ -1644,6 +1644,8 @@ func (s InvokeInput) GoString() string {
 
 // Upon success, returns an empty response. Otherwise, throws an exception.
 type InvokeOutput struct {
+	_ struct{} `type:"structure" payload:"Payload"`
+
 	// Indicates whether an error occurred while executing the Lambda function.
 	// If an error occurred this field will have one of two values; Handled or Unhandled.
 	// Handled errors are errors that are reported by the function while the Unhandled
@@ -1670,8 +1672,6 @@ type InvokeOutput struct {
 	// "Event" invocation type this status code will be 202. For the "DryRun" invocation
 	// type the status code will be 204.
 	StatusCode *int64 `location:"statusCode" type:"integer"`
-
-	_ struct{} `type:"structure" payload:"Payload"`
 }
 
 // String returns the string representation
@@ -1685,6 +1685,8 @@ func (s InvokeOutput) GoString() string {
 }
 
 type ListAliasesInput struct {
+	_ struct{} `type:"structure"`
+
 	// Lambda function name for which the alias is created.
 	FunctionName *string `location:"uri" locationName:"FunctionName" min:"1" type:"string" required:"true"`
 
@@ -1700,8 +1702,6 @@ type ListAliasesInput struct {
 	// Optional integer. Specifies the maximum number of aliases to return in response.
 	// This parameter value must be greater than 0.
 	MaxItems *int64 `location:"querystring" locationName:"MaxItems" min:"1" type:"integer"`
-
-	_ struct{} `type:"structure"`
 }
 
 // String returns the string representation
@@ -1715,13 +1715,13 @@ func (s ListAliasesInput) GoString() string {
 }
 
 type ListAliasesOutput struct {
+	_ struct{} `type:"structure"`
+
 	// An list of alises.
 	Aliases []*AliasConfiguration `type:"list"`
 
 	// A string, present if there are more aliases.
 	NextMarker *string `type:"string"`
-
-	_ struct{} `type:"structure"`
 }
 
 // String returns the string representation
@@ -1735,6 +1735,8 @@ func (s ListAliasesOutput) GoString() string {
 }
 
 type ListEventSourceMappingsInput struct {
+	_ struct{} `type:"structure"`
+
 	// The Amazon Resource Name (ARN) of the Amazon Kinesis stream.
 	EventSourceArn *string `location:"querystring" locationName:"EventSourceArn" type:"string"`
 
@@ -1756,8 +1758,6 @@ type ListEventSourceMappingsInput struct {
 	// Optional integer. Specifies the maximum number of event sources to return
 	// in response. This value must be greater than 0.
 	MaxItems *int64 `location:"querystring" locationName:"MaxItems" min:"1" type:"integer"`
-
-	_ struct{} `type:"structure"`
 }
 
 // String returns the string representation
@@ -1772,13 +1772,13 @@ func (s ListEventSourceMappingsInput) GoString() string {
 
 // Contains a list of event sources (see API_EventSourceMappingConfiguration)
 type ListEventSourceMappingsOutput struct {
+	_ struct{} `type:"structure"`
+
 	// An array of EventSourceMappingConfiguration objects.
 	EventSourceMappings []*EventSourceMappingConfiguration `type:"list"`
 
 	// A string, present if there are more event source mappings.
 	NextMarker *string `type:"string"`
-
-	_ struct{} `type:"structure"`
 }
 
 // String returns the string representation
@@ -1792,6 +1792,8 @@ func (s ListEventSourceMappingsOutput) GoString() string {
 }
 
 type ListFunctionsInput struct {
+	_ struct{} `type:"structure"`
+
 	// Optional string. An opaque pagination token returned from a previous ListFunctions
 	// operation. If present, indicates where to continue the listing.
 	Marker *string `location:"querystring" locationName:"Marker" type:"string"`
@@ -1799,8 +1801,6 @@ type ListFunctionsInput struct {
 	// Optional integer. Specifies the maximum number of AWS Lambda functions to
 	// return in response. This parameter value must be greater than 0.
 	MaxItems *int64 `location:"querystring" locationName:"MaxItems" min:"1" type:"integer"`
-
-	_ struct{} `type:"structure"`
 }
 
 // String returns the string representation
@@ -1815,13 +1815,13 @@ func (s ListFunctionsInput) GoString() string {
 
 // Contains a list of AWS Lambda function configurations (see FunctionConfiguration.
 type ListFunctionsOutput struct {
+	_ struct{} `type:"structure"`
+
 	// A list of Lambda functions.
 	Functions []*FunctionConfiguration `type:"list"`
 
 	// A string, present if there are more functions.
 	NextMarker *string `type:"string"`
-
-	_ struct{} `type:"structure"`
 }
 
 // String returns the string representation
@@ -1835,6 +1835,8 @@ func (s ListFunctionsOutput) GoString() string {
 }
 
 type ListVersionsByFunctionInput struct {
+	_ struct{} `type:"structure"`
+
 	// Function name whose versions to list. You can specify an unqualified function
 	// name (for example, "Thumbnail") or you can specify Amazon Resource Name (ARN)
 	// of the function (for example, "arn:aws:lambda:us-west-2:account-id:function:ThumbNail").
@@ -1851,8 +1853,6 @@ type ListVersionsByFunctionInput struct {
 	// Optional integer. Specifies the maximum number of AWS Lambda function versions
 	// to return in response. This parameter value must be greater than 0.
 	MaxItems *int64 `location:"querystring" locationName:"MaxItems" min:"1" type:"integer"`
-
-	_ struct{} `type:"structure"`
 }
 
 // String returns the string representation
@@ -1866,13 +1866,13 @@ func (s ListVersionsByFunctionInput) GoString() string {
 }
 
 type ListVersionsByFunctionOutput struct {
+	_ struct{} `type:"structure"`
+
 	// A string, present if there are more function versions.
 	NextMarker *string `type:"string"`
 
 	// A list of Lambda function versions.
 	Versions []*FunctionConfiguration `type:"list"`
-
-	_ struct{} `type:"structure"`
 }
 
 // String returns the string representation
@@ -1886,6 +1886,8 @@ func (s ListVersionsByFunctionOutput) GoString() string {
 }
 
 type PublishVersionInput struct {
+	_ struct{} `type:"structure"`
+
 	// The SHA256 hash of the deployment package you want to publish. This provides
 	// validation on the code you are publishing. If you provide this parameter
 	// value must match the SHA256 of the HEAD version for the publication to succeed.
@@ -1903,8 +1905,6 @@ type PublishVersionInput struct {
 	// only to the ARN. If you specify only the function name, it is limited to
 	// 64 character in length.
 	FunctionName *string `location:"uri" locationName:"FunctionName" min:"1" type:"string" required:"true"`
-
-	_ struct{} `type:"structure"`
 }
 
 // String returns the string representation
@@ -1918,6 +1918,8 @@ func (s PublishVersionInput) GoString() string {
 }
 
 type RemovePermissionInput struct {
+	_ struct{} `type:"structure"`
+
 	// Lambda function whose resource policy you want to remove a permission from.
 	//
 	//  You can specify an unqualified function name (for example, "Thumbnail")
@@ -1936,8 +1938,6 @@ type RemovePermissionInput struct {
 
 	// Statement ID of the permission to remove.
 	StatementId *string `location:"uri" locationName:"StatementId" min:"1" type:"string" required:"true"`
-
-	_ struct{} `type:"structure"`
 }
 
 // String returns the string representation
@@ -1965,6 +1965,8 @@ func (s RemovePermissionOutput) GoString() string {
 }
 
 type UpdateAliasInput struct {
+	_ struct{} `type:"structure"`
+
 	// You can optionally change the description of the alias using this parameter.
 	Description *string `type:"string"`
 
@@ -1977,8 +1979,6 @@ type UpdateAliasInput struct {
 
 	// The alias name.
 	Name *string `location:"uri" locationName:"Name" min:"1" type:"string" required:"true"`
-
-	_ struct{} `type:"structure"`
 }
 
 // String returns the string representation
@@ -1992,6 +1992,8 @@ func (s UpdateAliasInput) GoString() string {
 }
 
 type UpdateEventSourceMappingInput struct {
+	_ struct{} `type:"structure"`
+
 	// The maximum number of stream records that can be sent to your Lambda function
 	// for a single invocation.
 	BatchSize *int64 `min:"1" type:"integer"`
@@ -2012,8 +2014,6 @@ type UpdateEventSourceMappingInput struct {
 
 	// The event source mapping identifier.
 	UUID *string `location:"uri" locationName:"UUID" type:"string" required:"true"`
-
-	_ struct{} `type:"structure"`
 }
 
 // String returns the string representation
@@ -2027,6 +2027,8 @@ func (s UpdateEventSourceMappingInput) GoString() string {
 }
 
 type UpdateFunctionCodeInput struct {
+	_ struct{} `type:"structure"`
+
 	// The existing Lambda function name whose code you want to replace.
 	//
 	//  You can specify an unqualified function name (for example, "Thumbnail")
@@ -2054,8 +2056,6 @@ type UpdateFunctionCodeInput struct {
 
 	// Based64-encoded .zip file containing your packaged source code.
 	ZipFile []byte `type:"blob"`
-
-	_ struct{} `type:"structure"`
 }
 
 // String returns the string representation
@@ -2069,6 +2069,8 @@ func (s UpdateFunctionCodeInput) GoString() string {
 }
 
 type UpdateFunctionConfigurationInput struct {
+	_ struct{} `type:"structure"`
+
 	// A short user-defined function description. AWS Lambda does not use this value.
 	// Assign a meaningful description as you see fit.
 	Description *string `type:"string"`
@@ -2103,8 +2105,6 @@ type UpdateFunctionConfigurationInput struct {
 	// Because the execution time has cost implications, we recommend you set this
 	// value based on your expected execution time. The default is 3 seconds.
 	Timeout *int64 `min:"1" type:"integer"`
-
-	_ struct{} `type:"structure"`
 }
 
 // String returns the string representation

--- a/service/lambda/api.go
+++ b/service/lambda/api.go
@@ -916,11 +916,7 @@ type AddPermissionInput struct {
 	// A unique statement identifier.
 	StatementId *string `min:"1" type:"string" required:"true"`
 
-	metadataAddPermissionInput `json:"-" xml:"-"`
-}
-
-type metadataAddPermissionInput struct {
-	SDKShapeTraits bool `type:"structure"`
+	_ struct{} `type:"structure"`
 }
 
 // String returns the string representation
@@ -938,11 +934,7 @@ type AddPermissionOutput struct {
 	// the same as a string using "\" as an escape character in the JSON.
 	Statement *string `type:"string"`
 
-	metadataAddPermissionOutput `json:"-" xml:"-"`
-}
-
-type metadataAddPermissionOutput struct {
-	SDKShapeTraits bool `type:"structure"`
+	_ struct{} `type:"structure"`
 }
 
 // String returns the string representation
@@ -971,11 +963,7 @@ type AliasConfiguration struct {
 	// Alias name.
 	Name *string `min:"1" type:"string"`
 
-	metadataAliasConfiguration `json:"-" xml:"-"`
-}
-
-type metadataAliasConfiguration struct {
-	SDKShapeTraits bool `type:"structure"`
+	_ struct{} `type:"structure"`
 }
 
 // String returns the string representation
@@ -1001,11 +989,7 @@ type CreateAliasInput struct {
 	// Name for the alias your creating.
 	Name *string `min:"1" type:"string" required:"true"`
 
-	metadataCreateAliasInput `json:"-" xml:"-"`
-}
-
-type metadataCreateAliasInput struct {
-	SDKShapeTraits bool `type:"structure"`
+	_ struct{} `type:"structure"`
 }
 
 // String returns the string representation
@@ -1050,11 +1034,7 @@ type CreateEventSourceMappingInput struct {
 	// in the Amazon Kinesis API Reference.
 	StartingPosition *string `type:"string" required:"true" enum:"EventSourcePosition"`
 
-	metadataCreateEventSourceMappingInput `json:"-" xml:"-"`
-}
-
-type metadataCreateEventSourceMappingInput struct {
-	SDKShapeTraits bool `type:"structure"`
+	_ struct{} `type:"structure"`
 }
 
 // String returns the string representation
@@ -1118,11 +1098,7 @@ type CreateFunctionInput struct {
 	// value based on your expected execution time. The default is 3 seconds.
 	Timeout *int64 `min:"1" type:"integer"`
 
-	metadataCreateFunctionInput `json:"-" xml:"-"`
-}
-
-type metadataCreateFunctionInput struct {
-	SDKShapeTraits bool `type:"structure"`
+	_ struct{} `type:"structure"`
 }
 
 // String returns the string representation
@@ -1142,11 +1118,7 @@ type DeleteAliasInput struct {
 	// Name of the alias to delete.
 	Name *string `location:"uri" locationName:"Name" min:"1" type:"string" required:"true"`
 
-	metadataDeleteAliasInput `json:"-" xml:"-"`
-}
-
-type metadataDeleteAliasInput struct {
-	SDKShapeTraits bool `type:"structure"`
+	_ struct{} `type:"structure"`
 }
 
 // String returns the string representation
@@ -1160,11 +1132,7 @@ func (s DeleteAliasInput) GoString() string {
 }
 
 type DeleteAliasOutput struct {
-	metadataDeleteAliasOutput `json:"-" xml:"-"`
-}
-
-type metadataDeleteAliasOutput struct {
-	SDKShapeTraits bool `type:"structure"`
+	_ struct{} `type:"structure"`
 }
 
 // String returns the string representation
@@ -1181,11 +1149,7 @@ type DeleteEventSourceMappingInput struct {
 	// The event source mapping ID.
 	UUID *string `location:"uri" locationName:"UUID" type:"string" required:"true"`
 
-	metadataDeleteEventSourceMappingInput `json:"-" xml:"-"`
-}
-
-type metadataDeleteEventSourceMappingInput struct {
-	SDKShapeTraits bool `type:"structure"`
+	_ struct{} `type:"structure"`
 }
 
 // String returns the string representation
@@ -1224,11 +1188,7 @@ type DeleteFunctionInput struct {
 	// including all its versions and aliases.
 	Qualifier *string `location:"querystring" locationName:"Qualifier" min:"1" type:"string"`
 
-	metadataDeleteFunctionInput `json:"-" xml:"-"`
-}
-
-type metadataDeleteFunctionInput struct {
-	SDKShapeTraits bool `type:"structure"`
+	_ struct{} `type:"structure"`
 }
 
 // String returns the string representation
@@ -1242,11 +1202,7 @@ func (s DeleteFunctionInput) GoString() string {
 }
 
 type DeleteFunctionOutput struct {
-	metadataDeleteFunctionOutput `json:"-" xml:"-"`
-}
-
-type metadataDeleteFunctionOutput struct {
-	SDKShapeTraits bool `type:"structure"`
+	_ struct{} `type:"structure"`
 }
 
 // String returns the string representation
@@ -1290,11 +1246,7 @@ type EventSourceMappingConfiguration struct {
 	// The AWS Lambda assigned opaque identifier for the mapping.
 	UUID *string `type:"string"`
 
-	metadataEventSourceMappingConfiguration `json:"-" xml:"-"`
-}
-
-type metadataEventSourceMappingConfiguration struct {
-	SDKShapeTraits bool `type:"structure"`
+	_ struct{} `type:"structure"`
 }
 
 // String returns the string representation
@@ -1325,11 +1277,7 @@ type FunctionCode struct {
 	// in the AWS Lambda Developer Guide.
 	ZipFile []byte `type:"blob"`
 
-	metadataFunctionCode `json:"-" xml:"-"`
-}
-
-type metadataFunctionCode struct {
-	SDKShapeTraits bool `type:"structure"`
+	_ struct{} `type:"structure"`
 }
 
 // String returns the string representation
@@ -1351,11 +1299,7 @@ type FunctionCodeLocation struct {
 	// The repository from which you can download the function.
 	RepositoryType *string `type:"string"`
 
-	metadataFunctionCodeLocation `json:"-" xml:"-"`
-}
-
-type metadataFunctionCodeLocation struct {
-	SDKShapeTraits bool `type:"structure"`
+	_ struct{} `type:"structure"`
 }
 
 // String returns the string representation
@@ -1410,11 +1354,7 @@ type FunctionConfiguration struct {
 	// The version of the Lambda function.
 	Version *string `min:"1" type:"string"`
 
-	metadataFunctionConfiguration `json:"-" xml:"-"`
-}
-
-type metadataFunctionConfiguration struct {
-	SDKShapeTraits bool `type:"structure"`
+	_ struct{} `type:"structure"`
 }
 
 // String returns the string representation
@@ -1436,11 +1376,7 @@ type GetAliasInput struct {
 	// Name of the alias for which you want to retrieve information.
 	Name *string `location:"uri" locationName:"Name" min:"1" type:"string" required:"true"`
 
-	metadataGetAliasInput `json:"-" xml:"-"`
-}
-
-type metadataGetAliasInput struct {
-	SDKShapeTraits bool `type:"structure"`
+	_ struct{} `type:"structure"`
 }
 
 // String returns the string representation
@@ -1457,11 +1393,7 @@ type GetEventSourceMappingInput struct {
 	// The AWS Lambda assigned ID of the event source mapping.
 	UUID *string `location:"uri" locationName:"UUID" type:"string" required:"true"`
 
-	metadataGetEventSourceMappingInput `json:"-" xml:"-"`
-}
-
-type metadataGetEventSourceMappingInput struct {
-	SDKShapeTraits bool `type:"structure"`
+	_ struct{} `type:"structure"`
 }
 
 // String returns the string representation
@@ -1496,11 +1428,7 @@ type GetFunctionConfigurationInput struct {
 	// and returns information about the $LATEST function version.
 	Qualifier *string `location:"querystring" locationName:"Qualifier" min:"1" type:"string"`
 
-	metadataGetFunctionConfigurationInput `json:"-" xml:"-"`
-}
-
-type metadataGetFunctionConfigurationInput struct {
-	SDKShapeTraits bool `type:"structure"`
+	_ struct{} `type:"structure"`
 }
 
 // String returns the string representation
@@ -1533,11 +1461,7 @@ type GetFunctionInput struct {
 	// about the $LATEST version of the Lambda function.
 	Qualifier *string `location:"querystring" locationName:"Qualifier" min:"1" type:"string"`
 
-	metadataGetFunctionInput `json:"-" xml:"-"`
-}
-
-type metadataGetFunctionInput struct {
-	SDKShapeTraits bool `type:"structure"`
+	_ struct{} `type:"structure"`
 }
 
 // String returns the string representation
@@ -1558,11 +1482,7 @@ type GetFunctionOutput struct {
 	// A complex type that describes function metadata.
 	Configuration *FunctionConfiguration `type:"structure"`
 
-	metadataGetFunctionOutput `json:"-" xml:"-"`
-}
-
-type metadataGetFunctionOutput struct {
-	SDKShapeTraits bool `type:"structure"`
+	_ struct{} `type:"structure"`
 }
 
 // String returns the string representation
@@ -1592,11 +1512,7 @@ type GetPolicyInput struct {
 	// return permissions that apply to the unqualified function ARN.
 	Qualifier *string `min:"1" type:"string"`
 
-	metadataGetPolicyInput `json:"-" xml:"-"`
-}
-
-type metadataGetPolicyInput struct {
-	SDKShapeTraits bool `type:"structure"`
+	_ struct{} `type:"structure"`
 }
 
 // String returns the string representation
@@ -1614,11 +1530,7 @@ type GetPolicyOutput struct {
 	// returns the same as a string using "\" as an escape character in the JSON.
 	Policy *string `type:"string"`
 
-	metadataGetPolicyOutput `json:"-" xml:"-"`
-}
-
-type metadataGetPolicyOutput struct {
-	SDKShapeTraits bool `type:"structure"`
+	_ struct{} `type:"structure"`
 }
 
 // String returns the string representation
@@ -1638,11 +1550,7 @@ type InvokeAsyncInput struct {
 	// JSON that you want to provide to your Lambda function as input.
 	InvokeArgs io.ReadSeeker `type:"blob" required:"true"`
 
-	metadataInvokeAsyncInput `json:"-" xml:"-"`
-}
-
-type metadataInvokeAsyncInput struct {
-	SDKShapeTraits bool `type:"structure" payload:"InvokeArgs"`
+	_ struct{} `type:"structure" payload:"InvokeArgs"`
 }
 
 // String returns the string representation
@@ -1660,11 +1568,7 @@ type InvokeAsyncOutput struct {
 	// It will be 202 upon success.
 	Status *int64 `location:"statusCode" type:"integer"`
 
-	metadataInvokeAsyncOutput `json:"-" xml:"-"`
-}
-
-type metadataInvokeAsyncOutput struct {
-	SDKShapeTraits bool `type:"structure"`
+	_ struct{} `type:"structure"`
 }
 
 // String returns the string representation
@@ -1725,11 +1629,7 @@ type InvokeInput struct {
 	// ARN which results in invocation of the $LATEST version.
 	Qualifier *string `location:"querystring" locationName:"Qualifier" min:"1" type:"string"`
 
-	metadataInvokeInput `json:"-" xml:"-"`
-}
-
-type metadataInvokeInput struct {
-	SDKShapeTraits bool `type:"structure" payload:"Payload"`
+	_ struct{} `type:"structure" payload:"Payload"`
 }
 
 // String returns the string representation
@@ -1771,11 +1671,7 @@ type InvokeOutput struct {
 	// type the status code will be 204.
 	StatusCode *int64 `location:"statusCode" type:"integer"`
 
-	metadataInvokeOutput `json:"-" xml:"-"`
-}
-
-type metadataInvokeOutput struct {
-	SDKShapeTraits bool `type:"structure" payload:"Payload"`
+	_ struct{} `type:"structure" payload:"Payload"`
 }
 
 // String returns the string representation
@@ -1805,11 +1701,7 @@ type ListAliasesInput struct {
 	// This parameter value must be greater than 0.
 	MaxItems *int64 `location:"querystring" locationName:"MaxItems" min:"1" type:"integer"`
 
-	metadataListAliasesInput `json:"-" xml:"-"`
-}
-
-type metadataListAliasesInput struct {
-	SDKShapeTraits bool `type:"structure"`
+	_ struct{} `type:"structure"`
 }
 
 // String returns the string representation
@@ -1829,11 +1721,7 @@ type ListAliasesOutput struct {
 	// A string, present if there are more aliases.
 	NextMarker *string `type:"string"`
 
-	metadataListAliasesOutput `json:"-" xml:"-"`
-}
-
-type metadataListAliasesOutput struct {
-	SDKShapeTraits bool `type:"structure"`
+	_ struct{} `type:"structure"`
 }
 
 // String returns the string representation
@@ -1869,11 +1757,7 @@ type ListEventSourceMappingsInput struct {
 	// in response. This value must be greater than 0.
 	MaxItems *int64 `location:"querystring" locationName:"MaxItems" min:"1" type:"integer"`
 
-	metadataListEventSourceMappingsInput `json:"-" xml:"-"`
-}
-
-type metadataListEventSourceMappingsInput struct {
-	SDKShapeTraits bool `type:"structure"`
+	_ struct{} `type:"structure"`
 }
 
 // String returns the string representation
@@ -1894,11 +1778,7 @@ type ListEventSourceMappingsOutput struct {
 	// A string, present if there are more event source mappings.
 	NextMarker *string `type:"string"`
 
-	metadataListEventSourceMappingsOutput `json:"-" xml:"-"`
-}
-
-type metadataListEventSourceMappingsOutput struct {
-	SDKShapeTraits bool `type:"structure"`
+	_ struct{} `type:"structure"`
 }
 
 // String returns the string representation
@@ -1920,11 +1800,7 @@ type ListFunctionsInput struct {
 	// return in response. This parameter value must be greater than 0.
 	MaxItems *int64 `location:"querystring" locationName:"MaxItems" min:"1" type:"integer"`
 
-	metadataListFunctionsInput `json:"-" xml:"-"`
-}
-
-type metadataListFunctionsInput struct {
-	SDKShapeTraits bool `type:"structure"`
+	_ struct{} `type:"structure"`
 }
 
 // String returns the string representation
@@ -1945,11 +1821,7 @@ type ListFunctionsOutput struct {
 	// A string, present if there are more functions.
 	NextMarker *string `type:"string"`
 
-	metadataListFunctionsOutput `json:"-" xml:"-"`
-}
-
-type metadataListFunctionsOutput struct {
-	SDKShapeTraits bool `type:"structure"`
+	_ struct{} `type:"structure"`
 }
 
 // String returns the string representation
@@ -1980,11 +1852,7 @@ type ListVersionsByFunctionInput struct {
 	// to return in response. This parameter value must be greater than 0.
 	MaxItems *int64 `location:"querystring" locationName:"MaxItems" min:"1" type:"integer"`
 
-	metadataListVersionsByFunctionInput `json:"-" xml:"-"`
-}
-
-type metadataListVersionsByFunctionInput struct {
-	SDKShapeTraits bool `type:"structure"`
+	_ struct{} `type:"structure"`
 }
 
 // String returns the string representation
@@ -2004,11 +1872,7 @@ type ListVersionsByFunctionOutput struct {
 	// A list of Lambda function versions.
 	Versions []*FunctionConfiguration `type:"list"`
 
-	metadataListVersionsByFunctionOutput `json:"-" xml:"-"`
-}
-
-type metadataListVersionsByFunctionOutput struct {
-	SDKShapeTraits bool `type:"structure"`
+	_ struct{} `type:"structure"`
 }
 
 // String returns the string representation
@@ -2040,11 +1904,7 @@ type PublishVersionInput struct {
 	// 64 character in length.
 	FunctionName *string `location:"uri" locationName:"FunctionName" min:"1" type:"string" required:"true"`
 
-	metadataPublishVersionInput `json:"-" xml:"-"`
-}
-
-type metadataPublishVersionInput struct {
-	SDKShapeTraits bool `type:"structure"`
+	_ struct{} `type:"structure"`
 }
 
 // String returns the string representation
@@ -2077,11 +1937,7 @@ type RemovePermissionInput struct {
 	// Statement ID of the permission to remove.
 	StatementId *string `location:"uri" locationName:"StatementId" min:"1" type:"string" required:"true"`
 
-	metadataRemovePermissionInput `json:"-" xml:"-"`
-}
-
-type metadataRemovePermissionInput struct {
-	SDKShapeTraits bool `type:"structure"`
+	_ struct{} `type:"structure"`
 }
 
 // String returns the string representation
@@ -2095,11 +1951,7 @@ func (s RemovePermissionInput) GoString() string {
 }
 
 type RemovePermissionOutput struct {
-	metadataRemovePermissionOutput `json:"-" xml:"-"`
-}
-
-type metadataRemovePermissionOutput struct {
-	SDKShapeTraits bool `type:"structure"`
+	_ struct{} `type:"structure"`
 }
 
 // String returns the string representation
@@ -2126,11 +1978,7 @@ type UpdateAliasInput struct {
 	// The alias name.
 	Name *string `location:"uri" locationName:"Name" min:"1" type:"string" required:"true"`
 
-	metadataUpdateAliasInput `json:"-" xml:"-"`
-}
-
-type metadataUpdateAliasInput struct {
-	SDKShapeTraits bool `type:"structure"`
+	_ struct{} `type:"structure"`
 }
 
 // String returns the string representation
@@ -2165,11 +2013,7 @@ type UpdateEventSourceMappingInput struct {
 	// The event source mapping identifier.
 	UUID *string `location:"uri" locationName:"UUID" type:"string" required:"true"`
 
-	metadataUpdateEventSourceMappingInput `json:"-" xml:"-"`
-}
-
-type metadataUpdateEventSourceMappingInput struct {
-	SDKShapeTraits bool `type:"structure"`
+	_ struct{} `type:"structure"`
 }
 
 // String returns the string representation
@@ -2211,11 +2055,7 @@ type UpdateFunctionCodeInput struct {
 	// Based64-encoded .zip file containing your packaged source code.
 	ZipFile []byte `type:"blob"`
 
-	metadataUpdateFunctionCodeInput `json:"-" xml:"-"`
-}
-
-type metadataUpdateFunctionCodeInput struct {
-	SDKShapeTraits bool `type:"structure"`
+	_ struct{} `type:"structure"`
 }
 
 // String returns the string representation
@@ -2264,11 +2104,7 @@ type UpdateFunctionConfigurationInput struct {
 	// value based on your expected execution time. The default is 3 seconds.
 	Timeout *int64 `min:"1" type:"integer"`
 
-	metadataUpdateFunctionConfigurationInput `json:"-" xml:"-"`
-}
-
-type metadataUpdateFunctionConfigurationInput struct {
-	SDKShapeTraits bool `type:"structure"`
+	_ struct{} `type:"structure"`
 }
 
 // String returns the string representation

--- a/service/machinelearning/api.go
+++ b/service/machinelearning/api.go
@@ -910,6 +910,8 @@ func (c *MachineLearning) UpdateMLModel(input *UpdateMLModelInput) (*UpdateMLMod
 //  The content consists of the detailed metadata, the status, and the data
 // file information of a Batch Prediction.
 type BatchPrediction struct {
+	_ struct{} `type:"structure"`
+
 	// The ID of the DataSource that points to the group of observations to predict.
 	BatchPredictionDataSourceId *string `min:"1" type:"string"`
 
@@ -959,8 +961,6 @@ type BatchPrediction struct {
 	// It is not usable.  COMPLETED - The batch prediction process completed successfully.
 	//  DELETED - The BatchPrediction is marked as deleted. It is not usable.
 	Status *string `type:"string" enum:"EntityStatus"`
-
-	_ struct{} `type:"structure"`
 }
 
 // String returns the string representation
@@ -974,6 +974,8 @@ func (s BatchPrediction) GoString() string {
 }
 
 type CreateBatchPredictionInput struct {
+	_ struct{} `type:"structure"`
+
 	// The ID of the DataSource that points to the group of observations to predict.
 	BatchPredictionDataSourceId *string `min:"1" type:"string" required:"true"`
 
@@ -995,8 +997,6 @@ type CreateBatchPredictionInput struct {
 	// For information about how to set permissions, see the Amazon Machine Learning
 	// Developer Guide (http://docs.aws.amazon.com/machine-learning/latest/dg).
 	OutputUri *string `type:"string" required:"true"`
-
-	_ struct{} `type:"structure"`
 }
 
 // String returns the string representation
@@ -1016,11 +1016,11 @@ func (s CreateBatchPredictionInput) GoString() string {
 // updates by using the GetBatchPrediction operation and checking the Status
 // parameter of the result.
 type CreateBatchPredictionOutput struct {
+	_ struct{} `type:"structure"`
+
 	// A user-supplied ID that uniquely identifies the BatchPrediction. This value
 	// is identical to the value of the BatchPredictionId in the request.
 	BatchPredictionId *string `min:"1" type:"string"`
-
-	_ struct{} `type:"structure"`
 }
 
 // String returns the string representation
@@ -1034,6 +1034,8 @@ func (s CreateBatchPredictionOutput) GoString() string {
 }
 
 type CreateDataSourceFromRDSInput struct {
+	_ struct{} `type:"structure"`
+
 	// The compute statistics for a DataSource. The statistics are generated from
 	// the observation data referenced by a DataSource. Amazon ML uses the statistics
 	// internally during an MLModel training. This parameter must be set to true
@@ -1092,8 +1094,6 @@ type CreateDataSourceFromRDSInput struct {
 	// a data pipeline in the user’s account and copy data (using the SelectSqlQuery)
 	// query from Amazon RDS to Amazon S3.
 	RoleARN *string `min:"1" type:"string" required:"true"`
-
-	_ struct{} `type:"structure"`
 }
 
 // String returns the string representation
@@ -1116,11 +1116,11 @@ func (s CreateDataSourceFromRDSInput) GoString() string {
 // console and looking up the pipeline using the pipelineId from the describe
 // call.
 type CreateDataSourceFromRDSOutput struct {
+	_ struct{} `type:"structure"`
+
 	// A user-supplied ID that uniquely identifies the datasource. This value should
 	// be identical to the value of the DataSourceID in the request.
 	DataSourceId *string `min:"1" type:"string"`
-
-	_ struct{} `type:"structure"`
 }
 
 // String returns the string representation
@@ -1134,6 +1134,8 @@ func (s CreateDataSourceFromRDSOutput) GoString() string {
 }
 
 type CreateDataSourceFromRedshiftInput struct {
+	_ struct{} `type:"structure"`
+
 	// The compute statistics for a DataSource. The statistics are generated from
 	// the observation data referenced by a DataSource. Amazon ML uses the statistics
 	// internally during MLModel training. This parameter must be set to true if
@@ -1181,8 +1183,6 @@ type CreateDataSourceFromRedshiftInput struct {
 	// An Amazon S3 bucket policy to grant Amazon ML read/write permissions on
 	// the S3StagingLocation
 	RoleARN *string `min:"1" type:"string" required:"true"`
-
-	_ struct{} `type:"structure"`
 }
 
 // String returns the string representation
@@ -1202,11 +1202,11 @@ func (s CreateDataSourceFromRedshiftInput) GoString() string {
 // for updates by using the GetBatchPrediction operation and checking the Status
 // parameter.
 type CreateDataSourceFromRedshiftOutput struct {
+	_ struct{} `type:"structure"`
+
 	// A user-supplied ID that uniquely identifies the datasource. This value should
 	// be identical to the value of the DataSourceID in the request.
 	DataSourceId *string `min:"1" type:"string"`
-
-	_ struct{} `type:"structure"`
 }
 
 // String returns the string representation
@@ -1220,6 +1220,8 @@ func (s CreateDataSourceFromRedshiftOutput) GoString() string {
 }
 
 type CreateDataSourceFromS3Input struct {
+	_ struct{} `type:"structure"`
+
 	// The compute statistics for a DataSource. The statistics are generated from
 	// the observation data referenced by a DataSource. Amazon ML uses the statistics
 	// internally during an MLModel training. This parameter must be set to true
@@ -1247,8 +1249,6 @@ type CreateDataSourceFromS3Input struct {
 	//
 	//   Sample -  "{\"splitting\":{\"percentBegin\":10,\"percentEnd\":60}}"
 	DataSpec *S3DataSpec `type:"structure" required:"true"`
-
-	_ struct{} `type:"structure"`
 }
 
 // String returns the string representation
@@ -1267,11 +1267,11 @@ func (s CreateDataSourceFromS3Input) GoString() string {
 // The CreateDataSourceFromS3 operation is asynchronous. You can poll for updates
 // by using the GetBatchPrediction operation and checking the Status parameter.
 type CreateDataSourceFromS3Output struct {
+	_ struct{} `type:"structure"`
+
 	// A user-supplied ID that uniquely identifies the datasource. This value should
 	// be identical to the value of the DataSourceID in the request.
 	DataSourceId *string `min:"1" type:"string"`
-
-	_ struct{} `type:"structure"`
 }
 
 // String returns the string representation
@@ -1285,6 +1285,8 @@ func (s CreateDataSourceFromS3Output) GoString() string {
 }
 
 type CreateEvaluationInput struct {
+	_ struct{} `type:"structure"`
+
 	// The ID of the DataSource for the evaluation. The schema of the DataSource
 	// must match the schema used to create the MLModel.
 	EvaluationDataSourceId *string `min:"1" type:"string" required:"true"`
@@ -1300,8 +1302,6 @@ type CreateEvaluationInput struct {
 	// The schema used in creating the MLModel must match the schema of the DataSource
 	// used in the Evaluation.
 	MLModelId *string `min:"1" type:"string" required:"true"`
-
-	_ struct{} `type:"structure"`
 }
 
 // String returns the string representation
@@ -1320,11 +1320,11 @@ func (s CreateEvaluationInput) GoString() string {
 // CreateEvaluation operation is asynchronous. You can poll for status updates
 // by using the GetEvaluation operation and checking the Status parameter.
 type CreateEvaluationOutput struct {
+	_ struct{} `type:"structure"`
+
 	// The user-supplied ID that uniquely identifies the Evaluation. This value
 	// should be identical to the value of the EvaluationId in the request.
 	EvaluationId *string `min:"1" type:"string"`
-
-	_ struct{} `type:"structure"`
 }
 
 // String returns the string representation
@@ -1338,6 +1338,8 @@ func (s CreateEvaluationOutput) GoString() string {
 }
 
 type CreateMLModelInput struct {
+	_ struct{} `type:"structure"`
+
 	// A user-supplied ID that uniquely identifies the MLModel.
 	MLModelId *string `min:"1" type:"string" required:"true"`
 
@@ -1399,8 +1401,6 @@ type CreateMLModelInput struct {
 
 	// The DataSource that points to the training data.
 	TrainingDataSourceId *string `min:"1" type:"string" required:"true"`
-
-	_ struct{} `type:"structure"`
 }
 
 // String returns the string representation
@@ -1419,11 +1419,11 @@ func (s CreateMLModelInput) GoString() string {
 // The CreateMLModel operation is asynchronous. You can poll for status updates
 // by using the GetMLModel operation and checking the Status parameter.
 type CreateMLModelOutput struct {
+	_ struct{} `type:"structure"`
+
 	// A user-supplied ID that uniquely identifies the MLModel. This value should
 	// be identical to the value of the MLModelId in the request.
 	MLModelId *string `min:"1" type:"string"`
-
-	_ struct{} `type:"structure"`
 }
 
 // String returns the string representation
@@ -1437,10 +1437,10 @@ func (s CreateMLModelOutput) GoString() string {
 }
 
 type CreateRealtimeEndpointInput struct {
+	_ struct{} `type:"structure"`
+
 	// The ID assigned to the MLModel during creation.
 	MLModelId *string `min:"1" type:"string" required:"true"`
-
-	_ struct{} `type:"structure"`
 }
 
 // String returns the string representation
@@ -1460,14 +1460,14 @@ func (s CreateRealtimeEndpointInput) GoString() string {
 //  The endpoint information includes the URI of the MLModel; that is, the
 // location to send online prediction requests for the specified MLModel.
 type CreateRealtimeEndpointOutput struct {
+	_ struct{} `type:"structure"`
+
 	// A user-supplied ID that uniquely identifies the MLModel. This value should
 	// be identical to the value of the MLModelId in the request.
 	MLModelId *string `min:"1" type:"string"`
 
 	// The endpoint information of the MLModel
 	RealtimeEndpointInfo *RealtimeEndpointInfo `type:"structure"`
-
-	_ struct{} `type:"structure"`
 }
 
 // String returns the string representation
@@ -1485,6 +1485,8 @@ func (s CreateRealtimeEndpointOutput) GoString() string {
 //  The content consists of the detailed metadata and data file information
 // and the current status of the DataSource.
 type DataSource struct {
+	_ struct{} `type:"structure"`
+
 	// The parameter is true if statistics need to be generated from the observation
 	// data.
 	ComputeStatistics *bool `type:"boolean"`
@@ -1544,8 +1546,6 @@ type DataSource struct {
 	// COMPLETED - The creation process completed successfully. DELETED - The DataSource
 	// is marked as deleted. It is not usable.
 	Status *string `type:"string" enum:"EntityStatus"`
-
-	_ struct{} `type:"structure"`
 }
 
 // String returns the string representation
@@ -1559,10 +1559,10 @@ func (s DataSource) GoString() string {
 }
 
 type DeleteBatchPredictionInput struct {
+	_ struct{} `type:"structure"`
+
 	// A user-supplied ID that uniquely identifies the BatchPrediction.
 	BatchPredictionId *string `min:"1" type:"string" required:"true"`
-
-	_ struct{} `type:"structure"`
 }
 
 // String returns the string representation
@@ -1580,11 +1580,11 @@ func (s DeleteBatchPredictionInput) GoString() string {
 // You can use the GetBatchPrediction operation and check the value of the
 // Status parameter to see whether a BatchPrediction is marked as DELETED.
 type DeleteBatchPredictionOutput struct {
+	_ struct{} `type:"structure"`
+
 	// A user-supplied ID that uniquely identifies the BatchPrediction. This value
 	// should be identical to the value of the BatchPredictionID in the request.
 	BatchPredictionId *string `min:"1" type:"string"`
-
-	_ struct{} `type:"structure"`
 }
 
 // String returns the string representation
@@ -1598,10 +1598,10 @@ func (s DeleteBatchPredictionOutput) GoString() string {
 }
 
 type DeleteDataSourceInput struct {
+	_ struct{} `type:"structure"`
+
 	// A user-supplied ID that uniquely identifies the DataSource.
 	DataSourceId *string `min:"1" type:"string" required:"true"`
-
-	_ struct{} `type:"structure"`
 }
 
 // String returns the string representation
@@ -1616,11 +1616,11 @@ func (s DeleteDataSourceInput) GoString() string {
 
 // Represents the output of a DeleteDataSource operation.
 type DeleteDataSourceOutput struct {
+	_ struct{} `type:"structure"`
+
 	// A user-supplied ID that uniquely identifies the DataSource. This value should
 	// be identical to the value of the DataSourceID in the request.
 	DataSourceId *string `min:"1" type:"string"`
-
-	_ struct{} `type:"structure"`
 }
 
 // String returns the string representation
@@ -1634,10 +1634,10 @@ func (s DeleteDataSourceOutput) GoString() string {
 }
 
 type DeleteEvaluationInput struct {
+	_ struct{} `type:"structure"`
+
 	// A user-supplied ID that uniquely identifies the Evaluation to delete.
 	EvaluationId *string `min:"1" type:"string" required:"true"`
-
-	_ struct{} `type:"structure"`
 }
 
 // String returns the string representation
@@ -1656,11 +1656,11 @@ func (s DeleteEvaluationInput) GoString() string {
 // You can use the GetEvaluation operation and check the value of the Status
 // parameter to see whether an Evaluation is marked as DELETED.
 type DeleteEvaluationOutput struct {
+	_ struct{} `type:"structure"`
+
 	// A user-supplied ID that uniquely identifies the Evaluation. This value should
 	// be identical to the value of the EvaluationId in the request.
 	EvaluationId *string `min:"1" type:"string"`
-
-	_ struct{} `type:"structure"`
 }
 
 // String returns the string representation
@@ -1674,10 +1674,10 @@ func (s DeleteEvaluationOutput) GoString() string {
 }
 
 type DeleteMLModelInput struct {
+	_ struct{} `type:"structure"`
+
 	// A user-supplied ID that uniquely identifies the MLModel.
 	MLModelId *string `min:"1" type:"string" required:"true"`
-
-	_ struct{} `type:"structure"`
 }
 
 // String returns the string representation
@@ -1695,11 +1695,11 @@ func (s DeleteMLModelInput) GoString() string {
 // You can use the GetMLModel operation and check the value of the Status parameter
 // to see whether an MLModel is marked as DELETED.
 type DeleteMLModelOutput struct {
+	_ struct{} `type:"structure"`
+
 	// A user-supplied ID that uniquely identifies the MLModel. This value should
 	// be identical to the value of the MLModelID in the request.
 	MLModelId *string `min:"1" type:"string"`
-
-	_ struct{} `type:"structure"`
 }
 
 // String returns the string representation
@@ -1713,10 +1713,10 @@ func (s DeleteMLModelOutput) GoString() string {
 }
 
 type DeleteRealtimeEndpointInput struct {
+	_ struct{} `type:"structure"`
+
 	// The ID assigned to the MLModel during creation.
 	MLModelId *string `min:"1" type:"string" required:"true"`
-
-	_ struct{} `type:"structure"`
 }
 
 // String returns the string representation
@@ -1733,14 +1733,14 @@ func (s DeleteRealtimeEndpointInput) GoString() string {
 //
 // The result contains the MLModelId and the endpoint information for the MLModel.
 type DeleteRealtimeEndpointOutput struct {
+	_ struct{} `type:"structure"`
+
 	// A user-supplied ID that uniquely identifies the MLModel. This value should
 	// be identical to the value of the MLModelId in the request.
 	MLModelId *string `min:"1" type:"string"`
 
 	// The endpoint information of the MLModel
 	RealtimeEndpointInfo *RealtimeEndpointInfo `type:"structure"`
-
-	_ struct{} `type:"structure"`
 }
 
 // String returns the string representation
@@ -1754,6 +1754,8 @@ func (s DeleteRealtimeEndpointOutput) GoString() string {
 }
 
 type DescribeBatchPredictionsInput struct {
+	_ struct{} `type:"structure"`
+
 	// The equal to operator. The BatchPrediction results will have FilterVariable
 	// values that exactly match the value specified with EQ.
 	EQ *string `type:"string"`
@@ -1819,8 +1821,6 @@ type DescribeBatchPredictionsInput struct {
 	//   asc - Arranges the list in ascending order (A-Z, 0-9).  dsc - Arranges
 	// the list in descending order (Z-A, 9-0).  Results are sorted by FilterVariable.
 	SortOrder *string `type:"string" enum:"SortOrder"`
-
-	_ struct{} `type:"structure"`
 }
 
 // String returns the string representation
@@ -1836,14 +1836,14 @@ func (s DescribeBatchPredictionsInput) GoString() string {
 // Represents the output of a DescribeBatchPredictions operation. The content
 // is essentially a list of BatchPredictions.
 type DescribeBatchPredictionsOutput struct {
+	_ struct{} `type:"structure"`
+
 	// The ID of the next page in the paginated results that indicates at least
 	// one more page follows.
 	NextToken *string `type:"string"`
 
 	// A list of BatchPrediction objects that meet the search criteria.
 	Results []*BatchPrediction `type:"list"`
-
-	_ struct{} `type:"structure"`
 }
 
 // String returns the string representation
@@ -1857,6 +1857,8 @@ func (s DescribeBatchPredictionsOutput) GoString() string {
 }
 
 type DescribeDataSourcesInput struct {
+	_ struct{} `type:"structure"`
+
 	// The equal to operator. The DataSource results will have FilterVariable values
 	// that exactly match the value specified with EQ.
 	EQ *string `type:"string"`
@@ -1917,8 +1919,6 @@ type DescribeDataSourcesInput struct {
 	//   asc - Arranges the list in ascending order (A-Z, 0-9).  dsc - Arranges
 	// the list in descending order (Z-A, 9-0).  Results are sorted by FilterVariable.
 	SortOrder *string `type:"string" enum:"SortOrder"`
-
-	_ struct{} `type:"structure"`
 }
 
 // String returns the string representation
@@ -1934,14 +1934,14 @@ func (s DescribeDataSourcesInput) GoString() string {
 // Represents the query results from a DescribeDataSources operation. The content
 // is essentially a list of DataSource.
 type DescribeDataSourcesOutput struct {
+	_ struct{} `type:"structure"`
+
 	// An ID of the next page in the paginated results that indicates at least one
 	// more page follows.
 	NextToken *string `type:"string"`
 
 	// A list of DataSource that meet the search criteria.
 	Results []*DataSource `type:"list"`
-
-	_ struct{} `type:"structure"`
 }
 
 // String returns the string representation
@@ -1955,6 +1955,8 @@ func (s DescribeDataSourcesOutput) GoString() string {
 }
 
 type DescribeEvaluationsInput struct {
+	_ struct{} `type:"structure"`
+
 	// The equal to operator. The Evaluation results will have FilterVariable values
 	// that exactly match the value specified with EQ.
 	EQ *string `type:"string"`
@@ -2017,8 +2019,6 @@ type DescribeEvaluationsInput struct {
 	//   asc - Arranges the list in ascending order (A-Z, 0-9).  dsc - Arranges
 	// the list in descending order (Z-A, 9-0).  Results are sorted by FilterVariable.
 	SortOrder *string `type:"string" enum:"SortOrder"`
-
-	_ struct{} `type:"structure"`
 }
 
 // String returns the string representation
@@ -2034,14 +2034,14 @@ func (s DescribeEvaluationsInput) GoString() string {
 // Represents the query results from a DescribeEvaluations operation. The content
 // is essentially a list of Evaluation.
 type DescribeEvaluationsOutput struct {
+	_ struct{} `type:"structure"`
+
 	// The ID of the next page in the paginated results that indicates at least
 	// one more page follows.
 	NextToken *string `type:"string"`
 
 	// A list of Evaluation that meet the search criteria.
 	Results []*Evaluation `type:"list"`
-
-	_ struct{} `type:"structure"`
 }
 
 // String returns the string representation
@@ -2055,6 +2055,8 @@ func (s DescribeEvaluationsOutput) GoString() string {
 }
 
 type DescribeMLModelsInput struct {
+	_ struct{} `type:"structure"`
+
 	// The equal to operator. The MLModel results will have FilterVariable values
 	// that exactly match the value specified with EQ.
 	EQ *string `type:"string"`
@@ -2120,8 +2122,6 @@ type DescribeMLModelsInput struct {
 	//   asc - Arranges the list in ascending order (A-Z, 0-9).  dsc - Arranges
 	// the list in descending order (Z-A, 9-0).  Results are sorted by FilterVariable.
 	SortOrder *string `type:"string" enum:"SortOrder"`
-
-	_ struct{} `type:"structure"`
 }
 
 // String returns the string representation
@@ -2137,14 +2137,14 @@ func (s DescribeMLModelsInput) GoString() string {
 // Represents the output of a DescribeMLModels operation. The content is essentially
 // a list of MLModel.
 type DescribeMLModelsOutput struct {
+	_ struct{} `type:"structure"`
+
 	// The ID of the next page in the paginated results that indicates at least
 	// one more page follows.
 	NextToken *string `type:"string"`
 
 	// A list of MLModel that meet the search criteria.
 	Results []*MLModel `type:"list"`
-
-	_ struct{} `type:"structure"`
 }
 
 // String returns the string representation
@@ -2162,6 +2162,8 @@ func (s DescribeMLModelsOutput) GoString() string {
 // The content consists of the detailed metadata and data file information
 // and the current status of the Evaluation.
 type Evaluation struct {
+	_ struct{} `type:"structure"`
+
 	// The time that the Evaluation was created. The time is expressed in epoch
 	// time.
 	CreatedAt *time.Time `type:"timestamp" timestampFormat:"unix"`
@@ -2221,8 +2223,6 @@ type Evaluation struct {
 	// - The evaluation process completed successfully.  DELETED - The Evaluation
 	// is marked as deleted. It is not usable.
 	Status *string `type:"string" enum:"EntityStatus"`
-
-	_ struct{} `type:"structure"`
 }
 
 // String returns the string representation
@@ -2236,10 +2236,10 @@ func (s Evaluation) GoString() string {
 }
 
 type GetBatchPredictionInput struct {
+	_ struct{} `type:"structure"`
+
 	// An ID assigned to the BatchPrediction at creation.
 	BatchPredictionId *string `min:"1" type:"string" required:"true"`
-
-	_ struct{} `type:"structure"`
 }
 
 // String returns the string representation
@@ -2254,6 +2254,8 @@ func (s GetBatchPredictionInput) GoString() string {
 
 // Represents the output of a GetBatchPrediction operation and describes a BatchPrediction.
 type GetBatchPredictionOutput struct {
+	_ struct{} `type:"structure"`
+
 	// The ID of the DataSource that was used to create the BatchPrediction.
 	BatchPredictionDataSourceId *string `min:"1" type:"string"`
 
@@ -2304,8 +2306,6 @@ type GetBatchPredictionOutput struct {
 	// It is not usable.  COMPLETED - The batch prediction process completed successfully.
 	//  DELETED - The BatchPrediction is marked as deleted. It is not usable.
 	Status *string `type:"string" enum:"EntityStatus"`
-
-	_ struct{} `type:"structure"`
 }
 
 // String returns the string representation
@@ -2319,6 +2319,8 @@ func (s GetBatchPredictionOutput) GoString() string {
 }
 
 type GetDataSourceInput struct {
+	_ struct{} `type:"structure"`
+
 	// The ID assigned to the DataSource at creation.
 	DataSourceId *string `min:"1" type:"string" required:"true"`
 
@@ -2328,8 +2330,6 @@ type GetDataSourceInput struct {
 	//
 	// If false, DataSourceSchema is not returned.
 	Verbose *bool `type:"boolean"`
-
-	_ struct{} `type:"structure"`
 }
 
 // String returns the string representation
@@ -2344,6 +2344,8 @@ func (s GetDataSourceInput) GoString() string {
 
 // Represents the output of a GetDataSource operation and describes a DataSource.
 type GetDataSourceOutput struct {
+	_ struct{} `type:"structure"`
+
 	// The parameter is true if statistics need to be generated from the observation
 	// data.
 	ComputeStatistics *bool `type:"boolean"`
@@ -2412,8 +2414,6 @@ type GetDataSourceOutput struct {
 	//  COMPLETED - The creation process completed successfully.  DELETED - The
 	// DataSource is marked as deleted. It is not usable.
 	Status *string `type:"string" enum:"EntityStatus"`
-
-	_ struct{} `type:"structure"`
 }
 
 // String returns the string representation
@@ -2427,11 +2427,11 @@ func (s GetDataSourceOutput) GoString() string {
 }
 
 type GetEvaluationInput struct {
+	_ struct{} `type:"structure"`
+
 	// The ID of the Evaluation to retrieve. The evaluation of each MLModel is recorded
 	// and cataloged. The ID provides the means to access the information.
 	EvaluationId *string `min:"1" type:"string" required:"true"`
-
-	_ struct{} `type:"structure"`
 }
 
 // String returns the string representation
@@ -2446,6 +2446,8 @@ func (s GetEvaluationInput) GoString() string {
 
 // Represents the output of a GetEvaluation operation and describes an Evaluation.
 type GetEvaluationOutput struct {
+	_ struct{} `type:"structure"`
+
 	// The time that the Evaluation was created. The time is expressed in epoch
 	// time.
 	CreatedAt *time.Time `type:"timestamp" timestampFormat:"unix"`
@@ -2508,8 +2510,6 @@ type GetEvaluationOutput struct {
 	// - The evaluation process completed successfully.  DELETED - The Evaluation
 	// is marked as deleted. It is not usable.
 	Status *string `type:"string" enum:"EntityStatus"`
-
-	_ struct{} `type:"structure"`
 }
 
 // String returns the string representation
@@ -2523,6 +2523,8 @@ func (s GetEvaluationOutput) GoString() string {
 }
 
 type GetMLModelInput struct {
+	_ struct{} `type:"structure"`
+
 	// The ID assigned to the MLModel at creation.
 	MLModelId *string `min:"1" type:"string" required:"true"`
 
@@ -2532,8 +2534,6 @@ type GetMLModelInput struct {
 	//
 	// If false, Recipe is not returned.
 	Verbose *bool `type:"boolean"`
-
-	_ struct{} `type:"structure"`
 }
 
 // String returns the string representation
@@ -2549,6 +2549,8 @@ func (s GetMLModelInput) GoString() string {
 // Represents the output of a GetMLModel operation, and provides detailed information
 // about a MLModel.
 type GetMLModelOutput struct {
+	_ struct{} `type:"structure"`
+
 	// The time that the MLModel was created. The time is expressed in epoch time.
 	CreatedAt *time.Time `type:"timestamp" timestampFormat:"unix"`
 
@@ -2660,8 +2662,6 @@ type GetMLModelOutput struct {
 	//  The value is an integer that ranges from 100000 to 2147483648. The default
 	// value is 33554432.
 	TrainingParameters map[string]*string `type:"map"`
-
-	_ struct{} `type:"structure"`
 }
 
 // String returns the string representation
@@ -2679,6 +2679,8 @@ func (s GetMLModelOutput) GoString() string {
 // The content consists of the detailed metadata and the current status of
 // the MLModel.
 type MLModel struct {
+	_ struct{} `type:"structure"`
+
 	// The algorithm used to train the MLModel. The following algorithm is supported:
 	//
 	//  SGD -- Stochastic gradient descent. The goal of SGD is to minimize the
@@ -2777,8 +2779,6 @@ type MLModel struct {
 	//  The value is an integer that ranges from 100000 to 2147483648. The default
 	// value is 33554432.
 	TrainingParameters map[string]*string `type:"map"`
-
-	_ struct{} `type:"structure"`
 }
 
 // String returns the string representation
@@ -2807,9 +2807,9 @@ func (s MLModel) GoString() string {
 //    For more information about performance metrics, please see the Amazon
 // Machine Learning Developer Guide (http://docs.aws.amazon.com/machine-learning/latest/dg).
 type PerformanceMetrics struct {
-	Properties map[string]*string `type:"map"`
-
 	_ struct{} `type:"structure"`
+
+	Properties map[string]*string `type:"map"`
 }
 
 // String returns the string representation
@@ -2823,6 +2823,8 @@ func (s PerformanceMetrics) GoString() string {
 }
 
 type PredictInput struct {
+	_ struct{} `type:"structure"`
+
 	// A unique identifier of the MLModel.
 	MLModelId *string `min:"1" type:"string" required:"true"`
 
@@ -2830,8 +2832,6 @@ type PredictInput struct {
 
 	// A map of variable name-value pairs that represent an observation.
 	Record map[string]*string `type:"map" required:"true"`
-
-	_ struct{} `type:"structure"`
 }
 
 // String returns the string representation
@@ -2845,6 +2845,8 @@ func (s PredictInput) GoString() string {
 }
 
 type PredictOutput struct {
+	_ struct{} `type:"structure"`
+
 	// The output from a Predict operation:
 	//
 	//    Details - Contains the following attributes: DetailsAttributes.PREDICTIVE_MODEL_TYPE
@@ -2857,8 +2859,6 @@ type PredictOutput struct {
 	//
 	//    PredictedValue - Present for a REGRESSION MLModel request.
 	Prediction *Prediction `type:"structure"`
-
-	_ struct{} `type:"structure"`
 }
 
 // String returns the string representation
@@ -2883,6 +2883,8 @@ func (s PredictOutput) GoString() string {
 //
 //    PredictedValue - Present for a REGRESSION MLModel request.
 type Prediction struct {
+	_ struct{} `type:"structure"`
+
 	// Provides any additional details regarding the prediction.
 	Details map[string]*string `locationName:"details" type:"map"`
 
@@ -2894,8 +2896,6 @@ type Prediction struct {
 
 	// The prediction value for REGRESSION MLModel.
 	PredictedValue *float64 `locationName:"predictedValue" type:"float"`
-
-	_ struct{} `type:"structure"`
 }
 
 // String returns the string representation
@@ -2911,6 +2911,8 @@ func (s Prediction) GoString() string {
 // The data specification of an Amazon Relational Database Service (Amazon RDS)
 // DataSource.
 type RDSDataSpec struct {
+	_ struct{} `type:"structure"`
+
 	// DataRearrangement - A JSON string that represents the splitting requirement
 	// of a DataSource.
 	//
@@ -2990,8 +2992,6 @@ type RDSDataSpec struct {
 	// is used by Data Pipeline to carry out the copy task from Amazon RDS to Amazon
 	// S3.
 	SubnetId *string `min:"1" type:"string" required:"true"`
-
-	_ struct{} `type:"structure"`
 }
 
 // String returns the string representation
@@ -3006,13 +3006,13 @@ func (s RDSDataSpec) GoString() string {
 
 // The database details of an Amazon RDS database.
 type RDSDatabase struct {
+	_ struct{} `type:"structure"`
+
 	// The name of a database hosted on an RDS DB instance.
 	DatabaseName *string `min:"1" type:"string" required:"true"`
 
 	// The ID of an RDS DB instance.
 	InstanceIdentifier *string `min:"1" type:"string" required:"true"`
-
-	_ struct{} `type:"structure"`
 }
 
 // String returns the string representation
@@ -3027,6 +3027,8 @@ func (s RDSDatabase) GoString() string {
 
 // The database credentials to connect to a database on an RDS DB instance.
 type RDSDatabaseCredentials struct {
+	_ struct{} `type:"structure"`
+
 	// The password to be used by Amazon ML to connect to a database on an RDS DB
 	// instance. The password should have sufficient permissions to execute the
 	// RDSSelectQuery query.
@@ -3036,8 +3038,6 @@ type RDSDatabaseCredentials struct {
 	// RDS instance. The username should have sufficient permissions to execute
 	// an RDSSelectSqlQuery query.
 	Username *string `min:"1" type:"string" required:"true"`
-
-	_ struct{} `type:"structure"`
 }
 
 // String returns the string representation
@@ -3052,6 +3052,8 @@ func (s RDSDatabaseCredentials) GoString() string {
 
 // The datasource details that are specific to Amazon RDS.
 type RDSMetadata struct {
+	_ struct{} `type:"structure"`
+
 	// The ID of the Data Pipeline instance that is used to carry to copy data from
 	// Amazon RDS to Amazon S3. You can use the ID to find details about the instance
 	// in the Data Pipeline console.
@@ -3080,8 +3082,6 @@ type RDSMetadata struct {
 	// information, see Role templates (http://docs.aws.amazon.com/datapipeline/latest/DeveloperGuide/dp-iam-roles.html)
 	// for data pipelines.
 	ServiceRole *string `min:"1" type:"string"`
-
-	_ struct{} `type:"structure"`
 }
 
 // String returns the string representation
@@ -3096,6 +3096,8 @@ func (s RDSMetadata) GoString() string {
 
 // Describes the real-time endpoint information for an MLModel.
 type RealtimeEndpointInfo struct {
+	_ struct{} `type:"structure"`
+
 	// The time that the request to create the real-time endpoint for the MLModel
 	// was received. The time is expressed in epoch time.
 	CreatedAt *time.Time `type:"timestamp" timestampFormat:"unix"`
@@ -3118,8 +3120,6 @@ type RealtimeEndpointInfo struct {
 	// The maximum processing rate for the real-time endpoint for MLModel, measured
 	// in incoming requests per second.
 	PeakRequestsPerSecond *int64 `type:"integer"`
-
-	_ struct{} `type:"structure"`
 }
 
 // String returns the string representation
@@ -3134,6 +3134,8 @@ func (s RealtimeEndpointInfo) GoString() string {
 
 // Describes the data specification of an Amazon Redshift DataSource.
 type RedshiftDataSpec struct {
+	_ struct{} `type:"structure"`
+
 	// Describes the splitting specifications for a DataSource.
 	DataRearrangement *string `type:"string"`
 
@@ -3188,8 +3190,6 @@ type RedshiftDataSpec struct {
 	// Describes the SQL Query to execute on an Amazon Redshift database for an
 	// Amazon Redshift DataSource.
 	SelectSqlQuery *string `min:"1" type:"string" required:"true"`
-
-	_ struct{} `type:"structure"`
 }
 
 // String returns the string representation
@@ -3205,13 +3205,13 @@ func (s RedshiftDataSpec) GoString() string {
 // Describes the database details required to connect to an Amazon Redshift
 // database.
 type RedshiftDatabase struct {
+	_ struct{} `type:"structure"`
+
 	// The ID of an Amazon Redshift cluster.
 	ClusterIdentifier *string `min:"1" type:"string" required:"true"`
 
 	// The name of a database hosted on an Amazon Redshift cluster.
 	DatabaseName *string `min:"1" type:"string" required:"true"`
-
-	_ struct{} `type:"structure"`
 }
 
 // String returns the string representation
@@ -3227,6 +3227,8 @@ func (s RedshiftDatabase) GoString() string {
 // Describes the database credentials for connecting to a database on an Amazon
 // Redshift cluster.
 type RedshiftDatabaseCredentials struct {
+	_ struct{} `type:"structure"`
+
 	// A password to be used by Amazon ML to connect to a database on an Amazon
 	// Redshift cluster. The password should have sufficient permissions to execute
 	// a RedshiftSelectSqlQuery query. The password should be valid for an Amazon
@@ -3238,8 +3240,6 @@ type RedshiftDatabaseCredentials struct {
 	// permissions to execute the RedshiftSelectSqlQuery query. The username should
 	// be valid for an Amazon Redshift USER (http://docs.aws.amazon.com/redshift/latest/dg/r_CREATE_USER.html).
 	Username *string `min:"1" type:"string" required:"true"`
-
-	_ struct{} `type:"structure"`
 }
 
 // String returns the string representation
@@ -3254,6 +3254,8 @@ func (s RedshiftDatabaseCredentials) GoString() string {
 
 // Describes the DataSource details specific to Amazon Redshift.
 type RedshiftMetadata struct {
+	_ struct{} `type:"structure"`
+
 	// A username to be used by Amazon Machine Learning (Amazon ML)to connect to
 	// a database on an Amazon Redshift cluster. The username should have sufficient
 	// permissions to execute the RedshiftSelectSqlQuery query. The username should
@@ -3267,8 +3269,6 @@ type RedshiftMetadata struct {
 	// The SQL query that is specified during CreateDataSourceFromRedshift. Returns
 	// only if Verbose is true in GetDataSourceInput.
 	SelectSqlQuery *string `min:"1" type:"string"`
-
-	_ struct{} `type:"structure"`
 }
 
 // String returns the string representation
@@ -3283,6 +3283,8 @@ func (s RedshiftMetadata) GoString() string {
 
 // Describes the data specification of a DataSource.
 type S3DataSpec struct {
+	_ struct{} `type:"structure"`
+
 	// The location of the data file(s) used by a DataSource. The URI specifies
 	// a data file or an Amazon Simple Storage Service (Amazon S3) directory or
 	// bucket containing data files.
@@ -3325,8 +3327,6 @@ type S3DataSpec struct {
 
 	// Describes the schema Location in Amazon S3.
 	DataSchemaLocationS3 *string `type:"string"`
-
-	_ struct{} `type:"structure"`
 }
 
 // String returns the string representation
@@ -3340,13 +3340,13 @@ func (s S3DataSpec) GoString() string {
 }
 
 type UpdateBatchPredictionInput struct {
+	_ struct{} `type:"structure"`
+
 	// The ID assigned to the BatchPrediction during creation.
 	BatchPredictionId *string `min:"1" type:"string" required:"true"`
 
 	// A new user-supplied name or description of the BatchPrediction.
 	BatchPredictionName *string `type:"string" required:"true"`
-
-	_ struct{} `type:"structure"`
 }
 
 // String returns the string representation
@@ -3363,11 +3363,11 @@ func (s UpdateBatchPredictionInput) GoString() string {
 //
 // You can see the updated content by using the GetBatchPrediction operation.
 type UpdateBatchPredictionOutput struct {
+	_ struct{} `type:"structure"`
+
 	// The ID assigned to the BatchPrediction during creation. This value should
 	// be identical to the value of the BatchPredictionId in the request.
 	BatchPredictionId *string `min:"1" type:"string"`
-
-	_ struct{} `type:"structure"`
 }
 
 // String returns the string representation
@@ -3381,14 +3381,14 @@ func (s UpdateBatchPredictionOutput) GoString() string {
 }
 
 type UpdateDataSourceInput struct {
+	_ struct{} `type:"structure"`
+
 	// The ID assigned to the DataSource during creation.
 	DataSourceId *string `min:"1" type:"string" required:"true"`
 
 	// A new user-supplied name or description of the DataSource that will replace
 	// the current description.
 	DataSourceName *string `type:"string" required:"true"`
-
-	_ struct{} `type:"structure"`
 }
 
 // String returns the string representation
@@ -3405,11 +3405,11 @@ func (s UpdateDataSourceInput) GoString() string {
 //
 // You can see the updated content by using the GetBatchPrediction operation.
 type UpdateDataSourceOutput struct {
+	_ struct{} `type:"structure"`
+
 	// The ID assigned to the DataSource during creation. This value should be identical
 	// to the value of the DataSourceID in the request.
 	DataSourceId *string `min:"1" type:"string"`
-
-	_ struct{} `type:"structure"`
 }
 
 // String returns the string representation
@@ -3423,14 +3423,14 @@ func (s UpdateDataSourceOutput) GoString() string {
 }
 
 type UpdateEvaluationInput struct {
+	_ struct{} `type:"structure"`
+
 	// The ID assigned to the Evaluation during creation.
 	EvaluationId *string `min:"1" type:"string" required:"true"`
 
 	// A new user-supplied name or description of the Evaluation that will replace
 	// the current content.
 	EvaluationName *string `type:"string" required:"true"`
-
-	_ struct{} `type:"structure"`
 }
 
 // String returns the string representation
@@ -3447,11 +3447,11 @@ func (s UpdateEvaluationInput) GoString() string {
 //
 // You can see the updated content by using the GetEvaluation operation.
 type UpdateEvaluationOutput struct {
+	_ struct{} `type:"structure"`
+
 	// The ID assigned to the Evaluation during creation. This value should be identical
 	// to the value of the Evaluation in the request.
 	EvaluationId *string `min:"1" type:"string"`
-
-	_ struct{} `type:"structure"`
 }
 
 // String returns the string representation
@@ -3465,6 +3465,8 @@ func (s UpdateEvaluationOutput) GoString() string {
 }
 
 type UpdateMLModelInput struct {
+	_ struct{} `type:"structure"`
+
 	// The ID assigned to the MLModel during creation.
 	MLModelId *string `min:"1" type:"string" required:"true"`
 
@@ -3478,8 +3480,6 @@ type UpdateMLModelInput struct {
 	// result from the MLModel, such as true. Output values less than the ScoreThreshold
 	// receive a negative response from the MLModel, such as false.
 	ScoreThreshold *float64 `type:"float"`
-
-	_ struct{} `type:"structure"`
 }
 
 // String returns the string representation
@@ -3496,11 +3496,11 @@ func (s UpdateMLModelInput) GoString() string {
 //
 // You can see the updated content by using the GetMLModel operation.
 type UpdateMLModelOutput struct {
+	_ struct{} `type:"structure"`
+
 	// The ID assigned to the MLModel during creation. This value should be identical
 	// to the value of the MLModelID in the request.
 	MLModelId *string `min:"1" type:"string"`
-
-	_ struct{} `type:"structure"`
 }
 
 // String returns the string representation

--- a/service/machinelearning/api.go
+++ b/service/machinelearning/api.go
@@ -960,11 +960,7 @@ type BatchPrediction struct {
 	//  DELETED - The BatchPrediction is marked as deleted. It is not usable.
 	Status *string `type:"string" enum:"EntityStatus"`
 
-	metadataBatchPrediction `json:"-" xml:"-"`
-}
-
-type metadataBatchPrediction struct {
-	SDKShapeTraits bool `type:"structure"`
+	_ struct{} `type:"structure"`
 }
 
 // String returns the string representation
@@ -1000,11 +996,7 @@ type CreateBatchPredictionInput struct {
 	// Developer Guide (http://docs.aws.amazon.com/machine-learning/latest/dg).
 	OutputUri *string `type:"string" required:"true"`
 
-	metadataCreateBatchPredictionInput `json:"-" xml:"-"`
-}
-
-type metadataCreateBatchPredictionInput struct {
-	SDKShapeTraits bool `type:"structure"`
+	_ struct{} `type:"structure"`
 }
 
 // String returns the string representation
@@ -1028,11 +1020,7 @@ type CreateBatchPredictionOutput struct {
 	// is identical to the value of the BatchPredictionId in the request.
 	BatchPredictionId *string `min:"1" type:"string"`
 
-	metadataCreateBatchPredictionOutput `json:"-" xml:"-"`
-}
-
-type metadataCreateBatchPredictionOutput struct {
-	SDKShapeTraits bool `type:"structure"`
+	_ struct{} `type:"structure"`
 }
 
 // String returns the string representation
@@ -1105,11 +1093,7 @@ type CreateDataSourceFromRDSInput struct {
 	// query from Amazon RDS to Amazon S3.
 	RoleARN *string `min:"1" type:"string" required:"true"`
 
-	metadataCreateDataSourceFromRDSInput `json:"-" xml:"-"`
-}
-
-type metadataCreateDataSourceFromRDSInput struct {
-	SDKShapeTraits bool `type:"structure"`
+	_ struct{} `type:"structure"`
 }
 
 // String returns the string representation
@@ -1136,11 +1120,7 @@ type CreateDataSourceFromRDSOutput struct {
 	// be identical to the value of the DataSourceID in the request.
 	DataSourceId *string `min:"1" type:"string"`
 
-	metadataCreateDataSourceFromRDSOutput `json:"-" xml:"-"`
-}
-
-type metadataCreateDataSourceFromRDSOutput struct {
-	SDKShapeTraits bool `type:"structure"`
+	_ struct{} `type:"structure"`
 }
 
 // String returns the string representation
@@ -1202,11 +1182,7 @@ type CreateDataSourceFromRedshiftInput struct {
 	// the S3StagingLocation
 	RoleARN *string `min:"1" type:"string" required:"true"`
 
-	metadataCreateDataSourceFromRedshiftInput `json:"-" xml:"-"`
-}
-
-type metadataCreateDataSourceFromRedshiftInput struct {
-	SDKShapeTraits bool `type:"structure"`
+	_ struct{} `type:"structure"`
 }
 
 // String returns the string representation
@@ -1230,11 +1206,7 @@ type CreateDataSourceFromRedshiftOutput struct {
 	// be identical to the value of the DataSourceID in the request.
 	DataSourceId *string `min:"1" type:"string"`
 
-	metadataCreateDataSourceFromRedshiftOutput `json:"-" xml:"-"`
-}
-
-type metadataCreateDataSourceFromRedshiftOutput struct {
-	SDKShapeTraits bool `type:"structure"`
+	_ struct{} `type:"structure"`
 }
 
 // String returns the string representation
@@ -1276,11 +1248,7 @@ type CreateDataSourceFromS3Input struct {
 	//   Sample -  "{\"splitting\":{\"percentBegin\":10,\"percentEnd\":60}}"
 	DataSpec *S3DataSpec `type:"structure" required:"true"`
 
-	metadataCreateDataSourceFromS3Input `json:"-" xml:"-"`
-}
-
-type metadataCreateDataSourceFromS3Input struct {
-	SDKShapeTraits bool `type:"structure"`
+	_ struct{} `type:"structure"`
 }
 
 // String returns the string representation
@@ -1303,11 +1271,7 @@ type CreateDataSourceFromS3Output struct {
 	// be identical to the value of the DataSourceID in the request.
 	DataSourceId *string `min:"1" type:"string"`
 
-	metadataCreateDataSourceFromS3Output `json:"-" xml:"-"`
-}
-
-type metadataCreateDataSourceFromS3Output struct {
-	SDKShapeTraits bool `type:"structure"`
+	_ struct{} `type:"structure"`
 }
 
 // String returns the string representation
@@ -1337,11 +1301,7 @@ type CreateEvaluationInput struct {
 	// used in the Evaluation.
 	MLModelId *string `min:"1" type:"string" required:"true"`
 
-	metadataCreateEvaluationInput `json:"-" xml:"-"`
-}
-
-type metadataCreateEvaluationInput struct {
-	SDKShapeTraits bool `type:"structure"`
+	_ struct{} `type:"structure"`
 }
 
 // String returns the string representation
@@ -1364,11 +1324,7 @@ type CreateEvaluationOutput struct {
 	// should be identical to the value of the EvaluationId in the request.
 	EvaluationId *string `min:"1" type:"string"`
 
-	metadataCreateEvaluationOutput `json:"-" xml:"-"`
-}
-
-type metadataCreateEvaluationOutput struct {
-	SDKShapeTraits bool `type:"structure"`
+	_ struct{} `type:"structure"`
 }
 
 // String returns the string representation
@@ -1444,11 +1400,7 @@ type CreateMLModelInput struct {
 	// The DataSource that points to the training data.
 	TrainingDataSourceId *string `min:"1" type:"string" required:"true"`
 
-	metadataCreateMLModelInput `json:"-" xml:"-"`
-}
-
-type metadataCreateMLModelInput struct {
-	SDKShapeTraits bool `type:"structure"`
+	_ struct{} `type:"structure"`
 }
 
 // String returns the string representation
@@ -1471,11 +1423,7 @@ type CreateMLModelOutput struct {
 	// be identical to the value of the MLModelId in the request.
 	MLModelId *string `min:"1" type:"string"`
 
-	metadataCreateMLModelOutput `json:"-" xml:"-"`
-}
-
-type metadataCreateMLModelOutput struct {
-	SDKShapeTraits bool `type:"structure"`
+	_ struct{} `type:"structure"`
 }
 
 // String returns the string representation
@@ -1492,11 +1440,7 @@ type CreateRealtimeEndpointInput struct {
 	// The ID assigned to the MLModel during creation.
 	MLModelId *string `min:"1" type:"string" required:"true"`
 
-	metadataCreateRealtimeEndpointInput `json:"-" xml:"-"`
-}
-
-type metadataCreateRealtimeEndpointInput struct {
-	SDKShapeTraits bool `type:"structure"`
+	_ struct{} `type:"structure"`
 }
 
 // String returns the string representation
@@ -1523,11 +1467,7 @@ type CreateRealtimeEndpointOutput struct {
 	// The endpoint information of the MLModel
 	RealtimeEndpointInfo *RealtimeEndpointInfo `type:"structure"`
 
-	metadataCreateRealtimeEndpointOutput `json:"-" xml:"-"`
-}
-
-type metadataCreateRealtimeEndpointOutput struct {
-	SDKShapeTraits bool `type:"structure"`
+	_ struct{} `type:"structure"`
 }
 
 // String returns the string representation
@@ -1605,11 +1545,7 @@ type DataSource struct {
 	// is marked as deleted. It is not usable.
 	Status *string `type:"string" enum:"EntityStatus"`
 
-	metadataDataSource `json:"-" xml:"-"`
-}
-
-type metadataDataSource struct {
-	SDKShapeTraits bool `type:"structure"`
+	_ struct{} `type:"structure"`
 }
 
 // String returns the string representation
@@ -1626,11 +1562,7 @@ type DeleteBatchPredictionInput struct {
 	// A user-supplied ID that uniquely identifies the BatchPrediction.
 	BatchPredictionId *string `min:"1" type:"string" required:"true"`
 
-	metadataDeleteBatchPredictionInput `json:"-" xml:"-"`
-}
-
-type metadataDeleteBatchPredictionInput struct {
-	SDKShapeTraits bool `type:"structure"`
+	_ struct{} `type:"structure"`
 }
 
 // String returns the string representation
@@ -1652,11 +1584,7 @@ type DeleteBatchPredictionOutput struct {
 	// should be identical to the value of the BatchPredictionID in the request.
 	BatchPredictionId *string `min:"1" type:"string"`
 
-	metadataDeleteBatchPredictionOutput `json:"-" xml:"-"`
-}
-
-type metadataDeleteBatchPredictionOutput struct {
-	SDKShapeTraits bool `type:"structure"`
+	_ struct{} `type:"structure"`
 }
 
 // String returns the string representation
@@ -1673,11 +1601,7 @@ type DeleteDataSourceInput struct {
 	// A user-supplied ID that uniquely identifies the DataSource.
 	DataSourceId *string `min:"1" type:"string" required:"true"`
 
-	metadataDeleteDataSourceInput `json:"-" xml:"-"`
-}
-
-type metadataDeleteDataSourceInput struct {
-	SDKShapeTraits bool `type:"structure"`
+	_ struct{} `type:"structure"`
 }
 
 // String returns the string representation
@@ -1696,11 +1620,7 @@ type DeleteDataSourceOutput struct {
 	// be identical to the value of the DataSourceID in the request.
 	DataSourceId *string `min:"1" type:"string"`
 
-	metadataDeleteDataSourceOutput `json:"-" xml:"-"`
-}
-
-type metadataDeleteDataSourceOutput struct {
-	SDKShapeTraits bool `type:"structure"`
+	_ struct{} `type:"structure"`
 }
 
 // String returns the string representation
@@ -1717,11 +1637,7 @@ type DeleteEvaluationInput struct {
 	// A user-supplied ID that uniquely identifies the Evaluation to delete.
 	EvaluationId *string `min:"1" type:"string" required:"true"`
 
-	metadataDeleteEvaluationInput `json:"-" xml:"-"`
-}
-
-type metadataDeleteEvaluationInput struct {
-	SDKShapeTraits bool `type:"structure"`
+	_ struct{} `type:"structure"`
 }
 
 // String returns the string representation
@@ -1744,11 +1660,7 @@ type DeleteEvaluationOutput struct {
 	// be identical to the value of the EvaluationId in the request.
 	EvaluationId *string `min:"1" type:"string"`
 
-	metadataDeleteEvaluationOutput `json:"-" xml:"-"`
-}
-
-type metadataDeleteEvaluationOutput struct {
-	SDKShapeTraits bool `type:"structure"`
+	_ struct{} `type:"structure"`
 }
 
 // String returns the string representation
@@ -1765,11 +1677,7 @@ type DeleteMLModelInput struct {
 	// A user-supplied ID that uniquely identifies the MLModel.
 	MLModelId *string `min:"1" type:"string" required:"true"`
 
-	metadataDeleteMLModelInput `json:"-" xml:"-"`
-}
-
-type metadataDeleteMLModelInput struct {
-	SDKShapeTraits bool `type:"structure"`
+	_ struct{} `type:"structure"`
 }
 
 // String returns the string representation
@@ -1791,11 +1699,7 @@ type DeleteMLModelOutput struct {
 	// be identical to the value of the MLModelID in the request.
 	MLModelId *string `min:"1" type:"string"`
 
-	metadataDeleteMLModelOutput `json:"-" xml:"-"`
-}
-
-type metadataDeleteMLModelOutput struct {
-	SDKShapeTraits bool `type:"structure"`
+	_ struct{} `type:"structure"`
 }
 
 // String returns the string representation
@@ -1812,11 +1716,7 @@ type DeleteRealtimeEndpointInput struct {
 	// The ID assigned to the MLModel during creation.
 	MLModelId *string `min:"1" type:"string" required:"true"`
 
-	metadataDeleteRealtimeEndpointInput `json:"-" xml:"-"`
-}
-
-type metadataDeleteRealtimeEndpointInput struct {
-	SDKShapeTraits bool `type:"structure"`
+	_ struct{} `type:"structure"`
 }
 
 // String returns the string representation
@@ -1840,11 +1740,7 @@ type DeleteRealtimeEndpointOutput struct {
 	// The endpoint information of the MLModel
 	RealtimeEndpointInfo *RealtimeEndpointInfo `type:"structure"`
 
-	metadataDeleteRealtimeEndpointOutput `json:"-" xml:"-"`
-}
-
-type metadataDeleteRealtimeEndpointOutput struct {
-	SDKShapeTraits bool `type:"structure"`
+	_ struct{} `type:"structure"`
 }
 
 // String returns the string representation
@@ -1924,11 +1820,7 @@ type DescribeBatchPredictionsInput struct {
 	// the list in descending order (Z-A, 9-0).  Results are sorted by FilterVariable.
 	SortOrder *string `type:"string" enum:"SortOrder"`
 
-	metadataDescribeBatchPredictionsInput `json:"-" xml:"-"`
-}
-
-type metadataDescribeBatchPredictionsInput struct {
-	SDKShapeTraits bool `type:"structure"`
+	_ struct{} `type:"structure"`
 }
 
 // String returns the string representation
@@ -1951,11 +1843,7 @@ type DescribeBatchPredictionsOutput struct {
 	// A list of BatchPrediction objects that meet the search criteria.
 	Results []*BatchPrediction `type:"list"`
 
-	metadataDescribeBatchPredictionsOutput `json:"-" xml:"-"`
-}
-
-type metadataDescribeBatchPredictionsOutput struct {
-	SDKShapeTraits bool `type:"structure"`
+	_ struct{} `type:"structure"`
 }
 
 // String returns the string representation
@@ -2030,11 +1918,7 @@ type DescribeDataSourcesInput struct {
 	// the list in descending order (Z-A, 9-0).  Results are sorted by FilterVariable.
 	SortOrder *string `type:"string" enum:"SortOrder"`
 
-	metadataDescribeDataSourcesInput `json:"-" xml:"-"`
-}
-
-type metadataDescribeDataSourcesInput struct {
-	SDKShapeTraits bool `type:"structure"`
+	_ struct{} `type:"structure"`
 }
 
 // String returns the string representation
@@ -2057,11 +1941,7 @@ type DescribeDataSourcesOutput struct {
 	// A list of DataSource that meet the search criteria.
 	Results []*DataSource `type:"list"`
 
-	metadataDescribeDataSourcesOutput `json:"-" xml:"-"`
-}
-
-type metadataDescribeDataSourcesOutput struct {
-	SDKShapeTraits bool `type:"structure"`
+	_ struct{} `type:"structure"`
 }
 
 // String returns the string representation
@@ -2138,11 +2018,7 @@ type DescribeEvaluationsInput struct {
 	// the list in descending order (Z-A, 9-0).  Results are sorted by FilterVariable.
 	SortOrder *string `type:"string" enum:"SortOrder"`
 
-	metadataDescribeEvaluationsInput `json:"-" xml:"-"`
-}
-
-type metadataDescribeEvaluationsInput struct {
-	SDKShapeTraits bool `type:"structure"`
+	_ struct{} `type:"structure"`
 }
 
 // String returns the string representation
@@ -2165,11 +2041,7 @@ type DescribeEvaluationsOutput struct {
 	// A list of Evaluation that meet the search criteria.
 	Results []*Evaluation `type:"list"`
 
-	metadataDescribeEvaluationsOutput `json:"-" xml:"-"`
-}
-
-type metadataDescribeEvaluationsOutput struct {
-	SDKShapeTraits bool `type:"structure"`
+	_ struct{} `type:"structure"`
 }
 
 // String returns the string representation
@@ -2249,11 +2121,7 @@ type DescribeMLModelsInput struct {
 	// the list in descending order (Z-A, 9-0).  Results are sorted by FilterVariable.
 	SortOrder *string `type:"string" enum:"SortOrder"`
 
-	metadataDescribeMLModelsInput `json:"-" xml:"-"`
-}
-
-type metadataDescribeMLModelsInput struct {
-	SDKShapeTraits bool `type:"structure"`
+	_ struct{} `type:"structure"`
 }
 
 // String returns the string representation
@@ -2276,11 +2144,7 @@ type DescribeMLModelsOutput struct {
 	// A list of MLModel that meet the search criteria.
 	Results []*MLModel `type:"list"`
 
-	metadataDescribeMLModelsOutput `json:"-" xml:"-"`
-}
-
-type metadataDescribeMLModelsOutput struct {
-	SDKShapeTraits bool `type:"structure"`
+	_ struct{} `type:"structure"`
 }
 
 // String returns the string representation
@@ -2358,11 +2222,7 @@ type Evaluation struct {
 	// is marked as deleted. It is not usable.
 	Status *string `type:"string" enum:"EntityStatus"`
 
-	metadataEvaluation `json:"-" xml:"-"`
-}
-
-type metadataEvaluation struct {
-	SDKShapeTraits bool `type:"structure"`
+	_ struct{} `type:"structure"`
 }
 
 // String returns the string representation
@@ -2379,11 +2239,7 @@ type GetBatchPredictionInput struct {
 	// An ID assigned to the BatchPrediction at creation.
 	BatchPredictionId *string `min:"1" type:"string" required:"true"`
 
-	metadataGetBatchPredictionInput `json:"-" xml:"-"`
-}
-
-type metadataGetBatchPredictionInput struct {
-	SDKShapeTraits bool `type:"structure"`
+	_ struct{} `type:"structure"`
 }
 
 // String returns the string representation
@@ -2449,11 +2305,7 @@ type GetBatchPredictionOutput struct {
 	//  DELETED - The BatchPrediction is marked as deleted. It is not usable.
 	Status *string `type:"string" enum:"EntityStatus"`
 
-	metadataGetBatchPredictionOutput `json:"-" xml:"-"`
-}
-
-type metadataGetBatchPredictionOutput struct {
-	SDKShapeTraits bool `type:"structure"`
+	_ struct{} `type:"structure"`
 }
 
 // String returns the string representation
@@ -2477,11 +2329,7 @@ type GetDataSourceInput struct {
 	// If false, DataSourceSchema is not returned.
 	Verbose *bool `type:"boolean"`
 
-	metadataGetDataSourceInput `json:"-" xml:"-"`
-}
-
-type metadataGetDataSourceInput struct {
-	SDKShapeTraits bool `type:"structure"`
+	_ struct{} `type:"structure"`
 }
 
 // String returns the string representation
@@ -2565,11 +2413,7 @@ type GetDataSourceOutput struct {
 	// DataSource is marked as deleted. It is not usable.
 	Status *string `type:"string" enum:"EntityStatus"`
 
-	metadataGetDataSourceOutput `json:"-" xml:"-"`
-}
-
-type metadataGetDataSourceOutput struct {
-	SDKShapeTraits bool `type:"structure"`
+	_ struct{} `type:"structure"`
 }
 
 // String returns the string representation
@@ -2587,11 +2431,7 @@ type GetEvaluationInput struct {
 	// and cataloged. The ID provides the means to access the information.
 	EvaluationId *string `min:"1" type:"string" required:"true"`
 
-	metadataGetEvaluationInput `json:"-" xml:"-"`
-}
-
-type metadataGetEvaluationInput struct {
-	SDKShapeTraits bool `type:"structure"`
+	_ struct{} `type:"structure"`
 }
 
 // String returns the string representation
@@ -2669,11 +2509,7 @@ type GetEvaluationOutput struct {
 	// is marked as deleted. It is not usable.
 	Status *string `type:"string" enum:"EntityStatus"`
 
-	metadataGetEvaluationOutput `json:"-" xml:"-"`
-}
-
-type metadataGetEvaluationOutput struct {
-	SDKShapeTraits bool `type:"structure"`
+	_ struct{} `type:"structure"`
 }
 
 // String returns the string representation
@@ -2697,11 +2533,7 @@ type GetMLModelInput struct {
 	// If false, Recipe is not returned.
 	Verbose *bool `type:"boolean"`
 
-	metadataGetMLModelInput `json:"-" xml:"-"`
-}
-
-type metadataGetMLModelInput struct {
-	SDKShapeTraits bool `type:"structure"`
+	_ struct{} `type:"structure"`
 }
 
 // String returns the string representation
@@ -2829,11 +2661,7 @@ type GetMLModelOutput struct {
 	// value is 33554432.
 	TrainingParameters map[string]*string `type:"map"`
 
-	metadataGetMLModelOutput `json:"-" xml:"-"`
-}
-
-type metadataGetMLModelOutput struct {
-	SDKShapeTraits bool `type:"structure"`
+	_ struct{} `type:"structure"`
 }
 
 // String returns the string representation
@@ -2950,11 +2778,7 @@ type MLModel struct {
 	// value is 33554432.
 	TrainingParameters map[string]*string `type:"map"`
 
-	metadataMLModel `json:"-" xml:"-"`
-}
-
-type metadataMLModel struct {
-	SDKShapeTraits bool `type:"structure"`
+	_ struct{} `type:"structure"`
 }
 
 // String returns the string representation
@@ -2985,11 +2809,7 @@ func (s MLModel) GoString() string {
 type PerformanceMetrics struct {
 	Properties map[string]*string `type:"map"`
 
-	metadataPerformanceMetrics `json:"-" xml:"-"`
-}
-
-type metadataPerformanceMetrics struct {
-	SDKShapeTraits bool `type:"structure"`
+	_ struct{} `type:"structure"`
 }
 
 // String returns the string representation
@@ -3011,11 +2831,7 @@ type PredictInput struct {
 	// A map of variable name-value pairs that represent an observation.
 	Record map[string]*string `type:"map" required:"true"`
 
-	metadataPredictInput `json:"-" xml:"-"`
-}
-
-type metadataPredictInput struct {
-	SDKShapeTraits bool `type:"structure"`
+	_ struct{} `type:"structure"`
 }
 
 // String returns the string representation
@@ -3042,11 +2858,7 @@ type PredictOutput struct {
 	//    PredictedValue - Present for a REGRESSION MLModel request.
 	Prediction *Prediction `type:"structure"`
 
-	metadataPredictOutput `json:"-" xml:"-"`
-}
-
-type metadataPredictOutput struct {
-	SDKShapeTraits bool `type:"structure"`
+	_ struct{} `type:"structure"`
 }
 
 // String returns the string representation
@@ -3083,11 +2895,7 @@ type Prediction struct {
 	// The prediction value for REGRESSION MLModel.
 	PredictedValue *float64 `locationName:"predictedValue" type:"float"`
 
-	metadataPrediction `json:"-" xml:"-"`
-}
-
-type metadataPrediction struct {
-	SDKShapeTraits bool `type:"structure"`
+	_ struct{} `type:"structure"`
 }
 
 // String returns the string representation
@@ -3183,11 +2991,7 @@ type RDSDataSpec struct {
 	// S3.
 	SubnetId *string `min:"1" type:"string" required:"true"`
 
-	metadataRDSDataSpec `json:"-" xml:"-"`
-}
-
-type metadataRDSDataSpec struct {
-	SDKShapeTraits bool `type:"structure"`
+	_ struct{} `type:"structure"`
 }
 
 // String returns the string representation
@@ -3208,11 +3012,7 @@ type RDSDatabase struct {
 	// The ID of an RDS DB instance.
 	InstanceIdentifier *string `min:"1" type:"string" required:"true"`
 
-	metadataRDSDatabase `json:"-" xml:"-"`
-}
-
-type metadataRDSDatabase struct {
-	SDKShapeTraits bool `type:"structure"`
+	_ struct{} `type:"structure"`
 }
 
 // String returns the string representation
@@ -3237,11 +3037,7 @@ type RDSDatabaseCredentials struct {
 	// an RDSSelectSqlQuery query.
 	Username *string `min:"1" type:"string" required:"true"`
 
-	metadataRDSDatabaseCredentials `json:"-" xml:"-"`
-}
-
-type metadataRDSDatabaseCredentials struct {
-	SDKShapeTraits bool `type:"structure"`
+	_ struct{} `type:"structure"`
 }
 
 // String returns the string representation
@@ -3285,11 +3081,7 @@ type RDSMetadata struct {
 	// for data pipelines.
 	ServiceRole *string `min:"1" type:"string"`
 
-	metadataRDSMetadata `json:"-" xml:"-"`
-}
-
-type metadataRDSMetadata struct {
-	SDKShapeTraits bool `type:"structure"`
+	_ struct{} `type:"structure"`
 }
 
 // String returns the string representation
@@ -3327,11 +3119,7 @@ type RealtimeEndpointInfo struct {
 	// in incoming requests per second.
 	PeakRequestsPerSecond *int64 `type:"integer"`
 
-	metadataRealtimeEndpointInfo `json:"-" xml:"-"`
-}
-
-type metadataRealtimeEndpointInfo struct {
-	SDKShapeTraits bool `type:"structure"`
+	_ struct{} `type:"structure"`
 }
 
 // String returns the string representation
@@ -3401,11 +3189,7 @@ type RedshiftDataSpec struct {
 	// Amazon Redshift DataSource.
 	SelectSqlQuery *string `min:"1" type:"string" required:"true"`
 
-	metadataRedshiftDataSpec `json:"-" xml:"-"`
-}
-
-type metadataRedshiftDataSpec struct {
-	SDKShapeTraits bool `type:"structure"`
+	_ struct{} `type:"structure"`
 }
 
 // String returns the string representation
@@ -3427,11 +3211,7 @@ type RedshiftDatabase struct {
 	// The name of a database hosted on an Amazon Redshift cluster.
 	DatabaseName *string `min:"1" type:"string" required:"true"`
 
-	metadataRedshiftDatabase `json:"-" xml:"-"`
-}
-
-type metadataRedshiftDatabase struct {
-	SDKShapeTraits bool `type:"structure"`
+	_ struct{} `type:"structure"`
 }
 
 // String returns the string representation
@@ -3459,11 +3239,7 @@ type RedshiftDatabaseCredentials struct {
 	// be valid for an Amazon Redshift USER (http://docs.aws.amazon.com/redshift/latest/dg/r_CREATE_USER.html).
 	Username *string `min:"1" type:"string" required:"true"`
 
-	metadataRedshiftDatabaseCredentials `json:"-" xml:"-"`
-}
-
-type metadataRedshiftDatabaseCredentials struct {
-	SDKShapeTraits bool `type:"structure"`
+	_ struct{} `type:"structure"`
 }
 
 // String returns the string representation
@@ -3492,11 +3268,7 @@ type RedshiftMetadata struct {
 	// only if Verbose is true in GetDataSourceInput.
 	SelectSqlQuery *string `min:"1" type:"string"`
 
-	metadataRedshiftMetadata `json:"-" xml:"-"`
-}
-
-type metadataRedshiftMetadata struct {
-	SDKShapeTraits bool `type:"structure"`
+	_ struct{} `type:"structure"`
 }
 
 // String returns the string representation
@@ -3554,11 +3326,7 @@ type S3DataSpec struct {
 	// Describes the schema Location in Amazon S3.
 	DataSchemaLocationS3 *string `type:"string"`
 
-	metadataS3DataSpec `json:"-" xml:"-"`
-}
-
-type metadataS3DataSpec struct {
-	SDKShapeTraits bool `type:"structure"`
+	_ struct{} `type:"structure"`
 }
 
 // String returns the string representation
@@ -3578,11 +3346,7 @@ type UpdateBatchPredictionInput struct {
 	// A new user-supplied name or description of the BatchPrediction.
 	BatchPredictionName *string `type:"string" required:"true"`
 
-	metadataUpdateBatchPredictionInput `json:"-" xml:"-"`
-}
-
-type metadataUpdateBatchPredictionInput struct {
-	SDKShapeTraits bool `type:"structure"`
+	_ struct{} `type:"structure"`
 }
 
 // String returns the string representation
@@ -3603,11 +3367,7 @@ type UpdateBatchPredictionOutput struct {
 	// be identical to the value of the BatchPredictionId in the request.
 	BatchPredictionId *string `min:"1" type:"string"`
 
-	metadataUpdateBatchPredictionOutput `json:"-" xml:"-"`
-}
-
-type metadataUpdateBatchPredictionOutput struct {
-	SDKShapeTraits bool `type:"structure"`
+	_ struct{} `type:"structure"`
 }
 
 // String returns the string representation
@@ -3628,11 +3388,7 @@ type UpdateDataSourceInput struct {
 	// the current description.
 	DataSourceName *string `type:"string" required:"true"`
 
-	metadataUpdateDataSourceInput `json:"-" xml:"-"`
-}
-
-type metadataUpdateDataSourceInput struct {
-	SDKShapeTraits bool `type:"structure"`
+	_ struct{} `type:"structure"`
 }
 
 // String returns the string representation
@@ -3653,11 +3409,7 @@ type UpdateDataSourceOutput struct {
 	// to the value of the DataSourceID in the request.
 	DataSourceId *string `min:"1" type:"string"`
 
-	metadataUpdateDataSourceOutput `json:"-" xml:"-"`
-}
-
-type metadataUpdateDataSourceOutput struct {
-	SDKShapeTraits bool `type:"structure"`
+	_ struct{} `type:"structure"`
 }
 
 // String returns the string representation
@@ -3678,11 +3430,7 @@ type UpdateEvaluationInput struct {
 	// the current content.
 	EvaluationName *string `type:"string" required:"true"`
 
-	metadataUpdateEvaluationInput `json:"-" xml:"-"`
-}
-
-type metadataUpdateEvaluationInput struct {
-	SDKShapeTraits bool `type:"structure"`
+	_ struct{} `type:"structure"`
 }
 
 // String returns the string representation
@@ -3703,11 +3451,7 @@ type UpdateEvaluationOutput struct {
 	// to the value of the Evaluation in the request.
 	EvaluationId *string `min:"1" type:"string"`
 
-	metadataUpdateEvaluationOutput `json:"-" xml:"-"`
-}
-
-type metadataUpdateEvaluationOutput struct {
-	SDKShapeTraits bool `type:"structure"`
+	_ struct{} `type:"structure"`
 }
 
 // String returns the string representation
@@ -3735,11 +3479,7 @@ type UpdateMLModelInput struct {
 	// receive a negative response from the MLModel, such as false.
 	ScoreThreshold *float64 `type:"float"`
 
-	metadataUpdateMLModelInput `json:"-" xml:"-"`
-}
-
-type metadataUpdateMLModelInput struct {
-	SDKShapeTraits bool `type:"structure"`
+	_ struct{} `type:"structure"`
 }
 
 // String returns the string representation
@@ -3760,11 +3500,7 @@ type UpdateMLModelOutput struct {
 	// to the value of the MLModelID in the request.
 	MLModelId *string `min:"1" type:"string"`
 
-	metadataUpdateMLModelOutput `json:"-" xml:"-"`
-}
-
-type metadataUpdateMLModelOutput struct {
-	SDKShapeTraits bool `type:"structure"`
+	_ struct{} `type:"structure"`
 }
 
 // String returns the string representation

--- a/service/marketplacecommerceanalytics/api.go
+++ b/service/marketplacecommerceanalytics/api.go
@@ -48,6 +48,8 @@ func (c *MarketplaceCommerceAnalytics) GenerateDataSet(input *GenerateDataSetInp
 
 // Container for the parameters to the GenerateDataSet operation.
 type GenerateDataSetInput struct {
+	_ struct{} `type:"structure"`
+
 	// The date a data set was published. For daily data sets, provide a date with
 	// day-level granularity for the desired day. For weekly data sets, provide
 	// a date with day-level granularity within the desired week (the day value
@@ -76,8 +78,6 @@ type GenerateDataSetInput struct {
 	// Amazon Resource Name (ARN) for the SNS Topic that will be notified when the
 	// data set has been published or if an error has occurred.
 	SnsTopicArn *string `locationName:"snsTopicArn" min:"1" type:"string" required:"true"`
-
-	_ struct{} `type:"structure"`
 }
 
 // String returns the string representation
@@ -92,12 +92,12 @@ func (s GenerateDataSetInput) GoString() string {
 
 // Container for the result of the GenerateDataSet operation.
 type GenerateDataSetOutput struct {
+	_ struct{} `type:"structure"`
+
 	// A unique identifier representing a specific request to the GenerateDataSet
 	// operation. This identifier can be used to correlate a request with notifications
 	// from the SNS topic.
 	DataSetRequestId *string `locationName:"dataSetRequestId" type:"string"`
-
-	_ struct{} `type:"structure"`
 }
 
 // String returns the string representation

--- a/service/marketplacecommerceanalytics/api.go
+++ b/service/marketplacecommerceanalytics/api.go
@@ -77,11 +77,7 @@ type GenerateDataSetInput struct {
 	// data set has been published or if an error has occurred.
 	SnsTopicArn *string `locationName:"snsTopicArn" min:"1" type:"string" required:"true"`
 
-	metadataGenerateDataSetInput `json:"-" xml:"-"`
-}
-
-type metadataGenerateDataSetInput struct {
-	SDKShapeTraits bool `type:"structure"`
+	_ struct{} `type:"structure"`
 }
 
 // String returns the string representation
@@ -101,11 +97,7 @@ type GenerateDataSetOutput struct {
 	// from the SNS topic.
 	DataSetRequestId *string `locationName:"dataSetRequestId" type:"string"`
 
-	metadataGenerateDataSetOutput `json:"-" xml:"-"`
-}
-
-type metadataGenerateDataSetOutput struct {
-	SDKShapeTraits bool `type:"structure"`
+	_ struct{} `type:"structure"`
 }
 
 // String returns the string representation

--- a/service/mobileanalytics/api.go
+++ b/service/mobileanalytics/api.go
@@ -65,11 +65,7 @@ type Event struct {
 	// The version of the event.
 	Version *string `locationName:"version" min:"1" type:"string"`
 
-	metadataEvent `json:"-" xml:"-"`
-}
-
-type metadataEvent struct {
-	SDKShapeTraits bool `type:"structure"`
+	_ struct{} `type:"structure"`
 }
 
 // String returns the string representation
@@ -94,11 +90,7 @@ type PutEventsInput struct {
 	// An array of Event JSON objects
 	Events []*Event `locationName:"events" type:"list" required:"true"`
 
-	metadataPutEventsInput `json:"-" xml:"-"`
-}
-
-type metadataPutEventsInput struct {
-	SDKShapeTraits bool `type:"structure"`
+	_ struct{} `type:"structure"`
 }
 
 // String returns the string representation
@@ -112,11 +104,7 @@ func (s PutEventsInput) GoString() string {
 }
 
 type PutEventsOutput struct {
-	metadataPutEventsOutput `json:"-" xml:"-"`
-}
-
-type metadataPutEventsOutput struct {
-	SDKShapeTraits bool `type:"structure"`
+	_ struct{} `type:"structure"`
 }
 
 // String returns the string representation
@@ -145,11 +133,7 @@ type Session struct {
 	// example, 2014-06-30T19:07:47.885Z
 	StopTimestamp *string `locationName:"stopTimestamp" type:"string"`
 
-	metadataSession `json:"-" xml:"-"`
-}
-
-type metadataSession struct {
-	SDKShapeTraits bool `type:"structure"`
+	_ struct{} `type:"structure"`
 }
 
 // String returns the string representation

--- a/service/mobileanalytics/api.go
+++ b/service/mobileanalytics/api.go
@@ -39,6 +39,8 @@ func (c *MobileAnalytics) PutEvents(input *PutEventsInput) (*PutEventsOutput, er
 
 // A JSON object representing a batch of unique event occurrences in your app.
 type Event struct {
+	_ struct{} `type:"structure"`
+
 	// A collection of key-value pairs that give additional context to the event.
 	// The key-value pairs are specified by the developer.
 	//
@@ -64,8 +66,6 @@ type Event struct {
 
 	// The version of the event.
 	Version *string `locationName:"version" min:"1" type:"string"`
-
-	_ struct{} `type:"structure"`
 }
 
 // String returns the string representation
@@ -80,6 +80,8 @@ func (s Event) GoString() string {
 
 // A container for the data needed for a PutEvent operation
 type PutEventsInput struct {
+	_ struct{} `type:"structure"`
+
 	// The client context including the client ID, app title, app version and package
 	// name.
 	ClientContext *string `location:"header" locationName:"x-amz-Client-Context" type:"string" required:"true"`
@@ -89,8 +91,6 @@ type PutEventsInput struct {
 
 	// An array of Event JSON objects
 	Events []*Event `locationName:"events" type:"list" required:"true"`
-
-	_ struct{} `type:"structure"`
 }
 
 // String returns the string representation
@@ -119,6 +119,8 @@ func (s PutEventsOutput) GoString() string {
 
 // Describes the session. Session information is required on ALL events.
 type Session struct {
+	_ struct{} `type:"structure"`
+
 	// The duration of the session.
 	Duration *int64 `locationName:"duration" type:"long"`
 
@@ -132,8 +134,6 @@ type Session struct {
 	// The time the event terminated in ISO 8601 standard date time format. For
 	// example, 2014-06-30T19:07:47.885Z
 	StopTimestamp *string `locationName:"stopTimestamp" type:"string"`
-
-	_ struct{} `type:"structure"`
 }
 
 // String returns the string representation

--- a/service/opsworks/api.go
+++ b/service/opsworks/api.go
@@ -2358,11 +2358,7 @@ type AgentVersion struct {
 	// The agent version.
 	Version *string `type:"string"`
 
-	metadataAgentVersion `json:"-" xml:"-"`
-}
-
-type metadataAgentVersion struct {
-	SDKShapeTraits bool `type:"structure"`
+	_ struct{} `type:"structure"`
 }
 
 // String returns the string representation
@@ -2430,11 +2426,7 @@ type App struct {
 	// The app type.
 	Type *string `type:"string" enum:"AppType"`
 
-	metadataApp `json:"-" xml:"-"`
-}
-
-type metadataApp struct {
-	SDKShapeTraits bool `type:"structure"`
+	_ struct{} `type:"structure"`
 }
 
 // String returns the string representation
@@ -2455,11 +2447,7 @@ type AssignInstanceInput struct {
 	// a registered instance to a built-in layer.
 	LayerIds []*string `type:"list" required:"true"`
 
-	metadataAssignInstanceInput `json:"-" xml:"-"`
-}
-
-type metadataAssignInstanceInput struct {
-	SDKShapeTraits bool `type:"structure"`
+	_ struct{} `type:"structure"`
 }
 
 // String returns the string representation
@@ -2473,11 +2461,7 @@ func (s AssignInstanceInput) GoString() string {
 }
 
 type AssignInstanceOutput struct {
-	metadataAssignInstanceOutput `json:"-" xml:"-"`
-}
-
-type metadataAssignInstanceOutput struct {
-	SDKShapeTraits bool `type:"structure"`
+	_ struct{} `type:"structure"`
 }
 
 // String returns the string representation
@@ -2497,11 +2481,7 @@ type AssignVolumeInput struct {
 	// The volume ID.
 	VolumeId *string `type:"string" required:"true"`
 
-	metadataAssignVolumeInput `json:"-" xml:"-"`
-}
-
-type metadataAssignVolumeInput struct {
-	SDKShapeTraits bool `type:"structure"`
+	_ struct{} `type:"structure"`
 }
 
 // String returns the string representation
@@ -2515,11 +2495,7 @@ func (s AssignVolumeInput) GoString() string {
 }
 
 type AssignVolumeOutput struct {
-	metadataAssignVolumeOutput `json:"-" xml:"-"`
-}
-
-type metadataAssignVolumeOutput struct {
-	SDKShapeTraits bool `type:"structure"`
+	_ struct{} `type:"structure"`
 }
 
 // String returns the string representation
@@ -2539,11 +2515,7 @@ type AssociateElasticIpInput struct {
 	// The instance ID.
 	InstanceId *string `type:"string"`
 
-	metadataAssociateElasticIpInput `json:"-" xml:"-"`
-}
-
-type metadataAssociateElasticIpInput struct {
-	SDKShapeTraits bool `type:"structure"`
+	_ struct{} `type:"structure"`
 }
 
 // String returns the string representation
@@ -2557,11 +2529,7 @@ func (s AssociateElasticIpInput) GoString() string {
 }
 
 type AssociateElasticIpOutput struct {
-	metadataAssociateElasticIpOutput `json:"-" xml:"-"`
-}
-
-type metadataAssociateElasticIpOutput struct {
-	SDKShapeTraits bool `type:"structure"`
+	_ struct{} `type:"structure"`
 }
 
 // String returns the string representation
@@ -2582,11 +2550,7 @@ type AttachElasticLoadBalancerInput struct {
 	// to.
 	LayerId *string `type:"string" required:"true"`
 
-	metadataAttachElasticLoadBalancerInput `json:"-" xml:"-"`
-}
-
-type metadataAttachElasticLoadBalancerInput struct {
-	SDKShapeTraits bool `type:"structure"`
+	_ struct{} `type:"structure"`
 }
 
 // String returns the string representation
@@ -2600,11 +2564,7 @@ func (s AttachElasticLoadBalancerInput) GoString() string {
 }
 
 type AttachElasticLoadBalancerOutput struct {
-	metadataAttachElasticLoadBalancerOutput `json:"-" xml:"-"`
-}
-
-type metadataAttachElasticLoadBalancerOutput struct {
-	SDKShapeTraits bool `type:"structure"`
+	_ struct{} `type:"structure"`
 }
 
 // String returns the string representation
@@ -2657,11 +2617,7 @@ type AutoScalingThresholds struct {
 	// more instances are added or removed.
 	ThresholdsWaitTime *int64 `min:"1" type:"integer"`
 
-	metadataAutoScalingThresholds `json:"-" xml:"-"`
-}
-
-type metadataAutoScalingThresholds struct {
-	SDKShapeTraits bool `type:"structure"`
+	_ struct{} `type:"structure"`
 }
 
 // String returns the string representation
@@ -2693,11 +2649,7 @@ type BlockDeviceMapping struct {
 	// The virtual device name. For more information, see BlockDeviceMapping (http://docs.aws.amazon.com/AWSEC2/latest/APIReference/API_BlockDeviceMapping.html).
 	VirtualName *string `type:"string"`
 
-	metadataBlockDeviceMapping `json:"-" xml:"-"`
-}
-
-type metadataBlockDeviceMapping struct {
-	SDKShapeTraits bool `type:"structure"`
+	_ struct{} `type:"structure"`
 }
 
 // String returns the string representation
@@ -2718,11 +2670,7 @@ type ChefConfiguration struct {
 	// Whether to enable Berkshelf.
 	ManageBerkshelf *bool `type:"boolean"`
 
-	metadataChefConfiguration `json:"-" xml:"-"`
-}
-
-type metadataChefConfiguration struct {
-	SDKShapeTraits bool `type:"structure"`
+	_ struct{} `type:"structure"`
 }
 
 // String returns the string representation
@@ -2911,11 +2859,7 @@ type CloneStackInput struct {
 	// (http://docs.aws.amazon.com/AWSEC2/latest/UserGuide/ec2-supported-platforms.html).
 	VpcId *string `type:"string"`
 
-	metadataCloneStackInput `json:"-" xml:"-"`
-}
-
-type metadataCloneStackInput struct {
-	SDKShapeTraits bool `type:"structure"`
+	_ struct{} `type:"structure"`
 }
 
 // String returns the string representation
@@ -2933,11 +2877,7 @@ type CloneStackOutput struct {
 	// The cloned stack ID.
 	StackId *string `type:"string"`
 
-	metadataCloneStackOutput `json:"-" xml:"-"`
-}
-
-type metadataCloneStackOutput struct {
-	SDKShapeTraits bool `type:"structure"`
+	_ struct{} `type:"structure"`
 }
 
 // String returns the string representation
@@ -2987,11 +2927,7 @@ type Command struct {
 	//   install_dependencies   update_custom_cookbooks   execute_recipes
 	Type *string `type:"string"`
 
-	metadataCommand `json:"-" xml:"-"`
-}
-
-type metadataCommand struct {
-	SDKShapeTraits bool `type:"structure"`
+	_ struct{} `type:"structure"`
 }
 
 // String returns the string representation
@@ -3059,11 +2995,7 @@ type CreateAppInput struct {
 	// your own Deploy recipes, specify other.
 	Type *string `type:"string" required:"true" enum:"AppType"`
 
-	metadataCreateAppInput `json:"-" xml:"-"`
-}
-
-type metadataCreateAppInput struct {
-	SDKShapeTraits bool `type:"structure"`
+	_ struct{} `type:"structure"`
 }
 
 // String returns the string representation
@@ -3081,11 +3013,7 @@ type CreateAppOutput struct {
 	// The app ID.
 	AppId *string `type:"string"`
 
-	metadataCreateAppOutput `json:"-" xml:"-"`
-}
-
-type metadataCreateAppOutput struct {
-	SDKShapeTraits bool `type:"structure"`
+	_ struct{} `type:"structure"`
 }
 
 // String returns the string representation
@@ -3126,11 +3054,7 @@ type CreateDeploymentInput struct {
 	// The stack ID.
 	StackId *string `type:"string" required:"true"`
 
-	metadataCreateDeploymentInput `json:"-" xml:"-"`
-}
-
-type metadataCreateDeploymentInput struct {
-	SDKShapeTraits bool `type:"structure"`
+	_ struct{} `type:"structure"`
 }
 
 // String returns the string representation
@@ -3149,11 +3073,7 @@ type CreateDeploymentOutput struct {
 	// deployment.
 	DeploymentId *string `type:"string"`
 
-	metadataCreateDeploymentOutput `json:"-" xml:"-"`
-}
-
-type metadataCreateDeploymentOutput struct {
-	SDKShapeTraits bool `type:"structure"`
+	_ struct{} `type:"structure"`
 }
 
 // String returns the string representation
@@ -3264,11 +3184,7 @@ type CreateInstanceInput struct {
 	// The instance's virtualization type, paravirtual or hvm.
 	VirtualizationType *string `type:"string"`
 
-	metadataCreateInstanceInput `json:"-" xml:"-"`
-}
-
-type metadataCreateInstanceInput struct {
-	SDKShapeTraits bool `type:"structure"`
+	_ struct{} `type:"structure"`
 }
 
 // String returns the string representation
@@ -3286,11 +3202,7 @@ type CreateInstanceOutput struct {
 	// The instance ID.
 	InstanceId *string `type:"string"`
 
-	metadataCreateInstanceOutput `json:"-" xml:"-"`
-}
-
-type metadataCreateInstanceOutput struct {
-	SDKShapeTraits bool `type:"structure"`
+	_ struct{} `type:"structure"`
 }
 
 // String returns the string representation
@@ -3381,11 +3293,7 @@ type CreateLayerInput struct {
 	// A VolumeConfigurations object that describes the layer's Amazon EBS volumes.
 	VolumeConfigurations []*VolumeConfiguration `type:"list"`
 
-	metadataCreateLayerInput `json:"-" xml:"-"`
-}
-
-type metadataCreateLayerInput struct {
-	SDKShapeTraits bool `type:"structure"`
+	_ struct{} `type:"structure"`
 }
 
 // String returns the string representation
@@ -3403,11 +3311,7 @@ type CreateLayerOutput struct {
 	// The layer ID.
 	LayerId *string `type:"string"`
 
-	metadataCreateLayerOutput `json:"-" xml:"-"`
-}
-
-type metadataCreateLayerOutput struct {
-	SDKShapeTraits bool `type:"structure"`
+	_ struct{} `type:"structure"`
 }
 
 // String returns the string representation
@@ -3580,11 +3484,7 @@ type CreateStackInput struct {
 	// (http://docs.aws.amazon.com/AWSEC2/latest/UserGuide/ec2-supported-platforms.html).
 	VpcId *string `type:"string"`
 
-	metadataCreateStackInput `json:"-" xml:"-"`
-}
-
-type metadataCreateStackInput struct {
-	SDKShapeTraits bool `type:"structure"`
+	_ struct{} `type:"structure"`
 }
 
 // String returns the string representation
@@ -3603,11 +3503,7 @@ type CreateStackOutput struct {
 	// when performing actions such as DescribeStacks.
 	StackId *string `type:"string"`
 
-	metadataCreateStackOutput `json:"-" xml:"-"`
-}
-
-type metadataCreateStackOutput struct {
-	SDKShapeTraits bool `type:"structure"`
+	_ struct{} `type:"structure"`
 }
 
 // String returns the string representation
@@ -3638,11 +3534,7 @@ type CreateUserProfileInput struct {
 	// IAM user name.
 	SshUsername *string `type:"string"`
 
-	metadataCreateUserProfileInput `json:"-" xml:"-"`
-}
-
-type metadataCreateUserProfileInput struct {
-	SDKShapeTraits bool `type:"structure"`
+	_ struct{} `type:"structure"`
 }
 
 // String returns the string representation
@@ -3660,11 +3552,7 @@ type CreateUserProfileOutput struct {
 	// The user's IAM ARN.
 	IamUserArn *string `type:"string"`
 
-	metadataCreateUserProfileOutput `json:"-" xml:"-"`
-}
-
-type metadataCreateUserProfileOutput struct {
-	SDKShapeTraits bool `type:"structure"`
+	_ struct{} `type:"structure"`
 }
 
 // String returns the string representation
@@ -3689,11 +3577,7 @@ type DataSource struct {
 	// or RdsDbInstance.
 	Type *string `type:"string"`
 
-	metadataDataSource `json:"-" xml:"-"`
-}
-
-type metadataDataSource struct {
-	SDKShapeTraits bool `type:"structure"`
+	_ struct{} `type:"structure"`
 }
 
 // String returns the string representation
@@ -3710,11 +3594,7 @@ type DeleteAppInput struct {
 	// The app ID.
 	AppId *string `type:"string" required:"true"`
 
-	metadataDeleteAppInput `json:"-" xml:"-"`
-}
-
-type metadataDeleteAppInput struct {
-	SDKShapeTraits bool `type:"structure"`
+	_ struct{} `type:"structure"`
 }
 
 // String returns the string representation
@@ -3728,11 +3608,7 @@ func (s DeleteAppInput) GoString() string {
 }
 
 type DeleteAppOutput struct {
-	metadataDeleteAppOutput `json:"-" xml:"-"`
-}
-
-type metadataDeleteAppOutput struct {
-	SDKShapeTraits bool `type:"structure"`
+	_ struct{} `type:"structure"`
 }
 
 // String returns the string representation
@@ -3755,11 +3631,7 @@ type DeleteInstanceInput struct {
 	// The instance ID.
 	InstanceId *string `type:"string" required:"true"`
 
-	metadataDeleteInstanceInput `json:"-" xml:"-"`
-}
-
-type metadataDeleteInstanceInput struct {
-	SDKShapeTraits bool `type:"structure"`
+	_ struct{} `type:"structure"`
 }
 
 // String returns the string representation
@@ -3773,11 +3645,7 @@ func (s DeleteInstanceInput) GoString() string {
 }
 
 type DeleteInstanceOutput struct {
-	metadataDeleteInstanceOutput `json:"-" xml:"-"`
-}
-
-type metadataDeleteInstanceOutput struct {
-	SDKShapeTraits bool `type:"structure"`
+	_ struct{} `type:"structure"`
 }
 
 // String returns the string representation
@@ -3794,11 +3662,7 @@ type DeleteLayerInput struct {
 	// The layer ID.
 	LayerId *string `type:"string" required:"true"`
 
-	metadataDeleteLayerInput `json:"-" xml:"-"`
-}
-
-type metadataDeleteLayerInput struct {
-	SDKShapeTraits bool `type:"structure"`
+	_ struct{} `type:"structure"`
 }
 
 // String returns the string representation
@@ -3812,11 +3676,7 @@ func (s DeleteLayerInput) GoString() string {
 }
 
 type DeleteLayerOutput struct {
-	metadataDeleteLayerOutput `json:"-" xml:"-"`
-}
-
-type metadataDeleteLayerOutput struct {
-	SDKShapeTraits bool `type:"structure"`
+	_ struct{} `type:"structure"`
 }
 
 // String returns the string representation
@@ -3833,11 +3693,7 @@ type DeleteStackInput struct {
 	// The stack ID.
 	StackId *string `type:"string" required:"true"`
 
-	metadataDeleteStackInput `json:"-" xml:"-"`
-}
-
-type metadataDeleteStackInput struct {
-	SDKShapeTraits bool `type:"structure"`
+	_ struct{} `type:"structure"`
 }
 
 // String returns the string representation
@@ -3851,11 +3707,7 @@ func (s DeleteStackInput) GoString() string {
 }
 
 type DeleteStackOutput struct {
-	metadataDeleteStackOutput `json:"-" xml:"-"`
-}
-
-type metadataDeleteStackOutput struct {
-	SDKShapeTraits bool `type:"structure"`
+	_ struct{} `type:"structure"`
 }
 
 // String returns the string representation
@@ -3872,11 +3724,7 @@ type DeleteUserProfileInput struct {
 	// The user's IAM ARN.
 	IamUserArn *string `type:"string" required:"true"`
 
-	metadataDeleteUserProfileInput `json:"-" xml:"-"`
-}
-
-type metadataDeleteUserProfileInput struct {
-	SDKShapeTraits bool `type:"structure"`
+	_ struct{} `type:"structure"`
 }
 
 // String returns the string representation
@@ -3890,11 +3738,7 @@ func (s DeleteUserProfileInput) GoString() string {
 }
 
 type DeleteUserProfileOutput struct {
-	metadataDeleteUserProfileOutput `json:"-" xml:"-"`
-}
-
-type metadataDeleteUserProfileOutput struct {
-	SDKShapeTraits bool `type:"structure"`
+	_ struct{} `type:"structure"`
 }
 
 // String returns the string representation
@@ -3955,11 +3799,7 @@ type Deployment struct {
 	//  running successful failed
 	Status *string `type:"string"`
 
-	metadataDeployment `json:"-" xml:"-"`
-}
-
-type metadataDeployment struct {
-	SDKShapeTraits bool `type:"structure"`
+	_ struct{} `type:"structure"`
 }
 
 // String returns the string representation
@@ -4018,11 +3858,7 @@ type DeploymentCommand struct {
 	// the app.
 	Name *string `type:"string" required:"true" enum:"DeploymentCommandName"`
 
-	metadataDeploymentCommand `json:"-" xml:"-"`
-}
-
-type metadataDeploymentCommand struct {
-	SDKShapeTraits bool `type:"structure"`
+	_ struct{} `type:"structure"`
 }
 
 // String returns the string representation
@@ -4039,11 +3875,7 @@ type DeregisterEcsClusterInput struct {
 	// The cluster's ARN.
 	EcsClusterArn *string `type:"string" required:"true"`
 
-	metadataDeregisterEcsClusterInput `json:"-" xml:"-"`
-}
-
-type metadataDeregisterEcsClusterInput struct {
-	SDKShapeTraits bool `type:"structure"`
+	_ struct{} `type:"structure"`
 }
 
 // String returns the string representation
@@ -4057,11 +3889,7 @@ func (s DeregisterEcsClusterInput) GoString() string {
 }
 
 type DeregisterEcsClusterOutput struct {
-	metadataDeregisterEcsClusterOutput `json:"-" xml:"-"`
-}
-
-type metadataDeregisterEcsClusterOutput struct {
-	SDKShapeTraits bool `type:"structure"`
+	_ struct{} `type:"structure"`
 }
 
 // String returns the string representation
@@ -4078,11 +3906,7 @@ type DeregisterElasticIpInput struct {
 	// The Elastic IP address.
 	ElasticIp *string `type:"string" required:"true"`
 
-	metadataDeregisterElasticIpInput `json:"-" xml:"-"`
-}
-
-type metadataDeregisterElasticIpInput struct {
-	SDKShapeTraits bool `type:"structure"`
+	_ struct{} `type:"structure"`
 }
 
 // String returns the string representation
@@ -4096,11 +3920,7 @@ func (s DeregisterElasticIpInput) GoString() string {
 }
 
 type DeregisterElasticIpOutput struct {
-	metadataDeregisterElasticIpOutput `json:"-" xml:"-"`
-}
-
-type metadataDeregisterElasticIpOutput struct {
-	SDKShapeTraits bool `type:"structure"`
+	_ struct{} `type:"structure"`
 }
 
 // String returns the string representation
@@ -4117,11 +3937,7 @@ type DeregisterInstanceInput struct {
 	// The instance ID.
 	InstanceId *string `type:"string" required:"true"`
 
-	metadataDeregisterInstanceInput `json:"-" xml:"-"`
-}
-
-type metadataDeregisterInstanceInput struct {
-	SDKShapeTraits bool `type:"structure"`
+	_ struct{} `type:"structure"`
 }
 
 // String returns the string representation
@@ -4135,11 +3951,7 @@ func (s DeregisterInstanceInput) GoString() string {
 }
 
 type DeregisterInstanceOutput struct {
-	metadataDeregisterInstanceOutput `json:"-" xml:"-"`
-}
-
-type metadataDeregisterInstanceOutput struct {
-	SDKShapeTraits bool `type:"structure"`
+	_ struct{} `type:"structure"`
 }
 
 // String returns the string representation
@@ -4156,11 +3968,7 @@ type DeregisterRdsDbInstanceInput struct {
 	// The Amazon RDS instance's ARN.
 	RdsDbInstanceArn *string `type:"string" required:"true"`
 
-	metadataDeregisterRdsDbInstanceInput `json:"-" xml:"-"`
-}
-
-type metadataDeregisterRdsDbInstanceInput struct {
-	SDKShapeTraits bool `type:"structure"`
+	_ struct{} `type:"structure"`
 }
 
 // String returns the string representation
@@ -4174,11 +3982,7 @@ func (s DeregisterRdsDbInstanceInput) GoString() string {
 }
 
 type DeregisterRdsDbInstanceOutput struct {
-	metadataDeregisterRdsDbInstanceOutput `json:"-" xml:"-"`
-}
-
-type metadataDeregisterRdsDbInstanceOutput struct {
-	SDKShapeTraits bool `type:"structure"`
+	_ struct{} `type:"structure"`
 }
 
 // String returns the string representation
@@ -4197,11 +4001,7 @@ type DeregisterVolumeInput struct {
 	// EC2 volume ID.
 	VolumeId *string `type:"string" required:"true"`
 
-	metadataDeregisterVolumeInput `json:"-" xml:"-"`
-}
-
-type metadataDeregisterVolumeInput struct {
-	SDKShapeTraits bool `type:"structure"`
+	_ struct{} `type:"structure"`
 }
 
 // String returns the string representation
@@ -4215,11 +4015,7 @@ func (s DeregisterVolumeInput) GoString() string {
 }
 
 type DeregisterVolumeOutput struct {
-	metadataDeregisterVolumeOutput `json:"-" xml:"-"`
-}
-
-type metadataDeregisterVolumeOutput struct {
-	SDKShapeTraits bool `type:"structure"`
+	_ struct{} `type:"structure"`
 }
 
 // String returns the string representation
@@ -4239,11 +4035,7 @@ type DescribeAgentVersionsInput struct {
 	// The stack ID.
 	StackId *string `type:"string"`
 
-	metadataDescribeAgentVersionsInput `json:"-" xml:"-"`
-}
-
-type metadataDescribeAgentVersionsInput struct {
-	SDKShapeTraits bool `type:"structure"`
+	_ struct{} `type:"structure"`
 }
 
 // String returns the string representation
@@ -4263,11 +4055,7 @@ type DescribeAgentVersionsOutput struct {
 	// used by the console.
 	AgentVersions []*AgentVersion `type:"list"`
 
-	metadataDescribeAgentVersionsOutput `json:"-" xml:"-"`
-}
-
-type metadataDescribeAgentVersionsOutput struct {
-	SDKShapeTraits bool `type:"structure"`
+	_ struct{} `type:"structure"`
 }
 
 // String returns the string representation
@@ -4290,11 +4078,7 @@ type DescribeAppsInput struct {
 	// of the apps in the specified stack.
 	StackId *string `type:"string"`
 
-	metadataDescribeAppsInput `json:"-" xml:"-"`
-}
-
-type metadataDescribeAppsInput struct {
-	SDKShapeTraits bool `type:"structure"`
+	_ struct{} `type:"structure"`
 }
 
 // String returns the string representation
@@ -4312,11 +4096,7 @@ type DescribeAppsOutput struct {
 	// An array of App objects that describe the specified apps.
 	Apps []*App `type:"list"`
 
-	metadataDescribeAppsOutput `json:"-" xml:"-"`
-}
-
-type metadataDescribeAppsOutput struct {
-	SDKShapeTraits bool `type:"structure"`
+	_ struct{} `type:"structure"`
 }
 
 // String returns the string representation
@@ -4343,11 +4123,7 @@ type DescribeCommandsInput struct {
 	// a description of the commands associated with the specified instance.
 	InstanceId *string `type:"string"`
 
-	metadataDescribeCommandsInput `json:"-" xml:"-"`
-}
-
-type metadataDescribeCommandsInput struct {
-	SDKShapeTraits bool `type:"structure"`
+	_ struct{} `type:"structure"`
 }
 
 // String returns the string representation
@@ -4365,11 +4141,7 @@ type DescribeCommandsOutput struct {
 	// An array of Command objects that describe each of the specified commands.
 	Commands []*Command `type:"list"`
 
-	metadataDescribeCommandsOutput `json:"-" xml:"-"`
-}
-
-type metadataDescribeCommandsOutput struct {
-	SDKShapeTraits bool `type:"structure"`
+	_ struct{} `type:"structure"`
 }
 
 // String returns the string representation
@@ -4396,11 +4168,7 @@ type DescribeDeploymentsInput struct {
 	// a description of the commands associated with the specified stack.
 	StackId *string `type:"string"`
 
-	metadataDescribeDeploymentsInput `json:"-" xml:"-"`
-}
-
-type metadataDescribeDeploymentsInput struct {
-	SDKShapeTraits bool `type:"structure"`
+	_ struct{} `type:"structure"`
 }
 
 // String returns the string representation
@@ -4418,11 +4186,7 @@ type DescribeDeploymentsOutput struct {
 	// An array of Deployment objects that describe the deployments.
 	Deployments []*Deployment `type:"list"`
 
-	metadataDescribeDeploymentsOutput `json:"-" xml:"-"`
-}
-
-type metadataDescribeDeploymentsOutput struct {
-	SDKShapeTraits bool `type:"structure"`
+	_ struct{} `type:"structure"`
 }
 
 // String returns the string representation
@@ -4457,11 +4221,7 @@ type DescribeEcsClustersInput struct {
 	// is registered with the stack.
 	StackId *string `type:"string"`
 
-	metadataDescribeEcsClustersInput `json:"-" xml:"-"`
-}
-
-type metadataDescribeEcsClustersInput struct {
-	SDKShapeTraits bool `type:"structure"`
+	_ struct{} `type:"structure"`
 }
 
 // String returns the string representation
@@ -4485,11 +4245,7 @@ type DescribeEcsClustersOutput struct {
 	// request returned all of the remaining results, this parameter is set to null.
 	NextToken *string `type:"string"`
 
-	metadataDescribeEcsClustersOutput `json:"-" xml:"-"`
-}
-
-type metadataDescribeEcsClustersOutput struct {
-	SDKShapeTraits bool `type:"structure"`
+	_ struct{} `type:"structure"`
 }
 
 // String returns the string representation
@@ -4516,11 +4272,7 @@ type DescribeElasticIpsInput struct {
 	// of the Elastic IP addresses that are registered with the specified stack.
 	StackId *string `type:"string"`
 
-	metadataDescribeElasticIpsInput `json:"-" xml:"-"`
-}
-
-type metadataDescribeElasticIpsInput struct {
-	SDKShapeTraits bool `type:"structure"`
+	_ struct{} `type:"structure"`
 }
 
 // String returns the string representation
@@ -4538,11 +4290,7 @@ type DescribeElasticIpsOutput struct {
 	// An ElasticIps object that describes the specified Elastic IP addresses.
 	ElasticIps []*ElasticIp `type:"list"`
 
-	metadataDescribeElasticIpsOutput `json:"-" xml:"-"`
-}
-
-type metadataDescribeElasticIpsOutput struct {
-	SDKShapeTraits bool `type:"structure"`
+	_ struct{} `type:"structure"`
 }
 
 // String returns the string representation
@@ -4563,11 +4311,7 @@ type DescribeElasticLoadBalancersInput struct {
 	// A stack ID. The action describes the stack's Elastic Load Balancing instances.
 	StackId *string `type:"string"`
 
-	metadataDescribeElasticLoadBalancersInput `json:"-" xml:"-"`
-}
-
-type metadataDescribeElasticLoadBalancersInput struct {
-	SDKShapeTraits bool `type:"structure"`
+	_ struct{} `type:"structure"`
 }
 
 // String returns the string representation
@@ -4586,11 +4330,7 @@ type DescribeElasticLoadBalancersOutput struct {
 	// Load Balancing instances.
 	ElasticLoadBalancers []*ElasticLoadBalancer `type:"list"`
 
-	metadataDescribeElasticLoadBalancersOutput `json:"-" xml:"-"`
-}
-
-type metadataDescribeElasticLoadBalancersOutput struct {
-	SDKShapeTraits bool `type:"structure"`
+	_ struct{} `type:"structure"`
 }
 
 // String returns the string representation
@@ -4617,11 +4357,7 @@ type DescribeInstancesInput struct {
 	// of the instances associated with the specified stack.
 	StackId *string `type:"string"`
 
-	metadataDescribeInstancesInput `json:"-" xml:"-"`
-}
-
-type metadataDescribeInstancesInput struct {
-	SDKShapeTraits bool `type:"structure"`
+	_ struct{} `type:"structure"`
 }
 
 // String returns the string representation
@@ -4639,11 +4375,7 @@ type DescribeInstancesOutput struct {
 	// An array of Instance objects that describe the instances.
 	Instances []*Instance `type:"list"`
 
-	metadataDescribeInstancesOutput `json:"-" xml:"-"`
-}
-
-type metadataDescribeInstancesOutput struct {
-	SDKShapeTraits bool `type:"structure"`
+	_ struct{} `type:"structure"`
 }
 
 // String returns the string representation
@@ -4665,11 +4397,7 @@ type DescribeLayersInput struct {
 	// The stack ID.
 	StackId *string `type:"string"`
 
-	metadataDescribeLayersInput `json:"-" xml:"-"`
-}
-
-type metadataDescribeLayersInput struct {
-	SDKShapeTraits bool `type:"structure"`
+	_ struct{} `type:"structure"`
 }
 
 // String returns the string representation
@@ -4687,11 +4415,7 @@ type DescribeLayersOutput struct {
 	// An array of Layer objects that describe the layers.
 	Layers []*Layer `type:"list"`
 
-	metadataDescribeLayersOutput `json:"-" xml:"-"`
-}
-
-type metadataDescribeLayersOutput struct {
-	SDKShapeTraits bool `type:"structure"`
+	_ struct{} `type:"structure"`
 }
 
 // String returns the string representation
@@ -4708,11 +4432,7 @@ type DescribeLoadBasedAutoScalingInput struct {
 	// An array of layer IDs.
 	LayerIds []*string `type:"list" required:"true"`
 
-	metadataDescribeLoadBasedAutoScalingInput `json:"-" xml:"-"`
-}
-
-type metadataDescribeLoadBasedAutoScalingInput struct {
-	SDKShapeTraits bool `type:"structure"`
+	_ struct{} `type:"structure"`
 }
 
 // String returns the string representation
@@ -4731,11 +4451,7 @@ type DescribeLoadBasedAutoScalingOutput struct {
 	// layer's configuration.
 	LoadBasedAutoScalingConfigurations []*LoadBasedAutoScalingConfiguration `type:"list"`
 
-	metadataDescribeLoadBasedAutoScalingOutput `json:"-" xml:"-"`
-}
-
-type metadataDescribeLoadBasedAutoScalingOutput struct {
-	SDKShapeTraits bool `type:"structure"`
+	_ struct{} `type:"structure"`
 }
 
 // String returns the string representation
@@ -4749,11 +4465,7 @@ func (s DescribeLoadBasedAutoScalingOutput) GoString() string {
 }
 
 type DescribeMyUserProfileInput struct {
-	metadataDescribeMyUserProfileInput `json:"-" xml:"-"`
-}
-
-type metadataDescribeMyUserProfileInput struct {
-	SDKShapeTraits bool `type:"structure"`
+	_ struct{} `type:"structure"`
 }
 
 // String returns the string representation
@@ -4771,11 +4483,7 @@ type DescribeMyUserProfileOutput struct {
 	// A UserProfile object that describes the user's SSH information.
 	UserProfile *SelfUserProfile `type:"structure"`
 
-	metadataDescribeMyUserProfileOutput `json:"-" xml:"-"`
-}
-
-type metadataDescribeMyUserProfileOutput struct {
-	SDKShapeTraits bool `type:"structure"`
+	_ struct{} `type:"structure"`
 }
 
 // String returns the string representation
@@ -4796,11 +4504,7 @@ type DescribePermissionsInput struct {
 	// The stack ID.
 	StackId *string `type:"string"`
 
-	metadataDescribePermissionsInput `json:"-" xml:"-"`
-}
-
-type metadataDescribePermissionsInput struct {
-	SDKShapeTraits bool `type:"structure"`
+	_ struct{} `type:"structure"`
 }
 
 // String returns the string representation
@@ -4825,11 +4529,7 @@ type DescribePermissionsOutput struct {
 	// for the specified stack and IAM ARN.
 	Permissions []*Permission `type:"list"`
 
-	metadataDescribePermissionsOutput `json:"-" xml:"-"`
-}
-
-type metadataDescribePermissionsOutput struct {
-	SDKShapeTraits bool `type:"structure"`
+	_ struct{} `type:"structure"`
 }
 
 // String returns the string representation
@@ -4855,11 +4555,7 @@ type DescribeRaidArraysInput struct {
 	// The stack ID.
 	StackId *string `type:"string"`
 
-	metadataDescribeRaidArraysInput `json:"-" xml:"-"`
-}
-
-type metadataDescribeRaidArraysInput struct {
-	SDKShapeTraits bool `type:"structure"`
+	_ struct{} `type:"structure"`
 }
 
 // String returns the string representation
@@ -4877,11 +4573,7 @@ type DescribeRaidArraysOutput struct {
 	// A RaidArrays object that describes the specified RAID arrays.
 	RaidArrays []*RaidArray `type:"list"`
 
-	metadataDescribeRaidArraysOutput `json:"-" xml:"-"`
-}
-
-type metadataDescribeRaidArraysOutput struct {
-	SDKShapeTraits bool `type:"structure"`
+	_ struct{} `type:"structure"`
 }
 
 // String returns the string representation
@@ -4902,11 +4594,7 @@ type DescribeRdsDbInstancesInput struct {
 	// descriptions of all registered Amazon RDS instances.
 	StackId *string `type:"string" required:"true"`
 
-	metadataDescribeRdsDbInstancesInput `json:"-" xml:"-"`
-}
-
-type metadataDescribeRdsDbInstancesInput struct {
-	SDKShapeTraits bool `type:"structure"`
+	_ struct{} `type:"structure"`
 }
 
 // String returns the string representation
@@ -4924,11 +4612,7 @@ type DescribeRdsDbInstancesOutput struct {
 	// An a array of RdsDbInstance objects that describe the instances.
 	RdsDbInstances []*RdsDbInstance `type:"list"`
 
-	metadataDescribeRdsDbInstancesOutput `json:"-" xml:"-"`
-}
-
-type metadataDescribeRdsDbInstancesOutput struct {
-	SDKShapeTraits bool `type:"structure"`
+	_ struct{} `type:"structure"`
 }
 
 // String returns the string representation
@@ -4955,11 +4639,7 @@ type DescribeServiceErrorsInput struct {
 	// of the errors associated with the specified stack.
 	StackId *string `type:"string"`
 
-	metadataDescribeServiceErrorsInput `json:"-" xml:"-"`
-}
-
-type metadataDescribeServiceErrorsInput struct {
-	SDKShapeTraits bool `type:"structure"`
+	_ struct{} `type:"structure"`
 }
 
 // String returns the string representation
@@ -4977,11 +4657,7 @@ type DescribeServiceErrorsOutput struct {
 	// An array of ServiceError objects that describe the specified service errors.
 	ServiceErrors []*ServiceError `type:"list"`
 
-	metadataDescribeServiceErrorsOutput `json:"-" xml:"-"`
-}
-
-type metadataDescribeServiceErrorsOutput struct {
-	SDKShapeTraits bool `type:"structure"`
+	_ struct{} `type:"structure"`
 }
 
 // String returns the string representation
@@ -4998,11 +4674,7 @@ type DescribeStackProvisioningParametersInput struct {
 	// The stack ID
 	StackId *string `type:"string" required:"true"`
 
-	metadataDescribeStackProvisioningParametersInput `json:"-" xml:"-"`
-}
-
-type metadataDescribeStackProvisioningParametersInput struct {
-	SDKShapeTraits bool `type:"structure"`
+	_ struct{} `type:"structure"`
 }
 
 // String returns the string representation
@@ -5023,11 +4695,7 @@ type DescribeStackProvisioningParametersOutput struct {
 	// An embedded object that contains the provisioning parameters.
 	Parameters map[string]*string `type:"map"`
 
-	metadataDescribeStackProvisioningParametersOutput `json:"-" xml:"-"`
-}
-
-type metadataDescribeStackProvisioningParametersOutput struct {
-	SDKShapeTraits bool `type:"structure"`
+	_ struct{} `type:"structure"`
 }
 
 // String returns the string representation
@@ -5044,11 +4712,7 @@ type DescribeStackSummaryInput struct {
 	// The stack ID.
 	StackId *string `type:"string" required:"true"`
 
-	metadataDescribeStackSummaryInput `json:"-" xml:"-"`
-}
-
-type metadataDescribeStackSummaryInput struct {
-	SDKShapeTraits bool `type:"structure"`
+	_ struct{} `type:"structure"`
 }
 
 // String returns the string representation
@@ -5066,11 +4730,7 @@ type DescribeStackSummaryOutput struct {
 	// A StackSummary object that contains the results.
 	StackSummary *StackSummary `type:"structure"`
 
-	metadataDescribeStackSummaryOutput `json:"-" xml:"-"`
-}
-
-type metadataDescribeStackSummaryOutput struct {
-	SDKShapeTraits bool `type:"structure"`
+	_ struct{} `type:"structure"`
 }
 
 // String returns the string representation
@@ -5088,11 +4748,7 @@ type DescribeStacksInput struct {
 	// this parameter, DescribeStacks returns a description of every stack.
 	StackIds []*string `type:"list"`
 
-	metadataDescribeStacksInput `json:"-" xml:"-"`
-}
-
-type metadataDescribeStacksInput struct {
-	SDKShapeTraits bool `type:"structure"`
+	_ struct{} `type:"structure"`
 }
 
 // String returns the string representation
@@ -5110,11 +4766,7 @@ type DescribeStacksOutput struct {
 	// An array of Stack objects that describe the stacks.
 	Stacks []*Stack `type:"list"`
 
-	metadataDescribeStacksOutput `json:"-" xml:"-"`
-}
-
-type metadataDescribeStacksOutput struct {
-	SDKShapeTraits bool `type:"structure"`
+	_ struct{} `type:"structure"`
 }
 
 // String returns the string representation
@@ -5131,11 +4783,7 @@ type DescribeTimeBasedAutoScalingInput struct {
 	// An array of instance IDs.
 	InstanceIds []*string `type:"list" required:"true"`
 
-	metadataDescribeTimeBasedAutoScalingInput `json:"-" xml:"-"`
-}
-
-type metadataDescribeTimeBasedAutoScalingInput struct {
-	SDKShapeTraits bool `type:"structure"`
+	_ struct{} `type:"structure"`
 }
 
 // String returns the string representation
@@ -5154,11 +4802,7 @@ type DescribeTimeBasedAutoScalingOutput struct {
 	// for the specified instances.
 	TimeBasedAutoScalingConfigurations []*TimeBasedAutoScalingConfiguration `type:"list"`
 
-	metadataDescribeTimeBasedAutoScalingOutput `json:"-" xml:"-"`
-}
-
-type metadataDescribeTimeBasedAutoScalingOutput struct {
-	SDKShapeTraits bool `type:"structure"`
+	_ struct{} `type:"structure"`
 }
 
 // String returns the string representation
@@ -5175,11 +4819,7 @@ type DescribeUserProfilesInput struct {
 	// An array of IAM user ARNs that identify the users to be described.
 	IamUserArns []*string `type:"list"`
 
-	metadataDescribeUserProfilesInput `json:"-" xml:"-"`
-}
-
-type metadataDescribeUserProfilesInput struct {
-	SDKShapeTraits bool `type:"structure"`
+	_ struct{} `type:"structure"`
 }
 
 // String returns the string representation
@@ -5197,11 +4837,7 @@ type DescribeUserProfilesOutput struct {
 	// A Users object that describes the specified users.
 	UserProfiles []*UserProfile `type:"list"`
 
-	metadataDescribeUserProfilesOutput `json:"-" xml:"-"`
-}
-
-type metadataDescribeUserProfilesOutput struct {
-	SDKShapeTraits bool `type:"structure"`
+	_ struct{} `type:"structure"`
 }
 
 // String returns the string representation
@@ -5231,11 +4867,7 @@ type DescribeVolumesInput struct {
 	// of every volume.
 	VolumeIds []*string `type:"list"`
 
-	metadataDescribeVolumesInput `json:"-" xml:"-"`
-}
-
-type metadataDescribeVolumesInput struct {
-	SDKShapeTraits bool `type:"structure"`
+	_ struct{} `type:"structure"`
 }
 
 // String returns the string representation
@@ -5253,11 +4885,7 @@ type DescribeVolumesOutput struct {
 	// An array of volume IDs.
 	Volumes []*Volume `type:"list"`
 
-	metadataDescribeVolumesOutput `json:"-" xml:"-"`
-}
-
-type metadataDescribeVolumesOutput struct {
-	SDKShapeTraits bool `type:"structure"`
+	_ struct{} `type:"structure"`
 }
 
 // String returns the string representation
@@ -5278,11 +4906,7 @@ type DetachElasticLoadBalancerInput struct {
 	// to.
 	LayerId *string `type:"string" required:"true"`
 
-	metadataDetachElasticLoadBalancerInput `json:"-" xml:"-"`
-}
-
-type metadataDetachElasticLoadBalancerInput struct {
-	SDKShapeTraits bool `type:"structure"`
+	_ struct{} `type:"structure"`
 }
 
 // String returns the string representation
@@ -5296,11 +4920,7 @@ func (s DetachElasticLoadBalancerInput) GoString() string {
 }
 
 type DetachElasticLoadBalancerOutput struct {
-	metadataDetachElasticLoadBalancerOutput `json:"-" xml:"-"`
-}
-
-type metadataDetachElasticLoadBalancerOutput struct {
-	SDKShapeTraits bool `type:"structure"`
+	_ struct{} `type:"structure"`
 }
 
 // String returns the string representation
@@ -5317,11 +4937,7 @@ type DisassociateElasticIpInput struct {
 	// The Elastic IP address.
 	ElasticIp *string `type:"string" required:"true"`
 
-	metadataDisassociateElasticIpInput `json:"-" xml:"-"`
-}
-
-type metadataDisassociateElasticIpInput struct {
-	SDKShapeTraits bool `type:"structure"`
+	_ struct{} `type:"structure"`
 }
 
 // String returns the string representation
@@ -5335,11 +4951,7 @@ func (s DisassociateElasticIpInput) GoString() string {
 }
 
 type DisassociateElasticIpOutput struct {
-	metadataDisassociateElasticIpOutput `json:"-" xml:"-"`
-}
-
-type metadataDisassociateElasticIpOutput struct {
-	SDKShapeTraits bool `type:"structure"`
+	_ struct{} `type:"structure"`
 }
 
 // String returns the string representation
@@ -5373,11 +4985,7 @@ type EbsBlockDevice struct {
 	// IOPS (SSD) volumes, and standard for Magnetic volumes.
 	VolumeType *string `type:"string" enum:"VolumeType"`
 
-	metadataEbsBlockDevice `json:"-" xml:"-"`
-}
-
-type metadataEbsBlockDevice struct {
-	SDKShapeTraits bool `type:"structure"`
+	_ struct{} `type:"structure"`
 }
 
 // String returns the string representation
@@ -5404,11 +5012,7 @@ type EcsCluster struct {
 	// The stack ID.
 	StackId *string `type:"string"`
 
-	metadataEcsCluster `json:"-" xml:"-"`
-}
-
-type metadataEcsCluster struct {
-	SDKShapeTraits bool `type:"structure"`
+	_ struct{} `type:"structure"`
 }
 
 // String returns the string representation
@@ -5438,11 +5042,7 @@ type ElasticIp struct {
 	// The AWS region. For more information, see Regions and Endpoints (http://docs.aws.amazon.com/general/latest/gr/rande.html).
 	Region *string `type:"string"`
 
-	metadataElasticIp `json:"-" xml:"-"`
-}
-
-type metadataElasticIp struct {
-	SDKShapeTraits bool `type:"structure"`
+	_ struct{} `type:"structure"`
 }
 
 // String returns the string representation
@@ -5485,11 +5085,7 @@ type ElasticLoadBalancer struct {
 	// The VPC ID.
 	VpcId *string `type:"string"`
 
-	metadataElasticLoadBalancer `json:"-" xml:"-"`
-}
-
-type metadataElasticLoadBalancer struct {
-	SDKShapeTraits bool `type:"structure"`
+	_ struct{} `type:"structure"`
 }
 
 // String returns the string representation
@@ -5521,11 +5117,7 @@ type EnvironmentVariable struct {
 	// be printable.
 	Value *string `type:"string" required:"true"`
 
-	metadataEnvironmentVariable `json:"-" xml:"-"`
-}
-
-type metadataEnvironmentVariable struct {
-	SDKShapeTraits bool `type:"structure"`
+	_ struct{} `type:"structure"`
 }
 
 // String returns the string representation
@@ -5542,11 +5134,7 @@ type GetHostnameSuggestionInput struct {
 	// The layer ID.
 	LayerId *string `type:"string" required:"true"`
 
-	metadataGetHostnameSuggestionInput `json:"-" xml:"-"`
-}
-
-type metadataGetHostnameSuggestionInput struct {
-	SDKShapeTraits bool `type:"structure"`
+	_ struct{} `type:"structure"`
 }
 
 // String returns the string representation
@@ -5567,11 +5155,7 @@ type GetHostnameSuggestionOutput struct {
 	// The layer ID.
 	LayerId *string `type:"string"`
 
-	metadataGetHostnameSuggestionOutput `json:"-" xml:"-"`
-}
-
-type metadataGetHostnameSuggestionOutput struct {
-	SDKShapeTraits bool `type:"structure"`
+	_ struct{} `type:"structure"`
 }
 
 // String returns the string representation
@@ -5594,11 +5178,7 @@ type GrantAccessInput struct {
 	// will be logged out.
 	ValidForInMinutes *int64 `min:"60" type:"integer"`
 
-	metadataGrantAccessInput `json:"-" xml:"-"`
-}
-
-type metadataGrantAccessInput struct {
-	SDKShapeTraits bool `type:"structure"`
+	_ struct{} `type:"structure"`
 }
 
 // String returns the string representation
@@ -5617,11 +5197,7 @@ type GrantAccessOutput struct {
 	// instance by RDP clients, such as the Microsoft Remote Desktop Connection.
 	TemporaryCredential *TemporaryCredential `type:"structure"`
 
-	metadataGrantAccessOutput `json:"-" xml:"-"`
-}
-
-type metadataGrantAccessOutput struct {
-	SDKShapeTraits bool `type:"structure"`
+	_ struct{} `type:"structure"`
 }
 
 // String returns the string representation
@@ -5770,11 +5346,7 @@ type Instance struct {
 	// The instance's virtualization type: paravirtual or hvm.
 	VirtualizationType *string `type:"string" enum:"VirtualizationType"`
 
-	metadataInstance `json:"-" xml:"-"`
-}
-
-type metadataInstance struct {
-	SDKShapeTraits bool `type:"structure"`
+	_ struct{} `type:"structure"`
 }
 
 // String returns the string representation
@@ -5796,11 +5368,7 @@ type InstanceIdentity struct {
 	// A signature that can be used to verify the document's accuracy and authenticity.
 	Signature *string `type:"string"`
 
-	metadataInstanceIdentity `json:"-" xml:"-"`
-}
-
-type metadataInstanceIdentity struct {
-	SDKShapeTraits bool `type:"structure"`
+	_ struct{} `type:"structure"`
 }
 
 // String returns the string representation
@@ -5872,11 +5440,7 @@ type InstancesCount struct {
 	// The number of instances in the Unassigning state.
 	Unassigning *int64 `type:"integer"`
 
-	metadataInstancesCount `json:"-" xml:"-"`
-}
-
-type metadataInstancesCount struct {
-	SDKShapeTraits bool `type:"structure"`
+	_ struct{} `type:"structure"`
 }
 
 // String returns the string representation
@@ -5982,11 +5546,7 @@ type Layer struct {
 	// A VolumeConfigurations object that describes the layer's Amazon EBS volumes.
 	VolumeConfigurations []*VolumeConfiguration `type:"list"`
 
-	metadataLayer `json:"-" xml:"-"`
-}
-
-type metadataLayer struct {
-	SDKShapeTraits bool `type:"structure"`
+	_ struct{} `type:"structure"`
 }
 
 // String returns the string representation
@@ -6004,11 +5564,7 @@ type LifecycleEventConfiguration struct {
 	// A ShutdownEventConfiguration object that specifies the Shutdown event configuration.
 	Shutdown *ShutdownEventConfiguration `type:"structure"`
 
-	metadataLifecycleEventConfiguration `json:"-" xml:"-"`
-}
-
-type metadataLifecycleEventConfiguration struct {
-	SDKShapeTraits bool `type:"structure"`
+	_ struct{} `type:"structure"`
 }
 
 // String returns the string representation
@@ -6037,11 +5593,7 @@ type LoadBasedAutoScalingConfiguration struct {
 	// which defines how and when AWS OpsWorks increases the number of instances.
 	UpScaling *AutoScalingThresholds `type:"structure"`
 
-	metadataLoadBasedAutoScalingConfiguration `json:"-" xml:"-"`
-}
-
-type metadataLoadBasedAutoScalingConfiguration struct {
-	SDKShapeTraits bool `type:"structure"`
+	_ struct{} `type:"structure"`
 }
 
 // String returns the string representation
@@ -6075,11 +5627,7 @@ type Permission struct {
 	// A stack ID.
 	StackId *string `type:"string"`
 
-	metadataPermission `json:"-" xml:"-"`
-}
-
-type metadataPermission struct {
-	SDKShapeTraits bool `type:"structure"`
+	_ struct{} `type:"structure"`
 }
 
 // String returns the string representation
@@ -6134,11 +5682,7 @@ type RaidArray struct {
 	// The volume type, standard or PIOPS.
 	VolumeType *string `type:"string"`
 
-	metadataRaidArray `json:"-" xml:"-"`
-}
-
-type metadataRaidArray struct {
-	SDKShapeTraits bool `type:"structure"`
+	_ struct{} `type:"structure"`
 }
 
 // String returns the string representation
@@ -6182,11 +5726,7 @@ type RdsDbInstance struct {
 	// The ID of the stack that the instance is registered with.
 	StackId *string `type:"string"`
 
-	metadataRdsDbInstance `json:"-" xml:"-"`
-}
-
-type metadataRdsDbInstance struct {
-	SDKShapeTraits bool `type:"structure"`
+	_ struct{} `type:"structure"`
 }
 
 // String returns the string representation
@@ -6203,11 +5743,7 @@ type RebootInstanceInput struct {
 	// The instance ID.
 	InstanceId *string `type:"string" required:"true"`
 
-	metadataRebootInstanceInput `json:"-" xml:"-"`
-}
-
-type metadataRebootInstanceInput struct {
-	SDKShapeTraits bool `type:"structure"`
+	_ struct{} `type:"structure"`
 }
 
 // String returns the string representation
@@ -6221,11 +5757,7 @@ func (s RebootInstanceInput) GoString() string {
 }
 
 type RebootInstanceOutput struct {
-	metadataRebootInstanceOutput `json:"-" xml:"-"`
-}
-
-type metadataRebootInstanceOutput struct {
-	SDKShapeTraits bool `type:"structure"`
+	_ struct{} `type:"structure"`
 }
 
 // String returns the string representation
@@ -6265,11 +5797,7 @@ type Recipes struct {
 	// An array of custom recipe names to be run following a undeploy event.
 	Undeploy []*string `type:"list"`
 
-	metadataRecipes `json:"-" xml:"-"`
-}
-
-type metadataRecipes struct {
-	SDKShapeTraits bool `type:"structure"`
+	_ struct{} `type:"structure"`
 }
 
 // String returns the string representation
@@ -6289,11 +5817,7 @@ type RegisterEcsClusterInput struct {
 	// The stack ID.
 	StackId *string `type:"string" required:"true"`
 
-	metadataRegisterEcsClusterInput `json:"-" xml:"-"`
-}
-
-type metadataRegisterEcsClusterInput struct {
-	SDKShapeTraits bool `type:"structure"`
+	_ struct{} `type:"structure"`
 }
 
 // String returns the string representation
@@ -6311,11 +5835,7 @@ type RegisterEcsClusterOutput struct {
 	// The cluster's ARN.
 	EcsClusterArn *string `type:"string"`
 
-	metadataRegisterEcsClusterOutput `json:"-" xml:"-"`
-}
-
-type metadataRegisterEcsClusterOutput struct {
-	SDKShapeTraits bool `type:"structure"`
+	_ struct{} `type:"structure"`
 }
 
 // String returns the string representation
@@ -6335,11 +5855,7 @@ type RegisterElasticIpInput struct {
 	// The stack ID.
 	StackId *string `type:"string" required:"true"`
 
-	metadataRegisterElasticIpInput `json:"-" xml:"-"`
-}
-
-type metadataRegisterElasticIpInput struct {
-	SDKShapeTraits bool `type:"structure"`
+	_ struct{} `type:"structure"`
 }
 
 // String returns the string representation
@@ -6357,11 +5873,7 @@ type RegisterElasticIpOutput struct {
 	// The Elastic IP address.
 	ElasticIp *string `type:"string"`
 
-	metadataRegisterElasticIpOutput `json:"-" xml:"-"`
-}
-
-type metadataRegisterElasticIpOutput struct {
-	SDKShapeTraits bool `type:"structure"`
+	_ struct{} `type:"structure"`
 }
 
 // String returns the string representation
@@ -6397,11 +5909,7 @@ type RegisterInstanceInput struct {
 	// The ID of the stack that the instance is to be registered with.
 	StackId *string `type:"string" required:"true"`
 
-	metadataRegisterInstanceInput `json:"-" xml:"-"`
-}
-
-type metadataRegisterInstanceInput struct {
-	SDKShapeTraits bool `type:"structure"`
+	_ struct{} `type:"structure"`
 }
 
 // String returns the string representation
@@ -6419,11 +5927,7 @@ type RegisterInstanceOutput struct {
 	// The registered instance's AWS OpsWorks ID.
 	InstanceId *string `type:"string"`
 
-	metadataRegisterInstanceOutput `json:"-" xml:"-"`
-}
-
-type metadataRegisterInstanceOutput struct {
-	SDKShapeTraits bool `type:"structure"`
+	_ struct{} `type:"structure"`
 }
 
 // String returns the string representation
@@ -6449,11 +5953,7 @@ type RegisterRdsDbInstanceInput struct {
 	// The stack ID.
 	StackId *string `type:"string" required:"true"`
 
-	metadataRegisterRdsDbInstanceInput `json:"-" xml:"-"`
-}
-
-type metadataRegisterRdsDbInstanceInput struct {
-	SDKShapeTraits bool `type:"structure"`
+	_ struct{} `type:"structure"`
 }
 
 // String returns the string representation
@@ -6467,11 +5967,7 @@ func (s RegisterRdsDbInstanceInput) GoString() string {
 }
 
 type RegisterRdsDbInstanceOutput struct {
-	metadataRegisterRdsDbInstanceOutput `json:"-" xml:"-"`
-}
-
-type metadataRegisterRdsDbInstanceOutput struct {
-	SDKShapeTraits bool `type:"structure"`
+	_ struct{} `type:"structure"`
 }
 
 // String returns the string representation
@@ -6491,11 +5987,7 @@ type RegisterVolumeInput struct {
 	// The stack ID.
 	StackId *string `type:"string" required:"true"`
 
-	metadataRegisterVolumeInput `json:"-" xml:"-"`
-}
-
-type metadataRegisterVolumeInput struct {
-	SDKShapeTraits bool `type:"structure"`
+	_ struct{} `type:"structure"`
 }
 
 // String returns the string representation
@@ -6513,11 +6005,7 @@ type RegisterVolumeOutput struct {
 	// The volume ID.
 	VolumeId *string `type:"string"`
 
-	metadataRegisterVolumeOutput `json:"-" xml:"-"`
-}
-
-type metadataRegisterVolumeOutput struct {
-	SDKShapeTraits bool `type:"structure"`
+	_ struct{} `type:"structure"`
 }
 
 // String returns the string representation
@@ -6541,11 +6029,7 @@ type ReportedOs struct {
 	// The operating system version.
 	Version *string `type:"string"`
 
-	metadataReportedOs `json:"-" xml:"-"`
-}
-
-type metadataReportedOs struct {
-	SDKShapeTraits bool `type:"structure"`
+	_ struct{} `type:"structure"`
 }
 
 // String returns the string representation
@@ -6572,11 +6056,7 @@ type SelfUserProfile struct {
 	// The user's SSH user name.
 	SshUsername *string `type:"string"`
 
-	metadataSelfUserProfile `json:"-" xml:"-"`
-}
-
-type metadataSelfUserProfile struct {
-	SDKShapeTraits bool `type:"structure"`
+	_ struct{} `type:"structure"`
 }
 
 // String returns the string representation
@@ -6609,11 +6089,7 @@ type ServiceError struct {
 	// The error type.
 	Type *string `type:"string"`
 
-	metadataServiceError `json:"-" xml:"-"`
-}
-
-type metadataServiceError struct {
-	SDKShapeTraits bool `type:"structure"`
+	_ struct{} `type:"structure"`
 }
 
 // String returns the string representation
@@ -6643,11 +6119,7 @@ type SetLoadBasedAutoScalingInput struct {
 	// OpsWorks starts a specified number of instances.
 	UpScaling *AutoScalingThresholds `type:"structure"`
 
-	metadataSetLoadBasedAutoScalingInput `json:"-" xml:"-"`
-}
-
-type metadataSetLoadBasedAutoScalingInput struct {
-	SDKShapeTraits bool `type:"structure"`
+	_ struct{} `type:"structure"`
 }
 
 // String returns the string representation
@@ -6661,11 +6133,7 @@ func (s SetLoadBasedAutoScalingInput) GoString() string {
 }
 
 type SetLoadBasedAutoScalingOutput struct {
-	metadataSetLoadBasedAutoScalingOutput `json:"-" xml:"-"`
-}
-
-type metadataSetLoadBasedAutoScalingOutput struct {
-	SDKShapeTraits bool `type:"structure"`
+	_ struct{} `type:"structure"`
 }
 
 // String returns the string representation
@@ -6698,11 +6166,7 @@ type SetPermissionInput struct {
 	// The stack ID.
 	StackId *string `type:"string" required:"true"`
 
-	metadataSetPermissionInput `json:"-" xml:"-"`
-}
-
-type metadataSetPermissionInput struct {
-	SDKShapeTraits bool `type:"structure"`
+	_ struct{} `type:"structure"`
 }
 
 // String returns the string representation
@@ -6716,11 +6180,7 @@ func (s SetPermissionInput) GoString() string {
 }
 
 type SetPermissionOutput struct {
-	metadataSetPermissionOutput `json:"-" xml:"-"`
-}
-
-type metadataSetPermissionOutput struct {
-	SDKShapeTraits bool `type:"structure"`
+	_ struct{} `type:"structure"`
 }
 
 // String returns the string representation
@@ -6740,11 +6200,7 @@ type SetTimeBasedAutoScalingInput struct {
 	// The instance ID.
 	InstanceId *string `type:"string" required:"true"`
 
-	metadataSetTimeBasedAutoScalingInput `json:"-" xml:"-"`
-}
-
-type metadataSetTimeBasedAutoScalingInput struct {
-	SDKShapeTraits bool `type:"structure"`
+	_ struct{} `type:"structure"`
 }
 
 // String returns the string representation
@@ -6758,11 +6214,7 @@ func (s SetTimeBasedAutoScalingInput) GoString() string {
 }
 
 type SetTimeBasedAutoScalingOutput struct {
-	metadataSetTimeBasedAutoScalingOutput `json:"-" xml:"-"`
-}
-
-type metadataSetTimeBasedAutoScalingOutput struct {
-	SDKShapeTraits bool `type:"structure"`
+	_ struct{} `type:"structure"`
 }
 
 // String returns the string representation
@@ -6785,11 +6237,7 @@ type ShutdownEventConfiguration struct {
 	// event before shutting down an instance.
 	ExecutionTimeout *int64 `type:"integer"`
 
-	metadataShutdownEventConfiguration `json:"-" xml:"-"`
-}
-
-type metadataShutdownEventConfiguration struct {
-	SDKShapeTraits bool `type:"structure"`
+	_ struct{} `type:"structure"`
 }
 
 // String returns the string representation
@@ -6841,11 +6289,7 @@ type Source struct {
 	// to the user name.
 	Username *string `type:"string"`
 
-	metadataSource `json:"-" xml:"-"`
-}
-
-type metadataSource struct {
-	SDKShapeTraits bool `type:"structure"`
+	_ struct{} `type:"structure"`
 }
 
 // String returns the string representation
@@ -6870,11 +6314,7 @@ type SslConfiguration struct {
 	// The private key; the contents of the certificate's domain.kex file.
 	PrivateKey *string `type:"string" required:"true"`
 
-	metadataSslConfiguration `json:"-" xml:"-"`
-}
-
-type metadataSslConfiguration struct {
-	SDKShapeTraits bool `type:"structure"`
+	_ struct{} `type:"structure"`
 }
 
 // String returns the string representation
@@ -6976,11 +6416,7 @@ type Stack struct {
 	// The VPC ID; applicable only if the stack is running in a VPC.
 	VpcId *string `type:"string"`
 
-	metadataStack `json:"-" xml:"-"`
-}
-
-type metadataStack struct {
-	SDKShapeTraits bool `type:"structure"`
+	_ struct{} `type:"structure"`
 }
 
 // String returns the string representation
@@ -7002,11 +6438,7 @@ type StackConfigurationManager struct {
 	// default value is 11.4.
 	Version *string `type:"string"`
 
-	metadataStackConfigurationManager `json:"-" xml:"-"`
-}
-
-type metadataStackConfigurationManager struct {
-	SDKShapeTraits bool `type:"structure"`
+	_ struct{} `type:"structure"`
 }
 
 // String returns the string representation
@@ -7039,11 +6471,7 @@ type StackSummary struct {
 	// The stack ID.
 	StackId *string `type:"string"`
 
-	metadataStackSummary `json:"-" xml:"-"`
-}
-
-type metadataStackSummary struct {
-	SDKShapeTraits bool `type:"structure"`
+	_ struct{} `type:"structure"`
 }
 
 // String returns the string representation
@@ -7060,11 +6488,7 @@ type StartInstanceInput struct {
 	// The instance ID.
 	InstanceId *string `type:"string" required:"true"`
 
-	metadataStartInstanceInput `json:"-" xml:"-"`
-}
-
-type metadataStartInstanceInput struct {
-	SDKShapeTraits bool `type:"structure"`
+	_ struct{} `type:"structure"`
 }
 
 // String returns the string representation
@@ -7078,11 +6502,7 @@ func (s StartInstanceInput) GoString() string {
 }
 
 type StartInstanceOutput struct {
-	metadataStartInstanceOutput `json:"-" xml:"-"`
-}
-
-type metadataStartInstanceOutput struct {
-	SDKShapeTraits bool `type:"structure"`
+	_ struct{} `type:"structure"`
 }
 
 // String returns the string representation
@@ -7099,11 +6519,7 @@ type StartStackInput struct {
 	// The stack ID.
 	StackId *string `type:"string" required:"true"`
 
-	metadataStartStackInput `json:"-" xml:"-"`
-}
-
-type metadataStartStackInput struct {
-	SDKShapeTraits bool `type:"structure"`
+	_ struct{} `type:"structure"`
 }
 
 // String returns the string representation
@@ -7117,11 +6533,7 @@ func (s StartStackInput) GoString() string {
 }
 
 type StartStackOutput struct {
-	metadataStartStackOutput `json:"-" xml:"-"`
-}
-
-type metadataStartStackOutput struct {
-	SDKShapeTraits bool `type:"structure"`
+	_ struct{} `type:"structure"`
 }
 
 // String returns the string representation
@@ -7138,11 +6550,7 @@ type StopInstanceInput struct {
 	// The instance ID.
 	InstanceId *string `type:"string" required:"true"`
 
-	metadataStopInstanceInput `json:"-" xml:"-"`
-}
-
-type metadataStopInstanceInput struct {
-	SDKShapeTraits bool `type:"structure"`
+	_ struct{} `type:"structure"`
 }
 
 // String returns the string representation
@@ -7156,11 +6564,7 @@ func (s StopInstanceInput) GoString() string {
 }
 
 type StopInstanceOutput struct {
-	metadataStopInstanceOutput `json:"-" xml:"-"`
-}
-
-type metadataStopInstanceOutput struct {
-	SDKShapeTraits bool `type:"structure"`
+	_ struct{} `type:"structure"`
 }
 
 // String returns the string representation
@@ -7177,11 +6581,7 @@ type StopStackInput struct {
 	// The stack ID.
 	StackId *string `type:"string" required:"true"`
 
-	metadataStopStackInput `json:"-" xml:"-"`
-}
-
-type metadataStopStackInput struct {
-	SDKShapeTraits bool `type:"structure"`
+	_ struct{} `type:"structure"`
 }
 
 // String returns the string representation
@@ -7195,11 +6595,7 @@ func (s StopStackInput) GoString() string {
 }
 
 type StopStackOutput struct {
-	metadataStopStackOutput `json:"-" xml:"-"`
-}
-
-type metadataStopStackOutput struct {
-	SDKShapeTraits bool `type:"structure"`
+	_ struct{} `type:"structure"`
 }
 
 // String returns the string representation
@@ -7230,11 +6626,7 @@ type TemporaryCredential struct {
 	// logged out.
 	ValidForInMinutes *int64 `type:"integer"`
 
-	metadataTemporaryCredential `json:"-" xml:"-"`
-}
-
-type metadataTemporaryCredential struct {
-	SDKShapeTraits bool `type:"structure"`
+	_ struct{} `type:"structure"`
 }
 
 // String returns the string representation
@@ -7255,11 +6647,7 @@ type TimeBasedAutoScalingConfiguration struct {
 	// The instance ID.
 	InstanceId *string `type:"string"`
 
-	metadataTimeBasedAutoScalingConfiguration `json:"-" xml:"-"`
-}
-
-type metadataTimeBasedAutoScalingConfiguration struct {
-	SDKShapeTraits bool `type:"structure"`
+	_ struct{} `type:"structure"`
 }
 
 // String returns the string representation
@@ -7276,11 +6664,7 @@ type UnassignInstanceInput struct {
 	// The instance ID.
 	InstanceId *string `type:"string" required:"true"`
 
-	metadataUnassignInstanceInput `json:"-" xml:"-"`
-}
-
-type metadataUnassignInstanceInput struct {
-	SDKShapeTraits bool `type:"structure"`
+	_ struct{} `type:"structure"`
 }
 
 // String returns the string representation
@@ -7294,11 +6678,7 @@ func (s UnassignInstanceInput) GoString() string {
 }
 
 type UnassignInstanceOutput struct {
-	metadataUnassignInstanceOutput `json:"-" xml:"-"`
-}
-
-type metadataUnassignInstanceOutput struct {
-	SDKShapeTraits bool `type:"structure"`
+	_ struct{} `type:"structure"`
 }
 
 // String returns the string representation
@@ -7315,11 +6695,7 @@ type UnassignVolumeInput struct {
 	// The volume ID.
 	VolumeId *string `type:"string" required:"true"`
 
-	metadataUnassignVolumeInput `json:"-" xml:"-"`
-}
-
-type metadataUnassignVolumeInput struct {
-	SDKShapeTraits bool `type:"structure"`
+	_ struct{} `type:"structure"`
 }
 
 // String returns the string representation
@@ -7333,11 +6709,7 @@ func (s UnassignVolumeInput) GoString() string {
 }
 
 type UnassignVolumeOutput struct {
-	metadataUnassignVolumeOutput `json:"-" xml:"-"`
-}
-
-type metadataUnassignVolumeOutput struct {
-	SDKShapeTraits bool `type:"structure"`
+	_ struct{} `type:"structure"`
 }
 
 // String returns the string representation
@@ -7398,11 +6770,7 @@ type UpdateAppInput struct {
 	// The app type.
 	Type *string `type:"string" enum:"AppType"`
 
-	metadataUpdateAppInput `json:"-" xml:"-"`
-}
-
-type metadataUpdateAppInput struct {
-	SDKShapeTraits bool `type:"structure"`
+	_ struct{} `type:"structure"`
 }
 
 // String returns the string representation
@@ -7416,11 +6784,7 @@ func (s UpdateAppInput) GoString() string {
 }
 
 type UpdateAppOutput struct {
-	metadataUpdateAppOutput `json:"-" xml:"-"`
-}
-
-type metadataUpdateAppOutput struct {
-	SDKShapeTraits bool `type:"structure"`
+	_ struct{} `type:"structure"`
 }
 
 // String returns the string representation
@@ -7440,11 +6804,7 @@ type UpdateElasticIpInput struct {
 	// The new name.
 	Name *string `type:"string"`
 
-	metadataUpdateElasticIpInput `json:"-" xml:"-"`
-}
-
-type metadataUpdateElasticIpInput struct {
-	SDKShapeTraits bool `type:"structure"`
+	_ struct{} `type:"structure"`
 }
 
 // String returns the string representation
@@ -7458,11 +6818,7 @@ func (s UpdateElasticIpInput) GoString() string {
 }
 
 type UpdateElasticIpOutput struct {
-	metadataUpdateElasticIpOutput `json:"-" xml:"-"`
-}
-
-type metadataUpdateElasticIpOutput struct {
-	SDKShapeTraits bool `type:"structure"`
+	_ struct{} `type:"structure"`
 }
 
 // String returns the string representation
@@ -7556,11 +6912,7 @@ type UpdateInstanceInput struct {
 	// The instance's Amazon EC2 key name.
 	SshKeyName *string `type:"string"`
 
-	metadataUpdateInstanceInput `json:"-" xml:"-"`
-}
-
-type metadataUpdateInstanceInput struct {
-	SDKShapeTraits bool `type:"structure"`
+	_ struct{} `type:"structure"`
 }
 
 // String returns the string representation
@@ -7574,11 +6926,7 @@ func (s UpdateInstanceInput) GoString() string {
 }
 
 type UpdateInstanceOutput struct {
-	metadataUpdateInstanceOutput `json:"-" xml:"-"`
-}
-
-type metadataUpdateInstanceOutput struct {
-	SDKShapeTraits bool `type:"structure"`
+	_ struct{} `type:"structure"`
 }
 
 // String returns the string representation
@@ -7659,11 +7007,7 @@ type UpdateLayerInput struct {
 	// A VolumeConfigurations object that describes the layer's Amazon EBS volumes.
 	VolumeConfigurations []*VolumeConfiguration `type:"list"`
 
-	metadataUpdateLayerInput `json:"-" xml:"-"`
-}
-
-type metadataUpdateLayerInput struct {
-	SDKShapeTraits bool `type:"structure"`
+	_ struct{} `type:"structure"`
 }
 
 // String returns the string representation
@@ -7677,11 +7021,7 @@ func (s UpdateLayerInput) GoString() string {
 }
 
 type UpdateLayerOutput struct {
-	metadataUpdateLayerOutput `json:"-" xml:"-"`
-}
-
-type metadataUpdateLayerOutput struct {
-	SDKShapeTraits bool `type:"structure"`
+	_ struct{} `type:"structure"`
 }
 
 // String returns the string representation
@@ -7698,11 +7038,7 @@ type UpdateMyUserProfileInput struct {
 	// The user's SSH public key.
 	SshPublicKey *string `type:"string"`
 
-	metadataUpdateMyUserProfileInput `json:"-" xml:"-"`
-}
-
-type metadataUpdateMyUserProfileInput struct {
-	SDKShapeTraits bool `type:"structure"`
+	_ struct{} `type:"structure"`
 }
 
 // String returns the string representation
@@ -7716,11 +7052,7 @@ func (s UpdateMyUserProfileInput) GoString() string {
 }
 
 type UpdateMyUserProfileOutput struct {
-	metadataUpdateMyUserProfileOutput `json:"-" xml:"-"`
-}
-
-type metadataUpdateMyUserProfileOutput struct {
-	SDKShapeTraits bool `type:"structure"`
+	_ struct{} `type:"structure"`
 }
 
 // String returns the string representation
@@ -7743,11 +7075,7 @@ type UpdateRdsDbInstanceInput struct {
 	// The Amazon RDS instance's ARN.
 	RdsDbInstanceArn *string `type:"string" required:"true"`
 
-	metadataUpdateRdsDbInstanceInput `json:"-" xml:"-"`
-}
-
-type metadataUpdateRdsDbInstanceInput struct {
-	SDKShapeTraits bool `type:"structure"`
+	_ struct{} `type:"structure"`
 }
 
 // String returns the string representation
@@ -7761,11 +7089,7 @@ func (s UpdateRdsDbInstanceInput) GoString() string {
 }
 
 type UpdateRdsDbInstanceOutput struct {
-	metadataUpdateRdsDbInstanceOutput `json:"-" xml:"-"`
-}
-
-type metadataUpdateRdsDbInstanceOutput struct {
-	SDKShapeTraits bool `type:"structure"`
+	_ struct{} `type:"structure"`
 }
 
 // String returns the string representation
@@ -7909,11 +7233,7 @@ type UpdateStackInput struct {
 	// more information, see Create a New Stack (http://docs.aws.amazon.com/opsworks/latest/userguide/workingstacks-creating.html).
 	UseOpsworksSecurityGroups *bool `type:"boolean"`
 
-	metadataUpdateStackInput `json:"-" xml:"-"`
-}
-
-type metadataUpdateStackInput struct {
-	SDKShapeTraits bool `type:"structure"`
+	_ struct{} `type:"structure"`
 }
 
 // String returns the string representation
@@ -7927,11 +7247,7 @@ func (s UpdateStackInput) GoString() string {
 }
 
 type UpdateStackOutput struct {
-	metadataUpdateStackOutput `json:"-" xml:"-"`
-}
-
-type metadataUpdateStackOutput struct {
-	SDKShapeTraits bool `type:"structure"`
+	_ struct{} `type:"structure"`
 }
 
 // String returns the string representation
@@ -7962,11 +7278,7 @@ type UpdateUserProfileInput struct {
 	// IAM user name.
 	SshUsername *string `type:"string"`
 
-	metadataUpdateUserProfileInput `json:"-" xml:"-"`
-}
-
-type metadataUpdateUserProfileInput struct {
-	SDKShapeTraits bool `type:"structure"`
+	_ struct{} `type:"structure"`
 }
 
 // String returns the string representation
@@ -7980,11 +7292,7 @@ func (s UpdateUserProfileInput) GoString() string {
 }
 
 type UpdateUserProfileOutput struct {
-	metadataUpdateUserProfileOutput `json:"-" xml:"-"`
-}
-
-type metadataUpdateUserProfileOutput struct {
-	SDKShapeTraits bool `type:"structure"`
+	_ struct{} `type:"structure"`
 }
 
 // String returns the string representation
@@ -8007,11 +7315,7 @@ type UpdateVolumeInput struct {
 	// The volume ID.
 	VolumeId *string `type:"string" required:"true"`
 
-	metadataUpdateVolumeInput `json:"-" xml:"-"`
-}
-
-type metadataUpdateVolumeInput struct {
-	SDKShapeTraits bool `type:"structure"`
+	_ struct{} `type:"structure"`
 }
 
 // String returns the string representation
@@ -8025,11 +7329,7 @@ func (s UpdateVolumeInput) GoString() string {
 }
 
 type UpdateVolumeOutput struct {
-	metadataUpdateVolumeOutput `json:"-" xml:"-"`
-}
-
-type metadataUpdateVolumeOutput struct {
-	SDKShapeTraits bool `type:"structure"`
+	_ struct{} `type:"structure"`
 }
 
 // String returns the string representation
@@ -8060,11 +7360,7 @@ type UserProfile struct {
 	// The user's SSH user name.
 	SshUsername *string `type:"string"`
 
-	metadataUserProfile `json:"-" xml:"-"`
-}
-
-type metadataUserProfile struct {
-	SDKShapeTraits bool `type:"structure"`
+	_ struct{} `type:"structure"`
 }
 
 // String returns the string representation
@@ -8120,11 +7416,7 @@ type Volume struct {
 	// The volume type, standard or PIOPS.
 	VolumeType *string `type:"string"`
 
-	metadataVolume `json:"-" xml:"-"`
-}
-
-type metadataVolume struct {
-	SDKShapeTraits bool `type:"structure"`
+	_ struct{} `type:"structure"`
 }
 
 // String returns the string representation
@@ -8160,11 +7452,7 @@ type VolumeConfiguration struct {
 	// (SSD)
 	VolumeType *string `type:"string"`
 
-	metadataVolumeConfiguration `json:"-" xml:"-"`
-}
-
-type metadataVolumeConfiguration struct {
-	SDKShapeTraits bool `type:"structure"`
+	_ struct{} `type:"structure"`
 }
 
 // String returns the string representation
@@ -8213,11 +7501,7 @@ type WeeklyAutoScalingSchedule struct {
 	// The schedule for Wednesday.
 	Wednesday map[string]*string `type:"map"`
 
-	metadataWeeklyAutoScalingSchedule `json:"-" xml:"-"`
-}
-
-type metadataWeeklyAutoScalingSchedule struct {
-	SDKShapeTraits bool `type:"structure"`
+	_ struct{} `type:"structure"`
 }
 
 // String returns the string representation

--- a/service/opsworks/api.go
+++ b/service/opsworks/api.go
@@ -2352,13 +2352,13 @@ func (c *OpsWorks) UpdateVolume(input *UpdateVolumeInput) (*UpdateVolumeOutput, 
 
 // Describes an agent version.
 type AgentVersion struct {
+	_ struct{} `type:"structure"`
+
 	// The configuration manager.
 	ConfigurationManager *StackConfigurationManager `type:"structure"`
 
 	// The agent version.
 	Version *string `type:"string"`
-
-	_ struct{} `type:"structure"`
 }
 
 // String returns the string representation
@@ -2373,6 +2373,8 @@ func (s AgentVersion) GoString() string {
 
 // A description of the app.
 type App struct {
+	_ struct{} `type:"structure"`
+
 	// The app ID.
 	AppId *string `type:"string"`
 
@@ -2425,8 +2427,6 @@ type App struct {
 
 	// The app type.
 	Type *string `type:"string" enum:"AppType"`
-
-	_ struct{} `type:"structure"`
 }
 
 // String returns the string representation
@@ -2440,14 +2440,14 @@ func (s App) GoString() string {
 }
 
 type AssignInstanceInput struct {
+	_ struct{} `type:"structure"`
+
 	// The instance ID.
 	InstanceId *string `type:"string" required:"true"`
 
 	// The layer ID, which must correspond to a custom layer. You cannot assign
 	// a registered instance to a built-in layer.
 	LayerIds []*string `type:"list" required:"true"`
-
-	_ struct{} `type:"structure"`
 }
 
 // String returns the string representation
@@ -2475,13 +2475,13 @@ func (s AssignInstanceOutput) GoString() string {
 }
 
 type AssignVolumeInput struct {
+	_ struct{} `type:"structure"`
+
 	// The instance ID.
 	InstanceId *string `type:"string"`
 
 	// The volume ID.
 	VolumeId *string `type:"string" required:"true"`
-
-	_ struct{} `type:"structure"`
 }
 
 // String returns the string representation
@@ -2509,13 +2509,13 @@ func (s AssignVolumeOutput) GoString() string {
 }
 
 type AssociateElasticIpInput struct {
+	_ struct{} `type:"structure"`
+
 	// The Elastic IP address.
 	ElasticIp *string `type:"string" required:"true"`
 
 	// The instance ID.
 	InstanceId *string `type:"string"`
-
-	_ struct{} `type:"structure"`
 }
 
 // String returns the string representation
@@ -2543,14 +2543,14 @@ func (s AssociateElasticIpOutput) GoString() string {
 }
 
 type AttachElasticLoadBalancerInput struct {
+	_ struct{} `type:"structure"`
+
 	// The Elastic Load Balancing instance's name.
 	ElasticLoadBalancerName *string `type:"string" required:"true"`
 
 	// The ID of the layer that the Elastic Load Balancing instance is to be attached
 	// to.
 	LayerId *string `type:"string" required:"true"`
-
-	_ struct{} `type:"structure"`
 }
 
 // String returns the string representation
@@ -2580,6 +2580,8 @@ func (s AttachElasticLoadBalancerOutput) GoString() string {
 // Describes a load-based auto scaling upscaling or downscaling threshold configuration,
 // which specifies when AWS OpsWorks starts or stops load-based instances.
 type AutoScalingThresholds struct {
+	_ struct{} `type:"structure"`
+
 	// Custom Cloudwatch auto scaling alarms, to be used as thresholds. This parameter
 	// takes a list of up to five alarm names, which are case sensitive and must
 	// be in the same region as the stack.
@@ -2616,8 +2618,6 @@ type AutoScalingThresholds struct {
 	// The amount of time, in minutes, that the load must exceed a threshold before
 	// more instances are added or removed.
 	ThresholdsWaitTime *int64 `min:"1" type:"integer"`
-
-	_ struct{} `type:"structure"`
 }
 
 // String returns the string representation
@@ -2634,6 +2634,8 @@ func (s AutoScalingThresholds) GoString() string {
 // EC2 BlockDeviceMapping (http://docs.aws.amazon.com/AWSEC2/latest/APIReference/API_BlockDeviceMapping.html)
 // data type.
 type BlockDeviceMapping struct {
+	_ struct{} `type:"structure"`
+
 	// The device name that is exposed to the instance, such as /dev/sdh. For the
 	// root device, you can use the explicit device name or you can set this parameter
 	// to ROOT_DEVICE and AWS OpsWorks will provide the correct device name.
@@ -2648,8 +2650,6 @@ type BlockDeviceMapping struct {
 
 	// The virtual device name. For more information, see BlockDeviceMapping (http://docs.aws.amazon.com/AWSEC2/latest/APIReference/API_BlockDeviceMapping.html).
 	VirtualName *string `type:"string"`
-
-	_ struct{} `type:"structure"`
 }
 
 // String returns the string representation
@@ -2664,13 +2664,13 @@ func (s BlockDeviceMapping) GoString() string {
 
 // Describes the Chef configuration.
 type ChefConfiguration struct {
+	_ struct{} `type:"structure"`
+
 	// The Berkshelf version.
 	BerkshelfVersion *string `type:"string"`
 
 	// Whether to enable Berkshelf.
 	ManageBerkshelf *bool `type:"boolean"`
-
-	_ struct{} `type:"structure"`
 }
 
 // String returns the string representation
@@ -2684,6 +2684,8 @@ func (s ChefConfiguration) GoString() string {
 }
 
 type CloneStackInput struct {
+	_ struct{} `type:"structure"`
+
 	// The default AWS OpsWorks agent version. You have the following options:
 	//
 	//  Auto-update - Set this parameter to LATEST. AWS OpsWorks automatically
@@ -2858,8 +2860,6 @@ type CloneStackInput struct {
 	// For more information on default VPC and EC2 Classic, see Supported Platforms
 	// (http://docs.aws.amazon.com/AWSEC2/latest/UserGuide/ec2-supported-platforms.html).
 	VpcId *string `type:"string"`
-
-	_ struct{} `type:"structure"`
 }
 
 // String returns the string representation
@@ -2874,10 +2874,10 @@ func (s CloneStackInput) GoString() string {
 
 // Contains the response to a CloneStack request.
 type CloneStackOutput struct {
+	_ struct{} `type:"structure"`
+
 	// The cloned stack ID.
 	StackId *string `type:"string"`
-
-	_ struct{} `type:"structure"`
 }
 
 // String returns the string representation
@@ -2892,6 +2892,8 @@ func (s CloneStackOutput) GoString() string {
 
 // Describes a command.
 type Command struct {
+	_ struct{} `type:"structure"`
+
 	// Date and time when the command was acknowledged.
 	AcknowledgedAt *string `type:"string"`
 
@@ -2926,8 +2928,6 @@ type Command struct {
 	//   deploy   rollback   start   stop   restart   undeploy   update_dependencies
 	//   install_dependencies   update_custom_cookbooks   execute_recipes
 	Type *string `type:"string"`
-
-	_ struct{} `type:"structure"`
 }
 
 // String returns the string representation
@@ -2941,6 +2941,8 @@ func (s Command) GoString() string {
 }
 
 type CreateAppInput struct {
+	_ struct{} `type:"structure"`
+
 	// A Source object that specifies the app repository.
 	AppSource *Source `type:"structure"`
 
@@ -2994,8 +2996,6 @@ type CreateAppInput struct {
 	// layer. If your app isn't one of the standard types, or you prefer to implement
 	// your own Deploy recipes, specify other.
 	Type *string `type:"string" required:"true" enum:"AppType"`
-
-	_ struct{} `type:"structure"`
 }
 
 // String returns the string representation
@@ -3010,10 +3010,10 @@ func (s CreateAppInput) GoString() string {
 
 // Contains the response to a CreateApp request.
 type CreateAppOutput struct {
+	_ struct{} `type:"structure"`
+
 	// The app ID.
 	AppId *string `type:"string"`
-
-	_ struct{} `type:"structure"`
 }
 
 // String returns the string representation
@@ -3027,6 +3027,8 @@ func (s CreateAppOutput) GoString() string {
 }
 
 type CreateDeploymentInput struct {
+	_ struct{} `type:"structure"`
+
 	// The app ID. This parameter is required for app deployments, but not for other
 	// deployment commands.
 	AppId *string `type:"string"`
@@ -3053,8 +3055,6 @@ type CreateDeploymentInput struct {
 
 	// The stack ID.
 	StackId *string `type:"string" required:"true"`
-
-	_ struct{} `type:"structure"`
 }
 
 // String returns the string representation
@@ -3069,11 +3069,11 @@ func (s CreateDeploymentInput) GoString() string {
 
 // Contains the response to a CreateDeployment request.
 type CreateDeploymentOutput struct {
+	_ struct{} `type:"structure"`
+
 	// The deployment ID, which can be used with other requests to identify the
 	// deployment.
 	DeploymentId *string `type:"string"`
-
-	_ struct{} `type:"structure"`
 }
 
 // String returns the string representation
@@ -3087,6 +3087,8 @@ func (s CreateDeploymentOutput) GoString() string {
 }
 
 type CreateInstanceInput struct {
+	_ struct{} `type:"structure"`
+
 	// The default AWS OpsWorks agent version. You have the following options:
 	//
 	//   INHERIT - Use the stack's default agent version setting.  version_number
@@ -3183,8 +3185,6 @@ type CreateInstanceInput struct {
 
 	// The instance's virtualization type, paravirtual or hvm.
 	VirtualizationType *string `type:"string"`
-
-	_ struct{} `type:"structure"`
 }
 
 // String returns the string representation
@@ -3199,10 +3199,10 @@ func (s CreateInstanceInput) GoString() string {
 
 // Contains the response to a CreateInstance request.
 type CreateInstanceOutput struct {
+	_ struct{} `type:"structure"`
+
 	// The instance ID.
 	InstanceId *string `type:"string"`
-
-	_ struct{} `type:"structure"`
 }
 
 // String returns the string representation
@@ -3216,6 +3216,8 @@ func (s CreateInstanceOutput) GoString() string {
 }
 
 type CreateLayerInput struct {
+	_ struct{} `type:"structure"`
+
 	// One or more user-defined key-value pairs to be added to the stack attributes.
 	//
 	// To create a cluster layer, set the EcsClusterArn attribute to the cluster's
@@ -3292,8 +3294,6 @@ type CreateLayerInput struct {
 
 	// A VolumeConfigurations object that describes the layer's Amazon EBS volumes.
 	VolumeConfigurations []*VolumeConfiguration `type:"list"`
-
-	_ struct{} `type:"structure"`
 }
 
 // String returns the string representation
@@ -3308,10 +3308,10 @@ func (s CreateLayerInput) GoString() string {
 
 // Contains the response to a CreateLayer request.
 type CreateLayerOutput struct {
+	_ struct{} `type:"structure"`
+
 	// The layer ID.
 	LayerId *string `type:"string"`
-
-	_ struct{} `type:"structure"`
 }
 
 // String returns the string representation
@@ -3325,6 +3325,8 @@ func (s CreateLayerOutput) GoString() string {
 }
 
 type CreateStackInput struct {
+	_ struct{} `type:"structure"`
+
 	// The default AWS OpsWorks agent version. You have the following options:
 	//
 	//  Auto-update - Set this parameter to LATEST. AWS OpsWorks automatically
@@ -3483,8 +3485,6 @@ type CreateStackInput struct {
 	// For more information on default VPC and EC2-Classic, see Supported Platforms
 	// (http://docs.aws.amazon.com/AWSEC2/latest/UserGuide/ec2-supported-platforms.html).
 	VpcId *string `type:"string"`
-
-	_ struct{} `type:"structure"`
 }
 
 // String returns the string representation
@@ -3499,11 +3499,11 @@ func (s CreateStackInput) GoString() string {
 
 // Contains the response to a CreateStack request.
 type CreateStackOutput struct {
+	_ struct{} `type:"structure"`
+
 	// The stack ID, which is an opaque string that you use to identify the stack
 	// when performing actions such as DescribeStacks.
 	StackId *string `type:"string"`
-
-	_ struct{} `type:"structure"`
 }
 
 // String returns the string representation
@@ -3517,6 +3517,8 @@ func (s CreateStackOutput) GoString() string {
 }
 
 type CreateUserProfileInput struct {
+	_ struct{} `type:"structure"`
+
 	// Whether users can specify their own SSH public key through the My Settings
 	// page. For more information, see Setting an IAM User's Public SSH Key (http://docs.aws.amazon.com/opsworks/latest/userguide/security-settingsshkey.html).
 	AllowSelfManagement *bool `type:"boolean"`
@@ -3533,8 +3535,6 @@ type CreateUserProfileInput struct {
 	// you do not specify an SSH user name, AWS OpsWorks generates one from the
 	// IAM user name.
 	SshUsername *string `type:"string"`
-
-	_ struct{} `type:"structure"`
 }
 
 // String returns the string representation
@@ -3549,10 +3549,10 @@ func (s CreateUserProfileInput) GoString() string {
 
 // Contains the response to a CreateUserProfile request.
 type CreateUserProfileOutput struct {
+	_ struct{} `type:"structure"`
+
 	// The user's IAM ARN.
 	IamUserArn *string `type:"string"`
-
-	_ struct{} `type:"structure"`
 }
 
 // String returns the string representation
@@ -3567,6 +3567,8 @@ func (s CreateUserProfileOutput) GoString() string {
 
 // Describes an app's data source.
 type DataSource struct {
+	_ struct{} `type:"structure"`
+
 	// The data source's ARN.
 	Arn *string `type:"string"`
 
@@ -3576,8 +3578,6 @@ type DataSource struct {
 	// The data source's type, AutoSelectOpsworksMysqlInstance, OpsworksMysqlInstance,
 	// or RdsDbInstance.
 	Type *string `type:"string"`
-
-	_ struct{} `type:"structure"`
 }
 
 // String returns the string representation
@@ -3591,10 +3591,10 @@ func (s DataSource) GoString() string {
 }
 
 type DeleteAppInput struct {
+	_ struct{} `type:"structure"`
+
 	// The app ID.
 	AppId *string `type:"string" required:"true"`
-
-	_ struct{} `type:"structure"`
 }
 
 // String returns the string representation
@@ -3622,6 +3622,8 @@ func (s DeleteAppOutput) GoString() string {
 }
 
 type DeleteInstanceInput struct {
+	_ struct{} `type:"structure"`
+
 	// Whether to delete the instance Elastic IP address.
 	DeleteElasticIp *bool `type:"boolean"`
 
@@ -3630,8 +3632,6 @@ type DeleteInstanceInput struct {
 
 	// The instance ID.
 	InstanceId *string `type:"string" required:"true"`
-
-	_ struct{} `type:"structure"`
 }
 
 // String returns the string representation
@@ -3659,10 +3659,10 @@ func (s DeleteInstanceOutput) GoString() string {
 }
 
 type DeleteLayerInput struct {
+	_ struct{} `type:"structure"`
+
 	// The layer ID.
 	LayerId *string `type:"string" required:"true"`
-
-	_ struct{} `type:"structure"`
 }
 
 // String returns the string representation
@@ -3690,10 +3690,10 @@ func (s DeleteLayerOutput) GoString() string {
 }
 
 type DeleteStackInput struct {
+	_ struct{} `type:"structure"`
+
 	// The stack ID.
 	StackId *string `type:"string" required:"true"`
-
-	_ struct{} `type:"structure"`
 }
 
 // String returns the string representation
@@ -3721,10 +3721,10 @@ func (s DeleteStackOutput) GoString() string {
 }
 
 type DeleteUserProfileInput struct {
+	_ struct{} `type:"structure"`
+
 	// The user's IAM ARN.
 	IamUserArn *string `type:"string" required:"true"`
-
-	_ struct{} `type:"structure"`
 }
 
 // String returns the string representation
@@ -3753,6 +3753,8 @@ func (s DeleteUserProfileOutput) GoString() string {
 
 // Describes a deployment of a stack or app.
 type Deployment struct {
+	_ struct{} `type:"structure"`
+
 	// The app ID.
 	AppId *string `type:"string"`
 
@@ -3798,8 +3800,6 @@ type Deployment struct {
 	//
 	//  running successful failed
 	Status *string `type:"string"`
-
-	_ struct{} `type:"structure"`
 }
 
 // String returns the string representation
@@ -3814,6 +3814,8 @@ func (s Deployment) GoString() string {
 
 // Used to specify a stack or deployment command.
 type DeploymentCommand struct {
+	_ struct{} `type:"structure"`
+
 	// The arguments of those commands that take arguments. It should be set to
 	// a JSON object with the following format:
 	//
@@ -3857,8 +3859,6 @@ type DeploymentCommand struct {
 	// restart: Restart the app's web or application server.  undeploy: Undeploy
 	// the app.
 	Name *string `type:"string" required:"true" enum:"DeploymentCommandName"`
-
-	_ struct{} `type:"structure"`
 }
 
 // String returns the string representation
@@ -3872,10 +3872,10 @@ func (s DeploymentCommand) GoString() string {
 }
 
 type DeregisterEcsClusterInput struct {
+	_ struct{} `type:"structure"`
+
 	// The cluster's ARN.
 	EcsClusterArn *string `type:"string" required:"true"`
-
-	_ struct{} `type:"structure"`
 }
 
 // String returns the string representation
@@ -3903,10 +3903,10 @@ func (s DeregisterEcsClusterOutput) GoString() string {
 }
 
 type DeregisterElasticIpInput struct {
+	_ struct{} `type:"structure"`
+
 	// The Elastic IP address.
 	ElasticIp *string `type:"string" required:"true"`
-
-	_ struct{} `type:"structure"`
 }
 
 // String returns the string representation
@@ -3934,10 +3934,10 @@ func (s DeregisterElasticIpOutput) GoString() string {
 }
 
 type DeregisterInstanceInput struct {
+	_ struct{} `type:"structure"`
+
 	// The instance ID.
 	InstanceId *string `type:"string" required:"true"`
-
-	_ struct{} `type:"structure"`
 }
 
 // String returns the string representation
@@ -3965,10 +3965,10 @@ func (s DeregisterInstanceOutput) GoString() string {
 }
 
 type DeregisterRdsDbInstanceInput struct {
+	_ struct{} `type:"structure"`
+
 	// The Amazon RDS instance's ARN.
 	RdsDbInstanceArn *string `type:"string" required:"true"`
-
-	_ struct{} `type:"structure"`
 }
 
 // String returns the string representation
@@ -3996,12 +3996,12 @@ func (s DeregisterRdsDbInstanceOutput) GoString() string {
 }
 
 type DeregisterVolumeInput struct {
+	_ struct{} `type:"structure"`
+
 	// The AWS OpsWorks volume ID, which is the GUID that AWS OpsWorks assigned
 	// to the instance when you registered the volume with the stack, not the Amazon
 	// EC2 volume ID.
 	VolumeId *string `type:"string" required:"true"`
-
-	_ struct{} `type:"structure"`
 }
 
 // String returns the string representation
@@ -4029,13 +4029,13 @@ func (s DeregisterVolumeOutput) GoString() string {
 }
 
 type DescribeAgentVersionsInput struct {
+	_ struct{} `type:"structure"`
+
 	// The configuration manager.
 	ConfigurationManager *StackConfigurationManager `type:"structure"`
 
 	// The stack ID.
 	StackId *string `type:"string"`
-
-	_ struct{} `type:"structure"`
 }
 
 // String returns the string representation
@@ -4050,12 +4050,12 @@ func (s DescribeAgentVersionsInput) GoString() string {
 
 // Contains the response to a DescribeAgentVersions request.
 type DescribeAgentVersionsOutput struct {
+	_ struct{} `type:"structure"`
+
 	// The agent versions for the specified stack or configuration manager. Note
 	// that this value is the complete version number, not the abbreviated number
 	// used by the console.
 	AgentVersions []*AgentVersion `type:"list"`
-
-	_ struct{} `type:"structure"`
 }
 
 // String returns the string representation
@@ -4069,6 +4069,8 @@ func (s DescribeAgentVersionsOutput) GoString() string {
 }
 
 type DescribeAppsInput struct {
+	_ struct{} `type:"structure"`
+
 	// An array of app IDs for the apps to be described. If you use this parameter,
 	// DescribeApps returns a description of the specified apps. Otherwise, it returns
 	// a description of every app.
@@ -4077,8 +4079,6 @@ type DescribeAppsInput struct {
 	// The app stack ID. If you use this parameter, DescribeApps returns a description
 	// of the apps in the specified stack.
 	StackId *string `type:"string"`
-
-	_ struct{} `type:"structure"`
 }
 
 // String returns the string representation
@@ -4093,10 +4093,10 @@ func (s DescribeAppsInput) GoString() string {
 
 // Contains the response to a DescribeApps request.
 type DescribeAppsOutput struct {
+	_ struct{} `type:"structure"`
+
 	// An array of App objects that describe the specified apps.
 	Apps []*App `type:"list"`
-
-	_ struct{} `type:"structure"`
 }
 
 // String returns the string representation
@@ -4110,6 +4110,8 @@ func (s DescribeAppsOutput) GoString() string {
 }
 
 type DescribeCommandsInput struct {
+	_ struct{} `type:"structure"`
+
 	// An array of command IDs. If you include this parameter, DescribeCommands
 	// returns a description of the specified commands. Otherwise, it returns a
 	// description of every command.
@@ -4122,8 +4124,6 @@ type DescribeCommandsInput struct {
 	// The instance ID. If you include this parameter, DescribeCommands returns
 	// a description of the commands associated with the specified instance.
 	InstanceId *string `type:"string"`
-
-	_ struct{} `type:"structure"`
 }
 
 // String returns the string representation
@@ -4138,10 +4138,10 @@ func (s DescribeCommandsInput) GoString() string {
 
 // Contains the response to a DescribeCommands request.
 type DescribeCommandsOutput struct {
+	_ struct{} `type:"structure"`
+
 	// An array of Command objects that describe each of the specified commands.
 	Commands []*Command `type:"list"`
-
-	_ struct{} `type:"structure"`
 }
 
 // String returns the string representation
@@ -4155,6 +4155,8 @@ func (s DescribeCommandsOutput) GoString() string {
 }
 
 type DescribeDeploymentsInput struct {
+	_ struct{} `type:"structure"`
+
 	// The app ID. If you include this parameter, DescribeDeployments returns a
 	// description of the commands associated with the specified app.
 	AppId *string `type:"string"`
@@ -4167,8 +4169,6 @@ type DescribeDeploymentsInput struct {
 	// The stack ID. If you include this parameter, DescribeDeployments returns
 	// a description of the commands associated with the specified stack.
 	StackId *string `type:"string"`
-
-	_ struct{} `type:"structure"`
 }
 
 // String returns the string representation
@@ -4183,10 +4183,10 @@ func (s DescribeDeploymentsInput) GoString() string {
 
 // Contains the response to a DescribeDeployments request.
 type DescribeDeploymentsOutput struct {
+	_ struct{} `type:"structure"`
+
 	// An array of Deployment objects that describe the deployments.
 	Deployments []*Deployment `type:"list"`
-
-	_ struct{} `type:"structure"`
 }
 
 // String returns the string representation
@@ -4200,6 +4200,8 @@ func (s DescribeDeploymentsOutput) GoString() string {
 }
 
 type DescribeEcsClustersInput struct {
+	_ struct{} `type:"structure"`
+
 	// A list of ARNs, one for each cluster to be described.
 	EcsClusterArns []*string `type:"list"`
 
@@ -4220,8 +4222,6 @@ type DescribeEcsClustersInput struct {
 	// A stack ID. DescribeEcsClusters returns a description of the cluster that
 	// is registered with the stack.
 	StackId *string `type:"string"`
-
-	_ struct{} `type:"structure"`
 }
 
 // String returns the string representation
@@ -4236,6 +4236,8 @@ func (s DescribeEcsClustersInput) GoString() string {
 
 // Contains the response to a DescribeEcsClusters request.
 type DescribeEcsClustersOutput struct {
+	_ struct{} `type:"structure"`
+
 	// A list of EcsCluster objects containing the cluster descriptions.
 	EcsClusters []*EcsCluster `type:"list"`
 
@@ -4244,8 +4246,6 @@ type DescribeEcsClustersOutput struct {
 	// parameter to retrieve the next set of results. If the previous paginated
 	// request returned all of the remaining results, this parameter is set to null.
 	NextToken *string `type:"string"`
-
-	_ struct{} `type:"structure"`
 }
 
 // String returns the string representation
@@ -4259,6 +4259,8 @@ func (s DescribeEcsClustersOutput) GoString() string {
 }
 
 type DescribeElasticIpsInput struct {
+	_ struct{} `type:"structure"`
+
 	// The instance ID. If you include this parameter, DescribeElasticIps returns
 	// a description of the Elastic IP addresses associated with the specified instance.
 	InstanceId *string `type:"string"`
@@ -4271,8 +4273,6 @@ type DescribeElasticIpsInput struct {
 	// A stack ID. If you include this parameter, DescribeElasticIps returns a description
 	// of the Elastic IP addresses that are registered with the specified stack.
 	StackId *string `type:"string"`
-
-	_ struct{} `type:"structure"`
 }
 
 // String returns the string representation
@@ -4287,10 +4287,10 @@ func (s DescribeElasticIpsInput) GoString() string {
 
 // Contains the response to a DescribeElasticIps request.
 type DescribeElasticIpsOutput struct {
+	_ struct{} `type:"structure"`
+
 	// An ElasticIps object that describes the specified Elastic IP addresses.
 	ElasticIps []*ElasticIp `type:"list"`
-
-	_ struct{} `type:"structure"`
 }
 
 // String returns the string representation
@@ -4304,14 +4304,14 @@ func (s DescribeElasticIpsOutput) GoString() string {
 }
 
 type DescribeElasticLoadBalancersInput struct {
+	_ struct{} `type:"structure"`
+
 	// A list of layer IDs. The action describes the Elastic Load Balancing instances
 	// for the specified layers.
 	LayerIds []*string `type:"list"`
 
 	// A stack ID. The action describes the stack's Elastic Load Balancing instances.
 	StackId *string `type:"string"`
-
-	_ struct{} `type:"structure"`
 }
 
 // String returns the string representation
@@ -4326,11 +4326,11 @@ func (s DescribeElasticLoadBalancersInput) GoString() string {
 
 // Contains the response to a DescribeElasticLoadBalancers request.
 type DescribeElasticLoadBalancersOutput struct {
+	_ struct{} `type:"structure"`
+
 	// A list of ElasticLoadBalancer objects that describe the specified Elastic
 	// Load Balancing instances.
 	ElasticLoadBalancers []*ElasticLoadBalancer `type:"list"`
-
-	_ struct{} `type:"structure"`
 }
 
 // String returns the string representation
@@ -4344,6 +4344,8 @@ func (s DescribeElasticLoadBalancersOutput) GoString() string {
 }
 
 type DescribeInstancesInput struct {
+	_ struct{} `type:"structure"`
+
 	// An array of instance IDs to be described. If you use this parameter, DescribeInstances
 	// returns a description of the specified instances. Otherwise, it returns a
 	// description of every instance.
@@ -4356,8 +4358,6 @@ type DescribeInstancesInput struct {
 	// A stack ID. If you use this parameter, DescribeInstances returns descriptions
 	// of the instances associated with the specified stack.
 	StackId *string `type:"string"`
-
-	_ struct{} `type:"structure"`
 }
 
 // String returns the string representation
@@ -4372,10 +4372,10 @@ func (s DescribeInstancesInput) GoString() string {
 
 // Contains the response to a DescribeInstances request.
 type DescribeInstancesOutput struct {
+	_ struct{} `type:"structure"`
+
 	// An array of Instance objects that describe the instances.
 	Instances []*Instance `type:"list"`
-
-	_ struct{} `type:"structure"`
 }
 
 // String returns the string representation
@@ -4389,6 +4389,8 @@ func (s DescribeInstancesOutput) GoString() string {
 }
 
 type DescribeLayersInput struct {
+	_ struct{} `type:"structure"`
+
 	// An array of layer IDs that specify the layers to be described. If you omit
 	// this parameter, DescribeLayers returns a description of every layer in the
 	// specified stack.
@@ -4396,8 +4398,6 @@ type DescribeLayersInput struct {
 
 	// The stack ID.
 	StackId *string `type:"string"`
-
-	_ struct{} `type:"structure"`
 }
 
 // String returns the string representation
@@ -4412,10 +4412,10 @@ func (s DescribeLayersInput) GoString() string {
 
 // Contains the response to a DescribeLayers request.
 type DescribeLayersOutput struct {
+	_ struct{} `type:"structure"`
+
 	// An array of Layer objects that describe the layers.
 	Layers []*Layer `type:"list"`
-
-	_ struct{} `type:"structure"`
 }
 
 // String returns the string representation
@@ -4429,10 +4429,10 @@ func (s DescribeLayersOutput) GoString() string {
 }
 
 type DescribeLoadBasedAutoScalingInput struct {
+	_ struct{} `type:"structure"`
+
 	// An array of layer IDs.
 	LayerIds []*string `type:"list" required:"true"`
-
-	_ struct{} `type:"structure"`
 }
 
 // String returns the string representation
@@ -4447,11 +4447,11 @@ func (s DescribeLoadBasedAutoScalingInput) GoString() string {
 
 // Contains the response to a DescribeLoadBasedAutoScaling request.
 type DescribeLoadBasedAutoScalingOutput struct {
+	_ struct{} `type:"structure"`
+
 	// An array of LoadBasedAutoScalingConfiguration objects that describe each
 	// layer's configuration.
 	LoadBasedAutoScalingConfigurations []*LoadBasedAutoScalingConfiguration `type:"list"`
-
-	_ struct{} `type:"structure"`
 }
 
 // String returns the string representation
@@ -4480,10 +4480,10 @@ func (s DescribeMyUserProfileInput) GoString() string {
 
 // Contains the response to a DescribeMyUserProfile request.
 type DescribeMyUserProfileOutput struct {
+	_ struct{} `type:"structure"`
+
 	// A UserProfile object that describes the user's SSH information.
 	UserProfile *SelfUserProfile `type:"structure"`
-
-	_ struct{} `type:"structure"`
 }
 
 // String returns the string representation
@@ -4497,14 +4497,14 @@ func (s DescribeMyUserProfileOutput) GoString() string {
 }
 
 type DescribePermissionsInput struct {
+	_ struct{} `type:"structure"`
+
 	// The user's IAM ARN. For more information about IAM ARNs, see Using Identifiers
 	// (http://docs.aws.amazon.com/IAM/latest/UserGuide/Using_Identifiers.html).
 	IamUserArn *string `type:"string"`
 
 	// The stack ID.
 	StackId *string `type:"string"`
-
-	_ struct{} `type:"structure"`
 }
 
 // String returns the string representation
@@ -4519,6 +4519,8 @@ func (s DescribePermissionsInput) GoString() string {
 
 // Contains the response to a DescribePermissions request.
 type DescribePermissionsOutput struct {
+	_ struct{} `type:"structure"`
+
 	// An array of Permission objects that describe the stack permissions.
 	//
 	//  If the request object contains only a stack ID, the array contains a Permission
@@ -4528,8 +4530,6 @@ type DescribePermissionsOutput struct {
 	// an IAM ARN, the array contains a single Permission object with permissions
 	// for the specified stack and IAM ARN.
 	Permissions []*Permission `type:"list"`
-
-	_ struct{} `type:"structure"`
 }
 
 // String returns the string representation
@@ -4543,6 +4543,8 @@ func (s DescribePermissionsOutput) GoString() string {
 }
 
 type DescribeRaidArraysInput struct {
+	_ struct{} `type:"structure"`
+
 	// The instance ID. If you use this parameter, DescribeRaidArrays returns descriptions
 	// of the RAID arrays associated with the specified instance.
 	InstanceId *string `type:"string"`
@@ -4554,8 +4556,6 @@ type DescribeRaidArraysInput struct {
 
 	// The stack ID.
 	StackId *string `type:"string"`
-
-	_ struct{} `type:"structure"`
 }
 
 // String returns the string representation
@@ -4570,10 +4570,10 @@ func (s DescribeRaidArraysInput) GoString() string {
 
 // Contains the response to a DescribeRaidArrays request.
 type DescribeRaidArraysOutput struct {
+	_ struct{} `type:"structure"`
+
 	// A RaidArrays object that describes the specified RAID arrays.
 	RaidArrays []*RaidArray `type:"list"`
-
-	_ struct{} `type:"structure"`
 }
 
 // String returns the string representation
@@ -4587,14 +4587,14 @@ func (s DescribeRaidArraysOutput) GoString() string {
 }
 
 type DescribeRdsDbInstancesInput struct {
+	_ struct{} `type:"structure"`
+
 	// An array containing the ARNs of the instances to be described.
 	RdsDbInstanceArns []*string `type:"list"`
 
 	// The stack ID that the instances are registered with. The operation returns
 	// descriptions of all registered Amazon RDS instances.
 	StackId *string `type:"string" required:"true"`
-
-	_ struct{} `type:"structure"`
 }
 
 // String returns the string representation
@@ -4609,10 +4609,10 @@ func (s DescribeRdsDbInstancesInput) GoString() string {
 
 // Contains the response to a DescribeRdsDbInstances request.
 type DescribeRdsDbInstancesOutput struct {
+	_ struct{} `type:"structure"`
+
 	// An a array of RdsDbInstance objects that describe the instances.
 	RdsDbInstances []*RdsDbInstance `type:"list"`
-
-	_ struct{} `type:"structure"`
 }
 
 // String returns the string representation
@@ -4626,6 +4626,8 @@ func (s DescribeRdsDbInstancesOutput) GoString() string {
 }
 
 type DescribeServiceErrorsInput struct {
+	_ struct{} `type:"structure"`
+
 	// The instance ID. If you use this parameter, DescribeServiceErrors returns
 	// descriptions of the errors associated with the specified instance.
 	InstanceId *string `type:"string"`
@@ -4638,8 +4640,6 @@ type DescribeServiceErrorsInput struct {
 	// The stack ID. If you use this parameter, DescribeServiceErrors returns descriptions
 	// of the errors associated with the specified stack.
 	StackId *string `type:"string"`
-
-	_ struct{} `type:"structure"`
 }
 
 // String returns the string representation
@@ -4654,10 +4654,10 @@ func (s DescribeServiceErrorsInput) GoString() string {
 
 // Contains the response to a DescribeServiceErrors request.
 type DescribeServiceErrorsOutput struct {
+	_ struct{} `type:"structure"`
+
 	// An array of ServiceError objects that describe the specified service errors.
 	ServiceErrors []*ServiceError `type:"list"`
-
-	_ struct{} `type:"structure"`
 }
 
 // String returns the string representation
@@ -4671,10 +4671,10 @@ func (s DescribeServiceErrorsOutput) GoString() string {
 }
 
 type DescribeStackProvisioningParametersInput struct {
+	_ struct{} `type:"structure"`
+
 	// The stack ID
 	StackId *string `type:"string" required:"true"`
-
-	_ struct{} `type:"structure"`
 }
 
 // String returns the string representation
@@ -4689,13 +4689,13 @@ func (s DescribeStackProvisioningParametersInput) GoString() string {
 
 // Contains the response to a DescribeStackProvisioningParameters request.
 type DescribeStackProvisioningParametersOutput struct {
+	_ struct{} `type:"structure"`
+
 	// The AWS OpsWorks agent installer's URL.
 	AgentInstallerUrl *string `type:"string"`
 
 	// An embedded object that contains the provisioning parameters.
 	Parameters map[string]*string `type:"map"`
-
-	_ struct{} `type:"structure"`
 }
 
 // String returns the string representation
@@ -4709,10 +4709,10 @@ func (s DescribeStackProvisioningParametersOutput) GoString() string {
 }
 
 type DescribeStackSummaryInput struct {
+	_ struct{} `type:"structure"`
+
 	// The stack ID.
 	StackId *string `type:"string" required:"true"`
-
-	_ struct{} `type:"structure"`
 }
 
 // String returns the string representation
@@ -4727,10 +4727,10 @@ func (s DescribeStackSummaryInput) GoString() string {
 
 // Contains the response to a DescribeStackSummary request.
 type DescribeStackSummaryOutput struct {
+	_ struct{} `type:"structure"`
+
 	// A StackSummary object that contains the results.
 	StackSummary *StackSummary `type:"structure"`
-
-	_ struct{} `type:"structure"`
 }
 
 // String returns the string representation
@@ -4744,11 +4744,11 @@ func (s DescribeStackSummaryOutput) GoString() string {
 }
 
 type DescribeStacksInput struct {
+	_ struct{} `type:"structure"`
+
 	// An array of stack IDs that specify the stacks to be described. If you omit
 	// this parameter, DescribeStacks returns a description of every stack.
 	StackIds []*string `type:"list"`
-
-	_ struct{} `type:"structure"`
 }
 
 // String returns the string representation
@@ -4763,10 +4763,10 @@ func (s DescribeStacksInput) GoString() string {
 
 // Contains the response to a DescribeStacks request.
 type DescribeStacksOutput struct {
+	_ struct{} `type:"structure"`
+
 	// An array of Stack objects that describe the stacks.
 	Stacks []*Stack `type:"list"`
-
-	_ struct{} `type:"structure"`
 }
 
 // String returns the string representation
@@ -4780,10 +4780,10 @@ func (s DescribeStacksOutput) GoString() string {
 }
 
 type DescribeTimeBasedAutoScalingInput struct {
+	_ struct{} `type:"structure"`
+
 	// An array of instance IDs.
 	InstanceIds []*string `type:"list" required:"true"`
-
-	_ struct{} `type:"structure"`
 }
 
 // String returns the string representation
@@ -4798,11 +4798,11 @@ func (s DescribeTimeBasedAutoScalingInput) GoString() string {
 
 // Contains the response to a DescribeTimeBasedAutoScaling request.
 type DescribeTimeBasedAutoScalingOutput struct {
+	_ struct{} `type:"structure"`
+
 	// An array of TimeBasedAutoScalingConfiguration objects that describe the configuration
 	// for the specified instances.
 	TimeBasedAutoScalingConfigurations []*TimeBasedAutoScalingConfiguration `type:"list"`
-
-	_ struct{} `type:"structure"`
 }
 
 // String returns the string representation
@@ -4816,10 +4816,10 @@ func (s DescribeTimeBasedAutoScalingOutput) GoString() string {
 }
 
 type DescribeUserProfilesInput struct {
+	_ struct{} `type:"structure"`
+
 	// An array of IAM user ARNs that identify the users to be described.
 	IamUserArns []*string `type:"list"`
-
-	_ struct{} `type:"structure"`
 }
 
 // String returns the string representation
@@ -4834,10 +4834,10 @@ func (s DescribeUserProfilesInput) GoString() string {
 
 // Contains the response to a DescribeUserProfiles request.
 type DescribeUserProfilesOutput struct {
+	_ struct{} `type:"structure"`
+
 	// A Users object that describes the specified users.
 	UserProfiles []*UserProfile `type:"list"`
-
-	_ struct{} `type:"structure"`
 }
 
 // String returns the string representation
@@ -4851,6 +4851,8 @@ func (s DescribeUserProfilesOutput) GoString() string {
 }
 
 type DescribeVolumesInput struct {
+	_ struct{} `type:"structure"`
+
 	// The instance ID. If you use this parameter, DescribeVolumes returns descriptions
 	// of the volumes associated with the specified instance.
 	InstanceId *string `type:"string"`
@@ -4866,8 +4868,6 @@ type DescribeVolumesInput struct {
 	// descriptions of the specified volumes. Otherwise, it returns a description
 	// of every volume.
 	VolumeIds []*string `type:"list"`
-
-	_ struct{} `type:"structure"`
 }
 
 // String returns the string representation
@@ -4882,10 +4882,10 @@ func (s DescribeVolumesInput) GoString() string {
 
 // Contains the response to a DescribeVolumes request.
 type DescribeVolumesOutput struct {
+	_ struct{} `type:"structure"`
+
 	// An array of volume IDs.
 	Volumes []*Volume `type:"list"`
-
-	_ struct{} `type:"structure"`
 }
 
 // String returns the string representation
@@ -4899,14 +4899,14 @@ func (s DescribeVolumesOutput) GoString() string {
 }
 
 type DetachElasticLoadBalancerInput struct {
+	_ struct{} `type:"structure"`
+
 	// The Elastic Load Balancing instance's name.
 	ElasticLoadBalancerName *string `type:"string" required:"true"`
 
 	// The ID of the layer that the Elastic Load Balancing instance is attached
 	// to.
 	LayerId *string `type:"string" required:"true"`
-
-	_ struct{} `type:"structure"`
 }
 
 // String returns the string representation
@@ -4934,10 +4934,10 @@ func (s DetachElasticLoadBalancerOutput) GoString() string {
 }
 
 type DisassociateElasticIpInput struct {
+	_ struct{} `type:"structure"`
+
 	// The Elastic IP address.
 	ElasticIp *string `type:"string" required:"true"`
-
-	_ struct{} `type:"structure"`
 }
 
 // String returns the string representation
@@ -4968,6 +4968,8 @@ func (s DisassociateElasticIpOutput) GoString() string {
 // EC2 EbsBlockDevice (http://docs.aws.amazon.com/AWSEC2/latest/APIReference/API_EbsBlockDevice.html)
 // data type.
 type EbsBlockDevice struct {
+	_ struct{} `type:"structure"`
+
 	// Whether the volume is deleted on instance termination.
 	DeleteOnTermination *bool `type:"boolean"`
 
@@ -4984,8 +4986,6 @@ type EbsBlockDevice struct {
 	// The volume type. gp2 for General Purpose (SSD) volumes, io1 for Provisioned
 	// IOPS (SSD) volumes, and standard for Magnetic volumes.
 	VolumeType *string `type:"string" enum:"VolumeType"`
-
-	_ struct{} `type:"structure"`
 }
 
 // String returns the string representation
@@ -5000,6 +5000,8 @@ func (s EbsBlockDevice) GoString() string {
 
 // Describes a registered Amazon ECS cluster.
 type EcsCluster struct {
+	_ struct{} `type:"structure"`
+
 	// The cluster's ARN.
 	EcsClusterArn *string `type:"string"`
 
@@ -5011,8 +5013,6 @@ type EcsCluster struct {
 
 	// The stack ID.
 	StackId *string `type:"string"`
-
-	_ struct{} `type:"structure"`
 }
 
 // String returns the string representation
@@ -5027,6 +5027,8 @@ func (s EcsCluster) GoString() string {
 
 // Describes an Elastic IP address.
 type ElasticIp struct {
+	_ struct{} `type:"structure"`
+
 	// The domain.
 	Domain *string `type:"string"`
 
@@ -5041,8 +5043,6 @@ type ElasticIp struct {
 
 	// The AWS region. For more information, see Regions and Endpoints (http://docs.aws.amazon.com/general/latest/gr/rande.html).
 	Region *string `type:"string"`
-
-	_ struct{} `type:"structure"`
 }
 
 // String returns the string representation
@@ -5057,6 +5057,8 @@ func (s ElasticIp) GoString() string {
 
 // Describes an Elastic Load Balancing instance.
 type ElasticLoadBalancer struct {
+	_ struct{} `type:"structure"`
+
 	// A list of Availability Zones.
 	AvailabilityZones []*string `type:"list"`
 
@@ -5084,8 +5086,6 @@ type ElasticLoadBalancer struct {
 
 	// The VPC ID.
 	VpcId *string `type:"string"`
-
-	_ struct{} `type:"structure"`
 }
 
 // String returns the string representation
@@ -5100,6 +5100,8 @@ func (s ElasticLoadBalancer) GoString() string {
 
 // Represents an app's environment variable.
 type EnvironmentVariable struct {
+	_ struct{} `type:"structure"`
+
 	// (Required) The environment variable's name, which can consist of up to 64
 	// characters and must be specified. The name can contain upper- and lowercase
 	// letters, numbers, and underscores (_), but it must start with a letter or
@@ -5116,8 +5118,6 @@ type EnvironmentVariable struct {
 	// you specify a value, it can contain up to 256 characters, which must all
 	// be printable.
 	Value *string `type:"string" required:"true"`
-
-	_ struct{} `type:"structure"`
 }
 
 // String returns the string representation
@@ -5131,10 +5131,10 @@ func (s EnvironmentVariable) GoString() string {
 }
 
 type GetHostnameSuggestionInput struct {
+	_ struct{} `type:"structure"`
+
 	// The layer ID.
 	LayerId *string `type:"string" required:"true"`
-
-	_ struct{} `type:"structure"`
 }
 
 // String returns the string representation
@@ -5149,13 +5149,13 @@ func (s GetHostnameSuggestionInput) GoString() string {
 
 // Contains the response to a GetHostnameSuggestion request.
 type GetHostnameSuggestionOutput struct {
+	_ struct{} `type:"structure"`
+
 	// The generated host name.
 	Hostname *string `type:"string"`
 
 	// The layer ID.
 	LayerId *string `type:"string"`
-
-	_ struct{} `type:"structure"`
 }
 
 // String returns the string representation
@@ -5169,6 +5169,8 @@ func (s GetHostnameSuggestionOutput) GoString() string {
 }
 
 type GrantAccessInput struct {
+	_ struct{} `type:"structure"`
+
 	// The instance's AWS OpsWorks ID.
 	InstanceId *string `type:"string" required:"true"`
 
@@ -5177,8 +5179,6 @@ type GrantAccessInput struct {
 	// to log in. If the user is logged in at the time, he or she automatically
 	// will be logged out.
 	ValidForInMinutes *int64 `min:"60" type:"integer"`
-
-	_ struct{} `type:"structure"`
 }
 
 // String returns the string representation
@@ -5193,11 +5193,11 @@ func (s GrantAccessInput) GoString() string {
 
 // Contains the response to a GrantAccess request.
 type GrantAccessOutput struct {
+	_ struct{} `type:"structure"`
+
 	// A TemporaryCredential object that contains the data needed to log in to the
 	// instance by RDP clients, such as the Microsoft Remote Desktop Connection.
 	TemporaryCredential *TemporaryCredential `type:"structure"`
-
-	_ struct{} `type:"structure"`
 }
 
 // String returns the string representation
@@ -5212,6 +5212,8 @@ func (s GrantAccessOutput) GoString() string {
 
 // Describes an instance.
 type Instance struct {
+	_ struct{} `type:"structure"`
+
 	// The agent version. This parameter is set to INHERIT if the instance inherits
 	// the default stack setting or to a a version number for a fixed agent version.
 	AgentVersion *string `type:"string"`
@@ -5345,8 +5347,6 @@ type Instance struct {
 
 	// The instance's virtualization type: paravirtual or hvm.
 	VirtualizationType *string `type:"string" enum:"VirtualizationType"`
-
-	_ struct{} `type:"structure"`
 }
 
 // String returns the string representation
@@ -5362,13 +5362,13 @@ func (s Instance) GoString() string {
 // Contains a description of an Amazon EC2 instance from the Amazon EC2 metadata
 // service. For more information, see Instance Metadata and User Data (http://docs.aws.amazon.com/sdkfornet/latest/apidocs/Index.html).
 type InstanceIdentity struct {
+	_ struct{} `type:"structure"`
+
 	// A JSON document that contains the metadata.
 	Document *string `type:"string"`
 
 	// A signature that can be used to verify the document's accuracy and authenticity.
 	Signature *string `type:"string"`
-
-	_ struct{} `type:"structure"`
 }
 
 // String returns the string representation
@@ -5383,6 +5383,8 @@ func (s InstanceIdentity) GoString() string {
 
 // Describes how many instances a stack has for each status.
 type InstancesCount struct {
+	_ struct{} `type:"structure"`
+
 	// The number of instances in the Assigning state.
 	Assigning *int64 `type:"integer"`
 
@@ -5439,8 +5441,6 @@ type InstancesCount struct {
 
 	// The number of instances in the Unassigning state.
 	Unassigning *int64 `type:"integer"`
-
-	_ struct{} `type:"structure"`
 }
 
 // String returns the string representation
@@ -5455,6 +5455,8 @@ func (s InstancesCount) GoString() string {
 
 // Describes a layer.
 type Layer struct {
+	_ struct{} `type:"structure"`
+
 	// The layer attributes.
 	//
 	// For the HaproxyStatsPassword, MysqlRootPassword, and GangliaPassword attributes,
@@ -5545,8 +5547,6 @@ type Layer struct {
 
 	// A VolumeConfigurations object that describes the layer's Amazon EBS volumes.
 	VolumeConfigurations []*VolumeConfiguration `type:"list"`
-
-	_ struct{} `type:"structure"`
 }
 
 // String returns the string representation
@@ -5561,10 +5561,10 @@ func (s Layer) GoString() string {
 
 // Specifies the lifecycle event configuration
 type LifecycleEventConfiguration struct {
+	_ struct{} `type:"structure"`
+
 	// A ShutdownEventConfiguration object that specifies the Shutdown event configuration.
 	Shutdown *ShutdownEventConfiguration `type:"structure"`
-
-	_ struct{} `type:"structure"`
 }
 
 // String returns the string representation
@@ -5579,6 +5579,8 @@ func (s LifecycleEventConfiguration) GoString() string {
 
 // Describes a layer's load-based auto scaling configuration.
 type LoadBasedAutoScalingConfiguration struct {
+	_ struct{} `type:"structure"`
+
 	// An AutoScalingThresholds object that describes the downscaling configuration,
 	// which defines how and when AWS OpsWorks reduces the number of instances.
 	DownScaling *AutoScalingThresholds `type:"structure"`
@@ -5592,8 +5594,6 @@ type LoadBasedAutoScalingConfiguration struct {
 	// An AutoScalingThresholds object that describes the upscaling configuration,
 	// which defines how and when AWS OpsWorks increases the number of instances.
 	UpScaling *AutoScalingThresholds `type:"structure"`
-
-	_ struct{} `type:"structure"`
 }
 
 // String returns the string representation
@@ -5608,6 +5608,8 @@ func (s LoadBasedAutoScalingConfiguration) GoString() string {
 
 // Describes stack or user permissions.
 type Permission struct {
+	_ struct{} `type:"structure"`
+
 	// Whether the user can use SSH.
 	AllowSsh *bool `type:"boolean"`
 
@@ -5626,8 +5628,6 @@ type Permission struct {
 
 	// A stack ID.
 	StackId *string `type:"string"`
-
-	_ struct{} `type:"structure"`
 }
 
 // String returns the string representation
@@ -5642,6 +5642,8 @@ func (s Permission) GoString() string {
 
 // Describes an instance's RAID array.
 type RaidArray struct {
+	_ struct{} `type:"structure"`
+
 	// The array's Availability Zone. For more information, see Regions and Endpoints
 	// (http://docs.aws.amazon.com/general/latest/gr/rande.html).
 	AvailabilityZone *string `type:"string"`
@@ -5681,8 +5683,6 @@ type RaidArray struct {
 
 	// The volume type, standard or PIOPS.
 	VolumeType *string `type:"string"`
-
-	_ struct{} `type:"structure"`
 }
 
 // String returns the string representation
@@ -5697,6 +5697,8 @@ func (s RaidArray) GoString() string {
 
 // Describes an Amazon RDS instance.
 type RdsDbInstance struct {
+	_ struct{} `type:"structure"`
+
 	// The instance's address.
 	Address *string `type:"string"`
 
@@ -5725,8 +5727,6 @@ type RdsDbInstance struct {
 
 	// The ID of the stack that the instance is registered with.
 	StackId *string `type:"string"`
-
-	_ struct{} `type:"structure"`
 }
 
 // String returns the string representation
@@ -5740,10 +5740,10 @@ func (s RdsDbInstance) GoString() string {
 }
 
 type RebootInstanceInput struct {
+	_ struct{} `type:"structure"`
+
 	// The instance ID.
 	InstanceId *string `type:"string" required:"true"`
-
-	_ struct{} `type:"structure"`
 }
 
 // String returns the string representation
@@ -5782,6 +5782,8 @@ func (s RebootInstanceOutput) GoString() string {
 // without the .rb extension. For example: phpapp2::dbsetup specifies the dbsetup.rb
 // recipe in the repository's phpapp2 folder.
 type Recipes struct {
+	_ struct{} `type:"structure"`
+
 	// An array of custom recipe names to be run following a configure event.
 	Configure []*string `type:"list"`
 
@@ -5796,8 +5798,6 @@ type Recipes struct {
 
 	// An array of custom recipe names to be run following a undeploy event.
 	Undeploy []*string `type:"list"`
-
-	_ struct{} `type:"structure"`
 }
 
 // String returns the string representation
@@ -5811,13 +5811,13 @@ func (s Recipes) GoString() string {
 }
 
 type RegisterEcsClusterInput struct {
+	_ struct{} `type:"structure"`
+
 	// The cluster's ARN.
 	EcsClusterArn *string `type:"string" required:"true"`
 
 	// The stack ID.
 	StackId *string `type:"string" required:"true"`
-
-	_ struct{} `type:"structure"`
 }
 
 // String returns the string representation
@@ -5832,10 +5832,10 @@ func (s RegisterEcsClusterInput) GoString() string {
 
 // Contains the response to a RegisterEcsCluster request.
 type RegisterEcsClusterOutput struct {
+	_ struct{} `type:"structure"`
+
 	// The cluster's ARN.
 	EcsClusterArn *string `type:"string"`
-
-	_ struct{} `type:"structure"`
 }
 
 // String returns the string representation
@@ -5849,13 +5849,13 @@ func (s RegisterEcsClusterOutput) GoString() string {
 }
 
 type RegisterElasticIpInput struct {
+	_ struct{} `type:"structure"`
+
 	// The Elastic IP address.
 	ElasticIp *string `type:"string" required:"true"`
 
 	// The stack ID.
 	StackId *string `type:"string" required:"true"`
-
-	_ struct{} `type:"structure"`
 }
 
 // String returns the string representation
@@ -5870,10 +5870,10 @@ func (s RegisterElasticIpInput) GoString() string {
 
 // Contains the response to a RegisterElasticIp request.
 type RegisterElasticIpOutput struct {
+	_ struct{} `type:"structure"`
+
 	// The Elastic IP address.
 	ElasticIp *string `type:"string"`
-
-	_ struct{} `type:"structure"`
 }
 
 // String returns the string representation
@@ -5887,6 +5887,8 @@ func (s RegisterElasticIpOutput) GoString() string {
 }
 
 type RegisterInstanceInput struct {
+	_ struct{} `type:"structure"`
+
 	// The instance's hostname.
 	Hostname *string `type:"string"`
 
@@ -5908,8 +5910,6 @@ type RegisterInstanceInput struct {
 
 	// The ID of the stack that the instance is to be registered with.
 	StackId *string `type:"string" required:"true"`
-
-	_ struct{} `type:"structure"`
 }
 
 // String returns the string representation
@@ -5924,10 +5924,10 @@ func (s RegisterInstanceInput) GoString() string {
 
 // Contains the response to a RegisterInstanceResult request.
 type RegisterInstanceOutput struct {
+	_ struct{} `type:"structure"`
+
 	// The registered instance's AWS OpsWorks ID.
 	InstanceId *string `type:"string"`
-
-	_ struct{} `type:"structure"`
 }
 
 // String returns the string representation
@@ -5941,6 +5941,8 @@ func (s RegisterInstanceOutput) GoString() string {
 }
 
 type RegisterRdsDbInstanceInput struct {
+	_ struct{} `type:"structure"`
+
 	// The database password.
 	DbPassword *string `type:"string" required:"true"`
 
@@ -5952,8 +5954,6 @@ type RegisterRdsDbInstanceInput struct {
 
 	// The stack ID.
 	StackId *string `type:"string" required:"true"`
-
-	_ struct{} `type:"structure"`
 }
 
 // String returns the string representation
@@ -5981,13 +5981,13 @@ func (s RegisterRdsDbInstanceOutput) GoString() string {
 }
 
 type RegisterVolumeInput struct {
+	_ struct{} `type:"structure"`
+
 	// The Amazon EBS volume ID.
 	Ec2VolumeId *string `type:"string"`
 
 	// The stack ID.
 	StackId *string `type:"string" required:"true"`
-
-	_ struct{} `type:"structure"`
 }
 
 // String returns the string representation
@@ -6002,10 +6002,10 @@ func (s RegisterVolumeInput) GoString() string {
 
 // Contains the response to a RegisterVolume request.
 type RegisterVolumeOutput struct {
+	_ struct{} `type:"structure"`
+
 	// The volume ID.
 	VolumeId *string `type:"string"`
-
-	_ struct{} `type:"structure"`
 }
 
 // String returns the string representation
@@ -6020,6 +6020,8 @@ func (s RegisterVolumeOutput) GoString() string {
 
 // A registered instance's reported operating system.
 type ReportedOs struct {
+	_ struct{} `type:"structure"`
+
 	// The operating system family.
 	Family *string `type:"string"`
 
@@ -6028,8 +6030,6 @@ type ReportedOs struct {
 
 	// The operating system version.
 	Version *string `type:"string"`
-
-	_ struct{} `type:"structure"`
 }
 
 // String returns the string representation
@@ -6044,6 +6044,8 @@ func (s ReportedOs) GoString() string {
 
 // Describes a user's SSH information.
 type SelfUserProfile struct {
+	_ struct{} `type:"structure"`
+
 	// The user's IAM ARN.
 	IamUserArn *string `type:"string"`
 
@@ -6055,8 +6057,6 @@ type SelfUserProfile struct {
 
 	// The user's SSH user name.
 	SshUsername *string `type:"string"`
-
-	_ struct{} `type:"structure"`
 }
 
 // String returns the string representation
@@ -6071,6 +6071,8 @@ func (s SelfUserProfile) GoString() string {
 
 // Describes an AWS OpsWorks service error.
 type ServiceError struct {
+	_ struct{} `type:"structure"`
+
 	// When the error occurred.
 	CreatedAt *string `type:"string"`
 
@@ -6088,8 +6090,6 @@ type ServiceError struct {
 
 	// The error type.
 	Type *string `type:"string"`
-
-	_ struct{} `type:"structure"`
 }
 
 // String returns the string representation
@@ -6103,6 +6103,8 @@ func (s ServiceError) GoString() string {
 }
 
 type SetLoadBasedAutoScalingInput struct {
+	_ struct{} `type:"structure"`
+
 	// An AutoScalingThresholds object with the downscaling threshold configuration.
 	// If the load falls below these thresholds for a specified amount of time,
 	// AWS OpsWorks stops a specified number of instances.
@@ -6118,8 +6120,6 @@ type SetLoadBasedAutoScalingInput struct {
 	// If the load exceeds these thresholds for a specified amount of time, AWS
 	// OpsWorks starts a specified number of instances.
 	UpScaling *AutoScalingThresholds `type:"structure"`
-
-	_ struct{} `type:"structure"`
 }
 
 // String returns the string representation
@@ -6147,6 +6147,8 @@ func (s SetLoadBasedAutoScalingOutput) GoString() string {
 }
 
 type SetPermissionInput struct {
+	_ struct{} `type:"structure"`
+
 	// The user is allowed to use SSH to communicate with the instance.
 	AllowSsh *bool `type:"boolean"`
 
@@ -6165,8 +6167,6 @@ type SetPermissionInput struct {
 
 	// The stack ID.
 	StackId *string `type:"string" required:"true"`
-
-	_ struct{} `type:"structure"`
 }
 
 // String returns the string representation
@@ -6194,13 +6194,13 @@ func (s SetPermissionOutput) GoString() string {
 }
 
 type SetTimeBasedAutoScalingInput struct {
+	_ struct{} `type:"structure"`
+
 	// An AutoScalingSchedule with the instance schedule.
 	AutoScalingSchedule *WeeklyAutoScalingSchedule `type:"structure"`
 
 	// The instance ID.
 	InstanceId *string `type:"string" required:"true"`
-
-	_ struct{} `type:"structure"`
 }
 
 // String returns the string representation
@@ -6229,6 +6229,8 @@ func (s SetTimeBasedAutoScalingOutput) GoString() string {
 
 // The Shutdown event configuration.
 type ShutdownEventConfiguration struct {
+	_ struct{} `type:"structure"`
+
 	// Whether to enable Elastic Load Balancing connection draining. For more information,
 	// see Connection Draining (http://docs.aws.amazon.com/ElasticLoadBalancing/latest/DeveloperGuide/TerminologyandKeyConcepts.html#conn-drain)
 	DelayUntilElbConnectionsDrained *bool `type:"boolean"`
@@ -6236,8 +6238,6 @@ type ShutdownEventConfiguration struct {
 	// The time, in seconds, that AWS OpsWorks will wait after triggering a Shutdown
 	// event before shutting down an instance.
 	ExecutionTimeout *int64 `type:"integer"`
-
-	_ struct{} `type:"structure"`
 }
 
 // String returns the string representation
@@ -6254,6 +6254,8 @@ func (s ShutdownEventConfiguration) GoString() string {
 // For more information, see Creating Apps (http://docs.aws.amazon.com/opsworks/latest/userguide/workingapps-creating.html)
 // or Custom Recipes and Cookbooks (http://docs.aws.amazon.com/opsworks/latest/userguide/workingcookbook.html).
 type Source struct {
+	_ struct{} `type:"structure"`
+
 	// When included in a request, the parameter depends on the repository type.
 	//
 	//  For Amazon S3 bundles, set Password to the appropriate IAM secret access
@@ -6288,8 +6290,6 @@ type Source struct {
 	// For HTTP bundles, Git repositories, and Subversion repositories, set Username
 	// to the user name.
 	Username *string `type:"string"`
-
-	_ struct{} `type:"structure"`
 }
 
 // String returns the string representation
@@ -6304,6 +6304,8 @@ func (s Source) GoString() string {
 
 // Describes an app's SSL configuration.
 type SslConfiguration struct {
+	_ struct{} `type:"structure"`
+
 	// The contents of the certificate's domain.crt file.
 	Certificate *string `type:"string" required:"true"`
 
@@ -6313,8 +6315,6 @@ type SslConfiguration struct {
 
 	// The private key; the contents of the certificate's domain.kex file.
 	PrivateKey *string `type:"string" required:"true"`
-
-	_ struct{} `type:"structure"`
 }
 
 // String returns the string representation
@@ -6329,6 +6329,8 @@ func (s SslConfiguration) GoString() string {
 
 // Describes a stack.
 type Stack struct {
+	_ struct{} `type:"structure"`
+
 	// The agent version. This parameter is set to LATEST for auto-update. or a
 	// version number for a fixed agent version.
 	AgentVersion *string `type:"string"`
@@ -6415,8 +6417,6 @@ type Stack struct {
 
 	// The VPC ID; applicable only if the stack is running in a VPC.
 	VpcId *string `type:"string"`
-
-	_ struct{} `type:"structure"`
 }
 
 // String returns the string representation
@@ -6431,14 +6431,14 @@ func (s Stack) GoString() string {
 
 // Describes the configuration manager.
 type StackConfigurationManager struct {
+	_ struct{} `type:"structure"`
+
 	// The name. This parameter must be set to "Chef".
 	Name *string `type:"string"`
 
 	// The Chef version. This parameter must be set to 0.9, 11.4, or 11.10. The
 	// default value is 11.4.
 	Version *string `type:"string"`
-
-	_ struct{} `type:"structure"`
 }
 
 // String returns the string representation
@@ -6453,6 +6453,8 @@ func (s StackConfigurationManager) GoString() string {
 
 // Summarizes the number of layers, instances, and apps in a stack.
 type StackSummary struct {
+	_ struct{} `type:"structure"`
+
 	// The number of apps.
 	AppsCount *int64 `type:"integer"`
 
@@ -6470,8 +6472,6 @@ type StackSummary struct {
 
 	// The stack ID.
 	StackId *string `type:"string"`
-
-	_ struct{} `type:"structure"`
 }
 
 // String returns the string representation
@@ -6485,10 +6485,10 @@ func (s StackSummary) GoString() string {
 }
 
 type StartInstanceInput struct {
+	_ struct{} `type:"structure"`
+
 	// The instance ID.
 	InstanceId *string `type:"string" required:"true"`
-
-	_ struct{} `type:"structure"`
 }
 
 // String returns the string representation
@@ -6516,10 +6516,10 @@ func (s StartInstanceOutput) GoString() string {
 }
 
 type StartStackInput struct {
+	_ struct{} `type:"structure"`
+
 	// The stack ID.
 	StackId *string `type:"string" required:"true"`
-
-	_ struct{} `type:"structure"`
 }
 
 // String returns the string representation
@@ -6547,10 +6547,10 @@ func (s StartStackOutput) GoString() string {
 }
 
 type StopInstanceInput struct {
+	_ struct{} `type:"structure"`
+
 	// The instance ID.
 	InstanceId *string `type:"string" required:"true"`
-
-	_ struct{} `type:"structure"`
 }
 
 // String returns the string representation
@@ -6578,10 +6578,10 @@ func (s StopInstanceOutput) GoString() string {
 }
 
 type StopStackInput struct {
+	_ struct{} `type:"structure"`
+
 	// The stack ID.
 	StackId *string `type:"string" required:"true"`
-
-	_ struct{} `type:"structure"`
 }
 
 // String returns the string representation
@@ -6611,6 +6611,8 @@ func (s StopStackOutput) GoString() string {
 // Contains the data needed by RDP clients such as the Microsoft Remote Desktop
 // Connection to log in to the instance.
 type TemporaryCredential struct {
+	_ struct{} `type:"structure"`
+
 	// The instance's AWS OpsWorks ID.
 	InstanceId *string `type:"string"`
 
@@ -6625,8 +6627,6 @@ type TemporaryCredential struct {
 	// to log in. If they are logged in at the time, they will be automatically
 	// logged out.
 	ValidForInMinutes *int64 `type:"integer"`
-
-	_ struct{} `type:"structure"`
 }
 
 // String returns the string representation
@@ -6641,13 +6641,13 @@ func (s TemporaryCredential) GoString() string {
 
 // Describes an instance's time-based auto scaling configuration.
 type TimeBasedAutoScalingConfiguration struct {
+	_ struct{} `type:"structure"`
+
 	// A WeeklyAutoScalingSchedule object with the instance schedule.
 	AutoScalingSchedule *WeeklyAutoScalingSchedule `type:"structure"`
 
 	// The instance ID.
 	InstanceId *string `type:"string"`
-
-	_ struct{} `type:"structure"`
 }
 
 // String returns the string representation
@@ -6661,10 +6661,10 @@ func (s TimeBasedAutoScalingConfiguration) GoString() string {
 }
 
 type UnassignInstanceInput struct {
+	_ struct{} `type:"structure"`
+
 	// The instance ID.
 	InstanceId *string `type:"string" required:"true"`
-
-	_ struct{} `type:"structure"`
 }
 
 // String returns the string representation
@@ -6692,10 +6692,10 @@ func (s UnassignInstanceOutput) GoString() string {
 }
 
 type UnassignVolumeInput struct {
+	_ struct{} `type:"structure"`
+
 	// The volume ID.
 	VolumeId *string `type:"string" required:"true"`
-
-	_ struct{} `type:"structure"`
 }
 
 // String returns the string representation
@@ -6723,6 +6723,8 @@ func (s UnassignVolumeOutput) GoString() string {
 }
 
 type UpdateAppInput struct {
+	_ struct{} `type:"structure"`
+
 	// The app ID.
 	AppId *string `type:"string" required:"true"`
 
@@ -6769,8 +6771,6 @@ type UpdateAppInput struct {
 
 	// The app type.
 	Type *string `type:"string" enum:"AppType"`
-
-	_ struct{} `type:"structure"`
 }
 
 // String returns the string representation
@@ -6798,13 +6798,13 @@ func (s UpdateAppOutput) GoString() string {
 }
 
 type UpdateElasticIpInput struct {
+	_ struct{} `type:"structure"`
+
 	// The address.
 	ElasticIp *string `type:"string" required:"true"`
 
 	// The new name.
 	Name *string `type:"string"`
-
-	_ struct{} `type:"structure"`
 }
 
 // String returns the string representation
@@ -6832,6 +6832,8 @@ func (s UpdateElasticIpOutput) GoString() string {
 }
 
 type UpdateInstanceInput struct {
+	_ struct{} `type:"structure"`
+
 	// The default AWS OpsWorks agent version. You have the following options:
 	//
 	//   INHERIT - Use the stack's default agent version setting.  version_number
@@ -6911,8 +6913,6 @@ type UpdateInstanceInput struct {
 
 	// The instance's Amazon EC2 key name.
 	SshKeyName *string `type:"string"`
-
-	_ struct{} `type:"structure"`
 }
 
 // String returns the string representation
@@ -6940,6 +6940,8 @@ func (s UpdateInstanceOutput) GoString() string {
 }
 
 type UpdateLayerInput struct {
+	_ struct{} `type:"structure"`
+
 	// One or more user-defined key/value pairs to be added to the stack attributes.
 	Attributes map[string]*string `type:"map"`
 
@@ -7006,8 +7008,6 @@ type UpdateLayerInput struct {
 
 	// A VolumeConfigurations object that describes the layer's Amazon EBS volumes.
 	VolumeConfigurations []*VolumeConfiguration `type:"list"`
-
-	_ struct{} `type:"structure"`
 }
 
 // String returns the string representation
@@ -7035,10 +7035,10 @@ func (s UpdateLayerOutput) GoString() string {
 }
 
 type UpdateMyUserProfileInput struct {
+	_ struct{} `type:"structure"`
+
 	// The user's SSH public key.
 	SshPublicKey *string `type:"string"`
-
-	_ struct{} `type:"structure"`
 }
 
 // String returns the string representation
@@ -7066,6 +7066,8 @@ func (s UpdateMyUserProfileOutput) GoString() string {
 }
 
 type UpdateRdsDbInstanceInput struct {
+	_ struct{} `type:"structure"`
+
 	// The database password.
 	DbPassword *string `type:"string"`
 
@@ -7074,8 +7076,6 @@ type UpdateRdsDbInstanceInput struct {
 
 	// The Amazon RDS instance's ARN.
 	RdsDbInstanceArn *string `type:"string" required:"true"`
-
-	_ struct{} `type:"structure"`
 }
 
 // String returns the string representation
@@ -7103,6 +7103,8 @@ func (s UpdateRdsDbInstanceOutput) GoString() string {
 }
 
 type UpdateStackInput struct {
+	_ struct{} `type:"structure"`
+
 	// The default AWS OpsWorks agent version. You have the following options:
 	//
 	//  Auto-update - Set this parameter to LATEST. AWS OpsWorks automatically
@@ -7232,8 +7234,6 @@ type UpdateStackInput struct {
 	// groups are required only for those layers that need custom settings.   For
 	// more information, see Create a New Stack (http://docs.aws.amazon.com/opsworks/latest/userguide/workingstacks-creating.html).
 	UseOpsworksSecurityGroups *bool `type:"boolean"`
-
-	_ struct{} `type:"structure"`
 }
 
 // String returns the string representation
@@ -7261,6 +7261,8 @@ func (s UpdateStackOutput) GoString() string {
 }
 
 type UpdateUserProfileInput struct {
+	_ struct{} `type:"structure"`
+
 	// Whether users can specify their own SSH public key through the My Settings
 	// page. For more information, see Managing User Permissions (http://docs.aws.amazon.com/opsworks/latest/userguide/security-settingsshkey.html).
 	AllowSelfManagement *bool `type:"boolean"`
@@ -7277,8 +7279,6 @@ type UpdateUserProfileInput struct {
 	// you do not specify an SSH user name, AWS OpsWorks generates one from the
 	// IAM user name.
 	SshUsername *string `type:"string"`
-
-	_ struct{} `type:"structure"`
 }
 
 // String returns the string representation
@@ -7306,6 +7306,8 @@ func (s UpdateUserProfileOutput) GoString() string {
 }
 
 type UpdateVolumeInput struct {
+	_ struct{} `type:"structure"`
+
 	// The new mount point.
 	MountPoint *string `type:"string"`
 
@@ -7314,8 +7316,6 @@ type UpdateVolumeInput struct {
 
 	// The volume ID.
 	VolumeId *string `type:"string" required:"true"`
-
-	_ struct{} `type:"structure"`
 }
 
 // String returns the string representation
@@ -7344,6 +7344,8 @@ func (s UpdateVolumeOutput) GoString() string {
 
 // Describes a user's SSH information.
 type UserProfile struct {
+	_ struct{} `type:"structure"`
+
 	// Whether users can specify their own SSH public key through the My Settings
 	// page. For more information, see Managing User Permissions (http://docs.aws.amazon.com/opsworks/latest/userguide/security-settingsshkey.html).
 	AllowSelfManagement *bool `type:"boolean"`
@@ -7359,8 +7361,6 @@ type UserProfile struct {
 
 	// The user's SSH user name.
 	SshUsername *string `type:"string"`
-
-	_ struct{} `type:"structure"`
 }
 
 // String returns the string representation
@@ -7375,6 +7375,8 @@ func (s UserProfile) GoString() string {
 
 // Describes an instance's Amazon EBS volume.
 type Volume struct {
+	_ struct{} `type:"structure"`
+
 	// The volume Availability Zone. For more information, see Regions and Endpoints
 	// (http://docs.aws.amazon.com/general/latest/gr/rande.html).
 	AvailabilityZone *string `type:"string"`
@@ -7415,8 +7417,6 @@ type Volume struct {
 
 	// The volume type, standard or PIOPS.
 	VolumeType *string `type:"string"`
-
-	_ struct{} `type:"structure"`
 }
 
 // String returns the string representation
@@ -7431,6 +7431,8 @@ func (s Volume) GoString() string {
 
 // Describes an Amazon EBS volume configuration.
 type VolumeConfiguration struct {
+	_ struct{} `type:"structure"`
+
 	// For PIOPS volumes, the IOPS per disk.
 	Iops *int64 `type:"integer"`
 
@@ -7451,8 +7453,6 @@ type VolumeConfiguration struct {
 	//   standard - Magnetic  io1 - Provisioned IOPS (SSD)  gp2 - General Purpose
 	// (SSD)
 	VolumeType *string `type:"string"`
-
-	_ struct{} `type:"structure"`
 }
 
 // String returns the string representation
@@ -7480,6 +7480,8 @@ func (s VolumeConfiguration) GoString() string {
 //
 //   { "12":"on", "13":"on", "14":"on", "15":"on" }
 type WeeklyAutoScalingSchedule struct {
+	_ struct{} `type:"structure"`
+
 	// The schedule for Friday.
 	Friday map[string]*string `type:"map"`
 
@@ -7500,8 +7502,6 @@ type WeeklyAutoScalingSchedule struct {
 
 	// The schedule for Wednesday.
 	Wednesday map[string]*string `type:"map"`
-
-	_ struct{} `type:"structure"`
 }
 
 // String returns the string representation

--- a/service/rds/api.go
+++ b/service/rds/api.go
@@ -2722,6 +2722,8 @@ func (c *RDS) RevokeDBSecurityGroupIngress(input *RevokeDBSecurityGroupIngressIn
 // Describes a quota for an AWS account, for example, the number of DB instances
 // allowed.
 type AccountQuota struct {
+	_ struct{} `type:"structure"`
+
 	// The name of the Amazon RDS quota for this AWS account.
 	AccountQuotaName *string `type:"string"`
 
@@ -2730,8 +2732,6 @@ type AccountQuota struct {
 
 	// The amount currently used toward the quota maximum.
 	Used *int64 `type:"long"`
-
-	_ struct{} `type:"structure"`
 }
 
 // String returns the string representation
@@ -2745,6 +2745,8 @@ func (s AccountQuota) GoString() string {
 }
 
 type AddSourceIdentifierToSubscriptionInput struct {
+	_ struct{} `type:"structure"`
+
 	// The identifier of the event source to be added. An identifier must begin
 	// with a letter and must contain only ASCII letters, digits, and hyphens; it
 	// cannot end with a hyphen or contain two consecutive hyphens.
@@ -2761,8 +2763,6 @@ type AddSourceIdentifierToSubscriptionInput struct {
 	// The name of the RDS event notification subscription you want to add a source
 	// identifier to.
 	SubscriptionName *string `type:"string" required:"true"`
-
-	_ struct{} `type:"structure"`
 }
 
 // String returns the string representation
@@ -2776,11 +2776,11 @@ func (s AddSourceIdentifierToSubscriptionInput) GoString() string {
 }
 
 type AddSourceIdentifierToSubscriptionOutput struct {
+	_ struct{} `type:"structure"`
+
 	// Contains the results of a successful invocation of the DescribeEventSubscriptions
 	// action.
 	EventSubscription *EventSubscription `type:"structure"`
-
-	_ struct{} `type:"structure"`
 }
 
 // String returns the string representation
@@ -2794,6 +2794,8 @@ func (s AddSourceIdentifierToSubscriptionOutput) GoString() string {
 }
 
 type AddTagsToResourceInput struct {
+	_ struct{} `type:"structure"`
+
 	// The Amazon RDS resource the tags will be added to. This value is an Amazon
 	// Resource Name (ARN). For information about creating an ARN, see  Constructing
 	// an RDS Amazon Resource Name (ARN) (http://docs.aws.amazon.com/AmazonRDS/latest/UserGuide/USER_Tagging.html#USER_Tagging.ARN).
@@ -2801,8 +2803,6 @@ type AddTagsToResourceInput struct {
 
 	// The tags to be assigned to the Amazon RDS resource.
 	Tags []*Tag `locationNameList:"Tag" type:"list" required:"true"`
-
-	_ struct{} `type:"structure"`
 }
 
 // String returns the string representation
@@ -2830,6 +2830,8 @@ func (s AddTagsToResourceOutput) GoString() string {
 }
 
 type ApplyPendingMaintenanceActionInput struct {
+	_ struct{} `type:"structure"`
+
 	// The pending maintenance action to apply to this resource.
 	ApplyAction *string `type:"string" required:"true"`
 
@@ -2847,8 +2849,6 @@ type ApplyPendingMaintenanceActionInput struct {
 	// action applies to. For information about creating an ARN, see  Constructing
 	// an RDS Amazon Resource Name (ARN) (http://docs.aws.amazon.com/AmazonRDS/latest/UserGuide/USER_Tagging.html#USER_Tagging.ARN).
 	ResourceIdentifier *string `type:"string" required:"true"`
-
-	_ struct{} `type:"structure"`
 }
 
 // String returns the string representation
@@ -2862,10 +2862,10 @@ func (s ApplyPendingMaintenanceActionInput) GoString() string {
 }
 
 type ApplyPendingMaintenanceActionOutput struct {
+	_ struct{} `type:"structure"`
+
 	// Describes the pending maintenance actions for a resource.
 	ResourcePendingMaintenanceActions *ResourcePendingMaintenanceActions `type:"structure"`
-
-	_ struct{} `type:"structure"`
 }
 
 // String returns the string representation
@@ -2879,6 +2879,8 @@ func (s ApplyPendingMaintenanceActionOutput) GoString() string {
 }
 
 type AuthorizeDBSecurityGroupIngressInput struct {
+	_ struct{} `type:"structure"`
+
 	// The IP range to authorize.
 	CIDRIP *string `type:"string"`
 
@@ -2901,8 +2903,6 @@ type AuthorizeDBSecurityGroupIngressInput struct {
 	// EC2SecurityGroupOwnerId and either EC2SecurityGroupName or EC2SecurityGroupId
 	// must be provided.
 	EC2SecurityGroupOwnerId *string `type:"string"`
-
-	_ struct{} `type:"structure"`
 }
 
 // String returns the string representation
@@ -2916,14 +2916,14 @@ func (s AuthorizeDBSecurityGroupIngressInput) GoString() string {
 }
 
 type AuthorizeDBSecurityGroupIngressOutput struct {
+	_ struct{} `type:"structure"`
+
 	// Contains the result of a successful invocation of the following actions:
 	//
 	//   DescribeDBSecurityGroups   AuthorizeDBSecurityGroupIngress   CreateDBSecurityGroup
 	//   RevokeDBSecurityGroupIngress   This data type is used as a response element
 	// in the DescribeDBSecurityGroups action.
 	DBSecurityGroup *DBSecurityGroup `type:"structure"`
-
-	_ struct{} `type:"structure"`
 }
 
 // String returns the string representation
@@ -2940,10 +2940,10 @@ func (s AuthorizeDBSecurityGroupIngressOutput) GoString() string {
 //
 //  This data type is used as an element in the following data type: OrderableDBInstanceOption
 type AvailabilityZone struct {
+	_ struct{} `type:"structure"`
+
 	// The name of the availability zone.
 	Name *string `type:"string"`
-
-	_ struct{} `type:"structure"`
 }
 
 // String returns the string representation
@@ -2958,6 +2958,8 @@ func (s AvailabilityZone) GoString() string {
 
 // A CA certificate for an AWS account.
 type Certificate struct {
+	_ struct{} `type:"structure"`
+
 	// The unique key that identifies a certificate.
 	CertificateIdentifier *string `type:"string"`
 
@@ -2972,8 +2974,6 @@ type Certificate struct {
 
 	// The final date that the certificate continues to be valid.
 	ValidTill *time.Time `type:"timestamp" timestampFormat:"iso8601"`
-
-	_ struct{} `type:"structure"`
 }
 
 // String returns the string representation
@@ -2988,13 +2988,13 @@ func (s Certificate) GoString() string {
 
 // This data type is used as a response element in the action DescribeDBEngineVersions.
 type CharacterSet struct {
+	_ struct{} `type:"structure"`
+
 	// The description of the character set.
 	CharacterSetDescription *string `type:"string"`
 
 	// The name of the character set.
 	CharacterSetName *string `type:"string"`
-
-	_ struct{} `type:"structure"`
 }
 
 // String returns the string representation
@@ -3008,6 +3008,8 @@ func (s CharacterSet) GoString() string {
 }
 
 type CopyDBClusterSnapshotInput struct {
+	_ struct{} `type:"structure"`
+
 	// The identifier of the DB cluster snapshot to copy. This parameter is not
 	// case-sensitive.
 	//
@@ -3030,8 +3032,6 @@ type CopyDBClusterSnapshotInput struct {
 	// must be a letter. Cannot end with a hyphen or contain two consecutive hyphens.
 	//  Example: my-cluster-snapshot2
 	TargetDBClusterSnapshotIdentifier *string `type:"string" required:"true"`
-
-	_ struct{} `type:"structure"`
 }
 
 // String returns the string representation
@@ -3045,13 +3045,13 @@ func (s CopyDBClusterSnapshotInput) GoString() string {
 }
 
 type CopyDBClusterSnapshotOutput struct {
+	_ struct{} `type:"structure"`
+
 	// Contains the result of a successful invocation of the following actions:
 	//
 	//   CreateDBClusterSnapshot   DeleteDBClusterSnapshot   This data type is
 	// used as a response element in the DescribeDBClusterSnapshots action.
 	DBClusterSnapshot *DBClusterSnapshot `type:"structure"`
-
-	_ struct{} `type:"structure"`
 }
 
 // String returns the string representation
@@ -3065,6 +3065,8 @@ func (s CopyDBClusterSnapshotOutput) GoString() string {
 }
 
 type CopyDBParameterGroupInput struct {
+	_ struct{} `type:"structure"`
+
 	// The identifier or ARN for the source DB parameter group. For information
 	// about creating an ARN, see  Constructing an RDS Amazon Resource Name (ARN)
 	// (http://docs.aws.amazon.com/AmazonRDS/latest/UserGuide/USER_Tagging.html#USER_Tagging.ARN).
@@ -3092,8 +3094,6 @@ type CopyDBParameterGroupInput struct {
 	// characters or hyphens First character must be a letter Cannot end with a
 	// hyphen or contain two consecutive hyphens  Example: my-db-parameter-group
 	TargetDBParameterGroupIdentifier *string `type:"string" required:"true"`
-
-	_ struct{} `type:"structure"`
 }
 
 // String returns the string representation
@@ -3107,14 +3107,14 @@ func (s CopyDBParameterGroupInput) GoString() string {
 }
 
 type CopyDBParameterGroupOutput struct {
+	_ struct{} `type:"structure"`
+
 	// Contains the result of a successful invocation of the CreateDBParameterGroup
 	// action.
 	//
 	// This data type is used as a request parameter in the DeleteDBParameterGroup
 	// action, and as a response element in the DescribeDBParameterGroups action.
 	DBParameterGroup *DBParameterGroup `type:"structure"`
-
-	_ struct{} `type:"structure"`
 }
 
 // String returns the string representation
@@ -3128,6 +3128,8 @@ func (s CopyDBParameterGroupOutput) GoString() string {
 }
 
 type CopyDBSnapshotInput struct {
+	_ struct{} `type:"structure"`
+
 	// True to copy all tags from the source DB snapshot to the target DB snapshot;
 	// otherwise false. The default is false.
 	CopyTags *bool `type:"boolean"`
@@ -3160,8 +3162,6 @@ type CopyDBSnapshotInput struct {
 	// characters or hyphens First character must be a letter Cannot end with a
 	// hyphen or contain two consecutive hyphens  Example: my-db-snapshot
 	TargetDBSnapshotIdentifier *string `type:"string" required:"true"`
-
-	_ struct{} `type:"structure"`
 }
 
 // String returns the string representation
@@ -3175,13 +3175,13 @@ func (s CopyDBSnapshotInput) GoString() string {
 }
 
 type CopyDBSnapshotOutput struct {
+	_ struct{} `type:"structure"`
+
 	// Contains the result of a successful invocation of the following actions:
 	//
 	//   CreateDBSnapshot   DeleteDBSnapshot   This data type is used as a response
 	// element in the DescribeDBSnapshots action.
 	DBSnapshot *DBSnapshot `type:"structure"`
-
-	_ struct{} `type:"structure"`
 }
 
 // String returns the string representation
@@ -3195,6 +3195,8 @@ func (s CopyDBSnapshotOutput) GoString() string {
 }
 
 type CopyOptionGroupInput struct {
+	_ struct{} `type:"structure"`
+
 	// The identifier or ARN for the source option group. For information about
 	// creating an ARN, see  Constructing an RDS Amazon Resource Name (ARN) (http://docs.aws.amazon.com/AmazonRDS/latest/UserGuide/USER_Tagging.html#USER_Tagging.ARN).
 	//
@@ -3220,8 +3222,6 @@ type CopyOptionGroupInput struct {
 	// characters or hyphens First character must be a letter Cannot end with a
 	// hyphen or contain two consecutive hyphens  Example: my-option-group
 	TargetOptionGroupIdentifier *string `type:"string" required:"true"`
-
-	_ struct{} `type:"structure"`
 }
 
 // String returns the string representation
@@ -3235,9 +3235,9 @@ func (s CopyOptionGroupInput) GoString() string {
 }
 
 type CopyOptionGroupOutput struct {
-	OptionGroup *OptionGroup `type:"structure"`
-
 	_ struct{} `type:"structure"`
+
+	OptionGroup *OptionGroup `type:"structure"`
 }
 
 // String returns the string representation
@@ -3251,6 +3251,8 @@ func (s CopyOptionGroupOutput) GoString() string {
 }
 
 type CreateDBClusterInput struct {
+	_ struct{} `type:"structure"`
+
 	// A list of EC2 Availability Zones that instances in the DB cluster can be
 	// created in. For information on regions and Availability Zones, see Regions
 	// and Availability Zones (http://docs.aws.amazon.com/AmazonRDS/latest/UserGuide/Concepts.RegionsAndAvailabilityZones.html).
@@ -3370,8 +3372,6 @@ type CreateDBClusterInput struct {
 
 	// A list of EC2 VPC security groups to associate with this DB cluster.
 	VpcSecurityGroupIds []*string `locationNameList:"VpcSecurityGroupId" type:"list"`
-
-	_ struct{} `type:"structure"`
 }
 
 // String returns the string representation
@@ -3385,14 +3385,14 @@ func (s CreateDBClusterInput) GoString() string {
 }
 
 type CreateDBClusterOutput struct {
+	_ struct{} `type:"structure"`
+
 	// Contains the result of a successful invocation of the following actions:
 	//
 	//   CreateDBCluster   DeleteDBCluster   FailoverDBCluster   ModifyDBCluster
 	//   RestoreDBClusterFromSnapshot   This data type is used as a response element
 	// in the DescribeDBClusters action.
 	DBCluster *DBCluster `type:"structure"`
-
-	_ struct{} `type:"structure"`
 }
 
 // String returns the string representation
@@ -3406,6 +3406,8 @@ func (s CreateDBClusterOutput) GoString() string {
 }
 
 type CreateDBClusterParameterGroupInput struct {
+	_ struct{} `type:"structure"`
+
 	// The name of the DB cluster parameter group.
 	//
 	//  Constraints:
@@ -3426,8 +3428,6 @@ type CreateDBClusterParameterGroupInput struct {
 
 	// A list of tags.
 	Tags []*Tag `locationNameList:"Tag" type:"list"`
-
-	_ struct{} `type:"structure"`
 }
 
 // String returns the string representation
@@ -3441,6 +3441,8 @@ func (s CreateDBClusterParameterGroupInput) GoString() string {
 }
 
 type CreateDBClusterParameterGroupOutput struct {
+	_ struct{} `type:"structure"`
+
 	// Contains the result of a successful invocation of the CreateDBClusterParameterGroup
 	// action.
 	//
@@ -3448,8 +3450,6 @@ type CreateDBClusterParameterGroupOutput struct {
 	// action, and as a response element in the DescribeDBClusterParameterGroups
 	// action.
 	DBClusterParameterGroup *DBClusterParameterGroup `type:"structure"`
-
-	_ struct{} `type:"structure"`
 }
 
 // String returns the string representation
@@ -3463,6 +3463,8 @@ func (s CreateDBClusterParameterGroupOutput) GoString() string {
 }
 
 type CreateDBClusterSnapshotInput struct {
+	_ struct{} `type:"structure"`
+
 	// The identifier of the DB cluster to create a snapshot for. This parameter
 	// is not case-sensitive.
 	//
@@ -3485,8 +3487,6 @@ type CreateDBClusterSnapshotInput struct {
 
 	// The tags to be assigned to the DB cluster snapshot.
 	Tags []*Tag `locationNameList:"Tag" type:"list"`
-
-	_ struct{} `type:"structure"`
 }
 
 // String returns the string representation
@@ -3500,13 +3500,13 @@ func (s CreateDBClusterSnapshotInput) GoString() string {
 }
 
 type CreateDBClusterSnapshotOutput struct {
+	_ struct{} `type:"structure"`
+
 	// Contains the result of a successful invocation of the following actions:
 	//
 	//   CreateDBClusterSnapshot   DeleteDBClusterSnapshot   This data type is
 	// used as a response element in the DescribeDBClusterSnapshots action.
 	DBClusterSnapshot *DBClusterSnapshot `type:"structure"`
-
-	_ struct{} `type:"structure"`
 }
 
 // String returns the string representation
@@ -3520,6 +3520,8 @@ func (s CreateDBClusterSnapshotOutput) GoString() string {
 }
 
 type CreateDBInstanceInput struct {
+	_ struct{} `type:"structure"`
+
 	// The amount of storage (in gigabytes) to be initially allocated for the database
 	// instance.
 	//
@@ -3988,8 +3990,6 @@ type CreateDBInstanceInput struct {
 	//
 	//  Default: The default EC2 VPC security group for the DB subnet group's VPC.
 	VpcSecurityGroupIds []*string `locationNameList:"VpcSecurityGroupId" type:"list"`
-
-	_ struct{} `type:"structure"`
 }
 
 // String returns the string representation
@@ -4003,13 +4003,13 @@ func (s CreateDBInstanceInput) GoString() string {
 }
 
 type CreateDBInstanceOutput struct {
+	_ struct{} `type:"structure"`
+
 	// Contains the result of a successful invocation of the following actions:
 	//
 	//   CreateDBInstance   DeleteDBInstance   ModifyDBInstance   This data type
 	// is used as a response element in the DescribeDBInstances action.
 	DBInstance *DBInstance `type:"structure"`
-
-	_ struct{} `type:"structure"`
 }
 
 // String returns the string representation
@@ -4023,6 +4023,8 @@ func (s CreateDBInstanceOutput) GoString() string {
 }
 
 type CreateDBInstanceReadReplicaInput struct {
+	_ struct{} `type:"structure"`
+
 	// Indicates that minor engine upgrades will be applied automatically to the
 	// Read Replica during the maintenance window.
 	//
@@ -4130,8 +4132,6 @@ type CreateDBInstanceReadReplicaInput struct {
 
 	// A list of tags.
 	Tags []*Tag `locationNameList:"Tag" type:"list"`
-
-	_ struct{} `type:"structure"`
 }
 
 // String returns the string representation
@@ -4145,13 +4145,13 @@ func (s CreateDBInstanceReadReplicaInput) GoString() string {
 }
 
 type CreateDBInstanceReadReplicaOutput struct {
+	_ struct{} `type:"structure"`
+
 	// Contains the result of a successful invocation of the following actions:
 	//
 	//   CreateDBInstance   DeleteDBInstance   ModifyDBInstance   This data type
 	// is used as a response element in the DescribeDBInstances action.
 	DBInstance *DBInstance `type:"structure"`
-
-	_ struct{} `type:"structure"`
 }
 
 // String returns the string representation
@@ -4165,6 +4165,8 @@ func (s CreateDBInstanceReadReplicaOutput) GoString() string {
 }
 
 type CreateDBParameterGroupInput struct {
+	_ struct{} `type:"structure"`
+
 	// The DB parameter group family name. A DB parameter group can be associated
 	// with one and only one DB parameter group family, and can be applied only
 	// to a DB instance running a database engine and engine version compatible
@@ -4185,8 +4187,6 @@ type CreateDBParameterGroupInput struct {
 
 	// A list of tags.
 	Tags []*Tag `locationNameList:"Tag" type:"list"`
-
-	_ struct{} `type:"structure"`
 }
 
 // String returns the string representation
@@ -4200,14 +4200,14 @@ func (s CreateDBParameterGroupInput) GoString() string {
 }
 
 type CreateDBParameterGroupOutput struct {
+	_ struct{} `type:"structure"`
+
 	// Contains the result of a successful invocation of the CreateDBParameterGroup
 	// action.
 	//
 	// This data type is used as a request parameter in the DeleteDBParameterGroup
 	// action, and as a response element in the DescribeDBParameterGroups action.
 	DBParameterGroup *DBParameterGroup `type:"structure"`
-
-	_ struct{} `type:"structure"`
 }
 
 // String returns the string representation
@@ -4221,6 +4221,8 @@ func (s CreateDBParameterGroupOutput) GoString() string {
 }
 
 type CreateDBSecurityGroupInput struct {
+	_ struct{} `type:"structure"`
+
 	// The description for the DB security group.
 	DBSecurityGroupDescription *string `type:"string" required:"true"`
 
@@ -4235,8 +4237,6 @@ type CreateDBSecurityGroupInput struct {
 
 	// A list of tags.
 	Tags []*Tag `locationNameList:"Tag" type:"list"`
-
-	_ struct{} `type:"structure"`
 }
 
 // String returns the string representation
@@ -4250,14 +4250,14 @@ func (s CreateDBSecurityGroupInput) GoString() string {
 }
 
 type CreateDBSecurityGroupOutput struct {
+	_ struct{} `type:"structure"`
+
 	// Contains the result of a successful invocation of the following actions:
 	//
 	//   DescribeDBSecurityGroups   AuthorizeDBSecurityGroupIngress   CreateDBSecurityGroup
 	//   RevokeDBSecurityGroupIngress   This data type is used as a response element
 	// in the DescribeDBSecurityGroups action.
 	DBSecurityGroup *DBSecurityGroup `type:"structure"`
-
-	_ struct{} `type:"structure"`
 }
 
 // String returns the string representation
@@ -4271,6 +4271,8 @@ func (s CreateDBSecurityGroupOutput) GoString() string {
 }
 
 type CreateDBSnapshotInput struct {
+	_ struct{} `type:"structure"`
+
 	// The DB instance identifier. This is the unique key that identifies a DB instance.
 	//
 	// Constraints:
@@ -4290,8 +4292,6 @@ type CreateDBSnapshotInput struct {
 
 	// A list of tags.
 	Tags []*Tag `locationNameList:"Tag" type:"list"`
-
-	_ struct{} `type:"structure"`
 }
 
 // String returns the string representation
@@ -4305,13 +4305,13 @@ func (s CreateDBSnapshotInput) GoString() string {
 }
 
 type CreateDBSnapshotOutput struct {
+	_ struct{} `type:"structure"`
+
 	// Contains the result of a successful invocation of the following actions:
 	//
 	//   CreateDBSnapshot   DeleteDBSnapshot   This data type is used as a response
 	// element in the DescribeDBSnapshots action.
 	DBSnapshot *DBSnapshot `type:"structure"`
-
-	_ struct{} `type:"structure"`
 }
 
 // String returns the string representation
@@ -4325,6 +4325,8 @@ func (s CreateDBSnapshotOutput) GoString() string {
 }
 
 type CreateDBSubnetGroupInput struct {
+	_ struct{} `type:"structure"`
+
 	// The description for the DB subnet group.
 	DBSubnetGroupDescription *string `type:"string" required:"true"`
 
@@ -4341,8 +4343,6 @@ type CreateDBSubnetGroupInput struct {
 
 	// A list of tags.
 	Tags []*Tag `locationNameList:"Tag" type:"list"`
-
-	_ struct{} `type:"structure"`
 }
 
 // String returns the string representation
@@ -4356,14 +4356,14 @@ func (s CreateDBSubnetGroupInput) GoString() string {
 }
 
 type CreateDBSubnetGroupOutput struct {
+	_ struct{} `type:"structure"`
+
 	// Contains the result of a successful invocation of the following actions:
 	//
 	//   CreateDBSubnetGroup   ModifyDBSubnetGroup   DescribeDBSubnetGroups   DeleteDBSubnetGroup
 	//   This data type is used as a response element in the DescribeDBSubnetGroups
 	// action.
 	DBSubnetGroup *DBSubnetGroup `type:"structure"`
-
-	_ struct{} `type:"structure"`
 }
 
 // String returns the string representation
@@ -4377,6 +4377,8 @@ func (s CreateDBSubnetGroupOutput) GoString() string {
 }
 
 type CreateEventSubscriptionInput struct {
+	_ struct{} `type:"structure"`
+
 	// A Boolean value; set to true to activate the subscription, set to false to
 	// create the subscription but not active it.
 	Enabled *bool `type:"boolean"`
@@ -4423,8 +4425,6 @@ type CreateEventSubscriptionInput struct {
 
 	// A list of tags.
 	Tags []*Tag `locationNameList:"Tag" type:"list"`
-
-	_ struct{} `type:"structure"`
 }
 
 // String returns the string representation
@@ -4438,11 +4438,11 @@ func (s CreateEventSubscriptionInput) GoString() string {
 }
 
 type CreateEventSubscriptionOutput struct {
+	_ struct{} `type:"structure"`
+
 	// Contains the results of a successful invocation of the DescribeEventSubscriptions
 	// action.
 	EventSubscription *EventSubscription `type:"structure"`
-
-	_ struct{} `type:"structure"`
 }
 
 // String returns the string representation
@@ -4456,6 +4456,8 @@ func (s CreateEventSubscriptionOutput) GoString() string {
 }
 
 type CreateOptionGroupInput struct {
+	_ struct{} `type:"structure"`
+
 	// Specifies the name of the engine that this option group should be associated
 	// with.
 	EngineName *string `type:"string" required:"true"`
@@ -4478,8 +4480,6 @@ type CreateOptionGroupInput struct {
 
 	// A list of tags.
 	Tags []*Tag `locationNameList:"Tag" type:"list"`
-
-	_ struct{} `type:"structure"`
 }
 
 // String returns the string representation
@@ -4493,9 +4493,9 @@ func (s CreateOptionGroupInput) GoString() string {
 }
 
 type CreateOptionGroupOutput struct {
-	OptionGroup *OptionGroup `type:"structure"`
-
 	_ struct{} `type:"structure"`
+
+	OptionGroup *OptionGroup `type:"structure"`
 }
 
 // String returns the string representation
@@ -4514,6 +4514,8 @@ func (s CreateOptionGroupOutput) GoString() string {
 //   RestoreDBClusterFromSnapshot   This data type is used as a response element
 // in the DescribeDBClusters action.
 type DBCluster struct {
+	_ struct{} `type:"structure"`
+
 	// Specifies the allocated storage size in gigabytes (GB).
 	AllocatedStorage *int64 `type:"integer"`
 
@@ -4592,8 +4594,6 @@ type DBCluster struct {
 
 	// Provides a list of VPC security groups that the DB cluster belongs to.
 	VpcSecurityGroups []*VpcSecurityGroupMembership `locationNameList:"VpcSecurityGroupMembership" type:"list"`
-
-	_ struct{} `type:"structure"`
 }
 
 // String returns the string representation
@@ -4608,6 +4608,8 @@ func (s DBCluster) GoString() string {
 
 // Contains information about an instance that is part of a DB cluster.
 type DBClusterMember struct {
+	_ struct{} `type:"structure"`
+
 	// Specifies the status of the DB cluster parameter group for this member of
 	// the DB cluster.
 	DBClusterParameterGroupStatus *string `type:"string"`
@@ -4618,8 +4620,6 @@ type DBClusterMember struct {
 	// Value that is true if the cluster member is the primary instance for the
 	// DB cluster and false otherwise.
 	IsClusterWriter *bool `type:"boolean"`
-
-	_ struct{} `type:"structure"`
 }
 
 // String returns the string representation
@@ -4634,13 +4634,13 @@ func (s DBClusterMember) GoString() string {
 
 // Contains status information for a DB cluster option group.
 type DBClusterOptionGroupStatus struct {
+	_ struct{} `type:"structure"`
+
 	// Specifies the name of the DB cluster option group.
 	DBClusterOptionGroupName *string `type:"string"`
 
 	// Specifies the status of the DB cluster option group.
 	Status *string `type:"string"`
-
-	_ struct{} `type:"structure"`
 }
 
 // String returns the string representation
@@ -4660,6 +4660,8 @@ func (s DBClusterOptionGroupStatus) GoString() string {
 // action, and as a response element in the DescribeDBClusterParameterGroups
 // action.
 type DBClusterParameterGroup struct {
+	_ struct{} `type:"structure"`
+
 	// Provides the name of the DB cluster parameter group.
 	DBClusterParameterGroupName *string `type:"string"`
 
@@ -4670,8 +4672,6 @@ type DBClusterParameterGroup struct {
 	// Provides the customer-specified description for this DB cluster parameter
 	// group.
 	Description *string `type:"string"`
-
-	_ struct{} `type:"structure"`
 }
 
 // String returns the string representation
@@ -4685,6 +4685,8 @@ func (s DBClusterParameterGroup) GoString() string {
 }
 
 type DBClusterParameterGroupNameMessage struct {
+	_ struct{} `type:"structure"`
+
 	// The name of the DB cluster parameter group.
 	//
 	//  Constraints:
@@ -4693,8 +4695,6 @@ type DBClusterParameterGroupNameMessage struct {
 	// Cannot end with a hyphen or contain two consecutive hyphens  This value is
 	// stored as a lowercase string.
 	DBClusterParameterGroupName *string `type:"string"`
-
-	_ struct{} `type:"structure"`
 }
 
 // String returns the string representation
@@ -4712,6 +4712,8 @@ func (s DBClusterParameterGroupNameMessage) GoString() string {
 //   CreateDBClusterSnapshot   DeleteDBClusterSnapshot   This data type is
 // used as a response element in the DescribeDBClusterSnapshots action.
 type DBClusterSnapshot struct {
+	_ struct{} `type:"structure"`
+
 	// Specifies the allocated storage size in gigabytes (GB).
 	AllocatedStorage *int64 `type:"integer"`
 
@@ -4761,8 +4763,6 @@ type DBClusterSnapshot struct {
 
 	// Provides the VPC ID associated with the DB cluster snapshot.
 	VpcId *string `type:"string"`
-
-	_ struct{} `type:"structure"`
 }
 
 // String returns the string representation
@@ -4777,6 +4777,8 @@ func (s DBClusterSnapshot) GoString() string {
 
 // This data type is used as a response element in the action DescribeDBEngineVersions.
 type DBEngineVersion struct {
+	_ struct{} `type:"structure"`
+
 	// The description of the database engine.
 	DBEngineDescription *string `type:"string"`
 
@@ -4803,8 +4805,6 @@ type DBEngineVersion struct {
 	// A list of engine versions that this database engine version can be upgraded
 	// to.
 	ValidUpgradeTarget []*UpgradeTarget `locationNameList:"UpgradeTarget" type:"list"`
-
-	_ struct{} `type:"structure"`
 }
 
 // String returns the string representation
@@ -4822,6 +4822,8 @@ func (s DBEngineVersion) GoString() string {
 //   CreateDBInstance   DeleteDBInstance   ModifyDBInstance   This data type
 // is used as a response element in the DescribeDBInstances action.
 type DBInstance struct {
+	_ struct{} `type:"structure"`
+
 	// Specifies the allocated storage size specified in gigabytes.
 	AllocatedStorage *int64 `type:"integer"`
 
@@ -4989,8 +4991,6 @@ type DBInstance struct {
 	// Provides List of VPC security group elements that the DB instance belongs
 	// to.
 	VpcSecurityGroups []*VpcSecurityGroupMembership `locationNameList:"VpcSecurityGroupMembership" type:"list"`
-
-	_ struct{} `type:"structure"`
 }
 
 // String returns the string representation
@@ -5005,6 +5005,8 @@ func (s DBInstance) GoString() string {
 
 // Provides a list of status information for a DB instance.
 type DBInstanceStatusInfo struct {
+	_ struct{} `type:"structure"`
+
 	// Details of the error if there is an error for the instance. If the instance
 	// is not in an error state, this value is blank.
 	Message *string `type:"string"`
@@ -5019,8 +5021,6 @@ type DBInstanceStatusInfo struct {
 
 	// This value is currently "read replication."
 	StatusType *string `type:"string"`
-
-	_ struct{} `type:"structure"`
 }
 
 // String returns the string representation
@@ -5039,6 +5039,8 @@ func (s DBInstanceStatusInfo) GoString() string {
 // This data type is used as a request parameter in the DeleteDBParameterGroup
 // action, and as a response element in the DescribeDBParameterGroups action.
 type DBParameterGroup struct {
+	_ struct{} `type:"structure"`
+
 	// Provides the name of the DB parameter group family that this DB parameter
 	// group is compatible with.
 	DBParameterGroupFamily *string `type:"string"`
@@ -5048,8 +5050,6 @@ type DBParameterGroup struct {
 
 	// Provides the customer-specified description for this DB parameter group.
 	Description *string `type:"string"`
-
-	_ struct{} `type:"structure"`
 }
 
 // String returns the string representation
@@ -5065,10 +5065,10 @@ func (s DBParameterGroup) GoString() string {
 // Contains the result of a successful invocation of the ModifyDBParameterGroup
 // or ResetDBParameterGroup action.
 type DBParameterGroupNameMessage struct {
+	_ struct{} `type:"structure"`
+
 	// Provides the name of the DB parameter group.
 	DBParameterGroupName *string `type:"string"`
-
-	_ struct{} `type:"structure"`
 }
 
 // String returns the string representation
@@ -5088,13 +5088,13 @@ func (s DBParameterGroupNameMessage) GoString() string {
 //   CreateDBInstance   CreateDBInstanceReadReplica   DeleteDBInstance   ModifyDBInstance
 //   RebootDBInstance   RestoreDBInstanceFromDBSnapshot
 type DBParameterGroupStatus struct {
+	_ struct{} `type:"structure"`
+
 	// The name of the DP parameter group.
 	DBParameterGroupName *string `type:"string"`
 
 	// The status of parameter updates.
 	ParameterApplyStatus *string `type:"string"`
-
-	_ struct{} `type:"structure"`
 }
 
 // String returns the string representation
@@ -5113,6 +5113,8 @@ func (s DBParameterGroupStatus) GoString() string {
 //   RevokeDBSecurityGroupIngress   This data type is used as a response element
 // in the DescribeDBSecurityGroups action.
 type DBSecurityGroup struct {
+	_ struct{} `type:"structure"`
+
 	// Provides the description of the DB security group.
 	DBSecurityGroupDescription *string `type:"string"`
 
@@ -5130,8 +5132,6 @@ type DBSecurityGroup struct {
 
 	// Provides the VpcId of the DB security group.
 	VpcId *string `type:"string"`
-
-	_ struct{} `type:"structure"`
 }
 
 // String returns the string representation
@@ -5149,13 +5149,13 @@ func (s DBSecurityGroup) GoString() string {
 //   ModifyDBInstance   RebootDBInstance   RestoreDBInstanceFromDBSnapshot
 //   RestoreDBInstanceToPointInTime
 type DBSecurityGroupMembership struct {
+	_ struct{} `type:"structure"`
+
 	// The name of the DB security group.
 	DBSecurityGroupName *string `type:"string"`
 
 	// The status of the DB security group.
 	Status *string `type:"string"`
-
-	_ struct{} `type:"structure"`
 }
 
 // String returns the string representation
@@ -5173,6 +5173,8 @@ func (s DBSecurityGroupMembership) GoString() string {
 //   CreateDBSnapshot   DeleteDBSnapshot   This data type is used as a response
 // element in the DescribeDBSnapshots action.
 type DBSnapshot struct {
+	_ struct{} `type:"structure"`
+
 	// Specifies the allocated storage size in gigabytes (GB).
 	AllocatedStorage *int64 `type:"integer"`
 
@@ -5248,8 +5250,6 @@ type DBSnapshot struct {
 
 	// Provides the VPC ID associated with the DB snapshot.
 	VpcId *string `type:"string"`
-
-	_ struct{} `type:"structure"`
 }
 
 // String returns the string representation
@@ -5268,6 +5268,8 @@ func (s DBSnapshot) GoString() string {
 // restore a manual DB snapshot. For more information, see the ModifyDBSnapshotAttribute
 // API.
 type DBSnapshotAttribute struct {
+	_ struct{} `type:"structure"`
+
 	// The name of the manual DB snapshot attribute.
 	//
 	// An attribute name of restore applies to the list of AWS accounts that have
@@ -5281,8 +5283,6 @@ type DBSnapshotAttribute struct {
 	// If a value of all is in the list, then the manual DB snapshot is public and
 	// available for any AWS account to copy or restore.
 	AttributeValues []*string `locationNameList:"AttributeValue" type:"list"`
-
-	_ struct{} `type:"structure"`
 }
 
 // String returns the string representation
@@ -5302,13 +5302,13 @@ func (s DBSnapshotAttribute) GoString() string {
 // copy or restore a manual DB snapshot. For more information, see the ModifyDBSnapshotAttribute
 // API.
 type DBSnapshotAttributesResult struct {
+	_ struct{} `type:"structure"`
+
 	// The list of attributes and values for the manual DB snapshot.
 	DBSnapshotAttributes []*DBSnapshotAttribute `locationNameList:"DBSnapshotAttribute" type:"list"`
 
 	// The identifier of the manual DB snapshot that the attributes apply to.
 	DBSnapshotIdentifier *string `type:"string"`
-
-	_ struct{} `type:"structure"`
 }
 
 // String returns the string representation
@@ -5327,6 +5327,8 @@ func (s DBSnapshotAttributesResult) GoString() string {
 //   This data type is used as a response element in the DescribeDBSubnetGroups
 // action.
 type DBSubnetGroup struct {
+	_ struct{} `type:"structure"`
+
 	// Provides the description of the DB subnet group.
 	DBSubnetGroupDescription *string `type:"string"`
 
@@ -5341,8 +5343,6 @@ type DBSubnetGroup struct {
 
 	// Provides the VpcId of the DB subnet group.
 	VpcId *string `type:"string"`
-
-	_ struct{} `type:"structure"`
 }
 
 // String returns the string representation
@@ -5356,6 +5356,8 @@ func (s DBSubnetGroup) GoString() string {
 }
 
 type DeleteDBClusterInput struct {
+	_ struct{} `type:"structure"`
+
 	// The DB cluster identifier for the DB cluster to be deleted. This parameter
 	// isn't case-sensitive.
 	//
@@ -5382,8 +5384,6 @@ type DeleteDBClusterInput struct {
 	// You must specify a FinalDBSnapshotIdentifier parameter if SkipFinalSnapshot
 	// is false. Default: false
 	SkipFinalSnapshot *bool `type:"boolean"`
-
-	_ struct{} `type:"structure"`
 }
 
 // String returns the string representation
@@ -5397,14 +5397,14 @@ func (s DeleteDBClusterInput) GoString() string {
 }
 
 type DeleteDBClusterOutput struct {
+	_ struct{} `type:"structure"`
+
 	// Contains the result of a successful invocation of the following actions:
 	//
 	//   CreateDBCluster   DeleteDBCluster   FailoverDBCluster   ModifyDBCluster
 	//   RestoreDBClusterFromSnapshot   This data type is used as a response element
 	// in the DescribeDBClusters action.
 	DBCluster *DBCluster `type:"structure"`
-
-	_ struct{} `type:"structure"`
 }
 
 // String returns the string representation
@@ -5418,6 +5418,8 @@ func (s DeleteDBClusterOutput) GoString() string {
 }
 
 type DeleteDBClusterParameterGroupInput struct {
+	_ struct{} `type:"structure"`
+
 	// The name of the DB cluster parameter group.
 	//
 	// Constraints:
@@ -5426,8 +5428,6 @@ type DeleteDBClusterParameterGroupInput struct {
 	// delete a default DB cluster parameter group. Cannot be associated with any
 	// DB clusters.
 	DBClusterParameterGroupName *string `type:"string" required:"true"`
-
-	_ struct{} `type:"structure"`
 }
 
 // String returns the string representation
@@ -5455,13 +5455,13 @@ func (s DeleteDBClusterParameterGroupOutput) GoString() string {
 }
 
 type DeleteDBClusterSnapshotInput struct {
+	_ struct{} `type:"structure"`
+
 	// The identifier of the DB cluster snapshot to delete.
 	//
 	// Constraints: Must be the name of an existing DB cluster snapshot in the
 	// available state.
 	DBClusterSnapshotIdentifier *string `type:"string" required:"true"`
-
-	_ struct{} `type:"structure"`
 }
 
 // String returns the string representation
@@ -5475,13 +5475,13 @@ func (s DeleteDBClusterSnapshotInput) GoString() string {
 }
 
 type DeleteDBClusterSnapshotOutput struct {
+	_ struct{} `type:"structure"`
+
 	// Contains the result of a successful invocation of the following actions:
 	//
 	//   CreateDBClusterSnapshot   DeleteDBClusterSnapshot   This data type is
 	// used as a response element in the DescribeDBClusterSnapshots action.
 	DBClusterSnapshot *DBClusterSnapshot `type:"structure"`
-
-	_ struct{} `type:"structure"`
 }
 
 // String returns the string representation
@@ -5495,6 +5495,8 @@ func (s DeleteDBClusterSnapshotOutput) GoString() string {
 }
 
 type DeleteDBInstanceInput struct {
+	_ struct{} `type:"structure"`
+
 	// The DB instance identifier for the DB instance to be deleted. This parameter
 	// isn't case-sensitive.
 	//
@@ -5528,8 +5530,6 @@ type DeleteDBInstanceInput struct {
 	// The FinalDBSnapshotIdentifier parameter must be specified if SkipFinalSnapshot
 	// is false. Default: false
 	SkipFinalSnapshot *bool `type:"boolean"`
-
-	_ struct{} `type:"structure"`
 }
 
 // String returns the string representation
@@ -5543,13 +5543,13 @@ func (s DeleteDBInstanceInput) GoString() string {
 }
 
 type DeleteDBInstanceOutput struct {
+	_ struct{} `type:"structure"`
+
 	// Contains the result of a successful invocation of the following actions:
 	//
 	//   CreateDBInstance   DeleteDBInstance   ModifyDBInstance   This data type
 	// is used as a response element in the DescribeDBInstances action.
 	DBInstance *DBInstance `type:"structure"`
-
-	_ struct{} `type:"structure"`
 }
 
 // String returns the string representation
@@ -5563,6 +5563,8 @@ func (s DeleteDBInstanceOutput) GoString() string {
 }
 
 type DeleteDBParameterGroupInput struct {
+	_ struct{} `type:"structure"`
+
 	// The name of the DB parameter group.
 	//
 	// Constraints:
@@ -5570,8 +5572,6 @@ type DeleteDBParameterGroupInput struct {
 	//  Must be the name of an existing DB parameter group You cannot delete a
 	// default DB parameter group Cannot be associated with any DB instances
 	DBParameterGroupName *string `type:"string" required:"true"`
-
-	_ struct{} `type:"structure"`
 }
 
 // String returns the string representation
@@ -5599,6 +5599,8 @@ func (s DeleteDBParameterGroupOutput) GoString() string {
 }
 
 type DeleteDBSecurityGroupInput struct {
+	_ struct{} `type:"structure"`
+
 	// The name of the DB security group to delete.
 	//
 	// You cannot delete the default DB security group.  Constraints:
@@ -5607,8 +5609,6 @@ type DeleteDBSecurityGroupInput struct {
 	// Cannot end with a hyphen or contain two consecutive hyphens Must not be "Default"
 	// Cannot contain spaces
 	DBSecurityGroupName *string `type:"string" required:"true"`
-
-	_ struct{} `type:"structure"`
 }
 
 // String returns the string representation
@@ -5636,13 +5636,13 @@ func (s DeleteDBSecurityGroupOutput) GoString() string {
 }
 
 type DeleteDBSnapshotInput struct {
+	_ struct{} `type:"structure"`
+
 	// The DBSnapshot identifier.
 	//
 	// Constraints: Must be the name of an existing DB snapshot in the available
 	// state.
 	DBSnapshotIdentifier *string `type:"string" required:"true"`
-
-	_ struct{} `type:"structure"`
 }
 
 // String returns the string representation
@@ -5656,13 +5656,13 @@ func (s DeleteDBSnapshotInput) GoString() string {
 }
 
 type DeleteDBSnapshotOutput struct {
+	_ struct{} `type:"structure"`
+
 	// Contains the result of a successful invocation of the following actions:
 	//
 	//   CreateDBSnapshot   DeleteDBSnapshot   This data type is used as a response
 	// element in the DescribeDBSnapshots action.
 	DBSnapshot *DBSnapshot `type:"structure"`
-
-	_ struct{} `type:"structure"`
 }
 
 // String returns the string representation
@@ -5676,6 +5676,8 @@ func (s DeleteDBSnapshotOutput) GoString() string {
 }
 
 type DeleteDBSubnetGroupInput struct {
+	_ struct{} `type:"structure"`
+
 	// The name of the database subnet group to delete.
 	//
 	// You cannot delete the default subnet group.  Constraints:
@@ -5683,8 +5685,6 @@ type DeleteDBSubnetGroupInput struct {
 	//  Must be 1 to 255 alphanumeric characters First character must be a letter
 	// Cannot end with a hyphen or contain two consecutive hyphens
 	DBSubnetGroupName *string `type:"string" required:"true"`
-
-	_ struct{} `type:"structure"`
 }
 
 // String returns the string representation
@@ -5712,10 +5712,10 @@ func (s DeleteDBSubnetGroupOutput) GoString() string {
 }
 
 type DeleteEventSubscriptionInput struct {
+	_ struct{} `type:"structure"`
+
 	// The name of the RDS event notification subscription you want to delete.
 	SubscriptionName *string `type:"string" required:"true"`
-
-	_ struct{} `type:"structure"`
 }
 
 // String returns the string representation
@@ -5729,11 +5729,11 @@ func (s DeleteEventSubscriptionInput) GoString() string {
 }
 
 type DeleteEventSubscriptionOutput struct {
+	_ struct{} `type:"structure"`
+
 	// Contains the results of a successful invocation of the DescribeEventSubscriptions
 	// action.
 	EventSubscription *EventSubscription `type:"structure"`
-
-	_ struct{} `type:"structure"`
 }
 
 // String returns the string representation
@@ -5747,12 +5747,12 @@ func (s DeleteEventSubscriptionOutput) GoString() string {
 }
 
 type DeleteOptionGroupInput struct {
+	_ struct{} `type:"structure"`
+
 	// The name of the option group to be deleted.
 	//
 	// You cannot delete default option groups.
 	OptionGroupName *string `type:"string" required:"true"`
-
-	_ struct{} `type:"structure"`
 }
 
 // String returns the string representation
@@ -5795,11 +5795,11 @@ func (s DescribeAccountAttributesInput) GoString() string {
 
 // Data returned by the DescribeAccountAttributes action.
 type DescribeAccountAttributesOutput struct {
+	_ struct{} `type:"structure"`
+
 	// A list of AccountQuota objects. Within this list, each quota has a name,
 	// a count of usage toward the quota maximum, and a maximum value for the quota.
 	AccountQuotas []*AccountQuota `locationNameList:"AccountQuota" type:"list"`
-
-	_ struct{} `type:"structure"`
 }
 
 // String returns the string representation
@@ -5813,6 +5813,8 @@ func (s DescribeAccountAttributesOutput) GoString() string {
 }
 
 type DescribeCertificatesInput struct {
+	_ struct{} `type:"structure"`
+
 	// The user-supplied certificate identifier. If this parameter is specified,
 	// information for only the identified certificate is returned. This parameter
 	// isn't case-sensitive.
@@ -5839,8 +5841,6 @@ type DescribeCertificatesInput struct {
 	//
 	// Constraints: Minimum 20, maximum 100.
 	MaxRecords *int64 `type:"integer"`
-
-	_ struct{} `type:"structure"`
 }
 
 // String returns the string representation
@@ -5855,6 +5855,8 @@ func (s DescribeCertificatesInput) GoString() string {
 
 // Data returned by the DescribeCertificates action.
 type DescribeCertificatesOutput struct {
+	_ struct{} `type:"structure"`
+
 	// The list of Certificate objects for the AWS account.
 	Certificates []*Certificate `locationNameList:"Certificate" type:"list"`
 
@@ -5862,8 +5864,6 @@ type DescribeCertificatesOutput struct {
 	// request. If this parameter is specified, the response includes only records
 	// beyond the marker, up to the value specified by MaxRecords .
 	Marker *string `type:"string"`
-
-	_ struct{} `type:"structure"`
 }
 
 // String returns the string representation
@@ -5877,6 +5877,8 @@ func (s DescribeCertificatesOutput) GoString() string {
 }
 
 type DescribeDBClusterParameterGroupsInput struct {
+	_ struct{} `type:"structure"`
+
 	// The name of a specific DB cluster parameter group to return details for.
 	//
 	// Constraints:
@@ -5901,8 +5903,6 @@ type DescribeDBClusterParameterGroupsInput struct {
 	//
 	// Constraints: Minimum 20, maximum 100.
 	MaxRecords *int64 `type:"integer"`
-
-	_ struct{} `type:"structure"`
 }
 
 // String returns the string representation
@@ -5916,6 +5916,8 @@ func (s DescribeDBClusterParameterGroupsInput) GoString() string {
 }
 
 type DescribeDBClusterParameterGroupsOutput struct {
+	_ struct{} `type:"structure"`
+
 	// A list of DB cluster parameter groups.
 	DBClusterParameterGroups []*DBClusterParameterGroup `locationNameList:"DBClusterParameterGroup" type:"list"`
 
@@ -5923,8 +5925,6 @@ type DescribeDBClusterParameterGroupsOutput struct {
 	// request. If this parameter is specified, the response includes only records
 	// beyond the marker, up to the value specified by MaxRecords.
 	Marker *string `type:"string"`
-
-	_ struct{} `type:"structure"`
 }
 
 // String returns the string representation
@@ -5938,6 +5938,8 @@ func (s DescribeDBClusterParameterGroupsOutput) GoString() string {
 }
 
 type DescribeDBClusterParametersInput struct {
+	_ struct{} `type:"structure"`
+
 	// The name of a specific DB cluster parameter group to return parameter details
 	// for.
 	//
@@ -5967,8 +5969,6 @@ type DescribeDBClusterParametersInput struct {
 	// A value that indicates to return only parameters for a specific source. Parameter
 	// sources can be engine, service, or customer.
 	Source *string `type:"string"`
-
-	_ struct{} `type:"structure"`
 }
 
 // String returns the string representation
@@ -5984,6 +5984,8 @@ func (s DescribeDBClusterParametersInput) GoString() string {
 // Provides details about a DB cluster parameter group including the parameters
 // in the DB cluster parameter group.
 type DescribeDBClusterParametersOutput struct {
+	_ struct{} `type:"structure"`
+
 	// An optional pagination token provided by a previous DescribeDBClusterParameters
 	// request. If this parameter is specified, the response includes only records
 	// beyond the marker, up to the value specified by MaxRecords .
@@ -5991,8 +5993,6 @@ type DescribeDBClusterParametersOutput struct {
 
 	// Provides a list of parameters for the DB cluster parameter group.
 	Parameters []*Parameter `locationNameList:"Parameter" type:"list"`
-
-	_ struct{} `type:"structure"`
 }
 
 // String returns the string representation
@@ -6006,6 +6006,8 @@ func (s DescribeDBClusterParametersOutput) GoString() string {
 }
 
 type DescribeDBClusterSnapshotsInput struct {
+	_ struct{} `type:"structure"`
+
 	// A DB cluster identifier to retrieve the list of DB cluster snapshots for.
 	// This parameter cannot be used in conjunction with the DBClusterSnapshotIdentifier
 	// parameter. This parameter is not case-sensitive.
@@ -6049,8 +6051,6 @@ type DescribeDBClusterSnapshotsInput struct {
 	// or manual. If this parameter is not specified, the returned results will
 	// include all snapshot types.
 	SnapshotType *string `type:"string"`
-
-	_ struct{} `type:"structure"`
 }
 
 // String returns the string representation
@@ -6066,6 +6066,8 @@ func (s DescribeDBClusterSnapshotsInput) GoString() string {
 // Provides a list of DB cluster snapshots for the user as the result of a call
 // to the DescribeDBClusterSnapshots action.
 type DescribeDBClusterSnapshotsOutput struct {
+	_ struct{} `type:"structure"`
+
 	// Provides a list of DB cluster snapshots for the user.
 	DBClusterSnapshots []*DBClusterSnapshot `locationNameList:"DBClusterSnapshot" type:"list"`
 
@@ -6073,8 +6075,6 @@ type DescribeDBClusterSnapshotsOutput struct {
 	// request. If this parameter is specified, the response includes only records
 	// beyond the marker, up to the value specified by MaxRecords.
 	Marker *string `type:"string"`
-
-	_ struct{} `type:"structure"`
 }
 
 // String returns the string representation
@@ -6088,6 +6088,8 @@ func (s DescribeDBClusterSnapshotsOutput) GoString() string {
 }
 
 type DescribeDBClustersInput struct {
+	_ struct{} `type:"structure"`
+
 	// The user-supplied DB cluster identifier. If this parameter is specified,
 	// information from only the specific DB cluster is returned. This parameter
 	// isn't case-sensitive.
@@ -6114,8 +6116,6 @@ type DescribeDBClustersInput struct {
 	//
 	// Constraints: Minimum 20, maximum 100.
 	MaxRecords *int64 `type:"integer"`
-
-	_ struct{} `type:"structure"`
 }
 
 // String returns the string representation
@@ -6131,13 +6131,13 @@ func (s DescribeDBClustersInput) GoString() string {
 // Contains the result of a successful invocation of the DescribeDBClusters
 // action.
 type DescribeDBClustersOutput struct {
+	_ struct{} `type:"structure"`
+
 	// Contains a list of DB clusters for the user.
 	DBClusters []*DBCluster `locationNameList:"DBCluster" type:"list"`
 
 	// A pagination token that can be used in a subsequent DescribeDBClusters request.
 	Marker *string `type:"string"`
-
-	_ struct{} `type:"structure"`
 }
 
 // String returns the string representation
@@ -6151,6 +6151,8 @@ func (s DescribeDBClustersOutput) GoString() string {
 }
 
 type DescribeDBEngineVersionsInput struct {
+	_ struct{} `type:"structure"`
+
 	// The name of a specific DB parameter group family to return details for.
 	//
 	// Constraints:
@@ -6192,8 +6194,6 @@ type DescribeDBEngineVersionsInput struct {
 	//
 	// Constraints: Minimum 20, maximum 100.
 	MaxRecords *int64 `type:"integer"`
-
-	_ struct{} `type:"structure"`
 }
 
 // String returns the string representation
@@ -6209,6 +6209,8 @@ func (s DescribeDBEngineVersionsInput) GoString() string {
 // Contains the result of a successful invocation of the DescribeDBEngineVersions
 // action.
 type DescribeDBEngineVersionsOutput struct {
+	_ struct{} `type:"structure"`
+
 	// A list of DBEngineVersion elements.
 	DBEngineVersions []*DBEngineVersion `locationNameList:"DBEngineVersion" type:"list"`
 
@@ -6216,8 +6218,6 @@ type DescribeDBEngineVersionsOutput struct {
 	// is specified, the response includes only records beyond the marker, up to
 	// the value specified by MaxRecords.
 	Marker *string `type:"string"`
-
-	_ struct{} `type:"structure"`
 }
 
 // String returns the string representation
@@ -6231,6 +6231,8 @@ func (s DescribeDBEngineVersionsOutput) GoString() string {
 }
 
 type DescribeDBInstancesInput struct {
+	_ struct{} `type:"structure"`
+
 	// The user-supplied instance identifier. If this parameter is specified, information
 	// from only the specific DB instance is returned. This parameter isn't case-sensitive.
 	//
@@ -6256,8 +6258,6 @@ type DescribeDBInstancesInput struct {
 	//
 	// Constraints: Minimum 20, maximum 100.
 	MaxRecords *int64 `type:"integer"`
-
-	_ struct{} `type:"structure"`
 }
 
 // String returns the string representation
@@ -6273,6 +6273,8 @@ func (s DescribeDBInstancesInput) GoString() string {
 // Contains the result of a successful invocation of the DescribeDBInstances
 // action.
 type DescribeDBInstancesOutput struct {
+	_ struct{} `type:"structure"`
+
 	// A list of DBInstance instances.
 	DBInstances []*DBInstance `locationNameList:"DBInstance" type:"list"`
 
@@ -6280,8 +6282,6 @@ type DescribeDBInstancesOutput struct {
 	// is specified, the response includes only records beyond the marker, up to
 	// the value specified by MaxRecords .
 	Marker *string `type:"string"`
-
-	_ struct{} `type:"structure"`
 }
 
 // String returns the string representation
@@ -6296,6 +6296,8 @@ func (s DescribeDBInstancesOutput) GoString() string {
 
 // This data type is used as a response element to DescribeDBLogFiles.
 type DescribeDBLogFilesDetails struct {
+	_ struct{} `type:"structure"`
+
 	// A POSIX timestamp when the last log entry was written.
 	LastWritten *int64 `type:"long"`
 
@@ -6304,8 +6306,6 @@ type DescribeDBLogFilesDetails struct {
 
 	// The size, in bytes, of the log file for the specified DB instance.
 	Size *int64 `type:"long"`
-
-	_ struct{} `type:"structure"`
 }
 
 // String returns the string representation
@@ -6319,6 +6319,8 @@ func (s DescribeDBLogFilesDetails) GoString() string {
 }
 
 type DescribeDBLogFilesInput struct {
+	_ struct{} `type:"structure"`
+
 	// The customer-assigned name of the DB instance that contains the log files
 	// you want to list.
 	//
@@ -6351,8 +6353,6 @@ type DescribeDBLogFilesInput struct {
 	// exist than the specified MaxRecords value, a pagination token called a marker
 	// is included in the response so that the remaining results can be retrieved.
 	MaxRecords *int64 `type:"integer"`
-
-	_ struct{} `type:"structure"`
 }
 
 // String returns the string representation
@@ -6367,13 +6367,13 @@ func (s DescribeDBLogFilesInput) GoString() string {
 
 // The response from a call to DescribeDBLogFiles.
 type DescribeDBLogFilesOutput struct {
+	_ struct{} `type:"structure"`
+
 	// The DB log files returned.
 	DescribeDBLogFiles []*DescribeDBLogFilesDetails `locationNameList:"DescribeDBLogFilesDetails" type:"list"`
 
 	// A pagination token that can be used in a subsequent DescribeDBLogFiles request.
 	Marker *string `type:"string"`
-
-	_ struct{} `type:"structure"`
 }
 
 // String returns the string representation
@@ -6387,6 +6387,8 @@ func (s DescribeDBLogFilesOutput) GoString() string {
 }
 
 type DescribeDBParameterGroupsInput struct {
+	_ struct{} `type:"structure"`
+
 	// The name of a specific DB parameter group to return details for.
 	//
 	// Constraints:
@@ -6411,8 +6413,6 @@ type DescribeDBParameterGroupsInput struct {
 	//
 	// Constraints: Minimum 20, maximum 100.
 	MaxRecords *int64 `type:"integer"`
-
-	_ struct{} `type:"structure"`
 }
 
 // String returns the string representation
@@ -6428,6 +6428,8 @@ func (s DescribeDBParameterGroupsInput) GoString() string {
 // Contains the result of a successful invocation of the DescribeDBParameterGroups
 // action.
 type DescribeDBParameterGroupsOutput struct {
+	_ struct{} `type:"structure"`
+
 	// A list of DBParameterGroup instances.
 	DBParameterGroups []*DBParameterGroup `locationNameList:"DBParameterGroup" type:"list"`
 
@@ -6435,8 +6437,6 @@ type DescribeDBParameterGroupsOutput struct {
 	// is specified, the response includes only records beyond the marker, up to
 	// the value specified by MaxRecords.
 	Marker *string `type:"string"`
-
-	_ struct{} `type:"structure"`
 }
 
 // String returns the string representation
@@ -6450,6 +6450,8 @@ func (s DescribeDBParameterGroupsOutput) GoString() string {
 }
 
 type DescribeDBParametersInput struct {
+	_ struct{} `type:"structure"`
+
 	// The name of a specific DB parameter group to return details for.
 	//
 	// Constraints:
@@ -6481,8 +6483,6 @@ type DescribeDBParametersInput struct {
 	//
 	// Valid Values: user | system | engine-default
 	Source *string `type:"string"`
-
-	_ struct{} `type:"structure"`
 }
 
 // String returns the string representation
@@ -6498,6 +6498,8 @@ func (s DescribeDBParametersInput) GoString() string {
 // Contains the result of a successful invocation of the DescribeDBParameters
 // action.
 type DescribeDBParametersOutput struct {
+	_ struct{} `type:"structure"`
+
 	// An optional pagination token provided by a previous request. If this parameter
 	// is specified, the response includes only records beyond the marker, up to
 	// the value specified by MaxRecords.
@@ -6505,8 +6507,6 @@ type DescribeDBParametersOutput struct {
 
 	// A list of Parameter values.
 	Parameters []*Parameter `locationNameList:"Parameter" type:"list"`
-
-	_ struct{} `type:"structure"`
 }
 
 // String returns the string representation
@@ -6520,6 +6520,8 @@ func (s DescribeDBParametersOutput) GoString() string {
 }
 
 type DescribeDBSecurityGroupsInput struct {
+	_ struct{} `type:"structure"`
+
 	// The name of the DB security group to return details for.
 	DBSecurityGroupName *string `type:"string"`
 
@@ -6539,8 +6541,6 @@ type DescribeDBSecurityGroupsInput struct {
 	//
 	// Constraints: Minimum 20, maximum 100.
 	MaxRecords *int64 `type:"integer"`
-
-	_ struct{} `type:"structure"`
 }
 
 // String returns the string representation
@@ -6556,6 +6556,8 @@ func (s DescribeDBSecurityGroupsInput) GoString() string {
 // Contains the result of a successful invocation of the DescribeDBSecurityGroups
 // action.
 type DescribeDBSecurityGroupsOutput struct {
+	_ struct{} `type:"structure"`
+
 	// A list of DBSecurityGroup instances.
 	DBSecurityGroups []*DBSecurityGroup `locationNameList:"DBSecurityGroup" type:"list"`
 
@@ -6563,8 +6565,6 @@ type DescribeDBSecurityGroupsOutput struct {
 	// is specified, the response includes only records beyond the marker, up to
 	// the value specified by MaxRecords.
 	Marker *string `type:"string"`
-
-	_ struct{} `type:"structure"`
 }
 
 // String returns the string representation
@@ -6578,10 +6578,10 @@ func (s DescribeDBSecurityGroupsOutput) GoString() string {
 }
 
 type DescribeDBSnapshotAttributesInput struct {
+	_ struct{} `type:"structure"`
+
 	// The identifier for the DB snapshot to modify the attributes for.
 	DBSnapshotIdentifier *string `type:"string"`
-
-	_ struct{} `type:"structure"`
 }
 
 // String returns the string representation
@@ -6595,6 +6595,8 @@ func (s DescribeDBSnapshotAttributesInput) GoString() string {
 }
 
 type DescribeDBSnapshotAttributesOutput struct {
+	_ struct{} `type:"structure"`
+
 	// Contains the results of a successful call to the DescribeDBSnapshotAttributes
 	// API.
 	//
@@ -6602,8 +6604,6 @@ type DescribeDBSnapshotAttributesOutput struct {
 	// copy or restore a manual DB snapshot. For more information, see the ModifyDBSnapshotAttribute
 	// API.
 	DBSnapshotAttributesResult *DBSnapshotAttributesResult `type:"structure"`
-
-	_ struct{} `type:"structure"`
 }
 
 // String returns the string representation
@@ -6617,6 +6617,8 @@ func (s DescribeDBSnapshotAttributesOutput) GoString() string {
 }
 
 type DescribeDBSnapshotsInput struct {
+	_ struct{} `type:"structure"`
+
 	// A DB instance identifier to retrieve the list of DB snapshots for. This parameter
 	// cannot be used in conjunction with DBSnapshotIdentifier. This parameter is
 	// not case-sensitive.
@@ -6689,8 +6691,6 @@ type DescribeDBSnapshotsInput struct {
 	// when SnapshotType is set to shared. the IncludeShared parameter does not
 	// apply when SnapshotType is set to public.
 	SnapshotType *string `type:"string"`
-
-	_ struct{} `type:"structure"`
 }
 
 // String returns the string representation
@@ -6706,6 +6706,8 @@ func (s DescribeDBSnapshotsInput) GoString() string {
 // Contains the result of a successful invocation of the DescribeDBSnapshots
 // action.
 type DescribeDBSnapshotsOutput struct {
+	_ struct{} `type:"structure"`
+
 	// A list of DBSnapshot instances.
 	DBSnapshots []*DBSnapshot `locationNameList:"DBSnapshot" type:"list"`
 
@@ -6713,8 +6715,6 @@ type DescribeDBSnapshotsOutput struct {
 	// is specified, the response includes only records beyond the marker, up to
 	// the value specified by MaxRecords.
 	Marker *string `type:"string"`
-
-	_ struct{} `type:"structure"`
 }
 
 // String returns the string representation
@@ -6728,6 +6728,8 @@ func (s DescribeDBSnapshotsOutput) GoString() string {
 }
 
 type DescribeDBSubnetGroupsInput struct {
+	_ struct{} `type:"structure"`
+
 	// The name of the DB subnet group to return details for.
 	DBSubnetGroupName *string `type:"string"`
 
@@ -6747,8 +6749,6 @@ type DescribeDBSubnetGroupsInput struct {
 	//
 	// Constraints: Minimum 20, maximum 100.
 	MaxRecords *int64 `type:"integer"`
-
-	_ struct{} `type:"structure"`
 }
 
 // String returns the string representation
@@ -6764,6 +6764,8 @@ func (s DescribeDBSubnetGroupsInput) GoString() string {
 // Contains the result of a successful invocation of the DescribeDBSubnetGroups
 // action.
 type DescribeDBSubnetGroupsOutput struct {
+	_ struct{} `type:"structure"`
+
 	// A list of DBSubnetGroup instances.
 	DBSubnetGroups []*DBSubnetGroup `locationNameList:"DBSubnetGroup" type:"list"`
 
@@ -6771,8 +6773,6 @@ type DescribeDBSubnetGroupsOutput struct {
 	// is specified, the response includes only records beyond the marker, up to
 	// the value specified by MaxRecords.
 	Marker *string `type:"string"`
-
-	_ struct{} `type:"structure"`
 }
 
 // String returns the string representation
@@ -6786,6 +6786,8 @@ func (s DescribeDBSubnetGroupsOutput) GoString() string {
 }
 
 type DescribeEngineDefaultClusterParametersInput struct {
+	_ struct{} `type:"structure"`
+
 	// The name of the DB cluster parameter group family to return engine parameter
 	// information for.
 	DBParameterGroupFamily *string `type:"string" required:"true"`
@@ -6806,8 +6808,6 @@ type DescribeEngineDefaultClusterParametersInput struct {
 	//
 	// Constraints: Minimum 20, maximum 100.
 	MaxRecords *int64 `type:"integer"`
-
-	_ struct{} `type:"structure"`
 }
 
 // String returns the string representation
@@ -6821,11 +6821,11 @@ func (s DescribeEngineDefaultClusterParametersInput) GoString() string {
 }
 
 type DescribeEngineDefaultClusterParametersOutput struct {
+	_ struct{} `type:"structure"`
+
 	// Contains the result of a successful invocation of the DescribeEngineDefaultParameters
 	// action.
 	EngineDefaults *EngineDefaults `type:"structure"`
-
-	_ struct{} `type:"structure"`
 }
 
 // String returns the string representation
@@ -6839,6 +6839,8 @@ func (s DescribeEngineDefaultClusterParametersOutput) GoString() string {
 }
 
 type DescribeEngineDefaultParametersInput struct {
+	_ struct{} `type:"structure"`
+
 	// The name of the DB parameter group family.
 	DBParameterGroupFamily *string `type:"string" required:"true"`
 
@@ -6858,8 +6860,6 @@ type DescribeEngineDefaultParametersInput struct {
 	//
 	// Constraints: Minimum 20, maximum 100.
 	MaxRecords *int64 `type:"integer"`
-
-	_ struct{} `type:"structure"`
 }
 
 // String returns the string representation
@@ -6873,11 +6873,11 @@ func (s DescribeEngineDefaultParametersInput) GoString() string {
 }
 
 type DescribeEngineDefaultParametersOutput struct {
+	_ struct{} `type:"structure"`
+
 	// Contains the result of a successful invocation of the DescribeEngineDefaultParameters
 	// action.
 	EngineDefaults *EngineDefaults `type:"structure"`
-
-	_ struct{} `type:"structure"`
 }
 
 // String returns the string representation
@@ -6891,6 +6891,8 @@ func (s DescribeEngineDefaultParametersOutput) GoString() string {
 }
 
 type DescribeEventCategoriesInput struct {
+	_ struct{} `type:"structure"`
+
 	// This parameter is not currently supported.
 	Filters []*Filter `locationNameList:"Filter" type:"list"`
 
@@ -6898,8 +6900,6 @@ type DescribeEventCategoriesInput struct {
 	//
 	// Valid values: db-instance | db-parameter-group | db-security-group | db-snapshot
 	SourceType *string `type:"string"`
-
-	_ struct{} `type:"structure"`
 }
 
 // String returns the string representation
@@ -6914,10 +6914,10 @@ func (s DescribeEventCategoriesInput) GoString() string {
 
 // Data returned from the DescribeEventCategories action.
 type DescribeEventCategoriesOutput struct {
+	_ struct{} `type:"structure"`
+
 	// A list of EventCategoriesMap data types.
 	EventCategoriesMapList []*EventCategoriesMap `locationNameList:"EventCategoriesMap" type:"list"`
-
-	_ struct{} `type:"structure"`
 }
 
 // String returns the string representation
@@ -6931,6 +6931,8 @@ func (s DescribeEventCategoriesOutput) GoString() string {
 }
 
 type DescribeEventSubscriptionsInput struct {
+	_ struct{} `type:"structure"`
+
 	// This parameter is not currently supported.
 	Filters []*Filter `locationNameList:"Filter" type:"list"`
 
@@ -6950,8 +6952,6 @@ type DescribeEventSubscriptionsInput struct {
 
 	// The name of the RDS event notification subscription you want to describe.
 	SubscriptionName *string `type:"string"`
-
-	_ struct{} `type:"structure"`
 }
 
 // String returns the string representation
@@ -6966,6 +6966,8 @@ func (s DescribeEventSubscriptionsInput) GoString() string {
 
 // Data returned by the DescribeEventSubscriptions action.
 type DescribeEventSubscriptionsOutput struct {
+	_ struct{} `type:"structure"`
+
 	// A list of EventSubscriptions data types.
 	EventSubscriptionsList []*EventSubscription `locationNameList:"EventSubscription" type:"list"`
 
@@ -6973,8 +6975,6 @@ type DescribeEventSubscriptionsOutput struct {
 	// request. If this parameter is specified, the response includes only records
 	// beyond the marker, up to the value specified by MaxRecords.
 	Marker *string `type:"string"`
-
-	_ struct{} `type:"structure"`
 }
 
 // String returns the string representation
@@ -6988,6 +6988,8 @@ func (s DescribeEventSubscriptionsOutput) GoString() string {
 }
 
 type DescribeEventsInput struct {
+	_ struct{} `type:"structure"`
+
 	// The number of minutes to retrieve events for.
 	//
 	// Default: 60
@@ -7044,8 +7046,6 @@ type DescribeEventsInput struct {
 	//
 	// Example: 2009-07-08T18:00Z
 	StartTime *time.Time `type:"timestamp" timestampFormat:"iso8601"`
-
-	_ struct{} `type:"structure"`
 }
 
 // String returns the string representation
@@ -7060,6 +7060,8 @@ func (s DescribeEventsInput) GoString() string {
 
 // Contains the result of a successful invocation of the DescribeEvents action.
 type DescribeEventsOutput struct {
+	_ struct{} `type:"structure"`
+
 	// A list of Event instances.
 	Events []*Event `locationNameList:"Event" type:"list"`
 
@@ -7067,8 +7069,6 @@ type DescribeEventsOutput struct {
 	// parameter is specified, the response includes only records beyond the marker,
 	// up to the value specified by MaxRecords .
 	Marker *string `type:"string"`
-
-	_ struct{} `type:"structure"`
 }
 
 // String returns the string representation
@@ -7082,6 +7082,8 @@ func (s DescribeEventsOutput) GoString() string {
 }
 
 type DescribeOptionGroupOptionsInput struct {
+	_ struct{} `type:"structure"`
+
 	// A required parameter. Options available for the given engine name will be
 	// described.
 	EngineName *string `type:"string" required:"true"`
@@ -7106,8 +7108,6 @@ type DescribeOptionGroupOptionsInput struct {
 	//
 	// Constraints: Minimum 20, maximum 100.
 	MaxRecords *int64 `type:"integer"`
-
-	_ struct{} `type:"structure"`
 }
 
 // String returns the string representation
@@ -7121,6 +7121,8 @@ func (s DescribeOptionGroupOptionsInput) GoString() string {
 }
 
 type DescribeOptionGroupOptionsOutput struct {
+	_ struct{} `type:"structure"`
+
 	// An optional pagination token provided by a previous request. If this parameter
 	// is specified, the response includes only records beyond the marker, up to
 	// the value specified by MaxRecords.
@@ -7128,8 +7130,6 @@ type DescribeOptionGroupOptionsOutput struct {
 
 	// List of available option group options.
 	OptionGroupOptions []*OptionGroupOption `locationNameList:"OptionGroupOption" type:"list"`
-
-	_ struct{} `type:"structure"`
 }
 
 // String returns the string representation
@@ -7143,6 +7143,8 @@ func (s DescribeOptionGroupOptionsOutput) GoString() string {
 }
 
 type DescribeOptionGroupsInput struct {
+	_ struct{} `type:"structure"`
+
 	// Filters the list of option groups to only include groups associated with
 	// a specific database engine.
 	EngineName *string `type:"string"`
@@ -7172,8 +7174,6 @@ type DescribeOptionGroupsInput struct {
 	// The name of the option group to describe. Cannot be supplied together with
 	// EngineName or MajorEngineVersion.
 	OptionGroupName *string `type:"string"`
-
-	_ struct{} `type:"structure"`
 }
 
 // String returns the string representation
@@ -7188,6 +7188,8 @@ func (s DescribeOptionGroupsInput) GoString() string {
 
 // List of option groups.
 type DescribeOptionGroupsOutput struct {
+	_ struct{} `type:"structure"`
+
 	// An optional pagination token provided by a previous request. If this parameter
 	// is specified, the response includes only records beyond the marker, up to
 	// the value specified by MaxRecords.
@@ -7195,8 +7197,6 @@ type DescribeOptionGroupsOutput struct {
 
 	// List of option groups.
 	OptionGroupsList []*OptionGroup `locationNameList:"OptionGroup" type:"list"`
-
-	_ struct{} `type:"structure"`
 }
 
 // String returns the string representation
@@ -7210,6 +7210,8 @@ func (s DescribeOptionGroupsOutput) GoString() string {
 }
 
 type DescribeOrderableDBInstanceOptionsInput struct {
+	_ struct{} `type:"structure"`
+
 	// The DB instance class filter value. Specify this parameter to show only the
 	// available offerings matching the specified DB instance class.
 	DBInstanceClass *string `type:"string"`
@@ -7245,8 +7247,6 @@ type DescribeOrderableDBInstanceOptionsInput struct {
 	// The VPC filter value. Specify this parameter to show only the available VPC
 	// or non-VPC offerings.
 	Vpc *bool `type:"boolean"`
-
-	_ struct{} `type:"structure"`
 }
 
 // String returns the string representation
@@ -7262,6 +7262,8 @@ func (s DescribeOrderableDBInstanceOptionsInput) GoString() string {
 // Contains the result of a successful invocation of the DescribeOrderableDBInstanceOptions
 // action.
 type DescribeOrderableDBInstanceOptionsOutput struct {
+	_ struct{} `type:"structure"`
+
 	// An optional pagination token provided by a previous OrderableDBInstanceOptions
 	// request. If this parameter is specified, the response includes only records
 	// beyond the marker, up to the value specified by MaxRecords .
@@ -7270,8 +7272,6 @@ type DescribeOrderableDBInstanceOptionsOutput struct {
 	// An OrderableDBInstanceOption structure containing information about orderable
 	// options for the DB instance.
 	OrderableDBInstanceOptions []*OrderableDBInstanceOption `locationNameList:"OrderableDBInstanceOption" type:"list"`
-
-	_ struct{} `type:"structure"`
 }
 
 // String returns the string representation
@@ -7285,6 +7285,8 @@ func (s DescribeOrderableDBInstanceOptionsOutput) GoString() string {
 }
 
 type DescribePendingMaintenanceActionsInput struct {
+	_ struct{} `type:"structure"`
+
 	// A filter that specifies one or more resources to return pending maintenance
 	// actions for.
 	//
@@ -7311,8 +7313,6 @@ type DescribePendingMaintenanceActionsInput struct {
 
 	// The ARN of a resource to return pending maintenance actions for.
 	ResourceIdentifier *string `type:"string"`
-
-	_ struct{} `type:"structure"`
 }
 
 // String returns the string representation
@@ -7327,6 +7327,8 @@ func (s DescribePendingMaintenanceActionsInput) GoString() string {
 
 // Data returned from the DescribePendingMaintenanceActions action.
 type DescribePendingMaintenanceActionsOutput struct {
+	_ struct{} `type:"structure"`
+
 	// An optional pagination token provided by a previous DescribePendingMaintenanceActions
 	// request. If this parameter is specified, the response includes only records
 	// beyond the marker, up to a number of records specified by MaxRecords.
@@ -7334,8 +7336,6 @@ type DescribePendingMaintenanceActionsOutput struct {
 
 	// A list of the pending maintenance actions for the resource.
 	PendingMaintenanceActions []*ResourcePendingMaintenanceActions `locationNameList:"ResourcePendingMaintenanceActions" type:"list"`
-
-	_ struct{} `type:"structure"`
 }
 
 // String returns the string representation
@@ -7349,6 +7349,8 @@ func (s DescribePendingMaintenanceActionsOutput) GoString() string {
 }
 
 type DescribeReservedDBInstancesInput struct {
+	_ struct{} `type:"structure"`
+
 	// The DB instance class filter value. Specify this parameter to show only those
 	// reservations matching the specified DB instances class.
 	DBInstanceClass *string `type:"string"`
@@ -7397,8 +7399,6 @@ type DescribeReservedDBInstancesInput struct {
 	// The offering identifier filter value. Specify this parameter to show only
 	// purchased reservations matching the specified offering identifier.
 	ReservedDBInstancesOfferingId *string `type:"string"`
-
-	_ struct{} `type:"structure"`
 }
 
 // String returns the string representation
@@ -7412,6 +7412,8 @@ func (s DescribeReservedDBInstancesInput) GoString() string {
 }
 
 type DescribeReservedDBInstancesOfferingsInput struct {
+	_ struct{} `type:"structure"`
+
 	// The DB instance class filter value. Specify this parameter to show only the
 	// available offerings matching the specified DB instance class.
 	DBInstanceClass *string `type:"string"`
@@ -7458,8 +7460,6 @@ type DescribeReservedDBInstancesOfferingsInput struct {
 	//
 	// Example: 438012d3-4052-4cc7-b2e3-8d3372e0e706
 	ReservedDBInstancesOfferingId *string `type:"string"`
-
-	_ struct{} `type:"structure"`
 }
 
 // String returns the string representation
@@ -7475,6 +7475,8 @@ func (s DescribeReservedDBInstancesOfferingsInput) GoString() string {
 // Contains the result of a successful invocation of the DescribeReservedDBInstancesOfferings
 // action.
 type DescribeReservedDBInstancesOfferingsOutput struct {
+	_ struct{} `type:"structure"`
+
 	// An optional pagination token provided by a previous request. If this parameter
 	// is specified, the response includes only records beyond the marker, up to
 	// the value specified by MaxRecords.
@@ -7482,8 +7484,6 @@ type DescribeReservedDBInstancesOfferingsOutput struct {
 
 	// A list of reserved DB instance offerings.
 	ReservedDBInstancesOfferings []*ReservedDBInstancesOffering `locationNameList:"ReservedDBInstancesOffering" type:"list"`
-
-	_ struct{} `type:"structure"`
 }
 
 // String returns the string representation
@@ -7499,6 +7499,8 @@ func (s DescribeReservedDBInstancesOfferingsOutput) GoString() string {
 // Contains the result of a successful invocation of the DescribeReservedDBInstances
 // action.
 type DescribeReservedDBInstancesOutput struct {
+	_ struct{} `type:"structure"`
+
 	// An optional pagination token provided by a previous request. If this parameter
 	// is specified, the response includes only records beyond the marker, up to
 	// the value specified by MaxRecords.
@@ -7506,8 +7508,6 @@ type DescribeReservedDBInstancesOutput struct {
 
 	// A list of reserved DB instances.
 	ReservedDBInstances []*ReservedDBInstance `locationNameList:"ReservedDBInstance" type:"list"`
-
-	_ struct{} `type:"structure"`
 }
 
 // String returns the string representation
@@ -7521,6 +7521,8 @@ func (s DescribeReservedDBInstancesOutput) GoString() string {
 }
 
 type DownloadDBLogFilePortionInput struct {
+	_ struct{} `type:"structure"`
+
 	// The customer-assigned name of the DB instance that contains the log files
 	// you want to list.
 	//
@@ -7558,8 +7560,6 @@ type DownloadDBLogFilePortionInput struct {
 	// value returned in the response as the Marker value for the next request,
 	// continuing until the AdditionalDataPending response element returns false.
 	NumberOfLines *int64 `type:"integer"`
-
-	_ struct{} `type:"structure"`
 }
 
 // String returns the string representation
@@ -7574,6 +7574,8 @@ func (s DownloadDBLogFilePortionInput) GoString() string {
 
 // This data type is used as a response element to DownloadDBLogFilePortion.
 type DownloadDBLogFilePortionOutput struct {
+	_ struct{} `type:"structure"`
+
 	// Boolean value that if true, indicates there is more data to be downloaded.
 	AdditionalDataPending *bool `type:"boolean"`
 
@@ -7583,8 +7585,6 @@ type DownloadDBLogFilePortionOutput struct {
 	// A pagination token that can be used in a subsequent DownloadDBLogFilePortion
 	// request.
 	Marker *string `type:"string"`
-
-	_ struct{} `type:"structure"`
 }
 
 // String returns the string representation
@@ -7601,6 +7601,8 @@ func (s DownloadDBLogFilePortionOutput) GoString() string {
 //
 //   AuthorizeDBSecurityGroupIngress   DescribeDBSecurityGroups   RevokeDBSecurityGroupIngress
 type EC2SecurityGroup struct {
+	_ struct{} `type:"structure"`
+
 	// Specifies the id of the EC2 security group.
 	EC2SecurityGroupId *string `type:"string"`
 
@@ -7614,8 +7616,6 @@ type EC2SecurityGroup struct {
 	// Provides the status of the EC2 security group. Status can be "authorizing",
 	// "authorized", "revoking", and "revoked".
 	Status *string `type:"string"`
-
-	_ struct{} `type:"structure"`
 }
 
 // String returns the string representation
@@ -7632,6 +7632,8 @@ func (s EC2SecurityGroup) GoString() string {
 //
 //   CreateDBInstance   DescribeDBInstances   DeleteDBInstance
 type Endpoint struct {
+	_ struct{} `type:"structure"`
+
 	// Specifies the DNS address of the DB instance.
 	Address *string `type:"string"`
 
@@ -7640,8 +7642,6 @@ type Endpoint struct {
 
 	// Specifies the port that the database engine is listening on.
 	Port *int64 `type:"integer"`
-
-	_ struct{} `type:"structure"`
 }
 
 // String returns the string representation
@@ -7657,6 +7657,8 @@ func (s Endpoint) GoString() string {
 // Contains the result of a successful invocation of the DescribeEngineDefaultParameters
 // action.
 type EngineDefaults struct {
+	_ struct{} `type:"structure"`
+
 	// Specifies the name of the DB parameter group family that the engine default
 	// parameters apply to.
 	DBParameterGroupFamily *string `type:"string"`
@@ -7668,8 +7670,6 @@ type EngineDefaults struct {
 
 	// Contains a list of engine default parameters.
 	Parameters []*Parameter `locationNameList:"Parameter" type:"list"`
-
-	_ struct{} `type:"structure"`
 }
 
 // String returns the string representation
@@ -7684,6 +7684,8 @@ func (s EngineDefaults) GoString() string {
 
 // This data type is used as a response element in the DescribeEvents action.
 type Event struct {
+	_ struct{} `type:"structure"`
+
 	// Specifies the date and time of the event.
 	Date *time.Time `type:"timestamp" timestampFormat:"iso8601"`
 
@@ -7698,8 +7700,6 @@ type Event struct {
 
 	// Specifies the source type for this event.
 	SourceType *string `type:"string" enum:"SourceType"`
-
-	_ struct{} `type:"structure"`
 }
 
 // String returns the string representation
@@ -7715,13 +7715,13 @@ func (s Event) GoString() string {
 // Contains the results of a successful invocation of the DescribeEventCategories
 // action.
 type EventCategoriesMap struct {
+	_ struct{} `type:"structure"`
+
 	// The event categories for the specified source type
 	EventCategories []*string `locationNameList:"EventCategory" type:"list"`
 
 	// The source type that the returned categories belong to
 	SourceType *string `type:"string"`
-
-	_ struct{} `type:"structure"`
 }
 
 // String returns the string representation
@@ -7737,6 +7737,8 @@ func (s EventCategoriesMap) GoString() string {
 // Contains the results of a successful invocation of the DescribeEventSubscriptions
 // action.
 type EventSubscription struct {
+	_ struct{} `type:"structure"`
+
 	// The RDS event notification subscription Id.
 	CustSubscriptionId *string `type:"string"`
 
@@ -7773,8 +7775,6 @@ type EventSubscription struct {
 
 	// The time the RDS event notification subscription was created.
 	SubscriptionCreationTime *string `type:"string"`
-
-	_ struct{} `type:"structure"`
 }
 
 // String returns the string representation
@@ -7788,6 +7788,8 @@ func (s EventSubscription) GoString() string {
 }
 
 type FailoverDBClusterInput struct {
+	_ struct{} `type:"structure"`
+
 	// A DB cluster identifier to force a failover for. This parameter is not case-sensitive.
 	//
 	// Constraints:
@@ -7795,8 +7797,6 @@ type FailoverDBClusterInput struct {
 	//  Must contain from 1 to 63 alphanumeric characters or hyphens First character
 	// must be a letter Cannot end with a hyphen or contain two consecutive hyphens
 	DBClusterIdentifier *string `type:"string"`
-
-	_ struct{} `type:"structure"`
 }
 
 // String returns the string representation
@@ -7810,14 +7810,14 @@ func (s FailoverDBClusterInput) GoString() string {
 }
 
 type FailoverDBClusterOutput struct {
+	_ struct{} `type:"structure"`
+
 	// Contains the result of a successful invocation of the following actions:
 	//
 	//   CreateDBCluster   DeleteDBCluster   FailoverDBCluster   ModifyDBCluster
 	//   RestoreDBClusterFromSnapshot   This data type is used as a response element
 	// in the DescribeDBClusters action.
 	DBCluster *DBCluster `type:"structure"`
-
-	_ struct{} `type:"structure"`
 }
 
 // String returns the string representation
@@ -7831,13 +7831,13 @@ func (s FailoverDBClusterOutput) GoString() string {
 }
 
 type Filter struct {
+	_ struct{} `type:"structure"`
+
 	// This parameter is not currently supported.
 	Name *string `type:"string" required:"true"`
 
 	// This parameter is not currently supported.
 	Values []*string `locationNameList:"Value" type:"list" required:"true"`
-
-	_ struct{} `type:"structure"`
 }
 
 // String returns the string representation
@@ -7853,14 +7853,14 @@ func (s Filter) GoString() string {
 // This data type is used as a response element in the DescribeDBSecurityGroups
 // action.
 type IPRange struct {
+	_ struct{} `type:"structure"`
+
 	// Specifies the IP range.
 	CIDRIP *string `type:"string"`
 
 	// Specifies the status of the IP range. Status can be "authorizing", "authorized",
 	// "revoking", and "revoked".
 	Status *string `type:"string"`
-
-	_ struct{} `type:"structure"`
 }
 
 // String returns the string representation
@@ -7874,6 +7874,8 @@ func (s IPRange) GoString() string {
 }
 
 type ListTagsForResourceInput struct {
+	_ struct{} `type:"structure"`
+
 	// This parameter is not currently supported.
 	Filters []*Filter `locationNameList:"Filter" type:"list"`
 
@@ -7881,8 +7883,6 @@ type ListTagsForResourceInput struct {
 	// Name (ARN). For information about creating an ARN, see  Constructing an RDS
 	// Amazon Resource Name (ARN) (http://docs.aws.amazon.com/AmazonRDS/latest/UserGuide/USER_Tagging.html#USER_Tagging.ARN).
 	ResourceName *string `type:"string" required:"true"`
-
-	_ struct{} `type:"structure"`
 }
 
 // String returns the string representation
@@ -7896,10 +7896,10 @@ func (s ListTagsForResourceInput) GoString() string {
 }
 
 type ListTagsForResourceOutput struct {
+	_ struct{} `type:"structure"`
+
 	// List of tags returned by the ListTagsForResource operation.
 	TagList []*Tag `locationNameList:"Tag" type:"list"`
-
-	_ struct{} `type:"structure"`
 }
 
 // String returns the string representation
@@ -7913,6 +7913,8 @@ func (s ListTagsForResourceOutput) GoString() string {
 }
 
 type ModifyDBClusterInput struct {
+	_ struct{} `type:"structure"`
+
 	// A value that specifies whether the modifications in this request and any
 	// pending modifications are asynchronously applied as soon as possible, regardless
 	// of the PreferredMaintenanceWindow setting for the DB cluster.
@@ -8013,8 +8015,6 @@ type ModifyDBClusterInput struct {
 
 	// A lst of VPC security groups that the DB cluster will belong to.
 	VpcSecurityGroupIds []*string `locationNameList:"VpcSecurityGroupId" type:"list"`
-
-	_ struct{} `type:"structure"`
 }
 
 // String returns the string representation
@@ -8028,14 +8028,14 @@ func (s ModifyDBClusterInput) GoString() string {
 }
 
 type ModifyDBClusterOutput struct {
+	_ struct{} `type:"structure"`
+
 	// Contains the result of a successful invocation of the following actions:
 	//
 	//   CreateDBCluster   DeleteDBCluster   FailoverDBCluster   ModifyDBCluster
 	//   RestoreDBClusterFromSnapshot   This data type is used as a response element
 	// in the DescribeDBClusters action.
 	DBCluster *DBCluster `type:"structure"`
-
-	_ struct{} `type:"structure"`
 }
 
 // String returns the string representation
@@ -8049,13 +8049,13 @@ func (s ModifyDBClusterOutput) GoString() string {
 }
 
 type ModifyDBClusterParameterGroupInput struct {
+	_ struct{} `type:"structure"`
+
 	// The name of the DB cluster parameter group to modify.
 	DBClusterParameterGroupName *string `type:"string" required:"true"`
 
 	// A list of parameters in the DB cluster parameter group to modify.
 	Parameters []*Parameter `locationNameList:"Parameter" type:"list" required:"true"`
-
-	_ struct{} `type:"structure"`
 }
 
 // String returns the string representation
@@ -8069,6 +8069,8 @@ func (s ModifyDBClusterParameterGroupInput) GoString() string {
 }
 
 type ModifyDBInstanceInput struct {
+	_ struct{} `type:"structure"`
+
 	// The new storage capacity of the RDS instance. Changing this setting does
 	// not result in an outage and the change is applied during the next maintenance
 	// window unless ApplyImmediately is set to true for this request.
@@ -8417,8 +8419,6 @@ type ModifyDBInstanceInput struct {
 	//  Must be 1 to 255 alphanumeric characters First character must be a letter
 	// Cannot end with a hyphen or contain two consecutive hyphens
 	VpcSecurityGroupIds []*string `locationNameList:"VpcSecurityGroupId" type:"list"`
-
-	_ struct{} `type:"structure"`
 }
 
 // String returns the string representation
@@ -8432,13 +8432,13 @@ func (s ModifyDBInstanceInput) GoString() string {
 }
 
 type ModifyDBInstanceOutput struct {
+	_ struct{} `type:"structure"`
+
 	// Contains the result of a successful invocation of the following actions:
 	//
 	//   CreateDBInstance   DeleteDBInstance   ModifyDBInstance   This data type
 	// is used as a response element in the DescribeDBInstances action.
 	DBInstance *DBInstance `type:"structure"`
-
-	_ struct{} `type:"structure"`
 }
 
 // String returns the string representation
@@ -8452,6 +8452,8 @@ func (s ModifyDBInstanceOutput) GoString() string {
 }
 
 type ModifyDBParameterGroupInput struct {
+	_ struct{} `type:"structure"`
+
 	// The name of the DB parameter group.
 	//
 	// Constraints:
@@ -8472,8 +8474,6 @@ type ModifyDBParameterGroupInput struct {
 	// the pending-reboot value for both dynamic and static parameters, and changes
 	// are applied when you reboot the DB instance without failover.
 	Parameters []*Parameter `locationNameList:"Parameter" type:"list" required:"true"`
-
-	_ struct{} `type:"structure"`
 }
 
 // String returns the string representation
@@ -8487,6 +8487,8 @@ func (s ModifyDBParameterGroupInput) GoString() string {
 }
 
 type ModifyDBSnapshotAttributeInput struct {
+	_ struct{} `type:"structure"`
+
 	// The name of the DB snapshot attribute to modify.
 	//
 	// To manage authorization for other AWS accounts to copy or restore a manual
@@ -8514,8 +8516,6 @@ type ModifyDBSnapshotAttributeInput struct {
 	// AWS accounts that have their account identifier explicitly added to the restore
 	// attribute can still copy or restore the manual DB snapshot.
 	ValuesToRemove []*string `locationNameList:"AttributeValue" type:"list"`
-
-	_ struct{} `type:"structure"`
 }
 
 // String returns the string representation
@@ -8529,6 +8529,8 @@ func (s ModifyDBSnapshotAttributeInput) GoString() string {
 }
 
 type ModifyDBSnapshotAttributeOutput struct {
+	_ struct{} `type:"structure"`
+
 	// Contains the results of a successful call to the DescribeDBSnapshotAttributes
 	// API.
 	//
@@ -8536,8 +8538,6 @@ type ModifyDBSnapshotAttributeOutput struct {
 	// copy or restore a manual DB snapshot. For more information, see the ModifyDBSnapshotAttribute
 	// API.
 	DBSnapshotAttributesResult *DBSnapshotAttributesResult `type:"structure"`
-
-	_ struct{} `type:"structure"`
 }
 
 // String returns the string representation
@@ -8551,6 +8551,8 @@ func (s ModifyDBSnapshotAttributeOutput) GoString() string {
 }
 
 type ModifyDBSubnetGroupInput struct {
+	_ struct{} `type:"structure"`
+
 	// The description for the DB subnet group.
 	DBSubnetGroupDescription *string `type:"string"`
 
@@ -8564,8 +8566,6 @@ type ModifyDBSubnetGroupInput struct {
 
 	// The EC2 subnet IDs for the DB subnet group.
 	SubnetIds []*string `locationNameList:"SubnetIdentifier" type:"list" required:"true"`
-
-	_ struct{} `type:"structure"`
 }
 
 // String returns the string representation
@@ -8579,14 +8579,14 @@ func (s ModifyDBSubnetGroupInput) GoString() string {
 }
 
 type ModifyDBSubnetGroupOutput struct {
+	_ struct{} `type:"structure"`
+
 	// Contains the result of a successful invocation of the following actions:
 	//
 	//   CreateDBSubnetGroup   ModifyDBSubnetGroup   DescribeDBSubnetGroups   DeleteDBSubnetGroup
 	//   This data type is used as a response element in the DescribeDBSubnetGroups
 	// action.
 	DBSubnetGroup *DBSubnetGroup `type:"structure"`
-
-	_ struct{} `type:"structure"`
 }
 
 // String returns the string representation
@@ -8600,6 +8600,8 @@ func (s ModifyDBSubnetGroupOutput) GoString() string {
 }
 
 type ModifyEventSubscriptionInput struct {
+	_ struct{} `type:"structure"`
+
 	// A Boolean value; set to true to activate the subscription.
 	Enabled *bool `type:"boolean"`
 
@@ -8625,8 +8627,6 @@ type ModifyEventSubscriptionInput struct {
 
 	// The name of the RDS event notification subscription.
 	SubscriptionName *string `type:"string" required:"true"`
-
-	_ struct{} `type:"structure"`
 }
 
 // String returns the string representation
@@ -8640,11 +8640,11 @@ func (s ModifyEventSubscriptionInput) GoString() string {
 }
 
 type ModifyEventSubscriptionOutput struct {
+	_ struct{} `type:"structure"`
+
 	// Contains the results of a successful invocation of the DescribeEventSubscriptions
 	// action.
 	EventSubscription *EventSubscription `type:"structure"`
-
-	_ struct{} `type:"structure"`
 }
 
 // String returns the string representation
@@ -8658,6 +8658,8 @@ func (s ModifyEventSubscriptionOutput) GoString() string {
 }
 
 type ModifyOptionGroupInput struct {
+	_ struct{} `type:"structure"`
+
 	// Indicates whether the changes should be applied immediately, or during the
 	// next maintenance window for each instance associated with the option group.
 	ApplyImmediately *bool `type:"boolean"`
@@ -8675,8 +8677,6 @@ type ModifyOptionGroupInput struct {
 
 	// Options in this list are removed from the option group.
 	OptionsToRemove []*string `type:"list"`
-
-	_ struct{} `type:"structure"`
 }
 
 // String returns the string representation
@@ -8690,9 +8690,9 @@ func (s ModifyOptionGroupInput) GoString() string {
 }
 
 type ModifyOptionGroupOutput struct {
-	OptionGroup *OptionGroup `type:"structure"`
-
 	_ struct{} `type:"structure"`
+
+	OptionGroup *OptionGroup `type:"structure"`
 }
 
 // String returns the string representation
@@ -8707,6 +8707,8 @@ func (s ModifyOptionGroupOutput) GoString() string {
 
 // Option details.
 type Option struct {
+	_ struct{} `type:"structure"`
+
 	// If the option requires access to a port, then this DB security group allows
 	// access to the port.
 	DBSecurityGroupMemberships []*DBSecurityGroupMembership `locationNameList:"DBSecurityGroup" type:"list"`
@@ -8732,8 +8734,6 @@ type Option struct {
 	// If the option requires access to a port, then this VPC security group allows
 	// access to the port.
 	VpcSecurityGroupMemberships []*VpcSecurityGroupMembership `locationNameList:"VpcSecurityGroupMembership" type:"list"`
-
-	_ struct{} `type:"structure"`
 }
 
 // String returns the string representation
@@ -8748,6 +8748,8 @@ func (s Option) GoString() string {
 
 // A list of all available options
 type OptionConfiguration struct {
+	_ struct{} `type:"structure"`
+
 	// A list of DBSecurityGroupMemebrship name strings used for this option.
 	DBSecurityGroupMemberships []*string `locationNameList:"DBSecurityGroupName" type:"list"`
 
@@ -8762,8 +8764,6 @@ type OptionConfiguration struct {
 
 	// A list of VpcSecurityGroupMemebrship name strings used for this option.
 	VpcSecurityGroupMemberships []*string `locationNameList:"VpcSecurityGroupId" type:"list"`
-
-	_ struct{} `type:"structure"`
 }
 
 // String returns the string representation
@@ -8777,6 +8777,8 @@ func (s OptionConfiguration) GoString() string {
 }
 
 type OptionGroup struct {
+	_ struct{} `type:"structure"`
+
 	// Indicates whether this option group can be applied to both VPC and non-VPC
 	// instances. The value true indicates the option group can be applied to both
 	// VPC and non-VPC instances.
@@ -8803,8 +8805,6 @@ type OptionGroup struct {
 	// field contains a value, then this option group can only be applied to instances
 	// that are in the VPC indicated by this field.
 	VpcId *string `type:"string"`
-
-	_ struct{} `type:"structure"`
 }
 
 // String returns the string representation
@@ -8819,14 +8819,14 @@ func (s OptionGroup) GoString() string {
 
 // Provides information on the option groups the DB instance is a member of.
 type OptionGroupMembership struct {
+	_ struct{} `type:"structure"`
+
 	// The name of the option group that the instance belongs to.
 	OptionGroupName *string `type:"string"`
 
 	// The status of the DB instance's option group membership (e.g. in-sync, pending,
 	// pending-maintenance, applying).
 	Status *string `type:"string"`
-
-	_ struct{} `type:"structure"`
 }
 
 // String returns the string representation
@@ -8841,6 +8841,8 @@ func (s OptionGroupMembership) GoString() string {
 
 // Available option.
 type OptionGroupOption struct {
+	_ struct{} `type:"structure"`
+
 	// If the option requires a port, specifies the default port for the option.
 	DefaultPort *int64 `type:"integer"`
 
@@ -8879,8 +8881,6 @@ type OptionGroupOption struct {
 
 	// Specifies whether the option requires a port.
 	PortRequired *bool `type:"boolean"`
-
-	_ struct{} `type:"structure"`
 }
 
 // String returns the string representation
@@ -8897,6 +8897,8 @@ func (s OptionGroupOption) GoString() string {
 // option with their default values and other information. These values are
 // used with the DescribeOptionGroupOptions action.
 type OptionGroupOptionSetting struct {
+	_ struct{} `type:"structure"`
+
 	// Indicates the acceptable values for the option group option.
 	AllowedValues *string `type:"string"`
 
@@ -8915,8 +8917,6 @@ type OptionGroupOptionSetting struct {
 
 	// The name of the option group option.
 	SettingName *string `type:"string"`
-
-	_ struct{} `type:"structure"`
 }
 
 // String returns the string representation
@@ -8934,6 +8934,8 @@ func (s OptionGroupOptionSetting) GoString() string {
 // For example, the NATIVE_NETWORK_ENCRYPTION option has a setting called SQLNET.ENCRYPTION_SERVER
 // that can have several different values.
 type OptionSetting struct {
+	_ struct{} `type:"structure"`
+
 	// The allowed values of the option setting.
 	AllowedValues *string `type:"string"`
 
@@ -8961,8 +8963,6 @@ type OptionSetting struct {
 
 	// The current value of the option setting.
 	Value *string `type:"string"`
-
-	_ struct{} `type:"structure"`
 }
 
 // String returns the string representation
@@ -8980,6 +8980,8 @@ func (s OptionSetting) GoString() string {
 //  This data type is used as a response element in the DescribeOrderableDBInstanceOptions
 // action.
 type OrderableDBInstanceOption struct {
+	_ struct{} `type:"structure"`
+
 	// A list of Availability Zones for the orderable DB instance.
 	AvailabilityZones []*AvailabilityZone `locationNameList:"AvailabilityZone" type:"list"`
 
@@ -9012,8 +9014,6 @@ type OrderableDBInstanceOption struct {
 
 	// Indicates whether this is a VPC orderable DB instance.
 	Vpc *bool `type:"boolean"`
-
-	_ struct{} `type:"structure"`
 }
 
 // String returns the string representation
@@ -9032,6 +9032,8 @@ func (s OrderableDBInstanceOption) GoString() string {
 // This data type is used as a response element in the DescribeEngineDefaultParameters
 // and DescribeDBParameters actions.
 type Parameter struct {
+	_ struct{} `type:"structure"`
+
 	// Specifies the valid range of values for the parameter.
 	AllowedValues *string `type:"string"`
 
@@ -9063,8 +9065,6 @@ type Parameter struct {
 
 	// Indicates the source of the parameter value.
 	Source *string `type:"string"`
-
-	_ struct{} `type:"structure"`
 }
 
 // String returns the string representation
@@ -9079,6 +9079,8 @@ func (s Parameter) GoString() string {
 
 // Provides information about a pending maintenance action for a resource.
 type PendingMaintenanceAction struct {
+	_ struct{} `type:"structure"`
+
 	// The type of pending maintenance action that is available for the resource.
 	Action *string `type:"string"`
 
@@ -9106,8 +9108,6 @@ type PendingMaintenanceAction struct {
 
 	// Indicates the type of opt-in request that has been received for the resource.
 	OptInStatus *string `type:"string"`
-
-	_ struct{} `type:"structure"`
 }
 
 // String returns the string representation
@@ -9122,6 +9122,8 @@ func (s PendingMaintenanceAction) GoString() string {
 
 // This data type is used as a response element in the ModifyDBInstance action.
 type PendingModifiedValues struct {
+	_ struct{} `type:"structure"`
+
 	// Contains the new AllocatedStorage size for the DB instance that will be applied
 	// or is in progress.
 	AllocatedStorage *int64 `type:"integer"`
@@ -9159,8 +9161,6 @@ type PendingModifiedValues struct {
 
 	// Specifies the storage type to be associated with the DB instance.
 	StorageType *string `type:"string"`
-
-	_ struct{} `type:"structure"`
 }
 
 // String returns the string representation
@@ -9174,6 +9174,8 @@ func (s PendingModifiedValues) GoString() string {
 }
 
 type PromoteReadReplicaInput struct {
+	_ struct{} `type:"structure"`
+
 	// The number of days to retain automated backups. Setting this parameter to
 	// a positive number enables backups. Setting this parameter to 0 disables automated
 	// backups.
@@ -9209,8 +9211,6 @@ type PromoteReadReplicaInput struct {
 	// Time (UTC). Must not conflict with the preferred maintenance window. Must
 	// be at least 30 minutes.
 	PreferredBackupWindow *string `type:"string"`
-
-	_ struct{} `type:"structure"`
 }
 
 // String returns the string representation
@@ -9224,13 +9224,13 @@ func (s PromoteReadReplicaInput) GoString() string {
 }
 
 type PromoteReadReplicaOutput struct {
+	_ struct{} `type:"structure"`
+
 	// Contains the result of a successful invocation of the following actions:
 	//
 	//   CreateDBInstance   DeleteDBInstance   ModifyDBInstance   This data type
 	// is used as a response element in the DescribeDBInstances action.
 	DBInstance *DBInstance `type:"structure"`
-
-	_ struct{} `type:"structure"`
 }
 
 // String returns the string representation
@@ -9244,6 +9244,8 @@ func (s PromoteReadReplicaOutput) GoString() string {
 }
 
 type PurchaseReservedDBInstancesOfferingInput struct {
+	_ struct{} `type:"structure"`
+
 	// The number of instances to reserve.
 	//
 	// Default: 1
@@ -9261,8 +9263,6 @@ type PurchaseReservedDBInstancesOfferingInput struct {
 
 	// A list of tags.
 	Tags []*Tag `locationNameList:"Tag" type:"list"`
-
-	_ struct{} `type:"structure"`
 }
 
 // String returns the string representation
@@ -9276,11 +9276,11 @@ func (s PurchaseReservedDBInstancesOfferingInput) GoString() string {
 }
 
 type PurchaseReservedDBInstancesOfferingOutput struct {
+	_ struct{} `type:"structure"`
+
 	// This data type is used as a response element in the DescribeReservedDBInstances
 	// and PurchaseReservedDBInstancesOffering actions.
 	ReservedDBInstance *ReservedDBInstance `type:"structure"`
-
-	_ struct{} `type:"structure"`
 }
 
 // String returns the string representation
@@ -9294,6 +9294,8 @@ func (s PurchaseReservedDBInstancesOfferingOutput) GoString() string {
 }
 
 type RebootDBInstanceInput struct {
+	_ struct{} `type:"structure"`
+
 	// The DB instance identifier. This parameter is stored as a lowercase string.
 	//
 	// Constraints:
@@ -9307,8 +9309,6 @@ type RebootDBInstanceInput struct {
 	// Constraint: You cannot specify true if the instance is not configured for
 	// MultiAZ.
 	ForceFailover *bool `type:"boolean"`
-
-	_ struct{} `type:"structure"`
 }
 
 // String returns the string representation
@@ -9322,13 +9322,13 @@ func (s RebootDBInstanceInput) GoString() string {
 }
 
 type RebootDBInstanceOutput struct {
+	_ struct{} `type:"structure"`
+
 	// Contains the result of a successful invocation of the following actions:
 	//
 	//   CreateDBInstance   DeleteDBInstance   ModifyDBInstance   This data type
 	// is used as a response element in the DescribeDBInstances action.
 	DBInstance *DBInstance `type:"structure"`
-
-	_ struct{} `type:"structure"`
 }
 
 // String returns the string representation
@@ -9344,13 +9344,13 @@ func (s RebootDBInstanceOutput) GoString() string {
 // This data type is used as a response element in the DescribeReservedDBInstances
 // and DescribeReservedDBInstancesOfferings actions.
 type RecurringCharge struct {
+	_ struct{} `type:"structure"`
+
 	// The amount of the recurring charge.
 	RecurringChargeAmount *float64 `type:"double"`
 
 	// The frequency of the recurring charge.
 	RecurringChargeFrequency *string `type:"string"`
-
-	_ struct{} `type:"structure"`
 }
 
 // String returns the string representation
@@ -9364,6 +9364,8 @@ func (s RecurringCharge) GoString() string {
 }
 
 type RemoveSourceIdentifierFromSubscriptionInput struct {
+	_ struct{} `type:"structure"`
+
 	// The source identifier to be removed from the subscription, such as the DB
 	// instance identifier for a DB instance or the name of a security group.
 	SourceIdentifier *string `type:"string" required:"true"`
@@ -9371,8 +9373,6 @@ type RemoveSourceIdentifierFromSubscriptionInput struct {
 	// The name of the RDS event notification subscription you want to remove a
 	// source identifier from.
 	SubscriptionName *string `type:"string" required:"true"`
-
-	_ struct{} `type:"structure"`
 }
 
 // String returns the string representation
@@ -9386,11 +9386,11 @@ func (s RemoveSourceIdentifierFromSubscriptionInput) GoString() string {
 }
 
 type RemoveSourceIdentifierFromSubscriptionOutput struct {
+	_ struct{} `type:"structure"`
+
 	// Contains the results of a successful invocation of the DescribeEventSubscriptions
 	// action.
 	EventSubscription *EventSubscription `type:"structure"`
-
-	_ struct{} `type:"structure"`
 }
 
 // String returns the string representation
@@ -9404,6 +9404,8 @@ func (s RemoveSourceIdentifierFromSubscriptionOutput) GoString() string {
 }
 
 type RemoveTagsFromResourceInput struct {
+	_ struct{} `type:"structure"`
+
 	// The Amazon RDS resource the tags will be removed from. This value is an Amazon
 	// Resource Name (ARN). For information about creating an ARN, see  Constructing
 	// an RDS Amazon Resource Name (ARN) (http://docs.aws.amazon.com/AmazonRDS/latest/UserGuide/USER_Tagging.html#USER_Tagging.ARN).
@@ -9411,8 +9413,6 @@ type RemoveTagsFromResourceInput struct {
 
 	// The tag key (name) of the tag to be removed.
 	TagKeys []*string `type:"list" required:"true"`
-
-	_ struct{} `type:"structure"`
 }
 
 // String returns the string representation
@@ -9442,6 +9442,8 @@ func (s RemoveTagsFromResourceOutput) GoString() string {
 // This data type is used as a response element in the DescribeReservedDBInstances
 // and PurchaseReservedDBInstancesOffering actions.
 type ReservedDBInstance struct {
+	_ struct{} `type:"structure"`
+
 	// The currency code for the reserved DB instance.
 	CurrencyCode *string `type:"string"`
 
@@ -9483,8 +9485,6 @@ type ReservedDBInstance struct {
 
 	// The hourly price charged for this reserved DB instance.
 	UsagePrice *float64 `type:"double"`
-
-	_ struct{} `type:"structure"`
 }
 
 // String returns the string representation
@@ -9500,6 +9500,8 @@ func (s ReservedDBInstance) GoString() string {
 // This data type is used as a response element in the DescribeReservedDBInstancesOfferings
 // action.
 type ReservedDBInstancesOffering struct {
+	_ struct{} `type:"structure"`
+
 	// The currency code for the reserved DB instance offering.
 	CurrencyCode *string `type:"string"`
 
@@ -9529,8 +9531,6 @@ type ReservedDBInstancesOffering struct {
 
 	// The hourly price charged for this offering.
 	UsagePrice *float64 `type:"double"`
-
-	_ struct{} `type:"structure"`
 }
 
 // String returns the string representation
@@ -9544,6 +9544,8 @@ func (s ReservedDBInstancesOffering) GoString() string {
 }
 
 type ResetDBClusterParameterGroupInput struct {
+	_ struct{} `type:"structure"`
+
 	// The name of the DB cluster parameter group to reset.
 	DBClusterParameterGroupName *string `type:"string" required:"true"`
 
@@ -9556,8 +9558,6 @@ type ResetDBClusterParameterGroupInput struct {
 	// group to their default values, and false otherwise. You cannot use this parameter
 	// if there is a list of parameter names specified for the Parameters parameter.
 	ResetAllParameters *bool `type:"boolean"`
-
-	_ struct{} `type:"structure"`
 }
 
 // String returns the string representation
@@ -9571,6 +9571,8 @@ func (s ResetDBClusterParameterGroupInput) GoString() string {
 }
 
 type ResetDBParameterGroupInput struct {
+	_ struct{} `type:"structure"`
+
 	// The name of the DB parameter group.
 	//
 	// Constraints:
@@ -9610,8 +9612,6 @@ type ResetDBParameterGroupInput struct {
 	//
 	// Default: true
 	ResetAllParameters *bool `type:"boolean"`
-
-	_ struct{} `type:"structure"`
 }
 
 // String returns the string representation
@@ -9626,14 +9626,14 @@ func (s ResetDBParameterGroupInput) GoString() string {
 
 // Describes the pending maintenance actions for a resource.
 type ResourcePendingMaintenanceActions struct {
+	_ struct{} `type:"structure"`
+
 	// A list that provides details about the pending maintenance actions for the
 	// resource.
 	PendingMaintenanceActionDetails []*PendingMaintenanceAction `locationNameList:"PendingMaintenanceAction" type:"list"`
 
 	// The ARN of the resource that has pending maintenance actions.
 	ResourceIdentifier *string `type:"string"`
-
-	_ struct{} `type:"structure"`
 }
 
 // String returns the string representation
@@ -9647,6 +9647,8 @@ func (s ResourcePendingMaintenanceActions) GoString() string {
 }
 
 type RestoreDBClusterFromSnapshotInput struct {
+	_ struct{} `type:"structure"`
+
 	// Provides the list of EC2 Availability Zones that instances in the restored
 	// DB cluster can be created in.
 	AvailabilityZones []*string `locationNameList:"AvailabilityZone" type:"list"`
@@ -9700,8 +9702,6 @@ type RestoreDBClusterFromSnapshotInput struct {
 
 	// A list of VPC security groups that the new DB cluster will belong to.
 	VpcSecurityGroupIds []*string `locationNameList:"VpcSecurityGroupId" type:"list"`
-
-	_ struct{} `type:"structure"`
 }
 
 // String returns the string representation
@@ -9715,14 +9715,14 @@ func (s RestoreDBClusterFromSnapshotInput) GoString() string {
 }
 
 type RestoreDBClusterFromSnapshotOutput struct {
+	_ struct{} `type:"structure"`
+
 	// Contains the result of a successful invocation of the following actions:
 	//
 	//   CreateDBCluster   DeleteDBCluster   FailoverDBCluster   ModifyDBCluster
 	//   RestoreDBClusterFromSnapshot   This data type is used as a response element
 	// in the DescribeDBClusters action.
 	DBCluster *DBCluster `type:"structure"`
-
-	_ struct{} `type:"structure"`
 }
 
 // String returns the string representation
@@ -9736,6 +9736,8 @@ func (s RestoreDBClusterFromSnapshotOutput) GoString() string {
 }
 
 type RestoreDBClusterToPointInTimeInput struct {
+	_ struct{} `type:"structure"`
+
 	// The name of the new DB cluster to be created.
 	//
 	// Constraints:
@@ -9789,8 +9791,6 @@ type RestoreDBClusterToPointInTimeInput struct {
 
 	// A lst of VPC security groups that the new DB cluster belongs to.
 	VpcSecurityGroupIds []*string `locationNameList:"VpcSecurityGroupId" type:"list"`
-
-	_ struct{} `type:"structure"`
 }
 
 // String returns the string representation
@@ -9804,14 +9804,14 @@ func (s RestoreDBClusterToPointInTimeInput) GoString() string {
 }
 
 type RestoreDBClusterToPointInTimeOutput struct {
+	_ struct{} `type:"structure"`
+
 	// Contains the result of a successful invocation of the following actions:
 	//
 	//   CreateDBCluster   DeleteDBCluster   FailoverDBCluster   ModifyDBCluster
 	//   RestoreDBClusterFromSnapshot   This data type is used as a response element
 	// in the DescribeDBClusters action.
 	DBCluster *DBCluster `type:"structure"`
-
-	_ struct{} `type:"structure"`
 }
 
 // String returns the string representation
@@ -9825,6 +9825,8 @@ func (s RestoreDBClusterToPointInTimeOutput) GoString() string {
 }
 
 type RestoreDBInstanceFromDBSnapshotInput struct {
+	_ struct{} `type:"structure"`
+
 	// Indicates that minor version upgrades will be applied automatically to the
 	// DB instance during the maintenance window.
 	AutoMinorVersionUpgrade *bool `type:"boolean"`
@@ -9964,8 +9966,6 @@ type RestoreDBInstanceFromDBSnapshotInput struct {
 	// The password for the given ARN from the Key Store in order to access the
 	// device.
 	TdeCredentialPassword *string `type:"string"`
-
-	_ struct{} `type:"structure"`
 }
 
 // String returns the string representation
@@ -9979,13 +9979,13 @@ func (s RestoreDBInstanceFromDBSnapshotInput) GoString() string {
 }
 
 type RestoreDBInstanceFromDBSnapshotOutput struct {
+	_ struct{} `type:"structure"`
+
 	// Contains the result of a successful invocation of the following actions:
 	//
 	//   CreateDBInstance   DeleteDBInstance   ModifyDBInstance   This data type
 	// is used as a response element in the DescribeDBInstances action.
 	DBInstance *DBInstance `type:"structure"`
-
-	_ struct{} `type:"structure"`
 }
 
 // String returns the string representation
@@ -9999,6 +9999,8 @@ func (s RestoreDBInstanceFromDBSnapshotOutput) GoString() string {
 }
 
 type RestoreDBInstanceToPointInTimeInput struct {
+	_ struct{} `type:"structure"`
+
 	// Indicates that minor version upgrades will be applied automatically to the
 	// DB instance during the maintenance window.
 	AutoMinorVersionUpgrade *bool `type:"boolean"`
@@ -10151,8 +10153,6 @@ type RestoreDBInstanceToPointInTimeInput struct {
 	//
 	// Constraints: Cannot be specified if RestoreTime parameter is provided.
 	UseLatestRestorableTime *bool `type:"boolean"`
-
-	_ struct{} `type:"structure"`
 }
 
 // String returns the string representation
@@ -10166,13 +10166,13 @@ func (s RestoreDBInstanceToPointInTimeInput) GoString() string {
 }
 
 type RestoreDBInstanceToPointInTimeOutput struct {
+	_ struct{} `type:"structure"`
+
 	// Contains the result of a successful invocation of the following actions:
 	//
 	//   CreateDBInstance   DeleteDBInstance   ModifyDBInstance   This data type
 	// is used as a response element in the DescribeDBInstances action.
 	DBInstance *DBInstance `type:"structure"`
-
-	_ struct{} `type:"structure"`
 }
 
 // String returns the string representation
@@ -10186,6 +10186,8 @@ func (s RestoreDBInstanceToPointInTimeOutput) GoString() string {
 }
 
 type RevokeDBSecurityGroupIngressInput struct {
+	_ struct{} `type:"structure"`
+
 	// The IP range to revoke access from. Must be a valid CIDR range. If CIDRIP
 	// is specified, EC2SecurityGroupName, EC2SecurityGroupId and EC2SecurityGroupOwnerId
 	// cannot be provided.
@@ -10210,8 +10212,6 @@ type RevokeDBSecurityGroupIngressInput struct {
 	// EC2SecurityGroupOwnerId and either EC2SecurityGroupName or EC2SecurityGroupId
 	// must be provided.
 	EC2SecurityGroupOwnerId *string `type:"string"`
-
-	_ struct{} `type:"structure"`
 }
 
 // String returns the string representation
@@ -10225,14 +10225,14 @@ func (s RevokeDBSecurityGroupIngressInput) GoString() string {
 }
 
 type RevokeDBSecurityGroupIngressOutput struct {
+	_ struct{} `type:"structure"`
+
 	// Contains the result of a successful invocation of the following actions:
 	//
 	//   DescribeDBSecurityGroups   AuthorizeDBSecurityGroupIngress   CreateDBSecurityGroup
 	//   RevokeDBSecurityGroupIngress   This data type is used as a response element
 	// in the DescribeDBSecurityGroups action.
 	DBSecurityGroup *DBSecurityGroup `type:"structure"`
-
-	_ struct{} `type:"structure"`
 }
 
 // String returns the string representation
@@ -10248,6 +10248,8 @@ func (s RevokeDBSecurityGroupIngressOutput) GoString() string {
 // This data type is used as a response element in the DescribeDBSubnetGroups
 // action.
 type Subnet struct {
+	_ struct{} `type:"structure"`
+
 	// Contains Availability Zone information.
 	//
 	//  This data type is used as an element in the following data type: OrderableDBInstanceOption
@@ -10258,8 +10260,6 @@ type Subnet struct {
 
 	// Specifies the status of the subnet.
 	SubnetStatus *string `type:"string"`
-
-	_ struct{} `type:"structure"`
 }
 
 // String returns the string representation
@@ -10274,6 +10274,8 @@ func (s Subnet) GoString() string {
 
 // Metadata assigned to an Amazon RDS resource consisting of a key-value pair.
 type Tag struct {
+	_ struct{} `type:"structure"`
+
 	// A key is the required name of the tag. The string value can be from 1 to
 	// 128 Unicode characters in length and cannot be prefixed with "aws:" or "rds:".
 	// The string can only contain only the set of Unicode letters, digits, white-space,
@@ -10285,8 +10287,6 @@ type Tag struct {
 	// "rds:". The string can only contain only the set of Unicode letters, digits,
 	// white-space, '_', '.', '/', '=', '+', '-' (Java regex: "^([\\p{L}\\p{Z}\\p{N}_.:/=+\\-]*)$").
 	Value *string `type:"string"`
-
-	_ struct{} `type:"structure"`
 }
 
 // String returns the string representation
@@ -10301,6 +10301,8 @@ func (s Tag) GoString() string {
 
 // The version of the database engine that a DB instance can be upgraded to.
 type UpgradeTarget struct {
+	_ struct{} `type:"structure"`
+
 	// A value that indicates whether the target version will be applied to any
 	// source DB instances that have AutoMinorVersionUpgrade set to true.
 	AutoUpgrade *bool `type:"boolean"`
@@ -10317,8 +10319,6 @@ type UpgradeTarget struct {
 	// A value that indicates whether a database engine will be upgraded to a major
 	// version.
 	IsMajorVersionUpgrade *bool `type:"boolean"`
-
-	_ struct{} `type:"structure"`
 }
 
 // String returns the string representation
@@ -10334,13 +10334,13 @@ func (s UpgradeTarget) GoString() string {
 // This data type is used as a response element for queries on VPC security
 // group membership.
 type VpcSecurityGroupMembership struct {
+	_ struct{} `type:"structure"`
+
 	// The status of the VPC security group.
 	Status *string `type:"string"`
 
 	// The name of the VPC security group.
 	VpcSecurityGroupId *string `type:"string"`
-
-	_ struct{} `type:"structure"`
 }
 
 // String returns the string representation

--- a/service/rds/api.go
+++ b/service/rds/api.go
@@ -2731,11 +2731,7 @@ type AccountQuota struct {
 	// The amount currently used toward the quota maximum.
 	Used *int64 `type:"long"`
 
-	metadataAccountQuota `json:"-" xml:"-"`
-}
-
-type metadataAccountQuota struct {
-	SDKShapeTraits bool `type:"structure"`
+	_ struct{} `type:"structure"`
 }
 
 // String returns the string representation
@@ -2766,11 +2762,7 @@ type AddSourceIdentifierToSubscriptionInput struct {
 	// identifier to.
 	SubscriptionName *string `type:"string" required:"true"`
 
-	metadataAddSourceIdentifierToSubscriptionInput `json:"-" xml:"-"`
-}
-
-type metadataAddSourceIdentifierToSubscriptionInput struct {
-	SDKShapeTraits bool `type:"structure"`
+	_ struct{} `type:"structure"`
 }
 
 // String returns the string representation
@@ -2788,11 +2780,7 @@ type AddSourceIdentifierToSubscriptionOutput struct {
 	// action.
 	EventSubscription *EventSubscription `type:"structure"`
 
-	metadataAddSourceIdentifierToSubscriptionOutput `json:"-" xml:"-"`
-}
-
-type metadataAddSourceIdentifierToSubscriptionOutput struct {
-	SDKShapeTraits bool `type:"structure"`
+	_ struct{} `type:"structure"`
 }
 
 // String returns the string representation
@@ -2814,11 +2802,7 @@ type AddTagsToResourceInput struct {
 	// The tags to be assigned to the Amazon RDS resource.
 	Tags []*Tag `locationNameList:"Tag" type:"list" required:"true"`
 
-	metadataAddTagsToResourceInput `json:"-" xml:"-"`
-}
-
-type metadataAddTagsToResourceInput struct {
-	SDKShapeTraits bool `type:"structure"`
+	_ struct{} `type:"structure"`
 }
 
 // String returns the string representation
@@ -2832,11 +2816,7 @@ func (s AddTagsToResourceInput) GoString() string {
 }
 
 type AddTagsToResourceOutput struct {
-	metadataAddTagsToResourceOutput `json:"-" xml:"-"`
-}
-
-type metadataAddTagsToResourceOutput struct {
-	SDKShapeTraits bool `type:"structure"`
+	_ struct{} `type:"structure"`
 }
 
 // String returns the string representation
@@ -2868,11 +2848,7 @@ type ApplyPendingMaintenanceActionInput struct {
 	// an RDS Amazon Resource Name (ARN) (http://docs.aws.amazon.com/AmazonRDS/latest/UserGuide/USER_Tagging.html#USER_Tagging.ARN).
 	ResourceIdentifier *string `type:"string" required:"true"`
 
-	metadataApplyPendingMaintenanceActionInput `json:"-" xml:"-"`
-}
-
-type metadataApplyPendingMaintenanceActionInput struct {
-	SDKShapeTraits bool `type:"structure"`
+	_ struct{} `type:"structure"`
 }
 
 // String returns the string representation
@@ -2889,11 +2865,7 @@ type ApplyPendingMaintenanceActionOutput struct {
 	// Describes the pending maintenance actions for a resource.
 	ResourcePendingMaintenanceActions *ResourcePendingMaintenanceActions `type:"structure"`
 
-	metadataApplyPendingMaintenanceActionOutput `json:"-" xml:"-"`
-}
-
-type metadataApplyPendingMaintenanceActionOutput struct {
-	SDKShapeTraits bool `type:"structure"`
+	_ struct{} `type:"structure"`
 }
 
 // String returns the string representation
@@ -2930,11 +2902,7 @@ type AuthorizeDBSecurityGroupIngressInput struct {
 	// must be provided.
 	EC2SecurityGroupOwnerId *string `type:"string"`
 
-	metadataAuthorizeDBSecurityGroupIngressInput `json:"-" xml:"-"`
-}
-
-type metadataAuthorizeDBSecurityGroupIngressInput struct {
-	SDKShapeTraits bool `type:"structure"`
+	_ struct{} `type:"structure"`
 }
 
 // String returns the string representation
@@ -2955,11 +2923,7 @@ type AuthorizeDBSecurityGroupIngressOutput struct {
 	// in the DescribeDBSecurityGroups action.
 	DBSecurityGroup *DBSecurityGroup `type:"structure"`
 
-	metadataAuthorizeDBSecurityGroupIngressOutput `json:"-" xml:"-"`
-}
-
-type metadataAuthorizeDBSecurityGroupIngressOutput struct {
-	SDKShapeTraits bool `type:"structure"`
+	_ struct{} `type:"structure"`
 }
 
 // String returns the string representation
@@ -2979,11 +2943,7 @@ type AvailabilityZone struct {
 	// The name of the availability zone.
 	Name *string `type:"string"`
 
-	metadataAvailabilityZone `json:"-" xml:"-"`
-}
-
-type metadataAvailabilityZone struct {
-	SDKShapeTraits bool `type:"structure"`
+	_ struct{} `type:"structure"`
 }
 
 // String returns the string representation
@@ -3013,11 +2973,7 @@ type Certificate struct {
 	// The final date that the certificate continues to be valid.
 	ValidTill *time.Time `type:"timestamp" timestampFormat:"iso8601"`
 
-	metadataCertificate `json:"-" xml:"-"`
-}
-
-type metadataCertificate struct {
-	SDKShapeTraits bool `type:"structure"`
+	_ struct{} `type:"structure"`
 }
 
 // String returns the string representation
@@ -3038,11 +2994,7 @@ type CharacterSet struct {
 	// The name of the character set.
 	CharacterSetName *string `type:"string"`
 
-	metadataCharacterSet `json:"-" xml:"-"`
-}
-
-type metadataCharacterSet struct {
-	SDKShapeTraits bool `type:"structure"`
+	_ struct{} `type:"structure"`
 }
 
 // String returns the string representation
@@ -3079,11 +3031,7 @@ type CopyDBClusterSnapshotInput struct {
 	//  Example: my-cluster-snapshot2
 	TargetDBClusterSnapshotIdentifier *string `type:"string" required:"true"`
 
-	metadataCopyDBClusterSnapshotInput `json:"-" xml:"-"`
-}
-
-type metadataCopyDBClusterSnapshotInput struct {
-	SDKShapeTraits bool `type:"structure"`
+	_ struct{} `type:"structure"`
 }
 
 // String returns the string representation
@@ -3103,11 +3051,7 @@ type CopyDBClusterSnapshotOutput struct {
 	// used as a response element in the DescribeDBClusterSnapshots action.
 	DBClusterSnapshot *DBClusterSnapshot `type:"structure"`
 
-	metadataCopyDBClusterSnapshotOutput `json:"-" xml:"-"`
-}
-
-type metadataCopyDBClusterSnapshotOutput struct {
-	SDKShapeTraits bool `type:"structure"`
+	_ struct{} `type:"structure"`
 }
 
 // String returns the string representation
@@ -3149,11 +3093,7 @@ type CopyDBParameterGroupInput struct {
 	// hyphen or contain two consecutive hyphens  Example: my-db-parameter-group
 	TargetDBParameterGroupIdentifier *string `type:"string" required:"true"`
 
-	metadataCopyDBParameterGroupInput `json:"-" xml:"-"`
-}
-
-type metadataCopyDBParameterGroupInput struct {
-	SDKShapeTraits bool `type:"structure"`
+	_ struct{} `type:"structure"`
 }
 
 // String returns the string representation
@@ -3174,11 +3114,7 @@ type CopyDBParameterGroupOutput struct {
 	// action, and as a response element in the DescribeDBParameterGroups action.
 	DBParameterGroup *DBParameterGroup `type:"structure"`
 
-	metadataCopyDBParameterGroupOutput `json:"-" xml:"-"`
-}
-
-type metadataCopyDBParameterGroupOutput struct {
-	SDKShapeTraits bool `type:"structure"`
+	_ struct{} `type:"structure"`
 }
 
 // String returns the string representation
@@ -3225,11 +3161,7 @@ type CopyDBSnapshotInput struct {
 	// hyphen or contain two consecutive hyphens  Example: my-db-snapshot
 	TargetDBSnapshotIdentifier *string `type:"string" required:"true"`
 
-	metadataCopyDBSnapshotInput `json:"-" xml:"-"`
-}
-
-type metadataCopyDBSnapshotInput struct {
-	SDKShapeTraits bool `type:"structure"`
+	_ struct{} `type:"structure"`
 }
 
 // String returns the string representation
@@ -3249,11 +3181,7 @@ type CopyDBSnapshotOutput struct {
 	// element in the DescribeDBSnapshots action.
 	DBSnapshot *DBSnapshot `type:"structure"`
 
-	metadataCopyDBSnapshotOutput `json:"-" xml:"-"`
-}
-
-type metadataCopyDBSnapshotOutput struct {
-	SDKShapeTraits bool `type:"structure"`
+	_ struct{} `type:"structure"`
 }
 
 // String returns the string representation
@@ -3293,11 +3221,7 @@ type CopyOptionGroupInput struct {
 	// hyphen or contain two consecutive hyphens  Example: my-option-group
 	TargetOptionGroupIdentifier *string `type:"string" required:"true"`
 
-	metadataCopyOptionGroupInput `json:"-" xml:"-"`
-}
-
-type metadataCopyOptionGroupInput struct {
-	SDKShapeTraits bool `type:"structure"`
+	_ struct{} `type:"structure"`
 }
 
 // String returns the string representation
@@ -3313,11 +3237,7 @@ func (s CopyOptionGroupInput) GoString() string {
 type CopyOptionGroupOutput struct {
 	OptionGroup *OptionGroup `type:"structure"`
 
-	metadataCopyOptionGroupOutput `json:"-" xml:"-"`
-}
-
-type metadataCopyOptionGroupOutput struct {
-	SDKShapeTraits bool `type:"structure"`
+	_ struct{} `type:"structure"`
 }
 
 // String returns the string representation
@@ -3451,11 +3371,7 @@ type CreateDBClusterInput struct {
 	// A list of EC2 VPC security groups to associate with this DB cluster.
 	VpcSecurityGroupIds []*string `locationNameList:"VpcSecurityGroupId" type:"list"`
 
-	metadataCreateDBClusterInput `json:"-" xml:"-"`
-}
-
-type metadataCreateDBClusterInput struct {
-	SDKShapeTraits bool `type:"structure"`
+	_ struct{} `type:"structure"`
 }
 
 // String returns the string representation
@@ -3476,11 +3392,7 @@ type CreateDBClusterOutput struct {
 	// in the DescribeDBClusters action.
 	DBCluster *DBCluster `type:"structure"`
 
-	metadataCreateDBClusterOutput `json:"-" xml:"-"`
-}
-
-type metadataCreateDBClusterOutput struct {
-	SDKShapeTraits bool `type:"structure"`
+	_ struct{} `type:"structure"`
 }
 
 // String returns the string representation
@@ -3515,11 +3427,7 @@ type CreateDBClusterParameterGroupInput struct {
 	// A list of tags.
 	Tags []*Tag `locationNameList:"Tag" type:"list"`
 
-	metadataCreateDBClusterParameterGroupInput `json:"-" xml:"-"`
-}
-
-type metadataCreateDBClusterParameterGroupInput struct {
-	SDKShapeTraits bool `type:"structure"`
+	_ struct{} `type:"structure"`
 }
 
 // String returns the string representation
@@ -3541,11 +3449,7 @@ type CreateDBClusterParameterGroupOutput struct {
 	// action.
 	DBClusterParameterGroup *DBClusterParameterGroup `type:"structure"`
 
-	metadataCreateDBClusterParameterGroupOutput `json:"-" xml:"-"`
-}
-
-type metadataCreateDBClusterParameterGroupOutput struct {
-	SDKShapeTraits bool `type:"structure"`
+	_ struct{} `type:"structure"`
 }
 
 // String returns the string representation
@@ -3582,11 +3486,7 @@ type CreateDBClusterSnapshotInput struct {
 	// The tags to be assigned to the DB cluster snapshot.
 	Tags []*Tag `locationNameList:"Tag" type:"list"`
 
-	metadataCreateDBClusterSnapshotInput `json:"-" xml:"-"`
-}
-
-type metadataCreateDBClusterSnapshotInput struct {
-	SDKShapeTraits bool `type:"structure"`
+	_ struct{} `type:"structure"`
 }
 
 // String returns the string representation
@@ -3606,11 +3506,7 @@ type CreateDBClusterSnapshotOutput struct {
 	// used as a response element in the DescribeDBClusterSnapshots action.
 	DBClusterSnapshot *DBClusterSnapshot `type:"structure"`
 
-	metadataCreateDBClusterSnapshotOutput `json:"-" xml:"-"`
-}
-
-type metadataCreateDBClusterSnapshotOutput struct {
-	SDKShapeTraits bool `type:"structure"`
+	_ struct{} `type:"structure"`
 }
 
 // String returns the string representation
@@ -4093,11 +3989,7 @@ type CreateDBInstanceInput struct {
 	//  Default: The default EC2 VPC security group for the DB subnet group's VPC.
 	VpcSecurityGroupIds []*string `locationNameList:"VpcSecurityGroupId" type:"list"`
 
-	metadataCreateDBInstanceInput `json:"-" xml:"-"`
-}
-
-type metadataCreateDBInstanceInput struct {
-	SDKShapeTraits bool `type:"structure"`
+	_ struct{} `type:"structure"`
 }
 
 // String returns the string representation
@@ -4117,11 +4009,7 @@ type CreateDBInstanceOutput struct {
 	// is used as a response element in the DescribeDBInstances action.
 	DBInstance *DBInstance `type:"structure"`
 
-	metadataCreateDBInstanceOutput `json:"-" xml:"-"`
-}
-
-type metadataCreateDBInstanceOutput struct {
-	SDKShapeTraits bool `type:"structure"`
+	_ struct{} `type:"structure"`
 }
 
 // String returns the string representation
@@ -4243,11 +4131,7 @@ type CreateDBInstanceReadReplicaInput struct {
 	// A list of tags.
 	Tags []*Tag `locationNameList:"Tag" type:"list"`
 
-	metadataCreateDBInstanceReadReplicaInput `json:"-" xml:"-"`
-}
-
-type metadataCreateDBInstanceReadReplicaInput struct {
-	SDKShapeTraits bool `type:"structure"`
+	_ struct{} `type:"structure"`
 }
 
 // String returns the string representation
@@ -4267,11 +4151,7 @@ type CreateDBInstanceReadReplicaOutput struct {
 	// is used as a response element in the DescribeDBInstances action.
 	DBInstance *DBInstance `type:"structure"`
 
-	metadataCreateDBInstanceReadReplicaOutput `json:"-" xml:"-"`
-}
-
-type metadataCreateDBInstanceReadReplicaOutput struct {
-	SDKShapeTraits bool `type:"structure"`
+	_ struct{} `type:"structure"`
 }
 
 // String returns the string representation
@@ -4306,11 +4186,7 @@ type CreateDBParameterGroupInput struct {
 	// A list of tags.
 	Tags []*Tag `locationNameList:"Tag" type:"list"`
 
-	metadataCreateDBParameterGroupInput `json:"-" xml:"-"`
-}
-
-type metadataCreateDBParameterGroupInput struct {
-	SDKShapeTraits bool `type:"structure"`
+	_ struct{} `type:"structure"`
 }
 
 // String returns the string representation
@@ -4331,11 +4207,7 @@ type CreateDBParameterGroupOutput struct {
 	// action, and as a response element in the DescribeDBParameterGroups action.
 	DBParameterGroup *DBParameterGroup `type:"structure"`
 
-	metadataCreateDBParameterGroupOutput `json:"-" xml:"-"`
-}
-
-type metadataCreateDBParameterGroupOutput struct {
-	SDKShapeTraits bool `type:"structure"`
+	_ struct{} `type:"structure"`
 }
 
 // String returns the string representation
@@ -4364,11 +4236,7 @@ type CreateDBSecurityGroupInput struct {
 	// A list of tags.
 	Tags []*Tag `locationNameList:"Tag" type:"list"`
 
-	metadataCreateDBSecurityGroupInput `json:"-" xml:"-"`
-}
-
-type metadataCreateDBSecurityGroupInput struct {
-	SDKShapeTraits bool `type:"structure"`
+	_ struct{} `type:"structure"`
 }
 
 // String returns the string representation
@@ -4389,11 +4257,7 @@ type CreateDBSecurityGroupOutput struct {
 	// in the DescribeDBSecurityGroups action.
 	DBSecurityGroup *DBSecurityGroup `type:"structure"`
 
-	metadataCreateDBSecurityGroupOutput `json:"-" xml:"-"`
-}
-
-type metadataCreateDBSecurityGroupOutput struct {
-	SDKShapeTraits bool `type:"structure"`
+	_ struct{} `type:"structure"`
 }
 
 // String returns the string representation
@@ -4427,11 +4291,7 @@ type CreateDBSnapshotInput struct {
 	// A list of tags.
 	Tags []*Tag `locationNameList:"Tag" type:"list"`
 
-	metadataCreateDBSnapshotInput `json:"-" xml:"-"`
-}
-
-type metadataCreateDBSnapshotInput struct {
-	SDKShapeTraits bool `type:"structure"`
+	_ struct{} `type:"structure"`
 }
 
 // String returns the string representation
@@ -4451,11 +4311,7 @@ type CreateDBSnapshotOutput struct {
 	// element in the DescribeDBSnapshots action.
 	DBSnapshot *DBSnapshot `type:"structure"`
 
-	metadataCreateDBSnapshotOutput `json:"-" xml:"-"`
-}
-
-type metadataCreateDBSnapshotOutput struct {
-	SDKShapeTraits bool `type:"structure"`
+	_ struct{} `type:"structure"`
 }
 
 // String returns the string representation
@@ -4486,11 +4342,7 @@ type CreateDBSubnetGroupInput struct {
 	// A list of tags.
 	Tags []*Tag `locationNameList:"Tag" type:"list"`
 
-	metadataCreateDBSubnetGroupInput `json:"-" xml:"-"`
-}
-
-type metadataCreateDBSubnetGroupInput struct {
-	SDKShapeTraits bool `type:"structure"`
+	_ struct{} `type:"structure"`
 }
 
 // String returns the string representation
@@ -4511,11 +4363,7 @@ type CreateDBSubnetGroupOutput struct {
 	// action.
 	DBSubnetGroup *DBSubnetGroup `type:"structure"`
 
-	metadataCreateDBSubnetGroupOutput `json:"-" xml:"-"`
-}
-
-type metadataCreateDBSubnetGroupOutput struct {
-	SDKShapeTraits bool `type:"structure"`
+	_ struct{} `type:"structure"`
 }
 
 // String returns the string representation
@@ -4576,11 +4424,7 @@ type CreateEventSubscriptionInput struct {
 	// A list of tags.
 	Tags []*Tag `locationNameList:"Tag" type:"list"`
 
-	metadataCreateEventSubscriptionInput `json:"-" xml:"-"`
-}
-
-type metadataCreateEventSubscriptionInput struct {
-	SDKShapeTraits bool `type:"structure"`
+	_ struct{} `type:"structure"`
 }
 
 // String returns the string representation
@@ -4598,11 +4442,7 @@ type CreateEventSubscriptionOutput struct {
 	// action.
 	EventSubscription *EventSubscription `type:"structure"`
 
-	metadataCreateEventSubscriptionOutput `json:"-" xml:"-"`
-}
-
-type metadataCreateEventSubscriptionOutput struct {
-	SDKShapeTraits bool `type:"structure"`
+	_ struct{} `type:"structure"`
 }
 
 // String returns the string representation
@@ -4639,11 +4479,7 @@ type CreateOptionGroupInput struct {
 	// A list of tags.
 	Tags []*Tag `locationNameList:"Tag" type:"list"`
 
-	metadataCreateOptionGroupInput `json:"-" xml:"-"`
-}
-
-type metadataCreateOptionGroupInput struct {
-	SDKShapeTraits bool `type:"structure"`
+	_ struct{} `type:"structure"`
 }
 
 // String returns the string representation
@@ -4659,11 +4495,7 @@ func (s CreateOptionGroupInput) GoString() string {
 type CreateOptionGroupOutput struct {
 	OptionGroup *OptionGroup `type:"structure"`
 
-	metadataCreateOptionGroupOutput `json:"-" xml:"-"`
-}
-
-type metadataCreateOptionGroupOutput struct {
-	SDKShapeTraits bool `type:"structure"`
+	_ struct{} `type:"structure"`
 }
 
 // String returns the string representation
@@ -4761,11 +4593,7 @@ type DBCluster struct {
 	// Provides a list of VPC security groups that the DB cluster belongs to.
 	VpcSecurityGroups []*VpcSecurityGroupMembership `locationNameList:"VpcSecurityGroupMembership" type:"list"`
 
-	metadataDBCluster `json:"-" xml:"-"`
-}
-
-type metadataDBCluster struct {
-	SDKShapeTraits bool `type:"structure"`
+	_ struct{} `type:"structure"`
 }
 
 // String returns the string representation
@@ -4791,11 +4619,7 @@ type DBClusterMember struct {
 	// DB cluster and false otherwise.
 	IsClusterWriter *bool `type:"boolean"`
 
-	metadataDBClusterMember `json:"-" xml:"-"`
-}
-
-type metadataDBClusterMember struct {
-	SDKShapeTraits bool `type:"structure"`
+	_ struct{} `type:"structure"`
 }
 
 // String returns the string representation
@@ -4816,11 +4640,7 @@ type DBClusterOptionGroupStatus struct {
 	// Specifies the status of the DB cluster option group.
 	Status *string `type:"string"`
 
-	metadataDBClusterOptionGroupStatus `json:"-" xml:"-"`
-}
-
-type metadataDBClusterOptionGroupStatus struct {
-	SDKShapeTraits bool `type:"structure"`
+	_ struct{} `type:"structure"`
 }
 
 // String returns the string representation
@@ -4851,11 +4671,7 @@ type DBClusterParameterGroup struct {
 	// group.
 	Description *string `type:"string"`
 
-	metadataDBClusterParameterGroup `json:"-" xml:"-"`
-}
-
-type metadataDBClusterParameterGroup struct {
-	SDKShapeTraits bool `type:"structure"`
+	_ struct{} `type:"structure"`
 }
 
 // String returns the string representation
@@ -4878,11 +4694,7 @@ type DBClusterParameterGroupNameMessage struct {
 	// stored as a lowercase string.
 	DBClusterParameterGroupName *string `type:"string"`
 
-	metadataDBClusterParameterGroupNameMessage `json:"-" xml:"-"`
-}
-
-type metadataDBClusterParameterGroupNameMessage struct {
-	SDKShapeTraits bool `type:"structure"`
+	_ struct{} `type:"structure"`
 }
 
 // String returns the string representation
@@ -4950,11 +4762,7 @@ type DBClusterSnapshot struct {
 	// Provides the VPC ID associated with the DB cluster snapshot.
 	VpcId *string `type:"string"`
 
-	metadataDBClusterSnapshot `json:"-" xml:"-"`
-}
-
-type metadataDBClusterSnapshot struct {
-	SDKShapeTraits bool `type:"structure"`
+	_ struct{} `type:"structure"`
 }
 
 // String returns the string representation
@@ -4996,11 +4804,7 @@ type DBEngineVersion struct {
 	// to.
 	ValidUpgradeTarget []*UpgradeTarget `locationNameList:"UpgradeTarget" type:"list"`
 
-	metadataDBEngineVersion `json:"-" xml:"-"`
-}
-
-type metadataDBEngineVersion struct {
-	SDKShapeTraits bool `type:"structure"`
+	_ struct{} `type:"structure"`
 }
 
 // String returns the string representation
@@ -5186,11 +4990,7 @@ type DBInstance struct {
 	// to.
 	VpcSecurityGroups []*VpcSecurityGroupMembership `locationNameList:"VpcSecurityGroupMembership" type:"list"`
 
-	metadataDBInstance `json:"-" xml:"-"`
-}
-
-type metadataDBInstance struct {
-	SDKShapeTraits bool `type:"structure"`
+	_ struct{} `type:"structure"`
 }
 
 // String returns the string representation
@@ -5220,11 +5020,7 @@ type DBInstanceStatusInfo struct {
 	// This value is currently "read replication."
 	StatusType *string `type:"string"`
 
-	metadataDBInstanceStatusInfo `json:"-" xml:"-"`
-}
-
-type metadataDBInstanceStatusInfo struct {
-	SDKShapeTraits bool `type:"structure"`
+	_ struct{} `type:"structure"`
 }
 
 // String returns the string representation
@@ -5253,11 +5049,7 @@ type DBParameterGroup struct {
 	// Provides the customer-specified description for this DB parameter group.
 	Description *string `type:"string"`
 
-	metadataDBParameterGroup `json:"-" xml:"-"`
-}
-
-type metadataDBParameterGroup struct {
-	SDKShapeTraits bool `type:"structure"`
+	_ struct{} `type:"structure"`
 }
 
 // String returns the string representation
@@ -5276,11 +5068,7 @@ type DBParameterGroupNameMessage struct {
 	// Provides the name of the DB parameter group.
 	DBParameterGroupName *string `type:"string"`
 
-	metadataDBParameterGroupNameMessage `json:"-" xml:"-"`
-}
-
-type metadataDBParameterGroupNameMessage struct {
-	SDKShapeTraits bool `type:"structure"`
+	_ struct{} `type:"structure"`
 }
 
 // String returns the string representation
@@ -5306,11 +5094,7 @@ type DBParameterGroupStatus struct {
 	// The status of parameter updates.
 	ParameterApplyStatus *string `type:"string"`
 
-	metadataDBParameterGroupStatus `json:"-" xml:"-"`
-}
-
-type metadataDBParameterGroupStatus struct {
-	SDKShapeTraits bool `type:"structure"`
+	_ struct{} `type:"structure"`
 }
 
 // String returns the string representation
@@ -5347,11 +5131,7 @@ type DBSecurityGroup struct {
 	// Provides the VpcId of the DB security group.
 	VpcId *string `type:"string"`
 
-	metadataDBSecurityGroup `json:"-" xml:"-"`
-}
-
-type metadataDBSecurityGroup struct {
-	SDKShapeTraits bool `type:"structure"`
+	_ struct{} `type:"structure"`
 }
 
 // String returns the string representation
@@ -5375,11 +5155,7 @@ type DBSecurityGroupMembership struct {
 	// The status of the DB security group.
 	Status *string `type:"string"`
 
-	metadataDBSecurityGroupMembership `json:"-" xml:"-"`
-}
-
-type metadataDBSecurityGroupMembership struct {
-	SDKShapeTraits bool `type:"structure"`
+	_ struct{} `type:"structure"`
 }
 
 // String returns the string representation
@@ -5473,11 +5249,7 @@ type DBSnapshot struct {
 	// Provides the VPC ID associated with the DB snapshot.
 	VpcId *string `type:"string"`
 
-	metadataDBSnapshot `json:"-" xml:"-"`
-}
-
-type metadataDBSnapshot struct {
-	SDKShapeTraits bool `type:"structure"`
+	_ struct{} `type:"structure"`
 }
 
 // String returns the string representation
@@ -5510,11 +5282,7 @@ type DBSnapshotAttribute struct {
 	// available for any AWS account to copy or restore.
 	AttributeValues []*string `locationNameList:"AttributeValue" type:"list"`
 
-	metadataDBSnapshotAttribute `json:"-" xml:"-"`
-}
-
-type metadataDBSnapshotAttribute struct {
-	SDKShapeTraits bool `type:"structure"`
+	_ struct{} `type:"structure"`
 }
 
 // String returns the string representation
@@ -5540,11 +5308,7 @@ type DBSnapshotAttributesResult struct {
 	// The identifier of the manual DB snapshot that the attributes apply to.
 	DBSnapshotIdentifier *string `type:"string"`
 
-	metadataDBSnapshotAttributesResult `json:"-" xml:"-"`
-}
-
-type metadataDBSnapshotAttributesResult struct {
-	SDKShapeTraits bool `type:"structure"`
+	_ struct{} `type:"structure"`
 }
 
 // String returns the string representation
@@ -5578,11 +5342,7 @@ type DBSubnetGroup struct {
 	// Provides the VpcId of the DB subnet group.
 	VpcId *string `type:"string"`
 
-	metadataDBSubnetGroup `json:"-" xml:"-"`
-}
-
-type metadataDBSubnetGroup struct {
-	SDKShapeTraits bool `type:"structure"`
+	_ struct{} `type:"structure"`
 }
 
 // String returns the string representation
@@ -5623,11 +5383,7 @@ type DeleteDBClusterInput struct {
 	// is false. Default: false
 	SkipFinalSnapshot *bool `type:"boolean"`
 
-	metadataDeleteDBClusterInput `json:"-" xml:"-"`
-}
-
-type metadataDeleteDBClusterInput struct {
-	SDKShapeTraits bool `type:"structure"`
+	_ struct{} `type:"structure"`
 }
 
 // String returns the string representation
@@ -5648,11 +5404,7 @@ type DeleteDBClusterOutput struct {
 	// in the DescribeDBClusters action.
 	DBCluster *DBCluster `type:"structure"`
 
-	metadataDeleteDBClusterOutput `json:"-" xml:"-"`
-}
-
-type metadataDeleteDBClusterOutput struct {
-	SDKShapeTraits bool `type:"structure"`
+	_ struct{} `type:"structure"`
 }
 
 // String returns the string representation
@@ -5675,11 +5427,7 @@ type DeleteDBClusterParameterGroupInput struct {
 	// DB clusters.
 	DBClusterParameterGroupName *string `type:"string" required:"true"`
 
-	metadataDeleteDBClusterParameterGroupInput `json:"-" xml:"-"`
-}
-
-type metadataDeleteDBClusterParameterGroupInput struct {
-	SDKShapeTraits bool `type:"structure"`
+	_ struct{} `type:"structure"`
 }
 
 // String returns the string representation
@@ -5693,11 +5441,7 @@ func (s DeleteDBClusterParameterGroupInput) GoString() string {
 }
 
 type DeleteDBClusterParameterGroupOutput struct {
-	metadataDeleteDBClusterParameterGroupOutput `json:"-" xml:"-"`
-}
-
-type metadataDeleteDBClusterParameterGroupOutput struct {
-	SDKShapeTraits bool `type:"structure"`
+	_ struct{} `type:"structure"`
 }
 
 // String returns the string representation
@@ -5717,11 +5461,7 @@ type DeleteDBClusterSnapshotInput struct {
 	// available state.
 	DBClusterSnapshotIdentifier *string `type:"string" required:"true"`
 
-	metadataDeleteDBClusterSnapshotInput `json:"-" xml:"-"`
-}
-
-type metadataDeleteDBClusterSnapshotInput struct {
-	SDKShapeTraits bool `type:"structure"`
+	_ struct{} `type:"structure"`
 }
 
 // String returns the string representation
@@ -5741,11 +5481,7 @@ type DeleteDBClusterSnapshotOutput struct {
 	// used as a response element in the DescribeDBClusterSnapshots action.
 	DBClusterSnapshot *DBClusterSnapshot `type:"structure"`
 
-	metadataDeleteDBClusterSnapshotOutput `json:"-" xml:"-"`
-}
-
-type metadataDeleteDBClusterSnapshotOutput struct {
-	SDKShapeTraits bool `type:"structure"`
+	_ struct{} `type:"structure"`
 }
 
 // String returns the string representation
@@ -5793,11 +5529,7 @@ type DeleteDBInstanceInput struct {
 	// is false. Default: false
 	SkipFinalSnapshot *bool `type:"boolean"`
 
-	metadataDeleteDBInstanceInput `json:"-" xml:"-"`
-}
-
-type metadataDeleteDBInstanceInput struct {
-	SDKShapeTraits bool `type:"structure"`
+	_ struct{} `type:"structure"`
 }
 
 // String returns the string representation
@@ -5817,11 +5549,7 @@ type DeleteDBInstanceOutput struct {
 	// is used as a response element in the DescribeDBInstances action.
 	DBInstance *DBInstance `type:"structure"`
 
-	metadataDeleteDBInstanceOutput `json:"-" xml:"-"`
-}
-
-type metadataDeleteDBInstanceOutput struct {
-	SDKShapeTraits bool `type:"structure"`
+	_ struct{} `type:"structure"`
 }
 
 // String returns the string representation
@@ -5843,11 +5571,7 @@ type DeleteDBParameterGroupInput struct {
 	// default DB parameter group Cannot be associated with any DB instances
 	DBParameterGroupName *string `type:"string" required:"true"`
 
-	metadataDeleteDBParameterGroupInput `json:"-" xml:"-"`
-}
-
-type metadataDeleteDBParameterGroupInput struct {
-	SDKShapeTraits bool `type:"structure"`
+	_ struct{} `type:"structure"`
 }
 
 // String returns the string representation
@@ -5861,11 +5585,7 @@ func (s DeleteDBParameterGroupInput) GoString() string {
 }
 
 type DeleteDBParameterGroupOutput struct {
-	metadataDeleteDBParameterGroupOutput `json:"-" xml:"-"`
-}
-
-type metadataDeleteDBParameterGroupOutput struct {
-	SDKShapeTraits bool `type:"structure"`
+	_ struct{} `type:"structure"`
 }
 
 // String returns the string representation
@@ -5888,11 +5608,7 @@ type DeleteDBSecurityGroupInput struct {
 	// Cannot contain spaces
 	DBSecurityGroupName *string `type:"string" required:"true"`
 
-	metadataDeleteDBSecurityGroupInput `json:"-" xml:"-"`
-}
-
-type metadataDeleteDBSecurityGroupInput struct {
-	SDKShapeTraits bool `type:"structure"`
+	_ struct{} `type:"structure"`
 }
 
 // String returns the string representation
@@ -5906,11 +5622,7 @@ func (s DeleteDBSecurityGroupInput) GoString() string {
 }
 
 type DeleteDBSecurityGroupOutput struct {
-	metadataDeleteDBSecurityGroupOutput `json:"-" xml:"-"`
-}
-
-type metadataDeleteDBSecurityGroupOutput struct {
-	SDKShapeTraits bool `type:"structure"`
+	_ struct{} `type:"structure"`
 }
 
 // String returns the string representation
@@ -5930,11 +5642,7 @@ type DeleteDBSnapshotInput struct {
 	// state.
 	DBSnapshotIdentifier *string `type:"string" required:"true"`
 
-	metadataDeleteDBSnapshotInput `json:"-" xml:"-"`
-}
-
-type metadataDeleteDBSnapshotInput struct {
-	SDKShapeTraits bool `type:"structure"`
+	_ struct{} `type:"structure"`
 }
 
 // String returns the string representation
@@ -5954,11 +5662,7 @@ type DeleteDBSnapshotOutput struct {
 	// element in the DescribeDBSnapshots action.
 	DBSnapshot *DBSnapshot `type:"structure"`
 
-	metadataDeleteDBSnapshotOutput `json:"-" xml:"-"`
-}
-
-type metadataDeleteDBSnapshotOutput struct {
-	SDKShapeTraits bool `type:"structure"`
+	_ struct{} `type:"structure"`
 }
 
 // String returns the string representation
@@ -5980,11 +5684,7 @@ type DeleteDBSubnetGroupInput struct {
 	// Cannot end with a hyphen or contain two consecutive hyphens
 	DBSubnetGroupName *string `type:"string" required:"true"`
 
-	metadataDeleteDBSubnetGroupInput `json:"-" xml:"-"`
-}
-
-type metadataDeleteDBSubnetGroupInput struct {
-	SDKShapeTraits bool `type:"structure"`
+	_ struct{} `type:"structure"`
 }
 
 // String returns the string representation
@@ -5998,11 +5698,7 @@ func (s DeleteDBSubnetGroupInput) GoString() string {
 }
 
 type DeleteDBSubnetGroupOutput struct {
-	metadataDeleteDBSubnetGroupOutput `json:"-" xml:"-"`
-}
-
-type metadataDeleteDBSubnetGroupOutput struct {
-	SDKShapeTraits bool `type:"structure"`
+	_ struct{} `type:"structure"`
 }
 
 // String returns the string representation
@@ -6019,11 +5715,7 @@ type DeleteEventSubscriptionInput struct {
 	// The name of the RDS event notification subscription you want to delete.
 	SubscriptionName *string `type:"string" required:"true"`
 
-	metadataDeleteEventSubscriptionInput `json:"-" xml:"-"`
-}
-
-type metadataDeleteEventSubscriptionInput struct {
-	SDKShapeTraits bool `type:"structure"`
+	_ struct{} `type:"structure"`
 }
 
 // String returns the string representation
@@ -6041,11 +5733,7 @@ type DeleteEventSubscriptionOutput struct {
 	// action.
 	EventSubscription *EventSubscription `type:"structure"`
 
-	metadataDeleteEventSubscriptionOutput `json:"-" xml:"-"`
-}
-
-type metadataDeleteEventSubscriptionOutput struct {
-	SDKShapeTraits bool `type:"structure"`
+	_ struct{} `type:"structure"`
 }
 
 // String returns the string representation
@@ -6064,11 +5752,7 @@ type DeleteOptionGroupInput struct {
 	// You cannot delete default option groups.
 	OptionGroupName *string `type:"string" required:"true"`
 
-	metadataDeleteOptionGroupInput `json:"-" xml:"-"`
-}
-
-type metadataDeleteOptionGroupInput struct {
-	SDKShapeTraits bool `type:"structure"`
+	_ struct{} `type:"structure"`
 }
 
 // String returns the string representation
@@ -6082,11 +5766,7 @@ func (s DeleteOptionGroupInput) GoString() string {
 }
 
 type DeleteOptionGroupOutput struct {
-	metadataDeleteOptionGroupOutput `json:"-" xml:"-"`
-}
-
-type metadataDeleteOptionGroupOutput struct {
-	SDKShapeTraits bool `type:"structure"`
+	_ struct{} `type:"structure"`
 }
 
 // String returns the string representation
@@ -6100,11 +5780,7 @@ func (s DeleteOptionGroupOutput) GoString() string {
 }
 
 type DescribeAccountAttributesInput struct {
-	metadataDescribeAccountAttributesInput `json:"-" xml:"-"`
-}
-
-type metadataDescribeAccountAttributesInput struct {
-	SDKShapeTraits bool `type:"structure"`
+	_ struct{} `type:"structure"`
 }
 
 // String returns the string representation
@@ -6123,11 +5799,7 @@ type DescribeAccountAttributesOutput struct {
 	// a count of usage toward the quota maximum, and a maximum value for the quota.
 	AccountQuotas []*AccountQuota `locationNameList:"AccountQuota" type:"list"`
 
-	metadataDescribeAccountAttributesOutput `json:"-" xml:"-"`
-}
-
-type metadataDescribeAccountAttributesOutput struct {
-	SDKShapeTraits bool `type:"structure"`
+	_ struct{} `type:"structure"`
 }
 
 // String returns the string representation
@@ -6168,11 +5840,7 @@ type DescribeCertificatesInput struct {
 	// Constraints: Minimum 20, maximum 100.
 	MaxRecords *int64 `type:"integer"`
 
-	metadataDescribeCertificatesInput `json:"-" xml:"-"`
-}
-
-type metadataDescribeCertificatesInput struct {
-	SDKShapeTraits bool `type:"structure"`
+	_ struct{} `type:"structure"`
 }
 
 // String returns the string representation
@@ -6195,11 +5863,7 @@ type DescribeCertificatesOutput struct {
 	// beyond the marker, up to the value specified by MaxRecords .
 	Marker *string `type:"string"`
 
-	metadataDescribeCertificatesOutput `json:"-" xml:"-"`
-}
-
-type metadataDescribeCertificatesOutput struct {
-	SDKShapeTraits bool `type:"structure"`
+	_ struct{} `type:"structure"`
 }
 
 // String returns the string representation
@@ -6238,11 +5902,7 @@ type DescribeDBClusterParameterGroupsInput struct {
 	// Constraints: Minimum 20, maximum 100.
 	MaxRecords *int64 `type:"integer"`
 
-	metadataDescribeDBClusterParameterGroupsInput `json:"-" xml:"-"`
-}
-
-type metadataDescribeDBClusterParameterGroupsInput struct {
-	SDKShapeTraits bool `type:"structure"`
+	_ struct{} `type:"structure"`
 }
 
 // String returns the string representation
@@ -6264,11 +5924,7 @@ type DescribeDBClusterParameterGroupsOutput struct {
 	// beyond the marker, up to the value specified by MaxRecords.
 	Marker *string `type:"string"`
 
-	metadataDescribeDBClusterParameterGroupsOutput `json:"-" xml:"-"`
-}
-
-type metadataDescribeDBClusterParameterGroupsOutput struct {
-	SDKShapeTraits bool `type:"structure"`
+	_ struct{} `type:"structure"`
 }
 
 // String returns the string representation
@@ -6312,11 +5968,7 @@ type DescribeDBClusterParametersInput struct {
 	// sources can be engine, service, or customer.
 	Source *string `type:"string"`
 
-	metadataDescribeDBClusterParametersInput `json:"-" xml:"-"`
-}
-
-type metadataDescribeDBClusterParametersInput struct {
-	SDKShapeTraits bool `type:"structure"`
+	_ struct{} `type:"structure"`
 }
 
 // String returns the string representation
@@ -6340,11 +5992,7 @@ type DescribeDBClusterParametersOutput struct {
 	// Provides a list of parameters for the DB cluster parameter group.
 	Parameters []*Parameter `locationNameList:"Parameter" type:"list"`
 
-	metadataDescribeDBClusterParametersOutput `json:"-" xml:"-"`
-}
-
-type metadataDescribeDBClusterParametersOutput struct {
-	SDKShapeTraits bool `type:"structure"`
+	_ struct{} `type:"structure"`
 }
 
 // String returns the string representation
@@ -6402,11 +6050,7 @@ type DescribeDBClusterSnapshotsInput struct {
 	// include all snapshot types.
 	SnapshotType *string `type:"string"`
 
-	metadataDescribeDBClusterSnapshotsInput `json:"-" xml:"-"`
-}
-
-type metadataDescribeDBClusterSnapshotsInput struct {
-	SDKShapeTraits bool `type:"structure"`
+	_ struct{} `type:"structure"`
 }
 
 // String returns the string representation
@@ -6430,11 +6074,7 @@ type DescribeDBClusterSnapshotsOutput struct {
 	// beyond the marker, up to the value specified by MaxRecords.
 	Marker *string `type:"string"`
 
-	metadataDescribeDBClusterSnapshotsOutput `json:"-" xml:"-"`
-}
-
-type metadataDescribeDBClusterSnapshotsOutput struct {
-	SDKShapeTraits bool `type:"structure"`
+	_ struct{} `type:"structure"`
 }
 
 // String returns the string representation
@@ -6475,11 +6115,7 @@ type DescribeDBClustersInput struct {
 	// Constraints: Minimum 20, maximum 100.
 	MaxRecords *int64 `type:"integer"`
 
-	metadataDescribeDBClustersInput `json:"-" xml:"-"`
-}
-
-type metadataDescribeDBClustersInput struct {
-	SDKShapeTraits bool `type:"structure"`
+	_ struct{} `type:"structure"`
 }
 
 // String returns the string representation
@@ -6501,11 +6137,7 @@ type DescribeDBClustersOutput struct {
 	// A pagination token that can be used in a subsequent DescribeDBClusters request.
 	Marker *string `type:"string"`
 
-	metadataDescribeDBClustersOutput `json:"-" xml:"-"`
-}
-
-type metadataDescribeDBClustersOutput struct {
-	SDKShapeTraits bool `type:"structure"`
+	_ struct{} `type:"structure"`
 }
 
 // String returns the string representation
@@ -6561,11 +6193,7 @@ type DescribeDBEngineVersionsInput struct {
 	// Constraints: Minimum 20, maximum 100.
 	MaxRecords *int64 `type:"integer"`
 
-	metadataDescribeDBEngineVersionsInput `json:"-" xml:"-"`
-}
-
-type metadataDescribeDBEngineVersionsInput struct {
-	SDKShapeTraits bool `type:"structure"`
+	_ struct{} `type:"structure"`
 }
 
 // String returns the string representation
@@ -6589,11 +6217,7 @@ type DescribeDBEngineVersionsOutput struct {
 	// the value specified by MaxRecords.
 	Marker *string `type:"string"`
 
-	metadataDescribeDBEngineVersionsOutput `json:"-" xml:"-"`
-}
-
-type metadataDescribeDBEngineVersionsOutput struct {
-	SDKShapeTraits bool `type:"structure"`
+	_ struct{} `type:"structure"`
 }
 
 // String returns the string representation
@@ -6633,11 +6257,7 @@ type DescribeDBInstancesInput struct {
 	// Constraints: Minimum 20, maximum 100.
 	MaxRecords *int64 `type:"integer"`
 
-	metadataDescribeDBInstancesInput `json:"-" xml:"-"`
-}
-
-type metadataDescribeDBInstancesInput struct {
-	SDKShapeTraits bool `type:"structure"`
+	_ struct{} `type:"structure"`
 }
 
 // String returns the string representation
@@ -6661,11 +6281,7 @@ type DescribeDBInstancesOutput struct {
 	// the value specified by MaxRecords .
 	Marker *string `type:"string"`
 
-	metadataDescribeDBInstancesOutput `json:"-" xml:"-"`
-}
-
-type metadataDescribeDBInstancesOutput struct {
-	SDKShapeTraits bool `type:"structure"`
+	_ struct{} `type:"structure"`
 }
 
 // String returns the string representation
@@ -6689,11 +6305,7 @@ type DescribeDBLogFilesDetails struct {
 	// The size, in bytes, of the log file for the specified DB instance.
 	Size *int64 `type:"long"`
 
-	metadataDescribeDBLogFilesDetails `json:"-" xml:"-"`
-}
-
-type metadataDescribeDBLogFilesDetails struct {
-	SDKShapeTraits bool `type:"structure"`
+	_ struct{} `type:"structure"`
 }
 
 // String returns the string representation
@@ -6740,11 +6352,7 @@ type DescribeDBLogFilesInput struct {
 	// is included in the response so that the remaining results can be retrieved.
 	MaxRecords *int64 `type:"integer"`
 
-	metadataDescribeDBLogFilesInput `json:"-" xml:"-"`
-}
-
-type metadataDescribeDBLogFilesInput struct {
-	SDKShapeTraits bool `type:"structure"`
+	_ struct{} `type:"structure"`
 }
 
 // String returns the string representation
@@ -6765,11 +6373,7 @@ type DescribeDBLogFilesOutput struct {
 	// A pagination token that can be used in a subsequent DescribeDBLogFiles request.
 	Marker *string `type:"string"`
 
-	metadataDescribeDBLogFilesOutput `json:"-" xml:"-"`
-}
-
-type metadataDescribeDBLogFilesOutput struct {
-	SDKShapeTraits bool `type:"structure"`
+	_ struct{} `type:"structure"`
 }
 
 // String returns the string representation
@@ -6808,11 +6412,7 @@ type DescribeDBParameterGroupsInput struct {
 	// Constraints: Minimum 20, maximum 100.
 	MaxRecords *int64 `type:"integer"`
 
-	metadataDescribeDBParameterGroupsInput `json:"-" xml:"-"`
-}
-
-type metadataDescribeDBParameterGroupsInput struct {
-	SDKShapeTraits bool `type:"structure"`
+	_ struct{} `type:"structure"`
 }
 
 // String returns the string representation
@@ -6836,11 +6436,7 @@ type DescribeDBParameterGroupsOutput struct {
 	// the value specified by MaxRecords.
 	Marker *string `type:"string"`
 
-	metadataDescribeDBParameterGroupsOutput `json:"-" xml:"-"`
-}
-
-type metadataDescribeDBParameterGroupsOutput struct {
-	SDKShapeTraits bool `type:"structure"`
+	_ struct{} `type:"structure"`
 }
 
 // String returns the string representation
@@ -6886,11 +6482,7 @@ type DescribeDBParametersInput struct {
 	// Valid Values: user | system | engine-default
 	Source *string `type:"string"`
 
-	metadataDescribeDBParametersInput `json:"-" xml:"-"`
-}
-
-type metadataDescribeDBParametersInput struct {
-	SDKShapeTraits bool `type:"structure"`
+	_ struct{} `type:"structure"`
 }
 
 // String returns the string representation
@@ -6914,11 +6506,7 @@ type DescribeDBParametersOutput struct {
 	// A list of Parameter values.
 	Parameters []*Parameter `locationNameList:"Parameter" type:"list"`
 
-	metadataDescribeDBParametersOutput `json:"-" xml:"-"`
-}
-
-type metadataDescribeDBParametersOutput struct {
-	SDKShapeTraits bool `type:"structure"`
+	_ struct{} `type:"structure"`
 }
 
 // String returns the string representation
@@ -6952,11 +6540,7 @@ type DescribeDBSecurityGroupsInput struct {
 	// Constraints: Minimum 20, maximum 100.
 	MaxRecords *int64 `type:"integer"`
 
-	metadataDescribeDBSecurityGroupsInput `json:"-" xml:"-"`
-}
-
-type metadataDescribeDBSecurityGroupsInput struct {
-	SDKShapeTraits bool `type:"structure"`
+	_ struct{} `type:"structure"`
 }
 
 // String returns the string representation
@@ -6980,11 +6564,7 @@ type DescribeDBSecurityGroupsOutput struct {
 	// the value specified by MaxRecords.
 	Marker *string `type:"string"`
 
-	metadataDescribeDBSecurityGroupsOutput `json:"-" xml:"-"`
-}
-
-type metadataDescribeDBSecurityGroupsOutput struct {
-	SDKShapeTraits bool `type:"structure"`
+	_ struct{} `type:"structure"`
 }
 
 // String returns the string representation
@@ -7001,11 +6581,7 @@ type DescribeDBSnapshotAttributesInput struct {
 	// The identifier for the DB snapshot to modify the attributes for.
 	DBSnapshotIdentifier *string `type:"string"`
 
-	metadataDescribeDBSnapshotAttributesInput `json:"-" xml:"-"`
-}
-
-type metadataDescribeDBSnapshotAttributesInput struct {
-	SDKShapeTraits bool `type:"structure"`
+	_ struct{} `type:"structure"`
 }
 
 // String returns the string representation
@@ -7027,11 +6603,7 @@ type DescribeDBSnapshotAttributesOutput struct {
 	// API.
 	DBSnapshotAttributesResult *DBSnapshotAttributesResult `type:"structure"`
 
-	metadataDescribeDBSnapshotAttributesOutput `json:"-" xml:"-"`
-}
-
-type metadataDescribeDBSnapshotAttributesOutput struct {
-	SDKShapeTraits bool `type:"structure"`
+	_ struct{} `type:"structure"`
 }
 
 // String returns the string representation
@@ -7118,11 +6690,7 @@ type DescribeDBSnapshotsInput struct {
 	// apply when SnapshotType is set to public.
 	SnapshotType *string `type:"string"`
 
-	metadataDescribeDBSnapshotsInput `json:"-" xml:"-"`
-}
-
-type metadataDescribeDBSnapshotsInput struct {
-	SDKShapeTraits bool `type:"structure"`
+	_ struct{} `type:"structure"`
 }
 
 // String returns the string representation
@@ -7146,11 +6714,7 @@ type DescribeDBSnapshotsOutput struct {
 	// the value specified by MaxRecords.
 	Marker *string `type:"string"`
 
-	metadataDescribeDBSnapshotsOutput `json:"-" xml:"-"`
-}
-
-type metadataDescribeDBSnapshotsOutput struct {
-	SDKShapeTraits bool `type:"structure"`
+	_ struct{} `type:"structure"`
 }
 
 // String returns the string representation
@@ -7184,11 +6748,7 @@ type DescribeDBSubnetGroupsInput struct {
 	// Constraints: Minimum 20, maximum 100.
 	MaxRecords *int64 `type:"integer"`
 
-	metadataDescribeDBSubnetGroupsInput `json:"-" xml:"-"`
-}
-
-type metadataDescribeDBSubnetGroupsInput struct {
-	SDKShapeTraits bool `type:"structure"`
+	_ struct{} `type:"structure"`
 }
 
 // String returns the string representation
@@ -7212,11 +6772,7 @@ type DescribeDBSubnetGroupsOutput struct {
 	// the value specified by MaxRecords.
 	Marker *string `type:"string"`
 
-	metadataDescribeDBSubnetGroupsOutput `json:"-" xml:"-"`
-}
-
-type metadataDescribeDBSubnetGroupsOutput struct {
-	SDKShapeTraits bool `type:"structure"`
+	_ struct{} `type:"structure"`
 }
 
 // String returns the string representation
@@ -7251,11 +6807,7 @@ type DescribeEngineDefaultClusterParametersInput struct {
 	// Constraints: Minimum 20, maximum 100.
 	MaxRecords *int64 `type:"integer"`
 
-	metadataDescribeEngineDefaultClusterParametersInput `json:"-" xml:"-"`
-}
-
-type metadataDescribeEngineDefaultClusterParametersInput struct {
-	SDKShapeTraits bool `type:"structure"`
+	_ struct{} `type:"structure"`
 }
 
 // String returns the string representation
@@ -7273,11 +6825,7 @@ type DescribeEngineDefaultClusterParametersOutput struct {
 	// action.
 	EngineDefaults *EngineDefaults `type:"structure"`
 
-	metadataDescribeEngineDefaultClusterParametersOutput `json:"-" xml:"-"`
-}
-
-type metadataDescribeEngineDefaultClusterParametersOutput struct {
-	SDKShapeTraits bool `type:"structure"`
+	_ struct{} `type:"structure"`
 }
 
 // String returns the string representation
@@ -7311,11 +6859,7 @@ type DescribeEngineDefaultParametersInput struct {
 	// Constraints: Minimum 20, maximum 100.
 	MaxRecords *int64 `type:"integer"`
 
-	metadataDescribeEngineDefaultParametersInput `json:"-" xml:"-"`
-}
-
-type metadataDescribeEngineDefaultParametersInput struct {
-	SDKShapeTraits bool `type:"structure"`
+	_ struct{} `type:"structure"`
 }
 
 // String returns the string representation
@@ -7333,11 +6877,7 @@ type DescribeEngineDefaultParametersOutput struct {
 	// action.
 	EngineDefaults *EngineDefaults `type:"structure"`
 
-	metadataDescribeEngineDefaultParametersOutput `json:"-" xml:"-"`
-}
-
-type metadataDescribeEngineDefaultParametersOutput struct {
-	SDKShapeTraits bool `type:"structure"`
+	_ struct{} `type:"structure"`
 }
 
 // String returns the string representation
@@ -7359,11 +6899,7 @@ type DescribeEventCategoriesInput struct {
 	// Valid values: db-instance | db-parameter-group | db-security-group | db-snapshot
 	SourceType *string `type:"string"`
 
-	metadataDescribeEventCategoriesInput `json:"-" xml:"-"`
-}
-
-type metadataDescribeEventCategoriesInput struct {
-	SDKShapeTraits bool `type:"structure"`
+	_ struct{} `type:"structure"`
 }
 
 // String returns the string representation
@@ -7381,11 +6917,7 @@ type DescribeEventCategoriesOutput struct {
 	// A list of EventCategoriesMap data types.
 	EventCategoriesMapList []*EventCategoriesMap `locationNameList:"EventCategoriesMap" type:"list"`
 
-	metadataDescribeEventCategoriesOutput `json:"-" xml:"-"`
-}
-
-type metadataDescribeEventCategoriesOutput struct {
-	SDKShapeTraits bool `type:"structure"`
+	_ struct{} `type:"structure"`
 }
 
 // String returns the string representation
@@ -7419,11 +6951,7 @@ type DescribeEventSubscriptionsInput struct {
 	// The name of the RDS event notification subscription you want to describe.
 	SubscriptionName *string `type:"string"`
 
-	metadataDescribeEventSubscriptionsInput `json:"-" xml:"-"`
-}
-
-type metadataDescribeEventSubscriptionsInput struct {
-	SDKShapeTraits bool `type:"structure"`
+	_ struct{} `type:"structure"`
 }
 
 // String returns the string representation
@@ -7446,11 +6974,7 @@ type DescribeEventSubscriptionsOutput struct {
 	// beyond the marker, up to the value specified by MaxRecords.
 	Marker *string `type:"string"`
 
-	metadataDescribeEventSubscriptionsOutput `json:"-" xml:"-"`
-}
-
-type metadataDescribeEventSubscriptionsOutput struct {
-	SDKShapeTraits bool `type:"structure"`
+	_ struct{} `type:"structure"`
 }
 
 // String returns the string representation
@@ -7521,11 +7045,7 @@ type DescribeEventsInput struct {
 	// Example: 2009-07-08T18:00Z
 	StartTime *time.Time `type:"timestamp" timestampFormat:"iso8601"`
 
-	metadataDescribeEventsInput `json:"-" xml:"-"`
-}
-
-type metadataDescribeEventsInput struct {
-	SDKShapeTraits bool `type:"structure"`
+	_ struct{} `type:"structure"`
 }
 
 // String returns the string representation
@@ -7548,11 +7068,7 @@ type DescribeEventsOutput struct {
 	// up to the value specified by MaxRecords .
 	Marker *string `type:"string"`
 
-	metadataDescribeEventsOutput `json:"-" xml:"-"`
-}
-
-type metadataDescribeEventsOutput struct {
-	SDKShapeTraits bool `type:"structure"`
+	_ struct{} `type:"structure"`
 }
 
 // String returns the string representation
@@ -7591,11 +7107,7 @@ type DescribeOptionGroupOptionsInput struct {
 	// Constraints: Minimum 20, maximum 100.
 	MaxRecords *int64 `type:"integer"`
 
-	metadataDescribeOptionGroupOptionsInput `json:"-" xml:"-"`
-}
-
-type metadataDescribeOptionGroupOptionsInput struct {
-	SDKShapeTraits bool `type:"structure"`
+	_ struct{} `type:"structure"`
 }
 
 // String returns the string representation
@@ -7617,11 +7129,7 @@ type DescribeOptionGroupOptionsOutput struct {
 	// List of available option group options.
 	OptionGroupOptions []*OptionGroupOption `locationNameList:"OptionGroupOption" type:"list"`
 
-	metadataDescribeOptionGroupOptionsOutput `json:"-" xml:"-"`
-}
-
-type metadataDescribeOptionGroupOptionsOutput struct {
-	SDKShapeTraits bool `type:"structure"`
+	_ struct{} `type:"structure"`
 }
 
 // String returns the string representation
@@ -7665,11 +7173,7 @@ type DescribeOptionGroupsInput struct {
 	// EngineName or MajorEngineVersion.
 	OptionGroupName *string `type:"string"`
 
-	metadataDescribeOptionGroupsInput `json:"-" xml:"-"`
-}
-
-type metadataDescribeOptionGroupsInput struct {
-	SDKShapeTraits bool `type:"structure"`
+	_ struct{} `type:"structure"`
 }
 
 // String returns the string representation
@@ -7692,11 +7196,7 @@ type DescribeOptionGroupsOutput struct {
 	// List of option groups.
 	OptionGroupsList []*OptionGroup `locationNameList:"OptionGroup" type:"list"`
 
-	metadataDescribeOptionGroupsOutput `json:"-" xml:"-"`
-}
-
-type metadataDescribeOptionGroupsOutput struct {
-	SDKShapeTraits bool `type:"structure"`
+	_ struct{} `type:"structure"`
 }
 
 // String returns the string representation
@@ -7746,11 +7246,7 @@ type DescribeOrderableDBInstanceOptionsInput struct {
 	// or non-VPC offerings.
 	Vpc *bool `type:"boolean"`
 
-	metadataDescribeOrderableDBInstanceOptionsInput `json:"-" xml:"-"`
-}
-
-type metadataDescribeOrderableDBInstanceOptionsInput struct {
-	SDKShapeTraits bool `type:"structure"`
+	_ struct{} `type:"structure"`
 }
 
 // String returns the string representation
@@ -7775,11 +7271,7 @@ type DescribeOrderableDBInstanceOptionsOutput struct {
 	// options for the DB instance.
 	OrderableDBInstanceOptions []*OrderableDBInstanceOption `locationNameList:"OrderableDBInstanceOption" type:"list"`
 
-	metadataDescribeOrderableDBInstanceOptionsOutput `json:"-" xml:"-"`
-}
-
-type metadataDescribeOrderableDBInstanceOptionsOutput struct {
-	SDKShapeTraits bool `type:"structure"`
+	_ struct{} `type:"structure"`
 }
 
 // String returns the string representation
@@ -7820,11 +7312,7 @@ type DescribePendingMaintenanceActionsInput struct {
 	// The ARN of a resource to return pending maintenance actions for.
 	ResourceIdentifier *string `type:"string"`
 
-	metadataDescribePendingMaintenanceActionsInput `json:"-" xml:"-"`
-}
-
-type metadataDescribePendingMaintenanceActionsInput struct {
-	SDKShapeTraits bool `type:"structure"`
+	_ struct{} `type:"structure"`
 }
 
 // String returns the string representation
@@ -7847,11 +7335,7 @@ type DescribePendingMaintenanceActionsOutput struct {
 	// A list of the pending maintenance actions for the resource.
 	PendingMaintenanceActions []*ResourcePendingMaintenanceActions `locationNameList:"ResourcePendingMaintenanceActions" type:"list"`
 
-	metadataDescribePendingMaintenanceActionsOutput `json:"-" xml:"-"`
-}
-
-type metadataDescribePendingMaintenanceActionsOutput struct {
-	SDKShapeTraits bool `type:"structure"`
+	_ struct{} `type:"structure"`
 }
 
 // String returns the string representation
@@ -7914,11 +7398,7 @@ type DescribeReservedDBInstancesInput struct {
 	// purchased reservations matching the specified offering identifier.
 	ReservedDBInstancesOfferingId *string `type:"string"`
 
-	metadataDescribeReservedDBInstancesInput `json:"-" xml:"-"`
-}
-
-type metadataDescribeReservedDBInstancesInput struct {
-	SDKShapeTraits bool `type:"structure"`
+	_ struct{} `type:"structure"`
 }
 
 // String returns the string representation
@@ -7979,11 +7459,7 @@ type DescribeReservedDBInstancesOfferingsInput struct {
 	// Example: 438012d3-4052-4cc7-b2e3-8d3372e0e706
 	ReservedDBInstancesOfferingId *string `type:"string"`
 
-	metadataDescribeReservedDBInstancesOfferingsInput `json:"-" xml:"-"`
-}
-
-type metadataDescribeReservedDBInstancesOfferingsInput struct {
-	SDKShapeTraits bool `type:"structure"`
+	_ struct{} `type:"structure"`
 }
 
 // String returns the string representation
@@ -8007,11 +7483,7 @@ type DescribeReservedDBInstancesOfferingsOutput struct {
 	// A list of reserved DB instance offerings.
 	ReservedDBInstancesOfferings []*ReservedDBInstancesOffering `locationNameList:"ReservedDBInstancesOffering" type:"list"`
 
-	metadataDescribeReservedDBInstancesOfferingsOutput `json:"-" xml:"-"`
-}
-
-type metadataDescribeReservedDBInstancesOfferingsOutput struct {
-	SDKShapeTraits bool `type:"structure"`
+	_ struct{} `type:"structure"`
 }
 
 // String returns the string representation
@@ -8035,11 +7507,7 @@ type DescribeReservedDBInstancesOutput struct {
 	// A list of reserved DB instances.
 	ReservedDBInstances []*ReservedDBInstance `locationNameList:"ReservedDBInstance" type:"list"`
 
-	metadataDescribeReservedDBInstancesOutput `json:"-" xml:"-"`
-}
-
-type metadataDescribeReservedDBInstancesOutput struct {
-	SDKShapeTraits bool `type:"structure"`
+	_ struct{} `type:"structure"`
 }
 
 // String returns the string representation
@@ -8091,11 +7559,7 @@ type DownloadDBLogFilePortionInput struct {
 	// continuing until the AdditionalDataPending response element returns false.
 	NumberOfLines *int64 `type:"integer"`
 
-	metadataDownloadDBLogFilePortionInput `json:"-" xml:"-"`
-}
-
-type metadataDownloadDBLogFilePortionInput struct {
-	SDKShapeTraits bool `type:"structure"`
+	_ struct{} `type:"structure"`
 }
 
 // String returns the string representation
@@ -8120,11 +7584,7 @@ type DownloadDBLogFilePortionOutput struct {
 	// request.
 	Marker *string `type:"string"`
 
-	metadataDownloadDBLogFilePortionOutput `json:"-" xml:"-"`
-}
-
-type metadataDownloadDBLogFilePortionOutput struct {
-	SDKShapeTraits bool `type:"structure"`
+	_ struct{} `type:"structure"`
 }
 
 // String returns the string representation
@@ -8155,11 +7615,7 @@ type EC2SecurityGroup struct {
 	// "authorized", "revoking", and "revoked".
 	Status *string `type:"string"`
 
-	metadataEC2SecurityGroup `json:"-" xml:"-"`
-}
-
-type metadataEC2SecurityGroup struct {
-	SDKShapeTraits bool `type:"structure"`
+	_ struct{} `type:"structure"`
 }
 
 // String returns the string representation
@@ -8185,11 +7641,7 @@ type Endpoint struct {
 	// Specifies the port that the database engine is listening on.
 	Port *int64 `type:"integer"`
 
-	metadataEndpoint `json:"-" xml:"-"`
-}
-
-type metadataEndpoint struct {
-	SDKShapeTraits bool `type:"structure"`
+	_ struct{} `type:"structure"`
 }
 
 // String returns the string representation
@@ -8217,11 +7669,7 @@ type EngineDefaults struct {
 	// Contains a list of engine default parameters.
 	Parameters []*Parameter `locationNameList:"Parameter" type:"list"`
 
-	metadataEngineDefaults `json:"-" xml:"-"`
-}
-
-type metadataEngineDefaults struct {
-	SDKShapeTraits bool `type:"structure"`
+	_ struct{} `type:"structure"`
 }
 
 // String returns the string representation
@@ -8251,11 +7699,7 @@ type Event struct {
 	// Specifies the source type for this event.
 	SourceType *string `type:"string" enum:"SourceType"`
 
-	metadataEvent `json:"-" xml:"-"`
-}
-
-type metadataEvent struct {
-	SDKShapeTraits bool `type:"structure"`
+	_ struct{} `type:"structure"`
 }
 
 // String returns the string representation
@@ -8277,11 +7721,7 @@ type EventCategoriesMap struct {
 	// The source type that the returned categories belong to
 	SourceType *string `type:"string"`
 
-	metadataEventCategoriesMap `json:"-" xml:"-"`
-}
-
-type metadataEventCategoriesMap struct {
-	SDKShapeTraits bool `type:"structure"`
+	_ struct{} `type:"structure"`
 }
 
 // String returns the string representation
@@ -8334,11 +7774,7 @@ type EventSubscription struct {
 	// The time the RDS event notification subscription was created.
 	SubscriptionCreationTime *string `type:"string"`
 
-	metadataEventSubscription `json:"-" xml:"-"`
-}
-
-type metadataEventSubscription struct {
-	SDKShapeTraits bool `type:"structure"`
+	_ struct{} `type:"structure"`
 }
 
 // String returns the string representation
@@ -8360,11 +7796,7 @@ type FailoverDBClusterInput struct {
 	// must be a letter Cannot end with a hyphen or contain two consecutive hyphens
 	DBClusterIdentifier *string `type:"string"`
 
-	metadataFailoverDBClusterInput `json:"-" xml:"-"`
-}
-
-type metadataFailoverDBClusterInput struct {
-	SDKShapeTraits bool `type:"structure"`
+	_ struct{} `type:"structure"`
 }
 
 // String returns the string representation
@@ -8385,11 +7817,7 @@ type FailoverDBClusterOutput struct {
 	// in the DescribeDBClusters action.
 	DBCluster *DBCluster `type:"structure"`
 
-	metadataFailoverDBClusterOutput `json:"-" xml:"-"`
-}
-
-type metadataFailoverDBClusterOutput struct {
-	SDKShapeTraits bool `type:"structure"`
+	_ struct{} `type:"structure"`
 }
 
 // String returns the string representation
@@ -8409,11 +7837,7 @@ type Filter struct {
 	// This parameter is not currently supported.
 	Values []*string `locationNameList:"Value" type:"list" required:"true"`
 
-	metadataFilter `json:"-" xml:"-"`
-}
-
-type metadataFilter struct {
-	SDKShapeTraits bool `type:"structure"`
+	_ struct{} `type:"structure"`
 }
 
 // String returns the string representation
@@ -8436,11 +7860,7 @@ type IPRange struct {
 	// "revoking", and "revoked".
 	Status *string `type:"string"`
 
-	metadataIPRange `json:"-" xml:"-"`
-}
-
-type metadataIPRange struct {
-	SDKShapeTraits bool `type:"structure"`
+	_ struct{} `type:"structure"`
 }
 
 // String returns the string representation
@@ -8462,11 +7882,7 @@ type ListTagsForResourceInput struct {
 	// Amazon Resource Name (ARN) (http://docs.aws.amazon.com/AmazonRDS/latest/UserGuide/USER_Tagging.html#USER_Tagging.ARN).
 	ResourceName *string `type:"string" required:"true"`
 
-	metadataListTagsForResourceInput `json:"-" xml:"-"`
-}
-
-type metadataListTagsForResourceInput struct {
-	SDKShapeTraits bool `type:"structure"`
+	_ struct{} `type:"structure"`
 }
 
 // String returns the string representation
@@ -8483,11 +7899,7 @@ type ListTagsForResourceOutput struct {
 	// List of tags returned by the ListTagsForResource operation.
 	TagList []*Tag `locationNameList:"Tag" type:"list"`
 
-	metadataListTagsForResourceOutput `json:"-" xml:"-"`
-}
-
-type metadataListTagsForResourceOutput struct {
-	SDKShapeTraits bool `type:"structure"`
+	_ struct{} `type:"structure"`
 }
 
 // String returns the string representation
@@ -8602,11 +8014,7 @@ type ModifyDBClusterInput struct {
 	// A lst of VPC security groups that the DB cluster will belong to.
 	VpcSecurityGroupIds []*string `locationNameList:"VpcSecurityGroupId" type:"list"`
 
-	metadataModifyDBClusterInput `json:"-" xml:"-"`
-}
-
-type metadataModifyDBClusterInput struct {
-	SDKShapeTraits bool `type:"structure"`
+	_ struct{} `type:"structure"`
 }
 
 // String returns the string representation
@@ -8627,11 +8035,7 @@ type ModifyDBClusterOutput struct {
 	// in the DescribeDBClusters action.
 	DBCluster *DBCluster `type:"structure"`
 
-	metadataModifyDBClusterOutput `json:"-" xml:"-"`
-}
-
-type metadataModifyDBClusterOutput struct {
-	SDKShapeTraits bool `type:"structure"`
+	_ struct{} `type:"structure"`
 }
 
 // String returns the string representation
@@ -8651,11 +8055,7 @@ type ModifyDBClusterParameterGroupInput struct {
 	// A list of parameters in the DB cluster parameter group to modify.
 	Parameters []*Parameter `locationNameList:"Parameter" type:"list" required:"true"`
 
-	metadataModifyDBClusterParameterGroupInput `json:"-" xml:"-"`
-}
-
-type metadataModifyDBClusterParameterGroupInput struct {
-	SDKShapeTraits bool `type:"structure"`
+	_ struct{} `type:"structure"`
 }
 
 // String returns the string representation
@@ -9018,11 +8418,7 @@ type ModifyDBInstanceInput struct {
 	// Cannot end with a hyphen or contain two consecutive hyphens
 	VpcSecurityGroupIds []*string `locationNameList:"VpcSecurityGroupId" type:"list"`
 
-	metadataModifyDBInstanceInput `json:"-" xml:"-"`
-}
-
-type metadataModifyDBInstanceInput struct {
-	SDKShapeTraits bool `type:"structure"`
+	_ struct{} `type:"structure"`
 }
 
 // String returns the string representation
@@ -9042,11 +8438,7 @@ type ModifyDBInstanceOutput struct {
 	// is used as a response element in the DescribeDBInstances action.
 	DBInstance *DBInstance `type:"structure"`
 
-	metadataModifyDBInstanceOutput `json:"-" xml:"-"`
-}
-
-type metadataModifyDBInstanceOutput struct {
-	SDKShapeTraits bool `type:"structure"`
+	_ struct{} `type:"structure"`
 }
 
 // String returns the string representation
@@ -9081,11 +8473,7 @@ type ModifyDBParameterGroupInput struct {
 	// are applied when you reboot the DB instance without failover.
 	Parameters []*Parameter `locationNameList:"Parameter" type:"list" required:"true"`
 
-	metadataModifyDBParameterGroupInput `json:"-" xml:"-"`
-}
-
-type metadataModifyDBParameterGroupInput struct {
-	SDKShapeTraits bool `type:"structure"`
+	_ struct{} `type:"structure"`
 }
 
 // String returns the string representation
@@ -9127,11 +8515,7 @@ type ModifyDBSnapshotAttributeInput struct {
 	// attribute can still copy or restore the manual DB snapshot.
 	ValuesToRemove []*string `locationNameList:"AttributeValue" type:"list"`
 
-	metadataModifyDBSnapshotAttributeInput `json:"-" xml:"-"`
-}
-
-type metadataModifyDBSnapshotAttributeInput struct {
-	SDKShapeTraits bool `type:"structure"`
+	_ struct{} `type:"structure"`
 }
 
 // String returns the string representation
@@ -9153,11 +8537,7 @@ type ModifyDBSnapshotAttributeOutput struct {
 	// API.
 	DBSnapshotAttributesResult *DBSnapshotAttributesResult `type:"structure"`
 
-	metadataModifyDBSnapshotAttributeOutput `json:"-" xml:"-"`
-}
-
-type metadataModifyDBSnapshotAttributeOutput struct {
-	SDKShapeTraits bool `type:"structure"`
+	_ struct{} `type:"structure"`
 }
 
 // String returns the string representation
@@ -9185,11 +8565,7 @@ type ModifyDBSubnetGroupInput struct {
 	// The EC2 subnet IDs for the DB subnet group.
 	SubnetIds []*string `locationNameList:"SubnetIdentifier" type:"list" required:"true"`
 
-	metadataModifyDBSubnetGroupInput `json:"-" xml:"-"`
-}
-
-type metadataModifyDBSubnetGroupInput struct {
-	SDKShapeTraits bool `type:"structure"`
+	_ struct{} `type:"structure"`
 }
 
 // String returns the string representation
@@ -9210,11 +8586,7 @@ type ModifyDBSubnetGroupOutput struct {
 	// action.
 	DBSubnetGroup *DBSubnetGroup `type:"structure"`
 
-	metadataModifyDBSubnetGroupOutput `json:"-" xml:"-"`
-}
-
-type metadataModifyDBSubnetGroupOutput struct {
-	SDKShapeTraits bool `type:"structure"`
+	_ struct{} `type:"structure"`
 }
 
 // String returns the string representation
@@ -9254,11 +8626,7 @@ type ModifyEventSubscriptionInput struct {
 	// The name of the RDS event notification subscription.
 	SubscriptionName *string `type:"string" required:"true"`
 
-	metadataModifyEventSubscriptionInput `json:"-" xml:"-"`
-}
-
-type metadataModifyEventSubscriptionInput struct {
-	SDKShapeTraits bool `type:"structure"`
+	_ struct{} `type:"structure"`
 }
 
 // String returns the string representation
@@ -9276,11 +8644,7 @@ type ModifyEventSubscriptionOutput struct {
 	// action.
 	EventSubscription *EventSubscription `type:"structure"`
 
-	metadataModifyEventSubscriptionOutput `json:"-" xml:"-"`
-}
-
-type metadataModifyEventSubscriptionOutput struct {
-	SDKShapeTraits bool `type:"structure"`
+	_ struct{} `type:"structure"`
 }
 
 // String returns the string representation
@@ -9312,11 +8676,7 @@ type ModifyOptionGroupInput struct {
 	// Options in this list are removed from the option group.
 	OptionsToRemove []*string `type:"list"`
 
-	metadataModifyOptionGroupInput `json:"-" xml:"-"`
-}
-
-type metadataModifyOptionGroupInput struct {
-	SDKShapeTraits bool `type:"structure"`
+	_ struct{} `type:"structure"`
 }
 
 // String returns the string representation
@@ -9332,11 +8692,7 @@ func (s ModifyOptionGroupInput) GoString() string {
 type ModifyOptionGroupOutput struct {
 	OptionGroup *OptionGroup `type:"structure"`
 
-	metadataModifyOptionGroupOutput `json:"-" xml:"-"`
-}
-
-type metadataModifyOptionGroupOutput struct {
-	SDKShapeTraits bool `type:"structure"`
+	_ struct{} `type:"structure"`
 }
 
 // String returns the string representation
@@ -9377,11 +8733,7 @@ type Option struct {
 	// access to the port.
 	VpcSecurityGroupMemberships []*VpcSecurityGroupMembership `locationNameList:"VpcSecurityGroupMembership" type:"list"`
 
-	metadataOption `json:"-" xml:"-"`
-}
-
-type metadataOption struct {
-	SDKShapeTraits bool `type:"structure"`
+	_ struct{} `type:"structure"`
 }
 
 // String returns the string representation
@@ -9411,11 +8763,7 @@ type OptionConfiguration struct {
 	// A list of VpcSecurityGroupMemebrship name strings used for this option.
 	VpcSecurityGroupMemberships []*string `locationNameList:"VpcSecurityGroupId" type:"list"`
 
-	metadataOptionConfiguration `json:"-" xml:"-"`
-}
-
-type metadataOptionConfiguration struct {
-	SDKShapeTraits bool `type:"structure"`
+	_ struct{} `type:"structure"`
 }
 
 // String returns the string representation
@@ -9456,11 +8804,7 @@ type OptionGroup struct {
 	// that are in the VPC indicated by this field.
 	VpcId *string `type:"string"`
 
-	metadataOptionGroup `json:"-" xml:"-"`
-}
-
-type metadataOptionGroup struct {
-	SDKShapeTraits bool `type:"structure"`
+	_ struct{} `type:"structure"`
 }
 
 // String returns the string representation
@@ -9482,11 +8826,7 @@ type OptionGroupMembership struct {
 	// pending-maintenance, applying).
 	Status *string `type:"string"`
 
-	metadataOptionGroupMembership `json:"-" xml:"-"`
-}
-
-type metadataOptionGroupMembership struct {
-	SDKShapeTraits bool `type:"structure"`
+	_ struct{} `type:"structure"`
 }
 
 // String returns the string representation
@@ -9540,11 +8880,7 @@ type OptionGroupOption struct {
 	// Specifies whether the option requires a port.
 	PortRequired *bool `type:"boolean"`
 
-	metadataOptionGroupOption `json:"-" xml:"-"`
-}
-
-type metadataOptionGroupOption struct {
-	SDKShapeTraits bool `type:"structure"`
+	_ struct{} `type:"structure"`
 }
 
 // String returns the string representation
@@ -9580,11 +8916,7 @@ type OptionGroupOptionSetting struct {
 	// The name of the option group option.
 	SettingName *string `type:"string"`
 
-	metadataOptionGroupOptionSetting `json:"-" xml:"-"`
-}
-
-type metadataOptionGroupOptionSetting struct {
-	SDKShapeTraits bool `type:"structure"`
+	_ struct{} `type:"structure"`
 }
 
 // String returns the string representation
@@ -9630,11 +8962,7 @@ type OptionSetting struct {
 	// The current value of the option setting.
 	Value *string `type:"string"`
 
-	metadataOptionSetting `json:"-" xml:"-"`
-}
-
-type metadataOptionSetting struct {
-	SDKShapeTraits bool `type:"structure"`
+	_ struct{} `type:"structure"`
 }
 
 // String returns the string representation
@@ -9685,11 +9013,7 @@ type OrderableDBInstanceOption struct {
 	// Indicates whether this is a VPC orderable DB instance.
 	Vpc *bool `type:"boolean"`
 
-	metadataOrderableDBInstanceOption `json:"-" xml:"-"`
-}
-
-type metadataOrderableDBInstanceOption struct {
-	SDKShapeTraits bool `type:"structure"`
+	_ struct{} `type:"structure"`
 }
 
 // String returns the string representation
@@ -9740,11 +9064,7 @@ type Parameter struct {
 	// Indicates the source of the parameter value.
 	Source *string `type:"string"`
 
-	metadataParameter `json:"-" xml:"-"`
-}
-
-type metadataParameter struct {
-	SDKShapeTraits bool `type:"structure"`
+	_ struct{} `type:"structure"`
 }
 
 // String returns the string representation
@@ -9787,11 +9107,7 @@ type PendingMaintenanceAction struct {
 	// Indicates the type of opt-in request that has been received for the resource.
 	OptInStatus *string `type:"string"`
 
-	metadataPendingMaintenanceAction `json:"-" xml:"-"`
-}
-
-type metadataPendingMaintenanceAction struct {
-	SDKShapeTraits bool `type:"structure"`
+	_ struct{} `type:"structure"`
 }
 
 // String returns the string representation
@@ -9844,11 +9160,7 @@ type PendingModifiedValues struct {
 	// Specifies the storage type to be associated with the DB instance.
 	StorageType *string `type:"string"`
 
-	metadataPendingModifiedValues `json:"-" xml:"-"`
-}
-
-type metadataPendingModifiedValues struct {
-	SDKShapeTraits bool `type:"structure"`
+	_ struct{} `type:"structure"`
 }
 
 // String returns the string representation
@@ -9898,11 +9210,7 @@ type PromoteReadReplicaInput struct {
 	// be at least 30 minutes.
 	PreferredBackupWindow *string `type:"string"`
 
-	metadataPromoteReadReplicaInput `json:"-" xml:"-"`
-}
-
-type metadataPromoteReadReplicaInput struct {
-	SDKShapeTraits bool `type:"structure"`
+	_ struct{} `type:"structure"`
 }
 
 // String returns the string representation
@@ -9922,11 +9230,7 @@ type PromoteReadReplicaOutput struct {
 	// is used as a response element in the DescribeDBInstances action.
 	DBInstance *DBInstance `type:"structure"`
 
-	metadataPromoteReadReplicaOutput `json:"-" xml:"-"`
-}
-
-type metadataPromoteReadReplicaOutput struct {
-	SDKShapeTraits bool `type:"structure"`
+	_ struct{} `type:"structure"`
 }
 
 // String returns the string representation
@@ -9958,11 +9262,7 @@ type PurchaseReservedDBInstancesOfferingInput struct {
 	// A list of tags.
 	Tags []*Tag `locationNameList:"Tag" type:"list"`
 
-	metadataPurchaseReservedDBInstancesOfferingInput `json:"-" xml:"-"`
-}
-
-type metadataPurchaseReservedDBInstancesOfferingInput struct {
-	SDKShapeTraits bool `type:"structure"`
+	_ struct{} `type:"structure"`
 }
 
 // String returns the string representation
@@ -9980,11 +9280,7 @@ type PurchaseReservedDBInstancesOfferingOutput struct {
 	// and PurchaseReservedDBInstancesOffering actions.
 	ReservedDBInstance *ReservedDBInstance `type:"structure"`
 
-	metadataPurchaseReservedDBInstancesOfferingOutput `json:"-" xml:"-"`
-}
-
-type metadataPurchaseReservedDBInstancesOfferingOutput struct {
-	SDKShapeTraits bool `type:"structure"`
+	_ struct{} `type:"structure"`
 }
 
 // String returns the string representation
@@ -10012,11 +9308,7 @@ type RebootDBInstanceInput struct {
 	// MultiAZ.
 	ForceFailover *bool `type:"boolean"`
 
-	metadataRebootDBInstanceInput `json:"-" xml:"-"`
-}
-
-type metadataRebootDBInstanceInput struct {
-	SDKShapeTraits bool `type:"structure"`
+	_ struct{} `type:"structure"`
 }
 
 // String returns the string representation
@@ -10036,11 +9328,7 @@ type RebootDBInstanceOutput struct {
 	// is used as a response element in the DescribeDBInstances action.
 	DBInstance *DBInstance `type:"structure"`
 
-	metadataRebootDBInstanceOutput `json:"-" xml:"-"`
-}
-
-type metadataRebootDBInstanceOutput struct {
-	SDKShapeTraits bool `type:"structure"`
+	_ struct{} `type:"structure"`
 }
 
 // String returns the string representation
@@ -10062,11 +9350,7 @@ type RecurringCharge struct {
 	// The frequency of the recurring charge.
 	RecurringChargeFrequency *string `type:"string"`
 
-	metadataRecurringCharge `json:"-" xml:"-"`
-}
-
-type metadataRecurringCharge struct {
-	SDKShapeTraits bool `type:"structure"`
+	_ struct{} `type:"structure"`
 }
 
 // String returns the string representation
@@ -10088,11 +9372,7 @@ type RemoveSourceIdentifierFromSubscriptionInput struct {
 	// source identifier from.
 	SubscriptionName *string `type:"string" required:"true"`
 
-	metadataRemoveSourceIdentifierFromSubscriptionInput `json:"-" xml:"-"`
-}
-
-type metadataRemoveSourceIdentifierFromSubscriptionInput struct {
-	SDKShapeTraits bool `type:"structure"`
+	_ struct{} `type:"structure"`
 }
 
 // String returns the string representation
@@ -10110,11 +9390,7 @@ type RemoveSourceIdentifierFromSubscriptionOutput struct {
 	// action.
 	EventSubscription *EventSubscription `type:"structure"`
 
-	metadataRemoveSourceIdentifierFromSubscriptionOutput `json:"-" xml:"-"`
-}
-
-type metadataRemoveSourceIdentifierFromSubscriptionOutput struct {
-	SDKShapeTraits bool `type:"structure"`
+	_ struct{} `type:"structure"`
 }
 
 // String returns the string representation
@@ -10136,11 +9412,7 @@ type RemoveTagsFromResourceInput struct {
 	// The tag key (name) of the tag to be removed.
 	TagKeys []*string `type:"list" required:"true"`
 
-	metadataRemoveTagsFromResourceInput `json:"-" xml:"-"`
-}
-
-type metadataRemoveTagsFromResourceInput struct {
-	SDKShapeTraits bool `type:"structure"`
+	_ struct{} `type:"structure"`
 }
 
 // String returns the string representation
@@ -10154,11 +9426,7 @@ func (s RemoveTagsFromResourceInput) GoString() string {
 }
 
 type RemoveTagsFromResourceOutput struct {
-	metadataRemoveTagsFromResourceOutput `json:"-" xml:"-"`
-}
-
-type metadataRemoveTagsFromResourceOutput struct {
-	SDKShapeTraits bool `type:"structure"`
+	_ struct{} `type:"structure"`
 }
 
 // String returns the string representation
@@ -10216,11 +9484,7 @@ type ReservedDBInstance struct {
 	// The hourly price charged for this reserved DB instance.
 	UsagePrice *float64 `type:"double"`
 
-	metadataReservedDBInstance `json:"-" xml:"-"`
-}
-
-type metadataReservedDBInstance struct {
-	SDKShapeTraits bool `type:"structure"`
+	_ struct{} `type:"structure"`
 }
 
 // String returns the string representation
@@ -10266,11 +9530,7 @@ type ReservedDBInstancesOffering struct {
 	// The hourly price charged for this offering.
 	UsagePrice *float64 `type:"double"`
 
-	metadataReservedDBInstancesOffering `json:"-" xml:"-"`
-}
-
-type metadataReservedDBInstancesOffering struct {
-	SDKShapeTraits bool `type:"structure"`
+	_ struct{} `type:"structure"`
 }
 
 // String returns the string representation
@@ -10297,11 +9557,7 @@ type ResetDBClusterParameterGroupInput struct {
 	// if there is a list of parameter names specified for the Parameters parameter.
 	ResetAllParameters *bool `type:"boolean"`
 
-	metadataResetDBClusterParameterGroupInput `json:"-" xml:"-"`
-}
-
-type metadataResetDBClusterParameterGroupInput struct {
-	SDKShapeTraits bool `type:"structure"`
+	_ struct{} `type:"structure"`
 }
 
 // String returns the string representation
@@ -10355,11 +9611,7 @@ type ResetDBParameterGroupInput struct {
 	// Default: true
 	ResetAllParameters *bool `type:"boolean"`
 
-	metadataResetDBParameterGroupInput `json:"-" xml:"-"`
-}
-
-type metadataResetDBParameterGroupInput struct {
-	SDKShapeTraits bool `type:"structure"`
+	_ struct{} `type:"structure"`
 }
 
 // String returns the string representation
@@ -10381,11 +9633,7 @@ type ResourcePendingMaintenanceActions struct {
 	// The ARN of the resource that has pending maintenance actions.
 	ResourceIdentifier *string `type:"string"`
 
-	metadataResourcePendingMaintenanceActions `json:"-" xml:"-"`
-}
-
-type metadataResourcePendingMaintenanceActions struct {
-	SDKShapeTraits bool `type:"structure"`
+	_ struct{} `type:"structure"`
 }
 
 // String returns the string representation
@@ -10453,11 +9701,7 @@ type RestoreDBClusterFromSnapshotInput struct {
 	// A list of VPC security groups that the new DB cluster will belong to.
 	VpcSecurityGroupIds []*string `locationNameList:"VpcSecurityGroupId" type:"list"`
 
-	metadataRestoreDBClusterFromSnapshotInput `json:"-" xml:"-"`
-}
-
-type metadataRestoreDBClusterFromSnapshotInput struct {
-	SDKShapeTraits bool `type:"structure"`
+	_ struct{} `type:"structure"`
 }
 
 // String returns the string representation
@@ -10478,11 +9722,7 @@ type RestoreDBClusterFromSnapshotOutput struct {
 	// in the DescribeDBClusters action.
 	DBCluster *DBCluster `type:"structure"`
 
-	metadataRestoreDBClusterFromSnapshotOutput `json:"-" xml:"-"`
-}
-
-type metadataRestoreDBClusterFromSnapshotOutput struct {
-	SDKShapeTraits bool `type:"structure"`
+	_ struct{} `type:"structure"`
 }
 
 // String returns the string representation
@@ -10550,11 +9790,7 @@ type RestoreDBClusterToPointInTimeInput struct {
 	// A lst of VPC security groups that the new DB cluster belongs to.
 	VpcSecurityGroupIds []*string `locationNameList:"VpcSecurityGroupId" type:"list"`
 
-	metadataRestoreDBClusterToPointInTimeInput `json:"-" xml:"-"`
-}
-
-type metadataRestoreDBClusterToPointInTimeInput struct {
-	SDKShapeTraits bool `type:"structure"`
+	_ struct{} `type:"structure"`
 }
 
 // String returns the string representation
@@ -10575,11 +9811,7 @@ type RestoreDBClusterToPointInTimeOutput struct {
 	// in the DescribeDBClusters action.
 	DBCluster *DBCluster `type:"structure"`
 
-	metadataRestoreDBClusterToPointInTimeOutput `json:"-" xml:"-"`
-}
-
-type metadataRestoreDBClusterToPointInTimeOutput struct {
-	SDKShapeTraits bool `type:"structure"`
+	_ struct{} `type:"structure"`
 }
 
 // String returns the string representation
@@ -10733,11 +9965,7 @@ type RestoreDBInstanceFromDBSnapshotInput struct {
 	// device.
 	TdeCredentialPassword *string `type:"string"`
 
-	metadataRestoreDBInstanceFromDBSnapshotInput `json:"-" xml:"-"`
-}
-
-type metadataRestoreDBInstanceFromDBSnapshotInput struct {
-	SDKShapeTraits bool `type:"structure"`
+	_ struct{} `type:"structure"`
 }
 
 // String returns the string representation
@@ -10757,11 +9985,7 @@ type RestoreDBInstanceFromDBSnapshotOutput struct {
 	// is used as a response element in the DescribeDBInstances action.
 	DBInstance *DBInstance `type:"structure"`
 
-	metadataRestoreDBInstanceFromDBSnapshotOutput `json:"-" xml:"-"`
-}
-
-type metadataRestoreDBInstanceFromDBSnapshotOutput struct {
-	SDKShapeTraits bool `type:"structure"`
+	_ struct{} `type:"structure"`
 }
 
 // String returns the string representation
@@ -10928,11 +10152,7 @@ type RestoreDBInstanceToPointInTimeInput struct {
 	// Constraints: Cannot be specified if RestoreTime parameter is provided.
 	UseLatestRestorableTime *bool `type:"boolean"`
 
-	metadataRestoreDBInstanceToPointInTimeInput `json:"-" xml:"-"`
-}
-
-type metadataRestoreDBInstanceToPointInTimeInput struct {
-	SDKShapeTraits bool `type:"structure"`
+	_ struct{} `type:"structure"`
 }
 
 // String returns the string representation
@@ -10952,11 +10172,7 @@ type RestoreDBInstanceToPointInTimeOutput struct {
 	// is used as a response element in the DescribeDBInstances action.
 	DBInstance *DBInstance `type:"structure"`
 
-	metadataRestoreDBInstanceToPointInTimeOutput `json:"-" xml:"-"`
-}
-
-type metadataRestoreDBInstanceToPointInTimeOutput struct {
-	SDKShapeTraits bool `type:"structure"`
+	_ struct{} `type:"structure"`
 }
 
 // String returns the string representation
@@ -10995,11 +10211,7 @@ type RevokeDBSecurityGroupIngressInput struct {
 	// must be provided.
 	EC2SecurityGroupOwnerId *string `type:"string"`
 
-	metadataRevokeDBSecurityGroupIngressInput `json:"-" xml:"-"`
-}
-
-type metadataRevokeDBSecurityGroupIngressInput struct {
-	SDKShapeTraits bool `type:"structure"`
+	_ struct{} `type:"structure"`
 }
 
 // String returns the string representation
@@ -11020,11 +10232,7 @@ type RevokeDBSecurityGroupIngressOutput struct {
 	// in the DescribeDBSecurityGroups action.
 	DBSecurityGroup *DBSecurityGroup `type:"structure"`
 
-	metadataRevokeDBSecurityGroupIngressOutput `json:"-" xml:"-"`
-}
-
-type metadataRevokeDBSecurityGroupIngressOutput struct {
-	SDKShapeTraits bool `type:"structure"`
+	_ struct{} `type:"structure"`
 }
 
 // String returns the string representation
@@ -11051,11 +10259,7 @@ type Subnet struct {
 	// Specifies the status of the subnet.
 	SubnetStatus *string `type:"string"`
 
-	metadataSubnet `json:"-" xml:"-"`
-}
-
-type metadataSubnet struct {
-	SDKShapeTraits bool `type:"structure"`
+	_ struct{} `type:"structure"`
 }
 
 // String returns the string representation
@@ -11082,11 +10286,7 @@ type Tag struct {
 	// white-space, '_', '.', '/', '=', '+', '-' (Java regex: "^([\\p{L}\\p{Z}\\p{N}_.:/=+\\-]*)$").
 	Value *string `type:"string"`
 
-	metadataTag `json:"-" xml:"-"`
-}
-
-type metadataTag struct {
-	SDKShapeTraits bool `type:"structure"`
+	_ struct{} `type:"structure"`
 }
 
 // String returns the string representation
@@ -11118,11 +10318,7 @@ type UpgradeTarget struct {
 	// version.
 	IsMajorVersionUpgrade *bool `type:"boolean"`
 
-	metadataUpgradeTarget `json:"-" xml:"-"`
-}
-
-type metadataUpgradeTarget struct {
-	SDKShapeTraits bool `type:"structure"`
+	_ struct{} `type:"structure"`
 }
 
 // String returns the string representation
@@ -11144,11 +10340,7 @@ type VpcSecurityGroupMembership struct {
 	// The name of the VPC security group.
 	VpcSecurityGroupId *string `type:"string"`
 
-	metadataVpcSecurityGroupMembership `json:"-" xml:"-"`
-}
-
-type metadataVpcSecurityGroupMembership struct {
-	SDKShapeTraits bool `type:"structure"`
+	_ struct{} `type:"structure"`
 }
 
 // String returns the string representation

--- a/service/redshift/api.go
+++ b/service/redshift/api.go
@@ -2197,11 +2197,7 @@ type AccountWithRestoreAccess struct {
 	// The identifier of an AWS customer account authorized to restore a snapshot.
 	AccountId *string `type:"string"`
 
-	metadataAccountWithRestoreAccess `json:"-" xml:"-"`
-}
-
-type metadataAccountWithRestoreAccess struct {
-	SDKShapeTraits bool `type:"structure"`
+	_ struct{} `type:"structure"`
 }
 
 // String returns the string representation
@@ -2232,11 +2228,7 @@ type AuthorizeClusterSecurityGroupIngressInput struct {
 	//  Example: 111122223333
 	EC2SecurityGroupOwnerId *string `type:"string"`
 
-	metadataAuthorizeClusterSecurityGroupIngressInput `json:"-" xml:"-"`
-}
-
-type metadataAuthorizeClusterSecurityGroupIngressInput struct {
-	SDKShapeTraits bool `type:"structure"`
+	_ struct{} `type:"structure"`
 }
 
 // String returns the string representation
@@ -2253,11 +2245,7 @@ type AuthorizeClusterSecurityGroupIngressOutput struct {
 	// Describes a security group.
 	ClusterSecurityGroup *ClusterSecurityGroup `type:"structure"`
 
-	metadataAuthorizeClusterSecurityGroupIngressOutput `json:"-" xml:"-"`
-}
-
-type metadataAuthorizeClusterSecurityGroupIngressOutput struct {
-	SDKShapeTraits bool `type:"structure"`
+	_ struct{} `type:"structure"`
 }
 
 // String returns the string representation
@@ -2283,11 +2271,7 @@ type AuthorizeSnapshotAccessInput struct {
 	// The identifier of the snapshot the account is authorized to restore.
 	SnapshotIdentifier *string `type:"string" required:"true"`
 
-	metadataAuthorizeSnapshotAccessInput `json:"-" xml:"-"`
-}
-
-type metadataAuthorizeSnapshotAccessInput struct {
-	SDKShapeTraits bool `type:"structure"`
+	_ struct{} `type:"structure"`
 }
 
 // String returns the string representation
@@ -2304,11 +2288,7 @@ type AuthorizeSnapshotAccessOutput struct {
 	// Describes a snapshot.
 	Snapshot *Snapshot `type:"structure"`
 
-	metadataAuthorizeSnapshotAccessOutput `json:"-" xml:"-"`
-}
-
-type metadataAuthorizeSnapshotAccessOutput struct {
-	SDKShapeTraits bool `type:"structure"`
+	_ struct{} `type:"structure"`
 }
 
 // String returns the string representation
@@ -2326,11 +2306,7 @@ type AvailabilityZone struct {
 	// The name of the availability zone.
 	Name *string `type:"string"`
 
-	metadataAvailabilityZone `json:"-" xml:"-"`
-}
-
-type metadataAvailabilityZone struct {
-	SDKShapeTraits bool `type:"structure"`
+	_ struct{} `type:"structure"`
 }
 
 // String returns the string representation
@@ -2460,11 +2436,7 @@ type Cluster struct {
 	// VPC.
 	VpcSecurityGroups []*VpcSecurityGroupMembership `locationNameList:"VpcSecurityGroup" type:"list"`
 
-	metadataCluster `json:"-" xml:"-"`
-}
-
-type metadataCluster struct {
-	SDKShapeTraits bool `type:"structure"`
+	_ struct{} `type:"structure"`
 }
 
 // String returns the string representation
@@ -2488,11 +2460,7 @@ type ClusterNode struct {
 	// The public IP address of a node within a cluster.
 	PublicIPAddress *string `type:"string"`
 
-	metadataClusterNode `json:"-" xml:"-"`
-}
-
-type metadataClusterNode struct {
-	SDKShapeTraits bool `type:"structure"`
+	_ struct{} `type:"structure"`
 }
 
 // String returns the string representation
@@ -2520,11 +2488,7 @@ type ClusterParameterGroup struct {
 	// The list of tags for the cluster parameter group.
 	Tags []*Tag `locationNameList:"Tag" type:"list"`
 
-	metadataClusterParameterGroup `json:"-" xml:"-"`
-}
-
-type metadataClusterParameterGroup struct {
-	SDKShapeTraits bool `type:"structure"`
+	_ struct{} `type:"structure"`
 }
 
 // String returns the string representation
@@ -2549,11 +2513,7 @@ type ClusterParameterGroupNameMessage struct {
 	// of an associated cluster.
 	ParameterGroupStatus *string `type:"string"`
 
-	metadataClusterParameterGroupNameMessage `json:"-" xml:"-"`
-}
-
-type metadataClusterParameterGroupNameMessage struct {
-	SDKShapeTraits bool `type:"structure"`
+	_ struct{} `type:"structure"`
 }
 
 // String returns the string representation
@@ -2581,11 +2541,7 @@ type ClusterParameterGroupStatus struct {
 	// The name of the cluster parameter group.
 	ParameterGroupName *string `type:"string"`
 
-	metadataClusterParameterGroupStatus `json:"-" xml:"-"`
-}
-
-type metadataClusterParameterGroupStatus struct {
-	SDKShapeTraits bool `type:"structure"`
+	_ struct{} `type:"structure"`
 }
 
 // String returns the string representation
@@ -2622,11 +2578,7 @@ type ClusterParameterStatus struct {
 	// The name of the parameter.
 	ParameterName *string `type:"string"`
 
-	metadataClusterParameterStatus `json:"-" xml:"-"`
-}
-
-type metadataClusterParameterStatus struct {
-	SDKShapeTraits bool `type:"structure"`
+	_ struct{} `type:"structure"`
 }
 
 // String returns the string representation
@@ -2658,11 +2610,7 @@ type ClusterSecurityGroup struct {
 	// The list of tags for the cluster security group.
 	Tags []*Tag `locationNameList:"Tag" type:"list"`
 
-	metadataClusterSecurityGroup `json:"-" xml:"-"`
-}
-
-type metadataClusterSecurityGroup struct {
-	SDKShapeTraits bool `type:"structure"`
+	_ struct{} `type:"structure"`
 }
 
 // String returns the string representation
@@ -2683,11 +2631,7 @@ type ClusterSecurityGroupMembership struct {
 	// The status of the cluster security group.
 	Status *string `type:"string"`
 
-	metadataClusterSecurityGroupMembership `json:"-" xml:"-"`
-}
-
-type metadataClusterSecurityGroupMembership struct {
-	SDKShapeTraits bool `type:"structure"`
+	_ struct{} `type:"structure"`
 }
 
 // String returns the string representation
@@ -2714,11 +2658,7 @@ type ClusterSnapshotCopyStatus struct {
 	// The name of the snapshot copy grant.
 	SnapshotCopyGrantName *string `type:"string"`
 
-	metadataClusterSnapshotCopyStatus `json:"-" xml:"-"`
-}
-
-type metadataClusterSnapshotCopyStatus struct {
-	SDKShapeTraits bool `type:"structure"`
+	_ struct{} `type:"structure"`
 }
 
 // String returns the string representation
@@ -2752,11 +2692,7 @@ type ClusterSubnetGroup struct {
 	// The VPC ID of the cluster subnet group.
 	VpcId *string `type:"string"`
 
-	metadataClusterSubnetGroup `json:"-" xml:"-"`
-}
-
-type metadataClusterSubnetGroup struct {
-	SDKShapeTraits bool `type:"structure"`
+	_ struct{} `type:"structure"`
 }
 
 // String returns the string representation
@@ -2781,11 +2717,7 @@ type ClusterVersion struct {
 	// The description of the cluster version.
 	Description *string `type:"string"`
 
-	metadataClusterVersion `json:"-" xml:"-"`
-}
-
-type metadataClusterVersion struct {
-	SDKShapeTraits bool `type:"structure"`
+	_ struct{} `type:"structure"`
 }
 
 // String returns the string representation
@@ -2825,11 +2757,7 @@ type CopyClusterSnapshotInput struct {
 	// that is making the request.
 	TargetSnapshotIdentifier *string `type:"string" required:"true"`
 
-	metadataCopyClusterSnapshotInput `json:"-" xml:"-"`
-}
-
-type metadataCopyClusterSnapshotInput struct {
-	SDKShapeTraits bool `type:"structure"`
+	_ struct{} `type:"structure"`
 }
 
 // String returns the string representation
@@ -2846,11 +2774,7 @@ type CopyClusterSnapshotOutput struct {
 	// Describes a snapshot.
 	Snapshot *Snapshot `type:"structure"`
 
-	metadataCopyClusterSnapshotOutput `json:"-" xml:"-"`
-}
-
-type metadataCopyClusterSnapshotOutput struct {
-	SDKShapeTraits bool `type:"structure"`
+	_ struct{} `type:"structure"`
 }
 
 // String returns the string representation
@@ -3077,11 +3001,7 @@ type CreateClusterInput struct {
 	// Default: The default VPC security group is associated with the cluster.
 	VpcSecurityGroupIds []*string `locationNameList:"VpcSecurityGroupId" type:"list"`
 
-	metadataCreateClusterInput `json:"-" xml:"-"`
-}
-
-type metadataCreateClusterInput struct {
-	SDKShapeTraits bool `type:"structure"`
+	_ struct{} `type:"structure"`
 }
 
 // String returns the string representation
@@ -3098,11 +3018,7 @@ type CreateClusterOutput struct {
 	// Describes a cluster.
 	Cluster *Cluster `type:"structure"`
 
-	metadataCreateClusterOutput `json:"-" xml:"-"`
-}
-
-type metadataCreateClusterOutput struct {
-	SDKShapeTraits bool `type:"structure"`
+	_ struct{} `type:"structure"`
 }
 
 // String returns the string representation
@@ -3143,11 +3059,7 @@ type CreateClusterParameterGroupInput struct {
 	// A list of tag instances.
 	Tags []*Tag `locationNameList:"Tag" type:"list"`
 
-	metadataCreateClusterParameterGroupInput `json:"-" xml:"-"`
-}
-
-type metadataCreateClusterParameterGroupInput struct {
-	SDKShapeTraits bool `type:"structure"`
+	_ struct{} `type:"structure"`
 }
 
 // String returns the string representation
@@ -3164,11 +3076,7 @@ type CreateClusterParameterGroupOutput struct {
 	// Describes a parameter group.
 	ClusterParameterGroup *ClusterParameterGroup `type:"structure"`
 
-	metadataCreateClusterParameterGroupOutput `json:"-" xml:"-"`
-}
-
-type metadataCreateClusterParameterGroupOutput struct {
-	SDKShapeTraits bool `type:"structure"`
+	_ struct{} `type:"structure"`
 }
 
 // String returns the string representation
@@ -3199,11 +3107,7 @@ type CreateClusterSecurityGroupInput struct {
 	// A list of tag instances.
 	Tags []*Tag `locationNameList:"Tag" type:"list"`
 
-	metadataCreateClusterSecurityGroupInput `json:"-" xml:"-"`
-}
-
-type metadataCreateClusterSecurityGroupInput struct {
-	SDKShapeTraits bool `type:"structure"`
+	_ struct{} `type:"structure"`
 }
 
 // String returns the string representation
@@ -3220,11 +3124,7 @@ type CreateClusterSecurityGroupOutput struct {
 	// Describes a security group.
 	ClusterSecurityGroup *ClusterSecurityGroup `type:"structure"`
 
-	metadataCreateClusterSecurityGroupOutput `json:"-" xml:"-"`
-}
-
-type metadataCreateClusterSecurityGroupOutput struct {
-	SDKShapeTraits bool `type:"structure"`
+	_ struct{} `type:"structure"`
 }
 
 // String returns the string representation
@@ -3254,11 +3154,7 @@ type CreateClusterSnapshotInput struct {
 	// A list of tag instances.
 	Tags []*Tag `locationNameList:"Tag" type:"list"`
 
-	metadataCreateClusterSnapshotInput `json:"-" xml:"-"`
-}
-
-type metadataCreateClusterSnapshotInput struct {
-	SDKShapeTraits bool `type:"structure"`
+	_ struct{} `type:"structure"`
 }
 
 // String returns the string representation
@@ -3275,11 +3171,7 @@ type CreateClusterSnapshotOutput struct {
 	// Describes a snapshot.
 	Snapshot *Snapshot `type:"structure"`
 
-	metadataCreateClusterSnapshotOutput `json:"-" xml:"-"`
-}
-
-type metadataCreateClusterSnapshotOutput struct {
-	SDKShapeTraits bool `type:"structure"`
+	_ struct{} `type:"structure"`
 }
 
 // String returns the string representation
@@ -3313,11 +3205,7 @@ type CreateClusterSubnetGroupInput struct {
 	// A list of tag instances.
 	Tags []*Tag `locationNameList:"Tag" type:"list"`
 
-	metadataCreateClusterSubnetGroupInput `json:"-" xml:"-"`
-}
-
-type metadataCreateClusterSubnetGroupInput struct {
-	SDKShapeTraits bool `type:"structure"`
+	_ struct{} `type:"structure"`
 }
 
 // String returns the string representation
@@ -3334,11 +3222,7 @@ type CreateClusterSubnetGroupOutput struct {
 	// Describes a subnet group.
 	ClusterSubnetGroup *ClusterSubnetGroup `type:"structure"`
 
-	metadataCreateClusterSubnetGroupOutput `json:"-" xml:"-"`
-}
-
-type metadataCreateClusterSubnetGroupOutput struct {
-	SDKShapeTraits bool `type:"structure"`
+	_ struct{} `type:"structure"`
 }
 
 // String returns the string representation
@@ -3406,11 +3290,7 @@ type CreateEventSubscriptionInput struct {
 	// A list of tag instances.
 	Tags []*Tag `locationNameList:"Tag" type:"list"`
 
-	metadataCreateEventSubscriptionInput `json:"-" xml:"-"`
-}
-
-type metadataCreateEventSubscriptionInput struct {
-	SDKShapeTraits bool `type:"structure"`
+	_ struct{} `type:"structure"`
 }
 
 // String returns the string representation
@@ -3426,11 +3306,7 @@ func (s CreateEventSubscriptionInput) GoString() string {
 type CreateEventSubscriptionOutput struct {
 	EventSubscription *EventSubscription `type:"structure"`
 
-	metadataCreateEventSubscriptionOutput `json:"-" xml:"-"`
-}
-
-type metadataCreateEventSubscriptionOutput struct {
-	SDKShapeTraits bool `type:"structure"`
+	_ struct{} `type:"structure"`
 }
 
 // String returns the string representation
@@ -3451,11 +3327,7 @@ type CreateHsmClientCertificateInput struct {
 	// A list of tag instances.
 	Tags []*Tag `locationNameList:"Tag" type:"list"`
 
-	metadataCreateHsmClientCertificateInput `json:"-" xml:"-"`
-}
-
-type metadataCreateHsmClientCertificateInput struct {
-	SDKShapeTraits bool `type:"structure"`
+	_ struct{} `type:"structure"`
 }
 
 // String returns the string representation
@@ -3474,11 +3346,7 @@ type CreateHsmClientCertificateOutput struct {
 	// cluster to encrypt data files.
 	HsmClientCertificate *HsmClientCertificate `type:"structure"`
 
-	metadataCreateHsmClientCertificateOutput `json:"-" xml:"-"`
-}
-
-type metadataCreateHsmClientCertificateOutput struct {
-	SDKShapeTraits bool `type:"structure"`
+	_ struct{} `type:"structure"`
 }
 
 // String returns the string representation
@@ -3515,11 +3383,7 @@ type CreateHsmConfigurationInput struct {
 	// A list of tag instances.
 	Tags []*Tag `locationNameList:"Tag" type:"list"`
 
-	metadataCreateHsmConfigurationInput `json:"-" xml:"-"`
-}
-
-type metadataCreateHsmConfigurationInput struct {
-	SDKShapeTraits bool `type:"structure"`
+	_ struct{} `type:"structure"`
 }
 
 // String returns the string representation
@@ -3538,11 +3402,7 @@ type CreateHsmConfigurationOutput struct {
 	// HSM where they can store database encryption keys.
 	HsmConfiguration *HsmConfiguration `type:"structure"`
 
-	metadataCreateHsmConfigurationOutput `json:"-" xml:"-"`
-}
-
-type metadataCreateHsmConfigurationOutput struct {
-	SDKShapeTraits bool `type:"structure"`
+	_ struct{} `type:"structure"`
 }
 
 // String returns the string representation
@@ -3575,11 +3435,7 @@ type CreateSnapshotCopyGrantInput struct {
 	// A list of tag instances.
 	Tags []*Tag `locationNameList:"Tag" type:"list"`
 
-	metadataCreateSnapshotCopyGrantInput `json:"-" xml:"-"`
-}
-
-type metadataCreateSnapshotCopyGrantInput struct {
-	SDKShapeTraits bool `type:"structure"`
+	_ struct{} `type:"structure"`
 }
 
 // String returns the string representation
@@ -3602,11 +3458,7 @@ type CreateSnapshotCopyGrantOutput struct {
 	// in the Amazon Redshift Cluster Management Guide.
 	SnapshotCopyGrant *SnapshotCopyGrant `type:"structure"`
 
-	metadataCreateSnapshotCopyGrantOutput `json:"-" xml:"-"`
-}
-
-type metadataCreateSnapshotCopyGrantOutput struct {
-	SDKShapeTraits bool `type:"structure"`
+	_ struct{} `type:"structure"`
 }
 
 // String returns the string representation
@@ -3632,11 +3484,7 @@ type CreateTagsInput struct {
 	// "Key"="owner","Value"="admin" "Key"="environment","Value"="test" "Key"="version","Value"="1.0".
 	Tags []*Tag `locationNameList:"Tag" type:"list" required:"true"`
 
-	metadataCreateTagsInput `json:"-" xml:"-"`
-}
-
-type metadataCreateTagsInput struct {
-	SDKShapeTraits bool `type:"structure"`
+	_ struct{} `type:"structure"`
 }
 
 // String returns the string representation
@@ -3650,11 +3498,7 @@ func (s CreateTagsInput) GoString() string {
 }
 
 type CreateTagsOutput struct {
-	metadataCreateTagsOutput `json:"-" xml:"-"`
-}
-
-type metadataCreateTagsOutput struct {
-	SDKShapeTraits bool `type:"structure"`
+	_ struct{} `type:"structure"`
 }
 
 // String returns the string representation
@@ -3683,11 +3527,7 @@ type DefaultClusterParameters struct {
 	// The list of cluster default parameters.
 	Parameters []*Parameter `locationNameList:"Parameter" type:"list"`
 
-	metadataDefaultClusterParameters `json:"-" xml:"-"`
-}
-
-type metadataDefaultClusterParameters struct {
-	SDKShapeTraits bool `type:"structure"`
+	_ struct{} `type:"structure"`
 }
 
 // String returns the string representation
@@ -3728,11 +3568,7 @@ type DeleteClusterInput struct {
 	// is false. Default: false
 	SkipFinalClusterSnapshot *bool `type:"boolean"`
 
-	metadataDeleteClusterInput `json:"-" xml:"-"`
-}
-
-type metadataDeleteClusterInput struct {
-	SDKShapeTraits bool `type:"structure"`
+	_ struct{} `type:"structure"`
 }
 
 // String returns the string representation
@@ -3749,11 +3585,7 @@ type DeleteClusterOutput struct {
 	// Describes a cluster.
 	Cluster *Cluster `type:"structure"`
 
-	metadataDeleteClusterOutput `json:"-" xml:"-"`
-}
-
-type metadataDeleteClusterOutput struct {
-	SDKShapeTraits bool `type:"structure"`
+	_ struct{} `type:"structure"`
 }
 
 // String returns the string representation
@@ -3775,11 +3607,7 @@ type DeleteClusterParameterGroupInput struct {
 	// a default cluster parameter group.
 	ParameterGroupName *string `type:"string" required:"true"`
 
-	metadataDeleteClusterParameterGroupInput `json:"-" xml:"-"`
-}
-
-type metadataDeleteClusterParameterGroupInput struct {
-	SDKShapeTraits bool `type:"structure"`
+	_ struct{} `type:"structure"`
 }
 
 // String returns the string representation
@@ -3793,11 +3621,7 @@ func (s DeleteClusterParameterGroupInput) GoString() string {
 }
 
 type DeleteClusterParameterGroupOutput struct {
-	metadataDeleteClusterParameterGroupOutput `json:"-" xml:"-"`
-}
-
-type metadataDeleteClusterParameterGroupOutput struct {
-	SDKShapeTraits bool `type:"structure"`
+	_ struct{} `type:"structure"`
 }
 
 // String returns the string representation
@@ -3814,11 +3638,7 @@ type DeleteClusterSecurityGroupInput struct {
 	// The name of the cluster security group to be deleted.
 	ClusterSecurityGroupName *string `type:"string" required:"true"`
 
-	metadataDeleteClusterSecurityGroupInput `json:"-" xml:"-"`
-}
-
-type metadataDeleteClusterSecurityGroupInput struct {
-	SDKShapeTraits bool `type:"structure"`
+	_ struct{} `type:"structure"`
 }
 
 // String returns the string representation
@@ -3832,11 +3652,7 @@ func (s DeleteClusterSecurityGroupInput) GoString() string {
 }
 
 type DeleteClusterSecurityGroupOutput struct {
-	metadataDeleteClusterSecurityGroupOutput `json:"-" xml:"-"`
-}
-
-type metadataDeleteClusterSecurityGroupOutput struct {
-	SDKShapeTraits bool `type:"structure"`
+	_ struct{} `type:"structure"`
 }
 
 // String returns the string representation
@@ -3863,11 +3679,7 @@ type DeleteClusterSnapshotInput struct {
 	// state.
 	SnapshotIdentifier *string `type:"string" required:"true"`
 
-	metadataDeleteClusterSnapshotInput `json:"-" xml:"-"`
-}
-
-type metadataDeleteClusterSnapshotInput struct {
-	SDKShapeTraits bool `type:"structure"`
+	_ struct{} `type:"structure"`
 }
 
 // String returns the string representation
@@ -3884,11 +3696,7 @@ type DeleteClusterSnapshotOutput struct {
 	// Describes a snapshot.
 	Snapshot *Snapshot `type:"structure"`
 
-	metadataDeleteClusterSnapshotOutput `json:"-" xml:"-"`
-}
-
-type metadataDeleteClusterSnapshotOutput struct {
-	SDKShapeTraits bool `type:"structure"`
+	_ struct{} `type:"structure"`
 }
 
 // String returns the string representation
@@ -3905,11 +3713,7 @@ type DeleteClusterSubnetGroupInput struct {
 	// The name of the cluster subnet group name to be deleted.
 	ClusterSubnetGroupName *string `type:"string" required:"true"`
 
-	metadataDeleteClusterSubnetGroupInput `json:"-" xml:"-"`
-}
-
-type metadataDeleteClusterSubnetGroupInput struct {
-	SDKShapeTraits bool `type:"structure"`
+	_ struct{} `type:"structure"`
 }
 
 // String returns the string representation
@@ -3923,11 +3727,7 @@ func (s DeleteClusterSubnetGroupInput) GoString() string {
 }
 
 type DeleteClusterSubnetGroupOutput struct {
-	metadataDeleteClusterSubnetGroupOutput `json:"-" xml:"-"`
-}
-
-type metadataDeleteClusterSubnetGroupOutput struct {
-	SDKShapeTraits bool `type:"structure"`
+	_ struct{} `type:"structure"`
 }
 
 // String returns the string representation
@@ -3944,11 +3744,7 @@ type DeleteEventSubscriptionInput struct {
 	// The name of the Amazon Redshift event notification subscription to be deleted.
 	SubscriptionName *string `type:"string" required:"true"`
 
-	metadataDeleteEventSubscriptionInput `json:"-" xml:"-"`
-}
-
-type metadataDeleteEventSubscriptionInput struct {
-	SDKShapeTraits bool `type:"structure"`
+	_ struct{} `type:"structure"`
 }
 
 // String returns the string representation
@@ -3962,11 +3758,7 @@ func (s DeleteEventSubscriptionInput) GoString() string {
 }
 
 type DeleteEventSubscriptionOutput struct {
-	metadataDeleteEventSubscriptionOutput `json:"-" xml:"-"`
-}
-
-type metadataDeleteEventSubscriptionOutput struct {
-	SDKShapeTraits bool `type:"structure"`
+	_ struct{} `type:"structure"`
 }
 
 // String returns the string representation
@@ -3983,11 +3775,7 @@ type DeleteHsmClientCertificateInput struct {
 	// The identifier of the HSM client certificate to be deleted.
 	HsmClientCertificateIdentifier *string `type:"string" required:"true"`
 
-	metadataDeleteHsmClientCertificateInput `json:"-" xml:"-"`
-}
-
-type metadataDeleteHsmClientCertificateInput struct {
-	SDKShapeTraits bool `type:"structure"`
+	_ struct{} `type:"structure"`
 }
 
 // String returns the string representation
@@ -4001,11 +3789,7 @@ func (s DeleteHsmClientCertificateInput) GoString() string {
 }
 
 type DeleteHsmClientCertificateOutput struct {
-	metadataDeleteHsmClientCertificateOutput `json:"-" xml:"-"`
-}
-
-type metadataDeleteHsmClientCertificateOutput struct {
-	SDKShapeTraits bool `type:"structure"`
+	_ struct{} `type:"structure"`
 }
 
 // String returns the string representation
@@ -4022,11 +3806,7 @@ type DeleteHsmConfigurationInput struct {
 	// The identifier of the Amazon Redshift HSM configuration to be deleted.
 	HsmConfigurationIdentifier *string `type:"string" required:"true"`
 
-	metadataDeleteHsmConfigurationInput `json:"-" xml:"-"`
-}
-
-type metadataDeleteHsmConfigurationInput struct {
-	SDKShapeTraits bool `type:"structure"`
+	_ struct{} `type:"structure"`
 }
 
 // String returns the string representation
@@ -4040,11 +3820,7 @@ func (s DeleteHsmConfigurationInput) GoString() string {
 }
 
 type DeleteHsmConfigurationOutput struct {
-	metadataDeleteHsmConfigurationOutput `json:"-" xml:"-"`
-}
-
-type metadataDeleteHsmConfigurationOutput struct {
-	SDKShapeTraits bool `type:"structure"`
+	_ struct{} `type:"structure"`
 }
 
 // String returns the string representation
@@ -4062,11 +3838,7 @@ type DeleteSnapshotCopyGrantInput struct {
 	// The name of the snapshot copy grant to delete.
 	SnapshotCopyGrantName *string `type:"string" required:"true"`
 
-	metadataDeleteSnapshotCopyGrantInput `json:"-" xml:"-"`
-}
-
-type metadataDeleteSnapshotCopyGrantInput struct {
-	SDKShapeTraits bool `type:"structure"`
+	_ struct{} `type:"structure"`
 }
 
 // String returns the string representation
@@ -4080,11 +3852,7 @@ func (s DeleteSnapshotCopyGrantInput) GoString() string {
 }
 
 type DeleteSnapshotCopyGrantOutput struct {
-	metadataDeleteSnapshotCopyGrantOutput `json:"-" xml:"-"`
-}
-
-type metadataDeleteSnapshotCopyGrantOutput struct {
-	SDKShapeTraits bool `type:"structure"`
+	_ struct{} `type:"structure"`
 }
 
 // String returns the string representation
@@ -4106,11 +3874,7 @@ type DeleteTagsInput struct {
 	// The tag key that you want to delete.
 	TagKeys []*string `locationNameList:"TagKey" type:"list" required:"true"`
 
-	metadataDeleteTagsInput `json:"-" xml:"-"`
-}
-
-type metadataDeleteTagsInput struct {
-	SDKShapeTraits bool `type:"structure"`
+	_ struct{} `type:"structure"`
 }
 
 // String returns the string representation
@@ -4124,11 +3888,7 @@ func (s DeleteTagsInput) GoString() string {
 }
 
 type DeleteTagsOutput struct {
-	metadataDeleteTagsOutput `json:"-" xml:"-"`
-}
-
-type metadataDeleteTagsOutput struct {
-	SDKShapeTraits bool `type:"structure"`
+	_ struct{} `type:"structure"`
 }
 
 // String returns the string representation
@@ -4180,11 +3940,7 @@ type DescribeClusterParameterGroupsInput struct {
 	// both of these tag values associated with them.
 	TagValues []*string `locationNameList:"TagValue" type:"list"`
 
-	metadataDescribeClusterParameterGroupsInput `json:"-" xml:"-"`
-}
-
-type metadataDescribeClusterParameterGroupsInput struct {
-	SDKShapeTraits bool `type:"structure"`
+	_ struct{} `type:"structure"`
 }
 
 // String returns the string representation
@@ -4210,11 +3966,7 @@ type DescribeClusterParameterGroupsOutput struct {
 	// parameter group.
 	ParameterGroups []*ClusterParameterGroup `locationNameList:"ClusterParameterGroup" type:"list"`
 
-	metadataDescribeClusterParameterGroupsOutput `json:"-" xml:"-"`
-}
-
-type metadataDescribeClusterParameterGroupsOutput struct {
-	SDKShapeTraits bool `type:"structure"`
+	_ struct{} `type:"structure"`
 }
 
 // String returns the string representation
@@ -4258,11 +4010,7 @@ type DescribeClusterParametersInput struct {
 	// Valid Values: user | engine-default
 	Source *string `type:"string"`
 
-	metadataDescribeClusterParametersInput `json:"-" xml:"-"`
-}
-
-type metadataDescribeClusterParametersInput struct {
-	SDKShapeTraits bool `type:"structure"`
+	_ struct{} `type:"structure"`
 }
 
 // String returns the string representation
@@ -4288,11 +4036,7 @@ type DescribeClusterParametersOutput struct {
 	// cluster parameter group.
 	Parameters []*Parameter `locationNameList:"Parameter" type:"list"`
 
-	metadataDescribeClusterParametersOutput `json:"-" xml:"-"`
-}
-
-type metadataDescribeClusterParametersOutput struct {
-	SDKShapeTraits bool `type:"structure"`
+	_ struct{} `type:"structure"`
 }
 
 // String returns the string representation
@@ -4351,11 +4095,7 @@ type DescribeClusterSecurityGroupsInput struct {
 	// both of these tag values associated with them.
 	TagValues []*string `locationNameList:"TagValue" type:"list"`
 
-	metadataDescribeClusterSecurityGroupsInput `json:"-" xml:"-"`
-}
-
-type metadataDescribeClusterSecurityGroupsInput struct {
-	SDKShapeTraits bool `type:"structure"`
+	_ struct{} `type:"structure"`
 }
 
 // String returns the string representation
@@ -4380,11 +4120,7 @@ type DescribeClusterSecurityGroupsOutput struct {
 	// records have been retrieved for the request.
 	Marker *string `type:"string"`
 
-	metadataDescribeClusterSecurityGroupsOutput `json:"-" xml:"-"`
-}
-
-type metadataDescribeClusterSecurityGroupsOutput struct {
-	SDKShapeTraits bool `type:"structure"`
+	_ struct{} `type:"structure"`
 }
 
 // String returns the string representation
@@ -4464,11 +4200,7 @@ type DescribeClusterSnapshotsInput struct {
 	// these tag values associated with them.
 	TagValues []*string `locationNameList:"TagValue" type:"list"`
 
-	metadataDescribeClusterSnapshotsInput `json:"-" xml:"-"`
-}
-
-type metadataDescribeClusterSnapshotsInput struct {
-	SDKShapeTraits bool `type:"structure"`
+	_ struct{} `type:"structure"`
 }
 
 // String returns the string representation
@@ -4493,11 +4225,7 @@ type DescribeClusterSnapshotsOutput struct {
 	// A list of Snapshot instances.
 	Snapshots []*Snapshot `locationNameList:"Snapshot" type:"list"`
 
-	metadataDescribeClusterSnapshotsOutput `json:"-" xml:"-"`
-}
-
-type metadataDescribeClusterSnapshotsOutput struct {
-	SDKShapeTraits bool `type:"structure"`
+	_ struct{} `type:"structure"`
 }
 
 // String returns the string representation
@@ -4548,11 +4276,7 @@ type DescribeClusterSubnetGroupsInput struct {
 	// of these tag values associated with them.
 	TagValues []*string `locationNameList:"TagValue" type:"list"`
 
-	metadataDescribeClusterSubnetGroupsInput `json:"-" xml:"-"`
-}
-
-type metadataDescribeClusterSubnetGroupsInput struct {
-	SDKShapeTraits bool `type:"structure"`
+	_ struct{} `type:"structure"`
 }
 
 // String returns the string representation
@@ -4577,11 +4301,7 @@ type DescribeClusterSubnetGroupsOutput struct {
 	// records have been retrieved for the request.
 	Marker *string `type:"string"`
 
-	metadataDescribeClusterSubnetGroupsOutput `json:"-" xml:"-"`
-}
-
-type metadataDescribeClusterSubnetGroupsOutput struct {
-	SDKShapeTraits bool `type:"structure"`
+	_ struct{} `type:"structure"`
 }
 
 // String returns the string representation
@@ -4625,11 +4345,7 @@ type DescribeClusterVersionsInput struct {
 	// Constraints: minimum 20, maximum 100.
 	MaxRecords *int64 `type:"integer"`
 
-	metadataDescribeClusterVersionsInput `json:"-" xml:"-"`
-}
-
-type metadataDescribeClusterVersionsInput struct {
-	SDKShapeTraits bool `type:"structure"`
+	_ struct{} `type:"structure"`
 }
 
 // String returns the string representation
@@ -4654,11 +4370,7 @@ type DescribeClusterVersionsOutput struct {
 	// records have been retrieved for the request.
 	Marker *string `type:"string"`
 
-	metadataDescribeClusterVersionsOutput `json:"-" xml:"-"`
-}
-
-type metadataDescribeClusterVersionsOutput struct {
-	SDKShapeTraits bool `type:"structure"`
+	_ struct{} `type:"structure"`
 }
 
 // String returns the string representation
@@ -4714,11 +4426,7 @@ type DescribeClustersInput struct {
 	// values associated with them.
 	TagValues []*string `locationNameList:"TagValue" type:"list"`
 
-	metadataDescribeClustersInput `json:"-" xml:"-"`
-}
-
-type metadataDescribeClustersInput struct {
-	SDKShapeTraits bool `type:"structure"`
+	_ struct{} `type:"structure"`
 }
 
 // String returns the string representation
@@ -4743,11 +4451,7 @@ type DescribeClustersOutput struct {
 	// records have been retrieved for the request.
 	Marker *string `type:"string"`
 
-	metadataDescribeClustersOutput `json:"-" xml:"-"`
-}
-
-type metadataDescribeClustersOutput struct {
-	SDKShapeTraits bool `type:"structure"`
+	_ struct{} `type:"structure"`
 }
 
 // String returns the string representation
@@ -4782,11 +4486,7 @@ type DescribeDefaultClusterParametersInput struct {
 	// The name of the cluster parameter group family.
 	ParameterGroupFamily *string `type:"string" required:"true"`
 
-	metadataDescribeDefaultClusterParametersInput `json:"-" xml:"-"`
-}
-
-type metadataDescribeDefaultClusterParametersInput struct {
-	SDKShapeTraits bool `type:"structure"`
+	_ struct{} `type:"structure"`
 }
 
 // String returns the string representation
@@ -4803,11 +4503,7 @@ type DescribeDefaultClusterParametersOutput struct {
 	// Describes the default cluster parameters for a parameter group family.
 	DefaultClusterParameters *DefaultClusterParameters `type:"structure"`
 
-	metadataDescribeDefaultClusterParametersOutput `json:"-" xml:"-"`
-}
-
-type metadataDescribeDefaultClusterParametersOutput struct {
-	SDKShapeTraits bool `type:"structure"`
+	_ struct{} `type:"structure"`
 }
 
 // String returns the string representation
@@ -4827,11 +4523,7 @@ type DescribeEventCategoriesInput struct {
 	//  Valid values: cluster, snapshot, parameter group, and security group.
 	SourceType *string `type:"string"`
 
-	metadataDescribeEventCategoriesInput `json:"-" xml:"-"`
-}
-
-type metadataDescribeEventCategoriesInput struct {
-	SDKShapeTraits bool `type:"structure"`
+	_ struct{} `type:"structure"`
 }
 
 // String returns the string representation
@@ -4848,11 +4540,7 @@ type DescribeEventCategoriesOutput struct {
 	// A list of event categories descriptions.
 	EventCategoriesMapList []*EventCategoriesMap `locationNameList:"EventCategoriesMap" type:"list"`
 
-	metadataDescribeEventCategoriesOutput `json:"-" xml:"-"`
-}
-
-type metadataDescribeEventCategoriesOutput struct {
-	SDKShapeTraits bool `type:"structure"`
+	_ struct{} `type:"structure"`
 }
 
 // String returns the string representation
@@ -4887,11 +4575,7 @@ type DescribeEventSubscriptionsInput struct {
 	// The name of the Amazon Redshift event notification subscription to be described.
 	SubscriptionName *string `type:"string"`
 
-	metadataDescribeEventSubscriptionsInput `json:"-" xml:"-"`
-}
-
-type metadataDescribeEventSubscriptionsInput struct {
-	SDKShapeTraits bool `type:"structure"`
+	_ struct{} `type:"structure"`
 }
 
 // String returns the string representation
@@ -4915,11 +4599,7 @@ type DescribeEventSubscriptionsOutput struct {
 	// records have been retrieved for the request.
 	Marker *string `type:"string"`
 
-	metadataDescribeEventSubscriptionsOutput `json:"-" xml:"-"`
-}
-
-type metadataDescribeEventSubscriptionsOutput struct {
-	SDKShapeTraits bool `type:"structure"`
+	_ struct{} `type:"structure"`
 }
 
 // String returns the string representation
@@ -4998,11 +4678,7 @@ type DescribeEventsInput struct {
 	// Example: 2009-07-08T18:00Z
 	StartTime *time.Time `type:"timestamp" timestampFormat:"iso8601"`
 
-	metadataDescribeEventsInput `json:"-" xml:"-"`
-}
-
-type metadataDescribeEventsInput struct {
-	SDKShapeTraits bool `type:"structure"`
+	_ struct{} `type:"structure"`
 }
 
 // String returns the string representation
@@ -5027,11 +4703,7 @@ type DescribeEventsOutput struct {
 	// records have been retrieved for the request.
 	Marker *string `type:"string"`
 
-	metadataDescribeEventsOutput `json:"-" xml:"-"`
-}
-
-type metadataDescribeEventsOutput struct {
-	SDKShapeTraits bool `type:"structure"`
+	_ struct{} `type:"structure"`
 }
 
 // String returns the string representation
@@ -5084,11 +4756,7 @@ type DescribeHsmClientCertificatesInput struct {
 	// that have either or both of these tag values associated with them.
 	TagValues []*string `locationNameList:"TagValue" type:"list"`
 
-	metadataDescribeHsmClientCertificatesInput `json:"-" xml:"-"`
-}
-
-type metadataDescribeHsmClientCertificatesInput struct {
-	SDKShapeTraits bool `type:"structure"`
+	_ struct{} `type:"structure"`
 }
 
 // String returns the string representation
@@ -5114,11 +4782,7 @@ type DescribeHsmClientCertificatesOutput struct {
 	// records have been retrieved for the request.
 	Marker *string `type:"string"`
 
-	metadataDescribeHsmClientCertificatesOutput `json:"-" xml:"-"`
-}
-
-type metadataDescribeHsmClientCertificatesOutput struct {
-	SDKShapeTraits bool `type:"structure"`
+	_ struct{} `type:"structure"`
 }
 
 // String returns the string representation
@@ -5171,11 +4835,7 @@ type DescribeHsmConfigurationsInput struct {
 	// or both of these tag values associated with them.
 	TagValues []*string `locationNameList:"TagValue" type:"list"`
 
-	metadataDescribeHsmConfigurationsInput `json:"-" xml:"-"`
-}
-
-type metadataDescribeHsmConfigurationsInput struct {
-	SDKShapeTraits bool `type:"structure"`
+	_ struct{} `type:"structure"`
 }
 
 // String returns the string representation
@@ -5199,11 +4859,7 @@ type DescribeHsmConfigurationsOutput struct {
 	// records have been retrieved for the request.
 	Marker *string `type:"string"`
 
-	metadataDescribeHsmConfigurationsOutput `json:"-" xml:"-"`
-}
-
-type metadataDescribeHsmConfigurationsOutput struct {
-	SDKShapeTraits bool `type:"structure"`
+	_ struct{} `type:"structure"`
 }
 
 // String returns the string representation
@@ -5222,11 +4878,7 @@ type DescribeLoggingStatusInput struct {
 	// Example: examplecluster
 	ClusterIdentifier *string `type:"string" required:"true"`
 
-	metadataDescribeLoggingStatusInput `json:"-" xml:"-"`
-}
-
-type metadataDescribeLoggingStatusInput struct {
-	SDKShapeTraits bool `type:"structure"`
+	_ struct{} `type:"structure"`
 }
 
 // String returns the string representation
@@ -5270,11 +4922,7 @@ type DescribeOrderableClusterOptionsInput struct {
 	// offerings matching the specified node type.
 	NodeType *string `type:"string"`
 
-	metadataDescribeOrderableClusterOptionsInput `json:"-" xml:"-"`
-}
-
-type metadataDescribeOrderableClusterOptionsInput struct {
-	SDKShapeTraits bool `type:"structure"`
+	_ struct{} `type:"structure"`
 }
 
 // String returns the string representation
@@ -5300,11 +4948,7 @@ type DescribeOrderableClusterOptionsOutput struct {
 	// options for the Cluster.
 	OrderableClusterOptions []*OrderableClusterOption `locationNameList:"OrderableClusterOption" type:"list"`
 
-	metadataDescribeOrderableClusterOptionsOutput `json:"-" xml:"-"`
-}
-
-type metadataDescribeOrderableClusterOptionsOutput struct {
-	SDKShapeTraits bool `type:"structure"`
+	_ struct{} `type:"structure"`
 }
 
 // String returns the string representation
@@ -5339,11 +4983,7 @@ type DescribeReservedNodeOfferingsInput struct {
 	// The unique identifier for the offering.
 	ReservedNodeOfferingId *string `type:"string"`
 
-	metadataDescribeReservedNodeOfferingsInput `json:"-" xml:"-"`
-}
-
-type metadataDescribeReservedNodeOfferingsInput struct {
-	SDKShapeTraits bool `type:"structure"`
+	_ struct{} `type:"structure"`
 }
 
 // String returns the string representation
@@ -5368,11 +5008,7 @@ type DescribeReservedNodeOfferingsOutput struct {
 	// A list of reserved node offerings.
 	ReservedNodeOfferings []*ReservedNodeOffering `locationNameList:"ReservedNodeOffering" type:"list"`
 
-	metadataDescribeReservedNodeOfferingsOutput `json:"-" xml:"-"`
-}
-
-type metadataDescribeReservedNodeOfferingsOutput struct {
-	SDKShapeTraits bool `type:"structure"`
+	_ struct{} `type:"structure"`
 }
 
 // String returns the string representation
@@ -5406,11 +5042,7 @@ type DescribeReservedNodesInput struct {
 	// Identifier for the node reservation.
 	ReservedNodeId *string `type:"string"`
 
-	metadataDescribeReservedNodesInput `json:"-" xml:"-"`
-}
-
-type metadataDescribeReservedNodesInput struct {
-	SDKShapeTraits bool `type:"structure"`
+	_ struct{} `type:"structure"`
 }
 
 // String returns the string representation
@@ -5435,11 +5067,7 @@ type DescribeReservedNodesOutput struct {
 	// The list of reserved nodes.
 	ReservedNodes []*ReservedNode `locationNameList:"ReservedNode" type:"list"`
 
-	metadataDescribeReservedNodesOutput `json:"-" xml:"-"`
-}
-
-type metadataDescribeReservedNodesOutput struct {
-	SDKShapeTraits bool `type:"structure"`
+	_ struct{} `type:"structure"`
 }
 
 // String returns the string representation
@@ -5460,11 +5088,7 @@ type DescribeResizeInput struct {
 	// are returned.
 	ClusterIdentifier *string `type:"string" required:"true"`
 
-	metadataDescribeResizeInput `json:"-" xml:"-"`
-}
-
-type metadataDescribeResizeInput struct {
-	SDKShapeTraits bool `type:"structure"`
+	_ struct{} `type:"structure"`
 }
 
 // String returns the string representation
@@ -5538,11 +5162,7 @@ type DescribeResizeOutput struct {
 	// resize operation began.
 	TotalResizeDataInMegaBytes *int64 `type:"long"`
 
-	metadataDescribeResizeOutput `json:"-" xml:"-"`
-}
-
-type metadataDescribeResizeOutput struct {
-	SDKShapeTraits bool `type:"structure"`
+	_ struct{} `type:"structure"`
 }
 
 // String returns the string representation
@@ -5597,11 +5217,7 @@ type DescribeSnapshotCopyGrantsInput struct {
 	// associated with them.
 	TagValues []*string `locationNameList:"TagValue" type:"list"`
 
-	metadataDescribeSnapshotCopyGrantsInput `json:"-" xml:"-"`
-}
-
-type metadataDescribeSnapshotCopyGrantsInput struct {
-	SDKShapeTraits bool `type:"structure"`
+	_ struct{} `type:"structure"`
 }
 
 // String returns the string representation
@@ -5630,11 +5246,7 @@ type DescribeSnapshotCopyGrantsOutput struct {
 	// The list of snapshot copy grants.
 	SnapshotCopyGrants []*SnapshotCopyGrant `locationNameList:"SnapshotCopyGrant" type:"list"`
 
-	metadataDescribeSnapshotCopyGrantsOutput `json:"-" xml:"-"`
-}
-
-type metadataDescribeSnapshotCopyGrantsOutput struct {
-	SDKShapeTraits bool `type:"structure"`
+	_ struct{} `type:"structure"`
 }
 
 // String returns the string representation
@@ -5692,11 +5304,7 @@ type DescribeTagsInput struct {
 	// associated with them.
 	TagValues []*string `locationNameList:"TagValue" type:"list"`
 
-	metadataDescribeTagsInput `json:"-" xml:"-"`
-}
-
-type metadataDescribeTagsInput struct {
-	SDKShapeTraits bool `type:"structure"`
+	_ struct{} `type:"structure"`
 }
 
 // String returns the string representation
@@ -5721,11 +5329,7 @@ type DescribeTagsOutput struct {
 	// A list of tags with their associated resources.
 	TaggedResources []*TaggedResource `locationNameList:"TaggedResource" type:"list"`
 
-	metadataDescribeTagsOutput `json:"-" xml:"-"`
-}
-
-type metadataDescribeTagsOutput struct {
-	SDKShapeTraits bool `type:"structure"`
+	_ struct{} `type:"structure"`
 }
 
 // String returns the string representation
@@ -5744,11 +5348,7 @@ type DisableLoggingInput struct {
 	// Example: examplecluster
 	ClusterIdentifier *string `type:"string" required:"true"`
 
-	metadataDisableLoggingInput `json:"-" xml:"-"`
-}
-
-type metadataDisableLoggingInput struct {
-	SDKShapeTraits bool `type:"structure"`
+	_ struct{} `type:"structure"`
 }
 
 // String returns the string representation
@@ -5769,11 +5369,7 @@ type DisableSnapshotCopyInput struct {
 	// snapshot copy enabled.
 	ClusterIdentifier *string `type:"string" required:"true"`
 
-	metadataDisableSnapshotCopyInput `json:"-" xml:"-"`
-}
-
-type metadataDisableSnapshotCopyInput struct {
-	SDKShapeTraits bool `type:"structure"`
+	_ struct{} `type:"structure"`
 }
 
 // String returns the string representation
@@ -5790,11 +5386,7 @@ type DisableSnapshotCopyOutput struct {
 	// Describes a cluster.
 	Cluster *Cluster `type:"structure"`
 
-	metadataDisableSnapshotCopyOutput `json:"-" xml:"-"`
-}
-
-type metadataDisableSnapshotCopyOutput struct {
-	SDKShapeTraits bool `type:"structure"`
+	_ struct{} `type:"structure"`
 }
 
 // String returns the string representation
@@ -5822,11 +5414,7 @@ type EC2SecurityGroup struct {
 	// The list of tags for the EC2 security group.
 	Tags []*Tag `locationNameList:"Tag" type:"list"`
 
-	metadataEC2SecurityGroup `json:"-" xml:"-"`
-}
-
-type metadataEC2SecurityGroup struct {
-	SDKShapeTraits bool `type:"structure"`
+	_ struct{} `type:"structure"`
 }
 
 // String returns the string representation
@@ -5847,11 +5435,7 @@ type ElasticIpStatus struct {
 	// Describes the status of the elastic IP (EIP) address.
 	Status *string `type:"string"`
 
-	metadataElasticIpStatus `json:"-" xml:"-"`
-}
-
-type metadataElasticIpStatus struct {
-	SDKShapeTraits bool `type:"structure"`
+	_ struct{} `type:"structure"`
 }
 
 // String returns the string representation
@@ -5887,11 +5471,7 @@ type EnableLoggingInput struct {
 	// codes for invalid characters are:  x00 to x20 x22 x27 x5c x7f or larger
 	S3KeyPrefix *string `type:"string"`
 
-	metadataEnableLoggingInput `json:"-" xml:"-"`
-}
-
-type metadataEnableLoggingInput struct {
-	SDKShapeTraits bool `type:"structure"`
+	_ struct{} `type:"structure"`
 }
 
 // String returns the string representation
@@ -5930,11 +5510,7 @@ type EnableSnapshotCopyInput struct {
 	// cluster are copied to the destination region.
 	SnapshotCopyGrantName *string `type:"string"`
 
-	metadataEnableSnapshotCopyInput `json:"-" xml:"-"`
-}
-
-type metadataEnableSnapshotCopyInput struct {
-	SDKShapeTraits bool `type:"structure"`
+	_ struct{} `type:"structure"`
 }
 
 // String returns the string representation
@@ -5951,11 +5527,7 @@ type EnableSnapshotCopyOutput struct {
 	// Describes a cluster.
 	Cluster *Cluster `type:"structure"`
 
-	metadataEnableSnapshotCopyOutput `json:"-" xml:"-"`
-}
-
-type metadataEnableSnapshotCopyOutput struct {
-	SDKShapeTraits bool `type:"structure"`
+	_ struct{} `type:"structure"`
 }
 
 // String returns the string representation
@@ -5976,11 +5548,7 @@ type Endpoint struct {
 	// The port that the database engine is listening on.
 	Port *int64 `type:"integer"`
 
-	metadataEndpoint `json:"-" xml:"-"`
-}
-
-type metadataEndpoint struct {
-	SDKShapeTraits bool `type:"structure"`
+	_ struct{} `type:"structure"`
 }
 
 // String returns the string representation
@@ -6020,11 +5588,7 @@ type Event struct {
 	// The source type for this event.
 	SourceType *string `type:"string" enum:"SourceType"`
 
-	metadataEvent `json:"-" xml:"-"`
-}
-
-type metadataEvent struct {
-	SDKShapeTraits bool `type:"structure"`
+	_ struct{} `type:"structure"`
 }
 
 // String returns the string representation
@@ -6045,11 +5609,7 @@ type EventCategoriesMap struct {
 	// the returned categories belong to.
 	SourceType *string `type:"string"`
 
-	metadataEventCategoriesMap `json:"-" xml:"-"`
-}
-
-type metadataEventCategoriesMap struct {
-	SDKShapeTraits bool `type:"structure"`
+	_ struct{} `type:"structure"`
 }
 
 // String returns the string representation
@@ -6077,11 +5637,7 @@ type EventInfoMap struct {
 	// Values: ERROR, INFO
 	Severity *string `type:"string"`
 
-	metadataEventInfoMap `json:"-" xml:"-"`
-}
-
-type metadataEventInfoMap struct {
-	SDKShapeTraits bool `type:"structure"`
+	_ struct{} `type:"structure"`
 }
 
 // String returns the string representation
@@ -6146,11 +5702,7 @@ type EventSubscription struct {
 	// The list of tags for the event subscription.
 	Tags []*Tag `locationNameList:"Tag" type:"list"`
 
-	metadataEventSubscription `json:"-" xml:"-"`
-}
-
-type metadataEventSubscription struct {
-	SDKShapeTraits bool `type:"structure"`
+	_ struct{} `type:"structure"`
 }
 
 // String returns the string representation
@@ -6177,11 +5729,7 @@ type HsmClientCertificate struct {
 	// The list of tags for the HSM client certificate.
 	Tags []*Tag `locationNameList:"Tag" type:"list"`
 
-	metadataHsmClientCertificate `json:"-" xml:"-"`
-}
-
-type metadataHsmClientCertificate struct {
-	SDKShapeTraits bool `type:"structure"`
+	_ struct{} `type:"structure"`
 }
 
 // String returns the string representation
@@ -6214,11 +5762,7 @@ type HsmConfiguration struct {
 	// The list of tags for the HSM configuration.
 	Tags []*Tag `locationNameList:"Tag" type:"list"`
 
-	metadataHsmConfiguration `json:"-" xml:"-"`
-}
-
-type metadataHsmConfiguration struct {
-	SDKShapeTraits bool `type:"structure"`
+	_ struct{} `type:"structure"`
 }
 
 // String returns the string representation
@@ -6246,11 +5790,7 @@ type HsmStatus struct {
 	// Values: active, applying
 	Status *string `type:"string"`
 
-	metadataHsmStatus `json:"-" xml:"-"`
-}
-
-type metadataHsmStatus struct {
-	SDKShapeTraits bool `type:"structure"`
+	_ struct{} `type:"structure"`
 }
 
 // String returns the string representation
@@ -6274,11 +5814,7 @@ type IPRange struct {
 	// The list of tags for the IP range.
 	Tags []*Tag `locationNameList:"Tag" type:"list"`
 
-	metadataIPRange `json:"-" xml:"-"`
-}
-
-type metadataIPRange struct {
-	SDKShapeTraits bool `type:"structure"`
+	_ struct{} `type:"structure"`
 }
 
 // String returns the string representation
@@ -6311,11 +5847,7 @@ type LoggingStatus struct {
 	// The prefix applied to the log file names.
 	S3KeyPrefix *string `type:"string"`
 
-	metadataLoggingStatus `json:"-" xml:"-"`
-}
-
-type metadataLoggingStatus struct {
-	SDKShapeTraits bool `type:"structure"`
+	_ struct{} `type:"structure"`
 }
 
 // String returns the string representation
@@ -6484,11 +6016,7 @@ type ModifyClusterInput struct {
 	// the cluster.
 	VpcSecurityGroupIds []*string `locationNameList:"VpcSecurityGroupId" type:"list"`
 
-	metadataModifyClusterInput `json:"-" xml:"-"`
-}
-
-type metadataModifyClusterInput struct {
-	SDKShapeTraits bool `type:"structure"`
+	_ struct{} `type:"structure"`
 }
 
 // String returns the string representation
@@ -6505,11 +6033,7 @@ type ModifyClusterOutput struct {
 	// Describes a cluster.
 	Cluster *Cluster `type:"structure"`
 
-	metadataModifyClusterOutput `json:"-" xml:"-"`
-}
-
-type metadataModifyClusterOutput struct {
-	SDKShapeTraits bool `type:"structure"`
+	_ struct{} `type:"structure"`
 }
 
 // String returns the string representation
@@ -6536,11 +6060,7 @@ type ModifyClusterParameterGroupInput struct {
 	// name-value pairs in the wlm_json_configuration parameter.
 	Parameters []*Parameter `locationNameList:"Parameter" type:"list" required:"true"`
 
-	metadataModifyClusterParameterGroupInput `json:"-" xml:"-"`
-}
-
-type metadataModifyClusterParameterGroupInput struct {
-	SDKShapeTraits bool `type:"structure"`
+	_ struct{} `type:"structure"`
 }
 
 // String returns the string representation
@@ -6564,11 +6084,7 @@ type ModifyClusterSubnetGroupInput struct {
 	// single request.
 	SubnetIds []*string `locationNameList:"SubnetIdentifier" type:"list" required:"true"`
 
-	metadataModifyClusterSubnetGroupInput `json:"-" xml:"-"`
-}
-
-type metadataModifyClusterSubnetGroupInput struct {
-	SDKShapeTraits bool `type:"structure"`
+	_ struct{} `type:"structure"`
 }
 
 // String returns the string representation
@@ -6585,11 +6101,7 @@ type ModifyClusterSubnetGroupOutput struct {
 	// Describes a subnet group.
 	ClusterSubnetGroup *ClusterSubnetGroup `type:"structure"`
 
-	metadataModifyClusterSubnetGroupOutput `json:"-" xml:"-"`
-}
-
-type metadataModifyClusterSubnetGroupOutput struct {
-	SDKShapeTraits bool `type:"structure"`
+	_ struct{} `type:"structure"`
 }
 
 // String returns the string representation
@@ -6647,11 +6159,7 @@ type ModifyEventSubscriptionInput struct {
 	// The name of the modified Amazon Redshift event notification subscription.
 	SubscriptionName *string `type:"string" required:"true"`
 
-	metadataModifyEventSubscriptionInput `json:"-" xml:"-"`
-}
-
-type metadataModifyEventSubscriptionInput struct {
-	SDKShapeTraits bool `type:"structure"`
+	_ struct{} `type:"structure"`
 }
 
 // String returns the string representation
@@ -6667,11 +6175,7 @@ func (s ModifyEventSubscriptionInput) GoString() string {
 type ModifyEventSubscriptionOutput struct {
 	EventSubscription *EventSubscription `type:"structure"`
 
-	metadataModifyEventSubscriptionOutput `json:"-" xml:"-"`
-}
-
-type metadataModifyEventSubscriptionOutput struct {
-	SDKShapeTraits bool `type:"structure"`
+	_ struct{} `type:"structure"`
 }
 
 // String returns the string representation
@@ -6703,11 +6207,7 @@ type ModifySnapshotCopyRetentionPeriodInput struct {
 	//  Constraints: Must be at least 1 and no more than 35.
 	RetentionPeriod *int64 `type:"integer" required:"true"`
 
-	metadataModifySnapshotCopyRetentionPeriodInput `json:"-" xml:"-"`
-}
-
-type metadataModifySnapshotCopyRetentionPeriodInput struct {
-	SDKShapeTraits bool `type:"structure"`
+	_ struct{} `type:"structure"`
 }
 
 // String returns the string representation
@@ -6724,11 +6224,7 @@ type ModifySnapshotCopyRetentionPeriodOutput struct {
 	// Describes a cluster.
 	Cluster *Cluster `type:"structure"`
 
-	metadataModifySnapshotCopyRetentionPeriodOutput `json:"-" xml:"-"`
-}
-
-type metadataModifySnapshotCopyRetentionPeriodOutput struct {
-	SDKShapeTraits bool `type:"structure"`
+	_ struct{} `type:"structure"`
 }
 
 // String returns the string representation
@@ -6755,11 +6251,7 @@ type OrderableClusterOption struct {
 	// The node type for the orderable cluster.
 	NodeType *string `type:"string"`
 
-	metadataOrderableClusterOption `json:"-" xml:"-"`
-}
-
-type metadataOrderableClusterOption struct {
-	SDKShapeTraits bool `type:"structure"`
+	_ struct{} `type:"structure"`
 }
 
 // String returns the string representation
@@ -6802,11 +6294,7 @@ type Parameter struct {
 	// The source of the parameter value, such as "engine-default" or "user".
 	Source *string `type:"string"`
 
-	metadataParameter `json:"-" xml:"-"`
-}
-
-type metadataParameter struct {
-	SDKShapeTraits bool `type:"structure"`
+	_ struct{} `type:"structure"`
 }
 
 // String returns the string representation
@@ -6843,11 +6331,7 @@ type PendingModifiedValues struct {
 	// The pending or in-progress change of the number of nodes in the cluster.
 	NumberOfNodes *int64 `type:"integer"`
 
-	metadataPendingModifiedValues `json:"-" xml:"-"`
-}
-
-type metadataPendingModifiedValues struct {
-	SDKShapeTraits bool `type:"structure"`
+	_ struct{} `type:"structure"`
 }
 
 // String returns the string representation
@@ -6869,11 +6353,7 @@ type PurchaseReservedNodeOfferingInput struct {
 	// The unique identifier of the reserved node offering you want to purchase.
 	ReservedNodeOfferingId *string `type:"string" required:"true"`
 
-	metadataPurchaseReservedNodeOfferingInput `json:"-" xml:"-"`
-}
-
-type metadataPurchaseReservedNodeOfferingInput struct {
-	SDKShapeTraits bool `type:"structure"`
+	_ struct{} `type:"structure"`
 }
 
 // String returns the string representation
@@ -6891,11 +6371,7 @@ type PurchaseReservedNodeOfferingOutput struct {
 	// API to obtain the available reserved node offerings.
 	ReservedNode *ReservedNode `type:"structure"`
 
-	metadataPurchaseReservedNodeOfferingOutput `json:"-" xml:"-"`
-}
-
-type metadataPurchaseReservedNodeOfferingOutput struct {
-	SDKShapeTraits bool `type:"structure"`
+	_ struct{} `type:"structure"`
 }
 
 // String returns the string representation
@@ -6912,11 +6388,7 @@ type RebootClusterInput struct {
 	// The cluster identifier.
 	ClusterIdentifier *string `type:"string" required:"true"`
 
-	metadataRebootClusterInput `json:"-" xml:"-"`
-}
-
-type metadataRebootClusterInput struct {
-	SDKShapeTraits bool `type:"structure"`
+	_ struct{} `type:"structure"`
 }
 
 // String returns the string representation
@@ -6933,11 +6405,7 @@ type RebootClusterOutput struct {
 	// Describes a cluster.
 	Cluster *Cluster `type:"structure"`
 
-	metadataRebootClusterOutput `json:"-" xml:"-"`
-}
-
-type metadataRebootClusterOutput struct {
-	SDKShapeTraits bool `type:"structure"`
+	_ struct{} `type:"structure"`
 }
 
 // String returns the string representation
@@ -6959,11 +6427,7 @@ type RecurringCharge struct {
 	// The frequency at which the recurring charge amount is applied.
 	RecurringChargeFrequency *string `type:"string"`
 
-	metadataRecurringCharge `json:"-" xml:"-"`
-}
-
-type metadataRecurringCharge struct {
-	SDKShapeTraits bool `type:"structure"`
+	_ struct{} `type:"structure"`
 }
 
 // String returns the string representation
@@ -7024,11 +6488,7 @@ type ReservedNode struct {
 	// The hourly rate Amazon Redshift charges you for this reserved node.
 	UsagePrice *float64 `type:"double"`
 
-	metadataReservedNode `json:"-" xml:"-"`
-}
-
-type metadataReservedNode struct {
-	SDKShapeTraits bool `type:"structure"`
+	_ struct{} `type:"structure"`
 }
 
 // String returns the string representation
@@ -7072,11 +6532,7 @@ type ReservedNodeOffering struct {
 	// is running.
 	UsagePrice *float64 `type:"double"`
 
-	metadataReservedNodeOffering `json:"-" xml:"-"`
-}
-
-type metadataReservedNodeOffering struct {
-	SDKShapeTraits bool `type:"structure"`
+	_ struct{} `type:"structure"`
 }
 
 // String returns the string representation
@@ -7105,11 +6561,7 @@ type ResetClusterParameterGroupInput struct {
 	// Default: true
 	ResetAllParameters *bool `type:"boolean"`
 
-	metadataResetClusterParameterGroupInput `json:"-" xml:"-"`
-}
-
-type metadataResetClusterParameterGroupInput struct {
-	SDKShapeTraits bool `type:"structure"`
+	_ struct{} `type:"structure"`
 }
 
 // String returns the string representation
@@ -7258,11 +6710,7 @@ type RestoreFromClusterSnapshotInput struct {
 	//  VPC security groups only apply to clusters in VPCs.
 	VpcSecurityGroupIds []*string `locationNameList:"VpcSecurityGroupId" type:"list"`
 
-	metadataRestoreFromClusterSnapshotInput `json:"-" xml:"-"`
-}
-
-type metadataRestoreFromClusterSnapshotInput struct {
-	SDKShapeTraits bool `type:"structure"`
+	_ struct{} `type:"structure"`
 }
 
 // String returns the string representation
@@ -7279,11 +6727,7 @@ type RestoreFromClusterSnapshotOutput struct {
 	// Describes a cluster.
 	Cluster *Cluster `type:"structure"`
 
-	metadataRestoreFromClusterSnapshotOutput `json:"-" xml:"-"`
-}
-
-type metadataRestoreFromClusterSnapshotOutput struct {
-	SDKShapeTraits bool `type:"structure"`
+	_ struct{} `type:"structure"`
 }
 
 // String returns the string representation
@@ -7321,11 +6765,7 @@ type RestoreStatus struct {
 	// or failed.
 	Status *string `type:"string"`
 
-	metadataRestoreStatus `json:"-" xml:"-"`
-}
-
-type metadataRestoreStatus struct {
-	SDKShapeTraits bool `type:"structure"`
+	_ struct{} `type:"structure"`
 }
 
 // String returns the string representation
@@ -7361,11 +6801,7 @@ type RevokeClusterSecurityGroupIngressInput struct {
 	// Example: 111122223333
 	EC2SecurityGroupOwnerId *string `type:"string"`
 
-	metadataRevokeClusterSecurityGroupIngressInput `json:"-" xml:"-"`
-}
-
-type metadataRevokeClusterSecurityGroupIngressInput struct {
-	SDKShapeTraits bool `type:"structure"`
+	_ struct{} `type:"structure"`
 }
 
 // String returns the string representation
@@ -7382,11 +6818,7 @@ type RevokeClusterSecurityGroupIngressOutput struct {
 	// Describes a security group.
 	ClusterSecurityGroup *ClusterSecurityGroup `type:"structure"`
 
-	metadataRevokeClusterSecurityGroupIngressOutput `json:"-" xml:"-"`
-}
-
-type metadataRevokeClusterSecurityGroupIngressOutput struct {
-	SDKShapeTraits bool `type:"structure"`
+	_ struct{} `type:"structure"`
 }
 
 // String returns the string representation
@@ -7412,11 +6844,7 @@ type RevokeSnapshotAccessInput struct {
 	// The identifier of the snapshot that the account can no longer access.
 	SnapshotIdentifier *string `type:"string" required:"true"`
 
-	metadataRevokeSnapshotAccessInput `json:"-" xml:"-"`
-}
-
-type metadataRevokeSnapshotAccessInput struct {
-	SDKShapeTraits bool `type:"structure"`
+	_ struct{} `type:"structure"`
 }
 
 // String returns the string representation
@@ -7433,11 +6861,7 @@ type RevokeSnapshotAccessOutput struct {
 	// Describes a snapshot.
 	Snapshot *Snapshot `type:"structure"`
 
-	metadataRevokeSnapshotAccessOutput `json:"-" xml:"-"`
-}
-
-type metadataRevokeSnapshotAccessOutput struct {
-	SDKShapeTraits bool `type:"structure"`
+	_ struct{} `type:"structure"`
 }
 
 // String returns the string representation
@@ -7457,11 +6881,7 @@ type RotateEncryptionKeyInput struct {
 	//  Constraints: Must be the name of valid cluster that has encryption enabled.
 	ClusterIdentifier *string `type:"string" required:"true"`
 
-	metadataRotateEncryptionKeyInput `json:"-" xml:"-"`
-}
-
-type metadataRotateEncryptionKeyInput struct {
-	SDKShapeTraits bool `type:"structure"`
+	_ struct{} `type:"structure"`
 }
 
 // String returns the string representation
@@ -7478,11 +6898,7 @@ type RotateEncryptionKeyOutput struct {
 	// Describes a cluster.
 	Cluster *Cluster `type:"structure"`
 
-	metadataRotateEncryptionKeyOutput `json:"-" xml:"-"`
-}
-
-type metadataRotateEncryptionKeyOutput struct {
-	SDKShapeTraits bool `type:"structure"`
+	_ struct{} `type:"structure"`
 }
 
 // String returns the string representation
@@ -7597,11 +7013,7 @@ type Snapshot struct {
 	// VPC. Otherwise, this field is not in the output.
 	VpcId *string `type:"string"`
 
-	metadataSnapshot `json:"-" xml:"-"`
-}
-
-type metadataSnapshot struct {
-	SDKShapeTraits bool `type:"structure"`
+	_ struct{} `type:"structure"`
 }
 
 // String returns the string representation
@@ -7632,11 +7044,7 @@ type SnapshotCopyGrant struct {
 	// A list of tag instances.
 	Tags []*Tag `locationNameList:"Tag" type:"list"`
 
-	metadataSnapshotCopyGrant `json:"-" xml:"-"`
-}
-
-type metadataSnapshotCopyGrant struct {
-	SDKShapeTraits bool `type:"structure"`
+	_ struct{} `type:"structure"`
 }
 
 // String returns the string representation
@@ -7660,11 +7068,7 @@ type Subnet struct {
 	// The status of the subnet.
 	SubnetStatus *string `type:"string"`
 
-	metadataSubnet `json:"-" xml:"-"`
-}
-
-type metadataSubnet struct {
-	SDKShapeTraits bool `type:"structure"`
+	_ struct{} `type:"structure"`
 }
 
 // String returns the string representation
@@ -7685,11 +7089,7 @@ type Tag struct {
 	// The value for the resource tag.
 	Value *string `type:"string"`
 
-	metadataTag `json:"-" xml:"-"`
-}
-
-type metadataTag struct {
-	SDKShapeTraits bool `type:"structure"`
+	_ struct{} `type:"structure"`
 }
 
 // String returns the string representation
@@ -7720,11 +7120,7 @@ type TaggedResource struct {
 	// The tag for the resource.
 	Tag *Tag `type:"structure"`
 
-	metadataTaggedResource `json:"-" xml:"-"`
-}
-
-type metadataTaggedResource struct {
-	SDKShapeTraits bool `type:"structure"`
+	_ struct{} `type:"structure"`
 }
 
 // String returns the string representation
@@ -7743,11 +7139,7 @@ type VpcSecurityGroupMembership struct {
 
 	VpcSecurityGroupId *string `type:"string"`
 
-	metadataVpcSecurityGroupMembership `json:"-" xml:"-"`
-}
-
-type metadataVpcSecurityGroupMembership struct {
-	SDKShapeTraits bool `type:"structure"`
+	_ struct{} `type:"structure"`
 }
 
 // String returns the string representation

--- a/service/redshift/api.go
+++ b/service/redshift/api.go
@@ -2194,10 +2194,10 @@ func (c *Redshift) RotateEncryptionKey(input *RotateEncryptionKeyInput) (*Rotate
 
 // Describes an AWS customer account authorized to restore a snapshot.
 type AccountWithRestoreAccess struct {
+	_ struct{} `type:"structure"`
+
 	// The identifier of an AWS customer account authorized to restore a snapshot.
 	AccountId *string `type:"string"`
-
-	_ struct{} `type:"structure"`
 }
 
 // String returns the string representation
@@ -2212,6 +2212,8 @@ func (s AccountWithRestoreAccess) GoString() string {
 
 // ???
 type AuthorizeClusterSecurityGroupIngressInput struct {
+	_ struct{} `type:"structure"`
+
 	// The IP range to be added the Amazon Redshift security group.
 	CIDRIP *string `type:"string"`
 
@@ -2227,8 +2229,6 @@ type AuthorizeClusterSecurityGroupIngressInput struct {
 	//
 	//  Example: 111122223333
 	EC2SecurityGroupOwnerId *string `type:"string"`
-
-	_ struct{} `type:"structure"`
 }
 
 // String returns the string representation
@@ -2242,10 +2242,10 @@ func (s AuthorizeClusterSecurityGroupIngressInput) GoString() string {
 }
 
 type AuthorizeClusterSecurityGroupIngressOutput struct {
+	_ struct{} `type:"structure"`
+
 	// Describes a security group.
 	ClusterSecurityGroup *ClusterSecurityGroup `type:"structure"`
-
-	_ struct{} `type:"structure"`
 }
 
 // String returns the string representation
@@ -2259,6 +2259,8 @@ func (s AuthorizeClusterSecurityGroupIngressOutput) GoString() string {
 }
 
 type AuthorizeSnapshotAccessInput struct {
+	_ struct{} `type:"structure"`
+
 	// The identifier of the AWS customer account authorized to restore the specified
 	// snapshot.
 	AccountWithRestoreAccess *string `type:"string" required:"true"`
@@ -2270,8 +2272,6 @@ type AuthorizeSnapshotAccessInput struct {
 
 	// The identifier of the snapshot the account is authorized to restore.
 	SnapshotIdentifier *string `type:"string" required:"true"`
-
-	_ struct{} `type:"structure"`
 }
 
 // String returns the string representation
@@ -2285,10 +2285,10 @@ func (s AuthorizeSnapshotAccessInput) GoString() string {
 }
 
 type AuthorizeSnapshotAccessOutput struct {
+	_ struct{} `type:"structure"`
+
 	// Describes a snapshot.
 	Snapshot *Snapshot `type:"structure"`
-
-	_ struct{} `type:"structure"`
 }
 
 // String returns the string representation
@@ -2303,10 +2303,10 @@ func (s AuthorizeSnapshotAccessOutput) GoString() string {
 
 // Describes an availability zone.
 type AvailabilityZone struct {
+	_ struct{} `type:"structure"`
+
 	// The name of the availability zone.
 	Name *string `type:"string"`
-
-	_ struct{} `type:"structure"`
 }
 
 // String returns the string representation
@@ -2321,6 +2321,8 @@ func (s AvailabilityZone) GoString() string {
 
 // Describes a cluster.
 type Cluster struct {
+	_ struct{} `type:"structure"`
+
 	// If true, major version upgrades will be applied automatically to the cluster
 	// during the maintenance window.
 	AllowVersionUpgrade *bool `type:"boolean"`
@@ -2435,8 +2437,6 @@ type Cluster struct {
 	// with the cluster. This parameter is returned only if the cluster is in a
 	// VPC.
 	VpcSecurityGroups []*VpcSecurityGroupMembership `locationNameList:"VpcSecurityGroup" type:"list"`
-
-	_ struct{} `type:"structure"`
 }
 
 // String returns the string representation
@@ -2451,6 +2451,8 @@ func (s Cluster) GoString() string {
 
 // The identifier of a node in a cluster.
 type ClusterNode struct {
+	_ struct{} `type:"structure"`
+
 	// Whether the node is a leader node or a compute node.
 	NodeRole *string `type:"string"`
 
@@ -2459,8 +2461,6 @@ type ClusterNode struct {
 
 	// The public IP address of a node within a cluster.
 	PublicIPAddress *string `type:"string"`
-
-	_ struct{} `type:"structure"`
 }
 
 // String returns the string representation
@@ -2475,6 +2475,8 @@ func (s ClusterNode) GoString() string {
 
 // Describes a parameter group.
 type ClusterParameterGroup struct {
+	_ struct{} `type:"structure"`
+
 	// The description of the parameter group.
 	Description *string `type:"string"`
 
@@ -2487,8 +2489,6 @@ type ClusterParameterGroup struct {
 
 	// The list of tags for the cluster parameter group.
 	Tags []*Tag `locationNameList:"Tag" type:"list"`
-
-	_ struct{} `type:"structure"`
 }
 
 // String returns the string representation
@@ -2505,6 +2505,8 @@ func (s ClusterParameterGroup) GoString() string {
 // actions and indicate the parameter group involved and the status of the operation
 // on the parameter group.
 type ClusterParameterGroupNameMessage struct {
+	_ struct{} `type:"structure"`
+
 	// The name of the cluster parameter group.
 	ParameterGroupName *string `type:"string"`
 
@@ -2512,8 +2514,6 @@ type ClusterParameterGroupNameMessage struct {
 	// parameter group name-value pair, then the change could be pending a reboot
 	// of an associated cluster.
 	ParameterGroupStatus *string `type:"string"`
-
-	_ struct{} `type:"structure"`
 }
 
 // String returns the string representation
@@ -2528,6 +2528,8 @@ func (s ClusterParameterGroupNameMessage) GoString() string {
 
 // Describes the status of a parameter group.
 type ClusterParameterGroupStatus struct {
+	_ struct{} `type:"structure"`
+
 	// The list of parameter statuses.
 	//
 	//  For more information about parameters and parameter groups, go to Amazon
@@ -2540,8 +2542,6 @@ type ClusterParameterGroupStatus struct {
 
 	// The name of the cluster parameter group.
 	ParameterGroupName *string `type:"string"`
-
-	_ struct{} `type:"structure"`
 }
 
 // String returns the string representation
@@ -2556,6 +2556,8 @@ func (s ClusterParameterGroupStatus) GoString() string {
 
 // Describes the status of a parameter group.
 type ClusterParameterStatus struct {
+	_ struct{} `type:"structure"`
+
 	// The error that prevented the parameter from being applied to the database.
 	ParameterApplyErrorDescription *string `type:"string"`
 
@@ -2577,8 +2579,6 @@ type ClusterParameterStatus struct {
 
 	// The name of the parameter.
 	ParameterName *string `type:"string"`
-
-	_ struct{} `type:"structure"`
 }
 
 // String returns the string representation
@@ -2593,6 +2593,8 @@ func (s ClusterParameterStatus) GoString() string {
 
 // Describes a security group.
 type ClusterSecurityGroup struct {
+	_ struct{} `type:"structure"`
+
 	// The name of the cluster security group to which the operation was applied.
 	ClusterSecurityGroupName *string `type:"string"`
 
@@ -2609,8 +2611,6 @@ type ClusterSecurityGroup struct {
 
 	// The list of tags for the cluster security group.
 	Tags []*Tag `locationNameList:"Tag" type:"list"`
-
-	_ struct{} `type:"structure"`
 }
 
 // String returns the string representation
@@ -2625,13 +2625,13 @@ func (s ClusterSecurityGroup) GoString() string {
 
 // Describes a security group.
 type ClusterSecurityGroupMembership struct {
+	_ struct{} `type:"structure"`
+
 	// The name of the cluster security group.
 	ClusterSecurityGroupName *string `type:"string"`
 
 	// The status of the cluster security group.
 	Status *string `type:"string"`
-
-	_ struct{} `type:"structure"`
 }
 
 // String returns the string representation
@@ -2647,6 +2647,8 @@ func (s ClusterSecurityGroupMembership) GoString() string {
 // Returns the destination region and retention period that are configured for
 // cross-region snapshot copy.
 type ClusterSnapshotCopyStatus struct {
+	_ struct{} `type:"structure"`
+
 	// The destination region that snapshots are automatically copied to when cross-region
 	// snapshot copy is enabled.
 	DestinationRegion *string `type:"string"`
@@ -2657,8 +2659,6 @@ type ClusterSnapshotCopyStatus struct {
 
 	// The name of the snapshot copy grant.
 	SnapshotCopyGrantName *string `type:"string"`
-
-	_ struct{} `type:"structure"`
 }
 
 // String returns the string representation
@@ -2673,6 +2673,8 @@ func (s ClusterSnapshotCopyStatus) GoString() string {
 
 // Describes a subnet group.
 type ClusterSubnetGroup struct {
+	_ struct{} `type:"structure"`
+
 	// The name of the cluster subnet group.
 	ClusterSubnetGroupName *string `type:"string"`
 
@@ -2691,8 +2693,6 @@ type ClusterSubnetGroup struct {
 
 	// The VPC ID of the cluster subnet group.
 	VpcId *string `type:"string"`
-
-	_ struct{} `type:"structure"`
 }
 
 // String returns the string representation
@@ -2708,6 +2708,8 @@ func (s ClusterSubnetGroup) GoString() string {
 // Describes a cluster version, including the parameter group family and description
 // of the version.
 type ClusterVersion struct {
+	_ struct{} `type:"structure"`
+
 	// The name of the cluster parameter group family for the cluster.
 	ClusterParameterGroupFamily *string `type:"string"`
 
@@ -2716,8 +2718,6 @@ type ClusterVersion struct {
 
 	// The description of the cluster version.
 	Description *string `type:"string"`
-
-	_ struct{} `type:"structure"`
 }
 
 // String returns the string representation
@@ -2731,6 +2731,8 @@ func (s ClusterVersion) GoString() string {
 }
 
 type CopyClusterSnapshotInput struct {
+	_ struct{} `type:"structure"`
+
 	// The identifier of the cluster the source snapshot was created from. This
 	// parameter is required if your IAM user has a policy containing a snapshot
 	// resource element that specifies anything other than * for the cluster name.
@@ -2756,8 +2758,6 @@ type CopyClusterSnapshotInput struct {
 	// a hyphen or contain two consecutive hyphens. Must be unique for the AWS account
 	// that is making the request.
 	TargetSnapshotIdentifier *string `type:"string" required:"true"`
-
-	_ struct{} `type:"structure"`
 }
 
 // String returns the string representation
@@ -2771,10 +2771,10 @@ func (s CopyClusterSnapshotInput) GoString() string {
 }
 
 type CopyClusterSnapshotOutput struct {
+	_ struct{} `type:"structure"`
+
 	// Describes a snapshot.
 	Snapshot *Snapshot `type:"structure"`
-
-	_ struct{} `type:"structure"`
 }
 
 // String returns the string representation
@@ -2788,6 +2788,8 @@ func (s CopyClusterSnapshotOutput) GoString() string {
 }
 
 type CreateClusterInput struct {
+	_ struct{} `type:"structure"`
+
 	// If true, major version upgrades can be applied during the maintenance window
 	// to the Amazon Redshift engine that is running on the cluster.
 	//
@@ -3000,8 +3002,6 @@ type CreateClusterInput struct {
 	//
 	// Default: The default VPC security group is associated with the cluster.
 	VpcSecurityGroupIds []*string `locationNameList:"VpcSecurityGroupId" type:"list"`
-
-	_ struct{} `type:"structure"`
 }
 
 // String returns the string representation
@@ -3015,10 +3015,10 @@ func (s CreateClusterInput) GoString() string {
 }
 
 type CreateClusterOutput struct {
+	_ struct{} `type:"structure"`
+
 	// Describes a cluster.
 	Cluster *Cluster `type:"structure"`
-
-	_ struct{} `type:"structure"`
 }
 
 // String returns the string representation
@@ -3032,6 +3032,8 @@ func (s CreateClusterOutput) GoString() string {
 }
 
 type CreateClusterParameterGroupInput struct {
+	_ struct{} `type:"structure"`
+
 	// A description of the parameter group.
 	Description *string `type:"string" required:"true"`
 
@@ -3058,8 +3060,6 @@ type CreateClusterParameterGroupInput struct {
 
 	// A list of tag instances.
 	Tags []*Tag `locationNameList:"Tag" type:"list"`
-
-	_ struct{} `type:"structure"`
 }
 
 // String returns the string representation
@@ -3073,10 +3073,10 @@ func (s CreateClusterParameterGroupInput) GoString() string {
 }
 
 type CreateClusterParameterGroupOutput struct {
+	_ struct{} `type:"structure"`
+
 	// Describes a parameter group.
 	ClusterParameterGroup *ClusterParameterGroup `type:"structure"`
-
-	_ struct{} `type:"structure"`
 }
 
 // String returns the string representation
@@ -3091,6 +3091,8 @@ func (s CreateClusterParameterGroupOutput) GoString() string {
 
 // ???
 type CreateClusterSecurityGroupInput struct {
+	_ struct{} `type:"structure"`
+
 	// The name for the security group. Amazon Redshift stores the value as a lowercase
 	// string.
 	//
@@ -3106,8 +3108,6 @@ type CreateClusterSecurityGroupInput struct {
 
 	// A list of tag instances.
 	Tags []*Tag `locationNameList:"Tag" type:"list"`
-
-	_ struct{} `type:"structure"`
 }
 
 // String returns the string representation
@@ -3121,10 +3121,10 @@ func (s CreateClusterSecurityGroupInput) GoString() string {
 }
 
 type CreateClusterSecurityGroupOutput struct {
+	_ struct{} `type:"structure"`
+
 	// Describes a security group.
 	ClusterSecurityGroup *ClusterSecurityGroup `type:"structure"`
-
-	_ struct{} `type:"structure"`
 }
 
 // String returns the string representation
@@ -3138,6 +3138,8 @@ func (s CreateClusterSecurityGroupOutput) GoString() string {
 }
 
 type CreateClusterSnapshotInput struct {
+	_ struct{} `type:"structure"`
+
 	// The cluster identifier for which you want a snapshot.
 	ClusterIdentifier *string `type:"string" required:"true"`
 
@@ -3153,8 +3155,6 @@ type CreateClusterSnapshotInput struct {
 
 	// A list of tag instances.
 	Tags []*Tag `locationNameList:"Tag" type:"list"`
-
-	_ struct{} `type:"structure"`
 }
 
 // String returns the string representation
@@ -3168,10 +3168,10 @@ func (s CreateClusterSnapshotInput) GoString() string {
 }
 
 type CreateClusterSnapshotOutput struct {
+	_ struct{} `type:"structure"`
+
 	// Describes a snapshot.
 	Snapshot *Snapshot `type:"structure"`
-
-	_ struct{} `type:"structure"`
 }
 
 // String returns the string representation
@@ -3185,6 +3185,8 @@ func (s CreateClusterSnapshotOutput) GoString() string {
 }
 
 type CreateClusterSubnetGroupInput struct {
+	_ struct{} `type:"structure"`
+
 	// The name for the subnet group. Amazon Redshift stores the value as a lowercase
 	// string.
 	//
@@ -3204,8 +3206,6 @@ type CreateClusterSubnetGroupInput struct {
 
 	// A list of tag instances.
 	Tags []*Tag `locationNameList:"Tag" type:"list"`
-
-	_ struct{} `type:"structure"`
 }
 
 // String returns the string representation
@@ -3219,10 +3219,10 @@ func (s CreateClusterSubnetGroupInput) GoString() string {
 }
 
 type CreateClusterSubnetGroupOutput struct {
+	_ struct{} `type:"structure"`
+
 	// Describes a subnet group.
 	ClusterSubnetGroup *ClusterSubnetGroup `type:"structure"`
-
-	_ struct{} `type:"structure"`
 }
 
 // String returns the string representation
@@ -3236,6 +3236,8 @@ func (s CreateClusterSubnetGroupOutput) GoString() string {
 }
 
 type CreateEventSubscriptionInput struct {
+	_ struct{} `type:"structure"`
+
 	// A Boolean value; set to true to activate the subscription, set to false to
 	// create the subscription but not active it.
 	Enabled *bool `type:"boolean"`
@@ -3289,8 +3291,6 @@ type CreateEventSubscriptionInput struct {
 
 	// A list of tag instances.
 	Tags []*Tag `locationNameList:"Tag" type:"list"`
-
-	_ struct{} `type:"structure"`
 }
 
 // String returns the string representation
@@ -3304,9 +3304,9 @@ func (s CreateEventSubscriptionInput) GoString() string {
 }
 
 type CreateEventSubscriptionOutput struct {
-	EventSubscription *EventSubscription `type:"structure"`
-
 	_ struct{} `type:"structure"`
+
+	EventSubscription *EventSubscription `type:"structure"`
 }
 
 // String returns the string representation
@@ -3320,14 +3320,14 @@ func (s CreateEventSubscriptionOutput) GoString() string {
 }
 
 type CreateHsmClientCertificateInput struct {
+	_ struct{} `type:"structure"`
+
 	// The identifier to be assigned to the new HSM client certificate that the
 	// cluster will use to connect to the HSM to use the database encryption keys.
 	HsmClientCertificateIdentifier *string `type:"string" required:"true"`
 
 	// A list of tag instances.
 	Tags []*Tag `locationNameList:"Tag" type:"list"`
-
-	_ struct{} `type:"structure"`
 }
 
 // String returns the string representation
@@ -3341,12 +3341,12 @@ func (s CreateHsmClientCertificateInput) GoString() string {
 }
 
 type CreateHsmClientCertificateOutput struct {
+	_ struct{} `type:"structure"`
+
 	// Returns information about an HSM client certificate. The certificate is stored
 	// in a secure Hardware Storage Module (HSM), and used by the Amazon Redshift
 	// cluster to encrypt data files.
 	HsmClientCertificate *HsmClientCertificate `type:"structure"`
-
-	_ struct{} `type:"structure"`
 }
 
 // String returns the string representation
@@ -3360,6 +3360,8 @@ func (s CreateHsmClientCertificateOutput) GoString() string {
 }
 
 type CreateHsmConfigurationInput struct {
+	_ struct{} `type:"structure"`
+
 	// A text description of the HSM configuration to be created.
 	Description *string `type:"string" required:"true"`
 
@@ -3382,8 +3384,6 @@ type CreateHsmConfigurationInput struct {
 
 	// A list of tag instances.
 	Tags []*Tag `locationNameList:"Tag" type:"list"`
-
-	_ struct{} `type:"structure"`
 }
 
 // String returns the string representation
@@ -3397,12 +3397,12 @@ func (s CreateHsmConfigurationInput) GoString() string {
 }
 
 type CreateHsmConfigurationOutput struct {
+	_ struct{} `type:"structure"`
+
 	// Returns information about an HSM configuration, which is an object that describes
 	// to Amazon Redshift clusters the information they require to connect to an
 	// HSM where they can store database encryption keys.
 	HsmConfiguration *HsmConfiguration `type:"structure"`
-
-	_ struct{} `type:"structure"`
 }
 
 // String returns the string representation
@@ -3417,6 +3417,8 @@ func (s CreateHsmConfigurationOutput) GoString() string {
 
 // The result of the CreateSnapshotCopyGrant action.
 type CreateSnapshotCopyGrantInput struct {
+	_ struct{} `type:"structure"`
+
 	// The unique identifier of the customer master key (CMK) to which to grant
 	// Amazon Redshift permission. If no key is specified, the default key is used.
 	KmsKeyId *string `type:"string"`
@@ -3434,8 +3436,6 @@ type CreateSnapshotCopyGrantInput struct {
 
 	// A list of tag instances.
 	Tags []*Tag `locationNameList:"Tag" type:"list"`
-
-	_ struct{} `type:"structure"`
 }
 
 // String returns the string representation
@@ -3449,6 +3449,8 @@ func (s CreateSnapshotCopyGrantInput) GoString() string {
 }
 
 type CreateSnapshotCopyGrantOutput struct {
+	_ struct{} `type:"structure"`
+
 	// The snapshot copy grant that grants Amazon Redshift permission to encrypt
 	// copied snapshots with the specified customer master key (CMK) from AWS KMS
 	// in the destination region.
@@ -3457,8 +3459,6 @@ type CreateSnapshotCopyGrantOutput struct {
 	// Redshift Database Encryption (http://docs.aws.amazon.com/redshift/latest/mgmt/working-with-db-encryption.html)
 	// in the Amazon Redshift Cluster Management Guide.
 	SnapshotCopyGrant *SnapshotCopyGrant `type:"structure"`
-
-	_ struct{} `type:"structure"`
 }
 
 // String returns the string representation
@@ -3473,6 +3473,8 @@ func (s CreateSnapshotCopyGrantOutput) GoString() string {
 
 // Contains the output from the CreateTags action.
 type CreateTagsInput struct {
+	_ struct{} `type:"structure"`
+
 	// The Amazon Resource Name (ARN) to which you want to add the tag or tags.
 	// For example, arn:aws:redshift:us-east-1:123456789:cluster:t1.
 	ResourceName *string `type:"string" required:"true"`
@@ -3483,8 +3485,6 @@ type CreateTagsInput struct {
 	// by a comma (,). Separate multiple tags with a space. For example, --tags
 	// "Key"="owner","Value"="admin" "Key"="environment","Value"="test" "Key"="version","Value"="1.0".
 	Tags []*Tag `locationNameList:"Tag" type:"list" required:"true"`
-
-	_ struct{} `type:"structure"`
 }
 
 // String returns the string representation
@@ -3513,6 +3513,8 @@ func (s CreateTagsOutput) GoString() string {
 
 // Describes the default cluster parameters for a parameter group family.
 type DefaultClusterParameters struct {
+	_ struct{} `type:"structure"`
+
 	// A value that indicates the starting point for the next set of response records
 	// in a subsequent request. If a value is returned in a response, you can retrieve
 	// the next set of records by providing this returned marker value in the Marker
@@ -3526,8 +3528,6 @@ type DefaultClusterParameters struct {
 
 	// The list of cluster default parameters.
 	Parameters []*Parameter `locationNameList:"Parameter" type:"list"`
-
-	_ struct{} `type:"structure"`
 }
 
 // String returns the string representation
@@ -3541,6 +3541,8 @@ func (s DefaultClusterParameters) GoString() string {
 }
 
 type DeleteClusterInput struct {
+	_ struct{} `type:"structure"`
+
 	// The identifier of the cluster to be deleted.
 	//
 	// Constraints:
@@ -3567,8 +3569,6 @@ type DeleteClusterInput struct {
 	// The FinalClusterSnapshotIdentifier parameter must be specified if SkipFinalClusterSnapshot
 	// is false. Default: false
 	SkipFinalClusterSnapshot *bool `type:"boolean"`
-
-	_ struct{} `type:"structure"`
 }
 
 // String returns the string representation
@@ -3582,10 +3582,10 @@ func (s DeleteClusterInput) GoString() string {
 }
 
 type DeleteClusterOutput struct {
+	_ struct{} `type:"structure"`
+
 	// Describes a cluster.
 	Cluster *Cluster `type:"structure"`
-
-	_ struct{} `type:"structure"`
 }
 
 // String returns the string representation
@@ -3599,6 +3599,8 @@ func (s DeleteClusterOutput) GoString() string {
 }
 
 type DeleteClusterParameterGroupInput struct {
+	_ struct{} `type:"structure"`
+
 	// The name of the parameter group to be deleted.
 	//
 	// Constraints:
@@ -3606,8 +3608,6 @@ type DeleteClusterParameterGroupInput struct {
 	//  Must be the name of an existing cluster parameter group. Cannot delete
 	// a default cluster parameter group.
 	ParameterGroupName *string `type:"string" required:"true"`
-
-	_ struct{} `type:"structure"`
 }
 
 // String returns the string representation
@@ -3635,10 +3635,10 @@ func (s DeleteClusterParameterGroupOutput) GoString() string {
 }
 
 type DeleteClusterSecurityGroupInput struct {
+	_ struct{} `type:"structure"`
+
 	// The name of the cluster security group to be deleted.
 	ClusterSecurityGroupName *string `type:"string" required:"true"`
-
-	_ struct{} `type:"structure"`
 }
 
 // String returns the string representation
@@ -3666,6 +3666,8 @@ func (s DeleteClusterSecurityGroupOutput) GoString() string {
 }
 
 type DeleteClusterSnapshotInput struct {
+	_ struct{} `type:"structure"`
+
 	// The unique identifier of the cluster the snapshot was created from. This
 	// parameter is required if your IAM user has a policy containing a snapshot
 	// resource element that specifies anything other than * for the cluster name.
@@ -3678,8 +3680,6 @@ type DeleteClusterSnapshotInput struct {
 	// Constraints: Must be the name of an existing snapshot that is in the available
 	// state.
 	SnapshotIdentifier *string `type:"string" required:"true"`
-
-	_ struct{} `type:"structure"`
 }
 
 // String returns the string representation
@@ -3693,10 +3693,10 @@ func (s DeleteClusterSnapshotInput) GoString() string {
 }
 
 type DeleteClusterSnapshotOutput struct {
+	_ struct{} `type:"structure"`
+
 	// Describes a snapshot.
 	Snapshot *Snapshot `type:"structure"`
-
-	_ struct{} `type:"structure"`
 }
 
 // String returns the string representation
@@ -3710,10 +3710,10 @@ func (s DeleteClusterSnapshotOutput) GoString() string {
 }
 
 type DeleteClusterSubnetGroupInput struct {
+	_ struct{} `type:"structure"`
+
 	// The name of the cluster subnet group name to be deleted.
 	ClusterSubnetGroupName *string `type:"string" required:"true"`
-
-	_ struct{} `type:"structure"`
 }
 
 // String returns the string representation
@@ -3741,10 +3741,10 @@ func (s DeleteClusterSubnetGroupOutput) GoString() string {
 }
 
 type DeleteEventSubscriptionInput struct {
+	_ struct{} `type:"structure"`
+
 	// The name of the Amazon Redshift event notification subscription to be deleted.
 	SubscriptionName *string `type:"string" required:"true"`
-
-	_ struct{} `type:"structure"`
 }
 
 // String returns the string representation
@@ -3772,10 +3772,10 @@ func (s DeleteEventSubscriptionOutput) GoString() string {
 }
 
 type DeleteHsmClientCertificateInput struct {
+	_ struct{} `type:"structure"`
+
 	// The identifier of the HSM client certificate to be deleted.
 	HsmClientCertificateIdentifier *string `type:"string" required:"true"`
-
-	_ struct{} `type:"structure"`
 }
 
 // String returns the string representation
@@ -3803,10 +3803,10 @@ func (s DeleteHsmClientCertificateOutput) GoString() string {
 }
 
 type DeleteHsmConfigurationInput struct {
+	_ struct{} `type:"structure"`
+
 	// The identifier of the Amazon Redshift HSM configuration to be deleted.
 	HsmConfigurationIdentifier *string `type:"string" required:"true"`
-
-	_ struct{} `type:"structure"`
 }
 
 // String returns the string representation
@@ -3835,10 +3835,10 @@ func (s DeleteHsmConfigurationOutput) GoString() string {
 
 // The result of the DeleteSnapshotCopyGrant action.
 type DeleteSnapshotCopyGrantInput struct {
+	_ struct{} `type:"structure"`
+
 	// The name of the snapshot copy grant to delete.
 	SnapshotCopyGrantName *string `type:"string" required:"true"`
-
-	_ struct{} `type:"structure"`
 }
 
 // String returns the string representation
@@ -3867,14 +3867,14 @@ func (s DeleteSnapshotCopyGrantOutput) GoString() string {
 
 // Contains the output from the DeleteTags action.
 type DeleteTagsInput struct {
+	_ struct{} `type:"structure"`
+
 	// The Amazon Resource Name (ARN) from which you want to remove the tag or tags.
 	// For example, arn:aws:redshift:us-east-1:123456789:cluster:t1.
 	ResourceName *string `type:"string" required:"true"`
 
 	// The tag key that you want to delete.
 	TagKeys []*string `locationNameList:"TagKey" type:"list" required:"true"`
-
-	_ struct{} `type:"structure"`
 }
 
 // String returns the string representation
@@ -3902,6 +3902,8 @@ func (s DeleteTagsOutput) GoString() string {
 }
 
 type DescribeClusterParameterGroupsInput struct {
+	_ struct{} `type:"structure"`
+
 	// An optional parameter that specifies the starting point to return a set of
 	// response records. When the results of a DescribeClusterParameterGroups request
 	// exceed the value specified in MaxRecords, AWS returns a value in the Marker
@@ -3939,8 +3941,6 @@ type DescribeClusterParameterGroupsInput struct {
 	// Redshift returns a response with the parameter groups that have either or
 	// both of these tag values associated with them.
 	TagValues []*string `locationNameList:"TagValue" type:"list"`
-
-	_ struct{} `type:"structure"`
 }
 
 // String returns the string representation
@@ -3955,6 +3955,8 @@ func (s DescribeClusterParameterGroupsInput) GoString() string {
 
 // Contains the output from the DescribeClusterParameterGroups action.
 type DescribeClusterParameterGroupsOutput struct {
+	_ struct{} `type:"structure"`
+
 	// A value that indicates the starting point for the next set of response records
 	// in a subsequent request. If a value is returned in a response, you can retrieve
 	// the next set of records by providing this returned marker value in the Marker
@@ -3965,8 +3967,6 @@ type DescribeClusterParameterGroupsOutput struct {
 	// A list of ClusterParameterGroup instances. Each instance describes one cluster
 	// parameter group.
 	ParameterGroups []*ClusterParameterGroup `locationNameList:"ClusterParameterGroup" type:"list"`
-
-	_ struct{} `type:"structure"`
 }
 
 // String returns the string representation
@@ -3980,6 +3980,8 @@ func (s DescribeClusterParameterGroupsOutput) GoString() string {
 }
 
 type DescribeClusterParametersInput struct {
+	_ struct{} `type:"structure"`
+
 	// An optional parameter that specifies the starting point to return a set of
 	// response records. When the results of a DescribeClusterParameters request
 	// exceed the value specified in MaxRecords, AWS returns a value in the Marker
@@ -4009,8 +4011,6 @@ type DescribeClusterParametersInput struct {
 	//
 	// Valid Values: user | engine-default
 	Source *string `type:"string"`
-
-	_ struct{} `type:"structure"`
 }
 
 // String returns the string representation
@@ -4025,6 +4025,8 @@ func (s DescribeClusterParametersInput) GoString() string {
 
 // Contains the output from the DescribeClusterParameters action.
 type DescribeClusterParametersOutput struct {
+	_ struct{} `type:"structure"`
+
 	// A value that indicates the starting point for the next set of response records
 	// in a subsequent request. If a value is returned in a response, you can retrieve
 	// the next set of records by providing this returned marker value in the Marker
@@ -4035,8 +4037,6 @@ type DescribeClusterParametersOutput struct {
 	// A list of Parameter instances. Each instance lists the parameters of one
 	// cluster parameter group.
 	Parameters []*Parameter `locationNameList:"Parameter" type:"list"`
-
-	_ struct{} `type:"structure"`
 }
 
 // String returns the string representation
@@ -4051,6 +4051,8 @@ func (s DescribeClusterParametersOutput) GoString() string {
 
 // ???
 type DescribeClusterSecurityGroupsInput struct {
+	_ struct{} `type:"structure"`
+
 	// The name of a cluster security group for which you are requesting details.
 	// You can specify either the Marker parameter or a ClusterSecurityGroupName
 	// parameter, but not both.
@@ -4094,8 +4096,6 @@ type DescribeClusterSecurityGroupsInput struct {
 	// Redshift returns a response with the security groups that have either or
 	// both of these tag values associated with them.
 	TagValues []*string `locationNameList:"TagValue" type:"list"`
-
-	_ struct{} `type:"structure"`
 }
 
 // String returns the string representation
@@ -4110,6 +4110,8 @@ func (s DescribeClusterSecurityGroupsInput) GoString() string {
 
 // Contains the output from the DescribeClusterSecurityGroups action.
 type DescribeClusterSecurityGroupsOutput struct {
+	_ struct{} `type:"structure"`
+
 	// A list of ClusterSecurityGroup instances.
 	ClusterSecurityGroups []*ClusterSecurityGroup `locationNameList:"ClusterSecurityGroup" type:"list"`
 
@@ -4119,8 +4121,6 @@ type DescribeClusterSecurityGroupsOutput struct {
 	// parameter and retrying the command. If the Marker field is empty, all response
 	// records have been retrieved for the request.
 	Marker *string `type:"string"`
-
-	_ struct{} `type:"structure"`
 }
 
 // String returns the string representation
@@ -4134,6 +4134,8 @@ func (s DescribeClusterSecurityGroupsOutput) GoString() string {
 }
 
 type DescribeClusterSnapshotsInput struct {
+	_ struct{} `type:"structure"`
+
 	// The identifier of the cluster for which information about snapshots is requested.
 	ClusterIdentifier *string `type:"string"`
 
@@ -4199,8 +4201,6 @@ type DescribeClusterSnapshotsInput struct {
 	// Redshift returns a response with the snapshots that have either or both of
 	// these tag values associated with them.
 	TagValues []*string `locationNameList:"TagValue" type:"list"`
-
-	_ struct{} `type:"structure"`
 }
 
 // String returns the string representation
@@ -4215,6 +4215,8 @@ func (s DescribeClusterSnapshotsInput) GoString() string {
 
 // Contains the output from the DescribeClusterSnapshots action.
 type DescribeClusterSnapshotsOutput struct {
+	_ struct{} `type:"structure"`
+
 	// A value that indicates the starting point for the next set of response records
 	// in a subsequent request. If a value is returned in a response, you can retrieve
 	// the next set of records by providing this returned marker value in the Marker
@@ -4224,8 +4226,6 @@ type DescribeClusterSnapshotsOutput struct {
 
 	// A list of Snapshot instances.
 	Snapshots []*Snapshot `locationNameList:"Snapshot" type:"list"`
-
-	_ struct{} `type:"structure"`
 }
 
 // String returns the string representation
@@ -4239,6 +4239,8 @@ func (s DescribeClusterSnapshotsOutput) GoString() string {
 }
 
 type DescribeClusterSubnetGroupsInput struct {
+	_ struct{} `type:"structure"`
+
 	// The name of the cluster subnet group for which information is requested.
 	ClusterSubnetGroupName *string `type:"string"`
 
@@ -4275,8 +4277,6 @@ type DescribeClusterSubnetGroupsInput struct {
 	// Redshift returns a response with the subnet groups that have either or both
 	// of these tag values associated with them.
 	TagValues []*string `locationNameList:"TagValue" type:"list"`
-
-	_ struct{} `type:"structure"`
 }
 
 // String returns the string representation
@@ -4291,6 +4291,8 @@ func (s DescribeClusterSubnetGroupsInput) GoString() string {
 
 // Contains the output from the DescribeClusterSubnetGroups action.
 type DescribeClusterSubnetGroupsOutput struct {
+	_ struct{} `type:"structure"`
+
 	// A list of ClusterSubnetGroup instances.
 	ClusterSubnetGroups []*ClusterSubnetGroup `locationNameList:"ClusterSubnetGroup" type:"list"`
 
@@ -4300,8 +4302,6 @@ type DescribeClusterSubnetGroupsOutput struct {
 	// parameter and retrying the command. If the Marker field is empty, all response
 	// records have been retrieved for the request.
 	Marker *string `type:"string"`
-
-	_ struct{} `type:"structure"`
 }
 
 // String returns the string representation
@@ -4315,6 +4315,8 @@ func (s DescribeClusterSubnetGroupsOutput) GoString() string {
 }
 
 type DescribeClusterVersionsInput struct {
+	_ struct{} `type:"structure"`
+
 	// The name of a specific cluster parameter group family to return details for.
 	//
 	// Constraints:
@@ -4344,8 +4346,6 @@ type DescribeClusterVersionsInput struct {
 	//
 	// Constraints: minimum 20, maximum 100.
 	MaxRecords *int64 `type:"integer"`
-
-	_ struct{} `type:"structure"`
 }
 
 // String returns the string representation
@@ -4360,6 +4360,8 @@ func (s DescribeClusterVersionsInput) GoString() string {
 
 // Contains the output from the DescribeClusterVersions action.
 type DescribeClusterVersionsOutput struct {
+	_ struct{} `type:"structure"`
+
 	// A list of Version elements.
 	ClusterVersions []*ClusterVersion `locationNameList:"ClusterVersion" type:"list"`
 
@@ -4369,8 +4371,6 @@ type DescribeClusterVersionsOutput struct {
 	// parameter and retrying the command. If the Marker field is empty, all response
 	// records have been retrieved for the request.
 	Marker *string `type:"string"`
-
-	_ struct{} `type:"structure"`
 }
 
 // String returns the string representation
@@ -4384,6 +4384,8 @@ func (s DescribeClusterVersionsOutput) GoString() string {
 }
 
 type DescribeClustersInput struct {
+	_ struct{} `type:"structure"`
+
 	// The unique identifier of a cluster whose properties you are requesting. This
 	// parameter is case sensitive.
 	//
@@ -4425,8 +4427,6 @@ type DescribeClustersInput struct {
 	// returns a response with the clusters that have either or both of these tag
 	// values associated with them.
 	TagValues []*string `locationNameList:"TagValue" type:"list"`
-
-	_ struct{} `type:"structure"`
 }
 
 // String returns the string representation
@@ -4441,6 +4441,8 @@ func (s DescribeClustersInput) GoString() string {
 
 // Contains the output from the DescribeClusters action.
 type DescribeClustersOutput struct {
+	_ struct{} `type:"structure"`
+
 	// A list of Cluster objects, where each object describes one cluster.
 	Clusters []*Cluster `locationNameList:"Cluster" type:"list"`
 
@@ -4450,8 +4452,6 @@ type DescribeClustersOutput struct {
 	// parameter and retrying the command. If the Marker field is empty, all response
 	// records have been retrieved for the request.
 	Marker *string `type:"string"`
-
-	_ struct{} `type:"structure"`
 }
 
 // String returns the string representation
@@ -4465,6 +4465,8 @@ func (s DescribeClustersOutput) GoString() string {
 }
 
 type DescribeDefaultClusterParametersInput struct {
+	_ struct{} `type:"structure"`
+
 	// An optional parameter that specifies the starting point to return a set of
 	// response records. When the results of a DescribeDefaultClusterParameters
 	// request exceed the value specified in MaxRecords, AWS returns a value in
@@ -4485,8 +4487,6 @@ type DescribeDefaultClusterParametersInput struct {
 
 	// The name of the cluster parameter group family.
 	ParameterGroupFamily *string `type:"string" required:"true"`
-
-	_ struct{} `type:"structure"`
 }
 
 // String returns the string representation
@@ -4500,10 +4500,10 @@ func (s DescribeDefaultClusterParametersInput) GoString() string {
 }
 
 type DescribeDefaultClusterParametersOutput struct {
+	_ struct{} `type:"structure"`
+
 	// Describes the default cluster parameters for a parameter group family.
 	DefaultClusterParameters *DefaultClusterParameters `type:"structure"`
-
-	_ struct{} `type:"structure"`
 }
 
 // String returns the string representation
@@ -4517,13 +4517,13 @@ func (s DescribeDefaultClusterParametersOutput) GoString() string {
 }
 
 type DescribeEventCategoriesInput struct {
+	_ struct{} `type:"structure"`
+
 	// The source type, such as cluster or parameter group, to which the described
 	// event categories apply.
 	//
 	//  Valid values: cluster, snapshot, parameter group, and security group.
 	SourceType *string `type:"string"`
-
-	_ struct{} `type:"structure"`
 }
 
 // String returns the string representation
@@ -4537,10 +4537,10 @@ func (s DescribeEventCategoriesInput) GoString() string {
 }
 
 type DescribeEventCategoriesOutput struct {
+	_ struct{} `type:"structure"`
+
 	// A list of event categories descriptions.
 	EventCategoriesMapList []*EventCategoriesMap `locationNameList:"EventCategoriesMap" type:"list"`
-
-	_ struct{} `type:"structure"`
 }
 
 // String returns the string representation
@@ -4554,6 +4554,8 @@ func (s DescribeEventCategoriesOutput) GoString() string {
 }
 
 type DescribeEventSubscriptionsInput struct {
+	_ struct{} `type:"structure"`
+
 	// An optional parameter that specifies the starting point to return a set of
 	// response records. When the results of a DescribeEventSubscriptions request
 	// exceed the value specified in MaxRecords, AWS returns a value in the Marker
@@ -4574,8 +4576,6 @@ type DescribeEventSubscriptionsInput struct {
 
 	// The name of the Amazon Redshift event notification subscription to be described.
 	SubscriptionName *string `type:"string"`
-
-	_ struct{} `type:"structure"`
 }
 
 // String returns the string representation
@@ -4589,6 +4589,8 @@ func (s DescribeEventSubscriptionsInput) GoString() string {
 }
 
 type DescribeEventSubscriptionsOutput struct {
+	_ struct{} `type:"structure"`
+
 	// A list of event subscriptions.
 	EventSubscriptionsList []*EventSubscription `locationNameList:"EventSubscription" type:"list"`
 
@@ -4598,8 +4600,6 @@ type DescribeEventSubscriptionsOutput struct {
 	// parameter and retrying the command. If the Marker field is empty, all response
 	// records have been retrieved for the request.
 	Marker *string `type:"string"`
-
-	_ struct{} `type:"structure"`
 }
 
 // String returns the string representation
@@ -4613,6 +4613,8 @@ func (s DescribeEventSubscriptionsOutput) GoString() string {
 }
 
 type DescribeEventsInput struct {
+	_ struct{} `type:"structure"`
+
 	// The number of minutes prior to the time of the request for which to retrieve
 	// events. For example, if the request is sent at 18:00 and you specify a duration
 	// of 60, then only events which have occurred after 17:00 will be returned.
@@ -4677,8 +4679,6 @@ type DescribeEventsInput struct {
 	//
 	// Example: 2009-07-08T18:00Z
 	StartTime *time.Time `type:"timestamp" timestampFormat:"iso8601"`
-
-	_ struct{} `type:"structure"`
 }
 
 // String returns the string representation
@@ -4693,6 +4693,8 @@ func (s DescribeEventsInput) GoString() string {
 
 // Contains the output from the DescribeEvents action.
 type DescribeEventsOutput struct {
+	_ struct{} `type:"structure"`
+
 	// A list of Event instances.
 	Events []*Event `locationNameList:"Event" type:"list"`
 
@@ -4702,8 +4704,6 @@ type DescribeEventsOutput struct {
 	// parameter and retrying the command. If the Marker field is empty, all response
 	// records have been retrieved for the request.
 	Marker *string `type:"string"`
-
-	_ struct{} `type:"structure"`
 }
 
 // String returns the string representation
@@ -4717,6 +4717,8 @@ func (s DescribeEventsOutput) GoString() string {
 }
 
 type DescribeHsmClientCertificatesInput struct {
+	_ struct{} `type:"structure"`
+
 	// The identifier of a specific HSM client certificate for which you want information.
 	// If no identifier is specified, information is returned for all HSM client
 	// certificates owned by your AWS customer account.
@@ -4755,8 +4757,6 @@ type DescribeHsmClientCertificatesInput struct {
 	// in the request, Amazon Redshift returns a response with the HSM client certificates
 	// that have either or both of these tag values associated with them.
 	TagValues []*string `locationNameList:"TagValue" type:"list"`
-
-	_ struct{} `type:"structure"`
 }
 
 // String returns the string representation
@@ -4770,6 +4770,8 @@ func (s DescribeHsmClientCertificatesInput) GoString() string {
 }
 
 type DescribeHsmClientCertificatesOutput struct {
+	_ struct{} `type:"structure"`
+
 	// A list of the identifiers for one or more HSM client certificates used by
 	// Amazon Redshift clusters to store and retrieve database encryption keys in
 	// an HSM.
@@ -4781,8 +4783,6 @@ type DescribeHsmClientCertificatesOutput struct {
 	// parameter and retrying the command. If the Marker field is empty, all response
 	// records have been retrieved for the request.
 	Marker *string `type:"string"`
-
-	_ struct{} `type:"structure"`
 }
 
 // String returns the string representation
@@ -4796,6 +4796,8 @@ func (s DescribeHsmClientCertificatesOutput) GoString() string {
 }
 
 type DescribeHsmConfigurationsInput struct {
+	_ struct{} `type:"structure"`
+
 	// The identifier of a specific Amazon Redshift HSM configuration to be described.
 	// If no identifier is specified, information is returned for all HSM configurations
 	// owned by your AWS customer account.
@@ -4834,8 +4836,6 @@ type DescribeHsmConfigurationsInput struct {
 	// Redshift returns a response with the HSM configurations that have either
 	// or both of these tag values associated with them.
 	TagValues []*string `locationNameList:"TagValue" type:"list"`
-
-	_ struct{} `type:"structure"`
 }
 
 // String returns the string representation
@@ -4849,6 +4849,8 @@ func (s DescribeHsmConfigurationsInput) GoString() string {
 }
 
 type DescribeHsmConfigurationsOutput struct {
+	_ struct{} `type:"structure"`
+
 	// A list of Amazon Redshift HSM configurations.
 	HsmConfigurations []*HsmConfiguration `locationNameList:"HsmConfiguration" type:"list"`
 
@@ -4858,8 +4860,6 @@ type DescribeHsmConfigurationsOutput struct {
 	// parameter and retrying the command. If the Marker field is empty, all response
 	// records have been retrieved for the request.
 	Marker *string `type:"string"`
-
-	_ struct{} `type:"structure"`
 }
 
 // String returns the string representation
@@ -4873,12 +4873,12 @@ func (s DescribeHsmConfigurationsOutput) GoString() string {
 }
 
 type DescribeLoggingStatusInput struct {
+	_ struct{} `type:"structure"`
+
 	// The identifier of the cluster to get the logging status from.
 	//
 	// Example: examplecluster
 	ClusterIdentifier *string `type:"string" required:"true"`
-
-	_ struct{} `type:"structure"`
 }
 
 // String returns the string representation
@@ -4892,6 +4892,8 @@ func (s DescribeLoggingStatusInput) GoString() string {
 }
 
 type DescribeOrderableClusterOptionsInput struct {
+	_ struct{} `type:"structure"`
+
 	// The version filter value. Specify this parameter to show only the available
 	// offerings matching the specified version.
 	//
@@ -4921,8 +4923,6 @@ type DescribeOrderableClusterOptionsInput struct {
 	// The node type filter value. Specify this parameter to show only the available
 	// offerings matching the specified node type.
 	NodeType *string `type:"string"`
-
-	_ struct{} `type:"structure"`
 }
 
 // String returns the string representation
@@ -4937,6 +4937,8 @@ func (s DescribeOrderableClusterOptionsInput) GoString() string {
 
 // Contains the output from the DescribeOrderableClusterOptions action.
 type DescribeOrderableClusterOptionsOutput struct {
+	_ struct{} `type:"structure"`
+
 	// A value that indicates the starting point for the next set of response records
 	// in a subsequent request. If a value is returned in a response, you can retrieve
 	// the next set of records by providing this returned marker value in the Marker
@@ -4947,8 +4949,6 @@ type DescribeOrderableClusterOptionsOutput struct {
 	// An OrderableClusterOption structure containing information about orderable
 	// options for the Cluster.
 	OrderableClusterOptions []*OrderableClusterOption `locationNameList:"OrderableClusterOption" type:"list"`
-
-	_ struct{} `type:"structure"`
 }
 
 // String returns the string representation
@@ -4962,6 +4962,8 @@ func (s DescribeOrderableClusterOptionsOutput) GoString() string {
 }
 
 type DescribeReservedNodeOfferingsInput struct {
+	_ struct{} `type:"structure"`
+
 	// An optional parameter that specifies the starting point to return a set of
 	// response records. When the results of a DescribeReservedNodeOfferings request
 	// exceed the value specified in MaxRecords, AWS returns a value in the Marker
@@ -4982,8 +4984,6 @@ type DescribeReservedNodeOfferingsInput struct {
 
 	// The unique identifier for the offering.
 	ReservedNodeOfferingId *string `type:"string"`
-
-	_ struct{} `type:"structure"`
 }
 
 // String returns the string representation
@@ -4998,6 +4998,8 @@ func (s DescribeReservedNodeOfferingsInput) GoString() string {
 
 // Contains the output from the DescribeReservedNodeOfferings action.
 type DescribeReservedNodeOfferingsOutput struct {
+	_ struct{} `type:"structure"`
+
 	// A value that indicates the starting point for the next set of response records
 	// in a subsequent request. If a value is returned in a response, you can retrieve
 	// the next set of records by providing this returned marker value in the Marker
@@ -5007,8 +5009,6 @@ type DescribeReservedNodeOfferingsOutput struct {
 
 	// A list of reserved node offerings.
 	ReservedNodeOfferings []*ReservedNodeOffering `locationNameList:"ReservedNodeOffering" type:"list"`
-
-	_ struct{} `type:"structure"`
 }
 
 // String returns the string representation
@@ -5022,6 +5022,8 @@ func (s DescribeReservedNodeOfferingsOutput) GoString() string {
 }
 
 type DescribeReservedNodesInput struct {
+	_ struct{} `type:"structure"`
+
 	// An optional parameter that specifies the starting point to return a set of
 	// response records. When the results of a DescribeReservedNodes request exceed
 	// the value specified in MaxRecords, AWS returns a value in the Marker field
@@ -5041,8 +5043,6 @@ type DescribeReservedNodesInput struct {
 
 	// Identifier for the node reservation.
 	ReservedNodeId *string `type:"string"`
-
-	_ struct{} `type:"structure"`
 }
 
 // String returns the string representation
@@ -5057,6 +5057,8 @@ func (s DescribeReservedNodesInput) GoString() string {
 
 // Contains the output from the DescribeReservedNodes action.
 type DescribeReservedNodesOutput struct {
+	_ struct{} `type:"structure"`
+
 	// A value that indicates the starting point for the next set of response records
 	// in a subsequent request. If a value is returned in a response, you can retrieve
 	// the next set of records by providing this returned marker value in the Marker
@@ -5066,8 +5068,6 @@ type DescribeReservedNodesOutput struct {
 
 	// The list of reserved nodes.
 	ReservedNodes []*ReservedNode `locationNameList:"ReservedNode" type:"list"`
-
-	_ struct{} `type:"structure"`
 }
 
 // String returns the string representation
@@ -5081,14 +5081,14 @@ func (s DescribeReservedNodesOutput) GoString() string {
 }
 
 type DescribeResizeInput struct {
+	_ struct{} `type:"structure"`
+
 	// The unique identifier of a cluster whose resize progress you are requesting.
 	// This parameter is case-sensitive.
 	//
 	// By default, resize operations for all clusters defined for an AWS account
 	// are returned.
 	ClusterIdentifier *string `type:"string" required:"true"`
-
-	_ struct{} `type:"structure"`
 }
 
 // String returns the string representation
@@ -5103,6 +5103,8 @@ func (s DescribeResizeInput) GoString() string {
 
 // Describes the result of a cluster resize operation.
 type DescribeResizeOutput struct {
+	_ struct{} `type:"structure"`
+
 	// The average rate of the resize operation over the last few minutes, measured
 	// in megabytes per second. After the resize operation completes, this value
 	// shows the average rate of the entire resize operation.
@@ -5161,8 +5163,6 @@ type DescribeResizeOutput struct {
 	// The estimated total amount of data, in megabytes, on the cluster before the
 	// resize operation began.
 	TotalResizeDataInMegaBytes *int64 `type:"long"`
-
-	_ struct{} `type:"structure"`
 }
 
 // String returns the string representation
@@ -5177,6 +5177,8 @@ func (s DescribeResizeOutput) GoString() string {
 
 // The result of the DescribeSnapshotCopyGrants action.
 type DescribeSnapshotCopyGrantsInput struct {
+	_ struct{} `type:"structure"`
+
 	// An optional parameter that specifies the starting point to return a set of
 	// response records. When the results of a DescribeSnapshotCopyGrant request
 	// exceed the value specified in MaxRecords, AWS returns a value in the Marker
@@ -5216,8 +5218,6 @@ type DescribeSnapshotCopyGrantsInput struct {
 	// a response with all resources that have either or both of these tag values
 	// associated with them.
 	TagValues []*string `locationNameList:"TagValue" type:"list"`
-
-	_ struct{} `type:"structure"`
 }
 
 // String returns the string representation
@@ -5232,6 +5232,8 @@ func (s DescribeSnapshotCopyGrantsInput) GoString() string {
 
 // The result of the snapshot copy grant.
 type DescribeSnapshotCopyGrantsOutput struct {
+	_ struct{} `type:"structure"`
+
 	// An optional parameter that specifies the starting point to return a set of
 	// response records. When the results of a DescribeSnapshotCopyGrant request
 	// exceed the value specified in MaxRecords, AWS returns a value in the Marker
@@ -5245,8 +5247,6 @@ type DescribeSnapshotCopyGrantsOutput struct {
 
 	// The list of snapshot copy grants.
 	SnapshotCopyGrants []*SnapshotCopyGrant `locationNameList:"SnapshotCopyGrant" type:"list"`
-
-	_ struct{} `type:"structure"`
 }
 
 // String returns the string representation
@@ -5261,6 +5261,8 @@ func (s DescribeSnapshotCopyGrantsOutput) GoString() string {
 
 // Contains the output from the DescribeTags action.
 type DescribeTagsInput struct {
+	_ struct{} `type:"structure"`
+
 	// A value that indicates the starting point for the next set of response records
 	// in a subsequent request. If a value is returned in a response, you can retrieve
 	// the next set of records by providing this returned marker value in the marker
@@ -5303,8 +5305,6 @@ type DescribeTagsInput struct {
 	// a response with all resources that have either or both of these tag values
 	// associated with them.
 	TagValues []*string `locationNameList:"TagValue" type:"list"`
-
-	_ struct{} `type:"structure"`
 }
 
 // String returns the string representation
@@ -5319,6 +5319,8 @@ func (s DescribeTagsInput) GoString() string {
 
 // Contains the output from the DescribeTags action.
 type DescribeTagsOutput struct {
+	_ struct{} `type:"structure"`
+
 	// A value that indicates the starting point for the next set of response records
 	// in a subsequent request. If a value is returned in a response, you can retrieve
 	// the next set of records by providing this returned marker value in the Marker
@@ -5328,8 +5330,6 @@ type DescribeTagsOutput struct {
 
 	// A list of tags with their associated resources.
 	TaggedResources []*TaggedResource `locationNameList:"TaggedResource" type:"list"`
-
-	_ struct{} `type:"structure"`
 }
 
 // String returns the string representation
@@ -5343,12 +5343,12 @@ func (s DescribeTagsOutput) GoString() string {
 }
 
 type DisableLoggingInput struct {
+	_ struct{} `type:"structure"`
+
 	// The identifier of the cluster on which logging is to be stopped.
 	//
 	// Example: examplecluster
 	ClusterIdentifier *string `type:"string" required:"true"`
-
-	_ struct{} `type:"structure"`
 }
 
 // String returns the string representation
@@ -5362,14 +5362,14 @@ func (s DisableLoggingInput) GoString() string {
 }
 
 type DisableSnapshotCopyInput struct {
+	_ struct{} `type:"structure"`
+
 	// The unique identifier of the source cluster that you want to disable copying
 	// of snapshots to a destination region.
 	//
 	//  Constraints: Must be the valid name of an existing cluster that has cross-region
 	// snapshot copy enabled.
 	ClusterIdentifier *string `type:"string" required:"true"`
-
-	_ struct{} `type:"structure"`
 }
 
 // String returns the string representation
@@ -5383,10 +5383,10 @@ func (s DisableSnapshotCopyInput) GoString() string {
 }
 
 type DisableSnapshotCopyOutput struct {
+	_ struct{} `type:"structure"`
+
 	// Describes a cluster.
 	Cluster *Cluster `type:"structure"`
-
-	_ struct{} `type:"structure"`
 }
 
 // String returns the string representation
@@ -5401,6 +5401,8 @@ func (s DisableSnapshotCopyOutput) GoString() string {
 
 // Describes an Amazon EC2 security group.
 type EC2SecurityGroup struct {
+	_ struct{} `type:"structure"`
+
 	// The name of the EC2 Security Group.
 	EC2SecurityGroupName *string `type:"string"`
 
@@ -5413,8 +5415,6 @@ type EC2SecurityGroup struct {
 
 	// The list of tags for the EC2 security group.
 	Tags []*Tag `locationNameList:"Tag" type:"list"`
-
-	_ struct{} `type:"structure"`
 }
 
 // String returns the string representation
@@ -5429,13 +5429,13 @@ func (s EC2SecurityGroup) GoString() string {
 
 // Describes the status of the elastic IP (EIP) address.
 type ElasticIpStatus struct {
+	_ struct{} `type:"structure"`
+
 	// The elastic IP (EIP) address for the cluster.
 	ElasticIp *string `type:"string"`
 
 	// Describes the status of the elastic IP (EIP) address.
 	Status *string `type:"string"`
-
-	_ struct{} `type:"structure"`
 }
 
 // String returns the string representation
@@ -5449,6 +5449,8 @@ func (s ElasticIpStatus) GoString() string {
 }
 
 type EnableLoggingInput struct {
+	_ struct{} `type:"structure"`
+
 	// The name of an existing S3 bucket where the log files are to be stored.
 	//
 	// Constraints:
@@ -5470,8 +5472,6 @@ type EnableLoggingInput struct {
 	// single quotes ('), a backslash (\), or control characters. The hexadecimal
 	// codes for invalid characters are:  x00 to x20 x22 x27 x5c x7f or larger
 	S3KeyPrefix *string `type:"string"`
-
-	_ struct{} `type:"structure"`
 }
 
 // String returns the string representation
@@ -5485,6 +5485,8 @@ func (s EnableLoggingInput) GoString() string {
 }
 
 type EnableSnapshotCopyInput struct {
+	_ struct{} `type:"structure"`
+
 	// The unique identifier of the source cluster to copy snapshots from.
 	//
 	//  Constraints: Must be the valid name of an existing cluster that does not
@@ -5509,8 +5511,6 @@ type EnableSnapshotCopyInput struct {
 	// The name of the snapshot copy grant to use when snapshots of an AWS KMS-encrypted
 	// cluster are copied to the destination region.
 	SnapshotCopyGrantName *string `type:"string"`
-
-	_ struct{} `type:"structure"`
 }
 
 // String returns the string representation
@@ -5524,10 +5524,10 @@ func (s EnableSnapshotCopyInput) GoString() string {
 }
 
 type EnableSnapshotCopyOutput struct {
+	_ struct{} `type:"structure"`
+
 	// Describes a cluster.
 	Cluster *Cluster `type:"structure"`
-
-	_ struct{} `type:"structure"`
 }
 
 // String returns the string representation
@@ -5542,13 +5542,13 @@ func (s EnableSnapshotCopyOutput) GoString() string {
 
 // Describes a connection endpoint.
 type Endpoint struct {
+	_ struct{} `type:"structure"`
+
 	// The DNS address of the Cluster.
 	Address *string `type:"string"`
 
 	// The port that the database engine is listening on.
 	Port *int64 `type:"integer"`
-
-	_ struct{} `type:"structure"`
 }
 
 // String returns the string representation
@@ -5563,6 +5563,8 @@ func (s Endpoint) GoString() string {
 
 // Describes an event.
 type Event struct {
+	_ struct{} `type:"structure"`
+
 	// The date and time of the event.
 	Date *time.Time `type:"timestamp" timestampFormat:"iso8601"`
 
@@ -5587,8 +5589,6 @@ type Event struct {
 
 	// The source type for this event.
 	SourceType *string `type:"string" enum:"SourceType"`
-
-	_ struct{} `type:"structure"`
 }
 
 // String returns the string representation
@@ -5602,14 +5602,14 @@ func (s Event) GoString() string {
 }
 
 type EventCategoriesMap struct {
+	_ struct{} `type:"structure"`
+
 	// The events in the event category.
 	Events []*EventInfoMap `locationNameList:"EventInfoMap" type:"list"`
 
 	// The Amazon Redshift source type, such as cluster or cluster-snapshot, that
 	// the returned categories belong to.
 	SourceType *string `type:"string"`
-
-	_ struct{} `type:"structure"`
 }
 
 // String returns the string representation
@@ -5623,6 +5623,8 @@ func (s EventCategoriesMap) GoString() string {
 }
 
 type EventInfoMap struct {
+	_ struct{} `type:"structure"`
+
 	// The category of an Amazon Redshift event.
 	EventCategories []*string `locationNameList:"EventCategory" type:"list"`
 
@@ -5636,8 +5638,6 @@ type EventInfoMap struct {
 	//
 	// Values: ERROR, INFO
 	Severity *string `type:"string"`
-
-	_ struct{} `type:"structure"`
 }
 
 // String returns the string representation
@@ -5651,6 +5651,8 @@ func (s EventInfoMap) GoString() string {
 }
 
 type EventSubscription struct {
+	_ struct{} `type:"structure"`
+
 	// The name of the Amazon Redshift event notification subscription.
 	CustSubscriptionId *string `type:"string"`
 
@@ -5701,8 +5703,6 @@ type EventSubscription struct {
 
 	// The list of tags for the event subscription.
 	Tags []*Tag `locationNameList:"Tag" type:"list"`
-
-	_ struct{} `type:"structure"`
 }
 
 // String returns the string representation
@@ -5719,6 +5719,8 @@ func (s EventSubscription) GoString() string {
 // in a secure Hardware Storage Module (HSM), and used by the Amazon Redshift
 // cluster to encrypt data files.
 type HsmClientCertificate struct {
+	_ struct{} `type:"structure"`
+
 	// The identifier of the HSM client certificate.
 	HsmClientCertificateIdentifier *string `type:"string"`
 
@@ -5728,8 +5730,6 @@ type HsmClientCertificate struct {
 
 	// The list of tags for the HSM client certificate.
 	Tags []*Tag `locationNameList:"Tag" type:"list"`
-
-	_ struct{} `type:"structure"`
 }
 
 // String returns the string representation
@@ -5746,6 +5746,8 @@ func (s HsmClientCertificate) GoString() string {
 // to Amazon Redshift clusters the information they require to connect to an
 // HSM where they can store database encryption keys.
 type HsmConfiguration struct {
+	_ struct{} `type:"structure"`
+
 	// A text description of the HSM configuration.
 	Description *string `type:"string"`
 
@@ -5761,8 +5763,6 @@ type HsmConfiguration struct {
 
 	// The list of tags for the HSM configuration.
 	Tags []*Tag `locationNameList:"Tag" type:"list"`
-
-	_ struct{} `type:"structure"`
 }
 
 // String returns the string representation
@@ -5776,6 +5776,8 @@ func (s HsmConfiguration) GoString() string {
 }
 
 type HsmStatus struct {
+	_ struct{} `type:"structure"`
+
 	// Specifies the name of the HSM client certificate the Amazon Redshift cluster
 	// uses to retrieve the data encryption keys stored in an HSM.
 	HsmClientCertificateIdentifier *string `type:"string"`
@@ -5789,8 +5791,6 @@ type HsmStatus struct {
 	//
 	// Values: active, applying
 	Status *string `type:"string"`
-
-	_ struct{} `type:"structure"`
 }
 
 // String returns the string representation
@@ -5805,6 +5805,8 @@ func (s HsmStatus) GoString() string {
 
 // Describes an IP range used in a security group.
 type IPRange struct {
+	_ struct{} `type:"structure"`
+
 	// The IP range in Classless Inter-Domain Routing (CIDR) notation.
 	CIDRIP *string `type:"string"`
 
@@ -5813,8 +5815,6 @@ type IPRange struct {
 
 	// The list of tags for the IP range.
 	Tags []*Tag `locationNameList:"Tag" type:"list"`
-
-	_ struct{} `type:"structure"`
 }
 
 // String returns the string representation
@@ -5829,6 +5829,8 @@ func (s IPRange) GoString() string {
 
 // Describes the status of logging for a cluster.
 type LoggingStatus struct {
+	_ struct{} `type:"structure"`
+
 	// The name of the S3 bucket where the log files are stored.
 	BucketName *string `type:"string"`
 
@@ -5846,8 +5848,6 @@ type LoggingStatus struct {
 
 	// The prefix applied to the log file names.
 	S3KeyPrefix *string `type:"string"`
-
-	_ struct{} `type:"structure"`
 }
 
 // String returns the string representation
@@ -5861,6 +5861,8 @@ func (s LoggingStatus) GoString() string {
 }
 
 type ModifyClusterInput struct {
+	_ struct{} `type:"structure"`
+
 	// If true, major version upgrades will be applied automatically to the cluster
 	// during the maintenance window.
 	//
@@ -6015,8 +6017,6 @@ type ModifyClusterInput struct {
 	// A list of virtual private cloud (VPC) security groups to be associated with
 	// the cluster.
 	VpcSecurityGroupIds []*string `locationNameList:"VpcSecurityGroupId" type:"list"`
-
-	_ struct{} `type:"structure"`
 }
 
 // String returns the string representation
@@ -6030,10 +6030,10 @@ func (s ModifyClusterInput) GoString() string {
 }
 
 type ModifyClusterOutput struct {
+	_ struct{} `type:"structure"`
+
 	// Describes a cluster.
 	Cluster *Cluster `type:"structure"`
-
-	_ struct{} `type:"structure"`
 }
 
 // String returns the string representation
@@ -6047,6 +6047,8 @@ func (s ModifyClusterOutput) GoString() string {
 }
 
 type ModifyClusterParameterGroupInput struct {
+	_ struct{} `type:"structure"`
+
 	// The name of the parameter group to be modified.
 	ParameterGroupName *string `type:"string" required:"true"`
 
@@ -6059,8 +6061,6 @@ type ModifyClusterParameterGroupInput struct {
 	//  For the workload management (WLM) configuration, you must supply all the
 	// name-value pairs in the wlm_json_configuration parameter.
 	Parameters []*Parameter `locationNameList:"Parameter" type:"list" required:"true"`
-
-	_ struct{} `type:"structure"`
 }
 
 // String returns the string representation
@@ -6074,6 +6074,8 @@ func (s ModifyClusterParameterGroupInput) GoString() string {
 }
 
 type ModifyClusterSubnetGroupInput struct {
+	_ struct{} `type:"structure"`
+
 	// The name of the subnet group to be modified.
 	ClusterSubnetGroupName *string `type:"string" required:"true"`
 
@@ -6083,8 +6085,6 @@ type ModifyClusterSubnetGroupInput struct {
 	// An array of VPC subnet IDs. A maximum of 20 subnets can be modified in a
 	// single request.
 	SubnetIds []*string `locationNameList:"SubnetIdentifier" type:"list" required:"true"`
-
-	_ struct{} `type:"structure"`
 }
 
 // String returns the string representation
@@ -6098,10 +6098,10 @@ func (s ModifyClusterSubnetGroupInput) GoString() string {
 }
 
 type ModifyClusterSubnetGroupOutput struct {
+	_ struct{} `type:"structure"`
+
 	// Describes a subnet group.
 	ClusterSubnetGroup *ClusterSubnetGroup `type:"structure"`
-
-	_ struct{} `type:"structure"`
 }
 
 // String returns the string representation
@@ -6115,6 +6115,8 @@ func (s ModifyClusterSubnetGroupOutput) GoString() string {
 }
 
 type ModifyEventSubscriptionInput struct {
+	_ struct{} `type:"structure"`
+
 	// A Boolean value indicating if the subscription is enabled. true indicates
 	// the subscription is enabled
 	Enabled *bool `type:"boolean"`
@@ -6158,8 +6160,6 @@ type ModifyEventSubscriptionInput struct {
 
 	// The name of the modified Amazon Redshift event notification subscription.
 	SubscriptionName *string `type:"string" required:"true"`
-
-	_ struct{} `type:"structure"`
 }
 
 // String returns the string representation
@@ -6173,9 +6173,9 @@ func (s ModifyEventSubscriptionInput) GoString() string {
 }
 
 type ModifyEventSubscriptionOutput struct {
-	EventSubscription *EventSubscription `type:"structure"`
-
 	_ struct{} `type:"structure"`
+
+	EventSubscription *EventSubscription `type:"structure"`
 }
 
 // String returns the string representation
@@ -6189,6 +6189,8 @@ func (s ModifyEventSubscriptionOutput) GoString() string {
 }
 
 type ModifySnapshotCopyRetentionPeriodInput struct {
+	_ struct{} `type:"structure"`
+
 	// The unique identifier of the cluster for which you want to change the retention
 	// period for automated snapshots that are copied to a destination region.
 	//
@@ -6206,8 +6208,6 @@ type ModifySnapshotCopyRetentionPeriodInput struct {
 	//
 	//  Constraints: Must be at least 1 and no more than 35.
 	RetentionPeriod *int64 `type:"integer" required:"true"`
-
-	_ struct{} `type:"structure"`
 }
 
 // String returns the string representation
@@ -6221,10 +6221,10 @@ func (s ModifySnapshotCopyRetentionPeriodInput) GoString() string {
 }
 
 type ModifySnapshotCopyRetentionPeriodOutput struct {
+	_ struct{} `type:"structure"`
+
 	// Describes a cluster.
 	Cluster *Cluster `type:"structure"`
-
-	_ struct{} `type:"structure"`
 }
 
 // String returns the string representation
@@ -6239,6 +6239,8 @@ func (s ModifySnapshotCopyRetentionPeriodOutput) GoString() string {
 
 // Describes an orderable cluster option.
 type OrderableClusterOption struct {
+	_ struct{} `type:"structure"`
+
 	// A list of availability zones for the orderable cluster.
 	AvailabilityZones []*AvailabilityZone `locationNameList:"AvailabilityZone" type:"list"`
 
@@ -6250,8 +6252,6 @@ type OrderableClusterOption struct {
 
 	// The node type for the orderable cluster.
 	NodeType *string `type:"string"`
-
-	_ struct{} `type:"structure"`
 }
 
 // String returns the string representation
@@ -6266,6 +6266,8 @@ func (s OrderableClusterOption) GoString() string {
 
 // Describes a parameter in a cluster parameter group.
 type Parameter struct {
+	_ struct{} `type:"structure"`
+
 	// The valid range of values for the parameter.
 	AllowedValues *string `type:"string"`
 
@@ -6293,8 +6295,6 @@ type Parameter struct {
 
 	// The source of the parameter value, such as "engine-default" or "user".
 	Source *string `type:"string"`
-
-	_ struct{} `type:"structure"`
 }
 
 // String returns the string representation
@@ -6310,6 +6310,8 @@ func (s Parameter) GoString() string {
 // Describes cluster attributes that are in a pending state. A change to one
 // or more the attributes was requested and is in progress or will be applied.
 type PendingModifiedValues struct {
+	_ struct{} `type:"structure"`
+
 	// The pending or in-progress change of the automated snapshot retention period.
 	AutomatedSnapshotRetentionPeriod *int64 `type:"integer"`
 
@@ -6330,8 +6332,6 @@ type PendingModifiedValues struct {
 
 	// The pending or in-progress change of the number of nodes in the cluster.
 	NumberOfNodes *int64 `type:"integer"`
-
-	_ struct{} `type:"structure"`
 }
 
 // String returns the string representation
@@ -6345,6 +6345,8 @@ func (s PendingModifiedValues) GoString() string {
 }
 
 type PurchaseReservedNodeOfferingInput struct {
+	_ struct{} `type:"structure"`
+
 	// The number of reserved nodes you want to purchase.
 	//
 	// Default: 1
@@ -6352,8 +6354,6 @@ type PurchaseReservedNodeOfferingInput struct {
 
 	// The unique identifier of the reserved node offering you want to purchase.
 	ReservedNodeOfferingId *string `type:"string" required:"true"`
-
-	_ struct{} `type:"structure"`
 }
 
 // String returns the string representation
@@ -6367,11 +6367,11 @@ func (s PurchaseReservedNodeOfferingInput) GoString() string {
 }
 
 type PurchaseReservedNodeOfferingOutput struct {
+	_ struct{} `type:"structure"`
+
 	// Describes a reserved node. You can call the DescribeReservedNodeOfferings
 	// API to obtain the available reserved node offerings.
 	ReservedNode *ReservedNode `type:"structure"`
-
-	_ struct{} `type:"structure"`
 }
 
 // String returns the string representation
@@ -6385,10 +6385,10 @@ func (s PurchaseReservedNodeOfferingOutput) GoString() string {
 }
 
 type RebootClusterInput struct {
+	_ struct{} `type:"structure"`
+
 	// The cluster identifier.
 	ClusterIdentifier *string `type:"string" required:"true"`
-
-	_ struct{} `type:"structure"`
 }
 
 // String returns the string representation
@@ -6402,10 +6402,10 @@ func (s RebootClusterInput) GoString() string {
 }
 
 type RebootClusterOutput struct {
+	_ struct{} `type:"structure"`
+
 	// Describes a cluster.
 	Cluster *Cluster `type:"structure"`
-
-	_ struct{} `type:"structure"`
 }
 
 // String returns the string representation
@@ -6420,14 +6420,14 @@ func (s RebootClusterOutput) GoString() string {
 
 // Describes a recurring charge.
 type RecurringCharge struct {
+	_ struct{} `type:"structure"`
+
 	// The amount charged per the period of time specified by the recurring charge
 	// frequency.
 	RecurringChargeAmount *float64 `type:"double"`
 
 	// The frequency at which the recurring charge amount is applied.
 	RecurringChargeFrequency *string `type:"string"`
-
-	_ struct{} `type:"structure"`
 }
 
 // String returns the string representation
@@ -6443,6 +6443,8 @@ func (s RecurringCharge) GoString() string {
 // Describes a reserved node. You can call the DescribeReservedNodeOfferings
 // API to obtain the available reserved node offerings.
 type ReservedNode struct {
+	_ struct{} `type:"structure"`
+
 	// The currency code for the reserved cluster.
 	CurrencyCode *string `type:"string"`
 
@@ -6487,8 +6489,6 @@ type ReservedNode struct {
 
 	// The hourly rate Amazon Redshift charges you for this reserved node.
 	UsagePrice *float64 `type:"double"`
-
-	_ struct{} `type:"structure"`
 }
 
 // String returns the string representation
@@ -6503,6 +6503,8 @@ func (s ReservedNode) GoString() string {
 
 // Describes a reserved node offering.
 type ReservedNodeOffering struct {
+	_ struct{} `type:"structure"`
+
 	// The currency code for the compute nodes offering.
 	CurrencyCode *string `type:"string"`
 
@@ -6531,8 +6533,6 @@ type ReservedNodeOffering struct {
 	// The rate you are charged for each hour the cluster that is using the offering
 	// is running.
 	UsagePrice *float64 `type:"double"`
-
-	_ struct{} `type:"structure"`
 }
 
 // String returns the string representation
@@ -6546,6 +6546,8 @@ func (s ReservedNodeOffering) GoString() string {
 }
 
 type ResetClusterParameterGroupInput struct {
+	_ struct{} `type:"structure"`
+
 	// The name of the cluster parameter group to be reset.
 	ParameterGroupName *string `type:"string" required:"true"`
 
@@ -6560,8 +6562,6 @@ type ResetClusterParameterGroupInput struct {
 	//
 	// Default: true
 	ResetAllParameters *bool `type:"boolean"`
-
-	_ struct{} `type:"structure"`
 }
 
 // String returns the string representation
@@ -6575,6 +6575,8 @@ func (s ResetClusterParameterGroupInput) GoString() string {
 }
 
 type RestoreFromClusterSnapshotInput struct {
+	_ struct{} `type:"structure"`
+
 	// If true, major version upgrades can be applied during the maintenance window
 	// to the Amazon Redshift engine that is running on the cluster.
 	//
@@ -6709,8 +6711,6 @@ type RestoreFromClusterSnapshotInput struct {
 	//
 	//  VPC security groups only apply to clusters in VPCs.
 	VpcSecurityGroupIds []*string `locationNameList:"VpcSecurityGroupId" type:"list"`
-
-	_ struct{} `type:"structure"`
 }
 
 // String returns the string representation
@@ -6724,10 +6724,10 @@ func (s RestoreFromClusterSnapshotInput) GoString() string {
 }
 
 type RestoreFromClusterSnapshotOutput struct {
+	_ struct{} `type:"structure"`
+
 	// Describes a cluster.
 	Cluster *Cluster `type:"structure"`
-
-	_ struct{} `type:"structure"`
 }
 
 // String returns the string representation
@@ -6743,6 +6743,8 @@ func (s RestoreFromClusterSnapshotOutput) GoString() string {
 // Describes the status of a cluster restore action. Returns null if the cluster
 // was not created by restoring a snapshot.
 type RestoreStatus struct {
+	_ struct{} `type:"structure"`
+
 	// The number of megabytes per second being transferred from the backup storage.
 	// Returns the average rate for a completed backup.
 	CurrentRestoreRateInMegaBytesPerSecond *float64 `type:"double"`
@@ -6764,8 +6766,6 @@ type RestoreStatus struct {
 	// The status of the restore action. Returns starting, restoring, completed,
 	// or failed.
 	Status *string `type:"string"`
-
-	_ struct{} `type:"structure"`
 }
 
 // String returns the string representation
@@ -6780,6 +6780,8 @@ func (s RestoreStatus) GoString() string {
 
 // ???
 type RevokeClusterSecurityGroupIngressInput struct {
+	_ struct{} `type:"structure"`
+
 	// The IP range for which to revoke access. This range must be a valid Classless
 	// Inter-Domain Routing (CIDR) block of IP addresses. If CIDRIP is specified,
 	// EC2SecurityGroupName and EC2SecurityGroupOwnerId cannot be provided.
@@ -6800,8 +6802,6 @@ type RevokeClusterSecurityGroupIngressInput struct {
 	//
 	// Example: 111122223333
 	EC2SecurityGroupOwnerId *string `type:"string"`
-
-	_ struct{} `type:"structure"`
 }
 
 // String returns the string representation
@@ -6815,10 +6815,10 @@ func (s RevokeClusterSecurityGroupIngressInput) GoString() string {
 }
 
 type RevokeClusterSecurityGroupIngressOutput struct {
+	_ struct{} `type:"structure"`
+
 	// Describes a security group.
 	ClusterSecurityGroup *ClusterSecurityGroup `type:"structure"`
-
-	_ struct{} `type:"structure"`
 }
 
 // String returns the string representation
@@ -6832,6 +6832,8 @@ func (s RevokeClusterSecurityGroupIngressOutput) GoString() string {
 }
 
 type RevokeSnapshotAccessInput struct {
+	_ struct{} `type:"structure"`
+
 	// The identifier of the AWS customer account that can no longer restore the
 	// specified snapshot.
 	AccountWithRestoreAccess *string `type:"string" required:"true"`
@@ -6843,8 +6845,6 @@ type RevokeSnapshotAccessInput struct {
 
 	// The identifier of the snapshot that the account can no longer access.
 	SnapshotIdentifier *string `type:"string" required:"true"`
-
-	_ struct{} `type:"structure"`
 }
 
 // String returns the string representation
@@ -6858,10 +6858,10 @@ func (s RevokeSnapshotAccessInput) GoString() string {
 }
 
 type RevokeSnapshotAccessOutput struct {
+	_ struct{} `type:"structure"`
+
 	// Describes a snapshot.
 	Snapshot *Snapshot `type:"structure"`
-
-	_ struct{} `type:"structure"`
 }
 
 // String returns the string representation
@@ -6875,13 +6875,13 @@ func (s RevokeSnapshotAccessOutput) GoString() string {
 }
 
 type RotateEncryptionKeyInput struct {
+	_ struct{} `type:"structure"`
+
 	// The unique identifier of the cluster that you want to rotate the encryption
 	// keys for.
 	//
 	//  Constraints: Must be the name of valid cluster that has encryption enabled.
 	ClusterIdentifier *string `type:"string" required:"true"`
-
-	_ struct{} `type:"structure"`
 }
 
 // String returns the string representation
@@ -6895,10 +6895,10 @@ func (s RotateEncryptionKeyInput) GoString() string {
 }
 
 type RotateEncryptionKeyOutput struct {
+	_ struct{} `type:"structure"`
+
 	// Describes a cluster.
 	Cluster *Cluster `type:"structure"`
-
-	_ struct{} `type:"structure"`
 }
 
 // String returns the string representation
@@ -6913,6 +6913,8 @@ func (s RotateEncryptionKeyOutput) GoString() string {
 
 // Describes a snapshot.
 type Snapshot struct {
+	_ struct{} `type:"structure"`
+
 	// A list of the AWS customer accounts authorized to restore the snapshot. Returns
 	// null if no accounts are authorized. Visible only to the snapshot owner.
 	AccountsWithRestoreAccess []*AccountWithRestoreAccess `locationNameList:"AccountWithRestoreAccess" type:"list"`
@@ -7012,8 +7014,6 @@ type Snapshot struct {
 	// The VPC identifier of the cluster if the snapshot is from a cluster in a
 	// VPC. Otherwise, this field is not in the output.
 	VpcId *string `type:"string"`
-
-	_ struct{} `type:"structure"`
 }
 
 // String returns the string representation
@@ -7034,6 +7034,8 @@ func (s Snapshot) GoString() string {
 // Redshift Database Encryption (http://docs.aws.amazon.com/redshift/latest/mgmt/working-with-db-encryption.html)
 // in the Amazon Redshift Cluster Management Guide.
 type SnapshotCopyGrant struct {
+	_ struct{} `type:"structure"`
+
 	// The unique identifier of the customer master key (CMK) in AWS KMS to which
 	// Amazon Redshift is granted permission.
 	KmsKeyId *string `type:"string"`
@@ -7043,8 +7045,6 @@ type SnapshotCopyGrant struct {
 
 	// A list of tag instances.
 	Tags []*Tag `locationNameList:"Tag" type:"list"`
-
-	_ struct{} `type:"structure"`
 }
 
 // String returns the string representation
@@ -7059,6 +7059,8 @@ func (s SnapshotCopyGrant) GoString() string {
 
 // Describes a subnet.
 type Subnet struct {
+	_ struct{} `type:"structure"`
+
 	// Describes an availability zone.
 	SubnetAvailabilityZone *AvailabilityZone `type:"structure"`
 
@@ -7067,8 +7069,6 @@ type Subnet struct {
 
 	// The status of the subnet.
 	SubnetStatus *string `type:"string"`
-
-	_ struct{} `type:"structure"`
 }
 
 // String returns the string representation
@@ -7083,13 +7083,13 @@ func (s Subnet) GoString() string {
 
 // A tag consisting of a name/value pair for a resource.
 type Tag struct {
+	_ struct{} `type:"structure"`
+
 	// The key, or name, for the resource tag.
 	Key *string `type:"string"`
 
 	// The value for the resource tag.
 	Value *string `type:"string"`
-
-	_ struct{} `type:"structure"`
 }
 
 // String returns the string representation
@@ -7104,6 +7104,8 @@ func (s Tag) GoString() string {
 
 // A tag and its associated resource.
 type TaggedResource struct {
+	_ struct{} `type:"structure"`
+
 	// The Amazon Resource Name (ARN) with which the tag is associated. For example,
 	// arn:aws:redshift:us-east-1:123456789:cluster:t1.
 	ResourceName *string `type:"string"`
@@ -7119,8 +7121,6 @@ type TaggedResource struct {
 
 	// The tag for the resource.
 	Tag *Tag `type:"structure"`
-
-	_ struct{} `type:"structure"`
 }
 
 // String returns the string representation
@@ -7135,11 +7135,11 @@ func (s TaggedResource) GoString() string {
 
 // Describes the members of a VPC security group.
 type VpcSecurityGroupMembership struct {
+	_ struct{} `type:"structure"`
+
 	Status *string `type:"string"`
 
 	VpcSecurityGroupId *string `type:"string"`
-
-	_ struct{} `type:"structure"`
 }
 
 // String returns the string representation

--- a/service/route53/api.go
+++ b/service/route53/api.go
@@ -1121,11 +1121,7 @@ type AliasTarget struct {
 	// .
 	HostedZoneId *string `type:"string" required:"true"`
 
-	metadataAliasTarget `json:"-" xml:"-"`
-}
-
-type metadataAliasTarget struct {
-	SDKShapeTraits bool `type:"structure"`
+	_ struct{} `type:"structure"`
 }
 
 // String returns the string representation
@@ -1153,11 +1149,7 @@ type AssociateVPCWithHostedZoneInput struct {
 	// The VPC that you want your hosted zone to be associated with.
 	VPC *VPC `type:"structure" required:"true"`
 
-	metadataAssociateVPCWithHostedZoneInput `json:"-" xml:"-"`
-}
-
-type metadataAssociateVPCWithHostedZoneInput struct {
-	SDKShapeTraits bool `locationName:"AssociateVPCWithHostedZoneRequest" type:"structure" xmlURI:"https://route53.amazonaws.com/doc/2013-04-01/"`
+	_ struct{} `locationName:"AssociateVPCWithHostedZoneRequest" type:"structure" xmlURI:"https://route53.amazonaws.com/doc/2013-04-01/"`
 }
 
 // String returns the string representation
@@ -1176,11 +1168,7 @@ type AssociateVPCWithHostedZoneOutput struct {
 	// your AssociateVPCWithHostedZoneRequest.
 	ChangeInfo *ChangeInfo `type:"structure" required:"true"`
 
-	metadataAssociateVPCWithHostedZoneOutput `json:"-" xml:"-"`
-}
-
-type metadataAssociateVPCWithHostedZoneOutput struct {
-	SDKShapeTraits bool `type:"structure"`
+	_ struct{} `type:"structure"`
 }
 
 // String returns the string representation
@@ -1204,11 +1192,7 @@ type Change struct {
 	// Information about the resource record set to create or delete.
 	ResourceRecordSet *ResourceRecordSet `type:"structure" required:"true"`
 
-	metadataChange `json:"-" xml:"-"`
-}
-
-type metadataChange struct {
-	SDKShapeTraits bool `type:"structure"`
+	_ struct{} `type:"structure"`
 }
 
 // String returns the string representation
@@ -1231,11 +1215,7 @@ type ChangeBatch struct {
 	// Optional: Any comments you want to include about a change batch request.
 	Comment *string `type:"string"`
 
-	metadataChangeBatch `json:"-" xml:"-"`
-}
-
-type metadataChangeBatch struct {
-	SDKShapeTraits bool `type:"structure"`
+	_ struct{} `type:"structure"`
 }
 
 // String returns the string representation
@@ -1277,11 +1257,7 @@ type ChangeInfo struct {
 	// Time (UTC), which is synonymous with Greenwich Mean Time in this context.
 	SubmittedAt *time.Time `type:"timestamp" timestampFormat:"iso8601" required:"true"`
 
-	metadataChangeInfo `json:"-" xml:"-"`
-}
-
-type metadataChangeInfo struct {
-	SDKShapeTraits bool `type:"structure"`
+	_ struct{} `type:"structure"`
 }
 
 // String returns the string representation
@@ -1303,11 +1279,7 @@ type ChangeResourceRecordSetsInput struct {
 	// want to change.
 	HostedZoneId *string `location:"uri" locationName:"Id" type:"string" required:"true"`
 
-	metadataChangeResourceRecordSetsInput `json:"-" xml:"-"`
-}
-
-type metadataChangeResourceRecordSetsInput struct {
-	SDKShapeTraits bool `locationName:"ChangeResourceRecordSetsRequest" type:"structure" xmlURI:"https://route53.amazonaws.com/doc/2013-04-01/"`
+	_ struct{} `locationName:"ChangeResourceRecordSetsRequest" type:"structure" xmlURI:"https://route53.amazonaws.com/doc/2013-04-01/"`
 }
 
 // String returns the string representation
@@ -1329,11 +1301,7 @@ type ChangeResourceRecordSetsOutput struct {
 	// to get detailed information about the change.
 	ChangeInfo *ChangeInfo `type:"structure" required:"true"`
 
-	metadataChangeResourceRecordSetsOutput `json:"-" xml:"-"`
-}
-
-type metadataChangeResourceRecordSetsOutput struct {
-	SDKShapeTraits bool `type:"structure"`
+	_ struct{} `type:"structure"`
 }
 
 // String returns the string representation
@@ -1366,11 +1334,7 @@ type ChangeTagsForResourceInput struct {
 	// - The resource type for hosted zones is hostedzone.
 	ResourceType *string `location:"uri" locationName:"ResourceType" type:"string" required:"true" enum:"TagResourceType"`
 
-	metadataChangeTagsForResourceInput `json:"-" xml:"-"`
-}
-
-type metadataChangeTagsForResourceInput struct {
-	SDKShapeTraits bool `locationName:"ChangeTagsForResourceRequest" type:"structure" xmlURI:"https://route53.amazonaws.com/doc/2013-04-01/"`
+	_ struct{} `locationName:"ChangeTagsForResourceRequest" type:"structure" xmlURI:"https://route53.amazonaws.com/doc/2013-04-01/"`
 }
 
 // String returns the string representation
@@ -1385,11 +1349,7 @@ func (s ChangeTagsForResourceInput) GoString() string {
 
 // Empty response for the request.
 type ChangeTagsForResourceOutput struct {
-	metadataChangeTagsForResourceOutput `json:"-" xml:"-"`
-}
-
-type metadataChangeTagsForResourceOutput struct {
-	SDKShapeTraits bool `type:"structure"`
+	_ struct{} `type:"structure"`
 }
 
 // String returns the string representation
@@ -1418,11 +1378,7 @@ type CreateHealthCheckInput struct {
 	// A complex type that contains health check configuration.
 	HealthCheckConfig *HealthCheckConfig `type:"structure" required:"true"`
 
-	metadataCreateHealthCheckInput `json:"-" xml:"-"`
-}
-
-type metadataCreateHealthCheckInput struct {
-	SDKShapeTraits bool `locationName:"CreateHealthCheckRequest" type:"structure" xmlURI:"https://route53.amazonaws.com/doc/2013-04-01/"`
+	_ struct{} `locationName:"CreateHealthCheckRequest" type:"structure" xmlURI:"https://route53.amazonaws.com/doc/2013-04-01/"`
 }
 
 // String returns the string representation
@@ -1443,11 +1399,7 @@ type CreateHealthCheckOutput struct {
 	// The unique URL representing the new health check.
 	Location *string `location:"header" locationName:"Location" type:"string" required:"true"`
 
-	metadataCreateHealthCheckOutput `json:"-" xml:"-"`
-}
-
-type metadataCreateHealthCheckOutput struct {
-	SDKShapeTraits bool `type:"structure"`
+	_ struct{} `type:"structure"`
 }
 
 // String returns the string representation
@@ -1495,11 +1447,7 @@ type CreateHostedZoneInput struct {
 	// than the given VPC.
 	VPC *VPC `type:"structure"`
 
-	metadataCreateHostedZoneInput `json:"-" xml:"-"`
-}
-
-type metadataCreateHostedZoneInput struct {
-	SDKShapeTraits bool `locationName:"CreateHostedZoneRequest" type:"structure" xmlURI:"https://route53.amazonaws.com/doc/2013-04-01/"`
+	_ struct{} `locationName:"CreateHostedZoneRequest" type:"structure" xmlURI:"https://route53.amazonaws.com/doc/2013-04-01/"`
 }
 
 // String returns the string representation
@@ -1530,11 +1478,7 @@ type CreateHostedZoneOutput struct {
 
 	VPC *VPC `type:"structure"`
 
-	metadataCreateHostedZoneOutput `json:"-" xml:"-"`
-}
-
-type metadataCreateHostedZoneOutput struct {
-	SDKShapeTraits bool `type:"structure"`
+	_ struct{} `type:"structure"`
 }
 
 // String returns the string representation
@@ -1562,11 +1506,7 @@ type CreateReusableDelegationSetInput struct {
 	// It is an optional parameter.
 	HostedZoneId *string `type:"string"`
 
-	metadataCreateReusableDelegationSetInput `json:"-" xml:"-"`
-}
-
-type metadataCreateReusableDelegationSetInput struct {
-	SDKShapeTraits bool `locationName:"CreateReusableDelegationSetRequest" type:"structure" xmlURI:"https://route53.amazonaws.com/doc/2013-04-01/"`
+	_ struct{} `locationName:"CreateReusableDelegationSetRequest" type:"structure" xmlURI:"https://route53.amazonaws.com/doc/2013-04-01/"`
 }
 
 // String returns the string representation
@@ -1586,11 +1526,7 @@ type CreateReusableDelegationSetOutput struct {
 	// The unique URL representing the new reusbale delegation set.
 	Location *string `location:"header" locationName:"Location" type:"string" required:"true"`
 
-	metadataCreateReusableDelegationSetOutput `json:"-" xml:"-"`
-}
-
-type metadataCreateReusableDelegationSetOutput struct {
-	SDKShapeTraits bool `type:"structure"`
+	_ struct{} `type:"structure"`
 }
 
 // String returns the string representation
@@ -1614,11 +1550,7 @@ type DelegationSet struct {
 	// to your domain for each NameServer that is assigned to your hosted zone.
 	NameServers []*string `locationNameList:"NameServer" min:"1" type:"list" required:"true"`
 
-	metadataDelegationSet `json:"-" xml:"-"`
-}
-
-type metadataDelegationSet struct {
-	SDKShapeTraits bool `type:"structure"`
+	_ struct{} `type:"structure"`
 }
 
 // String returns the string representation
@@ -1636,11 +1568,7 @@ type DeleteHealthCheckInput struct {
 	// The ID of the health check to delete.
 	HealthCheckId *string `location:"uri" locationName:"HealthCheckId" type:"string" required:"true"`
 
-	metadataDeleteHealthCheckInput `json:"-" xml:"-"`
-}
-
-type metadataDeleteHealthCheckInput struct {
-	SDKShapeTraits bool `type:"structure"`
+	_ struct{} `type:"structure"`
 }
 
 // String returns the string representation
@@ -1655,11 +1583,7 @@ func (s DeleteHealthCheckInput) GoString() string {
 
 // Empty response for the request.
 type DeleteHealthCheckOutput struct {
-	metadataDeleteHealthCheckOutput `json:"-" xml:"-"`
-}
-
-type metadataDeleteHealthCheckOutput struct {
-	SDKShapeTraits bool `type:"structure"`
+	_ struct{} `type:"structure"`
 }
 
 // String returns the string representation
@@ -1678,11 +1602,7 @@ type DeleteHostedZoneInput struct {
 	// The ID of the hosted zone you want to delete.
 	Id *string `location:"uri" locationName:"Id" type:"string" required:"true"`
 
-	metadataDeleteHostedZoneInput `json:"-" xml:"-"`
-}
-
-type metadataDeleteHostedZoneInput struct {
-	SDKShapeTraits bool `type:"structure"`
+	_ struct{} `type:"structure"`
 }
 
 // String returns the string representation
@@ -1701,11 +1621,7 @@ type DeleteHostedZoneOutput struct {
 	// your delete request.
 	ChangeInfo *ChangeInfo `type:"structure" required:"true"`
 
-	metadataDeleteHostedZoneOutput `json:"-" xml:"-"`
-}
-
-type metadataDeleteHostedZoneOutput struct {
-	SDKShapeTraits bool `type:"structure"`
+	_ struct{} `type:"structure"`
 }
 
 // String returns the string representation
@@ -1723,11 +1639,7 @@ type DeleteReusableDelegationSetInput struct {
 	// The ID of the reusable delegation set you want to delete.
 	Id *string `location:"uri" locationName:"Id" type:"string" required:"true"`
 
-	metadataDeleteReusableDelegationSetInput `json:"-" xml:"-"`
-}
-
-type metadataDeleteReusableDelegationSetInput struct {
-	SDKShapeTraits bool `type:"structure"`
+	_ struct{} `type:"structure"`
 }
 
 // String returns the string representation
@@ -1742,11 +1654,7 @@ func (s DeleteReusableDelegationSetInput) GoString() string {
 
 // Empty response for the request.
 type DeleteReusableDelegationSetOutput struct {
-	metadataDeleteReusableDelegationSetOutput `json:"-" xml:"-"`
-}
-
-type metadataDeleteReusableDelegationSetOutput struct {
-	SDKShapeTraits bool `type:"structure"`
+	_ struct{} `type:"structure"`
 }
 
 // String returns the string representation
@@ -1773,11 +1681,7 @@ type DisassociateVPCFromHostedZoneInput struct {
 	// The VPC that you want your hosted zone to be disassociated from.
 	VPC *VPC `type:"structure" required:"true"`
 
-	metadataDisassociateVPCFromHostedZoneInput `json:"-" xml:"-"`
-}
-
-type metadataDisassociateVPCFromHostedZoneInput struct {
-	SDKShapeTraits bool `locationName:"DisassociateVPCFromHostedZoneRequest" type:"structure" xmlURI:"https://route53.amazonaws.com/doc/2013-04-01/"`
+	_ struct{} `locationName:"DisassociateVPCFromHostedZoneRequest" type:"structure" xmlURI:"https://route53.amazonaws.com/doc/2013-04-01/"`
 }
 
 // String returns the string representation
@@ -1796,11 +1700,7 @@ type DisassociateVPCFromHostedZoneOutput struct {
 	// your DisassociateVPCFromHostedZoneRequest.
 	ChangeInfo *ChangeInfo `type:"structure" required:"true"`
 
-	metadataDisassociateVPCFromHostedZoneOutput `json:"-" xml:"-"`
-}
-
-type metadataDisassociateVPCFromHostedZoneOutput struct {
-	SDKShapeTraits bool `type:"structure"`
+	_ struct{} `type:"structure"`
 }
 
 // String returns the string representation
@@ -1838,11 +1738,7 @@ type GeoLocation struct {
 	// error.
 	SubdivisionCode *string `min:"1" type:"string"`
 
-	metadataGeoLocation `json:"-" xml:"-"`
-}
-
-type metadataGeoLocation struct {
-	SDKShapeTraits bool `type:"structure"`
+	_ struct{} `type:"structure"`
 }
 
 // String returns the string representation
@@ -1884,11 +1780,7 @@ type GeoLocationDetails struct {
 	// is also present.
 	SubdivisionName *string `min:"1" type:"string"`
 
-	metadataGeoLocationDetails `json:"-" xml:"-"`
-}
-
-type metadataGeoLocationDetails struct {
-	SDKShapeTraits bool `type:"structure"`
+	_ struct{} `type:"structure"`
 }
 
 // String returns the string representation
@@ -1908,11 +1800,7 @@ type GetChangeInput struct {
 	// the request.
 	Id *string `location:"uri" locationName:"Id" type:"string" required:"true"`
 
-	metadataGetChangeInput `json:"-" xml:"-"`
-}
-
-type metadataGetChangeInput struct {
-	SDKShapeTraits bool `type:"structure"`
+	_ struct{} `type:"structure"`
 }
 
 // String returns the string representation
@@ -1932,11 +1820,7 @@ type GetChangeOutput struct {
 	// time of the request.
 	ChangeInfo *ChangeInfo `type:"structure" required:"true"`
 
-	metadataGetChangeOutput `json:"-" xml:"-"`
-}
-
-type metadataGetChangeOutput struct {
-	SDKShapeTraits bool `type:"structure"`
+	_ struct{} `type:"structure"`
 }
 
 // String returns the string representation
@@ -1951,11 +1835,7 @@ func (s GetChangeOutput) GoString() string {
 
 // Empty request.
 type GetCheckerIpRangesInput struct {
-	metadataGetCheckerIpRangesInput `json:"-" xml:"-"`
-}
-
-type metadataGetCheckerIpRangesInput struct {
-	SDKShapeTraits bool `type:"structure"`
+	_ struct{} `type:"structure"`
 }
 
 // String returns the string representation
@@ -1974,11 +1854,7 @@ type GetCheckerIpRangesOutput struct {
 	// Amazon Route 53 health checkers.
 	CheckerIpRanges []*string `type:"list" required:"true"`
 
-	metadataGetCheckerIpRangesOutput `json:"-" xml:"-"`
-}
-
-type metadataGetCheckerIpRangesOutput struct {
-	SDKShapeTraits bool `type:"structure"`
+	_ struct{} `type:"structure"`
 }
 
 // String returns the string representation
@@ -2016,11 +1892,7 @@ type GetGeoLocationInput struct {
 	// error.
 	SubdivisionCode *string `location:"querystring" locationName:"subdivisioncode" min:"1" type:"string"`
 
-	metadataGetGeoLocationInput `json:"-" xml:"-"`
-}
-
-type metadataGetGeoLocationInput struct {
-	SDKShapeTraits bool `type:"structure"`
+	_ struct{} `type:"structure"`
 }
 
 // String returns the string representation
@@ -2038,11 +1910,7 @@ type GetGeoLocationOutput struct {
 	// A complex type that contains the information about the specified geo location.
 	GeoLocationDetails *GeoLocationDetails `type:"structure" required:"true"`
 
-	metadataGetGeoLocationOutput `json:"-" xml:"-"`
-}
-
-type metadataGetGeoLocationOutput struct {
-	SDKShapeTraits bool `type:"structure"`
+	_ struct{} `type:"structure"`
 }
 
 // String returns the string representation
@@ -2058,11 +1926,7 @@ func (s GetGeoLocationOutput) GoString() string {
 // To retrieve a count of all your health checks, send a GET request to the
 // 2013-04-01/healthcheckcount resource.
 type GetHealthCheckCountInput struct {
-	metadataGetHealthCheckCountInput `json:"-" xml:"-"`
-}
-
-type metadataGetHealthCheckCountInput struct {
-	SDKShapeTraits bool `type:"structure"`
+	_ struct{} `type:"structure"`
 }
 
 // String returns the string representation
@@ -2081,11 +1945,7 @@ type GetHealthCheckCountOutput struct {
 	// The number of health checks associated with the current AWS account.
 	HealthCheckCount *int64 `type:"long" required:"true"`
 
-	metadataGetHealthCheckCountOutput `json:"-" xml:"-"`
-}
-
-type metadataGetHealthCheckCountOutput struct {
-	SDKShapeTraits bool `type:"structure"`
+	_ struct{} `type:"structure"`
 }
 
 // String returns the string representation
@@ -2104,11 +1964,7 @@ type GetHealthCheckInput struct {
 	// The ID of the health check to retrieve.
 	HealthCheckId *string `location:"uri" locationName:"HealthCheckId" type:"string" required:"true"`
 
-	metadataGetHealthCheckInput `json:"-" xml:"-"`
-}
-
-type metadataGetHealthCheckInput struct {
-	SDKShapeTraits bool `type:"structure"`
+	_ struct{} `type:"structure"`
 }
 
 // String returns the string representation
@@ -2128,11 +1984,7 @@ type GetHealthCheckLastFailureReasonInput struct {
 	// the most recent failure.
 	HealthCheckId *string `location:"uri" locationName:"HealthCheckId" type:"string" required:"true"`
 
-	metadataGetHealthCheckLastFailureReasonInput `json:"-" xml:"-"`
-}
-
-type metadataGetHealthCheckLastFailureReasonInput struct {
-	SDKShapeTraits bool `type:"structure"`
+	_ struct{} `type:"structure"`
 }
 
 // String returns the string representation
@@ -2152,11 +2004,7 @@ type GetHealthCheckLastFailureReasonOutput struct {
 	// health checker.
 	HealthCheckObservations []*HealthCheckObservation `locationNameList:"HealthCheckObservation" type:"list" required:"true"`
 
-	metadataGetHealthCheckLastFailureReasonOutput `json:"-" xml:"-"`
-}
-
-type metadataGetHealthCheckLastFailureReasonOutput struct {
-	SDKShapeTraits bool `type:"structure"`
+	_ struct{} `type:"structure"`
 }
 
 // String returns the string representation
@@ -2174,11 +2022,7 @@ type GetHealthCheckOutput struct {
 	// A complex type that contains the information about the specified health check.
 	HealthCheck *HealthCheck `type:"structure" required:"true"`
 
-	metadataGetHealthCheckOutput `json:"-" xml:"-"`
-}
-
-type metadataGetHealthCheckOutput struct {
-	SDKShapeTraits bool `type:"structure"`
+	_ struct{} `type:"structure"`
 }
 
 // String returns the string representation
@@ -2198,11 +2042,7 @@ type GetHealthCheckStatusInput struct {
 	// status.
 	HealthCheckId *string `location:"uri" locationName:"HealthCheckId" type:"string" required:"true"`
 
-	metadataGetHealthCheckStatusInput `json:"-" xml:"-"`
-}
-
-type metadataGetHealthCheckStatusInput struct {
-	SDKShapeTraits bool `type:"structure"`
+	_ struct{} `type:"structure"`
 }
 
 // String returns the string representation
@@ -2222,11 +2062,7 @@ type GetHealthCheckStatusOutput struct {
 	// health checker.
 	HealthCheckObservations []*HealthCheckObservation `locationNameList:"HealthCheckObservation" type:"list" required:"true"`
 
-	metadataGetHealthCheckStatusOutput `json:"-" xml:"-"`
-}
-
-type metadataGetHealthCheckStatusOutput struct {
-	SDKShapeTraits bool `type:"structure"`
+	_ struct{} `type:"structure"`
 }
 
 // String returns the string representation
@@ -2242,11 +2078,7 @@ func (s GetHealthCheckStatusOutput) GoString() string {
 // To retrieve a count of all your hosted zones, send a GET request to the 2013-04-01/hostedzonecount
 // resource.
 type GetHostedZoneCountInput struct {
-	metadataGetHostedZoneCountInput `json:"-" xml:"-"`
-}
-
-type metadataGetHostedZoneCountInput struct {
-	SDKShapeTraits bool `type:"structure"`
+	_ struct{} `type:"structure"`
 }
 
 // String returns the string representation
@@ -2265,11 +2097,7 @@ type GetHostedZoneCountOutput struct {
 	// The number of hosted zones associated with the current AWS account.
 	HostedZoneCount *int64 `type:"long" required:"true"`
 
-	metadataGetHostedZoneCountOutput `json:"-" xml:"-"`
-}
-
-type metadataGetHostedZoneCountOutput struct {
-	SDKShapeTraits bool `type:"structure"`
+	_ struct{} `type:"structure"`
 }
 
 // String returns the string representation
@@ -2288,11 +2116,7 @@ type GetHostedZoneInput struct {
 	// in the delegation set.
 	Id *string `location:"uri" locationName:"Id" type:"string" required:"true"`
 
-	metadataGetHostedZoneInput `json:"-" xml:"-"`
-}
-
-type metadataGetHostedZoneInput struct {
-	SDKShapeTraits bool `type:"structure"`
+	_ struct{} `type:"structure"`
 }
 
 // String returns the string representation
@@ -2318,11 +2142,7 @@ type GetHostedZoneOutput struct {
 	// hosted zone.
 	VPCs []*VPC `locationNameList:"VPC" min:"1" type:"list"`
 
-	metadataGetHostedZoneOutput `json:"-" xml:"-"`
-}
-
-type metadataGetHostedZoneOutput struct {
-	SDKShapeTraits bool `type:"structure"`
+	_ struct{} `type:"structure"`
 }
 
 // String returns the string representation
@@ -2341,11 +2161,7 @@ type GetReusableDelegationSetInput struct {
 	// the name server.
 	Id *string `location:"uri" locationName:"Id" type:"string" required:"true"`
 
-	metadataGetReusableDelegationSetInput `json:"-" xml:"-"`
-}
-
-type metadataGetReusableDelegationSetInput struct {
-	SDKShapeTraits bool `type:"structure"`
+	_ struct{} `type:"structure"`
 }
 
 // String returns the string representation
@@ -2365,11 +2181,7 @@ type GetReusableDelegationSetOutput struct {
 	// specified delegation set ID.
 	DelegationSet *DelegationSet `type:"structure" required:"true"`
 
-	metadataGetReusableDelegationSetOutput `json:"-" xml:"-"`
-}
-
-type metadataGetReusableDelegationSetOutput struct {
-	SDKShapeTraits bool `type:"structure"`
+	_ struct{} `type:"structure"`
 }
 
 // String returns the string representation
@@ -2398,11 +2210,7 @@ type HealthCheck struct {
 	// The ID of the specified health check.
 	Id *string `type:"string" required:"true"`
 
-	metadataHealthCheck `json:"-" xml:"-"`
-}
-
-type metadataHealthCheck struct {
-	SDKShapeTraits bool `type:"structure"`
+	_ struct{} `type:"structure"`
 }
 
 // String returns the string representation
@@ -2476,11 +2284,7 @@ type HealthCheckConfig struct {
 	// HTTP, HTTPS, HTTP_STR_MATCH, and HTTPS_STR_MATCH.
 	Type *string `type:"string" required:"true" enum:"HealthCheckType"`
 
-	metadataHealthCheckConfig `json:"-" xml:"-"`
-}
-
-type metadataHealthCheckConfig struct {
-	SDKShapeTraits bool `type:"structure"`
+	_ struct{} `type:"structure"`
 }
 
 // String returns the string representation
@@ -2503,11 +2307,7 @@ type HealthCheckObservation struct {
 	// the current observation.
 	StatusReport *StatusReport `type:"structure"`
 
-	metadataHealthCheckObservation `json:"-" xml:"-"`
-}
-
-type metadataHealthCheckObservation struct {
-	SDKShapeTraits bool `type:"structure"`
+	_ struct{} `type:"structure"`
 }
 
 // String returns the string representation
@@ -2544,11 +2344,7 @@ type HostedZone struct {
 	// Total number of resource record sets in the hosted zone.
 	ResourceRecordSetCount *int64 `type:"long"`
 
-	metadataHostedZone `json:"-" xml:"-"`
-}
-
-type metadataHostedZone struct {
-	SDKShapeTraits bool `type:"structure"`
+	_ struct{} `type:"structure"`
 }
 
 // String returns the string representation
@@ -2574,11 +2370,7 @@ type HostedZoneConfig struct {
 	// returned in the response; do not specify it in the request.
 	PrivateZone *bool `type:"boolean"`
 
-	metadataHostedZoneConfig `json:"-" xml:"-"`
-}
-
-type metadataHostedZoneConfig struct {
-	SDKShapeTraits bool `type:"structure"`
+	_ struct{} `type:"structure"`
 }
 
 // String returns the string representation
@@ -2620,11 +2412,7 @@ type ListGeoLocationsInput struct {
 	// error.
 	StartSubdivisionCode *string `location:"querystring" locationName:"startsubdivisioncode" min:"1" type:"string"`
 
-	metadataListGeoLocationsInput `json:"-" xml:"-"`
-}
-
-type metadataListGeoLocationsInput struct {
-	SDKShapeTraits bool `type:"structure"`
+	_ struct{} `type:"structure"`
 }
 
 // String returns the string representation
@@ -2672,11 +2460,7 @@ type ListGeoLocationsOutput struct {
 	// is true and the next geo location has a subdivision.
 	NextSubdivisionCode *string `min:"1" type:"string"`
 
-	metadataListGeoLocationsOutput `json:"-" xml:"-"`
-}
-
-type metadataListGeoLocationsOutput struct {
-	SDKShapeTraits bool `type:"structure"`
+	_ struct{} `type:"structure"`
 }
 
 // String returns the string representation
@@ -2707,11 +2491,7 @@ type ListHealthChecksInput struct {
 	// Specify the maximum number of health checks to return per page of results.
 	MaxItems *string `location:"querystring" locationName:"maxitems" type:"string"`
 
-	metadataListHealthChecksInput `json:"-" xml:"-"`
-}
-
-type metadataListHealthChecksInput struct {
-	SDKShapeTraits bool `type:"structure"`
+	_ struct{} `type:"structure"`
 }
 
 // String returns the string representation
@@ -2754,11 +2534,7 @@ type ListHealthChecksOutput struct {
 	// the NextMarker element in the Marker element to get the next page of results.
 	NextMarker *string `type:"string"`
 
-	metadataListHealthChecksOutput `json:"-" xml:"-"`
-}
-
-type metadataListHealthChecksOutput struct {
-	SDKShapeTraits bool `type:"structure"`
+	_ struct{} `type:"structure"`
 }
 
 // String returns the string representation
@@ -2800,11 +2576,7 @@ type ListHostedZonesByNameInput struct {
 	// Specify the maximum number of hosted zones to return per page of results.
 	MaxItems *string `location:"querystring" locationName:"maxitems" type:"string"`
 
-	metadataListHostedZonesByNameInput `json:"-" xml:"-"`
-}
-
-type metadataListHostedZonesByNameInput struct {
-	SDKShapeTraits bool `type:"structure"`
+	_ struct{} `type:"structure"`
 }
 
 // String returns the string representation
@@ -2858,11 +2630,7 @@ type ListHostedZonesByNameOutput struct {
 	// in the ListHostedZonesByNameRequest$HostedZoneId element.
 	NextHostedZoneId *string `type:"string"`
 
-	metadataListHostedZonesByNameOutput `json:"-" xml:"-"`
-}
-
-type metadataListHostedZonesByNameOutput struct {
-	SDKShapeTraits bool `type:"structure"`
+	_ struct{} `type:"structure"`
 }
 
 // String returns the string representation
@@ -2898,11 +2666,7 @@ type ListHostedZonesInput struct {
 	// Specify the maximum number of hosted zones to return per page of results.
 	MaxItems *string `location:"querystring" locationName:"maxitems" type:"string"`
 
-	metadataListHostedZonesInput `json:"-" xml:"-"`
-}
-
-type metadataListHostedZonesInput struct {
-	SDKShapeTraits bool `type:"structure"`
+	_ struct{} `type:"structure"`
 }
 
 // String returns the string representation
@@ -2945,11 +2709,7 @@ type ListHostedZonesOutput struct {
 	// the NextMarker element in the Marker element to get the next page of results.
 	NextMarker *string `type:"string"`
 
-	metadataListHostedZonesOutput `json:"-" xml:"-"`
-}
-
-type metadataListHostedZonesOutput struct {
-	SDKShapeTraits bool `type:"structure"`
+	_ struct{} `type:"structure"`
 }
 
 // String returns the string representation
@@ -2995,11 +2755,7 @@ type ListResourceRecordSetsInput struct {
 	// error.
 	StartRecordType *string `location:"querystring" locationName:"type" type:"string" enum:"RRType"`
 
-	metadataListResourceRecordSetsInput `json:"-" xml:"-"`
-}
-
-type metadataListResourceRecordSetsInput struct {
-	SDKShapeTraits bool `type:"structure"`
+	_ struct{} `type:"structure"`
 }
 
 // String returns the string representation
@@ -3046,11 +2802,7 @@ type ListResourceRecordSetsOutput struct {
 	// are returned by the request.
 	ResourceRecordSets []*ResourceRecordSet `locationNameList:"ResourceRecordSet" type:"list" required:"true"`
 
-	metadataListResourceRecordSetsOutput `json:"-" xml:"-"`
-}
-
-type metadataListResourceRecordSetsOutput struct {
-	SDKShapeTraits bool `type:"structure"`
+	_ struct{} `type:"structure"`
 }
 
 // String returns the string representation
@@ -3083,11 +2835,7 @@ type ListReusableDelegationSetsInput struct {
 	// of results.
 	MaxItems *string `location:"querystring" locationName:"maxitems" type:"string"`
 
-	metadataListReusableDelegationSetsInput `json:"-" xml:"-"`
-}
-
-type metadataListReusableDelegationSetsInput struct {
-	SDKShapeTraits bool `type:"structure"`
+	_ struct{} `type:"structure"`
 }
 
 // String returns the string representation
@@ -3132,11 +2880,7 @@ type ListReusableDelegationSetsOutput struct {
 	// of results.
 	NextMarker *string `type:"string"`
 
-	metadataListReusableDelegationSetsOutput `json:"-" xml:"-"`
-}
-
-type metadataListReusableDelegationSetsOutput struct {
-	SDKShapeTraits bool `type:"structure"`
+	_ struct{} `type:"structure"`
 }
 
 // String returns the string representation
@@ -3162,11 +2906,7 @@ type ListTagsForResourceInput struct {
 	// - The resource type for hosted zones is hostedzone.
 	ResourceType *string `location:"uri" locationName:"ResourceType" type:"string" required:"true" enum:"TagResourceType"`
 
-	metadataListTagsForResourceInput `json:"-" xml:"-"`
-}
-
-type metadataListTagsForResourceInput struct {
-	SDKShapeTraits bool `type:"structure"`
+	_ struct{} `type:"structure"`
 }
 
 // String returns the string representation
@@ -3184,11 +2924,7 @@ type ListTagsForResourceOutput struct {
 	// A ResourceTagSet containing tags associated with the specified resource.
 	ResourceTagSet *ResourceTagSet `type:"structure" required:"true"`
 
-	metadataListTagsForResourceOutput `json:"-" xml:"-"`
-}
-
-type metadataListTagsForResourceOutput struct {
-	SDKShapeTraits bool `type:"structure"`
+	_ struct{} `type:"structure"`
 }
 
 // String returns the string representation
@@ -3215,11 +2951,7 @@ type ListTagsForResourcesInput struct {
 	// - The resource type for hosted zones is hostedzone.
 	ResourceType *string `location:"uri" locationName:"ResourceType" type:"string" required:"true" enum:"TagResourceType"`
 
-	metadataListTagsForResourcesInput `json:"-" xml:"-"`
-}
-
-type metadataListTagsForResourcesInput struct {
-	SDKShapeTraits bool `locationName:"ListTagsForResourcesRequest" type:"structure" xmlURI:"https://route53.amazonaws.com/doc/2013-04-01/"`
+	_ struct{} `locationName:"ListTagsForResourcesRequest" type:"structure" xmlURI:"https://route53.amazonaws.com/doc/2013-04-01/"`
 }
 
 // String returns the string representation
@@ -3237,11 +2969,7 @@ type ListTagsForResourcesOutput struct {
 	// A list of ResourceTagSets containing tags associated with the specified resources.
 	ResourceTagSets []*ResourceTagSet `locationNameList:"ResourceTagSet" type:"list" required:"true"`
 
-	metadataListTagsForResourcesOutput `json:"-" xml:"-"`
-}
-
-type metadataListTagsForResourcesOutput struct {
-	SDKShapeTraits bool `type:"structure"`
+	_ struct{} `type:"structure"`
 }
 
 // String returns the string representation
@@ -3260,11 +2988,7 @@ type ResourceRecord struct {
 	// The value of the Value element for the current resource record set.
 	Value *string `type:"string" required:"true"`
 
-	metadataResourceRecord `json:"-" xml:"-"`
-}
-
-type metadataResourceRecord struct {
-	SDKShapeTraits bool `type:"structure"`
+	_ struct{} `type:"structure"`
 }
 
 // String returns the string representation
@@ -3341,11 +3065,7 @@ type ResourceRecordSet struct {
 	// location.
 	Weight *int64 `type:"long"`
 
-	metadataResourceRecordSet `json:"-" xml:"-"`
-}
-
-type metadataResourceRecordSet struct {
-	SDKShapeTraits bool `type:"structure"`
+	_ struct{} `type:"structure"`
 }
 
 // String returns the string representation
@@ -3373,11 +3093,7 @@ type ResourceTagSet struct {
 	// The tags associated with the specified resource.
 	Tags []*Tag `locationNameList:"Tag" min:"1" type:"list"`
 
-	metadataResourceTagSet `json:"-" xml:"-"`
-}
-
-type metadataResourceTagSet struct {
-	SDKShapeTraits bool `type:"structure"`
+	_ struct{} `type:"structure"`
 }
 
 // String returns the string representation
@@ -3402,11 +3118,7 @@ type StatusReport struct {
 	// The observed health check status.
 	Status *string `type:"string"`
 
-	metadataStatusReport `json:"-" xml:"-"`
-}
-
-type metadataStatusReport struct {
-	SDKShapeTraits bool `type:"structure"`
+	_ struct{} `type:"structure"`
 }
 
 // String returns the string representation
@@ -3427,11 +3139,7 @@ type Tag struct {
 	// The value for a Tag.
 	Value *string `type:"string"`
 
-	metadataTag `json:"-" xml:"-"`
-}
-
-type metadataTag struct {
-	SDKShapeTraits bool `type:"structure"`
+	_ struct{} `type:"structure"`
 }
 
 // String returns the string representation
@@ -3519,11 +3227,7 @@ type UpdateHealthCheckInput struct {
 	// Specify this value only if you want to change it.
 	SearchString *string `type:"string"`
 
-	metadataUpdateHealthCheckInput `json:"-" xml:"-"`
-}
-
-type metadataUpdateHealthCheckInput struct {
-	SDKShapeTraits bool `locationName:"UpdateHealthCheckRequest" type:"structure" xmlURI:"https://route53.amazonaws.com/doc/2013-04-01/"`
+	_ struct{} `locationName:"UpdateHealthCheckRequest" type:"structure" xmlURI:"https://route53.amazonaws.com/doc/2013-04-01/"`
 }
 
 // String returns the string representation
@@ -3540,11 +3244,7 @@ type UpdateHealthCheckOutput struct {
 	// A complex type that contains identifying information about the health check.
 	HealthCheck *HealthCheck `type:"structure" required:"true"`
 
-	metadataUpdateHealthCheckOutput `json:"-" xml:"-"`
-}
-
-type metadataUpdateHealthCheckOutput struct {
-	SDKShapeTraits bool `type:"structure"`
+	_ struct{} `type:"structure"`
 }
 
 // String returns the string representation
@@ -3566,11 +3266,7 @@ type UpdateHostedZoneCommentInput struct {
 	// The ID of the hosted zone you want to update.
 	Id *string `location:"uri" locationName:"Id" type:"string" required:"true"`
 
-	metadataUpdateHostedZoneCommentInput `json:"-" xml:"-"`
-}
-
-type metadataUpdateHostedZoneCommentInput struct {
-	SDKShapeTraits bool `locationName:"UpdateHostedZoneCommentRequest" type:"structure" xmlURI:"https://route53.amazonaws.com/doc/2013-04-01/"`
+	_ struct{} `locationName:"UpdateHostedZoneCommentRequest" type:"structure" xmlURI:"https://route53.amazonaws.com/doc/2013-04-01/"`
 }
 
 // String returns the string representation
@@ -3589,11 +3285,7 @@ type UpdateHostedZoneCommentOutput struct {
 	// A complex type that contain information about the specified hosted zone.
 	HostedZone *HostedZone `type:"structure" required:"true"`
 
-	metadataUpdateHostedZoneCommentOutput `json:"-" xml:"-"`
-}
-
-type metadataUpdateHostedZoneCommentOutput struct {
-	SDKShapeTraits bool `type:"structure"`
+	_ struct{} `type:"structure"`
 }
 
 // String returns the string representation
@@ -3612,11 +3304,7 @@ type VPC struct {
 
 	VPCRegion *string `min:"1" type:"string" enum:"VPCRegion"`
 
-	metadataVPC `json:"-" xml:"-"`
-}
-
-type metadataVPC struct {
-	SDKShapeTraits bool `type:"structure"`
+	_ struct{} `type:"structure"`
 }
 
 // String returns the string representation

--- a/service/route53/api.go
+++ b/service/route53/api.go
@@ -1090,6 +1090,8 @@ func (c *Route53) UpdateHostedZoneComment(input *UpdateHostedZoneCommentInput) (
 //
 // .
 type AliasTarget struct {
+	_ struct{} `type:"structure"`
+
 	// Alias resource record sets only: The external DNS name associated with the
 	// AWS Resource.
 	//
@@ -1120,8 +1122,6 @@ type AliasTarget struct {
 	//
 	// .
 	HostedZoneId *string `type:"string" required:"true"`
-
-	_ struct{} `type:"structure"`
 }
 
 // String returns the string representation
@@ -1137,6 +1137,8 @@ func (s AliasTarget) GoString() string {
 // A complex type that contains information about the request to associate a
 // VPC with an hosted zone.
 type AssociateVPCWithHostedZoneInput struct {
+	_ struct{} `locationName:"AssociateVPCWithHostedZoneRequest" type:"structure" xmlURI:"https://route53.amazonaws.com/doc/2013-04-01/"`
+
 	// Optional: Any comments you want to include about a AssociateVPCWithHostedZoneRequest.
 	Comment *string `type:"string"`
 
@@ -1148,8 +1150,6 @@ type AssociateVPCWithHostedZoneInput struct {
 
 	// The VPC that you want your hosted zone to be associated with.
 	VPC *VPC `type:"structure" required:"true"`
-
-	_ struct{} `locationName:"AssociateVPCWithHostedZoneRequest" type:"structure" xmlURI:"https://route53.amazonaws.com/doc/2013-04-01/"`
 }
 
 // String returns the string representation
@@ -1164,11 +1164,11 @@ func (s AssociateVPCWithHostedZoneInput) GoString() string {
 
 // A complex type containing the response information for the request.
 type AssociateVPCWithHostedZoneOutput struct {
+	_ struct{} `type:"structure"`
+
 	// A complex type that contains the ID, the status, and the date and time of
 	// your AssociateVPCWithHostedZoneRequest.
 	ChangeInfo *ChangeInfo `type:"structure" required:"true"`
-
-	_ struct{} `type:"structure"`
 }
 
 // String returns the string representation
@@ -1184,6 +1184,8 @@ func (s AssociateVPCWithHostedZoneOutput) GoString() string {
 // A complex type that contains the information for each change in a change
 // batch request.
 type Change struct {
+	_ struct{} `type:"structure"`
+
 	// The action to perform.
 	//
 	// Valid values: CREATE | DELETE | UPSERT
@@ -1191,8 +1193,6 @@ type Change struct {
 
 	// Information about the resource record set to create or delete.
 	ResourceRecordSet *ResourceRecordSet `type:"structure" required:"true"`
-
-	_ struct{} `type:"structure"`
 }
 
 // String returns the string representation
@@ -1208,14 +1208,14 @@ func (s Change) GoString() string {
 // A complex type that contains an optional comment and the changes that you
 // want to make with a change batch request.
 type ChangeBatch struct {
+	_ struct{} `type:"structure"`
+
 	// A complex type that contains one Change element for each resource record
 	// set that you want to create or delete.
 	Changes []*Change `locationNameList:"Change" min:"1" type:"list" required:"true"`
 
 	// Optional: Any comments you want to include about a change batch request.
 	Comment *string `type:"string"`
-
-	_ struct{} `type:"structure"`
 }
 
 // String returns the string representation
@@ -1234,6 +1234,8 @@ func (s ChangeBatch) GoString() string {
 // This element contains an ID that you use when performing a GetChange action
 // to get detailed information about the change.
 type ChangeInfo struct {
+	_ struct{} `type:"structure"`
+
 	// A complex type that describes change information about changes made to your
 	// hosted zone.
 	//
@@ -1256,8 +1258,6 @@ type ChangeInfo struct {
 	// The Z after the time indicates that the time is listed in Coordinated Universal
 	// Time (UTC), which is synonymous with Greenwich Mean Time in this context.
 	SubmittedAt *time.Time `type:"timestamp" timestampFormat:"iso8601" required:"true"`
-
-	_ struct{} `type:"structure"`
 }
 
 // String returns the string representation
@@ -1272,14 +1272,14 @@ func (s ChangeInfo) GoString() string {
 
 // A complex type that contains a change batch.
 type ChangeResourceRecordSetsInput struct {
+	_ struct{} `locationName:"ChangeResourceRecordSetsRequest" type:"structure" xmlURI:"https://route53.amazonaws.com/doc/2013-04-01/"`
+
 	// A complex type that contains an optional comment and the Changes element.
 	ChangeBatch *ChangeBatch `type:"structure" required:"true"`
 
 	// The ID of the hosted zone that contains the resource record sets that you
 	// want to change.
 	HostedZoneId *string `location:"uri" locationName:"Id" type:"string" required:"true"`
-
-	_ struct{} `locationName:"ChangeResourceRecordSetsRequest" type:"structure" xmlURI:"https://route53.amazonaws.com/doc/2013-04-01/"`
 }
 
 // String returns the string representation
@@ -1294,14 +1294,14 @@ func (s ChangeResourceRecordSetsInput) GoString() string {
 
 // A complex type containing the response for the request.
 type ChangeResourceRecordSetsOutput struct {
+	_ struct{} `type:"structure"`
+
 	// A complex type that contains information about changes made to your hosted
 	// zone.
 	//
 	// This element contains an ID that you use when performing a GetChange action
 	// to get detailed information about the change.
 	ChangeInfo *ChangeInfo `type:"structure" required:"true"`
-
-	_ struct{} `type:"structure"`
 }
 
 // String returns the string representation
@@ -1317,6 +1317,8 @@ func (s ChangeResourceRecordSetsOutput) GoString() string {
 // A complex type containing information about a request to add, change, or
 // delete the tags that are associated with a resource.
 type ChangeTagsForResourceInput struct {
+	_ struct{} `locationName:"ChangeTagsForResourceRequest" type:"structure" xmlURI:"https://route53.amazonaws.com/doc/2013-04-01/"`
+
 	// A complex type that contains a list of Tag elements. Each Tag element identifies
 	// a tag that you want to add or update for the specified resource.
 	AddTags []*Tag `locationNameList:"Tag" min:"1" type:"list"`
@@ -1333,8 +1335,6 @@ type ChangeTagsForResourceInput struct {
 	//
 	// - The resource type for hosted zones is hostedzone.
 	ResourceType *string `location:"uri" locationName:"ResourceType" type:"string" required:"true" enum:"TagResourceType"`
-
-	_ struct{} `locationName:"ChangeTagsForResourceRequest" type:"structure" xmlURI:"https://route53.amazonaws.com/doc/2013-04-01/"`
 }
 
 // String returns the string representation
@@ -1365,6 +1365,8 @@ func (s ChangeTagsForResourceOutput) GoString() string {
 // >A complex type that contains information about the request to create a health
 // check.
 type CreateHealthCheckInput struct {
+	_ struct{} `locationName:"CreateHealthCheckRequest" type:"structure" xmlURI:"https://route53.amazonaws.com/doc/2013-04-01/"`
+
 	// A unique string that identifies the request and that allows failed CreateHealthCheck
 	// requests to be retried without the risk of executing the operation twice.
 	// You must use a unique CallerReference string every time you create a health
@@ -1377,8 +1379,6 @@ type CreateHealthCheckInput struct {
 
 	// A complex type that contains health check configuration.
 	HealthCheckConfig *HealthCheckConfig `type:"structure" required:"true"`
-
-	_ struct{} `locationName:"CreateHealthCheckRequest" type:"structure" xmlURI:"https://route53.amazonaws.com/doc/2013-04-01/"`
 }
 
 // String returns the string representation
@@ -1393,13 +1393,13 @@ func (s CreateHealthCheckInput) GoString() string {
 
 // A complex type containing the response information for the new health check.
 type CreateHealthCheckOutput struct {
+	_ struct{} `type:"structure"`
+
 	// A complex type that contains identifying information about the health check.
 	HealthCheck *HealthCheck `type:"structure" required:"true"`
 
 	// The unique URL representing the new health check.
 	Location *string `location:"header" locationName:"Location" type:"string" required:"true"`
-
-	_ struct{} `type:"structure"`
 }
 
 // String returns the string representation
@@ -1415,6 +1415,8 @@ func (s CreateHealthCheckOutput) GoString() string {
 // A complex type that contains information about the request to create a hosted
 // zone.
 type CreateHostedZoneInput struct {
+	_ struct{} `locationName:"CreateHostedZoneRequest" type:"structure" xmlURI:"https://route53.amazonaws.com/doc/2013-04-01/"`
+
 	// A unique string that identifies the request and that allows failed CreateHostedZone
 	// requests to be retried without the risk of executing the operation twice.
 	// You must use a unique CallerReference string every time you create a hosted
@@ -1446,8 +1448,6 @@ type CreateHostedZoneInput struct {
 	// this parameter, your newly created hosted cannot be resolved anywhere other
 	// than the given VPC.
 	VPC *VPC `type:"structure"`
-
-	_ struct{} `locationName:"CreateHostedZoneRequest" type:"structure" xmlURI:"https://route53.amazonaws.com/doc/2013-04-01/"`
 }
 
 // String returns the string representation
@@ -1462,6 +1462,8 @@ func (s CreateHostedZoneInput) GoString() string {
 
 // A complex type containing the response information for the new hosted zone.
 type CreateHostedZoneOutput struct {
+	_ struct{} `type:"structure"`
+
 	// A complex type that contains information about the request to create a hosted
 	// zone. This includes an ID that you use when you call the GetChange action
 	// to get the current status of the change request.
@@ -1477,8 +1479,6 @@ type CreateHostedZoneOutput struct {
 	Location *string `location:"header" locationName:"Location" type:"string" required:"true"`
 
 	VPC *VPC `type:"structure"`
-
-	_ struct{} `type:"structure"`
 }
 
 // String returns the string representation
@@ -1492,6 +1492,8 @@ func (s CreateHostedZoneOutput) GoString() string {
 }
 
 type CreateReusableDelegationSetInput struct {
+	_ struct{} `locationName:"CreateReusableDelegationSetRequest" type:"structure" xmlURI:"https://route53.amazonaws.com/doc/2013-04-01/"`
+
 	// A unique string that identifies the request and that allows failed CreateReusableDelegationSet
 	// requests to be retried without the risk of executing the operation twice.
 	// You must use a unique CallerReference string every time you create a reusable
@@ -1505,8 +1507,6 @@ type CreateReusableDelegationSetInput struct {
 	// The ID of the hosted zone whose delegation set you want to mark as reusable.
 	// It is an optional parameter.
 	HostedZoneId *string `type:"string"`
-
-	_ struct{} `locationName:"CreateReusableDelegationSetRequest" type:"structure" xmlURI:"https://route53.amazonaws.com/doc/2013-04-01/"`
 }
 
 // String returns the string representation
@@ -1520,13 +1520,13 @@ func (s CreateReusableDelegationSetInput) GoString() string {
 }
 
 type CreateReusableDelegationSetOutput struct {
+	_ struct{} `type:"structure"`
+
 	// A complex type that contains name server information.
 	DelegationSet *DelegationSet `type:"structure" required:"true"`
 
 	// The unique URL representing the new reusbale delegation set.
 	Location *string `location:"header" locationName:"Location" type:"string" required:"true"`
-
-	_ struct{} `type:"structure"`
 }
 
 // String returns the string representation
@@ -1541,6 +1541,8 @@ func (s CreateReusableDelegationSetOutput) GoString() string {
 
 // A complex type that contains name server information.
 type DelegationSet struct {
+	_ struct{} `type:"structure"`
+
 	CallerReference *string `min:"1" type:"string"`
 
 	Id *string `type:"string"`
@@ -1549,8 +1551,6 @@ type DelegationSet struct {
 	// zone. Use the method provided by your domain registrar to add an NS record
 	// to your domain for each NameServer that is assigned to your hosted zone.
 	NameServers []*string `locationNameList:"NameServer" min:"1" type:"list" required:"true"`
-
-	_ struct{} `type:"structure"`
 }
 
 // String returns the string representation
@@ -1565,10 +1565,10 @@ func (s DelegationSet) GoString() string {
 
 // A complex type containing the request information for delete health check.
 type DeleteHealthCheckInput struct {
+	_ struct{} `type:"structure"`
+
 	// The ID of the health check to delete.
 	HealthCheckId *string `location:"uri" locationName:"HealthCheckId" type:"string" required:"true"`
-
-	_ struct{} `type:"structure"`
 }
 
 // String returns the string representation
@@ -1599,10 +1599,10 @@ func (s DeleteHealthCheckOutput) GoString() string {
 // A complex type that contains information about the hosted zone that you want
 // to delete.
 type DeleteHostedZoneInput struct {
+	_ struct{} `type:"structure"`
+
 	// The ID of the hosted zone you want to delete.
 	Id *string `location:"uri" locationName:"Id" type:"string" required:"true"`
-
-	_ struct{} `type:"structure"`
 }
 
 // String returns the string representation
@@ -1617,11 +1617,11 @@ func (s DeleteHostedZoneInput) GoString() string {
 
 // A complex type containing the response information for the request.
 type DeleteHostedZoneOutput struct {
+	_ struct{} `type:"structure"`
+
 	// A complex type that contains the ID, the status, and the date and time of
 	// your delete request.
 	ChangeInfo *ChangeInfo `type:"structure" required:"true"`
-
-	_ struct{} `type:"structure"`
 }
 
 // String returns the string representation
@@ -1636,10 +1636,10 @@ func (s DeleteHostedZoneOutput) GoString() string {
 
 // A complex type containing the information for the delete request.
 type DeleteReusableDelegationSetInput struct {
+	_ struct{} `type:"structure"`
+
 	// The ID of the reusable delegation set you want to delete.
 	Id *string `location:"uri" locationName:"Id" type:"string" required:"true"`
-
-	_ struct{} `type:"structure"`
 }
 
 // String returns the string representation
@@ -1670,6 +1670,8 @@ func (s DeleteReusableDelegationSetOutput) GoString() string {
 // A complex type that contains information about the request to disassociate
 // a VPC from an hosted zone.
 type DisassociateVPCFromHostedZoneInput struct {
+	_ struct{} `locationName:"DisassociateVPCFromHostedZoneRequest" type:"structure" xmlURI:"https://route53.amazonaws.com/doc/2013-04-01/"`
+
 	// Optional: Any comments you want to include about a DisassociateVPCFromHostedZoneRequest.
 	Comment *string `type:"string"`
 
@@ -1680,8 +1682,6 @@ type DisassociateVPCFromHostedZoneInput struct {
 
 	// The VPC that you want your hosted zone to be disassociated from.
 	VPC *VPC `type:"structure" required:"true"`
-
-	_ struct{} `locationName:"DisassociateVPCFromHostedZoneRequest" type:"structure" xmlURI:"https://route53.amazonaws.com/doc/2013-04-01/"`
 }
 
 // String returns the string representation
@@ -1696,11 +1696,11 @@ func (s DisassociateVPCFromHostedZoneInput) GoString() string {
 
 // A complex type containing the response information for the request.
 type DisassociateVPCFromHostedZoneOutput struct {
+	_ struct{} `type:"structure"`
+
 	// A complex type that contains the ID, the status, and the date and time of
 	// your DisassociateVPCFromHostedZoneRequest.
 	ChangeInfo *ChangeInfo `type:"structure" required:"true"`
-
-	_ struct{} `type:"structure"`
 }
 
 // String returns the string representation
@@ -1715,6 +1715,8 @@ func (s DisassociateVPCFromHostedZoneOutput) GoString() string {
 
 // A complex type that contains information about a geo location.
 type GeoLocation struct {
+	_ struct{} `type:"structure"`
+
 	// The code for a continent geo location. Note: only continent locations have
 	// a continent code.
 	//
@@ -1737,8 +1739,6 @@ type GeoLocation struct {
 	// Constraint: Specifying SubdivisionCode without CountryCode returns an InvalidInput
 	// error.
 	SubdivisionCode *string `min:"1" type:"string"`
-
-	_ struct{} `type:"structure"`
 }
 
 // String returns the string representation
@@ -1753,6 +1753,8 @@ func (s GeoLocation) GoString() string {
 
 // A complex type that contains information about a GeoLocation.
 type GeoLocationDetails struct {
+	_ struct{} `type:"structure"`
+
 	// The code for a continent geo location. Note: only continent locations have
 	// a continent code.
 	ContinentCode *string `min:"2" type:"string"`
@@ -1779,8 +1781,6 @@ type GeoLocationDetails struct {
 	// The name of the subdivision. This element is only present if SubdivisionCode
 	// is also present.
 	SubdivisionName *string `min:"1" type:"string"`
-
-	_ struct{} `type:"structure"`
 }
 
 // String returns the string representation
@@ -1795,12 +1795,12 @@ func (s GeoLocationDetails) GoString() string {
 
 // The input for a GetChange request.
 type GetChangeInput struct {
+	_ struct{} `type:"structure"`
+
 	// The ID of the change batch request. The value that you specify here is the
 	// value that ChangeResourceRecordSets returned in the Id element when you submitted
 	// the request.
 	Id *string `location:"uri" locationName:"Id" type:"string" required:"true"`
-
-	_ struct{} `type:"structure"`
 }
 
 // String returns the string representation
@@ -1815,12 +1815,12 @@ func (s GetChangeInput) GoString() string {
 
 // A complex type that contains the ChangeInfo element.
 type GetChangeOutput struct {
+	_ struct{} `type:"structure"`
+
 	// A complex type that contains information about the specified change batch,
 	// including the change batch ID, the status of the change, and the date and
 	// time of the request.
 	ChangeInfo *ChangeInfo `type:"structure" required:"true"`
-
-	_ struct{} `type:"structure"`
 }
 
 // String returns the string representation
@@ -1850,11 +1850,11 @@ func (s GetCheckerIpRangesInput) GoString() string {
 
 // A complex type that contains the CheckerIpRanges element.
 type GetCheckerIpRangesOutput struct {
+	_ struct{} `type:"structure"`
+
 	// A complex type that contains sorted list of IP ranges in CIDR format for
 	// Amazon Route 53 health checkers.
 	CheckerIpRanges []*string `type:"list" required:"true"`
-
-	_ struct{} `type:"structure"`
 }
 
 // String returns the string representation
@@ -1869,6 +1869,8 @@ func (s GetCheckerIpRangesOutput) GoString() string {
 
 // A complex type that contains information about the request to get a geo location.
 type GetGeoLocationInput struct {
+	_ struct{} `type:"structure"`
+
 	// The code for a continent geo location. Note: only continent locations have
 	// a continent code.
 	//
@@ -1891,8 +1893,6 @@ type GetGeoLocationInput struct {
 	// Constraint: Specifying SubdivisionCode without CountryCode returns an InvalidInput
 	// error.
 	SubdivisionCode *string `location:"querystring" locationName:"subdivisioncode" min:"1" type:"string"`
-
-	_ struct{} `type:"structure"`
 }
 
 // String returns the string representation
@@ -1907,10 +1907,10 @@ func (s GetGeoLocationInput) GoString() string {
 
 // A complex type containing information about the specified geo location.
 type GetGeoLocationOutput struct {
+	_ struct{} `type:"structure"`
+
 	// A complex type that contains the information about the specified geo location.
 	GeoLocationDetails *GeoLocationDetails `type:"structure" required:"true"`
-
-	_ struct{} `type:"structure"`
 }
 
 // String returns the string representation
@@ -1942,10 +1942,10 @@ func (s GetHealthCheckCountInput) GoString() string {
 // A complex type that contains the count of health checks associated with the
 // current AWS account.
 type GetHealthCheckCountOutput struct {
+	_ struct{} `type:"structure"`
+
 	// The number of health checks associated with the current AWS account.
 	HealthCheckCount *int64 `type:"long" required:"true"`
-
-	_ struct{} `type:"structure"`
 }
 
 // String returns the string representation
@@ -1961,10 +1961,10 @@ func (s GetHealthCheckCountOutput) GoString() string {
 // A complex type that contains information about the request to get a health
 // check.
 type GetHealthCheckInput struct {
+	_ struct{} `type:"structure"`
+
 	// The ID of the health check to retrieve.
 	HealthCheckId *string `location:"uri" locationName:"HealthCheckId" type:"string" required:"true"`
-
-	_ struct{} `type:"structure"`
 }
 
 // String returns the string representation
@@ -1980,11 +1980,11 @@ func (s GetHealthCheckInput) GoString() string {
 // A complex type that contains information about the request to get the most
 // recent failure reason for a health check.
 type GetHealthCheckLastFailureReasonInput struct {
+	_ struct{} `type:"structure"`
+
 	// The ID of the health check for which you want to retrieve the reason for
 	// the most recent failure.
 	HealthCheckId *string `location:"uri" locationName:"HealthCheckId" type:"string" required:"true"`
-
-	_ struct{} `type:"structure"`
 }
 
 // String returns the string representation
@@ -2000,11 +2000,11 @@ func (s GetHealthCheckLastFailureReasonInput) GoString() string {
 // A complex type that contains information about the most recent failure for
 // the specified health check.
 type GetHealthCheckLastFailureReasonOutput struct {
+	_ struct{} `type:"structure"`
+
 	// A list that contains one HealthCheckObservation element for each Route 53
 	// health checker.
 	HealthCheckObservations []*HealthCheckObservation `locationNameList:"HealthCheckObservation" type:"list" required:"true"`
-
-	_ struct{} `type:"structure"`
 }
 
 // String returns the string representation
@@ -2019,10 +2019,10 @@ func (s GetHealthCheckLastFailureReasonOutput) GoString() string {
 
 // A complex type containing information about the specified health check.
 type GetHealthCheckOutput struct {
+	_ struct{} `type:"structure"`
+
 	// A complex type that contains the information about the specified health check.
 	HealthCheck *HealthCheck `type:"structure" required:"true"`
-
-	_ struct{} `type:"structure"`
 }
 
 // String returns the string representation
@@ -2038,11 +2038,11 @@ func (s GetHealthCheckOutput) GoString() string {
 // A complex type that contains information about the request to get health
 // check status for a health check.
 type GetHealthCheckStatusInput struct {
+	_ struct{} `type:"structure"`
+
 	// The ID of the health check for which you want to retrieve the most recent
 	// status.
 	HealthCheckId *string `location:"uri" locationName:"HealthCheckId" type:"string" required:"true"`
-
-	_ struct{} `type:"structure"`
 }
 
 // String returns the string representation
@@ -2058,11 +2058,11 @@ func (s GetHealthCheckStatusInput) GoString() string {
 // A complex type that contains information about the status of the specified
 // health check.
 type GetHealthCheckStatusOutput struct {
+	_ struct{} `type:"structure"`
+
 	// A list that contains one HealthCheckObservation element for each Route 53
 	// health checker.
 	HealthCheckObservations []*HealthCheckObservation `locationNameList:"HealthCheckObservation" type:"list" required:"true"`
-
-	_ struct{} `type:"structure"`
 }
 
 // String returns the string representation
@@ -2094,10 +2094,10 @@ func (s GetHostedZoneCountInput) GoString() string {
 // A complex type that contains the count of hosted zones associated with the
 // current AWS account.
 type GetHostedZoneCountOutput struct {
+	_ struct{} `type:"structure"`
+
 	// The number of hosted zones associated with the current AWS account.
 	HostedZoneCount *int64 `type:"long" required:"true"`
-
-	_ struct{} `type:"structure"`
 }
 
 // String returns the string representation
@@ -2112,11 +2112,11 @@ func (s GetHostedZoneCountOutput) GoString() string {
 
 // The input for a GetHostedZone request.
 type GetHostedZoneInput struct {
+	_ struct{} `type:"structure"`
+
 	// The ID of the hosted zone for which you want to get a list of the name servers
 	// in the delegation set.
 	Id *string `location:"uri" locationName:"Id" type:"string" required:"true"`
-
-	_ struct{} `type:"structure"`
 }
 
 // String returns the string representation
@@ -2131,6 +2131,8 @@ func (s GetHostedZoneInput) GoString() string {
 
 // A complex type containing information about the specified hosted zone.
 type GetHostedZoneOutput struct {
+	_ struct{} `type:"structure"`
+
 	// A complex type that contains information about the name servers for the specified
 	// hosted zone.
 	DelegationSet *DelegationSet `type:"structure"`
@@ -2141,8 +2143,6 @@ type GetHostedZoneOutput struct {
 	// A complex type that contains information about VPCs associated with the specified
 	// hosted zone.
 	VPCs []*VPC `locationNameList:"VPC" min:"1" type:"list"`
-
-	_ struct{} `type:"structure"`
 }
 
 // String returns the string representation
@@ -2157,11 +2157,11 @@ func (s GetHostedZoneOutput) GoString() string {
 
 // The input for a GetReusableDelegationSet request.
 type GetReusableDelegationSetInput struct {
+	_ struct{} `type:"structure"`
+
 	// The ID of the reusable delegation set for which you want to get a list of
 	// the name server.
 	Id *string `location:"uri" locationName:"Id" type:"string" required:"true"`
-
-	_ struct{} `type:"structure"`
 }
 
 // String returns the string representation
@@ -2177,11 +2177,11 @@ func (s GetReusableDelegationSetInput) GoString() string {
 // A complex type containing information about the specified reusable delegation
 // set.
 type GetReusableDelegationSetOutput struct {
+	_ struct{} `type:"structure"`
+
 	// A complex type that contains the information about the nameservers for the
 	// specified delegation set ID.
 	DelegationSet *DelegationSet `type:"structure" required:"true"`
-
-	_ struct{} `type:"structure"`
 }
 
 // String returns the string representation
@@ -2196,6 +2196,8 @@ func (s GetReusableDelegationSetOutput) GoString() string {
 
 // A complex type that contains identifying information about the health check.
 type HealthCheck struct {
+	_ struct{} `type:"structure"`
+
 	// A unique string that identifies the request to create the health check.
 	CallerReference *string `min:"1" type:"string" required:"true"`
 
@@ -2209,8 +2211,6 @@ type HealthCheck struct {
 
 	// The ID of the specified health check.
 	Id *string `type:"string" required:"true"`
-
-	_ struct{} `type:"structure"`
 }
 
 // String returns the string representation
@@ -2225,6 +2225,8 @@ func (s HealthCheck) GoString() string {
 
 // A complex type that contains the health check configuration.
 type HealthCheckConfig struct {
+	_ struct{} `type:"structure"`
+
 	// For a specified parent health check, a list of HealthCheckId values for the
 	// associated child health checks.
 	ChildHealthChecks []*string `locationNameList:"ChildHealthCheck" type:"list"`
@@ -2283,8 +2285,6 @@ type HealthCheckConfig struct {
 	// The type of health check to be performed. Currently supported types are TCP,
 	// HTTP, HTTPS, HTTP_STR_MATCH, and HTTPS_STR_MATCH.
 	Type *string `type:"string" required:"true" enum:"HealthCheckType"`
-
-	_ struct{} `type:"structure"`
 }
 
 // String returns the string representation
@@ -2300,14 +2300,14 @@ func (s HealthCheckConfig) GoString() string {
 // A complex type that contains the IP address of a Route 53 health checker
 // and the reason for the health check status.
 type HealthCheckObservation struct {
+	_ struct{} `type:"structure"`
+
 	// The IP address of the Route 53 health checker that performed the health check.
 	IPAddress *string `type:"string"`
 
 	// A complex type that contains information about the health check status for
 	// the current observation.
 	StatusReport *StatusReport `type:"structure"`
-
-	_ struct{} `type:"structure"`
 }
 
 // String returns the string representation
@@ -2322,6 +2322,8 @@ func (s HealthCheckObservation) GoString() string {
 
 // A complex type that contain information about the specified hosted zone.
 type HostedZone struct {
+	_ struct{} `type:"structure"`
+
 	// A unique string that identifies the request to create the hosted zone.
 	CallerReference *string `min:"1" type:"string" required:"true"`
 
@@ -2343,8 +2345,6 @@ type HostedZone struct {
 
 	// Total number of resource record sets in the hosted zone.
 	ResourceRecordSetCount *int64 `type:"long"`
-
-	_ struct{} `type:"structure"`
 }
 
 // String returns the string representation
@@ -2361,6 +2361,8 @@ func (s HostedZone) GoString() string {
 // If you don't want to specify a comment, you can omit the HostedZoneConfig
 // and Comment elements from the XML document.
 type HostedZoneConfig struct {
+	_ struct{} `type:"structure"`
+
 	// An optional comment about your hosted zone. If you don't want to specify
 	// a comment, you can omit the HostedZoneConfig and Comment elements from the
 	// XML document.
@@ -2369,8 +2371,6 @@ type HostedZoneConfig struct {
 	// A value that indicates whether this is a private hosted zone. The value is
 	// returned in the response; do not specify it in the request.
 	PrivateZone *bool `type:"boolean"`
-
-	_ struct{} `type:"structure"`
 }
 
 // String returns the string representation
@@ -2385,6 +2385,8 @@ func (s HostedZoneConfig) GoString() string {
 
 // The input for a ListGeoLocations request.
 type ListGeoLocationsInput struct {
+	_ struct{} `type:"structure"`
+
 	// The maximum number of geo locations you want in the response body.
 	MaxItems *string `location:"querystring" locationName:"maxitems" type:"string"`
 
@@ -2411,8 +2413,6 @@ type ListGeoLocationsInput struct {
 	// Constraint: Specifying SubdivisionCode without CountryCode returns an InvalidInput
 	// error.
 	StartSubdivisionCode *string `location:"querystring" locationName:"startsubdivisioncode" min:"1" type:"string"`
-
-	_ struct{} `type:"structure"`
 }
 
 // String returns the string representation
@@ -2428,6 +2428,8 @@ func (s ListGeoLocationsInput) GoString() string {
 // A complex type that contains information about the geo locations that are
 // returned by the request and information about the response.
 type ListGeoLocationsOutput struct {
+	_ struct{} `type:"structure"`
+
 	// A complex type that contains information about the geo locations that are
 	// returned by the request.
 	GeoLocationDetailsList []*GeoLocationDetails `locationNameList:"GeoLocationDetails" type:"list" required:"true"`
@@ -2459,8 +2461,6 @@ type ListGeoLocationsOutput struct {
 	// in the list. This element is present only if ListGeoLocationsResponse$IsTruncated
 	// is true and the next geo location has a subdivision.
 	NextSubdivisionCode *string `min:"1" type:"string"`
-
-	_ struct{} `type:"structure"`
 }
 
 // String returns the string representation
@@ -2483,6 +2483,8 @@ func (s ListGeoLocationsOutput) GoString() string {
 //  Route 53 returns a maximum of 100 items. If you set MaxItems to a value
 // greater than 100, Route 53 returns only the first 100.
 type ListHealthChecksInput struct {
+	_ struct{} `type:"structure"`
+
 	// If the request returned more than one page of results, submit another request
 	// and specify the value of NextMarker from the last response in the marker
 	// parameter to get the next page of results.
@@ -2490,8 +2492,6 @@ type ListHealthChecksInput struct {
 
 	// Specify the maximum number of health checks to return per page of results.
 	MaxItems *string `location:"querystring" locationName:"maxitems" type:"string"`
-
-	_ struct{} `type:"structure"`
 }
 
 // String returns the string representation
@@ -2506,6 +2506,8 @@ func (s ListHealthChecksInput) GoString() string {
 
 // A complex type that contains the response for the request.
 type ListHealthChecksOutput struct {
+	_ struct{} `type:"structure"`
+
 	// A complex type that contains information about the health checks associated
 	// with the current AWS account.
 	HealthChecks []*HealthCheck `locationNameList:"HealthCheck" type:"list" required:"true"`
@@ -2533,8 +2535,6 @@ type ListHealthChecksOutput struct {
 	// is true, make another request to ListHealthChecks and include the value of
 	// the NextMarker element in the Marker element to get the next page of results.
 	NextMarker *string `type:"string"`
-
-	_ struct{} `type:"structure"`
 }
 
 // String returns the string representation
@@ -2560,6 +2560,8 @@ func (s ListHealthChecksOutput) GoString() string {
 // Zones for an AWS Account (http://docs.amazonwebservices.com/Route53/latest/DeveloperGuide/ListInfoOnHostedZone.html)
 // in the Amazon Route 53 Developer Guide.
 type ListHostedZonesByNameInput struct {
+	_ struct{} `type:"structure"`
+
 	// The first name in the lexicographic ordering of domain names that you want
 	// the ListHostedZonesByNameRequest request to list.
 	//
@@ -2575,8 +2577,6 @@ type ListHostedZonesByNameInput struct {
 
 	// Specify the maximum number of hosted zones to return per page of results.
 	MaxItems *string `location:"querystring" locationName:"maxitems" type:"string"`
-
-	_ struct{} `type:"structure"`
 }
 
 // String returns the string representation
@@ -2591,6 +2591,8 @@ func (s ListHostedZonesByNameInput) GoString() string {
 
 // A complex type that contains the response for the request.
 type ListHostedZonesByNameOutput struct {
+	_ struct{} `type:"structure"`
+
 	// The DNSName value sent in the request.
 	DNSName *string `type:"string"`
 
@@ -2629,8 +2631,6 @@ type ListHostedZonesByNameOutput struct {
 	// in the ListHostedZonesByNameRequest$DNSName element and ListHostedZonesByNameResponse$NextHostedZoneId
 	// in the ListHostedZonesByNameRequest$HostedZoneId element.
 	NextHostedZoneId *string `type:"string"`
-
-	_ struct{} `type:"structure"`
 }
 
 // String returns the string representation
@@ -2656,6 +2656,8 @@ func (s ListHostedZonesByNameOutput) GoString() string {
 //  Route 53 returns a maximum of 100 items. If you set MaxItems to a value
 // greater than 100, Route 53 returns only the first 100.
 type ListHostedZonesInput struct {
+	_ struct{} `type:"structure"`
+
 	DelegationSetId *string `location:"querystring" locationName:"delegationsetid" type:"string"`
 
 	// If the request returned more than one page of results, submit another request
@@ -2665,8 +2667,6 @@ type ListHostedZonesInput struct {
 
 	// Specify the maximum number of hosted zones to return per page of results.
 	MaxItems *string `location:"querystring" locationName:"maxitems" type:"string"`
-
-	_ struct{} `type:"structure"`
 }
 
 // String returns the string representation
@@ -2681,6 +2681,8 @@ func (s ListHostedZonesInput) GoString() string {
 
 // A complex type that contains the response for the request.
 type ListHostedZonesOutput struct {
+	_ struct{} `type:"structure"`
+
 	// A complex type that contains information about the hosted zones associated
 	// with the current AWS account.
 	HostedZones []*HostedZone `locationNameList:"HostedZone" type:"list" required:"true"`
@@ -2708,8 +2710,6 @@ type ListHostedZonesOutput struct {
 	// is true, make another request to ListHostedZones and include the value of
 	// the NextMarker element in the Marker element to get the next page of results.
 	NextMarker *string `type:"string"`
-
-	_ struct{} `type:"structure"`
 }
 
 // String returns the string representation
@@ -2724,6 +2724,8 @@ func (s ListHostedZonesOutput) GoString() string {
 
 // The input for a ListResourceRecordSets request.
 type ListResourceRecordSetsInput struct {
+	_ struct{} `type:"structure"`
+
 	// The ID of the hosted zone that contains the resource record sets that you
 	// want to get.
 	HostedZoneId *string `location:"uri" locationName:"Id" type:"string" required:"true"`
@@ -2754,8 +2756,6 @@ type ListResourceRecordSetsInput struct {
 	// Constraint: Specifying type without specifying name returns an InvalidInput
 	// error.
 	StartRecordType *string `location:"querystring" locationName:"type" type:"string" enum:"RRType"`
-
-	_ struct{} `type:"structure"`
 }
 
 // String returns the string representation
@@ -2771,6 +2771,8 @@ func (s ListResourceRecordSetsInput) GoString() string {
 // A complex type that contains information about the resource record sets that
 // are returned by the request and information about the response.
 type ListResourceRecordSetsOutput struct {
+	_ struct{} `type:"structure"`
+
 	// A flag that indicates whether there are more resource record sets to be listed.
 	// If your results were truncated, you can make a follow-up request for the
 	// next page of results by using the ListResourceRecordSetsResponse$NextRecordName
@@ -2801,8 +2803,6 @@ type ListResourceRecordSetsOutput struct {
 	// A complex type that contains information about the resource record sets that
 	// are returned by the request.
 	ResourceRecordSets []*ResourceRecordSet `locationNameList:"ResourceRecordSet" type:"list" required:"true"`
-
-	_ struct{} `type:"structure"`
 }
 
 // String returns the string representation
@@ -2826,6 +2826,8 @@ func (s ListResourceRecordSetsOutput) GoString() string {
 //  Route 53 returns a maximum of 100 items. If you set MaxItems to a value
 // greater than 100, Route 53 returns only the first 100.
 type ListReusableDelegationSetsInput struct {
+	_ struct{} `type:"structure"`
+
 	// If the request returned more than one page of results, submit another request
 	// and specify the value of NextMarker from the last response in the marker
 	// parameter to get the next page of results.
@@ -2834,8 +2836,6 @@ type ListReusableDelegationSetsInput struct {
 	// Specify the maximum number of reusable delegation sets to return per page
 	// of results.
 	MaxItems *string `location:"querystring" locationName:"maxitems" type:"string"`
-
-	_ struct{} `type:"structure"`
 }
 
 // String returns the string representation
@@ -2850,6 +2850,8 @@ func (s ListReusableDelegationSetsInput) GoString() string {
 
 // A complex type that contains the response for the request.
 type ListReusableDelegationSetsOutput struct {
+	_ struct{} `type:"structure"`
+
 	// A complex type that contains information about the reusable delegation sets
 	// associated with the current AWS account.
 	DelegationSets []*DelegationSet `locationNameList:"DelegationSet" type:"list" required:"true"`
@@ -2879,8 +2881,6 @@ type ListReusableDelegationSetsOutput struct {
 	// value of the NextMarker element in the Marker element to get the next page
 	// of results.
 	NextMarker *string `type:"string"`
-
-	_ struct{} `type:"structure"`
 }
 
 // String returns the string representation
@@ -2896,6 +2896,8 @@ func (s ListReusableDelegationSetsOutput) GoString() string {
 // A complex type containing information about a request for a list of the tags
 // that are associated with an individual resource.
 type ListTagsForResourceInput struct {
+	_ struct{} `type:"structure"`
+
 	// The ID of the resource for which you want to retrieve tags.
 	ResourceId *string `location:"uri" locationName:"ResourceId" type:"string" required:"true"`
 
@@ -2905,8 +2907,6 @@ type ListTagsForResourceInput struct {
 	//
 	// - The resource type for hosted zones is hostedzone.
 	ResourceType *string `location:"uri" locationName:"ResourceType" type:"string" required:"true" enum:"TagResourceType"`
-
-	_ struct{} `type:"structure"`
 }
 
 // String returns the string representation
@@ -2921,10 +2921,10 @@ func (s ListTagsForResourceInput) GoString() string {
 
 // A complex type containing tags for the specified resource.
 type ListTagsForResourceOutput struct {
+	_ struct{} `type:"structure"`
+
 	// A ResourceTagSet containing tags associated with the specified resource.
 	ResourceTagSet *ResourceTagSet `type:"structure" required:"true"`
-
-	_ struct{} `type:"structure"`
 }
 
 // String returns the string representation
@@ -2940,6 +2940,8 @@ func (s ListTagsForResourceOutput) GoString() string {
 // A complex type containing information about a request for a list of the tags
 // that are associated with up to 10 specified resources.
 type ListTagsForResourcesInput struct {
+	_ struct{} `locationName:"ListTagsForResourcesRequest" type:"structure" xmlURI:"https://route53.amazonaws.com/doc/2013-04-01/"`
+
 	// A complex type that contains the ResourceId element for each resource for
 	// which you want to get a list of tags.
 	ResourceIds []*string `locationNameList:"ResourceId" min:"1" type:"list" required:"true"`
@@ -2950,8 +2952,6 @@ type ListTagsForResourcesInput struct {
 	//
 	// - The resource type for hosted zones is hostedzone.
 	ResourceType *string `location:"uri" locationName:"ResourceType" type:"string" required:"true" enum:"TagResourceType"`
-
-	_ struct{} `locationName:"ListTagsForResourcesRequest" type:"structure" xmlURI:"https://route53.amazonaws.com/doc/2013-04-01/"`
 }
 
 // String returns the string representation
@@ -2966,10 +2966,10 @@ func (s ListTagsForResourcesInput) GoString() string {
 
 // A complex type containing tags for the specified resources.
 type ListTagsForResourcesOutput struct {
+	_ struct{} `type:"structure"`
+
 	// A list of ResourceTagSets containing tags associated with the specified resources.
 	ResourceTagSets []*ResourceTagSet `locationNameList:"ResourceTagSet" type:"list" required:"true"`
-
-	_ struct{} `type:"structure"`
 }
 
 // String returns the string representation
@@ -2985,10 +2985,10 @@ func (s ListTagsForResourcesOutput) GoString() string {
 // A complex type that contains the value of the Value element for the current
 // resource record set.
 type ResourceRecord struct {
+	_ struct{} `type:"structure"`
+
 	// The value of the Value element for the current resource record set.
 	Value *string `type:"string" required:"true"`
-
-	_ struct{} `type:"structure"`
 }
 
 // String returns the string representation
@@ -3004,6 +3004,8 @@ func (s ResourceRecord) GoString() string {
 // A complex type that contains information about the current resource record
 // set.
 type ResourceRecordSet struct {
+	_ struct{} `type:"structure"`
+
 	// Alias resource record sets only: Information about the AWS resource to which
 	// you are redirecting traffic.
 	AliasTarget *AliasTarget `type:"structure"`
@@ -3064,8 +3066,6 @@ type ResourceRecordSet struct {
 	// of traffic for the current resource record set is routed to the associated
 	// location.
 	Weight *int64 `type:"long"`
-
-	_ struct{} `type:"structure"`
 }
 
 // String returns the string representation
@@ -3080,6 +3080,8 @@ func (s ResourceRecordSet) GoString() string {
 
 // A complex type containing a resource and its associated tags.
 type ResourceTagSet struct {
+	_ struct{} `type:"structure"`
+
 	// The ID for the specified resource.
 	ResourceId *string `type:"string"`
 
@@ -3092,8 +3094,6 @@ type ResourceTagSet struct {
 
 	// The tags associated with the specified resource.
 	Tags []*Tag `locationNameList:"Tag" min:"1" type:"list"`
-
-	_ struct{} `type:"structure"`
 }
 
 // String returns the string representation
@@ -3109,6 +3109,8 @@ func (s ResourceTagSet) GoString() string {
 // A complex type that contains information about the health check status for
 // the current observation.
 type StatusReport struct {
+	_ struct{} `type:"structure"`
+
 	// The date and time the health check status was observed, in the format YYYY-MM-DDThh:mm:ssZ,
 	// as specified in the ISO 8601 standard (for example, 2009-11-19T19:37:58Z).
 	// The Z after the time indicates that the time is listed in Coordinated Universal
@@ -3117,8 +3119,6 @@ type StatusReport struct {
 
 	// The observed health check status.
 	Status *string `type:"string"`
-
-	_ struct{} `type:"structure"`
 }
 
 // String returns the string representation
@@ -3133,13 +3133,13 @@ func (s StatusReport) GoString() string {
 
 // A single tag containing a key and value.
 type Tag struct {
+	_ struct{} `type:"structure"`
+
 	// The key for a Tag.
 	Key *string `type:"string"`
 
 	// The value for a Tag.
 	Value *string `type:"string"`
-
-	_ struct{} `type:"structure"`
 }
 
 // String returns the string representation
@@ -3155,6 +3155,8 @@ func (s Tag) GoString() string {
 // >A complex type that contains information about the request to update a health
 // check.
 type UpdateHealthCheckInput struct {
+	_ struct{} `locationName:"UpdateHealthCheckRequest" type:"structure" xmlURI:"https://route53.amazonaws.com/doc/2013-04-01/"`
+
 	// For a specified parent health check, a list of HealthCheckId values for the
 	// associated child health checks.
 	//
@@ -3226,8 +3228,6 @@ type UpdateHealthCheckInput struct {
 	//
 	// Specify this value only if you want to change it.
 	SearchString *string `type:"string"`
-
-	_ struct{} `locationName:"UpdateHealthCheckRequest" type:"structure" xmlURI:"https://route53.amazonaws.com/doc/2013-04-01/"`
 }
 
 // String returns the string representation
@@ -3241,10 +3241,10 @@ func (s UpdateHealthCheckInput) GoString() string {
 }
 
 type UpdateHealthCheckOutput struct {
+	_ struct{} `type:"structure"`
+
 	// A complex type that contains identifying information about the health check.
 	HealthCheck *HealthCheck `type:"structure" required:"true"`
-
-	_ struct{} `type:"structure"`
 }
 
 // String returns the string representation
@@ -3260,13 +3260,13 @@ func (s UpdateHealthCheckOutput) GoString() string {
 // A complex type that contains information about the request to update a hosted
 // zone comment.
 type UpdateHostedZoneCommentInput struct {
+	_ struct{} `locationName:"UpdateHostedZoneCommentRequest" type:"structure" xmlURI:"https://route53.amazonaws.com/doc/2013-04-01/"`
+
 	// A comment about your hosted zone.
 	Comment *string `type:"string"`
 
 	// The ID of the hosted zone you want to update.
 	Id *string `location:"uri" locationName:"Id" type:"string" required:"true"`
-
-	_ struct{} `locationName:"UpdateHostedZoneCommentRequest" type:"structure" xmlURI:"https://route53.amazonaws.com/doc/2013-04-01/"`
 }
 
 // String returns the string representation
@@ -3282,10 +3282,10 @@ func (s UpdateHostedZoneCommentInput) GoString() string {
 // A complex type containing information about the specified hosted zone after
 // the update.
 type UpdateHostedZoneCommentOutput struct {
+	_ struct{} `type:"structure"`
+
 	// A complex type that contain information about the specified hosted zone.
 	HostedZone *HostedZone `type:"structure" required:"true"`
-
-	_ struct{} `type:"structure"`
 }
 
 // String returns the string representation
@@ -3299,12 +3299,12 @@ func (s UpdateHostedZoneCommentOutput) GoString() string {
 }
 
 type VPC struct {
+	_ struct{} `type:"structure"`
+
 	// A VPC ID
 	VPCId *string `type:"string"`
 
 	VPCRegion *string `min:"1" type:"string" enum:"VPCRegion"`
-
-	_ struct{} `type:"structure"`
 }
 
 // String returns the string representation

--- a/service/route53domains/api.go
+++ b/service/route53domains/api.go
@@ -648,11 +648,7 @@ type CheckDomainAvailabilityInput struct {
 	// Reserved for future use.
 	IdnLangCode *string `type:"string"`
 
-	metadataCheckDomainAvailabilityInput `json:"-" xml:"-"`
-}
-
-type metadataCheckDomainAvailabilityInput struct {
-	SDKShapeTraits bool `type:"structure"`
+	_ struct{} `type:"structure"`
 }
 
 // String returns the string representation
@@ -687,11 +683,7 @@ type CheckDomainAvailabilityOutput struct {
 	// later.
 	Availability *string `type:"string" required:"true" enum:"DomainAvailability"`
 
-	metadataCheckDomainAvailabilityOutput `json:"-" xml:"-"`
-}
-
-type metadataCheckDomainAvailabilityOutput struct {
-	SDKShapeTraits bool `type:"structure"`
+	_ struct{} `type:"structure"`
 }
 
 // String returns the string representation
@@ -896,11 +888,7 @@ type ContactDetail struct {
 	// Required: No
 	ZipCode *string `type:"string"`
 
-	metadataContactDetail `json:"-" xml:"-"`
-}
-
-type metadataContactDetail struct {
-	SDKShapeTraits bool `type:"structure"`
+	_ struct{} `type:"structure"`
 }
 
 // String returns the string representation
@@ -943,11 +931,7 @@ type DeleteTagsForDomainInput struct {
 	// '>
 	TagsToDelete []*string `type:"list" required:"true"`
 
-	metadataDeleteTagsForDomainInput `json:"-" xml:"-"`
-}
-
-type metadataDeleteTagsForDomainInput struct {
-	SDKShapeTraits bool `type:"structure"`
+	_ struct{} `type:"structure"`
 }
 
 // String returns the string representation
@@ -961,11 +945,7 @@ func (s DeleteTagsForDomainInput) GoString() string {
 }
 
 type DeleteTagsForDomainOutput struct {
-	metadataDeleteTagsForDomainOutput `json:"-" xml:"-"`
-}
-
-type metadataDeleteTagsForDomainOutput struct {
-	SDKShapeTraits bool `type:"structure"`
+	_ struct{} `type:"structure"`
 }
 
 // String returns the string representation
@@ -981,11 +961,7 @@ func (s DeleteTagsForDomainOutput) GoString() string {
 type DisableDomainAutoRenewInput struct {
 	DomainName *string `type:"string" required:"true"`
 
-	metadataDisableDomainAutoRenewInput `json:"-" xml:"-"`
-}
-
-type metadataDisableDomainAutoRenewInput struct {
-	SDKShapeTraits bool `type:"structure"`
+	_ struct{} `type:"structure"`
 }
 
 // String returns the string representation
@@ -999,11 +975,7 @@ func (s DisableDomainAutoRenewInput) GoString() string {
 }
 
 type DisableDomainAutoRenewOutput struct {
-	metadataDisableDomainAutoRenewOutput `json:"-" xml:"-"`
-}
-
-type metadataDisableDomainAutoRenewOutput struct {
-	SDKShapeTraits bool `type:"structure"`
+	_ struct{} `type:"structure"`
 }
 
 // String returns the string representation
@@ -1031,11 +1003,7 @@ type DisableDomainTransferLockInput struct {
 	// Required: Yes
 	DomainName *string `type:"string" required:"true"`
 
-	metadataDisableDomainTransferLockInput `json:"-" xml:"-"`
-}
-
-type metadataDisableDomainTransferLockInput struct {
-	SDKShapeTraits bool `type:"structure"`
+	_ struct{} `type:"structure"`
 }
 
 // String returns the string representation
@@ -1060,11 +1028,7 @@ type DisableDomainTransferLockOutput struct {
 	// Constraints: Maximum 255 characters.
 	OperationId *string `type:"string" required:"true"`
 
-	metadataDisableDomainTransferLockOutput `json:"-" xml:"-"`
-}
-
-type metadataDisableDomainTransferLockOutput struct {
-	SDKShapeTraits bool `type:"structure"`
+	_ struct{} `type:"structure"`
 }
 
 // String returns the string representation
@@ -1103,11 +1067,7 @@ type DomainSummary struct {
 	// Valid values: True | False
 	TransferLock *bool `type:"boolean"`
 
-	metadataDomainSummary `json:"-" xml:"-"`
-}
-
-type metadataDomainSummary struct {
-	SDKShapeTraits bool `type:"structure"`
+	_ struct{} `type:"structure"`
 }
 
 // String returns the string representation
@@ -1123,11 +1083,7 @@ func (s DomainSummary) GoString() string {
 type EnableDomainAutoRenewInput struct {
 	DomainName *string `type:"string" required:"true"`
 
-	metadataEnableDomainAutoRenewInput `json:"-" xml:"-"`
-}
-
-type metadataEnableDomainAutoRenewInput struct {
-	SDKShapeTraits bool `type:"structure"`
+	_ struct{} `type:"structure"`
 }
 
 // String returns the string representation
@@ -1141,11 +1097,7 @@ func (s EnableDomainAutoRenewInput) GoString() string {
 }
 
 type EnableDomainAutoRenewOutput struct {
-	metadataEnableDomainAutoRenewOutput `json:"-" xml:"-"`
-}
-
-type metadataEnableDomainAutoRenewOutput struct {
-	SDKShapeTraits bool `type:"structure"`
+	_ struct{} `type:"structure"`
 }
 
 // String returns the string representation
@@ -1173,11 +1125,7 @@ type EnableDomainTransferLockInput struct {
 	// Required: Yes
 	DomainName *string `type:"string" required:"true"`
 
-	metadataEnableDomainTransferLockInput `json:"-" xml:"-"`
-}
-
-type metadataEnableDomainTransferLockInput struct {
-	SDKShapeTraits bool `type:"structure"`
+	_ struct{} `type:"structure"`
 }
 
 // String returns the string representation
@@ -1202,11 +1150,7 @@ type EnableDomainTransferLockOutput struct {
 	// Constraints: Maximum 255 characters.
 	OperationId *string `type:"string" required:"true"`
 
-	metadataEnableDomainTransferLockOutput `json:"-" xml:"-"`
-}
-
-type metadataEnableDomainTransferLockOutput struct {
-	SDKShapeTraits bool `type:"structure"`
+	_ struct{} `type:"structure"`
 }
 
 // String returns the string representation
@@ -1252,11 +1196,7 @@ type ExtraParam struct {
 	// Required: Yes
 	Value *string `type:"string" required:"true"`
 
-	metadataExtraParam `json:"-" xml:"-"`
-}
-
-type metadataExtraParam struct {
-	SDKShapeTraits bool `type:"structure"`
+	_ struct{} `type:"structure"`
 }
 
 // String returns the string representation
@@ -1284,11 +1224,7 @@ type GetDomainDetailInput struct {
 	// Required: Yes
 	DomainName *string `type:"string" required:"true"`
 
-	metadataGetDomainDetailInput `json:"-" xml:"-"`
-}
-
-type metadataGetDomainDetailInput struct {
-	SDKShapeTraits bool `type:"structure"`
+	_ struct{} `type:"structure"`
 }
 
 // String returns the string representation
@@ -1440,11 +1376,7 @@ type GetDomainDetailOutput struct {
 	// Type: String
 	WhoIsServer *string `type:"string"`
 
-	metadataGetDomainDetailOutput `json:"-" xml:"-"`
-}
-
-type metadataGetDomainDetailOutput struct {
-	SDKShapeTraits bool `type:"structure"`
+	_ struct{} `type:"structure"`
 }
 
 // String returns the string representation
@@ -1469,11 +1401,7 @@ type GetOperationDetailInput struct {
 	// Required: Yes
 	OperationId *string `type:"string" required:"true"`
 
-	metadataGetOperationDetailInput `json:"-" xml:"-"`
-}
-
-type metadataGetOperationDetailInput struct {
-	SDKShapeTraits bool `type:"structure"`
+	_ struct{} `type:"structure"`
 }
 
 // String returns the string representation
@@ -1516,11 +1444,7 @@ type GetOperationDetailOutput struct {
 	// Type: String
 	Type *string `type:"string" enum:"OperationType"`
 
-	metadataGetOperationDetailOutput `json:"-" xml:"-"`
-}
-
-type metadataGetOperationDetailOutput struct {
-	SDKShapeTraits bool `type:"structure"`
+	_ struct{} `type:"structure"`
 }
 
 // String returns the string representation
@@ -1562,11 +1486,7 @@ type ListDomainsInput struct {
 	// Required: No
 	MaxItems *int64 `type:"integer"`
 
-	metadataListDomainsInput `json:"-" xml:"-"`
-}
-
-type metadataListDomainsInput struct {
-	SDKShapeTraits bool `type:"structure"`
+	_ struct{} `type:"structure"`
 }
 
 // String returns the string representation
@@ -1597,11 +1517,7 @@ type ListDomainsOutput struct {
 	// Parent: Operations
 	NextPageMarker *string `type:"string"`
 
-	metadataListDomainsOutput `json:"-" xml:"-"`
-}
-
-type metadataListDomainsOutput struct {
-	SDKShapeTraits bool `type:"structure"`
+	_ struct{} `type:"structure"`
 }
 
 // String returns the string representation
@@ -1641,11 +1557,7 @@ type ListOperationsInput struct {
 	// Required: No
 	MaxItems *int64 `type:"integer"`
 
-	metadataListOperationsInput `json:"-" xml:"-"`
-}
-
-type metadataListOperationsInput struct {
-	SDKShapeTraits bool `type:"structure"`
+	_ struct{} `type:"structure"`
 }
 
 // String returns the string representation
@@ -1676,11 +1588,7 @@ type ListOperationsOutput struct {
 	// Children: OperationId, Status, SubmittedDate, Type
 	Operations []*OperationSummary `type:"list" required:"true"`
 
-	metadataListOperationsOutput `json:"-" xml:"-"`
-}
-
-type metadataListOperationsOutput struct {
-	SDKShapeTraits bool `type:"structure"`
+	_ struct{} `type:"structure"`
 }
 
 // String returns the string representation
@@ -1698,11 +1606,7 @@ type ListTagsForDomainInput struct {
 	// The domain for which you want to get a list of tags.
 	DomainName *string `type:"string" required:"true"`
 
-	metadataListTagsForDomainInput `json:"-" xml:"-"`
-}
-
-type metadataListTagsForDomainInput struct {
-	SDKShapeTraits bool `type:"structure"`
+	_ struct{} `type:"structure"`
 }
 
 // String returns the string representation
@@ -1736,11 +1640,7 @@ type ListTagsForDomainOutput struct {
 	// Type: String
 	TagList []*Tag `type:"list" required:"true"`
 
-	metadataListTagsForDomainOutput `json:"-" xml:"-"`
-}
-
-type metadataListTagsForDomainOutput struct {
-	SDKShapeTraits bool `type:"structure"`
+	_ struct{} `type:"structure"`
 }
 
 // String returns the string representation
@@ -1776,11 +1676,7 @@ type Nameserver struct {
 	// Parent: Nameservers
 	Name *string `type:"string" required:"true"`
 
-	metadataNameserver `json:"-" xml:"-"`
-}
-
-type metadataNameserver struct {
-	SDKShapeTraits bool `type:"structure"`
+	_ struct{} `type:"structure"`
 }
 
 // String returns the string representation
@@ -1816,11 +1712,7 @@ type OperationSummary struct {
 	// | UPDATE_NAMESERVER | CHANGE_PRIVACY_PROTECTION | DOMAIN_LOCK
 	Type *string `type:"string" required:"true" enum:"OperationType"`
 
-	metadataOperationSummary `json:"-" xml:"-"`
-}
-
-type metadataOperationSummary struct {
-	SDKShapeTraits bool `type:"structure"`
+	_ struct{} `type:"structure"`
 }
 
 // String returns the string representation
@@ -1950,11 +1842,7 @@ type RegisterDomainInput struct {
 	// Required: Yes
 	TechContact *ContactDetail `type:"structure" required:"true"`
 
-	metadataRegisterDomainInput `json:"-" xml:"-"`
-}
-
-type metadataRegisterDomainInput struct {
-	SDKShapeTraits bool `type:"structure"`
+	_ struct{} `type:"structure"`
 }
 
 // String returns the string representation
@@ -1979,11 +1867,7 @@ type RegisterDomainOutput struct {
 	// Constraints: Maximum 255 characters.
 	OperationId *string `type:"string" required:"true"`
 
-	metadataRegisterDomainOutput `json:"-" xml:"-"`
-}
-
-type metadataRegisterDomainOutput struct {
-	SDKShapeTraits bool `type:"structure"`
+	_ struct{} `type:"structure"`
 }
 
 // String returns the string representation
@@ -2011,11 +1895,7 @@ type RetrieveDomainAuthCodeInput struct {
 	// Required: Yes
 	DomainName *string `type:"string" required:"true"`
 
-	metadataRetrieveDomainAuthCodeInput `json:"-" xml:"-"`
-}
-
-type metadataRetrieveDomainAuthCodeInput struct {
-	SDKShapeTraits bool `type:"structure"`
+	_ struct{} `type:"structure"`
 }
 
 // String returns the string representation
@@ -2035,11 +1915,7 @@ type RetrieveDomainAuthCodeOutput struct {
 	// Type: String
 	AuthCode *string `type:"string" required:"true"`
 
-	metadataRetrieveDomainAuthCodeOutput `json:"-" xml:"-"`
-}
-
-type metadataRetrieveDomainAuthCodeOutput struct {
-	SDKShapeTraits bool `type:"structure"`
+	_ struct{} `type:"structure"`
 }
 
 // String returns the string representation
@@ -2080,11 +1956,7 @@ type Tag struct {
 	// Required: Yes
 	Value *string `type:"string"`
 
-	metadataTag `json:"-" xml:"-"`
-}
-
-type metadataTag struct {
-	SDKShapeTraits bool `type:"structure"`
+	_ struct{} `type:"structure"`
 }
 
 // String returns the string representation
@@ -2231,11 +2103,7 @@ type TransferDomainInput struct {
 	// Required: Yes
 	TechContact *ContactDetail `type:"structure" required:"true"`
 
-	metadataTransferDomainInput `json:"-" xml:"-"`
-}
-
-type metadataTransferDomainInput struct {
-	SDKShapeTraits bool `type:"structure"`
+	_ struct{} `type:"structure"`
 }
 
 // String returns the string representation
@@ -2260,11 +2128,7 @@ type TransferDomainOutput struct {
 	// Constraints: Maximum 255 characters.
 	OperationId *string `type:"string" required:"true"`
 
-	metadataTransferDomainOutput `json:"-" xml:"-"`
-}
-
-type metadataTransferDomainOutput struct {
-	SDKShapeTraits bool `type:"structure"`
+	_ struct{} `type:"structure"`
 }
 
 // String returns the string representation
@@ -2325,11 +2189,7 @@ type UpdateDomainContactInput struct {
 	// Required: Yes
 	TechContact *ContactDetail `type:"structure"`
 
-	metadataUpdateDomainContactInput `json:"-" xml:"-"`
-}
-
-type metadataUpdateDomainContactInput struct {
-	SDKShapeTraits bool `type:"structure"`
+	_ struct{} `type:"structure"`
 }
 
 // String returns the string representation
@@ -2354,11 +2214,7 @@ type UpdateDomainContactOutput struct {
 	// Constraints: Maximum 255 characters.
 	OperationId *string `type:"string" required:"true"`
 
-	metadataUpdateDomainContactOutput `json:"-" xml:"-"`
-}
-
-type metadataUpdateDomainContactOutput struct {
-	SDKShapeTraits bool `type:"structure"`
+	_ struct{} `type:"structure"`
 }
 
 // String returns the string representation
@@ -2428,11 +2284,7 @@ type UpdateDomainContactPrivacyInput struct {
 	// Required: No
 	TechPrivacy *bool `type:"boolean"`
 
-	metadataUpdateDomainContactPrivacyInput `json:"-" xml:"-"`
-}
-
-type metadataUpdateDomainContactPrivacyInput struct {
-	SDKShapeTraits bool `type:"structure"`
+	_ struct{} `type:"structure"`
 }
 
 // String returns the string representation
@@ -2457,11 +2309,7 @@ type UpdateDomainContactPrivacyOutput struct {
 	// Constraints: Maximum 255 characters.
 	OperationId *string `type:"string" required:"true"`
 
-	metadataUpdateDomainContactPrivacyOutput `json:"-" xml:"-"`
-}
-
-type metadataUpdateDomainContactPrivacyOutput struct {
-	SDKShapeTraits bool `type:"structure"`
+	_ struct{} `type:"structure"`
 }
 
 // String returns the string representation
@@ -2501,11 +2349,7 @@ type UpdateDomainNameserversInput struct {
 	// Required: Yes
 	Nameservers []*Nameserver `type:"list" required:"true"`
 
-	metadataUpdateDomainNameserversInput `json:"-" xml:"-"`
-}
-
-type metadataUpdateDomainNameserversInput struct {
-	SDKShapeTraits bool `type:"structure"`
+	_ struct{} `type:"structure"`
 }
 
 // String returns the string representation
@@ -2530,11 +2374,7 @@ type UpdateDomainNameserversOutput struct {
 	// Constraints: Maximum 255 characters.
 	OperationId *string `type:"string" required:"true"`
 
-	metadataUpdateDomainNameserversOutput `json:"-" xml:"-"`
-}
-
-type metadataUpdateDomainNameserversOutput struct {
-	SDKShapeTraits bool `type:"structure"`
+	_ struct{} `type:"structure"`
 }
 
 // String returns the string representation
@@ -2606,11 +2446,7 @@ type UpdateTagsForDomainInput struct {
 	// Required: Yes
 	TagsToUpdate []*Tag `type:"list"`
 
-	metadataUpdateTagsForDomainInput `json:"-" xml:"-"`
-}
-
-type metadataUpdateTagsForDomainInput struct {
-	SDKShapeTraits bool `type:"structure"`
+	_ struct{} `type:"structure"`
 }
 
 // String returns the string representation
@@ -2624,11 +2460,7 @@ func (s UpdateTagsForDomainInput) GoString() string {
 }
 
 type UpdateTagsForDomainOutput struct {
-	metadataUpdateTagsForDomainOutput `json:"-" xml:"-"`
-}
-
-type metadataUpdateTagsForDomainOutput struct {
-	SDKShapeTraits bool `type:"structure"`
+	_ struct{} `type:"structure"`
 }
 
 // String returns the string representation

--- a/service/route53domains/api.go
+++ b/service/route53domains/api.go
@@ -632,6 +632,8 @@ func (c *Route53Domains) UpdateTagsForDomain(input *UpdateTagsForDomainInput) (*
 
 // The CheckDomainAvailability request contains the following elements.
 type CheckDomainAvailabilityInput struct {
+	_ struct{} `type:"structure"`
+
 	// The name of a domain.
 	//
 	// Type: String
@@ -647,8 +649,6 @@ type CheckDomainAvailabilityInput struct {
 
 	// Reserved for future use.
 	IdnLangCode *string `type:"string"`
-
-	_ struct{} `type:"structure"`
 }
 
 // String returns the string representation
@@ -663,6 +663,8 @@ func (s CheckDomainAvailabilityInput) GoString() string {
 
 // The CheckDomainAvailability response includes the following elements.
 type CheckDomainAvailabilityOutput struct {
+	_ struct{} `type:"structure"`
+
 	// Whether the domain name is available for registering.
 	//
 	//  You can only register domains designated as AVAILABLE.
@@ -682,8 +684,6 @@ type CheckDomainAvailabilityOutput struct {
 	// of reasons, for example, the registry is performing maintenance. Try again
 	// later.
 	Availability *string `type:"string" required:"true" enum:"DomainAvailability"`
-
-	_ struct{} `type:"structure"`
 }
 
 // String returns the string representation
@@ -698,6 +698,8 @@ func (s CheckDomainAvailabilityOutput) GoString() string {
 
 // ContactDetail includes the following elements.
 type ContactDetail struct {
+	_ struct{} `type:"structure"`
+
 	// First line of the contact's address.
 	//
 	// Type: String
@@ -887,8 +889,6 @@ type ContactDetail struct {
 	//
 	// Required: No
 	ZipCode *string `type:"string"`
-
-	_ struct{} `type:"structure"`
 }
 
 // String returns the string representation
@@ -903,6 +903,8 @@ func (s ContactDetail) GoString() string {
 
 // The DeleteTagsForDomainRequest includes the following elements.
 type DeleteTagsForDomainInput struct {
+	_ struct{} `type:"structure"`
+
 	// The domain for which you want to delete one or more tags.
 	//
 	// The name of a domain.
@@ -930,8 +932,6 @@ type DeleteTagsForDomainInput struct {
 	//
 	// '>
 	TagsToDelete []*string `type:"list" required:"true"`
-
-	_ struct{} `type:"structure"`
 }
 
 // String returns the string representation
@@ -959,9 +959,9 @@ func (s DeleteTagsForDomainOutput) GoString() string {
 }
 
 type DisableDomainAutoRenewInput struct {
-	DomainName *string `type:"string" required:"true"`
-
 	_ struct{} `type:"structure"`
+
+	DomainName *string `type:"string" required:"true"`
 }
 
 // String returns the string representation
@@ -990,6 +990,8 @@ func (s DisableDomainAutoRenewOutput) GoString() string {
 
 // The DisableDomainTransferLock request includes the following element.
 type DisableDomainTransferLockInput struct {
+	_ struct{} `type:"structure"`
+
 	// The name of a domain.
 	//
 	// Type: String
@@ -1002,8 +1004,6 @@ type DisableDomainTransferLockInput struct {
 	//
 	// Required: Yes
 	DomainName *string `type:"string" required:"true"`
-
-	_ struct{} `type:"structure"`
 }
 
 // String returns the string representation
@@ -1018,6 +1018,8 @@ func (s DisableDomainTransferLockInput) GoString() string {
 
 // The DisableDomainTransferLock response includes the following element.
 type DisableDomainTransferLockOutput struct {
+	_ struct{} `type:"structure"`
+
 	// Identifier for tracking the progress of the request. To use this ID to query
 	// the operation status, use GetOperationDetail.
 	//
@@ -1027,8 +1029,6 @@ type DisableDomainTransferLockOutput struct {
 	//
 	// Constraints: Maximum 255 characters.
 	OperationId *string `type:"string" required:"true"`
-
-	_ struct{} `type:"structure"`
 }
 
 // String returns the string representation
@@ -1042,6 +1042,8 @@ func (s DisableDomainTransferLockOutput) GoString() string {
 }
 
 type DomainSummary struct {
+	_ struct{} `type:"structure"`
+
 	// Indicates whether the domain is automatically renewed upon expiration.
 	//
 	// Type: Boolean
@@ -1066,8 +1068,6 @@ type DomainSummary struct {
 	//
 	// Valid values: True | False
 	TransferLock *bool `type:"boolean"`
-
-	_ struct{} `type:"structure"`
 }
 
 // String returns the string representation
@@ -1081,9 +1081,9 @@ func (s DomainSummary) GoString() string {
 }
 
 type EnableDomainAutoRenewInput struct {
-	DomainName *string `type:"string" required:"true"`
-
 	_ struct{} `type:"structure"`
+
+	DomainName *string `type:"string" required:"true"`
 }
 
 // String returns the string representation
@@ -1112,6 +1112,8 @@ func (s EnableDomainAutoRenewOutput) GoString() string {
 
 // The EnableDomainTransferLock request includes the following element.
 type EnableDomainTransferLockInput struct {
+	_ struct{} `type:"structure"`
+
 	// The name of a domain.
 	//
 	// Type: String
@@ -1124,8 +1126,6 @@ type EnableDomainTransferLockInput struct {
 	//
 	// Required: Yes
 	DomainName *string `type:"string" required:"true"`
-
-	_ struct{} `type:"structure"`
 }
 
 // String returns the string representation
@@ -1140,6 +1140,8 @@ func (s EnableDomainTransferLockInput) GoString() string {
 
 // The EnableDomainTransferLock response includes the following elements.
 type EnableDomainTransferLockOutput struct {
+	_ struct{} `type:"structure"`
+
 	// Identifier for tracking the progress of the request. To use this ID to query
 	// the operation status, use GetOperationDetail.
 	//
@@ -1149,8 +1151,6 @@ type EnableDomainTransferLockOutput struct {
 	//
 	// Constraints: Maximum 255 characters.
 	OperationId *string `type:"string" required:"true"`
-
-	_ struct{} `type:"structure"`
 }
 
 // String returns the string representation
@@ -1165,6 +1165,8 @@ func (s EnableDomainTransferLockOutput) GoString() string {
 
 // ExtraParam includes the following elements.
 type ExtraParam struct {
+	_ struct{} `type:"structure"`
+
 	// Name of the additional parameter required by the top-level domain.
 	//
 	// Type: String
@@ -1195,8 +1197,6 @@ type ExtraParam struct {
 	//
 	// Required: Yes
 	Value *string `type:"string" required:"true"`
-
-	_ struct{} `type:"structure"`
 }
 
 // String returns the string representation
@@ -1211,6 +1211,8 @@ func (s ExtraParam) GoString() string {
 
 // The GetDomainDetail request includes the following element.
 type GetDomainDetailInput struct {
+	_ struct{} `type:"structure"`
+
 	// The name of a domain.
 	//
 	// Type: String
@@ -1223,8 +1225,6 @@ type GetDomainDetailInput struct {
 	//
 	// Required: Yes
 	DomainName *string `type:"string" required:"true"`
-
-	_ struct{} `type:"structure"`
 }
 
 // String returns the string representation
@@ -1239,6 +1239,8 @@ func (s GetDomainDetailInput) GoString() string {
 
 // The GetDomainDetail response includes the following elements.
 type GetDomainDetailOutput struct {
+	_ struct{} `type:"structure"`
+
 	// Email address to contact to report incorrect contact information for a domain,
 	// to report that the domain is being used to send spam, to report that someone
 	// is cybersquatting on a domain name, or report some other type of abuse.
@@ -1375,8 +1377,6 @@ type GetDomainDetailOutput struct {
 	//
 	// Type: String
 	WhoIsServer *string `type:"string"`
-
-	_ struct{} `type:"structure"`
 }
 
 // String returns the string representation
@@ -1391,6 +1391,8 @@ func (s GetDomainDetailOutput) GoString() string {
 
 // The GetOperationDetail request includes the following element.
 type GetOperationDetailInput struct {
+	_ struct{} `type:"structure"`
+
 	// The identifier for the operation for which you want to get the status. Amazon
 	// Route 53 returned the identifier in the response to the original request.
 	//
@@ -1400,8 +1402,6 @@ type GetOperationDetailInput struct {
 	//
 	// Required: Yes
 	OperationId *string `type:"string" required:"true"`
-
-	_ struct{} `type:"structure"`
 }
 
 // String returns the string representation
@@ -1416,6 +1416,8 @@ func (s GetOperationDetailInput) GoString() string {
 
 // The GetOperationDetail response includes the following elements.
 type GetOperationDetailOutput struct {
+	_ struct{} `type:"structure"`
+
 	// The name of a domain.
 	//
 	// Type: String
@@ -1443,8 +1445,6 @@ type GetOperationDetailOutput struct {
 	//
 	// Type: String
 	Type *string `type:"string" enum:"OperationType"`
-
-	_ struct{} `type:"structure"`
 }
 
 // String returns the string representation
@@ -1459,6 +1459,8 @@ func (s GetOperationDetailOutput) GoString() string {
 
 // The ListDomains request includes the following elements.
 type ListDomainsInput struct {
+	_ struct{} `type:"structure"`
+
 	// For an initial request for a list of domains, omit this element. If the number
 	// of domains that are associated with the current AWS account is greater than
 	// the value that you specified for MaxItems, you can use Marker to return additional
@@ -1485,8 +1487,6 @@ type ListDomainsInput struct {
 	//
 	// Required: No
 	MaxItems *int64 `type:"integer"`
-
-	_ struct{} `type:"structure"`
 }
 
 // String returns the string representation
@@ -1501,6 +1501,8 @@ func (s ListDomainsInput) GoString() string {
 
 // The ListDomains response includes the following elements.
 type ListDomainsOutput struct {
+	_ struct{} `type:"structure"`
+
 	// A summary of domains.
 	//
 	// Type: Complex type containing a list of domain summaries.
@@ -1516,8 +1518,6 @@ type ListDomainsOutput struct {
 	//
 	// Parent: Operations
 	NextPageMarker *string `type:"string"`
-
-	_ struct{} `type:"structure"`
 }
 
 // String returns the string representation
@@ -1532,6 +1532,8 @@ func (s ListDomainsOutput) GoString() string {
 
 // The ListOperations request includes the following elements.
 type ListOperationsInput struct {
+	_ struct{} `type:"structure"`
+
 	// For an initial request for a list of operations, omit this element. If the
 	// number of operations that are not yet complete is greater than the value
 	// that you specified for MaxItems, you can use Marker to return additional
@@ -1556,8 +1558,6 @@ type ListOperationsInput struct {
 	//
 	// Required: No
 	MaxItems *int64 `type:"integer"`
-
-	_ struct{} `type:"structure"`
 }
 
 // String returns the string representation
@@ -1572,6 +1572,8 @@ func (s ListOperationsInput) GoString() string {
 
 // The ListOperations response includes the following elements.
 type ListOperationsOutput struct {
+	_ struct{} `type:"structure"`
+
 	// If there are more operations than you specified for MaxItems in the request,
 	// submit another request and include the value of NextPageMarker in the value
 	// of Marker.
@@ -1587,8 +1589,6 @@ type ListOperationsOutput struct {
 	//
 	// Children: OperationId, Status, SubmittedDate, Type
 	Operations []*OperationSummary `type:"list" required:"true"`
-
-	_ struct{} `type:"structure"`
 }
 
 // String returns the string representation
@@ -1603,10 +1603,10 @@ func (s ListOperationsOutput) GoString() string {
 
 // The ListTagsForDomainRequest includes the following elements.
 type ListTagsForDomainInput struct {
+	_ struct{} `type:"structure"`
+
 	// The domain for which you want to get a list of tags.
 	DomainName *string `type:"string" required:"true"`
-
-	_ struct{} `type:"structure"`
 }
 
 // String returns the string representation
@@ -1621,6 +1621,8 @@ func (s ListTagsForDomainInput) GoString() string {
 
 // The ListTagsForDomain response includes the following elements.
 type ListTagsForDomainOutput struct {
+	_ struct{} `type:"structure"`
+
 	// A list of the tags that are associated with the specified domain.
 	//
 	// Type: A complex type containing a list of tags
@@ -1639,8 +1641,6 @@ type ListTagsForDomainOutput struct {
 	//
 	// Type: String
 	TagList []*Tag `type:"list" required:"true"`
-
-	_ struct{} `type:"structure"`
 }
 
 // String returns the string representation
@@ -1655,6 +1655,8 @@ func (s ListTagsForDomainOutput) GoString() string {
 
 // Nameserver includes the following elements.
 type Nameserver struct {
+	_ struct{} `type:"structure"`
+
 	// Glue IP address of a name server entry. Glue IP addresses are required only
 	// when the name of the name server is a subdomain of the domain. For example,
 	// if your domain is example.com and the name server for the domain is ns.example.com,
@@ -1675,8 +1677,6 @@ type Nameserver struct {
 	//
 	// Parent: Nameservers
 	Name *string `type:"string" required:"true"`
-
-	_ struct{} `type:"structure"`
 }
 
 // String returns the string representation
@@ -1691,6 +1691,8 @@ func (s Nameserver) GoString() string {
 
 // OperationSummary includes the following elements.
 type OperationSummary struct {
+	_ struct{} `type:"structure"`
+
 	// Identifier returned to track the requested action.
 	//
 	// Type: String
@@ -1711,8 +1713,6 @@ type OperationSummary struct {
 	// Valid values: REGISTER_DOMAIN | DELETE_DOMAIN | TRANSFER_IN_DOMAIN | UPDATE_DOMAIN_CONTACT
 	// | UPDATE_NAMESERVER | CHANGE_PRIVACY_PROTECTION | DOMAIN_LOCK
 	Type *string `type:"string" required:"true" enum:"OperationType"`
-
-	_ struct{} `type:"structure"`
 }
 
 // String returns the string representation
@@ -1727,6 +1727,8 @@ func (s OperationSummary) GoString() string {
 
 // The RegisterDomain request includes the following elements.
 type RegisterDomainInput struct {
+	_ struct{} `type:"structure"`
+
 	// Provides detailed contact information.
 	//
 	// Type: Complex
@@ -1841,8 +1843,6 @@ type RegisterDomainInput struct {
 	//
 	// Required: Yes
 	TechContact *ContactDetail `type:"structure" required:"true"`
-
-	_ struct{} `type:"structure"`
 }
 
 // String returns the string representation
@@ -1857,6 +1857,8 @@ func (s RegisterDomainInput) GoString() string {
 
 // The RegisterDomain response includes the following element.
 type RegisterDomainOutput struct {
+	_ struct{} `type:"structure"`
+
 	// Identifier for tracking the progress of the request. To use this ID to query
 	// the operation status, use GetOperationDetail.
 	//
@@ -1866,8 +1868,6 @@ type RegisterDomainOutput struct {
 	//
 	// Constraints: Maximum 255 characters.
 	OperationId *string `type:"string" required:"true"`
-
-	_ struct{} `type:"structure"`
 }
 
 // String returns the string representation
@@ -1882,6 +1882,8 @@ func (s RegisterDomainOutput) GoString() string {
 
 // The RetrieveDomainAuthCode request includes the following element.
 type RetrieveDomainAuthCodeInput struct {
+	_ struct{} `type:"structure"`
+
 	// The name of a domain.
 	//
 	// Type: String
@@ -1894,8 +1896,6 @@ type RetrieveDomainAuthCodeInput struct {
 	//
 	// Required: Yes
 	DomainName *string `type:"string" required:"true"`
-
-	_ struct{} `type:"structure"`
 }
 
 // String returns the string representation
@@ -1910,12 +1910,12 @@ func (s RetrieveDomainAuthCodeInput) GoString() string {
 
 // The RetrieveDomainAuthCode response includes the following element.
 type RetrieveDomainAuthCodeOutput struct {
+	_ struct{} `type:"structure"`
+
 	// The authorization code for the domain.
 	//
 	// Type: String
 	AuthCode *string `type:"string" required:"true"`
-
-	_ struct{} `type:"structure"`
 }
 
 // String returns the string representation
@@ -1930,6 +1930,8 @@ func (s RetrieveDomainAuthCodeOutput) GoString() string {
 
 // Each tag includes the following elements.
 type Tag struct {
+	_ struct{} `type:"structure"`
+
 	// The key (name) of a tag.
 	//
 	// Type: String
@@ -1955,8 +1957,6 @@ type Tag struct {
 	//
 	// Required: Yes
 	Value *string `type:"string"`
-
-	_ struct{} `type:"structure"`
 }
 
 // String returns the string representation
@@ -1971,6 +1971,8 @@ func (s Tag) GoString() string {
 
 // The TransferDomain request includes the following elements.
 type TransferDomainInput struct {
+	_ struct{} `type:"structure"`
+
 	// Provides detailed contact information.
 	//
 	// Type: Complex
@@ -2102,8 +2104,6 @@ type TransferDomainInput struct {
 	//
 	// Required: Yes
 	TechContact *ContactDetail `type:"structure" required:"true"`
-
-	_ struct{} `type:"structure"`
 }
 
 // String returns the string representation
@@ -2118,6 +2118,8 @@ func (s TransferDomainInput) GoString() string {
 
 // The TranserDomain response includes the following element.
 type TransferDomainOutput struct {
+	_ struct{} `type:"structure"`
+
 	// Identifier for tracking the progress of the request. To use this ID to query
 	// the operation status, use GetOperationDetail.
 	//
@@ -2127,8 +2129,6 @@ type TransferDomainOutput struct {
 	//
 	// Constraints: Maximum 255 characters.
 	OperationId *string `type:"string" required:"true"`
-
-	_ struct{} `type:"structure"`
 }
 
 // String returns the string representation
@@ -2143,6 +2143,8 @@ func (s TransferDomainOutput) GoString() string {
 
 // The UpdateDomainContact request includes the following elements.
 type UpdateDomainContactInput struct {
+	_ struct{} `type:"structure"`
+
 	// Provides detailed contact information.
 	//
 	// Type: Complex
@@ -2188,8 +2190,6 @@ type UpdateDomainContactInput struct {
 	//
 	// Required: Yes
 	TechContact *ContactDetail `type:"structure"`
-
-	_ struct{} `type:"structure"`
 }
 
 // String returns the string representation
@@ -2204,6 +2204,8 @@ func (s UpdateDomainContactInput) GoString() string {
 
 // The UpdateDomainContact response includes the following element.
 type UpdateDomainContactOutput struct {
+	_ struct{} `type:"structure"`
+
 	// Identifier for tracking the progress of the request. To use this ID to query
 	// the operation status, use GetOperationDetail.
 	//
@@ -2213,8 +2215,6 @@ type UpdateDomainContactOutput struct {
 	//
 	// Constraints: Maximum 255 characters.
 	OperationId *string `type:"string" required:"true"`
-
-	_ struct{} `type:"structure"`
 }
 
 // String returns the string representation
@@ -2229,6 +2229,8 @@ func (s UpdateDomainContactOutput) GoString() string {
 
 // The UpdateDomainContactPrivacy request includes the following elements.
 type UpdateDomainContactPrivacyInput struct {
+	_ struct{} `type:"structure"`
+
 	// Whether you want to conceal contact information from WHOIS queries. If you
 	// specify true, WHOIS ("who is") queries will return contact information for
 	// our registrar partner, Gandi, instead of the contact information that you
@@ -2283,8 +2285,6 @@ type UpdateDomainContactPrivacyInput struct {
 	//
 	// Required: No
 	TechPrivacy *bool `type:"boolean"`
-
-	_ struct{} `type:"structure"`
 }
 
 // String returns the string representation
@@ -2299,6 +2299,8 @@ func (s UpdateDomainContactPrivacyInput) GoString() string {
 
 // The UpdateDomainContactPrivacy response includes the following element.
 type UpdateDomainContactPrivacyOutput struct {
+	_ struct{} `type:"structure"`
+
 	// Identifier for tracking the progress of the request. To use this ID to query
 	// the operation status, use GetOperationDetail.
 	//
@@ -2308,8 +2310,6 @@ type UpdateDomainContactPrivacyOutput struct {
 	//
 	// Constraints: Maximum 255 characters.
 	OperationId *string `type:"string" required:"true"`
-
-	_ struct{} `type:"structure"`
 }
 
 // String returns the string representation
@@ -2324,6 +2324,8 @@ func (s UpdateDomainContactPrivacyOutput) GoString() string {
 
 // The UpdateDomainNameserver request includes the following elements.
 type UpdateDomainNameserversInput struct {
+	_ struct{} `type:"structure"`
+
 	// The name of a domain.
 	//
 	// Type: String
@@ -2348,8 +2350,6 @@ type UpdateDomainNameserversInput struct {
 	//
 	// Required: Yes
 	Nameservers []*Nameserver `type:"list" required:"true"`
-
-	_ struct{} `type:"structure"`
 }
 
 // String returns the string representation
@@ -2364,6 +2364,8 @@ func (s UpdateDomainNameserversInput) GoString() string {
 
 // The UpdateDomainNameservers response includes the following element.
 type UpdateDomainNameserversOutput struct {
+	_ struct{} `type:"structure"`
+
 	// Identifier for tracking the progress of the request. To use this ID to query
 	// the operation status, use GetOperationDetail.
 	//
@@ -2373,8 +2375,6 @@ type UpdateDomainNameserversOutput struct {
 	//
 	// Constraints: Maximum 255 characters.
 	OperationId *string `type:"string" required:"true"`
-
-	_ struct{} `type:"structure"`
 }
 
 // String returns the string representation
@@ -2389,6 +2389,8 @@ func (s UpdateDomainNameserversOutput) GoString() string {
 
 // The UpdateTagsForDomainRequest includes the following elements.
 type UpdateTagsForDomainInput struct {
+	_ struct{} `type:"structure"`
+
 	// The domain for which you want to add or update tags.
 	//
 	// The name of a domain.
@@ -2445,8 +2447,6 @@ type UpdateTagsForDomainInput struct {
 	//
 	// Required: Yes
 	TagsToUpdate []*Tag `type:"list"`
-
-	_ struct{} `type:"structure"`
 }
 
 // String returns the string representation

--- a/service/s3/api.go
+++ b/service/s3/api.go
@@ -1627,11 +1627,7 @@ type AbortMultipartUploadInput struct {
 
 	UploadId *string `location:"querystring" locationName:"uploadId" type:"string" required:"true"`
 
-	metadataAbortMultipartUploadInput `json:"-" xml:"-"`
-}
-
-type metadataAbortMultipartUploadInput struct {
-	SDKShapeTraits bool `type:"structure"`
+	_ struct{} `type:"structure"`
 }
 
 // String returns the string representation
@@ -1649,11 +1645,7 @@ type AbortMultipartUploadOutput struct {
 	// request.
 	RequestCharged *string `location:"header" locationName:"x-amz-request-charged" type:"string" enum:"RequestCharged"`
 
-	metadataAbortMultipartUploadOutput `json:"-" xml:"-"`
-}
-
-type metadataAbortMultipartUploadOutput struct {
-	SDKShapeTraits bool `type:"structure"`
+	_ struct{} `type:"structure"`
 }
 
 // String returns the string representation
@@ -1672,11 +1664,7 @@ type AccessControlPolicy struct {
 
 	Owner *Owner `type:"structure"`
 
-	metadataAccessControlPolicy `json:"-" xml:"-"`
-}
-
-type metadataAccessControlPolicy struct {
-	SDKShapeTraits bool `type:"structure"`
+	_ struct{} `type:"structure"`
 }
 
 // String returns the string representation
@@ -1696,11 +1684,7 @@ type Bucket struct {
 	// The name of the bucket.
 	Name *string `type:"string"`
 
-	metadataBucket `json:"-" xml:"-"`
-}
-
-type metadataBucket struct {
-	SDKShapeTraits bool `type:"structure"`
+	_ struct{} `type:"structure"`
 }
 
 // String returns the string representation
@@ -1716,11 +1700,7 @@ func (s Bucket) GoString() string {
 type BucketLifecycleConfiguration struct {
 	Rules []*LifecycleRule `locationName:"Rule" type:"list" flattened:"true" required:"true"`
 
-	metadataBucketLifecycleConfiguration `json:"-" xml:"-"`
-}
-
-type metadataBucketLifecycleConfiguration struct {
-	SDKShapeTraits bool `type:"structure"`
+	_ struct{} `type:"structure"`
 }
 
 // String returns the string representation
@@ -1736,11 +1716,7 @@ func (s BucketLifecycleConfiguration) GoString() string {
 type BucketLoggingStatus struct {
 	LoggingEnabled *LoggingEnabled `type:"structure"`
 
-	metadataBucketLoggingStatus `json:"-" xml:"-"`
-}
-
-type metadataBucketLoggingStatus struct {
-	SDKShapeTraits bool `type:"structure"`
+	_ struct{} `type:"structure"`
 }
 
 // String returns the string representation
@@ -1756,11 +1732,7 @@ func (s BucketLoggingStatus) GoString() string {
 type CORSConfiguration struct {
 	CORSRules []*CORSRule `locationName:"CORSRule" type:"list" flattened:"true" required:"true"`
 
-	metadataCORSConfiguration `json:"-" xml:"-"`
-}
-
-type metadataCORSConfiguration struct {
-	SDKShapeTraits bool `type:"structure"`
+	_ struct{} `type:"structure"`
 }
 
 // String returns the string representation
@@ -1793,11 +1765,7 @@ type CORSRule struct {
 	// for the specified resource.
 	MaxAgeSeconds *int64 `type:"integer"`
 
-	metadataCORSRule `json:"-" xml:"-"`
-}
-
-type metadataCORSRule struct {
-	SDKShapeTraits bool `type:"structure"`
+	_ struct{} `type:"structure"`
 }
 
 // String returns the string representation
@@ -1824,11 +1792,7 @@ type CloudFunctionConfiguration struct {
 
 	InvocationRole *string `type:"string"`
 
-	metadataCloudFunctionConfiguration `json:"-" xml:"-"`
-}
-
-type metadataCloudFunctionConfiguration struct {
-	SDKShapeTraits bool `type:"structure"`
+	_ struct{} `type:"structure"`
 }
 
 // String returns the string representation
@@ -1844,11 +1808,7 @@ func (s CloudFunctionConfiguration) GoString() string {
 type CommonPrefix struct {
 	Prefix *string `type:"string"`
 
-	metadataCommonPrefix `json:"-" xml:"-"`
-}
-
-type metadataCommonPrefix struct {
-	SDKShapeTraits bool `type:"structure"`
+	_ struct{} `type:"structure"`
 }
 
 // String returns the string representation
@@ -1876,11 +1836,7 @@ type CompleteMultipartUploadInput struct {
 
 	UploadId *string `location:"querystring" locationName:"uploadId" type:"string" required:"true"`
 
-	metadataCompleteMultipartUploadInput `json:"-" xml:"-"`
-}
-
-type metadataCompleteMultipartUploadInput struct {
-	SDKShapeTraits bool `type:"structure" payload:"MultipartUpload"`
+	_ struct{} `type:"structure" payload:"MultipartUpload"`
 }
 
 // String returns the string representation
@@ -1922,11 +1878,7 @@ type CompleteMultipartUploadOutput struct {
 	// Version of the object.
 	VersionId *string `location:"header" locationName:"x-amz-version-id" type:"string"`
 
-	metadataCompleteMultipartUploadOutput `json:"-" xml:"-"`
-}
-
-type metadataCompleteMultipartUploadOutput struct {
-	SDKShapeTraits bool `type:"structure"`
+	_ struct{} `type:"structure"`
 }
 
 // String returns the string representation
@@ -1942,11 +1894,7 @@ func (s CompleteMultipartUploadOutput) GoString() string {
 type CompletedMultipartUpload struct {
 	Parts []*CompletedPart `locationName:"Part" type:"list" flattened:"true"`
 
-	metadataCompletedMultipartUpload `json:"-" xml:"-"`
-}
-
-type metadataCompletedMultipartUpload struct {
-	SDKShapeTraits bool `type:"structure"`
+	_ struct{} `type:"structure"`
 }
 
 // String returns the string representation
@@ -1967,11 +1915,7 @@ type CompletedPart struct {
 	// 1 and 10,000.
 	PartNumber *int64 `type:"integer"`
 
-	metadataCompletedPart `json:"-" xml:"-"`
-}
-
-type metadataCompletedPart struct {
-	SDKShapeTraits bool `type:"structure"`
+	_ struct{} `type:"structure"`
 }
 
 // String returns the string representation
@@ -2001,11 +1945,7 @@ type Condition struct {
 	// the redirect to be applied.
 	KeyPrefixEquals *string `type:"string"`
 
-	metadataCondition `json:"-" xml:"-"`
-}
-
-type metadataCondition struct {
-	SDKShapeTraits bool `type:"structure"`
+	_ struct{} `type:"structure"`
 }
 
 // String returns the string representation
@@ -2134,11 +2074,7 @@ type CopyObjectInput struct {
 	// the value of this header in the object metadata.
 	WebsiteRedirectLocation *string `location:"header" locationName:"x-amz-website-redirect-location" type:"string"`
 
-	metadataCopyObjectInput `json:"-" xml:"-"`
-}
-
-type metadataCopyObjectInput struct {
-	SDKShapeTraits bool `type:"structure"`
+	_ struct{} `type:"structure"`
 }
 
 // String returns the string representation
@@ -2184,11 +2120,7 @@ type CopyObjectOutput struct {
 	// Version ID of the newly created copy.
 	VersionId *string `location:"header" locationName:"x-amz-version-id" type:"string"`
 
-	metadataCopyObjectOutput `json:"-" xml:"-"`
-}
-
-type metadataCopyObjectOutput struct {
-	SDKShapeTraits bool `type:"structure" payload:"CopyObjectResult"`
+	_ struct{} `type:"structure" payload:"CopyObjectResult"`
 }
 
 // String returns the string representation
@@ -2206,11 +2138,7 @@ type CopyObjectResult struct {
 
 	LastModified *time.Time `type:"timestamp" timestampFormat:"iso8601"`
 
-	metadataCopyObjectResult `json:"-" xml:"-"`
-}
-
-type metadataCopyObjectResult struct {
-	SDKShapeTraits bool `type:"structure"`
+	_ struct{} `type:"structure"`
 }
 
 // String returns the string representation
@@ -2230,11 +2158,7 @@ type CopyPartResult struct {
 	// Date and time at which the object was uploaded.
 	LastModified *time.Time `type:"timestamp" timestampFormat:"iso8601"`
 
-	metadataCopyPartResult `json:"-" xml:"-"`
-}
-
-type metadataCopyPartResult struct {
-	SDKShapeTraits bool `type:"structure"`
+	_ struct{} `type:"structure"`
 }
 
 // String returns the string representation
@@ -2252,11 +2176,7 @@ type CreateBucketConfiguration struct {
 	// a region, the bucket will be created in US Standard.
 	LocationConstraint *string `type:"string" enum:"BucketLocationConstraint"`
 
-	metadataCreateBucketConfiguration `json:"-" xml:"-"`
-}
-
-type metadataCreateBucketConfiguration struct {
-	SDKShapeTraits bool `type:"structure"`
+	_ struct{} `type:"structure"`
 }
 
 // String returns the string representation
@@ -2293,11 +2213,7 @@ type CreateBucketInput struct {
 	// Allows grantee to write the ACL for the applicable bucket.
 	GrantWriteACP *string `location:"header" locationName:"x-amz-grant-write-acp" type:"string"`
 
-	metadataCreateBucketInput `json:"-" xml:"-"`
-}
-
-type metadataCreateBucketInput struct {
-	SDKShapeTraits bool `type:"structure" payload:"CreateBucketConfiguration"`
+	_ struct{} `type:"structure" payload:"CreateBucketConfiguration"`
 }
 
 // String returns the string representation
@@ -2313,11 +2229,7 @@ func (s CreateBucketInput) GoString() string {
 type CreateBucketOutput struct {
 	Location *string `location:"header" locationName:"Location" type:"string"`
 
-	metadataCreateBucketOutput `json:"-" xml:"-"`
-}
-
-type metadataCreateBucketOutput struct {
-	SDKShapeTraits bool `type:"structure"`
+	_ struct{} `type:"structure"`
 }
 
 // String returns the string representation
@@ -2412,11 +2324,7 @@ type CreateMultipartUploadInput struct {
 	// the value of this header in the object metadata.
 	WebsiteRedirectLocation *string `location:"header" locationName:"x-amz-website-redirect-location" type:"string"`
 
-	metadataCreateMultipartUploadInput `json:"-" xml:"-"`
-}
-
-type metadataCreateMultipartUploadInput struct {
-	SDKShapeTraits bool `type:"structure"`
+	_ struct{} `type:"structure"`
 }
 
 // String returns the string representation
@@ -2461,11 +2369,7 @@ type CreateMultipartUploadOutput struct {
 	// ID for the initiated multipart upload.
 	UploadId *string `type:"string"`
 
-	metadataCreateMultipartUploadOutput `json:"-" xml:"-"`
-}
-
-type metadataCreateMultipartUploadOutput struct {
-	SDKShapeTraits bool `type:"structure"`
+	_ struct{} `type:"structure"`
 }
 
 // String returns the string representation
@@ -2485,11 +2389,7 @@ type Delete struct {
 	// you must set its value to true.
 	Quiet *bool `type:"boolean"`
 
-	metadataDelete `json:"-" xml:"-"`
-}
-
-type metadataDelete struct {
-	SDKShapeTraits bool `type:"structure"`
+	_ struct{} `type:"structure"`
 }
 
 // String returns the string representation
@@ -2505,11 +2405,7 @@ func (s Delete) GoString() string {
 type DeleteBucketCorsInput struct {
 	Bucket *string `location:"uri" locationName:"Bucket" type:"string" required:"true"`
 
-	metadataDeleteBucketCorsInput `json:"-" xml:"-"`
-}
-
-type metadataDeleteBucketCorsInput struct {
-	SDKShapeTraits bool `type:"structure"`
+	_ struct{} `type:"structure"`
 }
 
 // String returns the string representation
@@ -2523,11 +2419,7 @@ func (s DeleteBucketCorsInput) GoString() string {
 }
 
 type DeleteBucketCorsOutput struct {
-	metadataDeleteBucketCorsOutput `json:"-" xml:"-"`
-}
-
-type metadataDeleteBucketCorsOutput struct {
-	SDKShapeTraits bool `type:"structure"`
+	_ struct{} `type:"structure"`
 }
 
 // String returns the string representation
@@ -2543,11 +2435,7 @@ func (s DeleteBucketCorsOutput) GoString() string {
 type DeleteBucketInput struct {
 	Bucket *string `location:"uri" locationName:"Bucket" type:"string" required:"true"`
 
-	metadataDeleteBucketInput `json:"-" xml:"-"`
-}
-
-type metadataDeleteBucketInput struct {
-	SDKShapeTraits bool `type:"structure"`
+	_ struct{} `type:"structure"`
 }
 
 // String returns the string representation
@@ -2563,11 +2451,7 @@ func (s DeleteBucketInput) GoString() string {
 type DeleteBucketLifecycleInput struct {
 	Bucket *string `location:"uri" locationName:"Bucket" type:"string" required:"true"`
 
-	metadataDeleteBucketLifecycleInput `json:"-" xml:"-"`
-}
-
-type metadataDeleteBucketLifecycleInput struct {
-	SDKShapeTraits bool `type:"structure"`
+	_ struct{} `type:"structure"`
 }
 
 // String returns the string representation
@@ -2581,11 +2465,7 @@ func (s DeleteBucketLifecycleInput) GoString() string {
 }
 
 type DeleteBucketLifecycleOutput struct {
-	metadataDeleteBucketLifecycleOutput `json:"-" xml:"-"`
-}
-
-type metadataDeleteBucketLifecycleOutput struct {
-	SDKShapeTraits bool `type:"structure"`
+	_ struct{} `type:"structure"`
 }
 
 // String returns the string representation
@@ -2599,11 +2479,7 @@ func (s DeleteBucketLifecycleOutput) GoString() string {
 }
 
 type DeleteBucketOutput struct {
-	metadataDeleteBucketOutput `json:"-" xml:"-"`
-}
-
-type metadataDeleteBucketOutput struct {
-	SDKShapeTraits bool `type:"structure"`
+	_ struct{} `type:"structure"`
 }
 
 // String returns the string representation
@@ -2619,11 +2495,7 @@ func (s DeleteBucketOutput) GoString() string {
 type DeleteBucketPolicyInput struct {
 	Bucket *string `location:"uri" locationName:"Bucket" type:"string" required:"true"`
 
-	metadataDeleteBucketPolicyInput `json:"-" xml:"-"`
-}
-
-type metadataDeleteBucketPolicyInput struct {
-	SDKShapeTraits bool `type:"structure"`
+	_ struct{} `type:"structure"`
 }
 
 // String returns the string representation
@@ -2637,11 +2509,7 @@ func (s DeleteBucketPolicyInput) GoString() string {
 }
 
 type DeleteBucketPolicyOutput struct {
-	metadataDeleteBucketPolicyOutput `json:"-" xml:"-"`
-}
-
-type metadataDeleteBucketPolicyOutput struct {
-	SDKShapeTraits bool `type:"structure"`
+	_ struct{} `type:"structure"`
 }
 
 // String returns the string representation
@@ -2657,11 +2525,7 @@ func (s DeleteBucketPolicyOutput) GoString() string {
 type DeleteBucketReplicationInput struct {
 	Bucket *string `location:"uri" locationName:"Bucket" type:"string" required:"true"`
 
-	metadataDeleteBucketReplicationInput `json:"-" xml:"-"`
-}
-
-type metadataDeleteBucketReplicationInput struct {
-	SDKShapeTraits bool `type:"structure"`
+	_ struct{} `type:"structure"`
 }
 
 // String returns the string representation
@@ -2675,11 +2539,7 @@ func (s DeleteBucketReplicationInput) GoString() string {
 }
 
 type DeleteBucketReplicationOutput struct {
-	metadataDeleteBucketReplicationOutput `json:"-" xml:"-"`
-}
-
-type metadataDeleteBucketReplicationOutput struct {
-	SDKShapeTraits bool `type:"structure"`
+	_ struct{} `type:"structure"`
 }
 
 // String returns the string representation
@@ -2695,11 +2555,7 @@ func (s DeleteBucketReplicationOutput) GoString() string {
 type DeleteBucketTaggingInput struct {
 	Bucket *string `location:"uri" locationName:"Bucket" type:"string" required:"true"`
 
-	metadataDeleteBucketTaggingInput `json:"-" xml:"-"`
-}
-
-type metadataDeleteBucketTaggingInput struct {
-	SDKShapeTraits bool `type:"structure"`
+	_ struct{} `type:"structure"`
 }
 
 // String returns the string representation
@@ -2713,11 +2569,7 @@ func (s DeleteBucketTaggingInput) GoString() string {
 }
 
 type DeleteBucketTaggingOutput struct {
-	metadataDeleteBucketTaggingOutput `json:"-" xml:"-"`
-}
-
-type metadataDeleteBucketTaggingOutput struct {
-	SDKShapeTraits bool `type:"structure"`
+	_ struct{} `type:"structure"`
 }
 
 // String returns the string representation
@@ -2733,11 +2585,7 @@ func (s DeleteBucketTaggingOutput) GoString() string {
 type DeleteBucketWebsiteInput struct {
 	Bucket *string `location:"uri" locationName:"Bucket" type:"string" required:"true"`
 
-	metadataDeleteBucketWebsiteInput `json:"-" xml:"-"`
-}
-
-type metadataDeleteBucketWebsiteInput struct {
-	SDKShapeTraits bool `type:"structure"`
+	_ struct{} `type:"structure"`
 }
 
 // String returns the string representation
@@ -2751,11 +2599,7 @@ func (s DeleteBucketWebsiteInput) GoString() string {
 }
 
 type DeleteBucketWebsiteOutput struct {
-	metadataDeleteBucketWebsiteOutput `json:"-" xml:"-"`
-}
-
-type metadataDeleteBucketWebsiteOutput struct {
-	SDKShapeTraits bool `type:"structure"`
+	_ struct{} `type:"structure"`
 }
 
 // String returns the string representation
@@ -2784,11 +2628,7 @@ type DeleteMarkerEntry struct {
 	// Version ID of an object.
 	VersionId *string `type:"string"`
 
-	metadataDeleteMarkerEntry `json:"-" xml:"-"`
-}
-
-type metadataDeleteMarkerEntry struct {
-	SDKShapeTraits bool `type:"structure"`
+	_ struct{} `type:"structure"`
 }
 
 // String returns the string representation
@@ -2819,11 +2659,7 @@ type DeleteObjectInput struct {
 	// VersionId used to reference a specific version of the object.
 	VersionId *string `location:"querystring" locationName:"versionId" type:"string"`
 
-	metadataDeleteObjectInput `json:"-" xml:"-"`
-}
-
-type metadataDeleteObjectInput struct {
-	SDKShapeTraits bool `type:"structure"`
+	_ struct{} `type:"structure"`
 }
 
 // String returns the string representation
@@ -2849,11 +2685,7 @@ type DeleteObjectOutput struct {
 	// operation.
 	VersionId *string `location:"header" locationName:"x-amz-version-id" type:"string"`
 
-	metadataDeleteObjectOutput `json:"-" xml:"-"`
-}
-
-type metadataDeleteObjectOutput struct {
-	SDKShapeTraits bool `type:"structure"`
+	_ struct{} `type:"structure"`
 }
 
 // String returns the string representation
@@ -2881,11 +2713,7 @@ type DeleteObjectsInput struct {
 	// at http://docs.aws.amazon.com/AmazonS3/latest/dev/ObjectsinRequesterPaysBuckets.html
 	RequestPayer *string `location:"header" locationName:"x-amz-request-payer" type:"string" enum:"RequestPayer"`
 
-	metadataDeleteObjectsInput `json:"-" xml:"-"`
-}
-
-type metadataDeleteObjectsInput struct {
-	SDKShapeTraits bool `type:"structure" payload:"Delete"`
+	_ struct{} `type:"structure" payload:"Delete"`
 }
 
 // String returns the string representation
@@ -2907,11 +2735,7 @@ type DeleteObjectsOutput struct {
 	// request.
 	RequestCharged *string `location:"header" locationName:"x-amz-request-charged" type:"string" enum:"RequestCharged"`
 
-	metadataDeleteObjectsOutput `json:"-" xml:"-"`
-}
-
-type metadataDeleteObjectsOutput struct {
-	SDKShapeTraits bool `type:"structure"`
+	_ struct{} `type:"structure"`
 }
 
 // String returns the string representation
@@ -2933,11 +2757,7 @@ type DeletedObject struct {
 
 	VersionId *string `type:"string"`
 
-	metadataDeletedObject `json:"-" xml:"-"`
-}
-
-type metadataDeletedObject struct {
-	SDKShapeTraits bool `type:"structure"`
+	_ struct{} `type:"structure"`
 }
 
 // String returns the string representation
@@ -2958,11 +2778,7 @@ type Destination struct {
 	// The class of storage used to store the object.
 	StorageClass *string `type:"string" enum:"StorageClass"`
 
-	metadataDestination `json:"-" xml:"-"`
-}
-
-type metadataDestination struct {
-	SDKShapeTraits bool `type:"structure"`
+	_ struct{} `type:"structure"`
 }
 
 // String returns the string representation
@@ -2984,11 +2800,7 @@ type Error struct {
 
 	VersionId *string `type:"string"`
 
-	metadataError `json:"-" xml:"-"`
-}
-
-type metadataError struct {
-	SDKShapeTraits bool `type:"structure"`
+	_ struct{} `type:"structure"`
 }
 
 // String returns the string representation
@@ -3005,11 +2817,7 @@ type ErrorDocument struct {
 	// The object key name to use when a 4XX class error occurs.
 	Key *string `min:"1" type:"string" required:"true"`
 
-	metadataErrorDocument `json:"-" xml:"-"`
-}
-
-type metadataErrorDocument struct {
-	SDKShapeTraits bool `type:"structure"`
+	_ struct{} `type:"structure"`
 }
 
 // String returns the string representation
@@ -3033,11 +2841,7 @@ type FilterRule struct {
 
 	Value *string `type:"string"`
 
-	metadataFilterRule `json:"-" xml:"-"`
-}
-
-type metadataFilterRule struct {
-	SDKShapeTraits bool `type:"structure"`
+	_ struct{} `type:"structure"`
 }
 
 // String returns the string representation
@@ -3053,11 +2857,7 @@ func (s FilterRule) GoString() string {
 type GetBucketAclInput struct {
 	Bucket *string `location:"uri" locationName:"Bucket" type:"string" required:"true"`
 
-	metadataGetBucketAclInput `json:"-" xml:"-"`
-}
-
-type metadataGetBucketAclInput struct {
-	SDKShapeTraits bool `type:"structure"`
+	_ struct{} `type:"structure"`
 }
 
 // String returns the string representation
@@ -3076,11 +2876,7 @@ type GetBucketAclOutput struct {
 
 	Owner *Owner `type:"structure"`
 
-	metadataGetBucketAclOutput `json:"-" xml:"-"`
-}
-
-type metadataGetBucketAclOutput struct {
-	SDKShapeTraits bool `type:"structure"`
+	_ struct{} `type:"structure"`
 }
 
 // String returns the string representation
@@ -3096,11 +2892,7 @@ func (s GetBucketAclOutput) GoString() string {
 type GetBucketCorsInput struct {
 	Bucket *string `location:"uri" locationName:"Bucket" type:"string" required:"true"`
 
-	metadataGetBucketCorsInput `json:"-" xml:"-"`
-}
-
-type metadataGetBucketCorsInput struct {
-	SDKShapeTraits bool `type:"structure"`
+	_ struct{} `type:"structure"`
 }
 
 // String returns the string representation
@@ -3116,11 +2908,7 @@ func (s GetBucketCorsInput) GoString() string {
 type GetBucketCorsOutput struct {
 	CORSRules []*CORSRule `locationName:"CORSRule" type:"list" flattened:"true"`
 
-	metadataGetBucketCorsOutput `json:"-" xml:"-"`
-}
-
-type metadataGetBucketCorsOutput struct {
-	SDKShapeTraits bool `type:"structure"`
+	_ struct{} `type:"structure"`
 }
 
 // String returns the string representation
@@ -3136,11 +2924,7 @@ func (s GetBucketCorsOutput) GoString() string {
 type GetBucketLifecycleConfigurationInput struct {
 	Bucket *string `location:"uri" locationName:"Bucket" type:"string" required:"true"`
 
-	metadataGetBucketLifecycleConfigurationInput `json:"-" xml:"-"`
-}
-
-type metadataGetBucketLifecycleConfigurationInput struct {
-	SDKShapeTraits bool `type:"structure"`
+	_ struct{} `type:"structure"`
 }
 
 // String returns the string representation
@@ -3156,11 +2940,7 @@ func (s GetBucketLifecycleConfigurationInput) GoString() string {
 type GetBucketLifecycleConfigurationOutput struct {
 	Rules []*LifecycleRule `locationName:"Rule" type:"list" flattened:"true"`
 
-	metadataGetBucketLifecycleConfigurationOutput `json:"-" xml:"-"`
-}
-
-type metadataGetBucketLifecycleConfigurationOutput struct {
-	SDKShapeTraits bool `type:"structure"`
+	_ struct{} `type:"structure"`
 }
 
 // String returns the string representation
@@ -3176,11 +2956,7 @@ func (s GetBucketLifecycleConfigurationOutput) GoString() string {
 type GetBucketLifecycleInput struct {
 	Bucket *string `location:"uri" locationName:"Bucket" type:"string" required:"true"`
 
-	metadataGetBucketLifecycleInput `json:"-" xml:"-"`
-}
-
-type metadataGetBucketLifecycleInput struct {
-	SDKShapeTraits bool `type:"structure"`
+	_ struct{} `type:"structure"`
 }
 
 // String returns the string representation
@@ -3196,11 +2972,7 @@ func (s GetBucketLifecycleInput) GoString() string {
 type GetBucketLifecycleOutput struct {
 	Rules []*Rule `locationName:"Rule" type:"list" flattened:"true"`
 
-	metadataGetBucketLifecycleOutput `json:"-" xml:"-"`
-}
-
-type metadataGetBucketLifecycleOutput struct {
-	SDKShapeTraits bool `type:"structure"`
+	_ struct{} `type:"structure"`
 }
 
 // String returns the string representation
@@ -3216,11 +2988,7 @@ func (s GetBucketLifecycleOutput) GoString() string {
 type GetBucketLocationInput struct {
 	Bucket *string `location:"uri" locationName:"Bucket" type:"string" required:"true"`
 
-	metadataGetBucketLocationInput `json:"-" xml:"-"`
-}
-
-type metadataGetBucketLocationInput struct {
-	SDKShapeTraits bool `type:"structure"`
+	_ struct{} `type:"structure"`
 }
 
 // String returns the string representation
@@ -3236,11 +3004,7 @@ func (s GetBucketLocationInput) GoString() string {
 type GetBucketLocationOutput struct {
 	LocationConstraint *string `type:"string" enum:"BucketLocationConstraint"`
 
-	metadataGetBucketLocationOutput `json:"-" xml:"-"`
-}
-
-type metadataGetBucketLocationOutput struct {
-	SDKShapeTraits bool `type:"structure"`
+	_ struct{} `type:"structure"`
 }
 
 // String returns the string representation
@@ -3256,11 +3020,7 @@ func (s GetBucketLocationOutput) GoString() string {
 type GetBucketLoggingInput struct {
 	Bucket *string `location:"uri" locationName:"Bucket" type:"string" required:"true"`
 
-	metadataGetBucketLoggingInput `json:"-" xml:"-"`
-}
-
-type metadataGetBucketLoggingInput struct {
-	SDKShapeTraits bool `type:"structure"`
+	_ struct{} `type:"structure"`
 }
 
 // String returns the string representation
@@ -3276,11 +3036,7 @@ func (s GetBucketLoggingInput) GoString() string {
 type GetBucketLoggingOutput struct {
 	LoggingEnabled *LoggingEnabled `type:"structure"`
 
-	metadataGetBucketLoggingOutput `json:"-" xml:"-"`
-}
-
-type metadataGetBucketLoggingOutput struct {
-	SDKShapeTraits bool `type:"structure"`
+	_ struct{} `type:"structure"`
 }
 
 // String returns the string representation
@@ -3297,11 +3053,7 @@ type GetBucketNotificationConfigurationRequest struct {
 	// Name of the buket to get the notification configuration for.
 	Bucket *string `location:"uri" locationName:"Bucket" type:"string" required:"true"`
 
-	metadataGetBucketNotificationConfigurationRequest `json:"-" xml:"-"`
-}
-
-type metadataGetBucketNotificationConfigurationRequest struct {
-	SDKShapeTraits bool `type:"structure"`
+	_ struct{} `type:"structure"`
 }
 
 // String returns the string representation
@@ -3317,11 +3069,7 @@ func (s GetBucketNotificationConfigurationRequest) GoString() string {
 type GetBucketPolicyInput struct {
 	Bucket *string `location:"uri" locationName:"Bucket" type:"string" required:"true"`
 
-	metadataGetBucketPolicyInput `json:"-" xml:"-"`
-}
-
-type metadataGetBucketPolicyInput struct {
-	SDKShapeTraits bool `type:"structure"`
+	_ struct{} `type:"structure"`
 }
 
 // String returns the string representation
@@ -3338,11 +3086,7 @@ type GetBucketPolicyOutput struct {
 	// The bucket policy as a JSON document.
 	Policy *string `type:"string"`
 
-	metadataGetBucketPolicyOutput `json:"-" xml:"-"`
-}
-
-type metadataGetBucketPolicyOutput struct {
-	SDKShapeTraits bool `type:"structure" payload:"Policy"`
+	_ struct{} `type:"structure" payload:"Policy"`
 }
 
 // String returns the string representation
@@ -3358,11 +3102,7 @@ func (s GetBucketPolicyOutput) GoString() string {
 type GetBucketReplicationInput struct {
 	Bucket *string `location:"uri" locationName:"Bucket" type:"string" required:"true"`
 
-	metadataGetBucketReplicationInput `json:"-" xml:"-"`
-}
-
-type metadataGetBucketReplicationInput struct {
-	SDKShapeTraits bool `type:"structure"`
+	_ struct{} `type:"structure"`
 }
 
 // String returns the string representation
@@ -3380,11 +3120,7 @@ type GetBucketReplicationOutput struct {
 	// replication configuration size can be up to 2 MB.
 	ReplicationConfiguration *ReplicationConfiguration `type:"structure"`
 
-	metadataGetBucketReplicationOutput `json:"-" xml:"-"`
-}
-
-type metadataGetBucketReplicationOutput struct {
-	SDKShapeTraits bool `type:"structure" payload:"ReplicationConfiguration"`
+	_ struct{} `type:"structure" payload:"ReplicationConfiguration"`
 }
 
 // String returns the string representation
@@ -3400,11 +3136,7 @@ func (s GetBucketReplicationOutput) GoString() string {
 type GetBucketRequestPaymentInput struct {
 	Bucket *string `location:"uri" locationName:"Bucket" type:"string" required:"true"`
 
-	metadataGetBucketRequestPaymentInput `json:"-" xml:"-"`
-}
-
-type metadataGetBucketRequestPaymentInput struct {
-	SDKShapeTraits bool `type:"structure"`
+	_ struct{} `type:"structure"`
 }
 
 // String returns the string representation
@@ -3421,11 +3153,7 @@ type GetBucketRequestPaymentOutput struct {
 	// Specifies who pays for the download and request fees.
 	Payer *string `type:"string" enum:"Payer"`
 
-	metadataGetBucketRequestPaymentOutput `json:"-" xml:"-"`
-}
-
-type metadataGetBucketRequestPaymentOutput struct {
-	SDKShapeTraits bool `type:"structure"`
+	_ struct{} `type:"structure"`
 }
 
 // String returns the string representation
@@ -3441,11 +3169,7 @@ func (s GetBucketRequestPaymentOutput) GoString() string {
 type GetBucketTaggingInput struct {
 	Bucket *string `location:"uri" locationName:"Bucket" type:"string" required:"true"`
 
-	metadataGetBucketTaggingInput `json:"-" xml:"-"`
-}
-
-type metadataGetBucketTaggingInput struct {
-	SDKShapeTraits bool `type:"structure"`
+	_ struct{} `type:"structure"`
 }
 
 // String returns the string representation
@@ -3461,11 +3185,7 @@ func (s GetBucketTaggingInput) GoString() string {
 type GetBucketTaggingOutput struct {
 	TagSet []*Tag `locationNameList:"Tag" type:"list" required:"true"`
 
-	metadataGetBucketTaggingOutput `json:"-" xml:"-"`
-}
-
-type metadataGetBucketTaggingOutput struct {
-	SDKShapeTraits bool `type:"structure"`
+	_ struct{} `type:"structure"`
 }
 
 // String returns the string representation
@@ -3481,11 +3201,7 @@ func (s GetBucketTaggingOutput) GoString() string {
 type GetBucketVersioningInput struct {
 	Bucket *string `location:"uri" locationName:"Bucket" type:"string" required:"true"`
 
-	metadataGetBucketVersioningInput `json:"-" xml:"-"`
-}
-
-type metadataGetBucketVersioningInput struct {
-	SDKShapeTraits bool `type:"structure"`
+	_ struct{} `type:"structure"`
 }
 
 // String returns the string representation
@@ -3507,11 +3223,7 @@ type GetBucketVersioningOutput struct {
 	// The versioning state of the bucket.
 	Status *string `type:"string" enum:"BucketVersioningStatus"`
 
-	metadataGetBucketVersioningOutput `json:"-" xml:"-"`
-}
-
-type metadataGetBucketVersioningOutput struct {
-	SDKShapeTraits bool `type:"structure"`
+	_ struct{} `type:"structure"`
 }
 
 // String returns the string representation
@@ -3527,11 +3239,7 @@ func (s GetBucketVersioningOutput) GoString() string {
 type GetBucketWebsiteInput struct {
 	Bucket *string `location:"uri" locationName:"Bucket" type:"string" required:"true"`
 
-	metadataGetBucketWebsiteInput `json:"-" xml:"-"`
-}
-
-type metadataGetBucketWebsiteInput struct {
-	SDKShapeTraits bool `type:"structure"`
+	_ struct{} `type:"structure"`
 }
 
 // String returns the string representation
@@ -3553,11 +3261,7 @@ type GetBucketWebsiteOutput struct {
 
 	RoutingRules []*RoutingRule `locationNameList:"RoutingRule" type:"list"`
 
-	metadataGetBucketWebsiteOutput `json:"-" xml:"-"`
-}
-
-type metadataGetBucketWebsiteOutput struct {
-	SDKShapeTraits bool `type:"structure"`
+	_ struct{} `type:"structure"`
 }
 
 // String returns the string representation
@@ -3584,11 +3288,7 @@ type GetObjectAclInput struct {
 	// VersionId used to reference a specific version of the object.
 	VersionId *string `location:"querystring" locationName:"versionId" type:"string"`
 
-	metadataGetObjectAclInput `json:"-" xml:"-"`
-}
-
-type metadataGetObjectAclInput struct {
-	SDKShapeTraits bool `type:"structure"`
+	_ struct{} `type:"structure"`
 }
 
 // String returns the string representation
@@ -3611,11 +3311,7 @@ type GetObjectAclOutput struct {
 	// request.
 	RequestCharged *string `location:"header" locationName:"x-amz-request-charged" type:"string" enum:"RequestCharged"`
 
-	metadataGetObjectAclOutput `json:"-" xml:"-"`
-}
-
-type metadataGetObjectAclOutput struct {
-	SDKShapeTraits bool `type:"structure"`
+	_ struct{} `type:"structure"`
 }
 
 // String returns the string representation
@@ -3695,11 +3391,7 @@ type GetObjectInput struct {
 	// VersionId used to reference a specific version of the object.
 	VersionId *string `location:"querystring" locationName:"versionId" type:"string"`
 
-	metadataGetObjectInput `json:"-" xml:"-"`
-}
-
-type metadataGetObjectInput struct {
-	SDKShapeTraits bool `type:"structure"`
+	_ struct{} `type:"structure"`
 }
 
 // String returns the string representation
@@ -3808,11 +3500,7 @@ type GetObjectOutput struct {
 	// the value of this header in the object metadata.
 	WebsiteRedirectLocation *string `location:"header" locationName:"x-amz-website-redirect-location" type:"string"`
 
-	metadataGetObjectOutput `json:"-" xml:"-"`
-}
-
-type metadataGetObjectOutput struct {
-	SDKShapeTraits bool `type:"structure" payload:"Body"`
+	_ struct{} `type:"structure" payload:"Body"`
 }
 
 // String returns the string representation
@@ -3836,11 +3524,7 @@ type GetObjectTorrentInput struct {
 	// at http://docs.aws.amazon.com/AmazonS3/latest/dev/ObjectsinRequesterPaysBuckets.html
 	RequestPayer *string `location:"header" locationName:"x-amz-request-payer" type:"string" enum:"RequestPayer"`
 
-	metadataGetObjectTorrentInput `json:"-" xml:"-"`
-}
-
-type metadataGetObjectTorrentInput struct {
-	SDKShapeTraits bool `type:"structure"`
+	_ struct{} `type:"structure"`
 }
 
 // String returns the string representation
@@ -3860,11 +3544,7 @@ type GetObjectTorrentOutput struct {
 	// request.
 	RequestCharged *string `location:"header" locationName:"x-amz-request-charged" type:"string" enum:"RequestCharged"`
 
-	metadataGetObjectTorrentOutput `json:"-" xml:"-"`
-}
-
-type metadataGetObjectTorrentOutput struct {
-	SDKShapeTraits bool `type:"structure" payload:"Body"`
+	_ struct{} `type:"structure" payload:"Body"`
 }
 
 // String returns the string representation
@@ -3883,11 +3563,7 @@ type Grant struct {
 	// Specifies the permission given to the grantee.
 	Permission *string `type:"string" enum:"Permission"`
 
-	metadataGrant `json:"-" xml:"-"`
-}
-
-type metadataGrant struct {
-	SDKShapeTraits bool `type:"structure"`
+	_ struct{} `type:"structure"`
 }
 
 // String returns the string representation
@@ -3916,11 +3592,7 @@ type Grantee struct {
 	// URI of the grantee group.
 	URI *string `type:"string"`
 
-	metadataGrantee `json:"-" xml:"-"`
-}
-
-type metadataGrantee struct {
-	SDKShapeTraits bool `type:"structure" xmlPrefix:"xsi" xmlURI:"http://www.w3.org/2001/XMLSchema-instance"`
+	_ struct{} `type:"structure" xmlPrefix:"xsi" xmlURI:"http://www.w3.org/2001/XMLSchema-instance"`
 }
 
 // String returns the string representation
@@ -3936,11 +3608,7 @@ func (s Grantee) GoString() string {
 type HeadBucketInput struct {
 	Bucket *string `location:"uri" locationName:"Bucket" type:"string" required:"true"`
 
-	metadataHeadBucketInput `json:"-" xml:"-"`
-}
-
-type metadataHeadBucketInput struct {
-	SDKShapeTraits bool `type:"structure"`
+	_ struct{} `type:"structure"`
 }
 
 // String returns the string representation
@@ -3954,11 +3622,7 @@ func (s HeadBucketInput) GoString() string {
 }
 
 type HeadBucketOutput struct {
-	metadataHeadBucketOutput `json:"-" xml:"-"`
-}
-
-type metadataHeadBucketOutput struct {
-	SDKShapeTraits bool `type:"structure"`
+	_ struct{} `type:"structure"`
 }
 
 // String returns the string representation
@@ -4020,11 +3684,7 @@ type HeadObjectInput struct {
 	// VersionId used to reference a specific version of the object.
 	VersionId *string `location:"querystring" locationName:"versionId" type:"string"`
 
-	metadataHeadObjectInput `json:"-" xml:"-"`
-}
-
-type metadataHeadObjectInput struct {
-	SDKShapeTraits bool `type:"structure"`
+	_ struct{} `type:"structure"`
 }
 
 // String returns the string representation
@@ -4127,11 +3787,7 @@ type HeadObjectOutput struct {
 	// the value of this header in the object metadata.
 	WebsiteRedirectLocation *string `location:"header" locationName:"x-amz-website-redirect-location" type:"string"`
 
-	metadataHeadObjectOutput `json:"-" xml:"-"`
-}
-
-type metadataHeadObjectOutput struct {
-	SDKShapeTraits bool `type:"structure"`
+	_ struct{} `type:"structure"`
 }
 
 // String returns the string representation
@@ -4151,11 +3807,7 @@ type IndexDocument struct {
 	// The suffix must not be empty and must not include a slash character.
 	Suffix *string `type:"string" required:"true"`
 
-	metadataIndexDocument `json:"-" xml:"-"`
-}
-
-type metadataIndexDocument struct {
-	SDKShapeTraits bool `type:"structure"`
+	_ struct{} `type:"structure"`
 }
 
 // String returns the string representation
@@ -4176,11 +3828,7 @@ type Initiator struct {
 	// the principal is an IAM User, it provides a user ARN value.
 	ID *string `type:"string"`
 
-	metadataInitiator `json:"-" xml:"-"`
-}
-
-type metadataInitiator struct {
-	SDKShapeTraits bool `type:"structure"`
+	_ struct{} `type:"structure"`
 }
 
 // String returns the string representation
@@ -4199,11 +3847,7 @@ type KeyFilter struct {
 	// filter rule.
 	FilterRules []*FilterRule `locationName:"FilterRule" type:"list" flattened:"true"`
 
-	metadataKeyFilter `json:"-" xml:"-"`
-}
-
-type metadataKeyFilter struct {
-	SDKShapeTraits bool `type:"structure"`
+	_ struct{} `type:"structure"`
 }
 
 // String returns the string representation
@@ -4233,11 +3877,7 @@ type LambdaFunctionConfiguration struct {
 	// of the specified type.
 	LambdaFunctionArn *string `locationName:"CloudFunction" type:"string" required:"true"`
 
-	metadataLambdaFunctionConfiguration `json:"-" xml:"-"`
-}
-
-type metadataLambdaFunctionConfiguration struct {
-	SDKShapeTraits bool `type:"structure"`
+	_ struct{} `type:"structure"`
 }
 
 // String returns the string representation
@@ -4253,11 +3893,7 @@ func (s LambdaFunctionConfiguration) GoString() string {
 type LifecycleConfiguration struct {
 	Rules []*Rule `locationName:"Rule" type:"list" flattened:"true" required:"true"`
 
-	metadataLifecycleConfiguration `json:"-" xml:"-"`
-}
-
-type metadataLifecycleConfiguration struct {
-	SDKShapeTraits bool `type:"structure"`
+	_ struct{} `type:"structure"`
 }
 
 // String returns the string representation
@@ -4279,11 +3915,7 @@ type LifecycleExpiration struct {
 	// The value must be a non-zero positive integer.
 	Days *int64 `type:"integer"`
 
-	metadataLifecycleExpiration `json:"-" xml:"-"`
-}
-
-type metadataLifecycleExpiration struct {
-	SDKShapeTraits bool `type:"structure"`
+	_ struct{} `type:"structure"`
 }
 
 // String returns the string representation
@@ -4320,11 +3952,7 @@ type LifecycleRule struct {
 
 	Transitions []*Transition `locationName:"Transition" type:"list" flattened:"true"`
 
-	metadataLifecycleRule `json:"-" xml:"-"`
-}
-
-type metadataLifecycleRule struct {
-	SDKShapeTraits bool `type:"structure"`
+	_ struct{} `type:"structure"`
 }
 
 // String returns the string representation
@@ -4338,11 +3966,7 @@ func (s LifecycleRule) GoString() string {
 }
 
 type ListBucketsInput struct {
-	metadataListBucketsInput `json:"-" xml:"-"`
-}
-
-type metadataListBucketsInput struct {
-	SDKShapeTraits bool `type:"structure"`
+	_ struct{} `type:"structure"`
 }
 
 // String returns the string representation
@@ -4360,11 +3984,7 @@ type ListBucketsOutput struct {
 
 	Owner *Owner `type:"structure"`
 
-	metadataListBucketsOutput `json:"-" xml:"-"`
-}
-
-type metadataListBucketsOutput struct {
-	SDKShapeTraits bool `type:"structure"`
+	_ struct{} `type:"structure"`
 }
 
 // String returns the string representation
@@ -4409,11 +4029,7 @@ type ListMultipartUploadsInput struct {
 	// is ignored.
 	UploadIdMarker *string `location:"querystring" locationName:"upload-id-marker" type:"string"`
 
-	metadataListMultipartUploadsInput `json:"-" xml:"-"`
-}
-
-type metadataListMultipartUploadsInput struct {
-	SDKShapeTraits bool `type:"structure"`
+	_ struct{} `type:"structure"`
 }
 
 // String returns the string representation
@@ -4467,11 +4083,7 @@ type ListMultipartUploadsOutput struct {
 
 	Uploads []*MultipartUpload `locationName:"Upload" type:"list" flattened:"true"`
 
-	metadataListMultipartUploadsOutput `json:"-" xml:"-"`
-}
-
-type metadataListMultipartUploadsOutput struct {
-	SDKShapeTraits bool `type:"structure"`
+	_ struct{} `type:"structure"`
 }
 
 // String returns the string representation
@@ -4511,11 +4123,7 @@ type ListObjectVersionsInput struct {
 	// Specifies the object version you want to start listing from.
 	VersionIdMarker *string `location:"querystring" locationName:"version-id-marker" type:"string"`
 
-	metadataListObjectVersionsInput `json:"-" xml:"-"`
-}
-
-type metadataListObjectVersionsInput struct {
-	SDKShapeTraits bool `type:"structure"`
+	_ struct{} `type:"structure"`
 }
 
 // String returns the string representation
@@ -4564,11 +4172,7 @@ type ListObjectVersionsOutput struct {
 
 	Versions []*ObjectVersion `locationName:"Version" type:"list" flattened:"true"`
 
-	metadataListObjectVersionsOutput `json:"-" xml:"-"`
-}
-
-type metadataListObjectVersionsOutput struct {
-	SDKShapeTraits bool `type:"structure"`
+	_ struct{} `type:"structure"`
 }
 
 // String returns the string representation
@@ -4605,11 +4209,7 @@ type ListObjectsInput struct {
 	// Limits the response to keys that begin with the specified prefix.
 	Prefix *string `location:"querystring" locationName:"prefix" type:"string"`
 
-	metadataListObjectsInput `json:"-" xml:"-"`
-}
-
-type metadataListObjectsInput struct {
-	SDKShapeTraits bool `type:"structure"`
+	_ struct{} `type:"structure"`
 }
 
 // String returns the string representation
@@ -4653,11 +4253,7 @@ type ListObjectsOutput struct {
 
 	Prefix *string `type:"string"`
 
-	metadataListObjectsOutput `json:"-" xml:"-"`
-}
-
-type metadataListObjectsOutput struct {
-	SDKShapeTraits bool `type:"structure"`
+	_ struct{} `type:"structure"`
 }
 
 // String returns the string representation
@@ -4691,11 +4287,7 @@ type ListPartsInput struct {
 	// Upload ID identifying the multipart upload whose parts are being listed.
 	UploadId *string `location:"querystring" locationName:"uploadId" type:"string" required:"true"`
 
-	metadataListPartsInput `json:"-" xml:"-"`
-}
-
-type metadataListPartsInput struct {
-	SDKShapeTraits bool `type:"structure"`
+	_ struct{} `type:"structure"`
 }
 
 // String returns the string representation
@@ -4746,11 +4338,7 @@ type ListPartsOutput struct {
 	// Upload ID identifying the multipart upload whose parts are being listed.
 	UploadId *string `type:"string"`
 
-	metadataListPartsOutput `json:"-" xml:"-"`
-}
-
-type metadataListPartsOutput struct {
-	SDKShapeTraits bool `type:"structure"`
+	_ struct{} `type:"structure"`
 }
 
 // String returns the string representation
@@ -4778,11 +4366,7 @@ type LoggingEnabled struct {
 	// be stored under.
 	TargetPrefix *string `type:"string"`
 
-	metadataLoggingEnabled `json:"-" xml:"-"`
-}
-
-type metadataLoggingEnabled struct {
-	SDKShapeTraits bool `type:"structure"`
+	_ struct{} `type:"structure"`
 }
 
 // String returns the string representation
@@ -4813,11 +4397,7 @@ type MultipartUpload struct {
 	// Upload ID that identifies the multipart upload.
 	UploadId *string `type:"string"`
 
-	metadataMultipartUpload `json:"-" xml:"-"`
-}
-
-type metadataMultipartUpload struct {
-	SDKShapeTraits bool `type:"structure"`
+	_ struct{} `type:"structure"`
 }
 
 // String returns the string representation
@@ -4843,11 +4423,7 @@ type NoncurrentVersionExpiration struct {
 	// Service Developer Guide.
 	NoncurrentDays *int64 `type:"integer"`
 
-	metadataNoncurrentVersionExpiration `json:"-" xml:"-"`
-}
-
-type metadataNoncurrentVersionExpiration struct {
-	SDKShapeTraits bool `type:"structure"`
+	_ struct{} `type:"structure"`
 }
 
 // String returns the string representation
@@ -4876,11 +4452,7 @@ type NoncurrentVersionTransition struct {
 	// The class of storage used to store the object.
 	StorageClass *string `type:"string" enum:"TransitionStorageClass"`
 
-	metadataNoncurrentVersionTransition `json:"-" xml:"-"`
-}
-
-type metadataNoncurrentVersionTransition struct {
-	SDKShapeTraits bool `type:"structure"`
+	_ struct{} `type:"structure"`
 }
 
 // String returns the string representation
@@ -4902,11 +4474,7 @@ type NotificationConfiguration struct {
 
 	TopicConfigurations []*TopicConfiguration `locationName:"TopicConfiguration" type:"list" flattened:"true"`
 
-	metadataNotificationConfiguration `json:"-" xml:"-"`
-}
-
-type metadataNotificationConfiguration struct {
-	SDKShapeTraits bool `type:"structure"`
+	_ struct{} `type:"structure"`
 }
 
 // String returns the string representation
@@ -4926,11 +4494,7 @@ type NotificationConfigurationDeprecated struct {
 
 	TopicConfiguration *TopicConfigurationDeprecated `type:"structure"`
 
-	metadataNotificationConfigurationDeprecated `json:"-" xml:"-"`
-}
-
-type metadataNotificationConfigurationDeprecated struct {
-	SDKShapeTraits bool `type:"structure"`
+	_ struct{} `type:"structure"`
 }
 
 // String returns the string representation
@@ -4950,11 +4514,7 @@ type NotificationConfigurationFilter struct {
 	// Container for object key name prefix and suffix filtering rules.
 	Key *KeyFilter `locationName:"S3Key" type:"structure"`
 
-	metadataNotificationConfigurationFilter `json:"-" xml:"-"`
-}
-
-type metadataNotificationConfigurationFilter struct {
-	SDKShapeTraits bool `type:"structure"`
+	_ struct{} `type:"structure"`
 }
 
 // String returns the string representation
@@ -4981,11 +4541,7 @@ type Object struct {
 	// The class of storage used to store the object.
 	StorageClass *string `type:"string" enum:"ObjectStorageClass"`
 
-	metadataObject `json:"-" xml:"-"`
-}
-
-type metadataObject struct {
-	SDKShapeTraits bool `type:"structure"`
+	_ struct{} `type:"structure"`
 }
 
 // String returns the string representation
@@ -5005,11 +4561,7 @@ type ObjectIdentifier struct {
 	// VersionId for the specific version of the object to delete.
 	VersionId *string `type:"string"`
 
-	metadataObjectIdentifier `json:"-" xml:"-"`
-}
-
-type metadataObjectIdentifier struct {
-	SDKShapeTraits bool `type:"structure"`
+	_ struct{} `type:"structure"`
 }
 
 // String returns the string representation
@@ -5046,11 +4598,7 @@ type ObjectVersion struct {
 	// Version ID of an object.
 	VersionId *string `type:"string"`
 
-	metadataObjectVersion `json:"-" xml:"-"`
-}
-
-type metadataObjectVersion struct {
-	SDKShapeTraits bool `type:"structure"`
+	_ struct{} `type:"structure"`
 }
 
 // String returns the string representation
@@ -5068,11 +4616,7 @@ type Owner struct {
 
 	ID *string `type:"string"`
 
-	metadataOwner `json:"-" xml:"-"`
-}
-
-type metadataOwner struct {
-	SDKShapeTraits bool `type:"structure"`
+	_ struct{} `type:"structure"`
 }
 
 // String returns the string representation
@@ -5099,11 +4643,7 @@ type Part struct {
 	// Size of the uploaded part data.
 	Size *int64 `type:"integer"`
 
-	metadataPart `json:"-" xml:"-"`
-}
-
-type metadataPart struct {
-	SDKShapeTraits bool `type:"structure"`
+	_ struct{} `type:"structure"`
 }
 
 // String returns the string representation
@@ -5140,11 +4680,7 @@ type PutBucketAclInput struct {
 	// Allows grantee to write the ACL for the applicable bucket.
 	GrantWriteACP *string `location:"header" locationName:"x-amz-grant-write-acp" type:"string"`
 
-	metadataPutBucketAclInput `json:"-" xml:"-"`
-}
-
-type metadataPutBucketAclInput struct {
-	SDKShapeTraits bool `type:"structure" payload:"AccessControlPolicy"`
+	_ struct{} `type:"structure" payload:"AccessControlPolicy"`
 }
 
 // String returns the string representation
@@ -5158,11 +4694,7 @@ func (s PutBucketAclInput) GoString() string {
 }
 
 type PutBucketAclOutput struct {
-	metadataPutBucketAclOutput `json:"-" xml:"-"`
-}
-
-type metadataPutBucketAclOutput struct {
-	SDKShapeTraits bool `type:"structure"`
+	_ struct{} `type:"structure"`
 }
 
 // String returns the string representation
@@ -5180,11 +4712,7 @@ type PutBucketCorsInput struct {
 
 	CORSConfiguration *CORSConfiguration `locationName:"CORSConfiguration" type:"structure" required:"true"`
 
-	metadataPutBucketCorsInput `json:"-" xml:"-"`
-}
-
-type metadataPutBucketCorsInput struct {
-	SDKShapeTraits bool `type:"structure" payload:"CORSConfiguration"`
+	_ struct{} `type:"structure" payload:"CORSConfiguration"`
 }
 
 // String returns the string representation
@@ -5198,11 +4726,7 @@ func (s PutBucketCorsInput) GoString() string {
 }
 
 type PutBucketCorsOutput struct {
-	metadataPutBucketCorsOutput `json:"-" xml:"-"`
-}
-
-type metadataPutBucketCorsOutput struct {
-	SDKShapeTraits bool `type:"structure"`
+	_ struct{} `type:"structure"`
 }
 
 // String returns the string representation
@@ -5220,11 +4744,7 @@ type PutBucketLifecycleConfigurationInput struct {
 
 	LifecycleConfiguration *BucketLifecycleConfiguration `locationName:"LifecycleConfiguration" type:"structure"`
 
-	metadataPutBucketLifecycleConfigurationInput `json:"-" xml:"-"`
-}
-
-type metadataPutBucketLifecycleConfigurationInput struct {
-	SDKShapeTraits bool `type:"structure" payload:"LifecycleConfiguration"`
+	_ struct{} `type:"structure" payload:"LifecycleConfiguration"`
 }
 
 // String returns the string representation
@@ -5238,11 +4758,7 @@ func (s PutBucketLifecycleConfigurationInput) GoString() string {
 }
 
 type PutBucketLifecycleConfigurationOutput struct {
-	metadataPutBucketLifecycleConfigurationOutput `json:"-" xml:"-"`
-}
-
-type metadataPutBucketLifecycleConfigurationOutput struct {
-	SDKShapeTraits bool `type:"structure"`
+	_ struct{} `type:"structure"`
 }
 
 // String returns the string representation
@@ -5260,11 +4776,7 @@ type PutBucketLifecycleInput struct {
 
 	LifecycleConfiguration *LifecycleConfiguration `locationName:"LifecycleConfiguration" type:"structure"`
 
-	metadataPutBucketLifecycleInput `json:"-" xml:"-"`
-}
-
-type metadataPutBucketLifecycleInput struct {
-	SDKShapeTraits bool `type:"structure" payload:"LifecycleConfiguration"`
+	_ struct{} `type:"structure" payload:"LifecycleConfiguration"`
 }
 
 // String returns the string representation
@@ -5278,11 +4790,7 @@ func (s PutBucketLifecycleInput) GoString() string {
 }
 
 type PutBucketLifecycleOutput struct {
-	metadataPutBucketLifecycleOutput `json:"-" xml:"-"`
-}
-
-type metadataPutBucketLifecycleOutput struct {
-	SDKShapeTraits bool `type:"structure"`
+	_ struct{} `type:"structure"`
 }
 
 // String returns the string representation
@@ -5300,11 +4808,7 @@ type PutBucketLoggingInput struct {
 
 	BucketLoggingStatus *BucketLoggingStatus `locationName:"BucketLoggingStatus" type:"structure" required:"true"`
 
-	metadataPutBucketLoggingInput `json:"-" xml:"-"`
-}
-
-type metadataPutBucketLoggingInput struct {
-	SDKShapeTraits bool `type:"structure" payload:"BucketLoggingStatus"`
+	_ struct{} `type:"structure" payload:"BucketLoggingStatus"`
 }
 
 // String returns the string representation
@@ -5318,11 +4822,7 @@ func (s PutBucketLoggingInput) GoString() string {
 }
 
 type PutBucketLoggingOutput struct {
-	metadataPutBucketLoggingOutput `json:"-" xml:"-"`
-}
-
-type metadataPutBucketLoggingOutput struct {
-	SDKShapeTraits bool `type:"structure"`
+	_ struct{} `type:"structure"`
 }
 
 // String returns the string representation
@@ -5342,11 +4842,7 @@ type PutBucketNotificationConfigurationInput struct {
 	// this element is empty, notifications are turned off on the bucket.
 	NotificationConfiguration *NotificationConfiguration `locationName:"NotificationConfiguration" type:"structure" required:"true"`
 
-	metadataPutBucketNotificationConfigurationInput `json:"-" xml:"-"`
-}
-
-type metadataPutBucketNotificationConfigurationInput struct {
-	SDKShapeTraits bool `type:"structure" payload:"NotificationConfiguration"`
+	_ struct{} `type:"structure" payload:"NotificationConfiguration"`
 }
 
 // String returns the string representation
@@ -5360,11 +4856,7 @@ func (s PutBucketNotificationConfigurationInput) GoString() string {
 }
 
 type PutBucketNotificationConfigurationOutput struct {
-	metadataPutBucketNotificationConfigurationOutput `json:"-" xml:"-"`
-}
-
-type metadataPutBucketNotificationConfigurationOutput struct {
-	SDKShapeTraits bool `type:"structure"`
+	_ struct{} `type:"structure"`
 }
 
 // String returns the string representation
@@ -5382,11 +4874,7 @@ type PutBucketNotificationInput struct {
 
 	NotificationConfiguration *NotificationConfigurationDeprecated `locationName:"NotificationConfiguration" type:"structure" required:"true"`
 
-	metadataPutBucketNotificationInput `json:"-" xml:"-"`
-}
-
-type metadataPutBucketNotificationInput struct {
-	SDKShapeTraits bool `type:"structure" payload:"NotificationConfiguration"`
+	_ struct{} `type:"structure" payload:"NotificationConfiguration"`
 }
 
 // String returns the string representation
@@ -5400,11 +4888,7 @@ func (s PutBucketNotificationInput) GoString() string {
 }
 
 type PutBucketNotificationOutput struct {
-	metadataPutBucketNotificationOutput `json:"-" xml:"-"`
-}
-
-type metadataPutBucketNotificationOutput struct {
-	SDKShapeTraits bool `type:"structure"`
+	_ struct{} `type:"structure"`
 }
 
 // String returns the string representation
@@ -5423,11 +4907,7 @@ type PutBucketPolicyInput struct {
 	// The bucket policy as a JSON document.
 	Policy *string `type:"string" required:"true"`
 
-	metadataPutBucketPolicyInput `json:"-" xml:"-"`
-}
-
-type metadataPutBucketPolicyInput struct {
-	SDKShapeTraits bool `type:"structure" payload:"Policy"`
+	_ struct{} `type:"structure" payload:"Policy"`
 }
 
 // String returns the string representation
@@ -5441,11 +4921,7 @@ func (s PutBucketPolicyInput) GoString() string {
 }
 
 type PutBucketPolicyOutput struct {
-	metadataPutBucketPolicyOutput `json:"-" xml:"-"`
-}
-
-type metadataPutBucketPolicyOutput struct {
-	SDKShapeTraits bool `type:"structure"`
+	_ struct{} `type:"structure"`
 }
 
 // String returns the string representation
@@ -5465,11 +4941,7 @@ type PutBucketReplicationInput struct {
 	// replication configuration size can be up to 2 MB.
 	ReplicationConfiguration *ReplicationConfiguration `locationName:"ReplicationConfiguration" type:"structure" required:"true"`
 
-	metadataPutBucketReplicationInput `json:"-" xml:"-"`
-}
-
-type metadataPutBucketReplicationInput struct {
-	SDKShapeTraits bool `type:"structure" payload:"ReplicationConfiguration"`
+	_ struct{} `type:"structure" payload:"ReplicationConfiguration"`
 }
 
 // String returns the string representation
@@ -5483,11 +4955,7 @@ func (s PutBucketReplicationInput) GoString() string {
 }
 
 type PutBucketReplicationOutput struct {
-	metadataPutBucketReplicationOutput `json:"-" xml:"-"`
-}
-
-type metadataPutBucketReplicationOutput struct {
-	SDKShapeTraits bool `type:"structure"`
+	_ struct{} `type:"structure"`
 }
 
 // String returns the string representation
@@ -5505,11 +4973,7 @@ type PutBucketRequestPaymentInput struct {
 
 	RequestPaymentConfiguration *RequestPaymentConfiguration `locationName:"RequestPaymentConfiguration" type:"structure" required:"true"`
 
-	metadataPutBucketRequestPaymentInput `json:"-" xml:"-"`
-}
-
-type metadataPutBucketRequestPaymentInput struct {
-	SDKShapeTraits bool `type:"structure" payload:"RequestPaymentConfiguration"`
+	_ struct{} `type:"structure" payload:"RequestPaymentConfiguration"`
 }
 
 // String returns the string representation
@@ -5523,11 +4987,7 @@ func (s PutBucketRequestPaymentInput) GoString() string {
 }
 
 type PutBucketRequestPaymentOutput struct {
-	metadataPutBucketRequestPaymentOutput `json:"-" xml:"-"`
-}
-
-type metadataPutBucketRequestPaymentOutput struct {
-	SDKShapeTraits bool `type:"structure"`
+	_ struct{} `type:"structure"`
 }
 
 // String returns the string representation
@@ -5545,11 +5005,7 @@ type PutBucketTaggingInput struct {
 
 	Tagging *Tagging `locationName:"Tagging" type:"structure" required:"true"`
 
-	metadataPutBucketTaggingInput `json:"-" xml:"-"`
-}
-
-type metadataPutBucketTaggingInput struct {
-	SDKShapeTraits bool `type:"structure" payload:"Tagging"`
+	_ struct{} `type:"structure" payload:"Tagging"`
 }
 
 // String returns the string representation
@@ -5563,11 +5019,7 @@ func (s PutBucketTaggingInput) GoString() string {
 }
 
 type PutBucketTaggingOutput struct {
-	metadataPutBucketTaggingOutput `json:"-" xml:"-"`
-}
-
-type metadataPutBucketTaggingOutput struct {
-	SDKShapeTraits bool `type:"structure"`
+	_ struct{} `type:"structure"`
 }
 
 // String returns the string representation
@@ -5589,11 +5041,7 @@ type PutBucketVersioningInput struct {
 
 	VersioningConfiguration *VersioningConfiguration `locationName:"VersioningConfiguration" type:"structure" required:"true"`
 
-	metadataPutBucketVersioningInput `json:"-" xml:"-"`
-}
-
-type metadataPutBucketVersioningInput struct {
-	SDKShapeTraits bool `type:"structure" payload:"VersioningConfiguration"`
+	_ struct{} `type:"structure" payload:"VersioningConfiguration"`
 }
 
 // String returns the string representation
@@ -5607,11 +5055,7 @@ func (s PutBucketVersioningInput) GoString() string {
 }
 
 type PutBucketVersioningOutput struct {
-	metadataPutBucketVersioningOutput `json:"-" xml:"-"`
-}
-
-type metadataPutBucketVersioningOutput struct {
-	SDKShapeTraits bool `type:"structure"`
+	_ struct{} `type:"structure"`
 }
 
 // String returns the string representation
@@ -5629,11 +5073,7 @@ type PutBucketWebsiteInput struct {
 
 	WebsiteConfiguration *WebsiteConfiguration `locationName:"WebsiteConfiguration" type:"structure" required:"true"`
 
-	metadataPutBucketWebsiteInput `json:"-" xml:"-"`
-}
-
-type metadataPutBucketWebsiteInput struct {
-	SDKShapeTraits bool `type:"structure" payload:"WebsiteConfiguration"`
+	_ struct{} `type:"structure" payload:"WebsiteConfiguration"`
 }
 
 // String returns the string representation
@@ -5647,11 +5087,7 @@ func (s PutBucketWebsiteInput) GoString() string {
 }
 
 type PutBucketWebsiteOutput struct {
-	metadataPutBucketWebsiteOutput `json:"-" xml:"-"`
-}
-
-type metadataPutBucketWebsiteOutput struct {
-	SDKShapeTraits bool `type:"structure"`
+	_ struct{} `type:"structure"`
 }
 
 // String returns the string representation
@@ -5696,11 +5132,7 @@ type PutObjectAclInput struct {
 	// at http://docs.aws.amazon.com/AmazonS3/latest/dev/ObjectsinRequesterPaysBuckets.html
 	RequestPayer *string `location:"header" locationName:"x-amz-request-payer" type:"string" enum:"RequestPayer"`
 
-	metadataPutObjectAclInput `json:"-" xml:"-"`
-}
-
-type metadataPutObjectAclInput struct {
-	SDKShapeTraits bool `type:"structure" payload:"AccessControlPolicy"`
+	_ struct{} `type:"structure" payload:"AccessControlPolicy"`
 }
 
 // String returns the string representation
@@ -5718,11 +5150,7 @@ type PutObjectAclOutput struct {
 	// request.
 	RequestCharged *string `location:"header" locationName:"x-amz-request-charged" type:"string" enum:"RequestCharged"`
 
-	metadataPutObjectAclOutput `json:"-" xml:"-"`
-}
-
-type metadataPutObjectAclOutput struct {
-	SDKShapeTraits bool `type:"structure"`
+	_ struct{} `type:"structure"`
 }
 
 // String returns the string representation
@@ -5824,11 +5252,7 @@ type PutObjectInput struct {
 	// the value of this header in the object metadata.
 	WebsiteRedirectLocation *string `location:"header" locationName:"x-amz-website-redirect-location" type:"string"`
 
-	metadataPutObjectInput `json:"-" xml:"-"`
-}
-
-type metadataPutObjectInput struct {
-	SDKShapeTraits bool `type:"structure" payload:"Body"`
+	_ struct{} `type:"structure" payload:"Body"`
 }
 
 // String returns the string representation
@@ -5874,11 +5298,7 @@ type PutObjectOutput struct {
 	// Version of the object.
 	VersionId *string `location:"header" locationName:"x-amz-version-id" type:"string"`
 
-	metadataPutObjectOutput `json:"-" xml:"-"`
-}
-
-type metadataPutObjectOutput struct {
-	SDKShapeTraits bool `type:"structure"`
+	_ struct{} `type:"structure"`
 }
 
 // String returns the string representation
@@ -5909,11 +5329,7 @@ type QueueConfiguration struct {
 	// events of specified type.
 	QueueArn *string `locationName:"Queue" type:"string" required:"true"`
 
-	metadataQueueConfiguration `json:"-" xml:"-"`
-}
-
-type metadataQueueConfiguration struct {
-	SDKShapeTraits bool `type:"structure"`
+	_ struct{} `type:"structure"`
 }
 
 // String returns the string representation
@@ -5938,11 +5354,7 @@ type QueueConfigurationDeprecated struct {
 
 	Queue *string `type:"string"`
 
-	metadataQueueConfigurationDeprecated `json:"-" xml:"-"`
-}
-
-type metadataQueueConfigurationDeprecated struct {
-	SDKShapeTraits bool `type:"structure"`
+	_ struct{} `type:"structure"`
 }
 
 // String returns the string representation
@@ -5980,11 +5392,7 @@ type Redirect struct {
 	// be present only if ReplaceKeyPrefixWith is not provided.
 	ReplaceKeyWith *string `type:"string"`
 
-	metadataRedirect `json:"-" xml:"-"`
-}
-
-type metadataRedirect struct {
-	SDKShapeTraits bool `type:"structure"`
+	_ struct{} `type:"structure"`
 }
 
 // String returns the string representation
@@ -6005,11 +5413,7 @@ type RedirectAllRequestsTo struct {
 	// protocol that is used in the original request.
 	Protocol *string `type:"string" enum:"Protocol"`
 
-	metadataRedirectAllRequestsTo `json:"-" xml:"-"`
-}
-
-type metadataRedirectAllRequestsTo struct {
-	SDKShapeTraits bool `type:"structure"`
+	_ struct{} `type:"structure"`
 }
 
 // String returns the string representation
@@ -6033,11 +5437,7 @@ type ReplicationConfiguration struct {
 	// configuration must have at least one rule and can contain up to 1,000 rules.
 	Rules []*ReplicationRule `locationName:"Rule" type:"list" flattened:"true" required:"true"`
 
-	metadataReplicationConfiguration `json:"-" xml:"-"`
-}
-
-type metadataReplicationConfiguration struct {
-	SDKShapeTraits bool `type:"structure"`
+	_ struct{} `type:"structure"`
 }
 
 // String returns the string representation
@@ -6064,11 +5464,7 @@ type ReplicationRule struct {
 	// The rule is ignored if status is not Enabled.
 	Status *string `type:"string" required:"true" enum:"ReplicationRuleStatus"`
 
-	metadataReplicationRule `json:"-" xml:"-"`
-}
-
-type metadataReplicationRule struct {
-	SDKShapeTraits bool `type:"structure"`
+	_ struct{} `type:"structure"`
 }
 
 // String returns the string representation
@@ -6085,11 +5481,7 @@ type RequestPaymentConfiguration struct {
 	// Specifies who pays for the download and request fees.
 	Payer *string `type:"string" required:"true" enum:"Payer"`
 
-	metadataRequestPaymentConfiguration `json:"-" xml:"-"`
-}
-
-type metadataRequestPaymentConfiguration struct {
-	SDKShapeTraits bool `type:"structure"`
+	_ struct{} `type:"structure"`
 }
 
 // String returns the string representation
@@ -6117,11 +5509,7 @@ type RestoreObjectInput struct {
 
 	VersionId *string `location:"querystring" locationName:"versionId" type:"string"`
 
-	metadataRestoreObjectInput `json:"-" xml:"-"`
-}
-
-type metadataRestoreObjectInput struct {
-	SDKShapeTraits bool `type:"structure" payload:"RestoreRequest"`
+	_ struct{} `type:"structure" payload:"RestoreRequest"`
 }
 
 // String returns the string representation
@@ -6139,11 +5527,7 @@ type RestoreObjectOutput struct {
 	// request.
 	RequestCharged *string `location:"header" locationName:"x-amz-request-charged" type:"string" enum:"RequestCharged"`
 
-	metadataRestoreObjectOutput `json:"-" xml:"-"`
-}
-
-type metadataRestoreObjectOutput struct {
-	SDKShapeTraits bool `type:"structure"`
+	_ struct{} `type:"structure"`
 }
 
 // String returns the string representation
@@ -6160,11 +5544,7 @@ type RestoreRequest struct {
 	// Lifetime of the active copy in days
 	Days *int64 `type:"integer" required:"true"`
 
-	metadataRestoreRequest `json:"-" xml:"-"`
-}
-
-type metadataRestoreRequest struct {
-	SDKShapeTraits bool `type:"structure"`
+	_ struct{} `type:"structure"`
 }
 
 // String returns the string representation
@@ -6189,11 +5569,7 @@ type RoutingRule struct {
 	// you can can specify a different error code to return.
 	Redirect *Redirect `type:"structure" required:"true"`
 
-	metadataRoutingRule `json:"-" xml:"-"`
-}
-
-type metadataRoutingRule struct {
-	SDKShapeTraits bool `type:"structure"`
+	_ struct{} `type:"structure"`
 }
 
 // String returns the string representation
@@ -6235,11 +5611,7 @@ type Rule struct {
 
 	Transition *Transition `type:"structure"`
 
-	metadataRule `json:"-" xml:"-"`
-}
-
-type metadataRule struct {
-	SDKShapeTraits bool `type:"structure"`
+	_ struct{} `type:"structure"`
 }
 
 // String returns the string representation
@@ -6259,11 +5631,7 @@ type Tag struct {
 	// Value of the tag.
 	Value *string `type:"string" required:"true"`
 
-	metadataTag `json:"-" xml:"-"`
-}
-
-type metadataTag struct {
-	SDKShapeTraits bool `type:"structure"`
+	_ struct{} `type:"structure"`
 }
 
 // String returns the string representation
@@ -6279,11 +5647,7 @@ func (s Tag) GoString() string {
 type Tagging struct {
 	TagSet []*Tag `locationNameList:"Tag" type:"list" required:"true"`
 
-	metadataTagging `json:"-" xml:"-"`
-}
-
-type metadataTagging struct {
-	SDKShapeTraits bool `type:"structure"`
+	_ struct{} `type:"structure"`
 }
 
 // String returns the string representation
@@ -6302,11 +5666,7 @@ type TargetGrant struct {
 	// Logging permissions assigned to the Grantee for the bucket.
 	Permission *string `type:"string" enum:"BucketLogsPermission"`
 
-	metadataTargetGrant `json:"-" xml:"-"`
-}
-
-type metadataTargetGrant struct {
-	SDKShapeTraits bool `type:"structure"`
+	_ struct{} `type:"structure"`
 }
 
 // String returns the string representation
@@ -6337,11 +5697,7 @@ type TopicConfiguration struct {
 	// events of specified type.
 	TopicArn *string `locationName:"Topic" type:"string" required:"true"`
 
-	metadataTopicConfiguration `json:"-" xml:"-"`
-}
-
-type metadataTopicConfiguration struct {
-	SDKShapeTraits bool `type:"structure"`
+	_ struct{} `type:"structure"`
 }
 
 // String returns the string representation
@@ -6368,11 +5724,7 @@ type TopicConfigurationDeprecated struct {
 	// specified events for the bucket.
 	Topic *string `type:"string"`
 
-	metadataTopicConfigurationDeprecated `json:"-" xml:"-"`
-}
-
-type metadataTopicConfigurationDeprecated struct {
-	SDKShapeTraits bool `type:"structure"`
+	_ struct{} `type:"structure"`
 }
 
 // String returns the string representation
@@ -6397,11 +5749,7 @@ type Transition struct {
 	// The class of storage used to store the object.
 	StorageClass *string `type:"string" enum:"TransitionStorageClass"`
 
-	metadataTransition `json:"-" xml:"-"`
-}
-
-type metadataTransition struct {
-	SDKShapeTraits bool `type:"structure"`
+	_ struct{} `type:"structure"`
 }
 
 // String returns the string representation
@@ -6485,11 +5833,7 @@ type UploadPartCopyInput struct {
 	// Upload ID identifying the multipart upload whose part is being copied.
 	UploadId *string `location:"querystring" locationName:"uploadId" type:"string" required:"true"`
 
-	metadataUploadPartCopyInput `json:"-" xml:"-"`
-}
-
-type metadataUploadPartCopyInput struct {
-	SDKShapeTraits bool `type:"structure"`
+	_ struct{} `type:"structure"`
 }
 
 // String returns the string representation
@@ -6531,11 +5875,7 @@ type UploadPartCopyOutput struct {
 	// (e.g., AES256, aws:kms).
 	ServerSideEncryption *string `location:"header" locationName:"x-amz-server-side-encryption" type:"string" enum:"ServerSideEncryption"`
 
-	metadataUploadPartCopyOutput `json:"-" xml:"-"`
-}
-
-type metadataUploadPartCopyOutput struct {
-	SDKShapeTraits bool `type:"structure" payload:"CopyPartResult"`
+	_ struct{} `type:"structure" payload:"CopyPartResult"`
 }
 
 // String returns the string representation
@@ -6588,11 +5928,7 @@ type UploadPartInput struct {
 	// Upload ID identifying the multipart upload whose part is being uploaded.
 	UploadId *string `location:"querystring" locationName:"uploadId" type:"string" required:"true"`
 
-	metadataUploadPartInput `json:"-" xml:"-"`
-}
-
-type metadataUploadPartInput struct {
-	SDKShapeTraits bool `type:"structure" payload:"Body"`
+	_ struct{} `type:"structure" payload:"Body"`
 }
 
 // String returns the string representation
@@ -6631,11 +5967,7 @@ type UploadPartOutput struct {
 	// (e.g., AES256, aws:kms).
 	ServerSideEncryption *string `location:"header" locationName:"x-amz-server-side-encryption" type:"string" enum:"ServerSideEncryption"`
 
-	metadataUploadPartOutput `json:"-" xml:"-"`
-}
-
-type metadataUploadPartOutput struct {
-	SDKShapeTraits bool `type:"structure"`
+	_ struct{} `type:"structure"`
 }
 
 // String returns the string representation
@@ -6657,11 +5989,7 @@ type VersioningConfiguration struct {
 	// The versioning state of the bucket.
 	Status *string `type:"string" enum:"BucketVersioningStatus"`
 
-	metadataVersioningConfiguration `json:"-" xml:"-"`
-}
-
-type metadataVersioningConfiguration struct {
-	SDKShapeTraits bool `type:"structure"`
+	_ struct{} `type:"structure"`
 }
 
 // String returns the string representation
@@ -6683,11 +6011,7 @@ type WebsiteConfiguration struct {
 
 	RoutingRules []*RoutingRule `locationNameList:"RoutingRule" type:"list"`
 
-	metadataWebsiteConfiguration `json:"-" xml:"-"`
-}
-
-type metadataWebsiteConfiguration struct {
-	SDKShapeTraits bool `type:"structure"`
+	_ struct{} `type:"structure"`
 }
 
 // String returns the string representation

--- a/service/s3/api.go
+++ b/service/s3/api.go
@@ -1615,6 +1615,8 @@ func (c *S3) UploadPartCopy(input *UploadPartCopyInput) (*UploadPartCopyOutput, 
 }
 
 type AbortMultipartUploadInput struct {
+	_ struct{} `type:"structure"`
+
 	Bucket *string `location:"uri" locationName:"Bucket" type:"string" required:"true"`
 
 	Key *string `location:"uri" locationName:"Key" min:"1" type:"string" required:"true"`
@@ -1626,8 +1628,6 @@ type AbortMultipartUploadInput struct {
 	RequestPayer *string `location:"header" locationName:"x-amz-request-payer" type:"string" enum:"RequestPayer"`
 
 	UploadId *string `location:"querystring" locationName:"uploadId" type:"string" required:"true"`
-
-	_ struct{} `type:"structure"`
 }
 
 // String returns the string representation
@@ -1641,11 +1641,11 @@ func (s AbortMultipartUploadInput) GoString() string {
 }
 
 type AbortMultipartUploadOutput struct {
+	_ struct{} `type:"structure"`
+
 	// If present, indicates that the requester was successfully charged for the
 	// request.
 	RequestCharged *string `location:"header" locationName:"x-amz-request-charged" type:"string" enum:"RequestCharged"`
-
-	_ struct{} `type:"structure"`
 }
 
 // String returns the string representation
@@ -1659,12 +1659,12 @@ func (s AbortMultipartUploadOutput) GoString() string {
 }
 
 type AccessControlPolicy struct {
+	_ struct{} `type:"structure"`
+
 	// A list of grants.
 	Grants []*Grant `locationName:"AccessControlList" locationNameList:"Grant" type:"list"`
 
 	Owner *Owner `type:"structure"`
-
-	_ struct{} `type:"structure"`
 }
 
 // String returns the string representation
@@ -1678,13 +1678,13 @@ func (s AccessControlPolicy) GoString() string {
 }
 
 type Bucket struct {
+	_ struct{} `type:"structure"`
+
 	// Date the bucket was created.
 	CreationDate *time.Time `type:"timestamp" timestampFormat:"iso8601"`
 
 	// The name of the bucket.
 	Name *string `type:"string"`
-
-	_ struct{} `type:"structure"`
 }
 
 // String returns the string representation
@@ -1698,9 +1698,9 @@ func (s Bucket) GoString() string {
 }
 
 type BucketLifecycleConfiguration struct {
-	Rules []*LifecycleRule `locationName:"Rule" type:"list" flattened:"true" required:"true"`
-
 	_ struct{} `type:"structure"`
+
+	Rules []*LifecycleRule `locationName:"Rule" type:"list" flattened:"true" required:"true"`
 }
 
 // String returns the string representation
@@ -1714,9 +1714,9 @@ func (s BucketLifecycleConfiguration) GoString() string {
 }
 
 type BucketLoggingStatus struct {
-	LoggingEnabled *LoggingEnabled `type:"structure"`
-
 	_ struct{} `type:"structure"`
+
+	LoggingEnabled *LoggingEnabled `type:"structure"`
 }
 
 // String returns the string representation
@@ -1730,9 +1730,9 @@ func (s BucketLoggingStatus) GoString() string {
 }
 
 type CORSConfiguration struct {
-	CORSRules []*CORSRule `locationName:"CORSRule" type:"list" flattened:"true" required:"true"`
-
 	_ struct{} `type:"structure"`
+
+	CORSRules []*CORSRule `locationName:"CORSRule" type:"list" flattened:"true" required:"true"`
 }
 
 // String returns the string representation
@@ -1746,6 +1746,8 @@ func (s CORSConfiguration) GoString() string {
 }
 
 type CORSRule struct {
+	_ struct{} `type:"structure"`
+
 	// Specifies which headers are allowed in a pre-flight OPTIONS request.
 	AllowedHeaders []*string `locationName:"AllowedHeader" type:"list" flattened:"true"`
 
@@ -1764,8 +1766,6 @@ type CORSRule struct {
 	// The time in seconds that your browser is to cache the preflight response
 	// for the specified resource.
 	MaxAgeSeconds *int64 `type:"integer"`
-
-	_ struct{} `type:"structure"`
 }
 
 // String returns the string representation
@@ -1779,6 +1779,8 @@ func (s CORSRule) GoString() string {
 }
 
 type CloudFunctionConfiguration struct {
+	_ struct{} `type:"structure"`
+
 	CloudFunction *string `type:"string"`
 
 	// Bucket event for which to send notifications.
@@ -1791,8 +1793,6 @@ type CloudFunctionConfiguration struct {
 	Id *string `type:"string"`
 
 	InvocationRole *string `type:"string"`
-
-	_ struct{} `type:"structure"`
 }
 
 // String returns the string representation
@@ -1806,9 +1806,9 @@ func (s CloudFunctionConfiguration) GoString() string {
 }
 
 type CommonPrefix struct {
-	Prefix *string `type:"string"`
-
 	_ struct{} `type:"structure"`
+
+	Prefix *string `type:"string"`
 }
 
 // String returns the string representation
@@ -1822,6 +1822,8 @@ func (s CommonPrefix) GoString() string {
 }
 
 type CompleteMultipartUploadInput struct {
+	_ struct{} `type:"structure" payload:"MultipartUpload"`
+
 	Bucket *string `location:"uri" locationName:"Bucket" type:"string" required:"true"`
 
 	Key *string `location:"uri" locationName:"Key" min:"1" type:"string" required:"true"`
@@ -1835,8 +1837,6 @@ type CompleteMultipartUploadInput struct {
 	RequestPayer *string `location:"header" locationName:"x-amz-request-payer" type:"string" enum:"RequestPayer"`
 
 	UploadId *string `location:"querystring" locationName:"uploadId" type:"string" required:"true"`
-
-	_ struct{} `type:"structure" payload:"MultipartUpload"`
 }
 
 // String returns the string representation
@@ -1850,6 +1850,8 @@ func (s CompleteMultipartUploadInput) GoString() string {
 }
 
 type CompleteMultipartUploadOutput struct {
+	_ struct{} `type:"structure"`
+
 	Bucket *string `type:"string"`
 
 	// Entity tag of the object.
@@ -1877,8 +1879,6 @@ type CompleteMultipartUploadOutput struct {
 
 	// Version of the object.
 	VersionId *string `location:"header" locationName:"x-amz-version-id" type:"string"`
-
-	_ struct{} `type:"structure"`
 }
 
 // String returns the string representation
@@ -1892,9 +1892,9 @@ func (s CompleteMultipartUploadOutput) GoString() string {
 }
 
 type CompletedMultipartUpload struct {
-	Parts []*CompletedPart `locationName:"Part" type:"list" flattened:"true"`
-
 	_ struct{} `type:"structure"`
+
+	Parts []*CompletedPart `locationName:"Part" type:"list" flattened:"true"`
 }
 
 // String returns the string representation
@@ -1908,14 +1908,14 @@ func (s CompletedMultipartUpload) GoString() string {
 }
 
 type CompletedPart struct {
+	_ struct{} `type:"structure"`
+
 	// Entity tag returned when the part was uploaded.
 	ETag *string `type:"string"`
 
 	// Part number that identifies the part. This is a positive integer between
 	// 1 and 10,000.
 	PartNumber *int64 `type:"integer"`
-
-	_ struct{} `type:"structure"`
 }
 
 // String returns the string representation
@@ -1929,6 +1929,8 @@ func (s CompletedPart) GoString() string {
 }
 
 type Condition struct {
+	_ struct{} `type:"structure"`
+
 	// The HTTP error code when the redirect is applied. In the event of an error,
 	// if the error code equals this value, then the specified redirect is applied.
 	// Required when parent element Condition is specified and sibling KeyPrefixEquals
@@ -1944,8 +1946,6 @@ type Condition struct {
 	// is not specified. If both conditions are specified, both must be true for
 	// the redirect to be applied.
 	KeyPrefixEquals *string `type:"string"`
-
-	_ struct{} `type:"structure"`
 }
 
 // String returns the string representation
@@ -1959,6 +1959,8 @@ func (s Condition) GoString() string {
 }
 
 type CopyObjectInput struct {
+	_ struct{} `type:"structure"`
+
 	// The canned ACL to apply to the object.
 	ACL *string `location:"header" locationName:"x-amz-acl" type:"string" enum:"ObjectCannedACL"`
 
@@ -2073,8 +2075,6 @@ type CopyObjectInput struct {
 	// to another object in the same bucket or to an external URL. Amazon S3 stores
 	// the value of this header in the object metadata.
 	WebsiteRedirectLocation *string `location:"header" locationName:"x-amz-website-redirect-location" type:"string"`
-
-	_ struct{} `type:"structure"`
 }
 
 // String returns the string representation
@@ -2088,6 +2088,8 @@ func (s CopyObjectInput) GoString() string {
 }
 
 type CopyObjectOutput struct {
+	_ struct{} `type:"structure" payload:"CopyObjectResult"`
+
 	CopyObjectResult *CopyObjectResult `type:"structure"`
 
 	CopySourceVersionId *string `location:"header" locationName:"x-amz-copy-source-version-id" type:"string"`
@@ -2119,8 +2121,6 @@ type CopyObjectOutput struct {
 
 	// Version ID of the newly created copy.
 	VersionId *string `location:"header" locationName:"x-amz-version-id" type:"string"`
-
-	_ struct{} `type:"structure" payload:"CopyObjectResult"`
 }
 
 // String returns the string representation
@@ -2134,11 +2134,11 @@ func (s CopyObjectOutput) GoString() string {
 }
 
 type CopyObjectResult struct {
+	_ struct{} `type:"structure"`
+
 	ETag *string `type:"string"`
 
 	LastModified *time.Time `type:"timestamp" timestampFormat:"iso8601"`
-
-	_ struct{} `type:"structure"`
 }
 
 // String returns the string representation
@@ -2152,13 +2152,13 @@ func (s CopyObjectResult) GoString() string {
 }
 
 type CopyPartResult struct {
+	_ struct{} `type:"structure"`
+
 	// Entity tag of the object.
 	ETag *string `type:"string"`
 
 	// Date and time at which the object was uploaded.
 	LastModified *time.Time `type:"timestamp" timestampFormat:"iso8601"`
-
-	_ struct{} `type:"structure"`
 }
 
 // String returns the string representation
@@ -2172,11 +2172,11 @@ func (s CopyPartResult) GoString() string {
 }
 
 type CreateBucketConfiguration struct {
+	_ struct{} `type:"structure"`
+
 	// Specifies the region where the bucket will be created. If you don't specify
 	// a region, the bucket will be created in US Standard.
 	LocationConstraint *string `type:"string" enum:"BucketLocationConstraint"`
-
-	_ struct{} `type:"structure"`
 }
 
 // String returns the string representation
@@ -2190,6 +2190,8 @@ func (s CreateBucketConfiguration) GoString() string {
 }
 
 type CreateBucketInput struct {
+	_ struct{} `type:"structure" payload:"CreateBucketConfiguration"`
+
 	// The canned ACL to apply to the bucket.
 	ACL *string `location:"header" locationName:"x-amz-acl" type:"string" enum:"BucketCannedACL"`
 
@@ -2212,8 +2214,6 @@ type CreateBucketInput struct {
 
 	// Allows grantee to write the ACL for the applicable bucket.
 	GrantWriteACP *string `location:"header" locationName:"x-amz-grant-write-acp" type:"string"`
-
-	_ struct{} `type:"structure" payload:"CreateBucketConfiguration"`
 }
 
 // String returns the string representation
@@ -2227,9 +2227,9 @@ func (s CreateBucketInput) GoString() string {
 }
 
 type CreateBucketOutput struct {
-	Location *string `location:"header" locationName:"Location" type:"string"`
-
 	_ struct{} `type:"structure"`
+
+	Location *string `location:"header" locationName:"Location" type:"string"`
 }
 
 // String returns the string representation
@@ -2243,6 +2243,8 @@ func (s CreateBucketOutput) GoString() string {
 }
 
 type CreateMultipartUploadInput struct {
+	_ struct{} `type:"structure"`
+
 	// The canned ACL to apply to the object.
 	ACL *string `location:"header" locationName:"x-amz-acl" type:"string" enum:"ObjectCannedACL"`
 
@@ -2323,8 +2325,6 @@ type CreateMultipartUploadInput struct {
 	// to another object in the same bucket or to an external URL. Amazon S3 stores
 	// the value of this header in the object metadata.
 	WebsiteRedirectLocation *string `location:"header" locationName:"x-amz-website-redirect-location" type:"string"`
-
-	_ struct{} `type:"structure"`
 }
 
 // String returns the string representation
@@ -2338,6 +2338,8 @@ func (s CreateMultipartUploadInput) GoString() string {
 }
 
 type CreateMultipartUploadOutput struct {
+	_ struct{} `type:"structure"`
+
 	// Name of the bucket to which the multipart upload was initiated.
 	Bucket *string `locationName:"Bucket" type:"string"`
 
@@ -2368,8 +2370,6 @@ type CreateMultipartUploadOutput struct {
 
 	// ID for the initiated multipart upload.
 	UploadId *string `type:"string"`
-
-	_ struct{} `type:"structure"`
 }
 
 // String returns the string representation
@@ -2383,13 +2383,13 @@ func (s CreateMultipartUploadOutput) GoString() string {
 }
 
 type Delete struct {
+	_ struct{} `type:"structure"`
+
 	Objects []*ObjectIdentifier `locationName:"Object" type:"list" flattened:"true" required:"true"`
 
 	// Element to enable quiet mode for the request. When you add this element,
 	// you must set its value to true.
 	Quiet *bool `type:"boolean"`
-
-	_ struct{} `type:"structure"`
 }
 
 // String returns the string representation
@@ -2403,9 +2403,9 @@ func (s Delete) GoString() string {
 }
 
 type DeleteBucketCorsInput struct {
-	Bucket *string `location:"uri" locationName:"Bucket" type:"string" required:"true"`
-
 	_ struct{} `type:"structure"`
+
+	Bucket *string `location:"uri" locationName:"Bucket" type:"string" required:"true"`
 }
 
 // String returns the string representation
@@ -2433,9 +2433,9 @@ func (s DeleteBucketCorsOutput) GoString() string {
 }
 
 type DeleteBucketInput struct {
-	Bucket *string `location:"uri" locationName:"Bucket" type:"string" required:"true"`
-
 	_ struct{} `type:"structure"`
+
+	Bucket *string `location:"uri" locationName:"Bucket" type:"string" required:"true"`
 }
 
 // String returns the string representation
@@ -2449,9 +2449,9 @@ func (s DeleteBucketInput) GoString() string {
 }
 
 type DeleteBucketLifecycleInput struct {
-	Bucket *string `location:"uri" locationName:"Bucket" type:"string" required:"true"`
-
 	_ struct{} `type:"structure"`
+
+	Bucket *string `location:"uri" locationName:"Bucket" type:"string" required:"true"`
 }
 
 // String returns the string representation
@@ -2493,9 +2493,9 @@ func (s DeleteBucketOutput) GoString() string {
 }
 
 type DeleteBucketPolicyInput struct {
-	Bucket *string `location:"uri" locationName:"Bucket" type:"string" required:"true"`
-
 	_ struct{} `type:"structure"`
+
+	Bucket *string `location:"uri" locationName:"Bucket" type:"string" required:"true"`
 }
 
 // String returns the string representation
@@ -2523,9 +2523,9 @@ func (s DeleteBucketPolicyOutput) GoString() string {
 }
 
 type DeleteBucketReplicationInput struct {
-	Bucket *string `location:"uri" locationName:"Bucket" type:"string" required:"true"`
-
 	_ struct{} `type:"structure"`
+
+	Bucket *string `location:"uri" locationName:"Bucket" type:"string" required:"true"`
 }
 
 // String returns the string representation
@@ -2553,9 +2553,9 @@ func (s DeleteBucketReplicationOutput) GoString() string {
 }
 
 type DeleteBucketTaggingInput struct {
-	Bucket *string `location:"uri" locationName:"Bucket" type:"string" required:"true"`
-
 	_ struct{} `type:"structure"`
+
+	Bucket *string `location:"uri" locationName:"Bucket" type:"string" required:"true"`
 }
 
 // String returns the string representation
@@ -2583,9 +2583,9 @@ func (s DeleteBucketTaggingOutput) GoString() string {
 }
 
 type DeleteBucketWebsiteInput struct {
-	Bucket *string `location:"uri" locationName:"Bucket" type:"string" required:"true"`
-
 	_ struct{} `type:"structure"`
+
+	Bucket *string `location:"uri" locationName:"Bucket" type:"string" required:"true"`
 }
 
 // String returns the string representation
@@ -2613,6 +2613,8 @@ func (s DeleteBucketWebsiteOutput) GoString() string {
 }
 
 type DeleteMarkerEntry struct {
+	_ struct{} `type:"structure"`
+
 	// Specifies whether the object is (true) or is not (false) the latest version
 	// of an object.
 	IsLatest *bool `type:"boolean"`
@@ -2627,8 +2629,6 @@ type DeleteMarkerEntry struct {
 
 	// Version ID of an object.
 	VersionId *string `type:"string"`
-
-	_ struct{} `type:"structure"`
 }
 
 // String returns the string representation
@@ -2642,6 +2642,8 @@ func (s DeleteMarkerEntry) GoString() string {
 }
 
 type DeleteObjectInput struct {
+	_ struct{} `type:"structure"`
+
 	Bucket *string `location:"uri" locationName:"Bucket" type:"string" required:"true"`
 
 	Key *string `location:"uri" locationName:"Key" min:"1" type:"string" required:"true"`
@@ -2658,8 +2660,6 @@ type DeleteObjectInput struct {
 
 	// VersionId used to reference a specific version of the object.
 	VersionId *string `location:"querystring" locationName:"versionId" type:"string"`
-
-	_ struct{} `type:"structure"`
 }
 
 // String returns the string representation
@@ -2673,6 +2673,8 @@ func (s DeleteObjectInput) GoString() string {
 }
 
 type DeleteObjectOutput struct {
+	_ struct{} `type:"structure"`
+
 	// Specifies whether the versioned object that was permanently deleted was (true)
 	// or was not (false) a delete marker.
 	DeleteMarker *bool `location:"header" locationName:"x-amz-delete-marker" type:"boolean"`
@@ -2684,8 +2686,6 @@ type DeleteObjectOutput struct {
 	// Returns the version ID of the delete marker created as a result of the DELETE
 	// operation.
 	VersionId *string `location:"header" locationName:"x-amz-version-id" type:"string"`
-
-	_ struct{} `type:"structure"`
 }
 
 // String returns the string representation
@@ -2699,6 +2699,8 @@ func (s DeleteObjectOutput) GoString() string {
 }
 
 type DeleteObjectsInput struct {
+	_ struct{} `type:"structure" payload:"Delete"`
+
 	Bucket *string `location:"uri" locationName:"Bucket" type:"string" required:"true"`
 
 	Delete *Delete `locationName:"Delete" type:"structure" required:"true"`
@@ -2712,8 +2714,6 @@ type DeleteObjectsInput struct {
 	// Documentation on downloading objects from requester pays buckets can be found
 	// at http://docs.aws.amazon.com/AmazonS3/latest/dev/ObjectsinRequesterPaysBuckets.html
 	RequestPayer *string `location:"header" locationName:"x-amz-request-payer" type:"string" enum:"RequestPayer"`
-
-	_ struct{} `type:"structure" payload:"Delete"`
 }
 
 // String returns the string representation
@@ -2727,6 +2727,8 @@ func (s DeleteObjectsInput) GoString() string {
 }
 
 type DeleteObjectsOutput struct {
+	_ struct{} `type:"structure"`
+
 	Deleted []*DeletedObject `type:"list" flattened:"true"`
 
 	Errors []*Error `locationName:"Error" type:"list" flattened:"true"`
@@ -2734,8 +2736,6 @@ type DeleteObjectsOutput struct {
 	// If present, indicates that the requester was successfully charged for the
 	// request.
 	RequestCharged *string `location:"header" locationName:"x-amz-request-charged" type:"string" enum:"RequestCharged"`
-
-	_ struct{} `type:"structure"`
 }
 
 // String returns the string representation
@@ -2749,6 +2749,8 @@ func (s DeleteObjectsOutput) GoString() string {
 }
 
 type DeletedObject struct {
+	_ struct{} `type:"structure"`
+
 	DeleteMarker *bool `type:"boolean"`
 
 	DeleteMarkerVersionId *string `type:"string"`
@@ -2756,8 +2758,6 @@ type DeletedObject struct {
 	Key *string `min:"1" type:"string"`
 
 	VersionId *string `type:"string"`
-
-	_ struct{} `type:"structure"`
 }
 
 // String returns the string representation
@@ -2771,14 +2771,14 @@ func (s DeletedObject) GoString() string {
 }
 
 type Destination struct {
+	_ struct{} `type:"structure"`
+
 	// Amazon resource name (ARN) of the bucket where you want Amazon S3 to store
 	// replicas of the object identified by the rule.
 	Bucket *string `type:"string" required:"true"`
 
 	// The class of storage used to store the object.
 	StorageClass *string `type:"string" enum:"StorageClass"`
-
-	_ struct{} `type:"structure"`
 }
 
 // String returns the string representation
@@ -2792,6 +2792,8 @@ func (s Destination) GoString() string {
 }
 
 type Error struct {
+	_ struct{} `type:"structure"`
+
 	Code *string `type:"string"`
 
 	Key *string `min:"1" type:"string"`
@@ -2799,8 +2801,6 @@ type Error struct {
 	Message *string `type:"string"`
 
 	VersionId *string `type:"string"`
-
-	_ struct{} `type:"structure"`
 }
 
 // String returns the string representation
@@ -2814,10 +2814,10 @@ func (s Error) GoString() string {
 }
 
 type ErrorDocument struct {
+	_ struct{} `type:"structure"`
+
 	// The object key name to use when a 4XX class error occurs.
 	Key *string `min:"1" type:"string" required:"true"`
-
-	_ struct{} `type:"structure"`
 }
 
 // String returns the string representation
@@ -2832,6 +2832,8 @@ func (s ErrorDocument) GoString() string {
 
 // Container for key value pair that defines the criteria for the filter rule.
 type FilterRule struct {
+	_ struct{} `type:"structure"`
+
 	// Object key name prefix or suffix identifying one or more objects to which
 	// the filtering rule applies. Maximum prefix length can be up to 1,024 characters.
 	// Overlapping prefixes and suffixes are not supported. For more information,
@@ -2840,8 +2842,6 @@ type FilterRule struct {
 	Name *string `type:"string" enum:"FilterRuleName"`
 
 	Value *string `type:"string"`
-
-	_ struct{} `type:"structure"`
 }
 
 // String returns the string representation
@@ -2855,9 +2855,9 @@ func (s FilterRule) GoString() string {
 }
 
 type GetBucketAclInput struct {
-	Bucket *string `location:"uri" locationName:"Bucket" type:"string" required:"true"`
-
 	_ struct{} `type:"structure"`
+
+	Bucket *string `location:"uri" locationName:"Bucket" type:"string" required:"true"`
 }
 
 // String returns the string representation
@@ -2871,12 +2871,12 @@ func (s GetBucketAclInput) GoString() string {
 }
 
 type GetBucketAclOutput struct {
+	_ struct{} `type:"structure"`
+
 	// A list of grants.
 	Grants []*Grant `locationName:"AccessControlList" locationNameList:"Grant" type:"list"`
 
 	Owner *Owner `type:"structure"`
-
-	_ struct{} `type:"structure"`
 }
 
 // String returns the string representation
@@ -2890,9 +2890,9 @@ func (s GetBucketAclOutput) GoString() string {
 }
 
 type GetBucketCorsInput struct {
-	Bucket *string `location:"uri" locationName:"Bucket" type:"string" required:"true"`
-
 	_ struct{} `type:"structure"`
+
+	Bucket *string `location:"uri" locationName:"Bucket" type:"string" required:"true"`
 }
 
 // String returns the string representation
@@ -2906,9 +2906,9 @@ func (s GetBucketCorsInput) GoString() string {
 }
 
 type GetBucketCorsOutput struct {
-	CORSRules []*CORSRule `locationName:"CORSRule" type:"list" flattened:"true"`
-
 	_ struct{} `type:"structure"`
+
+	CORSRules []*CORSRule `locationName:"CORSRule" type:"list" flattened:"true"`
 }
 
 // String returns the string representation
@@ -2922,9 +2922,9 @@ func (s GetBucketCorsOutput) GoString() string {
 }
 
 type GetBucketLifecycleConfigurationInput struct {
-	Bucket *string `location:"uri" locationName:"Bucket" type:"string" required:"true"`
-
 	_ struct{} `type:"structure"`
+
+	Bucket *string `location:"uri" locationName:"Bucket" type:"string" required:"true"`
 }
 
 // String returns the string representation
@@ -2938,9 +2938,9 @@ func (s GetBucketLifecycleConfigurationInput) GoString() string {
 }
 
 type GetBucketLifecycleConfigurationOutput struct {
-	Rules []*LifecycleRule `locationName:"Rule" type:"list" flattened:"true"`
-
 	_ struct{} `type:"structure"`
+
+	Rules []*LifecycleRule `locationName:"Rule" type:"list" flattened:"true"`
 }
 
 // String returns the string representation
@@ -2954,9 +2954,9 @@ func (s GetBucketLifecycleConfigurationOutput) GoString() string {
 }
 
 type GetBucketLifecycleInput struct {
-	Bucket *string `location:"uri" locationName:"Bucket" type:"string" required:"true"`
-
 	_ struct{} `type:"structure"`
+
+	Bucket *string `location:"uri" locationName:"Bucket" type:"string" required:"true"`
 }
 
 // String returns the string representation
@@ -2970,9 +2970,9 @@ func (s GetBucketLifecycleInput) GoString() string {
 }
 
 type GetBucketLifecycleOutput struct {
-	Rules []*Rule `locationName:"Rule" type:"list" flattened:"true"`
-
 	_ struct{} `type:"structure"`
+
+	Rules []*Rule `locationName:"Rule" type:"list" flattened:"true"`
 }
 
 // String returns the string representation
@@ -2986,9 +2986,9 @@ func (s GetBucketLifecycleOutput) GoString() string {
 }
 
 type GetBucketLocationInput struct {
-	Bucket *string `location:"uri" locationName:"Bucket" type:"string" required:"true"`
-
 	_ struct{} `type:"structure"`
+
+	Bucket *string `location:"uri" locationName:"Bucket" type:"string" required:"true"`
 }
 
 // String returns the string representation
@@ -3002,9 +3002,9 @@ func (s GetBucketLocationInput) GoString() string {
 }
 
 type GetBucketLocationOutput struct {
-	LocationConstraint *string `type:"string" enum:"BucketLocationConstraint"`
-
 	_ struct{} `type:"structure"`
+
+	LocationConstraint *string `type:"string" enum:"BucketLocationConstraint"`
 }
 
 // String returns the string representation
@@ -3018,9 +3018,9 @@ func (s GetBucketLocationOutput) GoString() string {
 }
 
 type GetBucketLoggingInput struct {
-	Bucket *string `location:"uri" locationName:"Bucket" type:"string" required:"true"`
-
 	_ struct{} `type:"structure"`
+
+	Bucket *string `location:"uri" locationName:"Bucket" type:"string" required:"true"`
 }
 
 // String returns the string representation
@@ -3034,9 +3034,9 @@ func (s GetBucketLoggingInput) GoString() string {
 }
 
 type GetBucketLoggingOutput struct {
-	LoggingEnabled *LoggingEnabled `type:"structure"`
-
 	_ struct{} `type:"structure"`
+
+	LoggingEnabled *LoggingEnabled `type:"structure"`
 }
 
 // String returns the string representation
@@ -3050,10 +3050,10 @@ func (s GetBucketLoggingOutput) GoString() string {
 }
 
 type GetBucketNotificationConfigurationRequest struct {
+	_ struct{} `type:"structure"`
+
 	// Name of the buket to get the notification configuration for.
 	Bucket *string `location:"uri" locationName:"Bucket" type:"string" required:"true"`
-
-	_ struct{} `type:"structure"`
 }
 
 // String returns the string representation
@@ -3067,9 +3067,9 @@ func (s GetBucketNotificationConfigurationRequest) GoString() string {
 }
 
 type GetBucketPolicyInput struct {
-	Bucket *string `location:"uri" locationName:"Bucket" type:"string" required:"true"`
-
 	_ struct{} `type:"structure"`
+
+	Bucket *string `location:"uri" locationName:"Bucket" type:"string" required:"true"`
 }
 
 // String returns the string representation
@@ -3083,10 +3083,10 @@ func (s GetBucketPolicyInput) GoString() string {
 }
 
 type GetBucketPolicyOutput struct {
+	_ struct{} `type:"structure" payload:"Policy"`
+
 	// The bucket policy as a JSON document.
 	Policy *string `type:"string"`
-
-	_ struct{} `type:"structure" payload:"Policy"`
 }
 
 // String returns the string representation
@@ -3100,9 +3100,9 @@ func (s GetBucketPolicyOutput) GoString() string {
 }
 
 type GetBucketReplicationInput struct {
-	Bucket *string `location:"uri" locationName:"Bucket" type:"string" required:"true"`
-
 	_ struct{} `type:"structure"`
+
+	Bucket *string `location:"uri" locationName:"Bucket" type:"string" required:"true"`
 }
 
 // String returns the string representation
@@ -3116,11 +3116,11 @@ func (s GetBucketReplicationInput) GoString() string {
 }
 
 type GetBucketReplicationOutput struct {
+	_ struct{} `type:"structure" payload:"ReplicationConfiguration"`
+
 	// Container for replication rules. You can add as many as 1,000 rules. Total
 	// replication configuration size can be up to 2 MB.
 	ReplicationConfiguration *ReplicationConfiguration `type:"structure"`
-
-	_ struct{} `type:"structure" payload:"ReplicationConfiguration"`
 }
 
 // String returns the string representation
@@ -3134,9 +3134,9 @@ func (s GetBucketReplicationOutput) GoString() string {
 }
 
 type GetBucketRequestPaymentInput struct {
-	Bucket *string `location:"uri" locationName:"Bucket" type:"string" required:"true"`
-
 	_ struct{} `type:"structure"`
+
+	Bucket *string `location:"uri" locationName:"Bucket" type:"string" required:"true"`
 }
 
 // String returns the string representation
@@ -3150,10 +3150,10 @@ func (s GetBucketRequestPaymentInput) GoString() string {
 }
 
 type GetBucketRequestPaymentOutput struct {
+	_ struct{} `type:"structure"`
+
 	// Specifies who pays for the download and request fees.
 	Payer *string `type:"string" enum:"Payer"`
-
-	_ struct{} `type:"structure"`
 }
 
 // String returns the string representation
@@ -3167,9 +3167,9 @@ func (s GetBucketRequestPaymentOutput) GoString() string {
 }
 
 type GetBucketTaggingInput struct {
-	Bucket *string `location:"uri" locationName:"Bucket" type:"string" required:"true"`
-
 	_ struct{} `type:"structure"`
+
+	Bucket *string `location:"uri" locationName:"Bucket" type:"string" required:"true"`
 }
 
 // String returns the string representation
@@ -3183,9 +3183,9 @@ func (s GetBucketTaggingInput) GoString() string {
 }
 
 type GetBucketTaggingOutput struct {
-	TagSet []*Tag `locationNameList:"Tag" type:"list" required:"true"`
-
 	_ struct{} `type:"structure"`
+
+	TagSet []*Tag `locationNameList:"Tag" type:"list" required:"true"`
 }
 
 // String returns the string representation
@@ -3199,9 +3199,9 @@ func (s GetBucketTaggingOutput) GoString() string {
 }
 
 type GetBucketVersioningInput struct {
-	Bucket *string `location:"uri" locationName:"Bucket" type:"string" required:"true"`
-
 	_ struct{} `type:"structure"`
+
+	Bucket *string `location:"uri" locationName:"Bucket" type:"string" required:"true"`
 }
 
 // String returns the string representation
@@ -3215,6 +3215,8 @@ func (s GetBucketVersioningInput) GoString() string {
 }
 
 type GetBucketVersioningOutput struct {
+	_ struct{} `type:"structure"`
+
 	// Specifies whether MFA delete is enabled in the bucket versioning configuration.
 	// This element is only returned if the bucket has been configured with MFA
 	// delete. If the bucket has never been so configured, this element is not returned.
@@ -3222,8 +3224,6 @@ type GetBucketVersioningOutput struct {
 
 	// The versioning state of the bucket.
 	Status *string `type:"string" enum:"BucketVersioningStatus"`
-
-	_ struct{} `type:"structure"`
 }
 
 // String returns the string representation
@@ -3237,9 +3237,9 @@ func (s GetBucketVersioningOutput) GoString() string {
 }
 
 type GetBucketWebsiteInput struct {
-	Bucket *string `location:"uri" locationName:"Bucket" type:"string" required:"true"`
-
 	_ struct{} `type:"structure"`
+
+	Bucket *string `location:"uri" locationName:"Bucket" type:"string" required:"true"`
 }
 
 // String returns the string representation
@@ -3253,6 +3253,8 @@ func (s GetBucketWebsiteInput) GoString() string {
 }
 
 type GetBucketWebsiteOutput struct {
+	_ struct{} `type:"structure"`
+
 	ErrorDocument *ErrorDocument `type:"structure"`
 
 	IndexDocument *IndexDocument `type:"structure"`
@@ -3260,8 +3262,6 @@ type GetBucketWebsiteOutput struct {
 	RedirectAllRequestsTo *RedirectAllRequestsTo `type:"structure"`
 
 	RoutingRules []*RoutingRule `locationNameList:"RoutingRule" type:"list"`
-
-	_ struct{} `type:"structure"`
 }
 
 // String returns the string representation
@@ -3275,6 +3275,8 @@ func (s GetBucketWebsiteOutput) GoString() string {
 }
 
 type GetObjectAclInput struct {
+	_ struct{} `type:"structure"`
+
 	Bucket *string `location:"uri" locationName:"Bucket" type:"string" required:"true"`
 
 	Key *string `location:"uri" locationName:"Key" min:"1" type:"string" required:"true"`
@@ -3287,8 +3289,6 @@ type GetObjectAclInput struct {
 
 	// VersionId used to reference a specific version of the object.
 	VersionId *string `location:"querystring" locationName:"versionId" type:"string"`
-
-	_ struct{} `type:"structure"`
 }
 
 // String returns the string representation
@@ -3302,6 +3302,8 @@ func (s GetObjectAclInput) GoString() string {
 }
 
 type GetObjectAclOutput struct {
+	_ struct{} `type:"structure"`
+
 	// A list of grants.
 	Grants []*Grant `locationName:"AccessControlList" locationNameList:"Grant" type:"list"`
 
@@ -3310,8 +3312,6 @@ type GetObjectAclOutput struct {
 	// If present, indicates that the requester was successfully charged for the
 	// request.
 	RequestCharged *string `location:"header" locationName:"x-amz-request-charged" type:"string" enum:"RequestCharged"`
-
-	_ struct{} `type:"structure"`
 }
 
 // String returns the string representation
@@ -3325,6 +3325,8 @@ func (s GetObjectAclOutput) GoString() string {
 }
 
 type GetObjectInput struct {
+	_ struct{} `type:"structure"`
+
 	Bucket *string `location:"uri" locationName:"Bucket" type:"string" required:"true"`
 
 	// Return the object only if its entity tag (ETag) is the same as the one specified,
@@ -3390,8 +3392,6 @@ type GetObjectInput struct {
 
 	// VersionId used to reference a specific version of the object.
 	VersionId *string `location:"querystring" locationName:"versionId" type:"string"`
-
-	_ struct{} `type:"structure"`
 }
 
 // String returns the string representation
@@ -3405,6 +3405,8 @@ func (s GetObjectInput) GoString() string {
 }
 
 type GetObjectOutput struct {
+	_ struct{} `type:"structure" payload:"Body"`
+
 	AcceptRanges *string `location:"header" locationName:"accept-ranges" type:"string"`
 
 	// Object data.
@@ -3499,8 +3501,6 @@ type GetObjectOutput struct {
 	// to another object in the same bucket or to an external URL. Amazon S3 stores
 	// the value of this header in the object metadata.
 	WebsiteRedirectLocation *string `location:"header" locationName:"x-amz-website-redirect-location" type:"string"`
-
-	_ struct{} `type:"structure" payload:"Body"`
 }
 
 // String returns the string representation
@@ -3514,6 +3514,8 @@ func (s GetObjectOutput) GoString() string {
 }
 
 type GetObjectTorrentInput struct {
+	_ struct{} `type:"structure"`
+
 	Bucket *string `location:"uri" locationName:"Bucket" type:"string" required:"true"`
 
 	Key *string `location:"uri" locationName:"Key" min:"1" type:"string" required:"true"`
@@ -3523,8 +3525,6 @@ type GetObjectTorrentInput struct {
 	// Documentation on downloading objects from requester pays buckets can be found
 	// at http://docs.aws.amazon.com/AmazonS3/latest/dev/ObjectsinRequesterPaysBuckets.html
 	RequestPayer *string `location:"header" locationName:"x-amz-request-payer" type:"string" enum:"RequestPayer"`
-
-	_ struct{} `type:"structure"`
 }
 
 // String returns the string representation
@@ -3538,13 +3538,13 @@ func (s GetObjectTorrentInput) GoString() string {
 }
 
 type GetObjectTorrentOutput struct {
+	_ struct{} `type:"structure" payload:"Body"`
+
 	Body io.ReadCloser `type:"blob"`
 
 	// If present, indicates that the requester was successfully charged for the
 	// request.
 	RequestCharged *string `location:"header" locationName:"x-amz-request-charged" type:"string" enum:"RequestCharged"`
-
-	_ struct{} `type:"structure" payload:"Body"`
 }
 
 // String returns the string representation
@@ -3558,12 +3558,12 @@ func (s GetObjectTorrentOutput) GoString() string {
 }
 
 type Grant struct {
+	_ struct{} `type:"structure"`
+
 	Grantee *Grantee `type:"structure"`
 
 	// Specifies the permission given to the grantee.
 	Permission *string `type:"string" enum:"Permission"`
-
-	_ struct{} `type:"structure"`
 }
 
 // String returns the string representation
@@ -3577,6 +3577,8 @@ func (s Grant) GoString() string {
 }
 
 type Grantee struct {
+	_ struct{} `type:"structure" xmlPrefix:"xsi" xmlURI:"http://www.w3.org/2001/XMLSchema-instance"`
+
 	// Screen name of the grantee.
 	DisplayName *string `type:"string"`
 
@@ -3591,8 +3593,6 @@ type Grantee struct {
 
 	// URI of the grantee group.
 	URI *string `type:"string"`
-
-	_ struct{} `type:"structure" xmlPrefix:"xsi" xmlURI:"http://www.w3.org/2001/XMLSchema-instance"`
 }
 
 // String returns the string representation
@@ -3606,9 +3606,9 @@ func (s Grantee) GoString() string {
 }
 
 type HeadBucketInput struct {
-	Bucket *string `location:"uri" locationName:"Bucket" type:"string" required:"true"`
-
 	_ struct{} `type:"structure"`
+
+	Bucket *string `location:"uri" locationName:"Bucket" type:"string" required:"true"`
 }
 
 // String returns the string representation
@@ -3636,6 +3636,8 @@ func (s HeadBucketOutput) GoString() string {
 }
 
 type HeadObjectInput struct {
+	_ struct{} `type:"structure"`
+
 	Bucket *string `location:"uri" locationName:"Bucket" type:"string" required:"true"`
 
 	// Return the object only if its entity tag (ETag) is the same as the one specified,
@@ -3683,8 +3685,6 @@ type HeadObjectInput struct {
 
 	// VersionId used to reference a specific version of the object.
 	VersionId *string `location:"querystring" locationName:"versionId" type:"string"`
-
-	_ struct{} `type:"structure"`
 }
 
 // String returns the string representation
@@ -3698,6 +3698,8 @@ func (s HeadObjectInput) GoString() string {
 }
 
 type HeadObjectOutput struct {
+	_ struct{} `type:"structure"`
+
 	AcceptRanges *string `location:"header" locationName:"accept-ranges" type:"string"`
 
 	// Specifies caching behavior along the request/reply chain.
@@ -3786,8 +3788,6 @@ type HeadObjectOutput struct {
 	// to another object in the same bucket or to an external URL. Amazon S3 stores
 	// the value of this header in the object metadata.
 	WebsiteRedirectLocation *string `location:"header" locationName:"x-amz-website-redirect-location" type:"string"`
-
-	_ struct{} `type:"structure"`
 }
 
 // String returns the string representation
@@ -3801,13 +3801,13 @@ func (s HeadObjectOutput) GoString() string {
 }
 
 type IndexDocument struct {
+	_ struct{} `type:"structure"`
+
 	// A suffix that is appended to a request that is for a directory on the website
 	// endpoint (e.g. if the suffix is index.html and you make a request to samplebucket/images/
 	// the data that is returned will be for the object with the key name images/index.html)
 	// The suffix must not be empty and must not include a slash character.
 	Suffix *string `type:"string" required:"true"`
-
-	_ struct{} `type:"structure"`
 }
 
 // String returns the string representation
@@ -3821,14 +3821,14 @@ func (s IndexDocument) GoString() string {
 }
 
 type Initiator struct {
+	_ struct{} `type:"structure"`
+
 	// Name of the Principal.
 	DisplayName *string `type:"string"`
 
 	// If the principal is an AWS account, it provides the Canonical User ID. If
 	// the principal is an IAM User, it provides a user ARN value.
 	ID *string `type:"string"`
-
-	_ struct{} `type:"structure"`
 }
 
 // String returns the string representation
@@ -3843,11 +3843,11 @@ func (s Initiator) GoString() string {
 
 // Container for object key name prefix and suffix filtering rules.
 type KeyFilter struct {
+	_ struct{} `type:"structure"`
+
 	// A list of containers for key value pair that defines the criteria for the
 	// filter rule.
 	FilterRules []*FilterRule `locationName:"FilterRule" type:"list" flattened:"true"`
-
-	_ struct{} `type:"structure"`
 }
 
 // String returns the string representation
@@ -3862,6 +3862,8 @@ func (s KeyFilter) GoString() string {
 
 // Container for specifying the AWS Lambda notification configuration.
 type LambdaFunctionConfiguration struct {
+	_ struct{} `type:"structure"`
+
 	Events []*string `locationName:"Event" type:"list" flattened:"true" required:"true"`
 
 	// Container for object key name filtering rules. For information about key
@@ -3876,8 +3878,6 @@ type LambdaFunctionConfiguration struct {
 	// Lambda cloud function ARN that Amazon S3 can invoke when it detects events
 	// of the specified type.
 	LambdaFunctionArn *string `locationName:"CloudFunction" type:"string" required:"true"`
-
-	_ struct{} `type:"structure"`
 }
 
 // String returns the string representation
@@ -3891,9 +3891,9 @@ func (s LambdaFunctionConfiguration) GoString() string {
 }
 
 type LifecycleConfiguration struct {
-	Rules []*Rule `locationName:"Rule" type:"list" flattened:"true" required:"true"`
-
 	_ struct{} `type:"structure"`
+
+	Rules []*Rule `locationName:"Rule" type:"list" flattened:"true" required:"true"`
 }
 
 // String returns the string representation
@@ -3907,6 +3907,8 @@ func (s LifecycleConfiguration) GoString() string {
 }
 
 type LifecycleExpiration struct {
+	_ struct{} `type:"structure"`
+
 	// Indicates at what date the object is to be moved or deleted. Should be in
 	// GMT ISO 8601 Format.
 	Date *time.Time `type:"timestamp" timestampFormat:"iso8601"`
@@ -3914,8 +3916,6 @@ type LifecycleExpiration struct {
 	// Indicates the lifetime, in days, of the objects that are subject to the rule.
 	// The value must be a non-zero positive integer.
 	Days *int64 `type:"integer"`
-
-	_ struct{} `type:"structure"`
 }
 
 // String returns the string representation
@@ -3929,6 +3929,8 @@ func (s LifecycleExpiration) GoString() string {
 }
 
 type LifecycleRule struct {
+	_ struct{} `type:"structure"`
+
 	Expiration *LifecycleExpiration `type:"structure"`
 
 	// Unique identifier for the rule. The value cannot be longer than 255 characters.
@@ -3951,8 +3953,6 @@ type LifecycleRule struct {
 	Status *string `type:"string" required:"true" enum:"ExpirationStatus"`
 
 	Transitions []*Transition `locationName:"Transition" type:"list" flattened:"true"`
-
-	_ struct{} `type:"structure"`
 }
 
 // String returns the string representation
@@ -3980,11 +3980,11 @@ func (s ListBucketsInput) GoString() string {
 }
 
 type ListBucketsOutput struct {
+	_ struct{} `type:"structure"`
+
 	Buckets []*Bucket `locationNameList:"Bucket" type:"list"`
 
 	Owner *Owner `type:"structure"`
-
-	_ struct{} `type:"structure"`
 }
 
 // String returns the string representation
@@ -3998,6 +3998,8 @@ func (s ListBucketsOutput) GoString() string {
 }
 
 type ListMultipartUploadsInput struct {
+	_ struct{} `type:"structure"`
+
 	Bucket *string `location:"uri" locationName:"Bucket" type:"string" required:"true"`
 
 	// Character you use to group keys.
@@ -4028,8 +4030,6 @@ type ListMultipartUploadsInput struct {
 	// should begin. If key-marker is not specified, the upload-id-marker parameter
 	// is ignored.
 	UploadIdMarker *string `location:"querystring" locationName:"upload-id-marker" type:"string"`
-
-	_ struct{} `type:"structure"`
 }
 
 // String returns the string representation
@@ -4043,6 +4043,8 @@ func (s ListMultipartUploadsInput) GoString() string {
 }
 
 type ListMultipartUploadsOutput struct {
+	_ struct{} `type:"structure"`
+
 	// Name of the bucket to which the multipart upload was initiated.
 	Bucket *string `type:"string"`
 
@@ -4082,8 +4084,6 @@ type ListMultipartUploadsOutput struct {
 	UploadIdMarker *string `type:"string"`
 
 	Uploads []*MultipartUpload `locationName:"Upload" type:"list" flattened:"true"`
-
-	_ struct{} `type:"structure"`
 }
 
 // String returns the string representation
@@ -4097,6 +4097,8 @@ func (s ListMultipartUploadsOutput) GoString() string {
 }
 
 type ListObjectVersionsInput struct {
+	_ struct{} `type:"structure"`
+
 	Bucket *string `location:"uri" locationName:"Bucket" type:"string" required:"true"`
 
 	// A delimiter is a character you use to group keys.
@@ -4122,8 +4124,6 @@ type ListObjectVersionsInput struct {
 
 	// Specifies the object version you want to start listing from.
 	VersionIdMarker *string `location:"querystring" locationName:"version-id-marker" type:"string"`
-
-	_ struct{} `type:"structure"`
 }
 
 // String returns the string representation
@@ -4137,6 +4137,8 @@ func (s ListObjectVersionsInput) GoString() string {
 }
 
 type ListObjectVersionsOutput struct {
+	_ struct{} `type:"structure"`
+
 	CommonPrefixes []*CommonPrefix `type:"list" flattened:"true"`
 
 	DeleteMarkers []*DeleteMarkerEntry `locationName:"DeleteMarker" type:"list" flattened:"true"`
@@ -4171,8 +4173,6 @@ type ListObjectVersionsOutput struct {
 	VersionIdMarker *string `type:"string"`
 
 	Versions []*ObjectVersion `locationName:"Version" type:"list" flattened:"true"`
-
-	_ struct{} `type:"structure"`
 }
 
 // String returns the string representation
@@ -4186,6 +4186,8 @@ func (s ListObjectVersionsOutput) GoString() string {
 }
 
 type ListObjectsInput struct {
+	_ struct{} `type:"structure"`
+
 	Bucket *string `location:"uri" locationName:"Bucket" type:"string" required:"true"`
 
 	// A delimiter is a character you use to group keys.
@@ -4208,8 +4210,6 @@ type ListObjectsInput struct {
 
 	// Limits the response to keys that begin with the specified prefix.
 	Prefix *string `location:"querystring" locationName:"prefix" type:"string"`
-
-	_ struct{} `type:"structure"`
 }
 
 // String returns the string representation
@@ -4223,6 +4223,8 @@ func (s ListObjectsInput) GoString() string {
 }
 
 type ListObjectsOutput struct {
+	_ struct{} `type:"structure"`
+
 	CommonPrefixes []*CommonPrefix `type:"list" flattened:"true"`
 
 	Contents []*Object `type:"list" flattened:"true"`
@@ -4252,8 +4254,6 @@ type ListObjectsOutput struct {
 	NextMarker *string `type:"string"`
 
 	Prefix *string `type:"string"`
-
-	_ struct{} `type:"structure"`
 }
 
 // String returns the string representation
@@ -4267,6 +4267,8 @@ func (s ListObjectsOutput) GoString() string {
 }
 
 type ListPartsInput struct {
+	_ struct{} `type:"structure"`
+
 	Bucket *string `location:"uri" locationName:"Bucket" type:"string" required:"true"`
 
 	Key *string `location:"uri" locationName:"Key" min:"1" type:"string" required:"true"`
@@ -4286,8 +4288,6 @@ type ListPartsInput struct {
 
 	// Upload ID identifying the multipart upload whose parts are being listed.
 	UploadId *string `location:"querystring" locationName:"uploadId" type:"string" required:"true"`
-
-	_ struct{} `type:"structure"`
 }
 
 // String returns the string representation
@@ -4301,6 +4301,8 @@ func (s ListPartsInput) GoString() string {
 }
 
 type ListPartsOutput struct {
+	_ struct{} `type:"structure"`
+
 	// Name of the bucket to which the multipart upload was initiated.
 	Bucket *string `type:"string"`
 
@@ -4337,8 +4339,6 @@ type ListPartsOutput struct {
 
 	// Upload ID identifying the multipart upload whose parts are being listed.
 	UploadId *string `type:"string"`
-
-	_ struct{} `type:"structure"`
 }
 
 // String returns the string representation
@@ -4352,6 +4352,8 @@ func (s ListPartsOutput) GoString() string {
 }
 
 type LoggingEnabled struct {
+	_ struct{} `type:"structure"`
+
 	// Specifies the bucket where you want Amazon S3 to store server access logs.
 	// You can have your logs delivered to any bucket that you own, including the
 	// same bucket that is being logged. You can also configure multiple buckets
@@ -4365,8 +4367,6 @@ type LoggingEnabled struct {
 	// This element lets you specify a prefix for the keys that the log files will
 	// be stored under.
 	TargetPrefix *string `type:"string"`
-
-	_ struct{} `type:"structure"`
 }
 
 // String returns the string representation
@@ -4380,6 +4380,8 @@ func (s LoggingEnabled) GoString() string {
 }
 
 type MultipartUpload struct {
+	_ struct{} `type:"structure"`
+
 	// Date and time at which the multipart upload was initiated.
 	Initiated *time.Time `type:"timestamp" timestampFormat:"iso8601"`
 
@@ -4396,8 +4398,6 @@ type MultipartUpload struct {
 
 	// Upload ID that identifies the multipart upload.
 	UploadId *string `type:"string"`
-
-	_ struct{} `type:"structure"`
 }
 
 // String returns the string representation
@@ -4416,14 +4416,14 @@ func (s MultipartUpload) GoString() string {
 // to request that Amazon S3 delete noncurrent object versions at a specific
 // period in the object's lifetime.
 type NoncurrentVersionExpiration struct {
+	_ struct{} `type:"structure"`
+
 	// Specifies the number of days an object is noncurrent before Amazon S3 can
 	// perform the associated action. For information about the noncurrent days
 	// calculations, see How Amazon S3 Calculates When an Object Became Noncurrent
 	// (/AmazonS3/latest/dev/s3-access-control.html) in the Amazon Simple Storage
 	// Service Developer Guide.
 	NoncurrentDays *int64 `type:"integer"`
-
-	_ struct{} `type:"structure"`
 }
 
 // String returns the string representation
@@ -4442,6 +4442,8 @@ func (s NoncurrentVersionExpiration) GoString() string {
 // to request that Amazon S3 transition noncurrent object versions to the STANDARD_IA
 // or GLACIER storage class at a specific period in the object's lifetime.
 type NoncurrentVersionTransition struct {
+	_ struct{} `type:"structure"`
+
 	// Specifies the number of days an object is noncurrent before Amazon S3 can
 	// perform the associated action. For information about the noncurrent days
 	// calculations, see How Amazon S3 Calculates When an Object Became Noncurrent
@@ -4451,8 +4453,6 @@ type NoncurrentVersionTransition struct {
 
 	// The class of storage used to store the object.
 	StorageClass *string `type:"string" enum:"TransitionStorageClass"`
-
-	_ struct{} `type:"structure"`
 }
 
 // String returns the string representation
@@ -4468,13 +4468,13 @@ func (s NoncurrentVersionTransition) GoString() string {
 // Container for specifying the notification configuration of the bucket. If
 // this element is empty, notifications are turned off on the bucket.
 type NotificationConfiguration struct {
+	_ struct{} `type:"structure"`
+
 	LambdaFunctionConfigurations []*LambdaFunctionConfiguration `locationName:"CloudFunctionConfiguration" type:"list" flattened:"true"`
 
 	QueueConfigurations []*QueueConfiguration `locationName:"QueueConfiguration" type:"list" flattened:"true"`
 
 	TopicConfigurations []*TopicConfiguration `locationName:"TopicConfiguration" type:"list" flattened:"true"`
-
-	_ struct{} `type:"structure"`
 }
 
 // String returns the string representation
@@ -4488,13 +4488,13 @@ func (s NotificationConfiguration) GoString() string {
 }
 
 type NotificationConfigurationDeprecated struct {
+	_ struct{} `type:"structure"`
+
 	CloudFunctionConfiguration *CloudFunctionConfiguration `type:"structure"`
 
 	QueueConfiguration *QueueConfigurationDeprecated `type:"structure"`
 
 	TopicConfiguration *TopicConfigurationDeprecated `type:"structure"`
-
-	_ struct{} `type:"structure"`
 }
 
 // String returns the string representation
@@ -4511,10 +4511,10 @@ func (s NotificationConfigurationDeprecated) GoString() string {
 // name filtering, go to Configuring Event Notifications (http://docs.aws.amazon.com/AmazonS3/latest/dev/NotificationHowTo.html)
 // in the Amazon Simple Storage Service Developer Guide.
 type NotificationConfigurationFilter struct {
+	_ struct{} `type:"structure"`
+
 	// Container for object key name prefix and suffix filtering rules.
 	Key *KeyFilter `locationName:"S3Key" type:"structure"`
-
-	_ struct{} `type:"structure"`
 }
 
 // String returns the string representation
@@ -4528,6 +4528,8 @@ func (s NotificationConfigurationFilter) GoString() string {
 }
 
 type Object struct {
+	_ struct{} `type:"structure"`
+
 	ETag *string `type:"string"`
 
 	Key *string `min:"1" type:"string"`
@@ -4540,8 +4542,6 @@ type Object struct {
 
 	// The class of storage used to store the object.
 	StorageClass *string `type:"string" enum:"ObjectStorageClass"`
-
-	_ struct{} `type:"structure"`
 }
 
 // String returns the string representation
@@ -4555,13 +4555,13 @@ func (s Object) GoString() string {
 }
 
 type ObjectIdentifier struct {
+	_ struct{} `type:"structure"`
+
 	// Key name of the object to delete.
 	Key *string `min:"1" type:"string" required:"true"`
 
 	// VersionId for the specific version of the object to delete.
 	VersionId *string `type:"string"`
-
-	_ struct{} `type:"structure"`
 }
 
 // String returns the string representation
@@ -4575,6 +4575,8 @@ func (s ObjectIdentifier) GoString() string {
 }
 
 type ObjectVersion struct {
+	_ struct{} `type:"structure"`
+
 	ETag *string `type:"string"`
 
 	// Specifies whether the object is (true) or is not (false) the latest version
@@ -4597,8 +4599,6 @@ type ObjectVersion struct {
 
 	// Version ID of an object.
 	VersionId *string `type:"string"`
-
-	_ struct{} `type:"structure"`
 }
 
 // String returns the string representation
@@ -4612,11 +4612,11 @@ func (s ObjectVersion) GoString() string {
 }
 
 type Owner struct {
+	_ struct{} `type:"structure"`
+
 	DisplayName *string `type:"string"`
 
 	ID *string `type:"string"`
-
-	_ struct{} `type:"structure"`
 }
 
 // String returns the string representation
@@ -4630,6 +4630,8 @@ func (s Owner) GoString() string {
 }
 
 type Part struct {
+	_ struct{} `type:"structure"`
+
 	// Entity tag returned when the part was uploaded.
 	ETag *string `type:"string"`
 
@@ -4642,8 +4644,6 @@ type Part struct {
 
 	// Size of the uploaded part data.
 	Size *int64 `type:"integer"`
-
-	_ struct{} `type:"structure"`
 }
 
 // String returns the string representation
@@ -4657,6 +4657,8 @@ func (s Part) GoString() string {
 }
 
 type PutBucketAclInput struct {
+	_ struct{} `type:"structure" payload:"AccessControlPolicy"`
+
 	// The canned ACL to apply to the bucket.
 	ACL *string `location:"header" locationName:"x-amz-acl" type:"string" enum:"BucketCannedACL"`
 
@@ -4679,8 +4681,6 @@ type PutBucketAclInput struct {
 
 	// Allows grantee to write the ACL for the applicable bucket.
 	GrantWriteACP *string `location:"header" locationName:"x-amz-grant-write-acp" type:"string"`
-
-	_ struct{} `type:"structure" payload:"AccessControlPolicy"`
 }
 
 // String returns the string representation
@@ -4708,11 +4708,11 @@ func (s PutBucketAclOutput) GoString() string {
 }
 
 type PutBucketCorsInput struct {
+	_ struct{} `type:"structure" payload:"CORSConfiguration"`
+
 	Bucket *string `location:"uri" locationName:"Bucket" type:"string" required:"true"`
 
 	CORSConfiguration *CORSConfiguration `locationName:"CORSConfiguration" type:"structure" required:"true"`
-
-	_ struct{} `type:"structure" payload:"CORSConfiguration"`
 }
 
 // String returns the string representation
@@ -4740,11 +4740,11 @@ func (s PutBucketCorsOutput) GoString() string {
 }
 
 type PutBucketLifecycleConfigurationInput struct {
+	_ struct{} `type:"structure" payload:"LifecycleConfiguration"`
+
 	Bucket *string `location:"uri" locationName:"Bucket" type:"string" required:"true"`
 
 	LifecycleConfiguration *BucketLifecycleConfiguration `locationName:"LifecycleConfiguration" type:"structure"`
-
-	_ struct{} `type:"structure" payload:"LifecycleConfiguration"`
 }
 
 // String returns the string representation
@@ -4772,11 +4772,11 @@ func (s PutBucketLifecycleConfigurationOutput) GoString() string {
 }
 
 type PutBucketLifecycleInput struct {
+	_ struct{} `type:"structure" payload:"LifecycleConfiguration"`
+
 	Bucket *string `location:"uri" locationName:"Bucket" type:"string" required:"true"`
 
 	LifecycleConfiguration *LifecycleConfiguration `locationName:"LifecycleConfiguration" type:"structure"`
-
-	_ struct{} `type:"structure" payload:"LifecycleConfiguration"`
 }
 
 // String returns the string representation
@@ -4804,11 +4804,11 @@ func (s PutBucketLifecycleOutput) GoString() string {
 }
 
 type PutBucketLoggingInput struct {
+	_ struct{} `type:"structure" payload:"BucketLoggingStatus"`
+
 	Bucket *string `location:"uri" locationName:"Bucket" type:"string" required:"true"`
 
 	BucketLoggingStatus *BucketLoggingStatus `locationName:"BucketLoggingStatus" type:"structure" required:"true"`
-
-	_ struct{} `type:"structure" payload:"BucketLoggingStatus"`
 }
 
 // String returns the string representation
@@ -4836,13 +4836,13 @@ func (s PutBucketLoggingOutput) GoString() string {
 }
 
 type PutBucketNotificationConfigurationInput struct {
+	_ struct{} `type:"structure" payload:"NotificationConfiguration"`
+
 	Bucket *string `location:"uri" locationName:"Bucket" type:"string" required:"true"`
 
 	// Container for specifying the notification configuration of the bucket. If
 	// this element is empty, notifications are turned off on the bucket.
 	NotificationConfiguration *NotificationConfiguration `locationName:"NotificationConfiguration" type:"structure" required:"true"`
-
-	_ struct{} `type:"structure" payload:"NotificationConfiguration"`
 }
 
 // String returns the string representation
@@ -4870,11 +4870,11 @@ func (s PutBucketNotificationConfigurationOutput) GoString() string {
 }
 
 type PutBucketNotificationInput struct {
+	_ struct{} `type:"structure" payload:"NotificationConfiguration"`
+
 	Bucket *string `location:"uri" locationName:"Bucket" type:"string" required:"true"`
 
 	NotificationConfiguration *NotificationConfigurationDeprecated `locationName:"NotificationConfiguration" type:"structure" required:"true"`
-
-	_ struct{} `type:"structure" payload:"NotificationConfiguration"`
 }
 
 // String returns the string representation
@@ -4902,12 +4902,12 @@ func (s PutBucketNotificationOutput) GoString() string {
 }
 
 type PutBucketPolicyInput struct {
+	_ struct{} `type:"structure" payload:"Policy"`
+
 	Bucket *string `location:"uri" locationName:"Bucket" type:"string" required:"true"`
 
 	// The bucket policy as a JSON document.
 	Policy *string `type:"string" required:"true"`
-
-	_ struct{} `type:"structure" payload:"Policy"`
 }
 
 // String returns the string representation
@@ -4935,13 +4935,13 @@ func (s PutBucketPolicyOutput) GoString() string {
 }
 
 type PutBucketReplicationInput struct {
+	_ struct{} `type:"structure" payload:"ReplicationConfiguration"`
+
 	Bucket *string `location:"uri" locationName:"Bucket" type:"string" required:"true"`
 
 	// Container for replication rules. You can add as many as 1,000 rules. Total
 	// replication configuration size can be up to 2 MB.
 	ReplicationConfiguration *ReplicationConfiguration `locationName:"ReplicationConfiguration" type:"structure" required:"true"`
-
-	_ struct{} `type:"structure" payload:"ReplicationConfiguration"`
 }
 
 // String returns the string representation
@@ -4969,11 +4969,11 @@ func (s PutBucketReplicationOutput) GoString() string {
 }
 
 type PutBucketRequestPaymentInput struct {
+	_ struct{} `type:"structure" payload:"RequestPaymentConfiguration"`
+
 	Bucket *string `location:"uri" locationName:"Bucket" type:"string" required:"true"`
 
 	RequestPaymentConfiguration *RequestPaymentConfiguration `locationName:"RequestPaymentConfiguration" type:"structure" required:"true"`
-
-	_ struct{} `type:"structure" payload:"RequestPaymentConfiguration"`
 }
 
 // String returns the string representation
@@ -5001,11 +5001,11 @@ func (s PutBucketRequestPaymentOutput) GoString() string {
 }
 
 type PutBucketTaggingInput struct {
+	_ struct{} `type:"structure" payload:"Tagging"`
+
 	Bucket *string `location:"uri" locationName:"Bucket" type:"string" required:"true"`
 
 	Tagging *Tagging `locationName:"Tagging" type:"structure" required:"true"`
-
-	_ struct{} `type:"structure" payload:"Tagging"`
 }
 
 // String returns the string representation
@@ -5033,6 +5033,8 @@ func (s PutBucketTaggingOutput) GoString() string {
 }
 
 type PutBucketVersioningInput struct {
+	_ struct{} `type:"structure" payload:"VersioningConfiguration"`
+
 	Bucket *string `location:"uri" locationName:"Bucket" type:"string" required:"true"`
 
 	// The concatenation of the authentication device's serial number, a space,
@@ -5040,8 +5042,6 @@ type PutBucketVersioningInput struct {
 	MFA *string `location:"header" locationName:"x-amz-mfa" type:"string"`
 
 	VersioningConfiguration *VersioningConfiguration `locationName:"VersioningConfiguration" type:"structure" required:"true"`
-
-	_ struct{} `type:"structure" payload:"VersioningConfiguration"`
 }
 
 // String returns the string representation
@@ -5069,11 +5069,11 @@ func (s PutBucketVersioningOutput) GoString() string {
 }
 
 type PutBucketWebsiteInput struct {
+	_ struct{} `type:"structure" payload:"WebsiteConfiguration"`
+
 	Bucket *string `location:"uri" locationName:"Bucket" type:"string" required:"true"`
 
 	WebsiteConfiguration *WebsiteConfiguration `locationName:"WebsiteConfiguration" type:"structure" required:"true"`
-
-	_ struct{} `type:"structure" payload:"WebsiteConfiguration"`
 }
 
 // String returns the string representation
@@ -5101,6 +5101,8 @@ func (s PutBucketWebsiteOutput) GoString() string {
 }
 
 type PutObjectAclInput struct {
+	_ struct{} `type:"structure" payload:"AccessControlPolicy"`
+
 	// The canned ACL to apply to the object.
 	ACL *string `location:"header" locationName:"x-amz-acl" type:"string" enum:"ObjectCannedACL"`
 
@@ -5131,8 +5133,6 @@ type PutObjectAclInput struct {
 	// Documentation on downloading objects from requester pays buckets can be found
 	// at http://docs.aws.amazon.com/AmazonS3/latest/dev/ObjectsinRequesterPaysBuckets.html
 	RequestPayer *string `location:"header" locationName:"x-amz-request-payer" type:"string" enum:"RequestPayer"`
-
-	_ struct{} `type:"structure" payload:"AccessControlPolicy"`
 }
 
 // String returns the string representation
@@ -5146,11 +5146,11 @@ func (s PutObjectAclInput) GoString() string {
 }
 
 type PutObjectAclOutput struct {
+	_ struct{} `type:"structure"`
+
 	// If present, indicates that the requester was successfully charged for the
 	// request.
 	RequestCharged *string `location:"header" locationName:"x-amz-request-charged" type:"string" enum:"RequestCharged"`
-
-	_ struct{} `type:"structure"`
 }
 
 // String returns the string representation
@@ -5164,6 +5164,8 @@ func (s PutObjectAclOutput) GoString() string {
 }
 
 type PutObjectInput struct {
+	_ struct{} `type:"structure" payload:"Body"`
+
 	// The canned ACL to apply to the object.
 	ACL *string `location:"header" locationName:"x-amz-acl" type:"string" enum:"ObjectCannedACL"`
 
@@ -5251,8 +5253,6 @@ type PutObjectInput struct {
 	// to another object in the same bucket or to an external URL. Amazon S3 stores
 	// the value of this header in the object metadata.
 	WebsiteRedirectLocation *string `location:"header" locationName:"x-amz-website-redirect-location" type:"string"`
-
-	_ struct{} `type:"structure" payload:"Body"`
 }
 
 // String returns the string representation
@@ -5266,6 +5266,8 @@ func (s PutObjectInput) GoString() string {
 }
 
 type PutObjectOutput struct {
+	_ struct{} `type:"structure"`
+
 	// Entity tag for the uploaded object.
 	ETag *string `location:"header" locationName:"ETag" type:"string"`
 
@@ -5297,8 +5299,6 @@ type PutObjectOutput struct {
 
 	// Version of the object.
 	VersionId *string `location:"header" locationName:"x-amz-version-id" type:"string"`
-
-	_ struct{} `type:"structure"`
 }
 
 // String returns the string representation
@@ -5314,6 +5314,8 @@ func (s PutObjectOutput) GoString() string {
 // Container for specifying an configuration when you want Amazon S3 to publish
 // events to an Amazon Simple Queue Service (Amazon SQS) queue.
 type QueueConfiguration struct {
+	_ struct{} `type:"structure"`
+
 	Events []*string `locationName:"Event" type:"list" flattened:"true" required:"true"`
 
 	// Container for object key name filtering rules. For information about key
@@ -5328,8 +5330,6 @@ type QueueConfiguration struct {
 	// Amazon SQS queue ARN to which Amazon S3 will publish a message when it detects
 	// events of specified type.
 	QueueArn *string `locationName:"Queue" type:"string" required:"true"`
-
-	_ struct{} `type:"structure"`
 }
 
 // String returns the string representation
@@ -5343,6 +5343,8 @@ func (s QueueConfiguration) GoString() string {
 }
 
 type QueueConfigurationDeprecated struct {
+	_ struct{} `type:"structure"`
+
 	// Bucket event for which to send notifications.
 	Event *string `type:"string" enum:"Event"`
 
@@ -5353,8 +5355,6 @@ type QueueConfigurationDeprecated struct {
 	Id *string `type:"string"`
 
 	Queue *string `type:"string"`
-
-	_ struct{} `type:"structure"`
 }
 
 // String returns the string representation
@@ -5368,6 +5368,8 @@ func (s QueueConfigurationDeprecated) GoString() string {
 }
 
 type Redirect struct {
+	_ struct{} `type:"structure"`
+
 	// The host name to use in the redirect request.
 	HostName *string `type:"string"`
 
@@ -5391,8 +5393,6 @@ type Redirect struct {
 	// request to error.html. Not required if one of the sibling is present. Can
 	// be present only if ReplaceKeyPrefixWith is not provided.
 	ReplaceKeyWith *string `type:"string"`
-
-	_ struct{} `type:"structure"`
 }
 
 // String returns the string representation
@@ -5406,14 +5406,14 @@ func (s Redirect) GoString() string {
 }
 
 type RedirectAllRequestsTo struct {
+	_ struct{} `type:"structure"`
+
 	// Name of the host where requests will be redirected.
 	HostName *string `type:"string" required:"true"`
 
 	// Protocol to use (http, https) when redirecting requests. The default is the
 	// protocol that is used in the original request.
 	Protocol *string `type:"string" enum:"Protocol"`
-
-	_ struct{} `type:"structure"`
 }
 
 // String returns the string representation
@@ -5429,6 +5429,8 @@ func (s RedirectAllRequestsTo) GoString() string {
 // Container for replication rules. You can add as many as 1,000 rules. Total
 // replication configuration size can be up to 2 MB.
 type ReplicationConfiguration struct {
+	_ struct{} `type:"structure"`
+
 	// Amazon Resource Name (ARN) of an IAM role for Amazon S3 to assume when replicating
 	// the objects.
 	Role *string `type:"string" required:"true"`
@@ -5436,8 +5438,6 @@ type ReplicationConfiguration struct {
 	// Container for information about a particular replication rule. Replication
 	// configuration must have at least one rule and can contain up to 1,000 rules.
 	Rules []*ReplicationRule `locationName:"Rule" type:"list" flattened:"true" required:"true"`
-
-	_ struct{} `type:"structure"`
 }
 
 // String returns the string representation
@@ -5451,6 +5451,8 @@ func (s ReplicationConfiguration) GoString() string {
 }
 
 type ReplicationRule struct {
+	_ struct{} `type:"structure"`
+
 	Destination *Destination `type:"structure" required:"true"`
 
 	// Unique identifier for the rule. The value cannot be longer than 255 characters.
@@ -5463,8 +5465,6 @@ type ReplicationRule struct {
 
 	// The rule is ignored if status is not Enabled.
 	Status *string `type:"string" required:"true" enum:"ReplicationRuleStatus"`
-
-	_ struct{} `type:"structure"`
 }
 
 // String returns the string representation
@@ -5478,10 +5478,10 @@ func (s ReplicationRule) GoString() string {
 }
 
 type RequestPaymentConfiguration struct {
+	_ struct{} `type:"structure"`
+
 	// Specifies who pays for the download and request fees.
 	Payer *string `type:"string" required:"true" enum:"Payer"`
-
-	_ struct{} `type:"structure"`
 }
 
 // String returns the string representation
@@ -5495,6 +5495,8 @@ func (s RequestPaymentConfiguration) GoString() string {
 }
 
 type RestoreObjectInput struct {
+	_ struct{} `type:"structure" payload:"RestoreRequest"`
+
 	Bucket *string `location:"uri" locationName:"Bucket" type:"string" required:"true"`
 
 	Key *string `location:"uri" locationName:"Key" min:"1" type:"string" required:"true"`
@@ -5508,8 +5510,6 @@ type RestoreObjectInput struct {
 	RestoreRequest *RestoreRequest `locationName:"RestoreRequest" type:"structure"`
 
 	VersionId *string `location:"querystring" locationName:"versionId" type:"string"`
-
-	_ struct{} `type:"structure" payload:"RestoreRequest"`
 }
 
 // String returns the string representation
@@ -5523,11 +5523,11 @@ func (s RestoreObjectInput) GoString() string {
 }
 
 type RestoreObjectOutput struct {
+	_ struct{} `type:"structure"`
+
 	// If present, indicates that the requester was successfully charged for the
 	// request.
 	RequestCharged *string `location:"header" locationName:"x-amz-request-charged" type:"string" enum:"RequestCharged"`
-
-	_ struct{} `type:"structure"`
 }
 
 // String returns the string representation
@@ -5541,10 +5541,10 @@ func (s RestoreObjectOutput) GoString() string {
 }
 
 type RestoreRequest struct {
+	_ struct{} `type:"structure"`
+
 	// Lifetime of the active copy in days
 	Days *int64 `type:"integer" required:"true"`
-
-	_ struct{} `type:"structure"`
 }
 
 // String returns the string representation
@@ -5558,6 +5558,8 @@ func (s RestoreRequest) GoString() string {
 }
 
 type RoutingRule struct {
+	_ struct{} `type:"structure"`
+
 	// A container for describing a condition that must be met for the specified
 	// redirect to apply. For example, 1. If request is for pages in the /docs folder,
 	// redirect to the /documents folder. 2. If request results in HTTP error 4xx,
@@ -5568,8 +5570,6 @@ type RoutingRule struct {
 	// host, to another page, or with another protocol. In the event of an error,
 	// you can can specify a different error code to return.
 	Redirect *Redirect `type:"structure" required:"true"`
-
-	_ struct{} `type:"structure"`
 }
 
 // String returns the string representation
@@ -5583,6 +5583,8 @@ func (s RoutingRule) GoString() string {
 }
 
 type Rule struct {
+	_ struct{} `type:"structure"`
+
 	Expiration *LifecycleExpiration `type:"structure"`
 
 	// Unique identifier for the rule. The value cannot be longer than 255 characters.
@@ -5610,8 +5612,6 @@ type Rule struct {
 	Status *string `type:"string" required:"true" enum:"ExpirationStatus"`
 
 	Transition *Transition `type:"structure"`
-
-	_ struct{} `type:"structure"`
 }
 
 // String returns the string representation
@@ -5625,13 +5625,13 @@ func (s Rule) GoString() string {
 }
 
 type Tag struct {
+	_ struct{} `type:"structure"`
+
 	// Name of the tag.
 	Key *string `min:"1" type:"string" required:"true"`
 
 	// Value of the tag.
 	Value *string `type:"string" required:"true"`
-
-	_ struct{} `type:"structure"`
 }
 
 // String returns the string representation
@@ -5645,9 +5645,9 @@ func (s Tag) GoString() string {
 }
 
 type Tagging struct {
-	TagSet []*Tag `locationNameList:"Tag" type:"list" required:"true"`
-
 	_ struct{} `type:"structure"`
+
+	TagSet []*Tag `locationNameList:"Tag" type:"list" required:"true"`
 }
 
 // String returns the string representation
@@ -5661,12 +5661,12 @@ func (s Tagging) GoString() string {
 }
 
 type TargetGrant struct {
+	_ struct{} `type:"structure"`
+
 	Grantee *Grantee `type:"structure"`
 
 	// Logging permissions assigned to the Grantee for the bucket.
 	Permission *string `type:"string" enum:"BucketLogsPermission"`
-
-	_ struct{} `type:"structure"`
 }
 
 // String returns the string representation
@@ -5682,6 +5682,8 @@ func (s TargetGrant) GoString() string {
 // Container for specifying the configuration when you want Amazon S3 to publish
 // events to an Amazon Simple Notification Service (Amazon SNS) topic.
 type TopicConfiguration struct {
+	_ struct{} `type:"structure"`
+
 	Events []*string `locationName:"Event" type:"list" flattened:"true" required:"true"`
 
 	// Container for object key name filtering rules. For information about key
@@ -5696,8 +5698,6 @@ type TopicConfiguration struct {
 	// Amazon SNS topic ARN to which Amazon S3 will publish a message when it detects
 	// events of specified type.
 	TopicArn *string `locationName:"Topic" type:"string" required:"true"`
-
-	_ struct{} `type:"structure"`
 }
 
 // String returns the string representation
@@ -5711,6 +5711,8 @@ func (s TopicConfiguration) GoString() string {
 }
 
 type TopicConfigurationDeprecated struct {
+	_ struct{} `type:"structure"`
+
 	// Bucket event for which to send notifications.
 	Event *string `type:"string" enum:"Event"`
 
@@ -5723,8 +5725,6 @@ type TopicConfigurationDeprecated struct {
 	// Amazon SNS topic to which Amazon S3 will publish a message to report the
 	// specified events for the bucket.
 	Topic *string `type:"string"`
-
-	_ struct{} `type:"structure"`
 }
 
 // String returns the string representation
@@ -5738,6 +5738,8 @@ func (s TopicConfigurationDeprecated) GoString() string {
 }
 
 type Transition struct {
+	_ struct{} `type:"structure"`
+
 	// Indicates at what date the object is to be moved or deleted. Should be in
 	// GMT ISO 8601 Format.
 	Date *time.Time `type:"timestamp" timestampFormat:"iso8601"`
@@ -5748,8 +5750,6 @@ type Transition struct {
 
 	// The class of storage used to store the object.
 	StorageClass *string `type:"string" enum:"TransitionStorageClass"`
-
-	_ struct{} `type:"structure"`
 }
 
 // String returns the string representation
@@ -5763,6 +5763,8 @@ func (s Transition) GoString() string {
 }
 
 type UploadPartCopyInput struct {
+	_ struct{} `type:"structure"`
+
 	Bucket *string `location:"uri" locationName:"Bucket" type:"string" required:"true"`
 
 	// The name of the source bucket and key name of the source object, separated
@@ -5832,8 +5834,6 @@ type UploadPartCopyInput struct {
 
 	// Upload ID identifying the multipart upload whose part is being copied.
 	UploadId *string `location:"querystring" locationName:"uploadId" type:"string" required:"true"`
-
-	_ struct{} `type:"structure"`
 }
 
 // String returns the string representation
@@ -5847,6 +5847,8 @@ func (s UploadPartCopyInput) GoString() string {
 }
 
 type UploadPartCopyOutput struct {
+	_ struct{} `type:"structure" payload:"CopyPartResult"`
+
 	CopyPartResult *CopyPartResult `type:"structure"`
 
 	// The version of the source object that was copied, if you have enabled versioning
@@ -5874,8 +5876,6 @@ type UploadPartCopyOutput struct {
 	// The Server-side encryption algorithm used when storing this object in S3
 	// (e.g., AES256, aws:kms).
 	ServerSideEncryption *string `location:"header" locationName:"x-amz-server-side-encryption" type:"string" enum:"ServerSideEncryption"`
-
-	_ struct{} `type:"structure" payload:"CopyPartResult"`
 }
 
 // String returns the string representation
@@ -5889,6 +5889,8 @@ func (s UploadPartCopyOutput) GoString() string {
 }
 
 type UploadPartInput struct {
+	_ struct{} `type:"structure" payload:"Body"`
+
 	Body io.ReadSeeker `type:"blob"`
 
 	Bucket *string `location:"uri" locationName:"Bucket" type:"string" required:"true"`
@@ -5927,8 +5929,6 @@ type UploadPartInput struct {
 
 	// Upload ID identifying the multipart upload whose part is being uploaded.
 	UploadId *string `location:"querystring" locationName:"uploadId" type:"string" required:"true"`
-
-	_ struct{} `type:"structure" payload:"Body"`
 }
 
 // String returns the string representation
@@ -5942,6 +5942,8 @@ func (s UploadPartInput) GoString() string {
 }
 
 type UploadPartOutput struct {
+	_ struct{} `type:"structure"`
+
 	// Entity tag for the uploaded object.
 	ETag *string `location:"header" locationName:"ETag" type:"string"`
 
@@ -5966,8 +5968,6 @@ type UploadPartOutput struct {
 	// The Server-side encryption algorithm used when storing this object in S3
 	// (e.g., AES256, aws:kms).
 	ServerSideEncryption *string `location:"header" locationName:"x-amz-server-side-encryption" type:"string" enum:"ServerSideEncryption"`
-
-	_ struct{} `type:"structure"`
 }
 
 // String returns the string representation
@@ -5981,6 +5981,8 @@ func (s UploadPartOutput) GoString() string {
 }
 
 type VersioningConfiguration struct {
+	_ struct{} `type:"structure"`
+
 	// Specifies whether MFA delete is enabled in the bucket versioning configuration.
 	// This element is only returned if the bucket has been configured with MFA
 	// delete. If the bucket has never been so configured, this element is not returned.
@@ -5988,8 +5990,6 @@ type VersioningConfiguration struct {
 
 	// The versioning state of the bucket.
 	Status *string `type:"string" enum:"BucketVersioningStatus"`
-
-	_ struct{} `type:"structure"`
 }
 
 // String returns the string representation
@@ -6003,6 +6003,8 @@ func (s VersioningConfiguration) GoString() string {
 }
 
 type WebsiteConfiguration struct {
+	_ struct{} `type:"structure"`
+
 	ErrorDocument *ErrorDocument `type:"structure"`
 
 	IndexDocument *IndexDocument `type:"structure"`
@@ -6010,8 +6012,6 @@ type WebsiteConfiguration struct {
 	RedirectAllRequestsTo *RedirectAllRequestsTo `type:"structure"`
 
 	RoutingRules []*RoutingRule `locationNameList:"RoutingRule" type:"list"`
-
-	_ struct{} `type:"structure"`
 }
 
 // String returns the string representation

--- a/service/ses/api.go
+++ b/service/ses/api.go
@@ -1377,6 +1377,8 @@ func (c *SES) VerifyEmailIdentity(input *VerifyEmailIdentityInput) (*VerifyEmail
 // For information about adding a header using a receipt rule, see the Amazon
 // SES Developer Guide (http://docs.aws.amazon.com/ses/latest/DeveloperGuide/receiving-email-action-add-header.html).
 type AddHeaderAction struct {
+	_ struct{} `type:"structure"`
+
 	// The name of the header to add. Must be between 1 and 50 characters, inclusive,
 	// and consist of alphanumeric (a-z, A-Z, 0-9) characters and dashes only.
 	HeaderName *string `type:"string" required:"true"`
@@ -1384,8 +1386,6 @@ type AddHeaderAction struct {
 	// Must be less than 2048 characters, and must not contain newline characters
 	// ("\r" or "\n").
 	HeaderValue *string `type:"string" required:"true"`
-
-	_ struct{} `type:"structure"`
 }
 
 // String returns the string representation
@@ -1402,6 +1402,8 @@ func (s AddHeaderAction) GoString() string {
 // If you use both, then the message should display correctly in the widest
 // variety of email clients.
 type Body struct {
+	_ struct{} `type:"structure"`
+
 	// The content of the message, in HTML format. Use this for email clients that
 	// can process HTML. You can include clickable links, formatted text, and much
 	// more in an HTML message.
@@ -1410,8 +1412,6 @@ type Body struct {
 	// The content of the message, in text format. Use this for text-based email
 	// clients, or clients on high-latency networks (such as mobile devices).
 	Text *Content `type:"structure"`
-
-	_ struct{} `type:"structure"`
 }
 
 // String returns the string representation
@@ -1431,6 +1431,8 @@ func (s Body) GoString() string {
 // For information about sending a bounce message in response to a received
 // email, see the Amazon SES Developer Guide (http://docs.aws.amazon.com/ses/latest/DeveloperGuide/receiving-email-action-bounce.html).
 type BounceAction struct {
+	_ struct{} `type:"structure"`
+
 	// Human-readable text to include in the bounce message.
 	Message *string `type:"string" required:"true"`
 
@@ -1449,8 +1451,6 @@ type BounceAction struct {
 	// For more information about Amazon SNS topics, see the Amazon SNS Developer
 	// Guide (http://docs.aws.amazon.com/sns/latest/dg/CreateTopic.html).
 	TopicArn *string `type:"string"`
-
-	_ struct{} `type:"structure"`
 }
 
 // String returns the string representation
@@ -1469,6 +1469,8 @@ func (s BounceAction) GoString() string {
 // For information about receiving email through Amazon SES, see the Amazon
 // SES Developer Guide (http://docs.aws.amazon.com/ses/latest/DeveloperGuide/receiving-email.html).
 type BouncedRecipientInfo struct {
+	_ struct{} `type:"structure"`
+
 	// The reason for the bounce. You must provide either this parameter or RecipientDsnFields.
 	BounceType *string `type:"string" enum:"BounceType"`
 
@@ -1485,8 +1487,6 @@ type BouncedRecipientInfo struct {
 	// when provided with a BounceType. You must provide either this parameter or
 	// BounceType.
 	RecipientDsnFields *RecipientDsnFields `type:"structure"`
-
-	_ struct{} `type:"structure"`
 }
 
 // String returns the string representation
@@ -1500,6 +1500,8 @@ func (s BouncedRecipientInfo) GoString() string {
 }
 
 type CloneReceiptRuleSetInput struct {
+	_ struct{} `type:"structure"`
+
 	// The name of the rule set to clone.
 	OriginalRuleSetName *string `type:"string" required:"true"`
 
@@ -1509,8 +1511,6 @@ type CloneReceiptRuleSetInput struct {
 	// (_), or dashes (-). Start and end with a letter or number. Contain less than
 	// 64 characters.
 	RuleSetName *string `type:"string" required:"true"`
-
-	_ struct{} `type:"structure"`
 }
 
 // String returns the string representation
@@ -1543,13 +1543,13 @@ func (s CloneReceiptRuleSetOutput) GoString() string {
 // SMTP protocol. If the text must contain any other characters, then you must
 // also specify a character set. Examples include UTF-8, ISO-8859-1, and Shift_JIS.
 type Content struct {
+	_ struct{} `type:"structure"`
+
 	// The character set of the content.
 	Charset *string `type:"string"`
 
 	// The textual data of the content.
 	Data *string `type:"string" required:"true"`
-
-	_ struct{} `type:"structure"`
 }
 
 // String returns the string representation
@@ -1563,11 +1563,11 @@ func (s Content) GoString() string {
 }
 
 type CreateReceiptFilterInput struct {
+	_ struct{} `type:"structure"`
+
 	// A data structure that describes the IP address filter to create, which consists
 	// of a name, an IP address range, and whether to allow or block mail from it.
 	Filter *ReceiptFilter `type:"structure" required:"true"`
-
-	_ struct{} `type:"structure"`
 }
 
 // String returns the string representation
@@ -1595,6 +1595,8 @@ func (s CreateReceiptFilterOutput) GoString() string {
 }
 
 type CreateReceiptRuleInput struct {
+	_ struct{} `type:"structure"`
+
 	// The name of an existing rule after which the new rule will be placed. If
 	// this parameter is null, the new rule will be inserted at the beginning of
 	// the rule list.
@@ -1606,8 +1608,6 @@ type CreateReceiptRuleInput struct {
 
 	// The name of the rule set to which to add the rule.
 	RuleSetName *string `type:"string" required:"true"`
-
-	_ struct{} `type:"structure"`
 }
 
 // String returns the string representation
@@ -1635,14 +1635,14 @@ func (s CreateReceiptRuleOutput) GoString() string {
 }
 
 type CreateReceiptRuleSetInput struct {
+	_ struct{} `type:"structure"`
+
 	// The name of the rule set to create. The name must:
 	//
 	//  Contain only ASCII letters (a-z, A-Z), numbers (0-9), periods (.), underscores
 	// (_), or dashes (-). Start and end with a letter or number. Contain less than
 	// 64 characters.
 	RuleSetName *string `type:"string" required:"true"`
-
-	_ struct{} `type:"structure"`
 }
 
 // String returns the string representation
@@ -1672,10 +1672,10 @@ func (s CreateReceiptRuleSetOutput) GoString() string {
 // Represents a request instructing the service to delete an identity from the
 // list of identities for the AWS Account.
 type DeleteIdentityInput struct {
+	_ struct{} `type:"structure"`
+
 	// The identity to be removed from the list of identities for the AWS Account.
 	Identity *string `type:"string" required:"true"`
-
-	_ struct{} `type:"structure"`
 }
 
 // String returns the string representation
@@ -1709,6 +1709,8 @@ func (s DeleteIdentityOutput) GoString() string {
 //
 // This request succeeds regardless of whether the specified policy exists.
 type DeleteIdentityPolicyInput struct {
+	_ struct{} `type:"structure"`
+
 	// The identity that is associated with the policy that you want to delete.
 	// You can specify the identity by using its name or by using its Amazon Resource
 	// Name (ARN). Examples: user@example.com, example.com, arn:aws:ses:us-east-1:123456789012:identity/example.com.
@@ -1718,8 +1720,6 @@ type DeleteIdentityPolicyInput struct {
 
 	// The name of the policy to be deleted.
 	PolicyName *string `min:"1" type:"string" required:"true"`
-
-	_ struct{} `type:"structure"`
 }
 
 // String returns the string representation
@@ -1749,10 +1749,10 @@ func (s DeleteIdentityPolicyOutput) GoString() string {
 }
 
 type DeleteReceiptFilterInput struct {
+	_ struct{} `type:"structure"`
+
 	// The name of the IP address filter to delete.
 	FilterName *string `type:"string" required:"true"`
-
-	_ struct{} `type:"structure"`
 }
 
 // String returns the string representation
@@ -1780,13 +1780,13 @@ func (s DeleteReceiptFilterOutput) GoString() string {
 }
 
 type DeleteReceiptRuleInput struct {
+	_ struct{} `type:"structure"`
+
 	// The name of the receipt rule to delete.
 	RuleName *string `type:"string" required:"true"`
 
 	// The name of the receipt rule set that contains the receipt rule to delete.
 	RuleSetName *string `type:"string" required:"true"`
-
-	_ struct{} `type:"structure"`
 }
 
 // String returns the string representation
@@ -1814,10 +1814,10 @@ func (s DeleteReceiptRuleOutput) GoString() string {
 }
 
 type DeleteReceiptRuleSetInput struct {
+	_ struct{} `type:"structure"`
+
 	// The name of the receipt rule set to delete.
 	RuleSetName *string `type:"string" required:"true"`
-
-	_ struct{} `type:"structure"`
 }
 
 // String returns the string representation
@@ -1847,10 +1847,10 @@ func (s DeleteReceiptRuleSetOutput) GoString() string {
 // Represents a request instructing the service to delete an address from the
 // list of verified email addresses.
 type DeleteVerifiedEmailAddressInput struct {
+	_ struct{} `type:"structure"`
+
 	// An email address to be removed from the list of verified addresses.
 	EmailAddress *string `type:"string" required:"true"`
-
-	_ struct{} `type:"structure"`
 }
 
 // String returns the string representation
@@ -1892,14 +1892,14 @@ func (s DescribeActiveReceiptRuleSetInput) GoString() string {
 }
 
 type DescribeActiveReceiptRuleSetOutput struct {
+	_ struct{} `type:"structure"`
+
 	// The metadata for the currently active receipt rule set. The metadata consists
 	// of the rule set name and a timestamp of when the rule set was created.
 	Metadata *ReceiptRuleSetMetadata `type:"structure"`
 
 	// The receipt rules that belong to the active rule set.
 	Rules []*ReceiptRule `type:"list"`
-
-	_ struct{} `type:"structure"`
 }
 
 // String returns the string representation
@@ -1913,13 +1913,13 @@ func (s DescribeActiveReceiptRuleSetOutput) GoString() string {
 }
 
 type DescribeReceiptRuleInput struct {
+	_ struct{} `type:"structure"`
+
 	// The name of the receipt rule.
 	RuleName *string `type:"string" required:"true"`
 
 	// The name of the receipt rule set to which the receipt rule belongs.
 	RuleSetName *string `type:"string" required:"true"`
-
-	_ struct{} `type:"structure"`
 }
 
 // String returns the string representation
@@ -1933,12 +1933,12 @@ func (s DescribeReceiptRuleInput) GoString() string {
 }
 
 type DescribeReceiptRuleOutput struct {
+	_ struct{} `type:"structure"`
+
 	// A data structure that contains the specified receipt rule's name, actions,
 	// recipients, domains, enabled status, scan status, and Transport Layer Security
 	// (TLS) policy.
 	Rule *ReceiptRule `type:"structure"`
-
-	_ struct{} `type:"structure"`
 }
 
 // String returns the string representation
@@ -1952,10 +1952,10 @@ func (s DescribeReceiptRuleOutput) GoString() string {
 }
 
 type DescribeReceiptRuleSetInput struct {
+	_ struct{} `type:"structure"`
+
 	// The name of the receipt rule set to describe.
 	RuleSetName *string `type:"string" required:"true"`
-
-	_ struct{} `type:"structure"`
 }
 
 // String returns the string representation
@@ -1969,14 +1969,14 @@ func (s DescribeReceiptRuleSetInput) GoString() string {
 }
 
 type DescribeReceiptRuleSetOutput struct {
+	_ struct{} `type:"structure"`
+
 	// The metadata for the receipt rule set, which consists of the rule set name
 	// and the timestamp of when the rule set was created.
 	Metadata *ReceiptRuleSetMetadata `type:"structure"`
 
 	// A list of the receipt rules that belong to the specified receipt rule set.
 	Rules []*ReceiptRule `type:"list"`
-
-	_ struct{} `type:"structure"`
 }
 
 // String returns the string representation
@@ -1997,6 +1997,8 @@ func (s DescribeReceiptRuleSetOutput) GoString() string {
 // of a literal string. MIME encoded-word syntax uses the following form: =?charset?encoding?encoded-text?=.
 // For more information, see RFC 2047 (http://tools.ietf.org/html/rfc2047).
 type Destination struct {
+	_ struct{} `type:"structure"`
+
 	// The BCC: field(s) of the message.
 	BccAddresses []*string `type:"list"`
 
@@ -2005,8 +2007,6 @@ type Destination struct {
 
 	// The To: field(s) of the message.
 	ToAddresses []*string `type:"list"`
-
-	_ struct{} `type:"structure"`
 }
 
 // String returns the string representation
@@ -2025,6 +2025,8 @@ func (s Destination) GoString() string {
 // For information about receiving email through Amazon SES, see the Amazon
 // SES Developer Guide (http://docs.aws.amazon.com/ses/latest/DeveloperGuide/receiving-email.html).
 type ExtensionField struct {
+	_ struct{} `type:"structure"`
+
 	// The name of the header to add. Must be between 1 and 50 characters, inclusive,
 	// and consist of alphanumeric (a-z, A-Z, 0-9) characters and dashes only.
 	Name *string `type:"string" required:"true"`
@@ -2032,8 +2034,6 @@ type ExtensionField struct {
 	// The value of the header to add. Must be less than 2048 characters, and must
 	// not contain newline characters ("\r" or "\n").
 	Value *string `type:"string" required:"true"`
-
-	_ struct{} `type:"structure"`
 }
 
 // String returns the string representation
@@ -2053,11 +2053,11 @@ func (s ExtensionField) GoString() string {
 // as the DNS records (tokens) that must remain published in the domain name's
 // DNS.
 type GetIdentityDkimAttributesInput struct {
+	_ struct{} `type:"structure"`
+
 	// A list of one or more verified identities - email addresses, domains, or
 	// both.
 	Identities []*string `type:"list" required:"true"`
-
-	_ struct{} `type:"structure"`
 }
 
 // String returns the string representation
@@ -2072,10 +2072,10 @@ func (s GetIdentityDkimAttributesInput) GoString() string {
 
 // Represents a list of all the DKIM attributes for the specified identity.
 type GetIdentityDkimAttributesOutput struct {
+	_ struct{} `type:"structure"`
+
 	// The DKIM attributes for an email address or a domain.
 	DkimAttributes map[string]*IdentityDkimAttributes `type:"map" required:"true"`
-
-	_ struct{} `type:"structure"`
 }
 
 // String returns the string representation
@@ -2089,12 +2089,12 @@ func (s GetIdentityDkimAttributesOutput) GoString() string {
 }
 
 type GetIdentityNotificationAttributesInput struct {
+	_ struct{} `type:"structure"`
+
 	// A list of one or more identities. You can specify an identity by using its
 	// name or by using its Amazon Resource Name (ARN). Examples: user@example.com,
 	// example.com, arn:aws:ses:us-east-1:123456789012:identity/example.com.
 	Identities []*string `type:"list" required:"true"`
-
-	_ struct{} `type:"structure"`
 }
 
 // String returns the string representation
@@ -2112,10 +2112,10 @@ func (s GetIdentityNotificationAttributesInput) GoString() string {
 // specifies whether feedback forwarding is enabled for bounce and complaint
 // notifications.
 type GetIdentityNotificationAttributesOutput struct {
+	_ struct{} `type:"structure"`
+
 	// A map of Identity to IdentityNotificationAttributes.
 	NotificationAttributes map[string]*IdentityNotificationAttributes `type:"map" required:"true"`
-
-	_ struct{} `type:"structure"`
 }
 
 // String returns the string representation
@@ -2131,6 +2131,8 @@ func (s GetIdentityNotificationAttributesOutput) GoString() string {
 // Represents a request instructing the service to retrieve the text of a list
 // of authorization policies applying to an identity.
 type GetIdentityPoliciesInput struct {
+	_ struct{} `type:"structure"`
+
 	// The identity for which the policies will be retrieved. You can specify an
 	// identity by using its name or by using its Amazon Resource Name (ARN). Examples:
 	// user@example.com, example.com, arn:aws:ses:us-east-1:123456789012:identity/example.com.
@@ -2142,8 +2144,6 @@ type GetIdentityPoliciesInput struct {
 	// of 20 policies at a time. If you do not know the names of the policies that
 	// are attached to the identity, you can use ListIdentityPolicies.
 	PolicyNames []*string `type:"list" required:"true"`
-
-	_ struct{} `type:"structure"`
 }
 
 // String returns the string representation
@@ -2159,10 +2159,10 @@ func (s GetIdentityPoliciesInput) GoString() string {
 // Represents a map of policy names to policies returned from a successful GetIdentityPolicies
 // request.
 type GetIdentityPoliciesOutput struct {
+	_ struct{} `type:"structure"`
+
 	// A map of policy names to policies.
 	Policies map[string]*string `type:"map" required:"true"`
-
-	_ struct{} `type:"structure"`
 }
 
 // String returns the string representation
@@ -2178,10 +2178,10 @@ func (s GetIdentityPoliciesOutput) GoString() string {
 // Represents a request instructing the service to provide the verification
 // attributes for a list of identities.
 type GetIdentityVerificationAttributesInput struct {
+	_ struct{} `type:"structure"`
+
 	// A list of identities.
 	Identities []*string `type:"list" required:"true"`
-
-	_ struct{} `type:"structure"`
 }
 
 // String returns the string representation
@@ -2196,10 +2196,10 @@ func (s GetIdentityVerificationAttributesInput) GoString() string {
 
 // Represents the verification attributes for a list of identities.
 type GetIdentityVerificationAttributesOutput struct {
+	_ struct{} `type:"structure"`
+
 	// A map of Identities to IdentityVerificationAttributes objects.
 	VerificationAttributes map[string]*IdentityVerificationAttributes `type:"map" required:"true"`
-
-	_ struct{} `type:"structure"`
 }
 
 // String returns the string representation
@@ -2229,6 +2229,8 @@ func (s GetSendQuotaInput) GoString() string {
 // Represents the user's current activity limits returned from a successful
 // GetSendQuota request.
 type GetSendQuotaOutput struct {
+	_ struct{} `type:"structure"`
+
 	// The maximum number of emails the user is allowed to send in a 24-hour interval.
 	// A value of -1 signifies an unlimited quota.
 	Max24HourSend *float64 `type:"double"`
@@ -2242,8 +2244,6 @@ type GetSendQuotaOutput struct {
 
 	// The number of emails sent during the previous 24 hours.
 	SentLast24Hours *float64 `type:"double"`
-
-	_ struct{} `type:"structure"`
 }
 
 // String returns the string representation
@@ -2274,10 +2274,10 @@ func (s GetSendStatisticsInput) GoString() string {
 // request. This list contains aggregated data from the previous two weeks of
 // sending activity.
 type GetSendStatisticsOutput struct {
+	_ struct{} `type:"structure"`
+
 	// A list of data points, each of which represents 15 minutes of activity.
 	SendDataPoints []*SendDataPoint `type:"list"`
-
-	_ struct{} `type:"structure"`
 }
 
 // String returns the string representation
@@ -2292,6 +2292,8 @@ func (s GetSendStatisticsOutput) GoString() string {
 
 // Represents the DKIM attributes of a verified email address or a domain.
 type IdentityDkimAttributes struct {
+	_ struct{} `type:"structure"`
+
 	// True if DKIM signing is enabled for email sent from the identity; false otherwise.
 	DkimEnabled *bool `type:"boolean" required:"true"`
 
@@ -2311,8 +2313,6 @@ type IdentityDkimAttributes struct {
 	// (tokens) published in the domain name's DNS. (This only applies to domain
 	// identities, not email address identities.)
 	DkimVerificationStatus *string `type:"string" required:"true" enum:"VerificationStatus"`
-
-	_ struct{} `type:"structure"`
 }
 
 // String returns the string representation
@@ -2330,6 +2330,8 @@ func (s IdentityDkimAttributes) GoString() string {
 // for bounce, complaint, and/or delivery notifications, and whether feedback
 // forwarding is enabled for bounce and complaint notifications.
 type IdentityNotificationAttributes struct {
+	_ struct{} `type:"structure"`
+
 	// The Amazon Resource Name (ARN) of the Amazon SNS topic where Amazon SES will
 	// publish bounce notifications.
 	BounceTopic *string `type:"string" required:"true"`
@@ -2347,8 +2349,6 @@ type IdentityNotificationAttributes struct {
 	// notifications as email, while false indicates that bounce and complaint notifications
 	// will be published only to the specified bounce and complaint Amazon SNS topics.
 	ForwardingEnabled *bool `type:"boolean" required:"true"`
-
-	_ struct{} `type:"structure"`
 }
 
 // String returns the string representation
@@ -2363,14 +2363,14 @@ func (s IdentityNotificationAttributes) GoString() string {
 
 // Represents the verification attributes of a single identity.
 type IdentityVerificationAttributes struct {
+	_ struct{} `type:"structure"`
+
 	// The verification status of the identity: "Pending", "Success", "Failed",
 	// or "TemporaryFailure".
 	VerificationStatus *string `type:"string" required:"true" enum:"VerificationStatus"`
 
 	// The verification token for a domain identity. Null for email address identities.
 	VerificationToken *string `type:"string"`
-
-	_ struct{} `type:"structure"`
 }
 
 // String returns the string representation
@@ -2395,6 +2395,8 @@ func (s IdentityVerificationAttributes) GoString() string {
 // For information about using AWS Lambda actions in receipt rules, see the
 // Amazon SES Developer Guide (http://docs.aws.amazon.com/ses/latest/DeveloperGuide/receiving-email-action-lambda.html).
 type LambdaAction struct {
+	_ struct{} `type:"structure"`
+
 	// The Amazon Resource Name (ARN) of the AWS Lambda function. An example of
 	// an AWS Lambda function ARN is arn:aws:lambda:us-west-2:account-id:function:MyFunction.
 	// For more information about AWS Lambda, see the AWS Lambda Developer Guide
@@ -2418,8 +2420,6 @@ type LambdaAction struct {
 	// For more information about Amazon SNS topics, see the Amazon SNS Developer
 	// Guide (http://docs.aws.amazon.com/sns/latest/dg/CreateTopic.html).
 	TopicArn *string `type:"string"`
-
-	_ struct{} `type:"structure"`
 }
 
 // String returns the string representation
@@ -2435,6 +2435,8 @@ func (s LambdaAction) GoString() string {
 // Represents a request instructing the service to list all identities for the
 // AWS Account.
 type ListIdentitiesInput struct {
+	_ struct{} `type:"structure"`
+
 	// The type of the identities to list. Possible values are "EmailAddress" and
 	// "Domain". If this parameter is omitted, then all identities will be listed.
 	IdentityType *string `type:"string" enum:"IdentityType"`
@@ -2444,8 +2446,6 @@ type ListIdentitiesInput struct {
 
 	// The token to use for pagination.
 	NextToken *string `type:"string"`
-
-	_ struct{} `type:"structure"`
 }
 
 // String returns the string representation
@@ -2460,13 +2460,13 @@ func (s ListIdentitiesInput) GoString() string {
 
 // Represents a list of all verified identities for the AWS Account.
 type ListIdentitiesOutput struct {
+	_ struct{} `type:"structure"`
+
 	// A list of identities.
 	Identities []*string `type:"list" required:"true"`
 
 	// The token used for pagination.
 	NextToken *string `type:"string"`
-
-	_ struct{} `type:"structure"`
 }
 
 // String returns the string representation
@@ -2482,14 +2482,14 @@ func (s ListIdentitiesOutput) GoString() string {
 // Represents a request instructing the service to list all authorization policies,
 // by name, applying to an identity.
 type ListIdentityPoliciesInput struct {
+	_ struct{} `type:"structure"`
+
 	// The identity that is associated with the policy for which the policies will
 	// be listed. You can specify an identity by using its name or by using its
 	// Amazon Resource Name (ARN). Examples: user@example.com, example.com, arn:aws:ses:us-east-1:123456789012:identity/example.com.
 	//
 	// To successfully call this API, you must own the identity.
 	Identity *string `type:"string" required:"true"`
-
-	_ struct{} `type:"structure"`
 }
 
 // String returns the string representation
@@ -2505,10 +2505,10 @@ func (s ListIdentityPoliciesInput) GoString() string {
 // Represents a list of policy names returned from a successful ListIdentityPolicies
 // request.
 type ListIdentityPoliciesOutput struct {
+	_ struct{} `type:"structure"`
+
 	// A list of names of policies that apply to the specified identity.
 	PolicyNames []*string `type:"list" required:"true"`
-
-	_ struct{} `type:"structure"`
 }
 
 // String returns the string representation
@@ -2536,11 +2536,11 @@ func (s ListReceiptFiltersInput) GoString() string {
 }
 
 type ListReceiptFiltersOutput struct {
+	_ struct{} `type:"structure"`
+
 	// A list of IP address filter data structures, which each consist of a name,
 	// an IP address range, and whether to allow or block mail from it.
 	Filters []*ReceiptFilter `type:"list"`
-
-	_ struct{} `type:"structure"`
 }
 
 // String returns the string representation
@@ -2554,11 +2554,11 @@ func (s ListReceiptFiltersOutput) GoString() string {
 }
 
 type ListReceiptRuleSetsInput struct {
+	_ struct{} `type:"structure"`
+
 	// A token returned from a previous call to ListReceiptRuleSets to indicate
 	// the position in the receipt rule set list.
 	NextToken *string `type:"string"`
-
-	_ struct{} `type:"structure"`
 }
 
 // String returns the string representation
@@ -2572,6 +2572,8 @@ func (s ListReceiptRuleSetsInput) GoString() string {
 }
 
 type ListReceiptRuleSetsOutput struct {
+	_ struct{} `type:"structure"`
+
 	// A token indicating that there are additional receipt rule sets available
 	// to be listed. Pass this token to successive calls of ListReceiptRuleSets
 	// to retrieve up to 100 receipt rule sets at a time.
@@ -2580,8 +2582,6 @@ type ListReceiptRuleSetsOutput struct {
 	// The metadata for the currently active receipt rule set. The metadata consists
 	// of the rule set name and the timestamp of when the rule set was created.
 	RuleSets []*ReceiptRuleSetMetadata `type:"list"`
-
-	_ struct{} `type:"structure"`
 }
 
 // String returns the string representation
@@ -2610,10 +2610,10 @@ func (s ListVerifiedEmailAddressesInput) GoString() string {
 
 // Represents a list of all the email addresses verified for the current user.
 type ListVerifiedEmailAddressesOutput struct {
+	_ struct{} `type:"structure"`
+
 	// A list of email addresses that have been verified.
 	VerifiedEmailAddresses []*string `type:"list"`
-
-	_ struct{} `type:"structure"`
 }
 
 // String returns the string representation
@@ -2628,14 +2628,14 @@ func (s ListVerifiedEmailAddressesOutput) GoString() string {
 
 // Represents the message to be sent, composed of a subject and a body.
 type Message struct {
+	_ struct{} `type:"structure"`
+
 	// The message body.
 	Body *Body `type:"structure" required:"true"`
 
 	// The subject of the message: A short summary of the content, which will appear
 	// in the recipient's inbox.
 	Subject *Content `type:"structure" required:"true"`
-
-	_ struct{} `type:"structure"`
 }
 
 // String returns the string representation
@@ -2654,6 +2654,8 @@ func (s Message) GoString() string {
 // For information about receiving email through Amazon SES, see the Amazon
 // SES Developer Guide (http://docs.aws.amazon.com/ses/latest/DeveloperGuide/receiving-email.html).
 type MessageDsn struct {
+	_ struct{} `type:"structure"`
+
 	// When the message was received by the reporting mail transfer agent (MTA),
 	// in RFC 822 (https://www.ietf.org/rfc/rfc0822.txt) date-time format.
 	ArrivalDate *time.Time `type:"timestamp" timestampFormat:"iso8601"`
@@ -2665,8 +2667,6 @@ type MessageDsn struct {
 	// in RFC 3464 (https://tools.ietf.org/html/rfc3464) (mta-name-type; mta-name).
 	// The default value is dns; inbound-smtp.[region].amazonaws.com.
 	ReportingMta *string `type:"string" required:"true"`
-
-	_ struct{} `type:"structure"`
 }
 
 // String returns the string representation
@@ -2682,6 +2682,8 @@ func (s MessageDsn) GoString() string {
 // Represents a request instructing the service to apply an authorization policy
 // to an identity.
 type PutIdentityPolicyInput struct {
+	_ struct{} `type:"structure"`
+
 	// The identity to which the policy will apply. You can specify an identity
 	// by using its name or by using its Amazon Resource Name (ARN). Examples: user@example.com,
 	// example.com, arn:aws:ses:us-east-1:123456789012:identity/example.com.
@@ -2700,8 +2702,6 @@ type PutIdentityPolicyInput struct {
 	// The policy name cannot exceed 64 characters and can only include alphanumeric
 	// characters, dashes, and underscores.
 	PolicyName *string `min:"1" type:"string" required:"true"`
-
-	_ struct{} `type:"structure"`
 }
 
 // String returns the string representation
@@ -2732,6 +2732,8 @@ func (s PutIdentityPolicyOutput) GoString() string {
 
 // Represents the raw data of the message.
 type RawMessage struct {
+	_ struct{} `type:"structure"`
+
 	// The raw data of the message. The client must ensure that the message format
 	// complies with Internet email standards regarding email header fields, MIME
 	// types, MIME encoding, and base64 encoding (if necessary).
@@ -2746,8 +2748,6 @@ type RawMessage struct {
 	// by Amazon SES before sending the email. For more information, go to the Amazon
 	// SES Developer Guide (http://docs.aws.amazon.com/ses/latest/DeveloperGuide/send-email-raw.html).
 	Data []byte `type:"blob" required:"true"`
-
-	_ struct{} `type:"structure"`
 }
 
 // String returns the string representation
@@ -2767,6 +2767,8 @@ func (s RawMessage) GoString() string {
 // For information about setting up receipt rules, see the Amazon SES Developer
 // Guide (http://docs.aws.amazon.com/ses/latest/DeveloperGuide/receiving-email-receipt-rules.html).
 type ReceiptAction struct {
+	_ struct{} `type:"structure"`
+
 	// Adds a header to the received email.
 	AddHeaderAction *AddHeaderAction `type:"structure"`
 
@@ -2793,8 +2795,6 @@ type ReceiptAction struct {
 	// Calls Amazon WorkMail and, optionally, publishes a notification to Amazon
 	// SNS.
 	WorkmailAction *WorkmailAction `type:"structure"`
-
-	_ struct{} `type:"structure"`
 }
 
 // String returns the string representation
@@ -2813,6 +2813,8 @@ func (s ReceiptAction) GoString() string {
 // For information about setting up IP address filters, see the Amazon SES
 // Developer Guide (http://docs.aws.amazon.com/ses/latest/DeveloperGuide/receiving-email-ip-filters.html).
 type ReceiptFilter struct {
+	_ struct{} `type:"structure"`
+
 	// A structure that provides the IP addresses to block or allow, and whether
 	// to block or allow incoming mail from them.
 	IpFilter *ReceiptIpFilter `type:"structure" required:"true"`
@@ -2823,8 +2825,6 @@ type ReceiptFilter struct {
 	// (_), or dashes (-). Start and end with a letter or number. Contain less than
 	// 64 characters.
 	Name *string `type:"string" required:"true"`
-
-	_ struct{} `type:"structure"`
 }
 
 // String returns the string representation
@@ -2843,6 +2843,8 @@ func (s ReceiptFilter) GoString() string {
 // For information about setting up IP address filters, see the Amazon SES
 // Developer Guide (http://docs.aws.amazon.com/ses/latest/DeveloperGuide/receiving-email-ip-filters.html).
 type ReceiptIpFilter struct {
+	_ struct{} `type:"structure"`
+
 	// A single IP address or a range of IP addresses that you want to block or
 	// allow, specified in Classless Inter-Domain Routing (CIDR) notation. An example
 	// of a single email address is 10.0.0.1. An example of a range of IP addresses
@@ -2851,8 +2853,6 @@ type ReceiptIpFilter struct {
 
 	// Indicates whether to block or allow incoming mail from the specified IP addresses.
 	Policy *string `type:"string" required:"true" enum:"ReceiptFilterPolicy"`
-
-	_ struct{} `type:"structure"`
 }
 
 // String returns the string representation
@@ -2877,6 +2877,8 @@ func (s ReceiptIpFilter) GoString() string {
 // For information about setting up receipt rules, see the Amazon SES Developer
 // Guide (http://docs.aws.amazon.com/ses/latest/DeveloperGuide/receiving-email-receipt-rules.html).
 type ReceiptRule struct {
+	_ struct{} `type:"structure"`
+
 	// An ordered list of actions to perform on messages that match at least one
 	// of the recipient email addresses or domains specified in the receipt rule.
 	Actions []*ReceiptAction `type:"list"`
@@ -2905,8 +2907,6 @@ type ReceiptRule struct {
 	// parameter is set to Require, Amazon SES will bounce emails that are not received
 	// over TLS. The default is Optional.
 	TlsPolicy *string `type:"string" enum:"TlsPolicy"`
-
-	_ struct{} `type:"structure"`
 }
 
 // String returns the string representation
@@ -2927,6 +2927,8 @@ func (s ReceiptRule) GoString() string {
 // For information about setting up receipt rule sets, see the Amazon SES Developer
 // Guide (http://docs.aws.amazon.com/ses/latest/DeveloperGuide/receiving-email-receipt-rule-set.html).
 type ReceiptRuleSetMetadata struct {
+	_ struct{} `type:"structure"`
+
 	// The date and time the receipt rule set was created.
 	CreatedTimestamp *time.Time `type:"timestamp" timestampFormat:"iso8601"`
 
@@ -2936,8 +2938,6 @@ type ReceiptRuleSetMetadata struct {
 	// (_), or dashes (-). Start and end with a letter or number. Contain less than
 	// 64 characters.
 	Name *string `type:"string"`
-
-	_ struct{} `type:"structure"`
 }
 
 // String returns the string representation
@@ -2956,6 +2956,8 @@ func (s ReceiptRuleSetMetadata) GoString() string {
 // For information about receiving email through Amazon SES, see the Amazon
 // SES Developer Guide (http://docs.aws.amazon.com/ses/latest/DeveloperGuide/receiving-email.html).
 type RecipientDsnFields struct {
+	_ struct{} `type:"structure"`
+
 	// The action performed by the reporting mail transfer agent (MTA) as a result
 	// of its attempt to deliver the message to the recipient address. This is required
 	// by RFC 3464 (https://tools.ietf.org/html/rfc3464).
@@ -2992,8 +2994,6 @@ type RecipientDsnFields struct {
 	// The status code that indicates what went wrong. This is required by RFC 3464
 	// (https://tools.ietf.org/html/rfc3464).
 	Status *string `type:"string" required:"true"`
-
-	_ struct{} `type:"structure"`
 }
 
 // String returns the string representation
@@ -3007,14 +3007,14 @@ func (s RecipientDsnFields) GoString() string {
 }
 
 type ReorderReceiptRuleSetInput struct {
+	_ struct{} `type:"structure"`
+
 	// A list of the specified receipt rule set's receipt rules in the order that
 	// you want to put them.
 	RuleNames []*string `type:"list" required:"true"`
 
 	// The name of the receipt rule set to reorder.
 	RuleSetName *string `type:"string" required:"true"`
-
-	_ struct{} `type:"structure"`
 }
 
 // String returns the string representation
@@ -3055,6 +3055,8 @@ func (s ReorderReceiptRuleSetOutput) GoString() string {
 // about specifying Amazon S3 actions in receipt rules, see the Amazon SES Developer
 // Guide (http://docs.aws.amazon.com/ses/latest/DeveloperGuide/receiving-email-action-s3.html).
 type S3Action struct {
+	_ struct{} `type:"structure"`
+
 	// The name of the Amazon S3 bucket to which to save the received email.
 	BucketName *string `type:"string" required:"true"`
 
@@ -3097,8 +3099,6 @@ type S3Action struct {
 	// For more information about Amazon SNS topics, see the Amazon SNS Developer
 	// Guide (http://docs.aws.amazon.com/sns/latest/dg/CreateTopic.html).
 	TopicArn *string `type:"string"`
-
-	_ struct{} `type:"structure"`
 }
 
 // String returns the string representation
@@ -3129,13 +3129,13 @@ func (s S3Action) GoString() string {
 // rule to publish an Amazon SNS notification, see the Amazon SES Developer
 // Guide (http://docs.aws.amazon.com/ses/latest/DeveloperGuide/receiving-email-action-sns.html).
 type SNSAction struct {
+	_ struct{} `type:"structure"`
+
 	// The Amazon Resource Name (ARN) of the Amazon SNS topic to notify. An example
 	// of an Amazon SNS topic ARN is arn:aws:sns:us-west-2:123456789012:MyTopic.
 	// For more information about Amazon SNS topics, see the Amazon SNS Developer
 	// Guide (http://docs.aws.amazon.com/sns/latest/dg/CreateTopic.html).
 	TopicArn *string `type:"string" required:"true"`
-
-	_ struct{} `type:"structure"`
 }
 
 // String returns the string representation
@@ -3151,6 +3151,8 @@ func (s SNSAction) GoString() string {
 // Request object for sending a simple/complex bounce. It contains all of the
 // information needed to generate a basic DSN or a fully-customized DSN.
 type SendBounceInput struct {
+	_ struct{} `type:"structure"`
+
 	// The address to use in the "From" header of the bounce message. This must
 	// be an identity that you have verified with Amazon SES.
 	BounceSender *string `type:"string" required:"true"`
@@ -3177,8 +3179,6 @@ type SendBounceInput struct {
 
 	// The message ID of the message to be bounced.
 	OriginalMessageId *string `type:"string" required:"true"`
-
-	_ struct{} `type:"structure"`
 }
 
 // String returns the string representation
@@ -3192,10 +3192,10 @@ func (s SendBounceInput) GoString() string {
 }
 
 type SendBounceOutput struct {
+	_ struct{} `type:"structure"`
+
 	// The message ID of the bounce message.
 	MessageId *string `type:"string"`
-
-	_ struct{} `type:"structure"`
 }
 
 // String returns the string representation
@@ -3211,6 +3211,8 @@ func (s SendBounceOutput) GoString() string {
 // Represents sending statistics data. Each SendDataPoint contains statistics
 // for a 15-minute period of sending activity.
 type SendDataPoint struct {
+	_ struct{} `type:"structure"`
+
 	// Number of emails that have bounced.
 	Bounces *int64 `type:"long"`
 
@@ -3225,8 +3227,6 @@ type SendDataPoint struct {
 
 	// Time of the data point.
 	Timestamp *time.Time `type:"timestamp" timestampFormat:"iso8601"`
-
-	_ struct{} `type:"structure"`
 }
 
 // String returns the string representation
@@ -3245,6 +3245,8 @@ func (s SendDataPoint) GoString() string {
 // of source, destination, message, reply-to, and return-path parts. This object
 // can then be sent using the SendEmail action.
 type SendEmailInput struct {
+	_ struct{} `type:"structure"`
+
 	// The destination for this email, composed of To:, CC:, and BCC: fields.
 	Destination *Destination `type:"structure" required:"true"`
 
@@ -3306,8 +3308,6 @@ type SendEmailInput struct {
 	// For more information about sending authorization, see the Amazon SES Developer
 	// Guide (http://docs.aws.amazon.com/ses/latest/DeveloperGuide/sending-authorization.html).
 	SourceArn *string `type:"string"`
-
-	_ struct{} `type:"structure"`
 }
 
 // String returns the string representation
@@ -3322,10 +3322,10 @@ func (s SendEmailInput) GoString() string {
 
 // Represents a unique message ID returned from a successful SendEmail request.
 type SendEmailOutput struct {
+	_ struct{} `type:"structure"`
+
 	// The unique message identifier returned from the SendEmail action.
 	MessageId *string `type:"string" required:"true"`
-
-	_ struct{} `type:"structure"`
 }
 
 // String returns the string representation
@@ -3344,6 +3344,8 @@ func (s SendEmailOutput) GoString() string {
 // of source, destination, and raw message text. This object can then be sent
 // using the SendRawEmail action.
 type SendRawEmailInput struct {
+	_ struct{} `type:"structure"`
+
 	// A list of destinations for the message, consisting of To:, CC:, and BCC:
 	// addresses.
 	Destinations []*string `type:"list"`
@@ -3420,8 +3422,6 @@ type SendRawEmailInput struct {
 	// For information about when to use this parameter, see the description of
 	// SendRawEmail in this guide, or see the Amazon SES Developer Guide (http://docs.aws.amazon.com/ses/latest/DeveloperGuide/sending-authorization-delegate-sender-tasks-email.html).
 	SourceArn *string `type:"string"`
-
-	_ struct{} `type:"structure"`
 }
 
 // String returns the string representation
@@ -3436,10 +3436,10 @@ func (s SendRawEmailInput) GoString() string {
 
 // Represents a unique message ID returned from a successful SendRawEmail request.
 type SendRawEmailOutput struct {
+	_ struct{} `type:"structure"`
+
 	// The unique message identifier returned from the SendRawEmail action.
 	MessageId *string `type:"string" required:"true"`
-
-	_ struct{} `type:"structure"`
 }
 
 // String returns the string representation
@@ -3453,11 +3453,11 @@ func (s SendRawEmailOutput) GoString() string {
 }
 
 type SetActiveReceiptRuleSetInput struct {
+	_ struct{} `type:"structure"`
+
 	// The name of the receipt rule set to make active. Setting this value to null
 	// disables all email receiving.
 	RuleSetName *string `type:"string"`
-
-	_ struct{} `type:"structure"`
 }
 
 // String returns the string representation
@@ -3487,14 +3487,14 @@ func (s SetActiveReceiptRuleSetOutput) GoString() string {
 // Represents a request instructing the service to enable or disable DKIM signing
 // for an identity.
 type SetIdentityDkimEnabledInput struct {
+	_ struct{} `type:"structure"`
+
 	// Sets whether DKIM signing is enabled for an identity. Set to true to enable
 	// DKIM signing for this identity; false to disable it.
 	DkimEnabled *bool `type:"boolean" required:"true"`
 
 	// The identity for which DKIM signing should be enabled or disabled.
 	Identity *string `type:"string" required:"true"`
-
-	_ struct{} `type:"structure"`
 }
 
 // String returns the string representation
@@ -3524,6 +3524,8 @@ func (s SetIdentityDkimEnabledOutput) GoString() string {
 }
 
 type SetIdentityFeedbackForwardingEnabledInput struct {
+	_ struct{} `type:"structure"`
+
 	// Sets whether Amazon SES will forward bounce and complaint notifications as
 	// email. true specifies that Amazon SES will forward bounce and complaint notifications
 	// as email, in addition to any Amazon SNS topic publishing otherwise specified.
@@ -3535,8 +3537,6 @@ type SetIdentityFeedbackForwardingEnabledInput struct {
 	// The identity for which to set bounce and complaint notification forwarding.
 	// Examples: user@example.com, example.com.
 	Identity *string `type:"string" required:"true"`
-
-	_ struct{} `type:"structure"`
 }
 
 // String returns the string representation
@@ -3567,6 +3567,8 @@ func (s SetIdentityFeedbackForwardingEnabledOutput) GoString() string {
 
 // Represents a request to set or clear an identity's notification topic.
 type SetIdentityNotificationTopicInput struct {
+	_ struct{} `type:"structure"`
+
 	// The identity for which the Amazon SNS topic will be set. You can specify
 	// an identity by using its name or by using its Amazon Resource Name (ARN).
 	// Examples: user@example.com, example.com, arn:aws:ses:us-east-1:123456789012:identity/example.com.
@@ -3580,8 +3582,6 @@ type SetIdentityNotificationTopicInput struct {
 	// is omitted from the request or a null value is passed, SnsTopic is cleared
 	// and publishing is disabled.
 	SnsTopic *string `type:"string"`
-
-	_ struct{} `type:"structure"`
 }
 
 // String returns the string representation
@@ -3611,6 +3611,8 @@ func (s SetIdentityNotificationTopicOutput) GoString() string {
 }
 
 type SetReceiptRulePositionInput struct {
+	_ struct{} `type:"structure"`
+
 	// The name of the receipt rule after which to place the specified receipt rule.
 	After *string `type:"string"`
 
@@ -3619,8 +3621,6 @@ type SetReceiptRulePositionInput struct {
 
 	// The name of the receipt rule set that contains the receipt rule to reposition.
 	RuleSetName *string `type:"string" required:"true"`
-
-	_ struct{} `type:"structure"`
 }
 
 // String returns the string representation
@@ -3654,6 +3654,8 @@ func (s SetReceiptRulePositionOutput) GoString() string {
 // For information about setting a stop action in a receipt rule, see the Amazon
 // SES Developer Guide (http://docs.aws.amazon.com/ses/latest/DeveloperGuide/receiving-email-action-stop.html).
 type StopAction struct {
+	_ struct{} `type:"structure"`
+
 	// The scope to which the Stop action applies. That is, what is being stopped.
 	Scope *string `type:"string" required:"true" enum:"StopScope"`
 
@@ -3662,8 +3664,6 @@ type StopAction struct {
 	// For more information about Amazon SNS topics, see the Amazon SNS Developer
 	// Guide (http://docs.aws.amazon.com/sns/latest/dg/CreateTopic.html).
 	TopicArn *string `type:"string"`
-
-	_ struct{} `type:"structure"`
 }
 
 // String returns the string representation
@@ -3677,13 +3677,13 @@ func (s StopAction) GoString() string {
 }
 
 type UpdateReceiptRuleInput struct {
+	_ struct{} `type:"structure"`
+
 	// A data structure that contains the updated receipt rule information.
 	Rule *ReceiptRule `type:"structure" required:"true"`
 
 	// The name of the receipt rule set to which the receipt rule belongs.
 	RuleSetName *string `type:"string" required:"true"`
-
-	_ struct{} `type:"structure"`
 }
 
 // String returns the string representation
@@ -3713,10 +3713,10 @@ func (s UpdateReceiptRuleOutput) GoString() string {
 // Represents a request instructing the service to begin DKIM verification for
 // a domain.
 type VerifyDomainDkimInput struct {
+	_ struct{} `type:"structure"`
+
 	// The name of the domain to be verified for Easy DKIM signing.
 	Domain *string `type:"string" required:"true"`
-
-	_ struct{} `type:"structure"`
 }
 
 // String returns the string representation
@@ -3732,6 +3732,8 @@ func (s VerifyDomainDkimInput) GoString() string {
 // Represents the DNS records that must be published in the domain name's DNS
 // to complete DKIM setup.
 type VerifyDomainDkimOutput struct {
+	_ struct{} `type:"structure"`
+
 	// A set of character strings that represent the domain's identity. If the identity
 	// is an email address, the tokens represent the domain of that address.
 	//
@@ -3744,8 +3746,6 @@ type VerifyDomainDkimOutput struct {
 	// For more information about creating DNS records using DKIM tokens, go to
 	// the Amazon SES Developer Guide (http://docs.aws.amazon.com/ses/latest/DeveloperGuide/easy-dkim-dns-records.html).
 	DkimTokens []*string `type:"list" required:"true"`
-
-	_ struct{} `type:"structure"`
 }
 
 // String returns the string representation
@@ -3760,10 +3760,10 @@ func (s VerifyDomainDkimOutput) GoString() string {
 
 // Represents a request instructing the service to begin domain verification.
 type VerifyDomainIdentityInput struct {
+	_ struct{} `type:"structure"`
+
 	// The domain to be verified.
 	Domain *string `type:"string" required:"true"`
-
-	_ struct{} `type:"structure"`
 }
 
 // String returns the string representation
@@ -3778,11 +3778,11 @@ func (s VerifyDomainIdentityInput) GoString() string {
 
 // Represents a token used for domain ownership verification.
 type VerifyDomainIdentityOutput struct {
+	_ struct{} `type:"structure"`
+
 	// A TXT record that must be placed in the DNS settings for the domain, in order
 	// to complete domain verification.
 	VerificationToken *string `type:"string" required:"true"`
-
-	_ struct{} `type:"structure"`
 }
 
 // String returns the string representation
@@ -3797,10 +3797,10 @@ func (s VerifyDomainIdentityOutput) GoString() string {
 
 // Represents a request instructing the service to begin email address verification.
 type VerifyEmailAddressInput struct {
+	_ struct{} `type:"structure"`
+
 	// The email address to be verified.
 	EmailAddress *string `type:"string" required:"true"`
-
-	_ struct{} `type:"structure"`
 }
 
 // String returns the string representation
@@ -3829,10 +3829,10 @@ func (s VerifyEmailAddressOutput) GoString() string {
 
 // Represents a request instructing the service to begin email address verification.
 type VerifyEmailIdentityInput struct {
+	_ struct{} `type:"structure"`
+
 	// The email address to be verified.
 	EmailAddress *string `type:"string" required:"true"`
-
-	_ struct{} `type:"structure"`
 }
 
 // String returns the string representation
@@ -3869,6 +3869,8 @@ func (s VerifyEmailIdentityOutput) GoString() string {
 // For information using a receipt rule to call Amazon WorkMail, see the Amazon
 // SES Developer Guide (http://docs.aws.amazon.com/ses/latest/DeveloperGuide/receiving-email-action-workmail.html).
 type WorkmailAction struct {
+	_ struct{} `type:"structure"`
+
 	// The ARN of the Amazon WorkMail organization. An example of an Amazon WorkMail
 	// organization ARN is arn:aws:workmail:us-west-2:123456789012:organization/m-68755160c4cb4e29a2b2f8fb58f359d7.
 	// For information about Amazon WorkMail organizations, see the Amazon WorkMail
@@ -3880,8 +3882,6 @@ type WorkmailAction struct {
 	// For more information about Amazon SNS topics, see the Amazon SNS Developer
 	// Guide (http://docs.aws.amazon.com/sns/latest/dg/CreateTopic.html).
 	TopicArn *string `type:"string"`
-
-	_ struct{} `type:"structure"`
 }
 
 // String returns the string representation

--- a/service/ses/api.go
+++ b/service/ses/api.go
@@ -1385,11 +1385,7 @@ type AddHeaderAction struct {
 	// ("\r" or "\n").
 	HeaderValue *string `type:"string" required:"true"`
 
-	metadataAddHeaderAction `json:"-" xml:"-"`
-}
-
-type metadataAddHeaderAction struct {
-	SDKShapeTraits bool `type:"structure"`
+	_ struct{} `type:"structure"`
 }
 
 // String returns the string representation
@@ -1415,11 +1411,7 @@ type Body struct {
 	// clients, or clients on high-latency networks (such as mobile devices).
 	Text *Content `type:"structure"`
 
-	metadataBody `json:"-" xml:"-"`
-}
-
-type metadataBody struct {
-	SDKShapeTraits bool `type:"structure"`
+	_ struct{} `type:"structure"`
 }
 
 // String returns the string representation
@@ -1458,11 +1450,7 @@ type BounceAction struct {
 	// Guide (http://docs.aws.amazon.com/sns/latest/dg/CreateTopic.html).
 	TopicArn *string `type:"string"`
 
-	metadataBounceAction `json:"-" xml:"-"`
-}
-
-type metadataBounceAction struct {
-	SDKShapeTraits bool `type:"structure"`
+	_ struct{} `type:"structure"`
 }
 
 // String returns the string representation
@@ -1498,11 +1486,7 @@ type BouncedRecipientInfo struct {
 	// BounceType.
 	RecipientDsnFields *RecipientDsnFields `type:"structure"`
 
-	metadataBouncedRecipientInfo `json:"-" xml:"-"`
-}
-
-type metadataBouncedRecipientInfo struct {
-	SDKShapeTraits bool `type:"structure"`
+	_ struct{} `type:"structure"`
 }
 
 // String returns the string representation
@@ -1526,11 +1510,7 @@ type CloneReceiptRuleSetInput struct {
 	// 64 characters.
 	RuleSetName *string `type:"string" required:"true"`
 
-	metadataCloneReceiptRuleSetInput `json:"-" xml:"-"`
-}
-
-type metadataCloneReceiptRuleSetInput struct {
-	SDKShapeTraits bool `type:"structure"`
+	_ struct{} `type:"structure"`
 }
 
 // String returns the string representation
@@ -1544,11 +1524,7 @@ func (s CloneReceiptRuleSetInput) GoString() string {
 }
 
 type CloneReceiptRuleSetOutput struct {
-	metadataCloneReceiptRuleSetOutput `json:"-" xml:"-"`
-}
-
-type metadataCloneReceiptRuleSetOutput struct {
-	SDKShapeTraits bool `type:"structure"`
+	_ struct{} `type:"structure"`
 }
 
 // String returns the string representation
@@ -1573,11 +1549,7 @@ type Content struct {
 	// The textual data of the content.
 	Data *string `type:"string" required:"true"`
 
-	metadataContent `json:"-" xml:"-"`
-}
-
-type metadataContent struct {
-	SDKShapeTraits bool `type:"structure"`
+	_ struct{} `type:"structure"`
 }
 
 // String returns the string representation
@@ -1595,11 +1567,7 @@ type CreateReceiptFilterInput struct {
 	// of a name, an IP address range, and whether to allow or block mail from it.
 	Filter *ReceiptFilter `type:"structure" required:"true"`
 
-	metadataCreateReceiptFilterInput `json:"-" xml:"-"`
-}
-
-type metadataCreateReceiptFilterInput struct {
-	SDKShapeTraits bool `type:"structure"`
+	_ struct{} `type:"structure"`
 }
 
 // String returns the string representation
@@ -1613,11 +1581,7 @@ func (s CreateReceiptFilterInput) GoString() string {
 }
 
 type CreateReceiptFilterOutput struct {
-	metadataCreateReceiptFilterOutput `json:"-" xml:"-"`
-}
-
-type metadataCreateReceiptFilterOutput struct {
-	SDKShapeTraits bool `type:"structure"`
+	_ struct{} `type:"structure"`
 }
 
 // String returns the string representation
@@ -1643,11 +1607,7 @@ type CreateReceiptRuleInput struct {
 	// The name of the rule set to which to add the rule.
 	RuleSetName *string `type:"string" required:"true"`
 
-	metadataCreateReceiptRuleInput `json:"-" xml:"-"`
-}
-
-type metadataCreateReceiptRuleInput struct {
-	SDKShapeTraits bool `type:"structure"`
+	_ struct{} `type:"structure"`
 }
 
 // String returns the string representation
@@ -1661,11 +1621,7 @@ func (s CreateReceiptRuleInput) GoString() string {
 }
 
 type CreateReceiptRuleOutput struct {
-	metadataCreateReceiptRuleOutput `json:"-" xml:"-"`
-}
-
-type metadataCreateReceiptRuleOutput struct {
-	SDKShapeTraits bool `type:"structure"`
+	_ struct{} `type:"structure"`
 }
 
 // String returns the string representation
@@ -1686,11 +1642,7 @@ type CreateReceiptRuleSetInput struct {
 	// 64 characters.
 	RuleSetName *string `type:"string" required:"true"`
 
-	metadataCreateReceiptRuleSetInput `json:"-" xml:"-"`
-}
-
-type metadataCreateReceiptRuleSetInput struct {
-	SDKShapeTraits bool `type:"structure"`
+	_ struct{} `type:"structure"`
 }
 
 // String returns the string representation
@@ -1704,11 +1656,7 @@ func (s CreateReceiptRuleSetInput) GoString() string {
 }
 
 type CreateReceiptRuleSetOutput struct {
-	metadataCreateReceiptRuleSetOutput `json:"-" xml:"-"`
-}
-
-type metadataCreateReceiptRuleSetOutput struct {
-	SDKShapeTraits bool `type:"structure"`
+	_ struct{} `type:"structure"`
 }
 
 // String returns the string representation
@@ -1727,11 +1675,7 @@ type DeleteIdentityInput struct {
 	// The identity to be removed from the list of identities for the AWS Account.
 	Identity *string `type:"string" required:"true"`
 
-	metadataDeleteIdentityInput `json:"-" xml:"-"`
-}
-
-type metadataDeleteIdentityInput struct {
-	SDKShapeTraits bool `type:"structure"`
+	_ struct{} `type:"structure"`
 }
 
 // String returns the string representation
@@ -1747,11 +1691,7 @@ func (s DeleteIdentityInput) GoString() string {
 // An empty element. Receiving this element indicates that the request completed
 // successfully.
 type DeleteIdentityOutput struct {
-	metadataDeleteIdentityOutput `json:"-" xml:"-"`
-}
-
-type metadataDeleteIdentityOutput struct {
-	SDKShapeTraits bool `type:"structure"`
+	_ struct{} `type:"structure"`
 }
 
 // String returns the string representation
@@ -1779,11 +1719,7 @@ type DeleteIdentityPolicyInput struct {
 	// The name of the policy to be deleted.
 	PolicyName *string `min:"1" type:"string" required:"true"`
 
-	metadataDeleteIdentityPolicyInput `json:"-" xml:"-"`
-}
-
-type metadataDeleteIdentityPolicyInput struct {
-	SDKShapeTraits bool `type:"structure"`
+	_ struct{} `type:"structure"`
 }
 
 // String returns the string representation
@@ -1799,11 +1735,7 @@ func (s DeleteIdentityPolicyInput) GoString() string {
 // An empty element. Receiving this element indicates that the request completed
 // successfully.
 type DeleteIdentityPolicyOutput struct {
-	metadataDeleteIdentityPolicyOutput `json:"-" xml:"-"`
-}
-
-type metadataDeleteIdentityPolicyOutput struct {
-	SDKShapeTraits bool `type:"structure"`
+	_ struct{} `type:"structure"`
 }
 
 // String returns the string representation
@@ -1820,11 +1752,7 @@ type DeleteReceiptFilterInput struct {
 	// The name of the IP address filter to delete.
 	FilterName *string `type:"string" required:"true"`
 
-	metadataDeleteReceiptFilterInput `json:"-" xml:"-"`
-}
-
-type metadataDeleteReceiptFilterInput struct {
-	SDKShapeTraits bool `type:"structure"`
+	_ struct{} `type:"structure"`
 }
 
 // String returns the string representation
@@ -1838,11 +1766,7 @@ func (s DeleteReceiptFilterInput) GoString() string {
 }
 
 type DeleteReceiptFilterOutput struct {
-	metadataDeleteReceiptFilterOutput `json:"-" xml:"-"`
-}
-
-type metadataDeleteReceiptFilterOutput struct {
-	SDKShapeTraits bool `type:"structure"`
+	_ struct{} `type:"structure"`
 }
 
 // String returns the string representation
@@ -1862,11 +1786,7 @@ type DeleteReceiptRuleInput struct {
 	// The name of the receipt rule set that contains the receipt rule to delete.
 	RuleSetName *string `type:"string" required:"true"`
 
-	metadataDeleteReceiptRuleInput `json:"-" xml:"-"`
-}
-
-type metadataDeleteReceiptRuleInput struct {
-	SDKShapeTraits bool `type:"structure"`
+	_ struct{} `type:"structure"`
 }
 
 // String returns the string representation
@@ -1880,11 +1800,7 @@ func (s DeleteReceiptRuleInput) GoString() string {
 }
 
 type DeleteReceiptRuleOutput struct {
-	metadataDeleteReceiptRuleOutput `json:"-" xml:"-"`
-}
-
-type metadataDeleteReceiptRuleOutput struct {
-	SDKShapeTraits bool `type:"structure"`
+	_ struct{} `type:"structure"`
 }
 
 // String returns the string representation
@@ -1901,11 +1817,7 @@ type DeleteReceiptRuleSetInput struct {
 	// The name of the receipt rule set to delete.
 	RuleSetName *string `type:"string" required:"true"`
 
-	metadataDeleteReceiptRuleSetInput `json:"-" xml:"-"`
-}
-
-type metadataDeleteReceiptRuleSetInput struct {
-	SDKShapeTraits bool `type:"structure"`
+	_ struct{} `type:"structure"`
 }
 
 // String returns the string representation
@@ -1919,11 +1831,7 @@ func (s DeleteReceiptRuleSetInput) GoString() string {
 }
 
 type DeleteReceiptRuleSetOutput struct {
-	metadataDeleteReceiptRuleSetOutput `json:"-" xml:"-"`
-}
-
-type metadataDeleteReceiptRuleSetOutput struct {
-	SDKShapeTraits bool `type:"structure"`
+	_ struct{} `type:"structure"`
 }
 
 // String returns the string representation
@@ -1942,11 +1850,7 @@ type DeleteVerifiedEmailAddressInput struct {
 	// An email address to be removed from the list of verified addresses.
 	EmailAddress *string `type:"string" required:"true"`
 
-	metadataDeleteVerifiedEmailAddressInput `json:"-" xml:"-"`
-}
-
-type metadataDeleteVerifiedEmailAddressInput struct {
-	SDKShapeTraits bool `type:"structure"`
+	_ struct{} `type:"structure"`
 }
 
 // String returns the string representation
@@ -1960,11 +1864,7 @@ func (s DeleteVerifiedEmailAddressInput) GoString() string {
 }
 
 type DeleteVerifiedEmailAddressOutput struct {
-	metadataDeleteVerifiedEmailAddressOutput `json:"-" xml:"-"`
-}
-
-type metadataDeleteVerifiedEmailAddressOutput struct {
-	SDKShapeTraits bool `type:"structure"`
+	_ struct{} `type:"structure"`
 }
 
 // String returns the string representation
@@ -1978,11 +1878,7 @@ func (s DeleteVerifiedEmailAddressOutput) GoString() string {
 }
 
 type DescribeActiveReceiptRuleSetInput struct {
-	metadataDescribeActiveReceiptRuleSetInput `json:"-" xml:"-"`
-}
-
-type metadataDescribeActiveReceiptRuleSetInput struct {
-	SDKShapeTraits bool `type:"structure"`
+	_ struct{} `type:"structure"`
 }
 
 // String returns the string representation
@@ -2003,11 +1899,7 @@ type DescribeActiveReceiptRuleSetOutput struct {
 	// The receipt rules that belong to the active rule set.
 	Rules []*ReceiptRule `type:"list"`
 
-	metadataDescribeActiveReceiptRuleSetOutput `json:"-" xml:"-"`
-}
-
-type metadataDescribeActiveReceiptRuleSetOutput struct {
-	SDKShapeTraits bool `type:"structure"`
+	_ struct{} `type:"structure"`
 }
 
 // String returns the string representation
@@ -2027,11 +1919,7 @@ type DescribeReceiptRuleInput struct {
 	// The name of the receipt rule set to which the receipt rule belongs.
 	RuleSetName *string `type:"string" required:"true"`
 
-	metadataDescribeReceiptRuleInput `json:"-" xml:"-"`
-}
-
-type metadataDescribeReceiptRuleInput struct {
-	SDKShapeTraits bool `type:"structure"`
+	_ struct{} `type:"structure"`
 }
 
 // String returns the string representation
@@ -2050,11 +1938,7 @@ type DescribeReceiptRuleOutput struct {
 	// (TLS) policy.
 	Rule *ReceiptRule `type:"structure"`
 
-	metadataDescribeReceiptRuleOutput `json:"-" xml:"-"`
-}
-
-type metadataDescribeReceiptRuleOutput struct {
-	SDKShapeTraits bool `type:"structure"`
+	_ struct{} `type:"structure"`
 }
 
 // String returns the string representation
@@ -2071,11 +1955,7 @@ type DescribeReceiptRuleSetInput struct {
 	// The name of the receipt rule set to describe.
 	RuleSetName *string `type:"string" required:"true"`
 
-	metadataDescribeReceiptRuleSetInput `json:"-" xml:"-"`
-}
-
-type metadataDescribeReceiptRuleSetInput struct {
-	SDKShapeTraits bool `type:"structure"`
+	_ struct{} `type:"structure"`
 }
 
 // String returns the string representation
@@ -2096,11 +1976,7 @@ type DescribeReceiptRuleSetOutput struct {
 	// A list of the receipt rules that belong to the specified receipt rule set.
 	Rules []*ReceiptRule `type:"list"`
 
-	metadataDescribeReceiptRuleSetOutput `json:"-" xml:"-"`
-}
-
-type metadataDescribeReceiptRuleSetOutput struct {
-	SDKShapeTraits bool `type:"structure"`
+	_ struct{} `type:"structure"`
 }
 
 // String returns the string representation
@@ -2130,11 +2006,7 @@ type Destination struct {
 	// The To: field(s) of the message.
 	ToAddresses []*string `type:"list"`
 
-	metadataDestination `json:"-" xml:"-"`
-}
-
-type metadataDestination struct {
-	SDKShapeTraits bool `type:"structure"`
+	_ struct{} `type:"structure"`
 }
 
 // String returns the string representation
@@ -2161,11 +2033,7 @@ type ExtensionField struct {
 	// not contain newline characters ("\r" or "\n").
 	Value *string `type:"string" required:"true"`
 
-	metadataExtensionField `json:"-" xml:"-"`
-}
-
-type metadataExtensionField struct {
-	SDKShapeTraits bool `type:"structure"`
+	_ struct{} `type:"structure"`
 }
 
 // String returns the string representation
@@ -2189,11 +2057,7 @@ type GetIdentityDkimAttributesInput struct {
 	// both.
 	Identities []*string `type:"list" required:"true"`
 
-	metadataGetIdentityDkimAttributesInput `json:"-" xml:"-"`
-}
-
-type metadataGetIdentityDkimAttributesInput struct {
-	SDKShapeTraits bool `type:"structure"`
+	_ struct{} `type:"structure"`
 }
 
 // String returns the string representation
@@ -2211,11 +2075,7 @@ type GetIdentityDkimAttributesOutput struct {
 	// The DKIM attributes for an email address or a domain.
 	DkimAttributes map[string]*IdentityDkimAttributes `type:"map" required:"true"`
 
-	metadataGetIdentityDkimAttributesOutput `json:"-" xml:"-"`
-}
-
-type metadataGetIdentityDkimAttributesOutput struct {
-	SDKShapeTraits bool `type:"structure"`
+	_ struct{} `type:"structure"`
 }
 
 // String returns the string representation
@@ -2234,11 +2094,7 @@ type GetIdentityNotificationAttributesInput struct {
 	// example.com, arn:aws:ses:us-east-1:123456789012:identity/example.com.
 	Identities []*string `type:"list" required:"true"`
 
-	metadataGetIdentityNotificationAttributesInput `json:"-" xml:"-"`
-}
-
-type metadataGetIdentityNotificationAttributesInput struct {
-	SDKShapeTraits bool `type:"structure"`
+	_ struct{} `type:"structure"`
 }
 
 // String returns the string representation
@@ -2259,11 +2115,7 @@ type GetIdentityNotificationAttributesOutput struct {
 	// A map of Identity to IdentityNotificationAttributes.
 	NotificationAttributes map[string]*IdentityNotificationAttributes `type:"map" required:"true"`
 
-	metadataGetIdentityNotificationAttributesOutput `json:"-" xml:"-"`
-}
-
-type metadataGetIdentityNotificationAttributesOutput struct {
-	SDKShapeTraits bool `type:"structure"`
+	_ struct{} `type:"structure"`
 }
 
 // String returns the string representation
@@ -2291,11 +2143,7 @@ type GetIdentityPoliciesInput struct {
 	// are attached to the identity, you can use ListIdentityPolicies.
 	PolicyNames []*string `type:"list" required:"true"`
 
-	metadataGetIdentityPoliciesInput `json:"-" xml:"-"`
-}
-
-type metadataGetIdentityPoliciesInput struct {
-	SDKShapeTraits bool `type:"structure"`
+	_ struct{} `type:"structure"`
 }
 
 // String returns the string representation
@@ -2314,11 +2162,7 @@ type GetIdentityPoliciesOutput struct {
 	// A map of policy names to policies.
 	Policies map[string]*string `type:"map" required:"true"`
 
-	metadataGetIdentityPoliciesOutput `json:"-" xml:"-"`
-}
-
-type metadataGetIdentityPoliciesOutput struct {
-	SDKShapeTraits bool `type:"structure"`
+	_ struct{} `type:"structure"`
 }
 
 // String returns the string representation
@@ -2337,11 +2181,7 @@ type GetIdentityVerificationAttributesInput struct {
 	// A list of identities.
 	Identities []*string `type:"list" required:"true"`
 
-	metadataGetIdentityVerificationAttributesInput `json:"-" xml:"-"`
-}
-
-type metadataGetIdentityVerificationAttributesInput struct {
-	SDKShapeTraits bool `type:"structure"`
+	_ struct{} `type:"structure"`
 }
 
 // String returns the string representation
@@ -2359,11 +2199,7 @@ type GetIdentityVerificationAttributesOutput struct {
 	// A map of Identities to IdentityVerificationAttributes objects.
 	VerificationAttributes map[string]*IdentityVerificationAttributes `type:"map" required:"true"`
 
-	metadataGetIdentityVerificationAttributesOutput `json:"-" xml:"-"`
-}
-
-type metadataGetIdentityVerificationAttributesOutput struct {
-	SDKShapeTraits bool `type:"structure"`
+	_ struct{} `type:"structure"`
 }
 
 // String returns the string representation
@@ -2377,11 +2213,7 @@ func (s GetIdentityVerificationAttributesOutput) GoString() string {
 }
 
 type GetSendQuotaInput struct {
-	metadataGetSendQuotaInput `json:"-" xml:"-"`
-}
-
-type metadataGetSendQuotaInput struct {
-	SDKShapeTraits bool `type:"structure"`
+	_ struct{} `type:"structure"`
 }
 
 // String returns the string representation
@@ -2411,11 +2243,7 @@ type GetSendQuotaOutput struct {
 	// The number of emails sent during the previous 24 hours.
 	SentLast24Hours *float64 `type:"double"`
 
-	metadataGetSendQuotaOutput `json:"-" xml:"-"`
-}
-
-type metadataGetSendQuotaOutput struct {
-	SDKShapeTraits bool `type:"structure"`
+	_ struct{} `type:"structure"`
 }
 
 // String returns the string representation
@@ -2429,11 +2257,7 @@ func (s GetSendQuotaOutput) GoString() string {
 }
 
 type GetSendStatisticsInput struct {
-	metadataGetSendStatisticsInput `json:"-" xml:"-"`
-}
-
-type metadataGetSendStatisticsInput struct {
-	SDKShapeTraits bool `type:"structure"`
+	_ struct{} `type:"structure"`
 }
 
 // String returns the string representation
@@ -2453,11 +2277,7 @@ type GetSendStatisticsOutput struct {
 	// A list of data points, each of which represents 15 minutes of activity.
 	SendDataPoints []*SendDataPoint `type:"list"`
 
-	metadataGetSendStatisticsOutput `json:"-" xml:"-"`
-}
-
-type metadataGetSendStatisticsOutput struct {
-	SDKShapeTraits bool `type:"structure"`
+	_ struct{} `type:"structure"`
 }
 
 // String returns the string representation
@@ -2492,11 +2312,7 @@ type IdentityDkimAttributes struct {
 	// identities, not email address identities.)
 	DkimVerificationStatus *string `type:"string" required:"true" enum:"VerificationStatus"`
 
-	metadataIdentityDkimAttributes `json:"-" xml:"-"`
-}
-
-type metadataIdentityDkimAttributes struct {
-	SDKShapeTraits bool `type:"structure"`
+	_ struct{} `type:"structure"`
 }
 
 // String returns the string representation
@@ -2532,11 +2348,7 @@ type IdentityNotificationAttributes struct {
 	// will be published only to the specified bounce and complaint Amazon SNS topics.
 	ForwardingEnabled *bool `type:"boolean" required:"true"`
 
-	metadataIdentityNotificationAttributes `json:"-" xml:"-"`
-}
-
-type metadataIdentityNotificationAttributes struct {
-	SDKShapeTraits bool `type:"structure"`
+	_ struct{} `type:"structure"`
 }
 
 // String returns the string representation
@@ -2558,11 +2370,7 @@ type IdentityVerificationAttributes struct {
 	// The verification token for a domain identity. Null for email address identities.
 	VerificationToken *string `type:"string"`
 
-	metadataIdentityVerificationAttributes `json:"-" xml:"-"`
-}
-
-type metadataIdentityVerificationAttributes struct {
-	SDKShapeTraits bool `type:"structure"`
+	_ struct{} `type:"structure"`
 }
 
 // String returns the string representation
@@ -2611,11 +2419,7 @@ type LambdaAction struct {
 	// Guide (http://docs.aws.amazon.com/sns/latest/dg/CreateTopic.html).
 	TopicArn *string `type:"string"`
 
-	metadataLambdaAction `json:"-" xml:"-"`
-}
-
-type metadataLambdaAction struct {
-	SDKShapeTraits bool `type:"structure"`
+	_ struct{} `type:"structure"`
 }
 
 // String returns the string representation
@@ -2641,11 +2445,7 @@ type ListIdentitiesInput struct {
 	// The token to use for pagination.
 	NextToken *string `type:"string"`
 
-	metadataListIdentitiesInput `json:"-" xml:"-"`
-}
-
-type metadataListIdentitiesInput struct {
-	SDKShapeTraits bool `type:"structure"`
+	_ struct{} `type:"structure"`
 }
 
 // String returns the string representation
@@ -2666,11 +2466,7 @@ type ListIdentitiesOutput struct {
 	// The token used for pagination.
 	NextToken *string `type:"string"`
 
-	metadataListIdentitiesOutput `json:"-" xml:"-"`
-}
-
-type metadataListIdentitiesOutput struct {
-	SDKShapeTraits bool `type:"structure"`
+	_ struct{} `type:"structure"`
 }
 
 // String returns the string representation
@@ -2693,11 +2489,7 @@ type ListIdentityPoliciesInput struct {
 	// To successfully call this API, you must own the identity.
 	Identity *string `type:"string" required:"true"`
 
-	metadataListIdentityPoliciesInput `json:"-" xml:"-"`
-}
-
-type metadataListIdentityPoliciesInput struct {
-	SDKShapeTraits bool `type:"structure"`
+	_ struct{} `type:"structure"`
 }
 
 // String returns the string representation
@@ -2716,11 +2508,7 @@ type ListIdentityPoliciesOutput struct {
 	// A list of names of policies that apply to the specified identity.
 	PolicyNames []*string `type:"list" required:"true"`
 
-	metadataListIdentityPoliciesOutput `json:"-" xml:"-"`
-}
-
-type metadataListIdentityPoliciesOutput struct {
-	SDKShapeTraits bool `type:"structure"`
+	_ struct{} `type:"structure"`
 }
 
 // String returns the string representation
@@ -2734,11 +2522,7 @@ func (s ListIdentityPoliciesOutput) GoString() string {
 }
 
 type ListReceiptFiltersInput struct {
-	metadataListReceiptFiltersInput `json:"-" xml:"-"`
-}
-
-type metadataListReceiptFiltersInput struct {
-	SDKShapeTraits bool `type:"structure"`
+	_ struct{} `type:"structure"`
 }
 
 // String returns the string representation
@@ -2756,11 +2540,7 @@ type ListReceiptFiltersOutput struct {
 	// an IP address range, and whether to allow or block mail from it.
 	Filters []*ReceiptFilter `type:"list"`
 
-	metadataListReceiptFiltersOutput `json:"-" xml:"-"`
-}
-
-type metadataListReceiptFiltersOutput struct {
-	SDKShapeTraits bool `type:"structure"`
+	_ struct{} `type:"structure"`
 }
 
 // String returns the string representation
@@ -2778,11 +2558,7 @@ type ListReceiptRuleSetsInput struct {
 	// the position in the receipt rule set list.
 	NextToken *string `type:"string"`
 
-	metadataListReceiptRuleSetsInput `json:"-" xml:"-"`
-}
-
-type metadataListReceiptRuleSetsInput struct {
-	SDKShapeTraits bool `type:"structure"`
+	_ struct{} `type:"structure"`
 }
 
 // String returns the string representation
@@ -2805,11 +2581,7 @@ type ListReceiptRuleSetsOutput struct {
 	// of the rule set name and the timestamp of when the rule set was created.
 	RuleSets []*ReceiptRuleSetMetadata `type:"list"`
 
-	metadataListReceiptRuleSetsOutput `json:"-" xml:"-"`
-}
-
-type metadataListReceiptRuleSetsOutput struct {
-	SDKShapeTraits bool `type:"structure"`
+	_ struct{} `type:"structure"`
 }
 
 // String returns the string representation
@@ -2823,11 +2595,7 @@ func (s ListReceiptRuleSetsOutput) GoString() string {
 }
 
 type ListVerifiedEmailAddressesInput struct {
-	metadataListVerifiedEmailAddressesInput `json:"-" xml:"-"`
-}
-
-type metadataListVerifiedEmailAddressesInput struct {
-	SDKShapeTraits bool `type:"structure"`
+	_ struct{} `type:"structure"`
 }
 
 // String returns the string representation
@@ -2845,11 +2613,7 @@ type ListVerifiedEmailAddressesOutput struct {
 	// A list of email addresses that have been verified.
 	VerifiedEmailAddresses []*string `type:"list"`
 
-	metadataListVerifiedEmailAddressesOutput `json:"-" xml:"-"`
-}
-
-type metadataListVerifiedEmailAddressesOutput struct {
-	SDKShapeTraits bool `type:"structure"`
+	_ struct{} `type:"structure"`
 }
 
 // String returns the string representation
@@ -2871,11 +2635,7 @@ type Message struct {
 	// in the recipient's inbox.
 	Subject *Content `type:"structure" required:"true"`
 
-	metadataMessage `json:"-" xml:"-"`
-}
-
-type metadataMessage struct {
-	SDKShapeTraits bool `type:"structure"`
+	_ struct{} `type:"structure"`
 }
 
 // String returns the string representation
@@ -2906,11 +2666,7 @@ type MessageDsn struct {
 	// The default value is dns; inbound-smtp.[region].amazonaws.com.
 	ReportingMta *string `type:"string" required:"true"`
 
-	metadataMessageDsn `json:"-" xml:"-"`
-}
-
-type metadataMessageDsn struct {
-	SDKShapeTraits bool `type:"structure"`
+	_ struct{} `type:"structure"`
 }
 
 // String returns the string representation
@@ -2945,11 +2701,7 @@ type PutIdentityPolicyInput struct {
 	// characters, dashes, and underscores.
 	PolicyName *string `min:"1" type:"string" required:"true"`
 
-	metadataPutIdentityPolicyInput `json:"-" xml:"-"`
-}
-
-type metadataPutIdentityPolicyInput struct {
-	SDKShapeTraits bool `type:"structure"`
+	_ struct{} `type:"structure"`
 }
 
 // String returns the string representation
@@ -2965,11 +2717,7 @@ func (s PutIdentityPolicyInput) GoString() string {
 // An empty element. Receiving this element indicates that the request completed
 // successfully.
 type PutIdentityPolicyOutput struct {
-	metadataPutIdentityPolicyOutput `json:"-" xml:"-"`
-}
-
-type metadataPutIdentityPolicyOutput struct {
-	SDKShapeTraits bool `type:"structure"`
+	_ struct{} `type:"structure"`
 }
 
 // String returns the string representation
@@ -2999,11 +2747,7 @@ type RawMessage struct {
 	// SES Developer Guide (http://docs.aws.amazon.com/ses/latest/DeveloperGuide/send-email-raw.html).
 	Data []byte `type:"blob" required:"true"`
 
-	metadataRawMessage `json:"-" xml:"-"`
-}
-
-type metadataRawMessage struct {
-	SDKShapeTraits bool `type:"structure"`
+	_ struct{} `type:"structure"`
 }
 
 // String returns the string representation
@@ -3050,11 +2794,7 @@ type ReceiptAction struct {
 	// SNS.
 	WorkmailAction *WorkmailAction `type:"structure"`
 
-	metadataReceiptAction `json:"-" xml:"-"`
-}
-
-type metadataReceiptAction struct {
-	SDKShapeTraits bool `type:"structure"`
+	_ struct{} `type:"structure"`
 }
 
 // String returns the string representation
@@ -3084,11 +2824,7 @@ type ReceiptFilter struct {
 	// 64 characters.
 	Name *string `type:"string" required:"true"`
 
-	metadataReceiptFilter `json:"-" xml:"-"`
-}
-
-type metadataReceiptFilter struct {
-	SDKShapeTraits bool `type:"structure"`
+	_ struct{} `type:"structure"`
 }
 
 // String returns the string representation
@@ -3116,11 +2852,7 @@ type ReceiptIpFilter struct {
 	// Indicates whether to block or allow incoming mail from the specified IP addresses.
 	Policy *string `type:"string" required:"true" enum:"ReceiptFilterPolicy"`
 
-	metadataReceiptIpFilter `json:"-" xml:"-"`
-}
-
-type metadataReceiptIpFilter struct {
-	SDKShapeTraits bool `type:"structure"`
+	_ struct{} `type:"structure"`
 }
 
 // String returns the string representation
@@ -3174,11 +2906,7 @@ type ReceiptRule struct {
 	// over TLS. The default is Optional.
 	TlsPolicy *string `type:"string" enum:"TlsPolicy"`
 
-	metadataReceiptRule `json:"-" xml:"-"`
-}
-
-type metadataReceiptRule struct {
-	SDKShapeTraits bool `type:"structure"`
+	_ struct{} `type:"structure"`
 }
 
 // String returns the string representation
@@ -3209,11 +2937,7 @@ type ReceiptRuleSetMetadata struct {
 	// 64 characters.
 	Name *string `type:"string"`
 
-	metadataReceiptRuleSetMetadata `json:"-" xml:"-"`
-}
-
-type metadataReceiptRuleSetMetadata struct {
-	SDKShapeTraits bool `type:"structure"`
+	_ struct{} `type:"structure"`
 }
 
 // String returns the string representation
@@ -3269,11 +2993,7 @@ type RecipientDsnFields struct {
 	// (https://tools.ietf.org/html/rfc3464).
 	Status *string `type:"string" required:"true"`
 
-	metadataRecipientDsnFields `json:"-" xml:"-"`
-}
-
-type metadataRecipientDsnFields struct {
-	SDKShapeTraits bool `type:"structure"`
+	_ struct{} `type:"structure"`
 }
 
 // String returns the string representation
@@ -3294,11 +3014,7 @@ type ReorderReceiptRuleSetInput struct {
 	// The name of the receipt rule set to reorder.
 	RuleSetName *string `type:"string" required:"true"`
 
-	metadataReorderReceiptRuleSetInput `json:"-" xml:"-"`
-}
-
-type metadataReorderReceiptRuleSetInput struct {
-	SDKShapeTraits bool `type:"structure"`
+	_ struct{} `type:"structure"`
 }
 
 // String returns the string representation
@@ -3312,11 +3028,7 @@ func (s ReorderReceiptRuleSetInput) GoString() string {
 }
 
 type ReorderReceiptRuleSetOutput struct {
-	metadataReorderReceiptRuleSetOutput `json:"-" xml:"-"`
-}
-
-type metadataReorderReceiptRuleSetOutput struct {
-	SDKShapeTraits bool `type:"structure"`
+	_ struct{} `type:"structure"`
 }
 
 // String returns the string representation
@@ -3386,11 +3098,7 @@ type S3Action struct {
 	// Guide (http://docs.aws.amazon.com/sns/latest/dg/CreateTopic.html).
 	TopicArn *string `type:"string"`
 
-	metadataS3Action `json:"-" xml:"-"`
-}
-
-type metadataS3Action struct {
-	SDKShapeTraits bool `type:"structure"`
+	_ struct{} `type:"structure"`
 }
 
 // String returns the string representation
@@ -3427,11 +3135,7 @@ type SNSAction struct {
 	// Guide (http://docs.aws.amazon.com/sns/latest/dg/CreateTopic.html).
 	TopicArn *string `type:"string" required:"true"`
 
-	metadataSNSAction `json:"-" xml:"-"`
-}
-
-type metadataSNSAction struct {
-	SDKShapeTraits bool `type:"structure"`
+	_ struct{} `type:"structure"`
 }
 
 // String returns the string representation
@@ -3474,11 +3178,7 @@ type SendBounceInput struct {
 	// The message ID of the message to be bounced.
 	OriginalMessageId *string `type:"string" required:"true"`
 
-	metadataSendBounceInput `json:"-" xml:"-"`
-}
-
-type metadataSendBounceInput struct {
-	SDKShapeTraits bool `type:"structure"`
+	_ struct{} `type:"structure"`
 }
 
 // String returns the string representation
@@ -3495,11 +3195,7 @@ type SendBounceOutput struct {
 	// The message ID of the bounce message.
 	MessageId *string `type:"string"`
 
-	metadataSendBounceOutput `json:"-" xml:"-"`
-}
-
-type metadataSendBounceOutput struct {
-	SDKShapeTraits bool `type:"structure"`
+	_ struct{} `type:"structure"`
 }
 
 // String returns the string representation
@@ -3530,11 +3226,7 @@ type SendDataPoint struct {
 	// Time of the data point.
 	Timestamp *time.Time `type:"timestamp" timestampFormat:"iso8601"`
 
-	metadataSendDataPoint `json:"-" xml:"-"`
-}
-
-type metadataSendDataPoint struct {
-	SDKShapeTraits bool `type:"structure"`
+	_ struct{} `type:"structure"`
 }
 
 // String returns the string representation
@@ -3615,11 +3307,7 @@ type SendEmailInput struct {
 	// Guide (http://docs.aws.amazon.com/ses/latest/DeveloperGuide/sending-authorization.html).
 	SourceArn *string `type:"string"`
 
-	metadataSendEmailInput `json:"-" xml:"-"`
-}
-
-type metadataSendEmailInput struct {
-	SDKShapeTraits bool `type:"structure"`
+	_ struct{} `type:"structure"`
 }
 
 // String returns the string representation
@@ -3637,11 +3325,7 @@ type SendEmailOutput struct {
 	// The unique message identifier returned from the SendEmail action.
 	MessageId *string `type:"string" required:"true"`
 
-	metadataSendEmailOutput `json:"-" xml:"-"`
-}
-
-type metadataSendEmailOutput struct {
-	SDKShapeTraits bool `type:"structure"`
+	_ struct{} `type:"structure"`
 }
 
 // String returns the string representation
@@ -3737,11 +3421,7 @@ type SendRawEmailInput struct {
 	// SendRawEmail in this guide, or see the Amazon SES Developer Guide (http://docs.aws.amazon.com/ses/latest/DeveloperGuide/sending-authorization-delegate-sender-tasks-email.html).
 	SourceArn *string `type:"string"`
 
-	metadataSendRawEmailInput `json:"-" xml:"-"`
-}
-
-type metadataSendRawEmailInput struct {
-	SDKShapeTraits bool `type:"structure"`
+	_ struct{} `type:"structure"`
 }
 
 // String returns the string representation
@@ -3759,11 +3439,7 @@ type SendRawEmailOutput struct {
 	// The unique message identifier returned from the SendRawEmail action.
 	MessageId *string `type:"string" required:"true"`
 
-	metadataSendRawEmailOutput `json:"-" xml:"-"`
-}
-
-type metadataSendRawEmailOutput struct {
-	SDKShapeTraits bool `type:"structure"`
+	_ struct{} `type:"structure"`
 }
 
 // String returns the string representation
@@ -3781,11 +3457,7 @@ type SetActiveReceiptRuleSetInput struct {
 	// disables all email receiving.
 	RuleSetName *string `type:"string"`
 
-	metadataSetActiveReceiptRuleSetInput `json:"-" xml:"-"`
-}
-
-type metadataSetActiveReceiptRuleSetInput struct {
-	SDKShapeTraits bool `type:"structure"`
+	_ struct{} `type:"structure"`
 }
 
 // String returns the string representation
@@ -3799,11 +3471,7 @@ func (s SetActiveReceiptRuleSetInput) GoString() string {
 }
 
 type SetActiveReceiptRuleSetOutput struct {
-	metadataSetActiveReceiptRuleSetOutput `json:"-" xml:"-"`
-}
-
-type metadataSetActiveReceiptRuleSetOutput struct {
-	SDKShapeTraits bool `type:"structure"`
+	_ struct{} `type:"structure"`
 }
 
 // String returns the string representation
@@ -3826,11 +3494,7 @@ type SetIdentityDkimEnabledInput struct {
 	// The identity for which DKIM signing should be enabled or disabled.
 	Identity *string `type:"string" required:"true"`
 
-	metadataSetIdentityDkimEnabledInput `json:"-" xml:"-"`
-}
-
-type metadataSetIdentityDkimEnabledInput struct {
-	SDKShapeTraits bool `type:"structure"`
+	_ struct{} `type:"structure"`
 }
 
 // String returns the string representation
@@ -3846,11 +3510,7 @@ func (s SetIdentityDkimEnabledInput) GoString() string {
 // An empty element. Receiving this element indicates that the request completed
 // successfully.
 type SetIdentityDkimEnabledOutput struct {
-	metadataSetIdentityDkimEnabledOutput `json:"-" xml:"-"`
-}
-
-type metadataSetIdentityDkimEnabledOutput struct {
-	SDKShapeTraits bool `type:"structure"`
+	_ struct{} `type:"structure"`
 }
 
 // String returns the string representation
@@ -3876,11 +3536,7 @@ type SetIdentityFeedbackForwardingEnabledInput struct {
 	// Examples: user@example.com, example.com.
 	Identity *string `type:"string" required:"true"`
 
-	metadataSetIdentityFeedbackForwardingEnabledInput `json:"-" xml:"-"`
-}
-
-type metadataSetIdentityFeedbackForwardingEnabledInput struct {
-	SDKShapeTraits bool `type:"structure"`
+	_ struct{} `type:"structure"`
 }
 
 // String returns the string representation
@@ -3896,11 +3552,7 @@ func (s SetIdentityFeedbackForwardingEnabledInput) GoString() string {
 // An empty element. Receiving this element indicates that the request completed
 // successfully.
 type SetIdentityFeedbackForwardingEnabledOutput struct {
-	metadataSetIdentityFeedbackForwardingEnabledOutput `json:"-" xml:"-"`
-}
-
-type metadataSetIdentityFeedbackForwardingEnabledOutput struct {
-	SDKShapeTraits bool `type:"structure"`
+	_ struct{} `type:"structure"`
 }
 
 // String returns the string representation
@@ -3929,11 +3581,7 @@ type SetIdentityNotificationTopicInput struct {
 	// and publishing is disabled.
 	SnsTopic *string `type:"string"`
 
-	metadataSetIdentityNotificationTopicInput `json:"-" xml:"-"`
-}
-
-type metadataSetIdentityNotificationTopicInput struct {
-	SDKShapeTraits bool `type:"structure"`
+	_ struct{} `type:"structure"`
 }
 
 // String returns the string representation
@@ -3949,11 +3597,7 @@ func (s SetIdentityNotificationTopicInput) GoString() string {
 // An empty element. Receiving this element indicates that the request completed
 // successfully.
 type SetIdentityNotificationTopicOutput struct {
-	metadataSetIdentityNotificationTopicOutput `json:"-" xml:"-"`
-}
-
-type metadataSetIdentityNotificationTopicOutput struct {
-	SDKShapeTraits bool `type:"structure"`
+	_ struct{} `type:"structure"`
 }
 
 // String returns the string representation
@@ -3976,11 +3620,7 @@ type SetReceiptRulePositionInput struct {
 	// The name of the receipt rule set that contains the receipt rule to reposition.
 	RuleSetName *string `type:"string" required:"true"`
 
-	metadataSetReceiptRulePositionInput `json:"-" xml:"-"`
-}
-
-type metadataSetReceiptRulePositionInput struct {
-	SDKShapeTraits bool `type:"structure"`
+	_ struct{} `type:"structure"`
 }
 
 // String returns the string representation
@@ -3994,11 +3634,7 @@ func (s SetReceiptRulePositionInput) GoString() string {
 }
 
 type SetReceiptRulePositionOutput struct {
-	metadataSetReceiptRulePositionOutput `json:"-" xml:"-"`
-}
-
-type metadataSetReceiptRulePositionOutput struct {
-	SDKShapeTraits bool `type:"structure"`
+	_ struct{} `type:"structure"`
 }
 
 // String returns the string representation
@@ -4027,11 +3663,7 @@ type StopAction struct {
 	// Guide (http://docs.aws.amazon.com/sns/latest/dg/CreateTopic.html).
 	TopicArn *string `type:"string"`
 
-	metadataStopAction `json:"-" xml:"-"`
-}
-
-type metadataStopAction struct {
-	SDKShapeTraits bool `type:"structure"`
+	_ struct{} `type:"structure"`
 }
 
 // String returns the string representation
@@ -4051,11 +3683,7 @@ type UpdateReceiptRuleInput struct {
 	// The name of the receipt rule set to which the receipt rule belongs.
 	RuleSetName *string `type:"string" required:"true"`
 
-	metadataUpdateReceiptRuleInput `json:"-" xml:"-"`
-}
-
-type metadataUpdateReceiptRuleInput struct {
-	SDKShapeTraits bool `type:"structure"`
+	_ struct{} `type:"structure"`
 }
 
 // String returns the string representation
@@ -4069,11 +3697,7 @@ func (s UpdateReceiptRuleInput) GoString() string {
 }
 
 type UpdateReceiptRuleOutput struct {
-	metadataUpdateReceiptRuleOutput `json:"-" xml:"-"`
-}
-
-type metadataUpdateReceiptRuleOutput struct {
-	SDKShapeTraits bool `type:"structure"`
+	_ struct{} `type:"structure"`
 }
 
 // String returns the string representation
@@ -4092,11 +3716,7 @@ type VerifyDomainDkimInput struct {
 	// The name of the domain to be verified for Easy DKIM signing.
 	Domain *string `type:"string" required:"true"`
 
-	metadataVerifyDomainDkimInput `json:"-" xml:"-"`
-}
-
-type metadataVerifyDomainDkimInput struct {
-	SDKShapeTraits bool `type:"structure"`
+	_ struct{} `type:"structure"`
 }
 
 // String returns the string representation
@@ -4125,11 +3745,7 @@ type VerifyDomainDkimOutput struct {
 	// the Amazon SES Developer Guide (http://docs.aws.amazon.com/ses/latest/DeveloperGuide/easy-dkim-dns-records.html).
 	DkimTokens []*string `type:"list" required:"true"`
 
-	metadataVerifyDomainDkimOutput `json:"-" xml:"-"`
-}
-
-type metadataVerifyDomainDkimOutput struct {
-	SDKShapeTraits bool `type:"structure"`
+	_ struct{} `type:"structure"`
 }
 
 // String returns the string representation
@@ -4147,11 +3763,7 @@ type VerifyDomainIdentityInput struct {
 	// The domain to be verified.
 	Domain *string `type:"string" required:"true"`
 
-	metadataVerifyDomainIdentityInput `json:"-" xml:"-"`
-}
-
-type metadataVerifyDomainIdentityInput struct {
-	SDKShapeTraits bool `type:"structure"`
+	_ struct{} `type:"structure"`
 }
 
 // String returns the string representation
@@ -4170,11 +3782,7 @@ type VerifyDomainIdentityOutput struct {
 	// to complete domain verification.
 	VerificationToken *string `type:"string" required:"true"`
 
-	metadataVerifyDomainIdentityOutput `json:"-" xml:"-"`
-}
-
-type metadataVerifyDomainIdentityOutput struct {
-	SDKShapeTraits bool `type:"structure"`
+	_ struct{} `type:"structure"`
 }
 
 // String returns the string representation
@@ -4192,11 +3800,7 @@ type VerifyEmailAddressInput struct {
 	// The email address to be verified.
 	EmailAddress *string `type:"string" required:"true"`
 
-	metadataVerifyEmailAddressInput `json:"-" xml:"-"`
-}
-
-type metadataVerifyEmailAddressInput struct {
-	SDKShapeTraits bool `type:"structure"`
+	_ struct{} `type:"structure"`
 }
 
 // String returns the string representation
@@ -4210,11 +3814,7 @@ func (s VerifyEmailAddressInput) GoString() string {
 }
 
 type VerifyEmailAddressOutput struct {
-	metadataVerifyEmailAddressOutput `json:"-" xml:"-"`
-}
-
-type metadataVerifyEmailAddressOutput struct {
-	SDKShapeTraits bool `type:"structure"`
+	_ struct{} `type:"structure"`
 }
 
 // String returns the string representation
@@ -4232,11 +3832,7 @@ type VerifyEmailIdentityInput struct {
 	// The email address to be verified.
 	EmailAddress *string `type:"string" required:"true"`
 
-	metadataVerifyEmailIdentityInput `json:"-" xml:"-"`
-}
-
-type metadataVerifyEmailIdentityInput struct {
-	SDKShapeTraits bool `type:"structure"`
+	_ struct{} `type:"structure"`
 }
 
 // String returns the string representation
@@ -4252,11 +3848,7 @@ func (s VerifyEmailIdentityInput) GoString() string {
 // An empty element. Receiving this element indicates that the request completed
 // successfully.
 type VerifyEmailIdentityOutput struct {
-	metadataVerifyEmailIdentityOutput `json:"-" xml:"-"`
-}
-
-type metadataVerifyEmailIdentityOutput struct {
-	SDKShapeTraits bool `type:"structure"`
+	_ struct{} `type:"structure"`
 }
 
 // String returns the string representation
@@ -4289,11 +3881,7 @@ type WorkmailAction struct {
 	// Guide (http://docs.aws.amazon.com/sns/latest/dg/CreateTopic.html).
 	TopicArn *string `type:"string"`
 
-	metadataWorkmailAction `json:"-" xml:"-"`
-}
-
-type metadataWorkmailAction struct {
-	SDKShapeTraits bool `type:"structure"`
+	_ struct{} `type:"structure"`
 }
 
 // String returns the string representation

--- a/service/simpledb/api.go
+++ b/service/simpledb/api.go
@@ -460,11 +460,7 @@ type Attribute struct {
 	// The value of the attribute.
 	Value *string `type:"string" required:"true"`
 
-	metadataAttribute `json:"-" xml:"-"`
-}
-
-type metadataAttribute struct {
-	SDKShapeTraits bool `type:"structure"`
+	_ struct{} `type:"structure"`
 }
 
 // String returns the string representation
@@ -484,11 +480,7 @@ type BatchDeleteAttributesInput struct {
 	// A list of items on which to perform the operation.
 	Items []*DeletableItem `locationNameList:"Item" type:"list" flattened:"true" required:"true"`
 
-	metadataBatchDeleteAttributesInput `json:"-" xml:"-"`
-}
-
-type metadataBatchDeleteAttributesInput struct {
-	SDKShapeTraits bool `type:"structure"`
+	_ struct{} `type:"structure"`
 }
 
 // String returns the string representation
@@ -502,11 +494,7 @@ func (s BatchDeleteAttributesInput) GoString() string {
 }
 
 type BatchDeleteAttributesOutput struct {
-	metadataBatchDeleteAttributesOutput `json:"-" xml:"-"`
-}
-
-type metadataBatchDeleteAttributesOutput struct {
-	SDKShapeTraits bool `type:"structure"`
+	_ struct{} `type:"structure"`
 }
 
 // String returns the string representation
@@ -526,11 +514,7 @@ type BatchPutAttributesInput struct {
 	// A list of items on which to perform the operation.
 	Items []*ReplaceableItem `locationNameList:"Item" type:"list" flattened:"true" required:"true"`
 
-	metadataBatchPutAttributesInput `json:"-" xml:"-"`
-}
-
-type metadataBatchPutAttributesInput struct {
-	SDKShapeTraits bool `type:"structure"`
+	_ struct{} `type:"structure"`
 }
 
 // String returns the string representation
@@ -544,11 +528,7 @@ func (s BatchPutAttributesInput) GoString() string {
 }
 
 type BatchPutAttributesOutput struct {
-	metadataBatchPutAttributesOutput `json:"-" xml:"-"`
-}
-
-type metadataBatchPutAttributesOutput struct {
-	SDKShapeTraits bool `type:"structure"`
+	_ struct{} `type:"structure"`
 }
 
 // String returns the string representation
@@ -566,11 +546,7 @@ type CreateDomainInput struct {
 	// and can contain the following characters: a-z, A-Z, 0-9, '_', '-', and '.'.
 	DomainName *string `type:"string" required:"true"`
 
-	metadataCreateDomainInput `json:"-" xml:"-"`
-}
-
-type metadataCreateDomainInput struct {
-	SDKShapeTraits bool `type:"structure"`
+	_ struct{} `type:"structure"`
 }
 
 // String returns the string representation
@@ -584,11 +560,7 @@ func (s CreateDomainInput) GoString() string {
 }
 
 type CreateDomainOutput struct {
-	metadataCreateDomainOutput `json:"-" xml:"-"`
-}
-
-type metadataCreateDomainOutput struct {
-	SDKShapeTraits bool `type:"structure"`
+	_ struct{} `type:"structure"`
 }
 
 // String returns the string representation
@@ -608,11 +580,7 @@ type DeletableAttribute struct {
 	// The value of the attribute.
 	Value *string `type:"string"`
 
-	metadataDeletableAttribute `json:"-" xml:"-"`
-}
-
-type metadataDeletableAttribute struct {
-	SDKShapeTraits bool `type:"structure"`
+	_ struct{} `type:"structure"`
 }
 
 // String returns the string representation
@@ -630,11 +598,7 @@ type DeletableItem struct {
 
 	Name *string `locationName:"ItemName" type:"string" required:"true"`
 
-	metadataDeletableItem `json:"-" xml:"-"`
-}
-
-type metadataDeletableItem struct {
-	SDKShapeTraits bool `type:"structure"`
+	_ struct{} `type:"structure"`
 }
 
 // String returns the string representation
@@ -664,11 +628,7 @@ type DeleteAttributesInput struct {
 	// objects that contain one or more value-attribute pairs.
 	ItemName *string `type:"string" required:"true"`
 
-	metadataDeleteAttributesInput `json:"-" xml:"-"`
-}
-
-type metadataDeleteAttributesInput struct {
-	SDKShapeTraits bool `type:"structure"`
+	_ struct{} `type:"structure"`
 }
 
 // String returns the string representation
@@ -682,11 +642,7 @@ func (s DeleteAttributesInput) GoString() string {
 }
 
 type DeleteAttributesOutput struct {
-	metadataDeleteAttributesOutput `json:"-" xml:"-"`
-}
-
-type metadataDeleteAttributesOutput struct {
-	SDKShapeTraits bool `type:"structure"`
+	_ struct{} `type:"structure"`
 }
 
 // String returns the string representation
@@ -703,11 +659,7 @@ type DeleteDomainInput struct {
 	// The name of the domain to delete.
 	DomainName *string `type:"string" required:"true"`
 
-	metadataDeleteDomainInput `json:"-" xml:"-"`
-}
-
-type metadataDeleteDomainInput struct {
-	SDKShapeTraits bool `type:"structure"`
+	_ struct{} `type:"structure"`
 }
 
 // String returns the string representation
@@ -721,11 +673,7 @@ func (s DeleteDomainInput) GoString() string {
 }
 
 type DeleteDomainOutput struct {
-	metadataDeleteDomainOutput `json:"-" xml:"-"`
-}
-
-type metadataDeleteDomainOutput struct {
-	SDKShapeTraits bool `type:"structure"`
+	_ struct{} `type:"structure"`
 }
 
 // String returns the string representation
@@ -742,11 +690,7 @@ type DomainMetadataInput struct {
 	// The name of the domain for which to display the metadata of.
 	DomainName *string `type:"string" required:"true"`
 
-	metadataDomainMetadataInput `json:"-" xml:"-"`
-}
-
-type metadataDomainMetadataInput struct {
-	SDKShapeTraits bool `type:"structure"`
+	_ struct{} `type:"structure"`
 }
 
 // String returns the string representation
@@ -781,11 +725,7 @@ type DomainMetadataOutput struct {
 	// The data and time when metadata was calculated, in Epoch (UNIX) seconds.
 	Timestamp *int64 `type:"integer"`
 
-	metadataDomainMetadataOutput `json:"-" xml:"-"`
-}
-
-type metadataDomainMetadataOutput struct {
-	SDKShapeTraits bool `type:"structure"`
+	_ struct{} `type:"structure"`
 }
 
 // String returns the string representation
@@ -814,11 +754,7 @@ type GetAttributesInput struct {
 	// The name of the item.
 	ItemName *string `type:"string" required:"true"`
 
-	metadataGetAttributesInput `json:"-" xml:"-"`
-}
-
-type metadataGetAttributesInput struct {
-	SDKShapeTraits bool `type:"structure"`
+	_ struct{} `type:"structure"`
 }
 
 // String returns the string representation
@@ -835,11 +771,7 @@ type GetAttributesOutput struct {
 	// The list of attributes returned by the operation.
 	Attributes []*Attribute `locationNameList:"Attribute" type:"list" flattened:"true"`
 
-	metadataGetAttributesOutput `json:"-" xml:"-"`
-}
-
-type metadataGetAttributesOutput struct {
-	SDKShapeTraits bool `type:"structure"`
+	_ struct{} `type:"structure"`
 }
 
 // String returns the string representation
@@ -861,11 +793,7 @@ type Item struct {
 	// The name of the item.
 	Name *string `type:"string" required:"true"`
 
-	metadataItem `json:"-" xml:"-"`
-}
-
-type metadataItem struct {
-	SDKShapeTraits bool `type:"structure"`
+	_ struct{} `type:"structure"`
 }
 
 // String returns the string representation
@@ -887,11 +815,7 @@ type ListDomainsInput struct {
 	// names.
 	NextToken *string `type:"string"`
 
-	metadataListDomainsInput `json:"-" xml:"-"`
-}
-
-type metadataListDomainsInput struct {
-	SDKShapeTraits bool `type:"structure"`
+	_ struct{} `type:"structure"`
 }
 
 // String returns the string representation
@@ -912,11 +836,7 @@ type ListDomainsOutput struct {
 	// MaxNumberOfDomains still available.
 	NextToken *string `type:"string"`
 
-	metadataListDomainsOutput `json:"-" xml:"-"`
-}
-
-type metadataListDomainsOutput struct {
-	SDKShapeTraits bool `type:"structure"`
+	_ struct{} `type:"structure"`
 }
 
 // String returns the string representation
@@ -944,11 +864,7 @@ type PutAttributesInput struct {
 	// The name of the item.
 	ItemName *string `type:"string" required:"true"`
 
-	metadataPutAttributesInput `json:"-" xml:"-"`
-}
-
-type metadataPutAttributesInput struct {
-	SDKShapeTraits bool `type:"structure"`
+	_ struct{} `type:"structure"`
 }
 
 // String returns the string representation
@@ -962,11 +878,7 @@ func (s PutAttributesInput) GoString() string {
 }
 
 type PutAttributesOutput struct {
-	metadataPutAttributesOutput `json:"-" xml:"-"`
-}
-
-type metadataPutAttributesOutput struct {
-	SDKShapeTraits bool `type:"structure"`
+	_ struct{} `type:"structure"`
 }
 
 // String returns the string representation
@@ -990,11 +902,7 @@ type ReplaceableAttribute struct {
 	// The value of the replaceable attribute.
 	Value *string `type:"string" required:"true"`
 
-	metadataReplaceableAttribute `json:"-" xml:"-"`
-}
-
-type metadataReplaceableAttribute struct {
-	SDKShapeTraits bool `type:"structure"`
+	_ struct{} `type:"structure"`
 }
 
 // String returns the string representation
@@ -1014,11 +922,7 @@ type ReplaceableItem struct {
 	// The name of the replaceable item.
 	Name *string `locationName:"ItemName" type:"string" required:"true"`
 
-	metadataReplaceableItem `json:"-" xml:"-"`
-}
-
-type metadataReplaceableItem struct {
-	SDKShapeTraits bool `type:"structure"`
+	_ struct{} `type:"structure"`
 }
 
 // String returns the string representation
@@ -1044,11 +948,7 @@ type SelectInput struct {
 	// The expression used to query the domain.
 	SelectExpression *string `type:"string" required:"true"`
 
-	metadataSelectInput `json:"-" xml:"-"`
-}
-
-type metadataSelectInput struct {
-	SDKShapeTraits bool `type:"structure"`
+	_ struct{} `type:"structure"`
 }
 
 // String returns the string representation
@@ -1069,11 +969,7 @@ type SelectOutput struct {
 	// the response size exceeded 1 megabyte, or the execution time exceeded 5 seconds.
 	NextToken *string `type:"string"`
 
-	metadataSelectOutput `json:"-" xml:"-"`
-}
-
-type metadataSelectOutput struct {
-	SDKShapeTraits bool `type:"structure"`
+	_ struct{} `type:"structure"`
 }
 
 // String returns the string representation
@@ -1105,11 +1001,7 @@ type UpdateCondition struct {
 	// parameter is equal to true.
 	Value *string `type:"string"`
 
-	metadataUpdateCondition `json:"-" xml:"-"`
-}
-
-type metadataUpdateCondition struct {
-	SDKShapeTraits bool `type:"structure"`
+	_ struct{} `type:"structure"`
 }
 
 // String returns the string representation

--- a/service/simpledb/api.go
+++ b/service/simpledb/api.go
@@ -450,6 +450,8 @@ func (c *SimpleDB) SelectPages(input *SelectInput, fn func(p *SelectOutput, last
 }
 
 type Attribute struct {
+	_ struct{} `type:"structure"`
+
 	AlternateNameEncoding *string `type:"string"`
 
 	AlternateValueEncoding *string `type:"string"`
@@ -459,8 +461,6 @@ type Attribute struct {
 
 	// The value of the attribute.
 	Value *string `type:"string" required:"true"`
-
-	_ struct{} `type:"structure"`
 }
 
 // String returns the string representation
@@ -474,13 +474,13 @@ func (s Attribute) GoString() string {
 }
 
 type BatchDeleteAttributesInput struct {
+	_ struct{} `type:"structure"`
+
 	// The name of the domain in which the attributes are being deleted.
 	DomainName *string `type:"string" required:"true"`
 
 	// A list of items on which to perform the operation.
 	Items []*DeletableItem `locationNameList:"Item" type:"list" flattened:"true" required:"true"`
-
-	_ struct{} `type:"structure"`
 }
 
 // String returns the string representation
@@ -508,13 +508,13 @@ func (s BatchDeleteAttributesOutput) GoString() string {
 }
 
 type BatchPutAttributesInput struct {
+	_ struct{} `type:"structure"`
+
 	// The name of the domain in which the attributes are being stored.
 	DomainName *string `type:"string" required:"true"`
 
 	// A list of items on which to perform the operation.
 	Items []*ReplaceableItem `locationNameList:"Item" type:"list" flattened:"true" required:"true"`
-
-	_ struct{} `type:"structure"`
 }
 
 // String returns the string representation
@@ -542,11 +542,11 @@ func (s BatchPutAttributesOutput) GoString() string {
 }
 
 type CreateDomainInput struct {
+	_ struct{} `type:"structure"`
+
 	// The name of the domain to create. The name can range between 3 and 255 characters
 	// and can contain the following characters: a-z, A-Z, 0-9, '_', '-', and '.'.
 	DomainName *string `type:"string" required:"true"`
-
-	_ struct{} `type:"structure"`
 }
 
 // String returns the string representation
@@ -574,13 +574,13 @@ func (s CreateDomainOutput) GoString() string {
 }
 
 type DeletableAttribute struct {
+	_ struct{} `type:"structure"`
+
 	// The name of the attribute.
 	Name *string `type:"string" required:"true"`
 
 	// The value of the attribute.
 	Value *string `type:"string"`
-
-	_ struct{} `type:"structure"`
 }
 
 // String returns the string representation
@@ -594,11 +594,11 @@ func (s DeletableAttribute) GoString() string {
 }
 
 type DeletableItem struct {
+	_ struct{} `type:"structure"`
+
 	Attributes []*DeletableAttribute `locationNameList:"Attribute" type:"list" flattened:"true"`
 
 	Name *string `locationName:"ItemName" type:"string" required:"true"`
-
-	_ struct{} `type:"structure"`
 }
 
 // String returns the string representation
@@ -612,6 +612,8 @@ func (s DeletableItem) GoString() string {
 }
 
 type DeleteAttributesInput struct {
+	_ struct{} `type:"structure"`
+
 	// A list of Attributes. Similar to columns on a spreadsheet, attributes represent
 	// categories of data that can be assigned to items.
 	Attributes []*DeletableAttribute `locationNameList:"Attribute" type:"list" flattened:"true"`
@@ -627,8 +629,6 @@ type DeleteAttributesInput struct {
 	// The name of the item. Similar to rows on a spreadsheet, items represent individual
 	// objects that contain one or more value-attribute pairs.
 	ItemName *string `type:"string" required:"true"`
-
-	_ struct{} `type:"structure"`
 }
 
 // String returns the string representation
@@ -656,10 +656,10 @@ func (s DeleteAttributesOutput) GoString() string {
 }
 
 type DeleteDomainInput struct {
+	_ struct{} `type:"structure"`
+
 	// The name of the domain to delete.
 	DomainName *string `type:"string" required:"true"`
-
-	_ struct{} `type:"structure"`
 }
 
 // String returns the string representation
@@ -687,10 +687,10 @@ func (s DeleteDomainOutput) GoString() string {
 }
 
 type DomainMetadataInput struct {
+	_ struct{} `type:"structure"`
+
 	// The name of the domain for which to display the metadata of.
 	DomainName *string `type:"string" required:"true"`
-
-	_ struct{} `type:"structure"`
 }
 
 // String returns the string representation
@@ -704,6 +704,8 @@ func (s DomainMetadataInput) GoString() string {
 }
 
 type DomainMetadataOutput struct {
+	_ struct{} `type:"structure"`
+
 	// The number of unique attribute names in the domain.
 	AttributeNameCount *int64 `type:"integer"`
 
@@ -724,8 +726,6 @@ type DomainMetadataOutput struct {
 
 	// The data and time when metadata was calculated, in Epoch (UNIX) seconds.
 	Timestamp *int64 `type:"integer"`
-
-	_ struct{} `type:"structure"`
 }
 
 // String returns the string representation
@@ -739,6 +739,8 @@ func (s DomainMetadataOutput) GoString() string {
 }
 
 type GetAttributesInput struct {
+	_ struct{} `type:"structure"`
+
 	// The names of the attributes.
 	AttributeNames []*string `locationNameList:"AttributeName" type:"list" flattened:"true"`
 
@@ -753,8 +755,6 @@ type GetAttributesInput struct {
 
 	// The name of the item.
 	ItemName *string `type:"string" required:"true"`
-
-	_ struct{} `type:"structure"`
 }
 
 // String returns the string representation
@@ -768,10 +768,10 @@ func (s GetAttributesInput) GoString() string {
 }
 
 type GetAttributesOutput struct {
+	_ struct{} `type:"structure"`
+
 	// The list of attributes returned by the operation.
 	Attributes []*Attribute `locationNameList:"Attribute" type:"list" flattened:"true"`
-
-	_ struct{} `type:"structure"`
 }
 
 // String returns the string representation
@@ -785,6 +785,8 @@ func (s GetAttributesOutput) GoString() string {
 }
 
 type Item struct {
+	_ struct{} `type:"structure"`
+
 	AlternateNameEncoding *string `type:"string"`
 
 	// A list of attributes.
@@ -792,8 +794,6 @@ type Item struct {
 
 	// The name of the item.
 	Name *string `type:"string" required:"true"`
-
-	_ struct{} `type:"structure"`
 }
 
 // String returns the string representation
@@ -807,6 +807,8 @@ func (s Item) GoString() string {
 }
 
 type ListDomainsInput struct {
+	_ struct{} `type:"structure"`
+
 	// The maximum number of domain names you want returned. The range is 1 to 100.
 	// The default setting is 100.
 	MaxNumberOfDomains *int64 `type:"integer"`
@@ -814,8 +816,6 @@ type ListDomainsInput struct {
 	// A string informing Amazon SimpleDB where to start the next list of domain
 	// names.
 	NextToken *string `type:"string"`
-
-	_ struct{} `type:"structure"`
 }
 
 // String returns the string representation
@@ -829,14 +829,14 @@ func (s ListDomainsInput) GoString() string {
 }
 
 type ListDomainsOutput struct {
+	_ struct{} `type:"structure"`
+
 	// A list of domain names that match the expression.
 	DomainNames []*string `locationNameList:"DomainName" type:"list" flattened:"true"`
 
 	// An opaque token indicating that there are more domains than the specified
 	// MaxNumberOfDomains still available.
 	NextToken *string `type:"string"`
-
-	_ struct{} `type:"structure"`
 }
 
 // String returns the string representation
@@ -850,6 +850,8 @@ func (s ListDomainsOutput) GoString() string {
 }
 
 type PutAttributesInput struct {
+	_ struct{} `type:"structure"`
+
 	// The list of attributes.
 	Attributes []*ReplaceableAttribute `locationNameList:"Attribute" type:"list" flattened:"true" required:"true"`
 
@@ -863,8 +865,6 @@ type PutAttributesInput struct {
 
 	// The name of the item.
 	ItemName *string `type:"string" required:"true"`
-
-	_ struct{} `type:"structure"`
 }
 
 // String returns the string representation
@@ -892,6 +892,8 @@ func (s PutAttributesOutput) GoString() string {
 }
 
 type ReplaceableAttribute struct {
+	_ struct{} `type:"structure"`
+
 	// The name of the replaceable attribute.
 	Name *string `type:"string" required:"true"`
 
@@ -901,8 +903,6 @@ type ReplaceableAttribute struct {
 
 	// The value of the replaceable attribute.
 	Value *string `type:"string" required:"true"`
-
-	_ struct{} `type:"structure"`
 }
 
 // String returns the string representation
@@ -916,13 +916,13 @@ func (s ReplaceableAttribute) GoString() string {
 }
 
 type ReplaceableItem struct {
+	_ struct{} `type:"structure"`
+
 	// The list of attributes for a replaceable item.
 	Attributes []*ReplaceableAttribute `locationNameList:"Attribute" type:"list" flattened:"true" required:"true"`
 
 	// The name of the replaceable item.
 	Name *string `locationName:"ItemName" type:"string" required:"true"`
-
-	_ struct{} `type:"structure"`
 }
 
 // String returns the string representation
@@ -936,6 +936,8 @@ func (s ReplaceableItem) GoString() string {
 }
 
 type SelectInput struct {
+	_ struct{} `type:"structure"`
+
 	// Determines whether or not strong consistency should be enforced when data
 	// is read from SimpleDB. If true, any data previously written to SimpleDB will
 	// be returned. Otherwise, results will be consistent eventually, and the client
@@ -947,8 +949,6 @@ type SelectInput struct {
 
 	// The expression used to query the domain.
 	SelectExpression *string `type:"string" required:"true"`
-
-	_ struct{} `type:"structure"`
 }
 
 // String returns the string representation
@@ -962,14 +962,14 @@ func (s SelectInput) GoString() string {
 }
 
 type SelectOutput struct {
+	_ struct{} `type:"structure"`
+
 	// A list of items that match the select expression.
 	Items []*Item `locationNameList:"Item" type:"list" flattened:"true"`
 
 	// An opaque token indicating that more items than MaxNumberOfItems were matched,
 	// the response size exceeded 1 megabyte, or the execution time exceeded 5 seconds.
 	NextToken *string `type:"string"`
-
-	_ struct{} `type:"structure"`
 }
 
 // String returns the string representation
@@ -987,6 +987,8 @@ func (s SelectOutput) GoString() string {
 // condition is satisfied. For example, if an attribute with a specific name
 // and value exists, or if a specific attribute doesn't exist.
 type UpdateCondition struct {
+	_ struct{} `type:"structure"`
+
 	// A value specifying whether or not the specified attribute must exist with
 	// the specified value in order for the update condition to be satisfied. Specify
 	// true if the attribute must exist for the update condition to be satisfied.
@@ -1000,8 +1002,6 @@ type UpdateCondition struct {
 	// The value of an attribute. This value can only be specified when the Exists
 	// parameter is equal to true.
 	Value *string `type:"string"`
-
-	_ struct{} `type:"structure"`
 }
 
 // String returns the string representation

--- a/service/sns/api.go
+++ b/service/sns/api.go
@@ -842,6 +842,8 @@ func (c *SNS) Unsubscribe(input *UnsubscribeInput) (*UnsubscribeOutput, error) {
 }
 
 type AddPermissionInput struct {
+	_ struct{} `type:"structure"`
+
 	// The AWS account IDs of the users (principals) who will be given access to
 	// the specified actions. The users must have AWS accounts, but do not need
 	// to be signed up for this service.
@@ -857,8 +859,6 @@ type AddPermissionInput struct {
 
 	// The ARN of the topic whose access control policy you wish to modify.
 	TopicArn *string `type:"string" required:"true"`
-
-	_ struct{} `type:"structure"`
 }
 
 // String returns the string representation
@@ -887,6 +887,8 @@ func (s AddPermissionOutput) GoString() string {
 
 // Input for ConfirmSubscription action.
 type ConfirmSubscriptionInput struct {
+	_ struct{} `type:"structure"`
+
 	// Disallows unauthenticated unsubscribes of the subscription. If the value
 	// of this parameter is true and the request has an AWS signature, then only
 	// the topic owner and the subscription owner can unsubscribe the endpoint.
@@ -898,8 +900,6 @@ type ConfirmSubscriptionInput struct {
 
 	// The ARN of the topic for which you wish to confirm a subscription.
 	TopicArn *string `type:"string" required:"true"`
-
-	_ struct{} `type:"structure"`
 }
 
 // String returns the string representation
@@ -914,10 +914,10 @@ func (s ConfirmSubscriptionInput) GoString() string {
 
 // Response for ConfirmSubscriptions action.
 type ConfirmSubscriptionOutput struct {
+	_ struct{} `type:"structure"`
+
 	// The ARN of the created subscription.
 	SubscriptionArn *string `type:"string"`
-
-	_ struct{} `type:"structure"`
 }
 
 // String returns the string representation
@@ -932,6 +932,8 @@ func (s ConfirmSubscriptionOutput) GoString() string {
 
 // Input for CreatePlatformApplication action.
 type CreatePlatformApplicationInput struct {
+	_ struct{} `type:"structure"`
+
 	// For a list of attributes, see SetPlatformApplicationAttributes (http://docs.aws.amazon.com/sns/latest/api/API_SetPlatformApplicationAttributes.html)
 	Attributes map[string]*string `type:"map" required:"true"`
 
@@ -943,8 +945,6 @@ type CreatePlatformApplicationInput struct {
 	// The following platforms are supported: ADM (Amazon Device Messaging), APNS
 	// (Apple Push Notification Service), APNS_SANDBOX, and GCM (Google Cloud Messaging).
 	Platform *string `type:"string" required:"true"`
-
-	_ struct{} `type:"structure"`
 }
 
 // String returns the string representation
@@ -959,10 +959,10 @@ func (s CreatePlatformApplicationInput) GoString() string {
 
 // Response from CreatePlatformApplication action.
 type CreatePlatformApplicationOutput struct {
+	_ struct{} `type:"structure"`
+
 	// PlatformApplicationArn is returned.
 	PlatformApplicationArn *string `type:"string"`
-
-	_ struct{} `type:"structure"`
 }
 
 // String returns the string representation
@@ -977,6 +977,8 @@ func (s CreatePlatformApplicationOutput) GoString() string {
 
 // Input for CreatePlatformEndpoint action.
 type CreatePlatformEndpointInput struct {
+	_ struct{} `type:"structure"`
+
 	// For a list of attributes, see SetEndpointAttributes (http://docs.aws.amazon.com/sns/latest/api/API_SetEndpointAttributes.html).
 	Attributes map[string]*string `type:"map"`
 
@@ -994,8 +996,6 @@ type CreatePlatformEndpointInput struct {
 	// you need the device token. Alternatively, when using GCM or ADM, the device
 	// token equivalent is called the registration ID.
 	Token *string `type:"string" required:"true"`
-
-	_ struct{} `type:"structure"`
 }
 
 // String returns the string representation
@@ -1010,10 +1010,10 @@ func (s CreatePlatformEndpointInput) GoString() string {
 
 // Response from CreateEndpoint action.
 type CreatePlatformEndpointOutput struct {
+	_ struct{} `type:"structure"`
+
 	// EndpointArn returned from CreateEndpoint action.
 	EndpointArn *string `type:"string"`
-
-	_ struct{} `type:"structure"`
 }
 
 // String returns the string representation
@@ -1028,14 +1028,14 @@ func (s CreatePlatformEndpointOutput) GoString() string {
 
 // Input for CreateTopic action.
 type CreateTopicInput struct {
+	_ struct{} `type:"structure"`
+
 	// The name of the topic you want to create.
 	//
 	// Constraints: Topic names must be made up of only uppercase and lowercase
 	// ASCII letters, numbers, underscores, and hyphens, and must be between 1 and
 	// 256 characters long.
 	Name *string `type:"string" required:"true"`
-
-	_ struct{} `type:"structure"`
 }
 
 // String returns the string representation
@@ -1050,10 +1050,10 @@ func (s CreateTopicInput) GoString() string {
 
 // Response from CreateTopic action.
 type CreateTopicOutput struct {
+	_ struct{} `type:"structure"`
+
 	// The Amazon Resource Name (ARN) assigned to the created topic.
 	TopicArn *string `type:"string"`
-
-	_ struct{} `type:"structure"`
 }
 
 // String returns the string representation
@@ -1068,10 +1068,10 @@ func (s CreateTopicOutput) GoString() string {
 
 // Input for DeleteEndpoint action.
 type DeleteEndpointInput struct {
+	_ struct{} `type:"structure"`
+
 	// EndpointArn of endpoint to delete.
 	EndpointArn *string `type:"string" required:"true"`
-
-	_ struct{} `type:"structure"`
 }
 
 // String returns the string representation
@@ -1100,10 +1100,10 @@ func (s DeleteEndpointOutput) GoString() string {
 
 // Input for DeletePlatformApplication action.
 type DeletePlatformApplicationInput struct {
+	_ struct{} `type:"structure"`
+
 	// PlatformApplicationArn of platform application object to delete.
 	PlatformApplicationArn *string `type:"string" required:"true"`
-
-	_ struct{} `type:"structure"`
 }
 
 // String returns the string representation
@@ -1131,10 +1131,10 @@ func (s DeletePlatformApplicationOutput) GoString() string {
 }
 
 type DeleteTopicInput struct {
+	_ struct{} `type:"structure"`
+
 	// The ARN of the topic you want to delete.
 	TopicArn *string `type:"string" required:"true"`
-
-	_ struct{} `type:"structure"`
 }
 
 // String returns the string representation
@@ -1163,13 +1163,13 @@ func (s DeleteTopicOutput) GoString() string {
 
 // Endpoint for mobile app and device.
 type Endpoint struct {
+	_ struct{} `type:"structure"`
+
 	// Attributes for endpoint.
 	Attributes map[string]*string `type:"map"`
 
 	// EndpointArn for mobile app and device.
 	EndpointArn *string `type:"string"`
-
-	_ struct{} `type:"structure"`
 }
 
 // String returns the string representation
@@ -1184,10 +1184,10 @@ func (s Endpoint) GoString() string {
 
 // Input for GetEndpointAttributes action.
 type GetEndpointAttributesInput struct {
+	_ struct{} `type:"structure"`
+
 	// EndpointArn for GetEndpointAttributes input.
 	EndpointArn *string `type:"string" required:"true"`
-
-	_ struct{} `type:"structure"`
 }
 
 // String returns the string representation
@@ -1202,6 +1202,8 @@ func (s GetEndpointAttributesInput) GoString() string {
 
 // Response from GetEndpointAttributes of the EndpointArn.
 type GetEndpointAttributesOutput struct {
+	_ struct{} `type:"structure"`
+
 	// Attributes include the following:
 	//
 	//   CustomUserData -- arbitrary user data to associate with the endpoint.
@@ -1214,8 +1216,6 @@ type GetEndpointAttributesOutput struct {
 	// service when an app and mobile device are registered with the notification
 	// service.
 	Attributes map[string]*string `type:"map"`
-
-	_ struct{} `type:"structure"`
 }
 
 // String returns the string representation
@@ -1230,10 +1230,10 @@ func (s GetEndpointAttributesOutput) GoString() string {
 
 // Input for GetPlatformApplicationAttributes action.
 type GetPlatformApplicationAttributesInput struct {
+	_ struct{} `type:"structure"`
+
 	// PlatformApplicationArn for GetPlatformApplicationAttributesInput.
 	PlatformApplicationArn *string `type:"string" required:"true"`
-
-	_ struct{} `type:"structure"`
 }
 
 // String returns the string representation
@@ -1248,6 +1248,8 @@ func (s GetPlatformApplicationAttributesInput) GoString() string {
 
 // Response for GetPlatformApplicationAttributes action.
 type GetPlatformApplicationAttributesOutput struct {
+	_ struct{} `type:"structure"`
+
 	// Attributes include the following:
 	//
 	//   EventEndpointCreated -- Topic ARN to which EndpointCreated event notifications
@@ -1258,8 +1260,6 @@ type GetPlatformApplicationAttributesOutput struct {
 	// upon Direct Publish delivery failure (permanent) to one of the application's
 	// endpoints.
 	Attributes map[string]*string `type:"map"`
-
-	_ struct{} `type:"structure"`
 }
 
 // String returns the string representation
@@ -1274,10 +1274,10 @@ func (s GetPlatformApplicationAttributesOutput) GoString() string {
 
 // Input for GetSubscriptionAttributes.
 type GetSubscriptionAttributesInput struct {
+	_ struct{} `type:"structure"`
+
 	// The ARN of the subscription whose properties you want to get.
 	SubscriptionArn *string `type:"string" required:"true"`
-
-	_ struct{} `type:"structure"`
 }
 
 // String returns the string representation
@@ -1292,6 +1292,8 @@ func (s GetSubscriptionAttributesInput) GoString() string {
 
 // Response for GetSubscriptionAttributes action.
 type GetSubscriptionAttributesOutput struct {
+	_ struct{} `type:"structure"`
+
 	// A map of the subscription's attributes. Attributes in this map include the
 	// following:
 	//
@@ -1303,8 +1305,6 @@ type GetSubscriptionAttributesOutput struct {
 	// of the effective delivery policy that takes into account the topic delivery
 	// policy and account system defaults
 	Attributes map[string]*string `type:"map"`
-
-	_ struct{} `type:"structure"`
 }
 
 // String returns the string representation
@@ -1319,10 +1319,10 @@ func (s GetSubscriptionAttributesOutput) GoString() string {
 
 // Input for GetTopicAttributes action.
 type GetTopicAttributesInput struct {
+	_ struct{} `type:"structure"`
+
 	// The ARN of the topic whose properties you want to get.
 	TopicArn *string `type:"string" required:"true"`
-
-	_ struct{} `type:"structure"`
 }
 
 // String returns the string representation
@@ -1337,6 +1337,8 @@ func (s GetTopicAttributesInput) GoString() string {
 
 // Response for GetTopicAttributes action.
 type GetTopicAttributesOutput struct {
+	_ struct{} `type:"structure"`
+
 	// A map of the topic's attributes. Attributes in this map include the following:
 	//
 	//   TopicArn -- the topic's ARN  Owner -- the AWS account ID of the topic's
@@ -1350,8 +1352,6 @@ type GetTopicAttributesOutput struct {
 	// -- the JSON serialization of the effective delivery policy that takes into
 	// account system defaults
 	Attributes map[string]*string `type:"map"`
-
-	_ struct{} `type:"structure"`
 }
 
 // String returns the string representation
@@ -1366,6 +1366,8 @@ func (s GetTopicAttributesOutput) GoString() string {
 
 // Input for ListEndpointsByPlatformApplication action.
 type ListEndpointsByPlatformApplicationInput struct {
+	_ struct{} `type:"structure"`
+
 	// NextToken string is used when calling ListEndpointsByPlatformApplication
 	// action to retrieve additional records that are available after the first
 	// page results.
@@ -1373,8 +1375,6 @@ type ListEndpointsByPlatformApplicationInput struct {
 
 	// PlatformApplicationArn for ListEndpointsByPlatformApplicationInput action.
 	PlatformApplicationArn *string `type:"string" required:"true"`
-
-	_ struct{} `type:"structure"`
 }
 
 // String returns the string representation
@@ -1389,14 +1389,14 @@ func (s ListEndpointsByPlatformApplicationInput) GoString() string {
 
 // Response for ListEndpointsByPlatformApplication action.
 type ListEndpointsByPlatformApplicationOutput struct {
+	_ struct{} `type:"structure"`
+
 	// Endpoints returned for ListEndpointsByPlatformApplication action.
 	Endpoints []*Endpoint `type:"list"`
 
 	// NextToken string is returned when calling ListEndpointsByPlatformApplication
 	// action if additional records are available after the first page results.
 	NextToken *string `type:"string"`
-
-	_ struct{} `type:"structure"`
 }
 
 // String returns the string representation
@@ -1411,11 +1411,11 @@ func (s ListEndpointsByPlatformApplicationOutput) GoString() string {
 
 // Input for ListPlatformApplications action.
 type ListPlatformApplicationsInput struct {
+	_ struct{} `type:"structure"`
+
 	// NextToken string is used when calling ListPlatformApplications action to
 	// retrieve additional records that are available after the first page results.
 	NextToken *string `type:"string"`
-
-	_ struct{} `type:"structure"`
 }
 
 // String returns the string representation
@@ -1430,14 +1430,14 @@ func (s ListPlatformApplicationsInput) GoString() string {
 
 // Response for ListPlatformApplications action.
 type ListPlatformApplicationsOutput struct {
+	_ struct{} `type:"structure"`
+
 	// NextToken string is returned when calling ListPlatformApplications action
 	// if additional records are available after the first page results.
 	NextToken *string `type:"string"`
 
 	// Platform applications returned when calling ListPlatformApplications action.
 	PlatformApplications []*PlatformApplication `type:"list"`
-
-	_ struct{} `type:"structure"`
 }
 
 // String returns the string representation
@@ -1452,13 +1452,13 @@ func (s ListPlatformApplicationsOutput) GoString() string {
 
 // Input for ListSubscriptionsByTopic action.
 type ListSubscriptionsByTopicInput struct {
+	_ struct{} `type:"structure"`
+
 	// Token returned by the previous ListSubscriptionsByTopic request.
 	NextToken *string `type:"string"`
 
 	// The ARN of the topic for which you wish to find subscriptions.
 	TopicArn *string `type:"string" required:"true"`
-
-	_ struct{} `type:"structure"`
 }
 
 // String returns the string representation
@@ -1473,14 +1473,14 @@ func (s ListSubscriptionsByTopicInput) GoString() string {
 
 // Response for ListSubscriptionsByTopic action.
 type ListSubscriptionsByTopicOutput struct {
+	_ struct{} `type:"structure"`
+
 	// Token to pass along to the next ListSubscriptionsByTopic request. This element
 	// is returned if there are more subscriptions to retrieve.
 	NextToken *string `type:"string"`
 
 	// A list of subscriptions.
 	Subscriptions []*Subscription `type:"list"`
-
-	_ struct{} `type:"structure"`
 }
 
 // String returns the string representation
@@ -1495,10 +1495,10 @@ func (s ListSubscriptionsByTopicOutput) GoString() string {
 
 // Input for ListSubscriptions action.
 type ListSubscriptionsInput struct {
+	_ struct{} `type:"structure"`
+
 	// Token returned by the previous ListSubscriptions request.
 	NextToken *string `type:"string"`
-
-	_ struct{} `type:"structure"`
 }
 
 // String returns the string representation
@@ -1513,14 +1513,14 @@ func (s ListSubscriptionsInput) GoString() string {
 
 // Response for ListSubscriptions action
 type ListSubscriptionsOutput struct {
+	_ struct{} `type:"structure"`
+
 	// Token to pass along to the next ListSubscriptions request. This element is
 	// returned if there are more subscriptions to retrieve.
 	NextToken *string `type:"string"`
 
 	// A list of subscriptions.
 	Subscriptions []*Subscription `type:"list"`
-
-	_ struct{} `type:"structure"`
 }
 
 // String returns the string representation
@@ -1534,10 +1534,10 @@ func (s ListSubscriptionsOutput) GoString() string {
 }
 
 type ListTopicsInput struct {
+	_ struct{} `type:"structure"`
+
 	// Token returned by the previous ListTopics request.
 	NextToken *string `type:"string"`
-
-	_ struct{} `type:"structure"`
 }
 
 // String returns the string representation
@@ -1552,14 +1552,14 @@ func (s ListTopicsInput) GoString() string {
 
 // Response for ListTopics action.
 type ListTopicsOutput struct {
+	_ struct{} `type:"structure"`
+
 	// Token to pass along to the next ListTopics request. This element is returned
 	// if there are additional topics to retrieve.
 	NextToken *string `type:"string"`
 
 	// A list of topic ARNs.
 	Topics []*Topic `type:"list"`
-
-	_ struct{} `type:"structure"`
 }
 
 // String returns the string representation
@@ -1582,6 +1582,8 @@ func (s ListTopicsOutput) GoString() string {
 // is currently 256 KB (262,144 bytes). For more information, see Using Amazon
 // SNS Message Attributes (http://docs.aws.amazon.com/sns/latest/dg/SNSMessageAttributes.html).
 type MessageAttributeValue struct {
+	_ struct{} `type:"structure"`
+
 	// Binary type attributes can store any binary data, for example, compressed
 	// data, encrypted data, or images.
 	BinaryValue []byte `type:"blob"`
@@ -1593,8 +1595,6 @@ type MessageAttributeValue struct {
 	// Strings are Unicode with UTF8 binary encoding. For a list of code values,
 	// see http://en.wikipedia.org/wiki/ASCII#ASCII_printable_characters (http://en.wikipedia.org/wiki/ASCII#ASCII_printable_characters).
 	StringValue *string `type:"string"`
-
-	_ struct{} `type:"structure"`
 }
 
 // String returns the string representation
@@ -1609,13 +1609,13 @@ func (s MessageAttributeValue) GoString() string {
 
 // Platform application object.
 type PlatformApplication struct {
+	_ struct{} `type:"structure"`
+
 	// Attributes for platform application object.
 	Attributes map[string]*string `type:"map"`
 
 	// PlatformApplicationArn for platform application object.
 	PlatformApplicationArn *string `type:"string"`
-
-	_ struct{} `type:"structure"`
 }
 
 // String returns the string representation
@@ -1630,6 +1630,8 @@ func (s PlatformApplication) GoString() string {
 
 // Input for Publish action.
 type PublishInput struct {
+	_ struct{} `type:"structure"`
+
 	// The message you want to send to the topic.
 	//
 	// If you want to send the same message to all transport protocols, include
@@ -1691,8 +1693,6 @@ type PublishInput struct {
 
 	// The topic you want to publish to.
 	TopicArn *string `type:"string"`
-
-	_ struct{} `type:"structure"`
 }
 
 // String returns the string representation
@@ -1707,12 +1707,12 @@ func (s PublishInput) GoString() string {
 
 // Response for Publish action.
 type PublishOutput struct {
+	_ struct{} `type:"structure"`
+
 	// Unique identifier assigned to the published message.
 	//
 	// Length Constraint: Maximum 100 characters
 	MessageId *string `type:"string"`
-
-	_ struct{} `type:"structure"`
 }
 
 // String returns the string representation
@@ -1727,13 +1727,13 @@ func (s PublishOutput) GoString() string {
 
 // Input for RemovePermission action.
 type RemovePermissionInput struct {
+	_ struct{} `type:"structure"`
+
 	// The unique label of the statement you want to remove.
 	Label *string `type:"string" required:"true"`
 
 	// The ARN of the topic whose access control policy you wish to modify.
 	TopicArn *string `type:"string" required:"true"`
-
-	_ struct{} `type:"structure"`
 }
 
 // String returns the string representation
@@ -1762,6 +1762,8 @@ func (s RemovePermissionOutput) GoString() string {
 
 // Input for SetEndpointAttributes action.
 type SetEndpointAttributesInput struct {
+	_ struct{} `type:"structure"`
+
 	// A map of the endpoint attributes. Attributes in this map include the following:
 	//
 	//   CustomUserData -- arbitrary user data to associate with the endpoint.
@@ -1777,8 +1779,6 @@ type SetEndpointAttributesInput struct {
 
 	// EndpointArn used for SetEndpointAttributes action.
 	EndpointArn *string `type:"string" required:"true"`
-
-	_ struct{} `type:"structure"`
 }
 
 // String returns the string representation
@@ -1807,6 +1807,8 @@ func (s SetEndpointAttributesOutput) GoString() string {
 
 // Input for SetPlatformApplicationAttributes action.
 type SetPlatformApplicationAttributesInput struct {
+	_ struct{} `type:"structure"`
+
 	// A map of the platform application attributes. Attributes in this map include
 	// the following:
 	//
@@ -1826,8 +1828,6 @@ type SetPlatformApplicationAttributesInput struct {
 
 	// PlatformApplicationArn for SetPlatformApplicationAttributes action.
 	PlatformApplicationArn *string `type:"string" required:"true"`
-
-	_ struct{} `type:"structure"`
 }
 
 // String returns the string representation
@@ -1856,6 +1856,8 @@ func (s SetPlatformApplicationAttributesOutput) GoString() string {
 
 // Input for SetSubscriptionAttributes action.
 type SetSubscriptionAttributesInput struct {
+	_ struct{} `type:"structure"`
+
 	// The name of the attribute you want to set. Only a subset of the subscriptions
 	// attributes are mutable.
 	//
@@ -1867,8 +1869,6 @@ type SetSubscriptionAttributesInput struct {
 
 	// The ARN of the subscription to modify.
 	SubscriptionArn *string `type:"string" required:"true"`
-
-	_ struct{} `type:"structure"`
 }
 
 // String returns the string representation
@@ -1897,6 +1897,8 @@ func (s SetSubscriptionAttributesOutput) GoString() string {
 
 // Input for SetTopicAttributes action.
 type SetTopicAttributesInput struct {
+	_ struct{} `type:"structure"`
+
 	// The name of the attribute you want to set. Only a subset of the topic's attributes
 	// are mutable.
 	//
@@ -1908,8 +1910,6 @@ type SetTopicAttributesInput struct {
 
 	// The ARN of the topic to modify.
 	TopicArn *string `type:"string" required:"true"`
-
-	_ struct{} `type:"structure"`
 }
 
 // String returns the string representation
@@ -1938,6 +1938,8 @@ func (s SetTopicAttributesOutput) GoString() string {
 
 // Input for Subscribe action.
 type SubscribeInput struct {
+	_ struct{} `type:"structure"`
+
 	// The endpoint that you want to receive notifications. Endpoints vary by protocol:
 	//
 	//  For the http protocol, the endpoint is an URL beginning with "http://"
@@ -1961,8 +1963,6 @@ type SubscribeInput struct {
 
 	// The ARN of the topic you want to subscribe to.
 	TopicArn *string `type:"string" required:"true"`
-
-	_ struct{} `type:"structure"`
 }
 
 // String returns the string representation
@@ -1977,11 +1977,11 @@ func (s SubscribeInput) GoString() string {
 
 // Response for Subscribe action.
 type SubscribeOutput struct {
+	_ struct{} `type:"structure"`
+
 	// The ARN of the subscription, if the service was able to create a subscription
 	// immediately (without requiring endpoint owner confirmation).
 	SubscriptionArn *string `type:"string"`
-
-	_ struct{} `type:"structure"`
 }
 
 // String returns the string representation
@@ -1996,6 +1996,8 @@ func (s SubscribeOutput) GoString() string {
 
 // A wrapper type for the attributes of an Amazon SNS subscription.
 type Subscription struct {
+	_ struct{} `type:"structure"`
+
 	// The subscription's endpoint (format depends on the protocol).
 	Endpoint *string `type:"string"`
 
@@ -2010,8 +2012,6 @@ type Subscription struct {
 
 	// The ARN of the subscription's topic.
 	TopicArn *string `type:"string"`
-
-	_ struct{} `type:"structure"`
 }
 
 // String returns the string representation
@@ -2027,10 +2027,10 @@ func (s Subscription) GoString() string {
 // A wrapper type for the topic's Amazon Resource Name (ARN). To retrieve a
 // topic's attributes, use GetTopicAttributes.
 type Topic struct {
+	_ struct{} `type:"structure"`
+
 	// The topic's ARN.
 	TopicArn *string `type:"string"`
-
-	_ struct{} `type:"structure"`
 }
 
 // String returns the string representation
@@ -2045,10 +2045,10 @@ func (s Topic) GoString() string {
 
 // Input for Unsubscribe action.
 type UnsubscribeInput struct {
+	_ struct{} `type:"structure"`
+
 	// The ARN of the subscription to be deleted.
 	SubscriptionArn *string `type:"string" required:"true"`
-
-	_ struct{} `type:"structure"`
 }
 
 // String returns the string representation

--- a/service/sns/api.go
+++ b/service/sns/api.go
@@ -858,11 +858,7 @@ type AddPermissionInput struct {
 	// The ARN of the topic whose access control policy you wish to modify.
 	TopicArn *string `type:"string" required:"true"`
 
-	metadataAddPermissionInput `json:"-" xml:"-"`
-}
-
-type metadataAddPermissionInput struct {
-	SDKShapeTraits bool `type:"structure"`
+	_ struct{} `type:"structure"`
 }
 
 // String returns the string representation
@@ -876,11 +872,7 @@ func (s AddPermissionInput) GoString() string {
 }
 
 type AddPermissionOutput struct {
-	metadataAddPermissionOutput `json:"-" xml:"-"`
-}
-
-type metadataAddPermissionOutput struct {
-	SDKShapeTraits bool `type:"structure"`
+	_ struct{} `type:"structure"`
 }
 
 // String returns the string representation
@@ -907,11 +899,7 @@ type ConfirmSubscriptionInput struct {
 	// The ARN of the topic for which you wish to confirm a subscription.
 	TopicArn *string `type:"string" required:"true"`
 
-	metadataConfirmSubscriptionInput `json:"-" xml:"-"`
-}
-
-type metadataConfirmSubscriptionInput struct {
-	SDKShapeTraits bool `type:"structure"`
+	_ struct{} `type:"structure"`
 }
 
 // String returns the string representation
@@ -929,11 +917,7 @@ type ConfirmSubscriptionOutput struct {
 	// The ARN of the created subscription.
 	SubscriptionArn *string `type:"string"`
 
-	metadataConfirmSubscriptionOutput `json:"-" xml:"-"`
-}
-
-type metadataConfirmSubscriptionOutput struct {
-	SDKShapeTraits bool `type:"structure"`
+	_ struct{} `type:"structure"`
 }
 
 // String returns the string representation
@@ -960,11 +944,7 @@ type CreatePlatformApplicationInput struct {
 	// (Apple Push Notification Service), APNS_SANDBOX, and GCM (Google Cloud Messaging).
 	Platform *string `type:"string" required:"true"`
 
-	metadataCreatePlatformApplicationInput `json:"-" xml:"-"`
-}
-
-type metadataCreatePlatformApplicationInput struct {
-	SDKShapeTraits bool `type:"structure"`
+	_ struct{} `type:"structure"`
 }
 
 // String returns the string representation
@@ -982,11 +962,7 @@ type CreatePlatformApplicationOutput struct {
 	// PlatformApplicationArn is returned.
 	PlatformApplicationArn *string `type:"string"`
 
-	metadataCreatePlatformApplicationOutput `json:"-" xml:"-"`
-}
-
-type metadataCreatePlatformApplicationOutput struct {
-	SDKShapeTraits bool `type:"structure"`
+	_ struct{} `type:"structure"`
 }
 
 // String returns the string representation
@@ -1019,11 +995,7 @@ type CreatePlatformEndpointInput struct {
 	// token equivalent is called the registration ID.
 	Token *string `type:"string" required:"true"`
 
-	metadataCreatePlatformEndpointInput `json:"-" xml:"-"`
-}
-
-type metadataCreatePlatformEndpointInput struct {
-	SDKShapeTraits bool `type:"structure"`
+	_ struct{} `type:"structure"`
 }
 
 // String returns the string representation
@@ -1041,11 +1013,7 @@ type CreatePlatformEndpointOutput struct {
 	// EndpointArn returned from CreateEndpoint action.
 	EndpointArn *string `type:"string"`
 
-	metadataCreatePlatformEndpointOutput `json:"-" xml:"-"`
-}
-
-type metadataCreatePlatformEndpointOutput struct {
-	SDKShapeTraits bool `type:"structure"`
+	_ struct{} `type:"structure"`
 }
 
 // String returns the string representation
@@ -1067,11 +1035,7 @@ type CreateTopicInput struct {
 	// 256 characters long.
 	Name *string `type:"string" required:"true"`
 
-	metadataCreateTopicInput `json:"-" xml:"-"`
-}
-
-type metadataCreateTopicInput struct {
-	SDKShapeTraits bool `type:"structure"`
+	_ struct{} `type:"structure"`
 }
 
 // String returns the string representation
@@ -1089,11 +1053,7 @@ type CreateTopicOutput struct {
 	// The Amazon Resource Name (ARN) assigned to the created topic.
 	TopicArn *string `type:"string"`
 
-	metadataCreateTopicOutput `json:"-" xml:"-"`
-}
-
-type metadataCreateTopicOutput struct {
-	SDKShapeTraits bool `type:"structure"`
+	_ struct{} `type:"structure"`
 }
 
 // String returns the string representation
@@ -1111,11 +1071,7 @@ type DeleteEndpointInput struct {
 	// EndpointArn of endpoint to delete.
 	EndpointArn *string `type:"string" required:"true"`
 
-	metadataDeleteEndpointInput `json:"-" xml:"-"`
-}
-
-type metadataDeleteEndpointInput struct {
-	SDKShapeTraits bool `type:"structure"`
+	_ struct{} `type:"structure"`
 }
 
 // String returns the string representation
@@ -1129,11 +1085,7 @@ func (s DeleteEndpointInput) GoString() string {
 }
 
 type DeleteEndpointOutput struct {
-	metadataDeleteEndpointOutput `json:"-" xml:"-"`
-}
-
-type metadataDeleteEndpointOutput struct {
-	SDKShapeTraits bool `type:"structure"`
+	_ struct{} `type:"structure"`
 }
 
 // String returns the string representation
@@ -1151,11 +1103,7 @@ type DeletePlatformApplicationInput struct {
 	// PlatformApplicationArn of platform application object to delete.
 	PlatformApplicationArn *string `type:"string" required:"true"`
 
-	metadataDeletePlatformApplicationInput `json:"-" xml:"-"`
-}
-
-type metadataDeletePlatformApplicationInput struct {
-	SDKShapeTraits bool `type:"structure"`
+	_ struct{} `type:"structure"`
 }
 
 // String returns the string representation
@@ -1169,11 +1117,7 @@ func (s DeletePlatformApplicationInput) GoString() string {
 }
 
 type DeletePlatformApplicationOutput struct {
-	metadataDeletePlatformApplicationOutput `json:"-" xml:"-"`
-}
-
-type metadataDeletePlatformApplicationOutput struct {
-	SDKShapeTraits bool `type:"structure"`
+	_ struct{} `type:"structure"`
 }
 
 // String returns the string representation
@@ -1190,11 +1134,7 @@ type DeleteTopicInput struct {
 	// The ARN of the topic you want to delete.
 	TopicArn *string `type:"string" required:"true"`
 
-	metadataDeleteTopicInput `json:"-" xml:"-"`
-}
-
-type metadataDeleteTopicInput struct {
-	SDKShapeTraits bool `type:"structure"`
+	_ struct{} `type:"structure"`
 }
 
 // String returns the string representation
@@ -1208,11 +1148,7 @@ func (s DeleteTopicInput) GoString() string {
 }
 
 type DeleteTopicOutput struct {
-	metadataDeleteTopicOutput `json:"-" xml:"-"`
-}
-
-type metadataDeleteTopicOutput struct {
-	SDKShapeTraits bool `type:"structure"`
+	_ struct{} `type:"structure"`
 }
 
 // String returns the string representation
@@ -1233,11 +1169,7 @@ type Endpoint struct {
 	// EndpointArn for mobile app and device.
 	EndpointArn *string `type:"string"`
 
-	metadataEndpoint `json:"-" xml:"-"`
-}
-
-type metadataEndpoint struct {
-	SDKShapeTraits bool `type:"structure"`
+	_ struct{} `type:"structure"`
 }
 
 // String returns the string representation
@@ -1255,11 +1187,7 @@ type GetEndpointAttributesInput struct {
 	// EndpointArn for GetEndpointAttributes input.
 	EndpointArn *string `type:"string" required:"true"`
 
-	metadataGetEndpointAttributesInput `json:"-" xml:"-"`
-}
-
-type metadataGetEndpointAttributesInput struct {
-	SDKShapeTraits bool `type:"structure"`
+	_ struct{} `type:"structure"`
 }
 
 // String returns the string representation
@@ -1287,11 +1215,7 @@ type GetEndpointAttributesOutput struct {
 	// service.
 	Attributes map[string]*string `type:"map"`
 
-	metadataGetEndpointAttributesOutput `json:"-" xml:"-"`
-}
-
-type metadataGetEndpointAttributesOutput struct {
-	SDKShapeTraits bool `type:"structure"`
+	_ struct{} `type:"structure"`
 }
 
 // String returns the string representation
@@ -1309,11 +1233,7 @@ type GetPlatformApplicationAttributesInput struct {
 	// PlatformApplicationArn for GetPlatformApplicationAttributesInput.
 	PlatformApplicationArn *string `type:"string" required:"true"`
 
-	metadataGetPlatformApplicationAttributesInput `json:"-" xml:"-"`
-}
-
-type metadataGetPlatformApplicationAttributesInput struct {
-	SDKShapeTraits bool `type:"structure"`
+	_ struct{} `type:"structure"`
 }
 
 // String returns the string representation
@@ -1339,11 +1259,7 @@ type GetPlatformApplicationAttributesOutput struct {
 	// endpoints.
 	Attributes map[string]*string `type:"map"`
 
-	metadataGetPlatformApplicationAttributesOutput `json:"-" xml:"-"`
-}
-
-type metadataGetPlatformApplicationAttributesOutput struct {
-	SDKShapeTraits bool `type:"structure"`
+	_ struct{} `type:"structure"`
 }
 
 // String returns the string representation
@@ -1361,11 +1277,7 @@ type GetSubscriptionAttributesInput struct {
 	// The ARN of the subscription whose properties you want to get.
 	SubscriptionArn *string `type:"string" required:"true"`
 
-	metadataGetSubscriptionAttributesInput `json:"-" xml:"-"`
-}
-
-type metadataGetSubscriptionAttributesInput struct {
-	SDKShapeTraits bool `type:"structure"`
+	_ struct{} `type:"structure"`
 }
 
 // String returns the string representation
@@ -1392,11 +1304,7 @@ type GetSubscriptionAttributesOutput struct {
 	// policy and account system defaults
 	Attributes map[string]*string `type:"map"`
 
-	metadataGetSubscriptionAttributesOutput `json:"-" xml:"-"`
-}
-
-type metadataGetSubscriptionAttributesOutput struct {
-	SDKShapeTraits bool `type:"structure"`
+	_ struct{} `type:"structure"`
 }
 
 // String returns the string representation
@@ -1414,11 +1322,7 @@ type GetTopicAttributesInput struct {
 	// The ARN of the topic whose properties you want to get.
 	TopicArn *string `type:"string" required:"true"`
 
-	metadataGetTopicAttributesInput `json:"-" xml:"-"`
-}
-
-type metadataGetTopicAttributesInput struct {
-	SDKShapeTraits bool `type:"structure"`
+	_ struct{} `type:"structure"`
 }
 
 // String returns the string representation
@@ -1447,11 +1351,7 @@ type GetTopicAttributesOutput struct {
 	// account system defaults
 	Attributes map[string]*string `type:"map"`
 
-	metadataGetTopicAttributesOutput `json:"-" xml:"-"`
-}
-
-type metadataGetTopicAttributesOutput struct {
-	SDKShapeTraits bool `type:"structure"`
+	_ struct{} `type:"structure"`
 }
 
 // String returns the string representation
@@ -1474,11 +1374,7 @@ type ListEndpointsByPlatformApplicationInput struct {
 	// PlatformApplicationArn for ListEndpointsByPlatformApplicationInput action.
 	PlatformApplicationArn *string `type:"string" required:"true"`
 
-	metadataListEndpointsByPlatformApplicationInput `json:"-" xml:"-"`
-}
-
-type metadataListEndpointsByPlatformApplicationInput struct {
-	SDKShapeTraits bool `type:"structure"`
+	_ struct{} `type:"structure"`
 }
 
 // String returns the string representation
@@ -1500,11 +1396,7 @@ type ListEndpointsByPlatformApplicationOutput struct {
 	// action if additional records are available after the first page results.
 	NextToken *string `type:"string"`
 
-	metadataListEndpointsByPlatformApplicationOutput `json:"-" xml:"-"`
-}
-
-type metadataListEndpointsByPlatformApplicationOutput struct {
-	SDKShapeTraits bool `type:"structure"`
+	_ struct{} `type:"structure"`
 }
 
 // String returns the string representation
@@ -1523,11 +1415,7 @@ type ListPlatformApplicationsInput struct {
 	// retrieve additional records that are available after the first page results.
 	NextToken *string `type:"string"`
 
-	metadataListPlatformApplicationsInput `json:"-" xml:"-"`
-}
-
-type metadataListPlatformApplicationsInput struct {
-	SDKShapeTraits bool `type:"structure"`
+	_ struct{} `type:"structure"`
 }
 
 // String returns the string representation
@@ -1549,11 +1437,7 @@ type ListPlatformApplicationsOutput struct {
 	// Platform applications returned when calling ListPlatformApplications action.
 	PlatformApplications []*PlatformApplication `type:"list"`
 
-	metadataListPlatformApplicationsOutput `json:"-" xml:"-"`
-}
-
-type metadataListPlatformApplicationsOutput struct {
-	SDKShapeTraits bool `type:"structure"`
+	_ struct{} `type:"structure"`
 }
 
 // String returns the string representation
@@ -1574,11 +1458,7 @@ type ListSubscriptionsByTopicInput struct {
 	// The ARN of the topic for which you wish to find subscriptions.
 	TopicArn *string `type:"string" required:"true"`
 
-	metadataListSubscriptionsByTopicInput `json:"-" xml:"-"`
-}
-
-type metadataListSubscriptionsByTopicInput struct {
-	SDKShapeTraits bool `type:"structure"`
+	_ struct{} `type:"structure"`
 }
 
 // String returns the string representation
@@ -1600,11 +1480,7 @@ type ListSubscriptionsByTopicOutput struct {
 	// A list of subscriptions.
 	Subscriptions []*Subscription `type:"list"`
 
-	metadataListSubscriptionsByTopicOutput `json:"-" xml:"-"`
-}
-
-type metadataListSubscriptionsByTopicOutput struct {
-	SDKShapeTraits bool `type:"structure"`
+	_ struct{} `type:"structure"`
 }
 
 // String returns the string representation
@@ -1622,11 +1498,7 @@ type ListSubscriptionsInput struct {
 	// Token returned by the previous ListSubscriptions request.
 	NextToken *string `type:"string"`
 
-	metadataListSubscriptionsInput `json:"-" xml:"-"`
-}
-
-type metadataListSubscriptionsInput struct {
-	SDKShapeTraits bool `type:"structure"`
+	_ struct{} `type:"structure"`
 }
 
 // String returns the string representation
@@ -1648,11 +1520,7 @@ type ListSubscriptionsOutput struct {
 	// A list of subscriptions.
 	Subscriptions []*Subscription `type:"list"`
 
-	metadataListSubscriptionsOutput `json:"-" xml:"-"`
-}
-
-type metadataListSubscriptionsOutput struct {
-	SDKShapeTraits bool `type:"structure"`
+	_ struct{} `type:"structure"`
 }
 
 // String returns the string representation
@@ -1669,11 +1537,7 @@ type ListTopicsInput struct {
 	// Token returned by the previous ListTopics request.
 	NextToken *string `type:"string"`
 
-	metadataListTopicsInput `json:"-" xml:"-"`
-}
-
-type metadataListTopicsInput struct {
-	SDKShapeTraits bool `type:"structure"`
+	_ struct{} `type:"structure"`
 }
 
 // String returns the string representation
@@ -1695,11 +1559,7 @@ type ListTopicsOutput struct {
 	// A list of topic ARNs.
 	Topics []*Topic `type:"list"`
 
-	metadataListTopicsOutput `json:"-" xml:"-"`
-}
-
-type metadataListTopicsOutput struct {
-	SDKShapeTraits bool `type:"structure"`
+	_ struct{} `type:"structure"`
 }
 
 // String returns the string representation
@@ -1734,11 +1594,7 @@ type MessageAttributeValue struct {
 	// see http://en.wikipedia.org/wiki/ASCII#ASCII_printable_characters (http://en.wikipedia.org/wiki/ASCII#ASCII_printable_characters).
 	StringValue *string `type:"string"`
 
-	metadataMessageAttributeValue `json:"-" xml:"-"`
-}
-
-type metadataMessageAttributeValue struct {
-	SDKShapeTraits bool `type:"structure"`
+	_ struct{} `type:"structure"`
 }
 
 // String returns the string representation
@@ -1759,11 +1615,7 @@ type PlatformApplication struct {
 	// PlatformApplicationArn for platform application object.
 	PlatformApplicationArn *string `type:"string"`
 
-	metadataPlatformApplication `json:"-" xml:"-"`
-}
-
-type metadataPlatformApplication struct {
-	SDKShapeTraits bool `type:"structure"`
+	_ struct{} `type:"structure"`
 }
 
 // String returns the string representation
@@ -1840,11 +1692,7 @@ type PublishInput struct {
 	// The topic you want to publish to.
 	TopicArn *string `type:"string"`
 
-	metadataPublishInput `json:"-" xml:"-"`
-}
-
-type metadataPublishInput struct {
-	SDKShapeTraits bool `type:"structure"`
+	_ struct{} `type:"structure"`
 }
 
 // String returns the string representation
@@ -1864,11 +1712,7 @@ type PublishOutput struct {
 	// Length Constraint: Maximum 100 characters
 	MessageId *string `type:"string"`
 
-	metadataPublishOutput `json:"-" xml:"-"`
-}
-
-type metadataPublishOutput struct {
-	SDKShapeTraits bool `type:"structure"`
+	_ struct{} `type:"structure"`
 }
 
 // String returns the string representation
@@ -1889,11 +1733,7 @@ type RemovePermissionInput struct {
 	// The ARN of the topic whose access control policy you wish to modify.
 	TopicArn *string `type:"string" required:"true"`
 
-	metadataRemovePermissionInput `json:"-" xml:"-"`
-}
-
-type metadataRemovePermissionInput struct {
-	SDKShapeTraits bool `type:"structure"`
+	_ struct{} `type:"structure"`
 }
 
 // String returns the string representation
@@ -1907,11 +1747,7 @@ func (s RemovePermissionInput) GoString() string {
 }
 
 type RemovePermissionOutput struct {
-	metadataRemovePermissionOutput `json:"-" xml:"-"`
-}
-
-type metadataRemovePermissionOutput struct {
-	SDKShapeTraits bool `type:"structure"`
+	_ struct{} `type:"structure"`
 }
 
 // String returns the string representation
@@ -1942,11 +1778,7 @@ type SetEndpointAttributesInput struct {
 	// EndpointArn used for SetEndpointAttributes action.
 	EndpointArn *string `type:"string" required:"true"`
 
-	metadataSetEndpointAttributesInput `json:"-" xml:"-"`
-}
-
-type metadataSetEndpointAttributesInput struct {
-	SDKShapeTraits bool `type:"structure"`
+	_ struct{} `type:"structure"`
 }
 
 // String returns the string representation
@@ -1960,11 +1792,7 @@ func (s SetEndpointAttributesInput) GoString() string {
 }
 
 type SetEndpointAttributesOutput struct {
-	metadataSetEndpointAttributesOutput `json:"-" xml:"-"`
-}
-
-type metadataSetEndpointAttributesOutput struct {
-	SDKShapeTraits bool `type:"structure"`
+	_ struct{} `type:"structure"`
 }
 
 // String returns the string representation
@@ -1999,11 +1827,7 @@ type SetPlatformApplicationAttributesInput struct {
 	// PlatformApplicationArn for SetPlatformApplicationAttributes action.
 	PlatformApplicationArn *string `type:"string" required:"true"`
 
-	metadataSetPlatformApplicationAttributesInput `json:"-" xml:"-"`
-}
-
-type metadataSetPlatformApplicationAttributesInput struct {
-	SDKShapeTraits bool `type:"structure"`
+	_ struct{} `type:"structure"`
 }
 
 // String returns the string representation
@@ -2017,11 +1841,7 @@ func (s SetPlatformApplicationAttributesInput) GoString() string {
 }
 
 type SetPlatformApplicationAttributesOutput struct {
-	metadataSetPlatformApplicationAttributesOutput `json:"-" xml:"-"`
-}
-
-type metadataSetPlatformApplicationAttributesOutput struct {
-	SDKShapeTraits bool `type:"structure"`
+	_ struct{} `type:"structure"`
 }
 
 // String returns the string representation
@@ -2048,11 +1868,7 @@ type SetSubscriptionAttributesInput struct {
 	// The ARN of the subscription to modify.
 	SubscriptionArn *string `type:"string" required:"true"`
 
-	metadataSetSubscriptionAttributesInput `json:"-" xml:"-"`
-}
-
-type metadataSetSubscriptionAttributesInput struct {
-	SDKShapeTraits bool `type:"structure"`
+	_ struct{} `type:"structure"`
 }
 
 // String returns the string representation
@@ -2066,11 +1882,7 @@ func (s SetSubscriptionAttributesInput) GoString() string {
 }
 
 type SetSubscriptionAttributesOutput struct {
-	metadataSetSubscriptionAttributesOutput `json:"-" xml:"-"`
-}
-
-type metadataSetSubscriptionAttributesOutput struct {
-	SDKShapeTraits bool `type:"structure"`
+	_ struct{} `type:"structure"`
 }
 
 // String returns the string representation
@@ -2097,11 +1909,7 @@ type SetTopicAttributesInput struct {
 	// The ARN of the topic to modify.
 	TopicArn *string `type:"string" required:"true"`
 
-	metadataSetTopicAttributesInput `json:"-" xml:"-"`
-}
-
-type metadataSetTopicAttributesInput struct {
-	SDKShapeTraits bool `type:"structure"`
+	_ struct{} `type:"structure"`
 }
 
 // String returns the string representation
@@ -2115,11 +1923,7 @@ func (s SetTopicAttributesInput) GoString() string {
 }
 
 type SetTopicAttributesOutput struct {
-	metadataSetTopicAttributesOutput `json:"-" xml:"-"`
-}
-
-type metadataSetTopicAttributesOutput struct {
-	SDKShapeTraits bool `type:"structure"`
+	_ struct{} `type:"structure"`
 }
 
 // String returns the string representation
@@ -2158,11 +1962,7 @@ type SubscribeInput struct {
 	// The ARN of the topic you want to subscribe to.
 	TopicArn *string `type:"string" required:"true"`
 
-	metadataSubscribeInput `json:"-" xml:"-"`
-}
-
-type metadataSubscribeInput struct {
-	SDKShapeTraits bool `type:"structure"`
+	_ struct{} `type:"structure"`
 }
 
 // String returns the string representation
@@ -2181,11 +1981,7 @@ type SubscribeOutput struct {
 	// immediately (without requiring endpoint owner confirmation).
 	SubscriptionArn *string `type:"string"`
 
-	metadataSubscribeOutput `json:"-" xml:"-"`
-}
-
-type metadataSubscribeOutput struct {
-	SDKShapeTraits bool `type:"structure"`
+	_ struct{} `type:"structure"`
 }
 
 // String returns the string representation
@@ -2215,11 +2011,7 @@ type Subscription struct {
 	// The ARN of the subscription's topic.
 	TopicArn *string `type:"string"`
 
-	metadataSubscription `json:"-" xml:"-"`
-}
-
-type metadataSubscription struct {
-	SDKShapeTraits bool `type:"structure"`
+	_ struct{} `type:"structure"`
 }
 
 // String returns the string representation
@@ -2238,11 +2030,7 @@ type Topic struct {
 	// The topic's ARN.
 	TopicArn *string `type:"string"`
 
-	metadataTopic `json:"-" xml:"-"`
-}
-
-type metadataTopic struct {
-	SDKShapeTraits bool `type:"structure"`
+	_ struct{} `type:"structure"`
 }
 
 // String returns the string representation
@@ -2260,11 +2048,7 @@ type UnsubscribeInput struct {
 	// The ARN of the subscription to be deleted.
 	SubscriptionArn *string `type:"string" required:"true"`
 
-	metadataUnsubscribeInput `json:"-" xml:"-"`
-}
-
-type metadataUnsubscribeInput struct {
-	SDKShapeTraits bool `type:"structure"`
+	_ struct{} `type:"structure"`
 }
 
 // String returns the string representation
@@ -2278,11 +2062,7 @@ func (s UnsubscribeInput) GoString() string {
 }
 
 type UnsubscribeOutput struct {
-	metadataUnsubscribeOutput `json:"-" xml:"-"`
-}
-
-type metadataUnsubscribeOutput struct {
-	SDKShapeTraits bool `type:"structure"`
+	_ struct{} `type:"structure"`
 }
 
 // String returns the string representation

--- a/service/sqs/api.go
+++ b/service/sqs/api.go
@@ -738,6 +738,8 @@ func (c *SQS) SetQueueAttributes(input *SetQueueAttributesInput) (*SetQueueAttri
 }
 
 type AddPermissionInput struct {
+	_ struct{} `type:"structure"`
+
 	// The AWS account number of the principal (http://docs.aws.amazon.com/general/latest/gr/glos-chap.html#P)
 	// who will be given permission. The principal must have an AWS account, but
 	// does not need to be signed up for Amazon SQS. For information about locating
@@ -763,8 +765,6 @@ type AddPermissionInput struct {
 
 	// The URL of the Amazon SQS queue to take action on.
 	QueueUrl *string `type:"string" required:"true"`
-
-	_ struct{} `type:"structure"`
 }
 
 // String returns the string representation
@@ -794,6 +794,8 @@ func (s AddPermissionOutput) GoString() string {
 // This is used in the responses of batch API to give a detailed description
 // of the result of an action on each entry in the request.
 type BatchResultErrorEntry struct {
+	_ struct{} `type:"structure"`
+
 	// An error code representing why the action failed on this entry.
 	Code *string `type:"string" required:"true"`
 
@@ -805,8 +807,6 @@ type BatchResultErrorEntry struct {
 
 	// Whether the error happened due to the sender's fault.
 	SenderFault *bool `type:"boolean" required:"true"`
-
-	_ struct{} `type:"structure"`
 }
 
 // String returns the string representation
@@ -820,14 +820,14 @@ func (s BatchResultErrorEntry) GoString() string {
 }
 
 type ChangeMessageVisibilityBatchInput struct {
+	_ struct{} `type:"structure"`
+
 	// A list of receipt handles of the messages for which the visibility timeout
 	// must be changed.
 	Entries []*ChangeMessageVisibilityBatchRequestEntry `locationNameList:"ChangeMessageVisibilityBatchRequestEntry" type:"list" flattened:"true" required:"true"`
 
 	// The URL of the Amazon SQS queue to take action on.
 	QueueUrl *string `type:"string" required:"true"`
-
-	_ struct{} `type:"structure"`
 }
 
 // String returns the string representation
@@ -844,13 +844,13 @@ func (s ChangeMessageVisibilityBatchInput) GoString() string {
 // tag if the message succeeds or a BatchResultErrorEntry tag if the message
 // fails.
 type ChangeMessageVisibilityBatchOutput struct {
+	_ struct{} `type:"structure"`
+
 	// A list of BatchResultErrorEntry items.
 	Failed []*BatchResultErrorEntry `locationNameList:"BatchResultErrorEntry" type:"list" flattened:"true" required:"true"`
 
 	// A list of ChangeMessageVisibilityBatchResultEntry items.
 	Successful []*ChangeMessageVisibilityBatchResultEntry `locationNameList:"ChangeMessageVisibilityBatchResultEntry" type:"list" flattened:"true" required:"true"`
-
-	_ struct{} `type:"structure"`
 }
 
 // String returns the string representation
@@ -876,6 +876,8 @@ func (s ChangeMessageVisibilityBatchOutput) GoString() string {
 //
 // &ChangeMessageVisibilityBatchRequestEntry.1.VisibilityTimeout=45
 type ChangeMessageVisibilityBatchRequestEntry struct {
+	_ struct{} `type:"structure"`
+
 	// An identifier for this particular receipt handle. This is used to communicate
 	// the result. Note that the Ids of a batch request need to be unique within
 	// the request.
@@ -886,8 +888,6 @@ type ChangeMessageVisibilityBatchRequestEntry struct {
 
 	// The new value (in seconds) for the message's visibility timeout.
 	VisibilityTimeout *int64 `type:"integer"`
-
-	_ struct{} `type:"structure"`
 }
 
 // String returns the string representation
@@ -902,10 +902,10 @@ func (s ChangeMessageVisibilityBatchRequestEntry) GoString() string {
 
 // Encloses the id of an entry in ChangeMessageVisibilityBatch.
 type ChangeMessageVisibilityBatchResultEntry struct {
+	_ struct{} `type:"structure"`
+
 	// Represents a message whose visibility timeout has been changed successfully.
 	Id *string `type:"string" required:"true"`
-
-	_ struct{} `type:"structure"`
 }
 
 // String returns the string representation
@@ -919,6 +919,8 @@ func (s ChangeMessageVisibilityBatchResultEntry) GoString() string {
 }
 
 type ChangeMessageVisibilityInput struct {
+	_ struct{} `type:"structure"`
+
 	// The URL of the Amazon SQS queue to take action on.
 	QueueUrl *string `type:"string" required:"true"`
 
@@ -929,8 +931,6 @@ type ChangeMessageVisibilityInput struct {
 	// The new value (in seconds - from 0 to 43200 - maximum 12 hours) for the message's
 	// visibility timeout.
 	VisibilityTimeout *int64 `type:"integer" required:"true"`
-
-	_ struct{} `type:"structure"`
 }
 
 // String returns the string representation
@@ -958,6 +958,8 @@ func (s ChangeMessageVisibilityOutput) GoString() string {
 }
 
 type CreateQueueInput struct {
+	_ struct{} `type:"structure"`
+
 	// A map of attributes with their corresponding values.
 	//
 	// The following lists the names, descriptions, and values of the special request
@@ -984,8 +986,6 @@ type CreateQueueInput struct {
 
 	// The name for the queue to be created.
 	QueueName *string `type:"string" required:"true"`
-
-	_ struct{} `type:"structure"`
 }
 
 // String returns the string representation
@@ -1000,10 +1000,10 @@ func (s CreateQueueInput) GoString() string {
 
 // Returns the QueueUrl element of the created queue.
 type CreateQueueOutput struct {
+	_ struct{} `type:"structure"`
+
 	// The URL for the created Amazon SQS queue.
 	QueueUrl *string `type:"string"`
-
-	_ struct{} `type:"structure"`
 }
 
 // String returns the string representation
@@ -1017,13 +1017,13 @@ func (s CreateQueueOutput) GoString() string {
 }
 
 type DeleteMessageBatchInput struct {
+	_ struct{} `type:"structure"`
+
 	// A list of receipt handles for the messages to be deleted.
 	Entries []*DeleteMessageBatchRequestEntry `locationNameList:"DeleteMessageBatchRequestEntry" type:"list" flattened:"true" required:"true"`
 
 	// The URL of the Amazon SQS queue to take action on.
 	QueueUrl *string `type:"string" required:"true"`
-
-	_ struct{} `type:"structure"`
 }
 
 // String returns the string representation
@@ -1040,13 +1040,13 @@ func (s DeleteMessageBatchInput) GoString() string {
 // tag if the message is deleted or a BatchResultErrorEntry tag if the message
 // cannot be deleted.
 type DeleteMessageBatchOutput struct {
+	_ struct{} `type:"structure"`
+
 	// A list of BatchResultErrorEntry items.
 	Failed []*BatchResultErrorEntry `locationNameList:"BatchResultErrorEntry" type:"list" flattened:"true" required:"true"`
 
 	// A list of DeleteMessageBatchResultEntry items.
 	Successful []*DeleteMessageBatchResultEntry `locationNameList:"DeleteMessageBatchResultEntry" type:"list" flattened:"true" required:"true"`
-
-	_ struct{} `type:"structure"`
 }
 
 // String returns the string representation
@@ -1061,6 +1061,8 @@ func (s DeleteMessageBatchOutput) GoString() string {
 
 // Encloses a receipt handle and an identifier for it.
 type DeleteMessageBatchRequestEntry struct {
+	_ struct{} `type:"structure"`
+
 	// An identifier for this particular receipt handle. This is used to communicate
 	// the result. Note that the Ids of a batch request need to be unique within
 	// the request.
@@ -1068,8 +1070,6 @@ type DeleteMessageBatchRequestEntry struct {
 
 	// A receipt handle.
 	ReceiptHandle *string `type:"string" required:"true"`
-
-	_ struct{} `type:"structure"`
 }
 
 // String returns the string representation
@@ -1084,10 +1084,10 @@ func (s DeleteMessageBatchRequestEntry) GoString() string {
 
 // Encloses the id an entry in DeleteMessageBatch.
 type DeleteMessageBatchResultEntry struct {
+	_ struct{} `type:"structure"`
+
 	// Represents a successfully deleted message.
 	Id *string `type:"string" required:"true"`
-
-	_ struct{} `type:"structure"`
 }
 
 // String returns the string representation
@@ -1101,13 +1101,13 @@ func (s DeleteMessageBatchResultEntry) GoString() string {
 }
 
 type DeleteMessageInput struct {
+	_ struct{} `type:"structure"`
+
 	// The URL of the Amazon SQS queue to take action on.
 	QueueUrl *string `type:"string" required:"true"`
 
 	// The receipt handle associated with the message to delete.
 	ReceiptHandle *string `type:"string" required:"true"`
-
-	_ struct{} `type:"structure"`
 }
 
 // String returns the string representation
@@ -1135,10 +1135,10 @@ func (s DeleteMessageOutput) GoString() string {
 }
 
 type DeleteQueueInput struct {
+	_ struct{} `type:"structure"`
+
 	// The URL of the Amazon SQS queue to take action on.
 	QueueUrl *string `type:"string" required:"true"`
-
-	_ struct{} `type:"structure"`
 }
 
 // String returns the string representation
@@ -1166,13 +1166,13 @@ func (s DeleteQueueOutput) GoString() string {
 }
 
 type GetQueueAttributesInput struct {
+	_ struct{} `type:"structure"`
+
 	// A list of attributes to retrieve information for.
 	AttributeNames []*string `locationNameList:"AttributeName" type:"list" flattened:"true"`
 
 	// The URL of the Amazon SQS queue to take action on.
 	QueueUrl *string `type:"string" required:"true"`
-
-	_ struct{} `type:"structure"`
 }
 
 // String returns the string representation
@@ -1187,10 +1187,10 @@ func (s GetQueueAttributesInput) GoString() string {
 
 // A list of returned queue attributes.
 type GetQueueAttributesOutput struct {
+	_ struct{} `type:"structure"`
+
 	// A map of attributes to the respective values.
 	Attributes map[string]*string `locationName:"Attribute" locationNameKey:"Name" locationNameValue:"Value" type:"map" flattened:"true"`
-
-	_ struct{} `type:"structure"`
 }
 
 // String returns the string representation
@@ -1204,14 +1204,14 @@ func (s GetQueueAttributesOutput) GoString() string {
 }
 
 type GetQueueUrlInput struct {
+	_ struct{} `type:"structure"`
+
 	// The name of the queue whose URL must be fetched. Maximum 80 characters; alphanumeric
 	// characters, hyphens (-), and underscores (_) are allowed.
 	QueueName *string `type:"string" required:"true"`
 
 	// The AWS account ID of the account that created the queue.
 	QueueOwnerAWSAccountId *string `type:"string"`
-
-	_ struct{} `type:"structure"`
 }
 
 // String returns the string representation
@@ -1227,10 +1227,10 @@ func (s GetQueueUrlInput) GoString() string {
 // For more information, see Responses (http://docs.aws.amazon.com/AWSSimpleQueueService/latest/SQSDeveloperGuide/UnderstandingResponses.html)
 // in the Amazon SQS Developer Guide.
 type GetQueueUrlOutput struct {
+	_ struct{} `type:"structure"`
+
 	// The URL for the queue.
 	QueueUrl *string `type:"string"`
-
-	_ struct{} `type:"structure"`
 }
 
 // String returns the string representation
@@ -1244,10 +1244,10 @@ func (s GetQueueUrlOutput) GoString() string {
 }
 
 type ListDeadLetterSourceQueuesInput struct {
+	_ struct{} `type:"structure"`
+
 	// The queue URL of a dead letter queue.
 	QueueUrl *string `type:"string" required:"true"`
-
-	_ struct{} `type:"structure"`
 }
 
 // String returns the string representation
@@ -1262,11 +1262,11 @@ func (s ListDeadLetterSourceQueuesInput) GoString() string {
 
 // A list of your dead letter source queues.
 type ListDeadLetterSourceQueuesOutput struct {
+	_ struct{} `type:"structure"`
+
 	// A list of source queue URLs that have the RedrivePolicy queue attribute configured
 	// with a dead letter queue.
 	QueueUrls []*string `locationName:"queueUrls" locationNameList:"QueueUrl" type:"list" flattened:"true" required:"true"`
-
-	_ struct{} `type:"structure"`
 }
 
 // String returns the string representation
@@ -1280,11 +1280,11 @@ func (s ListDeadLetterSourceQueuesOutput) GoString() string {
 }
 
 type ListQueuesInput struct {
+	_ struct{} `type:"structure"`
+
 	// A string to use for filtering the list results. Only those queues whose name
 	// begins with the specified string are returned.
 	QueueNamePrefix *string `type:"string"`
-
-	_ struct{} `type:"structure"`
 }
 
 // String returns the string representation
@@ -1299,10 +1299,10 @@ func (s ListQueuesInput) GoString() string {
 
 // A list of your queues.
 type ListQueuesOutput struct {
+	_ struct{} `type:"structure"`
+
 	// A list of queue URLs, up to 1000 entries.
 	QueueUrls []*string `locationNameList:"QueueUrl" type:"list" flattened:"true"`
-
-	_ struct{} `type:"structure"`
 }
 
 // String returns the string representation
@@ -1317,6 +1317,8 @@ func (s ListQueuesOutput) GoString() string {
 
 // An Amazon SQS message.
 type Message struct {
+	_ struct{} `type:"structure"`
+
 	// SenderId, SentTimestamp, ApproximateReceiveCount, and/or ApproximateFirstReceiveTimestamp.
 	// SentTimestamp and ApproximateFirstReceiveTimestamp are each returned as an
 	// integer representing the epoch time (http://en.wikipedia.org/wiki/Unix_time)
@@ -1347,8 +1349,6 @@ type Message struct {
 	// handle is returned every time you receive a message. When deleting a message,
 	// you provide the last received receipt handle to delete the message.
 	ReceiptHandle *string `type:"string"`
-
-	_ struct{} `type:"structure"`
 }
 
 // String returns the string representation
@@ -1370,6 +1370,8 @@ func (s Message) GoString() string {
 // name, type, and value, are included in the message size restriction, which
 // is currently 256 KB (262,144 bytes).
 type MessageAttributeValue struct {
+	_ struct{} `type:"structure"`
+
 	// Not implemented. Reserved for future use.
 	BinaryListValues [][]byte `locationName:"BinaryListValue" locationNameList:"BinaryListValue" type:"list" flattened:"true"`
 
@@ -1388,8 +1390,6 @@ type MessageAttributeValue struct {
 	// Strings are Unicode with UTF8 binary encoding. For a list of code values,
 	// see http://en.wikipedia.org/wiki/ASCII#ASCII_printable_characters (http://en.wikipedia.org/wiki/ASCII#ASCII_printable_characters).
 	StringValue *string `type:"string"`
-
-	_ struct{} `type:"structure"`
 }
 
 // String returns the string representation
@@ -1403,11 +1403,11 @@ func (s MessageAttributeValue) GoString() string {
 }
 
 type PurgeQueueInput struct {
+	_ struct{} `type:"structure"`
+
 	// The queue URL of the queue to delete the messages from when using the PurgeQueue
 	// API.
 	QueueUrl *string `type:"string" required:"true"`
-
-	_ struct{} `type:"structure"`
 }
 
 // String returns the string representation
@@ -1435,6 +1435,8 @@ func (s PurgeQueueOutput) GoString() string {
 }
 
 type ReceiveMessageInput struct {
+	_ struct{} `type:"structure"`
+
 	// A list of attributes that need to be returned along with each message.
 	//
 	//  The following lists the names and descriptions of the attributes that can
@@ -1482,8 +1484,6 @@ type ReceiveMessageInput struct {
 	// in the queue before returning. If a message is available, the call will return
 	// sooner than WaitTimeSeconds.
 	WaitTimeSeconds *int64 `type:"integer"`
-
-	_ struct{} `type:"structure"`
 }
 
 // String returns the string representation
@@ -1498,10 +1498,10 @@ func (s ReceiveMessageInput) GoString() string {
 
 // A list of received messages.
 type ReceiveMessageOutput struct {
+	_ struct{} `type:"structure"`
+
 	// A list of messages.
 	Messages []*Message `locationNameList:"Message" type:"list" flattened:"true"`
-
-	_ struct{} `type:"structure"`
 }
 
 // String returns the string representation
@@ -1515,14 +1515,14 @@ func (s ReceiveMessageOutput) GoString() string {
 }
 
 type RemovePermissionInput struct {
+	_ struct{} `type:"structure"`
+
 	// The identification of the permission to remove. This is the label added with
 	// the AddPermission action.
 	Label *string `type:"string" required:"true"`
 
 	// The URL of the Amazon SQS queue to take action on.
 	QueueUrl *string `type:"string" required:"true"`
-
-	_ struct{} `type:"structure"`
 }
 
 // String returns the string representation
@@ -1550,13 +1550,13 @@ func (s RemovePermissionOutput) GoString() string {
 }
 
 type SendMessageBatchInput struct {
+	_ struct{} `type:"structure"`
+
 	// A list of SendMessageBatchRequestEntry items.
 	Entries []*SendMessageBatchRequestEntry `locationNameList:"SendMessageBatchRequestEntry" type:"list" flattened:"true" required:"true"`
 
 	// The URL of the Amazon SQS queue to take action on.
 	QueueUrl *string `type:"string" required:"true"`
-
-	_ struct{} `type:"structure"`
 }
 
 // String returns the string representation
@@ -1573,14 +1573,14 @@ func (s SendMessageBatchInput) GoString() string {
 // tag if the message succeeds or a BatchResultErrorEntry tag if the message
 // fails.
 type SendMessageBatchOutput struct {
+	_ struct{} `type:"structure"`
+
 	// A list of BatchResultErrorEntry items with the error detail about each message
 	// that could not be enqueued.
 	Failed []*BatchResultErrorEntry `locationNameList:"BatchResultErrorEntry" type:"list" flattened:"true" required:"true"`
 
 	// A list of SendMessageBatchResultEntry items.
 	Successful []*SendMessageBatchResultEntry `locationNameList:"SendMessageBatchResultEntry" type:"list" flattened:"true" required:"true"`
-
-	_ struct{} `type:"structure"`
 }
 
 // String returns the string representation
@@ -1595,6 +1595,8 @@ func (s SendMessageBatchOutput) GoString() string {
 
 // Contains the details of a single Amazon SQS message along with a Id.
 type SendMessageBatchRequestEntry struct {
+	_ struct{} `type:"structure"`
+
 	// The number of seconds for which the message has to be delayed.
 	DelaySeconds *int64 `type:"integer"`
 
@@ -1609,8 +1611,6 @@ type SendMessageBatchRequestEntry struct {
 
 	// Body of the message.
 	MessageBody *string `type:"string" required:"true"`
-
-	_ struct{} `type:"structure"`
 }
 
 // String returns the string representation
@@ -1625,6 +1625,8 @@ func (s SendMessageBatchRequestEntry) GoString() string {
 
 // Encloses a message ID for successfully enqueued message of a SendMessageBatch.
 type SendMessageBatchResultEntry struct {
+	_ struct{} `type:"structure"`
+
 	// An identifier for the message in this batch.
 	Id *string `type:"string" required:"true"`
 
@@ -1642,8 +1644,6 @@ type SendMessageBatchResultEntry struct {
 
 	// An identifier for the message.
 	MessageId *string `type:"string" required:"true"`
-
-	_ struct{} `type:"structure"`
 }
 
 // String returns the string representation
@@ -1657,6 +1657,8 @@ func (s SendMessageBatchResultEntry) GoString() string {
 }
 
 type SendMessageInput struct {
+	_ struct{} `type:"structure"`
+
 	// The number of seconds (0 to 900 - 15 minutes) to delay a specific message.
 	// Messages with a positive DelaySeconds value become available for processing
 	// after the delay time is finished. If you don't specify a value, the default
@@ -1673,8 +1675,6 @@ type SendMessageInput struct {
 
 	// The URL of the Amazon SQS queue to take action on.
 	QueueUrl *string `type:"string" required:"true"`
-
-	_ struct{} `type:"structure"`
 }
 
 // String returns the string representation
@@ -1689,6 +1689,8 @@ func (s SendMessageInput) GoString() string {
 
 // The MD5OfMessageBody and MessageId elements.
 type SendMessageOutput struct {
+	_ struct{} `type:"structure"`
+
 	// An MD5 digest of the non-URL-encoded message attribute string. This can be
 	// used to verify that Amazon SQS received the message correctly. Amazon SQS
 	// first URL decodes the message before creating the MD5 digest. For information
@@ -1705,8 +1707,6 @@ type SendMessageOutput struct {
 	// more information, see Queue and Message Identifiers (http://docs.aws.amazon.com/AWSSimpleQueueService/latest/SQSDeveloperGuide/ImportantIdentifiers.html)
 	// in the Amazon SQS Developer Guide.
 	MessageId *string `type:"string"`
-
-	_ struct{} `type:"structure"`
 }
 
 // String returns the string representation
@@ -1720,6 +1720,8 @@ func (s SendMessageOutput) GoString() string {
 }
 
 type SetQueueAttributesInput struct {
+	_ struct{} `type:"structure"`
+
 	// A map of attributes to set.
 	//
 	// The following lists the names, descriptions, and values of the special request
@@ -1748,8 +1750,6 @@ type SetQueueAttributesInput struct {
 
 	// The URL of the Amazon SQS queue to take action on.
 	QueueUrl *string `type:"string" required:"true"`
-
-	_ struct{} `type:"structure"`
 }
 
 // String returns the string representation

--- a/service/sqs/api.go
+++ b/service/sqs/api.go
@@ -764,11 +764,7 @@ type AddPermissionInput struct {
 	// The URL of the Amazon SQS queue to take action on.
 	QueueUrl *string `type:"string" required:"true"`
 
-	metadataAddPermissionInput `json:"-" xml:"-"`
-}
-
-type metadataAddPermissionInput struct {
-	SDKShapeTraits bool `type:"structure"`
+	_ struct{} `type:"structure"`
 }
 
 // String returns the string representation
@@ -782,11 +778,7 @@ func (s AddPermissionInput) GoString() string {
 }
 
 type AddPermissionOutput struct {
-	metadataAddPermissionOutput `json:"-" xml:"-"`
-}
-
-type metadataAddPermissionOutput struct {
-	SDKShapeTraits bool `type:"structure"`
+	_ struct{} `type:"structure"`
 }
 
 // String returns the string representation
@@ -814,11 +806,7 @@ type BatchResultErrorEntry struct {
 	// Whether the error happened due to the sender's fault.
 	SenderFault *bool `type:"boolean" required:"true"`
 
-	metadataBatchResultErrorEntry `json:"-" xml:"-"`
-}
-
-type metadataBatchResultErrorEntry struct {
-	SDKShapeTraits bool `type:"structure"`
+	_ struct{} `type:"structure"`
 }
 
 // String returns the string representation
@@ -839,11 +827,7 @@ type ChangeMessageVisibilityBatchInput struct {
 	// The URL of the Amazon SQS queue to take action on.
 	QueueUrl *string `type:"string" required:"true"`
 
-	metadataChangeMessageVisibilityBatchInput `json:"-" xml:"-"`
-}
-
-type metadataChangeMessageVisibilityBatchInput struct {
-	SDKShapeTraits bool `type:"structure"`
+	_ struct{} `type:"structure"`
 }
 
 // String returns the string representation
@@ -866,11 +850,7 @@ type ChangeMessageVisibilityBatchOutput struct {
 	// A list of ChangeMessageVisibilityBatchResultEntry items.
 	Successful []*ChangeMessageVisibilityBatchResultEntry `locationNameList:"ChangeMessageVisibilityBatchResultEntry" type:"list" flattened:"true" required:"true"`
 
-	metadataChangeMessageVisibilityBatchOutput `json:"-" xml:"-"`
-}
-
-type metadataChangeMessageVisibilityBatchOutput struct {
-	SDKShapeTraits bool `type:"structure"`
+	_ struct{} `type:"structure"`
 }
 
 // String returns the string representation
@@ -907,11 +887,7 @@ type ChangeMessageVisibilityBatchRequestEntry struct {
 	// The new value (in seconds) for the message's visibility timeout.
 	VisibilityTimeout *int64 `type:"integer"`
 
-	metadataChangeMessageVisibilityBatchRequestEntry `json:"-" xml:"-"`
-}
-
-type metadataChangeMessageVisibilityBatchRequestEntry struct {
-	SDKShapeTraits bool `type:"structure"`
+	_ struct{} `type:"structure"`
 }
 
 // String returns the string representation
@@ -929,11 +905,7 @@ type ChangeMessageVisibilityBatchResultEntry struct {
 	// Represents a message whose visibility timeout has been changed successfully.
 	Id *string `type:"string" required:"true"`
 
-	metadataChangeMessageVisibilityBatchResultEntry `json:"-" xml:"-"`
-}
-
-type metadataChangeMessageVisibilityBatchResultEntry struct {
-	SDKShapeTraits bool `type:"structure"`
+	_ struct{} `type:"structure"`
 }
 
 // String returns the string representation
@@ -958,11 +930,7 @@ type ChangeMessageVisibilityInput struct {
 	// visibility timeout.
 	VisibilityTimeout *int64 `type:"integer" required:"true"`
 
-	metadataChangeMessageVisibilityInput `json:"-" xml:"-"`
-}
-
-type metadataChangeMessageVisibilityInput struct {
-	SDKShapeTraits bool `type:"structure"`
+	_ struct{} `type:"structure"`
 }
 
 // String returns the string representation
@@ -976,11 +944,7 @@ func (s ChangeMessageVisibilityInput) GoString() string {
 }
 
 type ChangeMessageVisibilityOutput struct {
-	metadataChangeMessageVisibilityOutput `json:"-" xml:"-"`
-}
-
-type metadataChangeMessageVisibilityOutput struct {
-	SDKShapeTraits bool `type:"structure"`
+	_ struct{} `type:"structure"`
 }
 
 // String returns the string representation
@@ -1021,11 +985,7 @@ type CreateQueueInput struct {
 	// The name for the queue to be created.
 	QueueName *string `type:"string" required:"true"`
 
-	metadataCreateQueueInput `json:"-" xml:"-"`
-}
-
-type metadataCreateQueueInput struct {
-	SDKShapeTraits bool `type:"structure"`
+	_ struct{} `type:"structure"`
 }
 
 // String returns the string representation
@@ -1043,11 +1003,7 @@ type CreateQueueOutput struct {
 	// The URL for the created Amazon SQS queue.
 	QueueUrl *string `type:"string"`
 
-	metadataCreateQueueOutput `json:"-" xml:"-"`
-}
-
-type metadataCreateQueueOutput struct {
-	SDKShapeTraits bool `type:"structure"`
+	_ struct{} `type:"structure"`
 }
 
 // String returns the string representation
@@ -1067,11 +1023,7 @@ type DeleteMessageBatchInput struct {
 	// The URL of the Amazon SQS queue to take action on.
 	QueueUrl *string `type:"string" required:"true"`
 
-	metadataDeleteMessageBatchInput `json:"-" xml:"-"`
-}
-
-type metadataDeleteMessageBatchInput struct {
-	SDKShapeTraits bool `type:"structure"`
+	_ struct{} `type:"structure"`
 }
 
 // String returns the string representation
@@ -1094,11 +1046,7 @@ type DeleteMessageBatchOutput struct {
 	// A list of DeleteMessageBatchResultEntry items.
 	Successful []*DeleteMessageBatchResultEntry `locationNameList:"DeleteMessageBatchResultEntry" type:"list" flattened:"true" required:"true"`
 
-	metadataDeleteMessageBatchOutput `json:"-" xml:"-"`
-}
-
-type metadataDeleteMessageBatchOutput struct {
-	SDKShapeTraits bool `type:"structure"`
+	_ struct{} `type:"structure"`
 }
 
 // String returns the string representation
@@ -1121,11 +1069,7 @@ type DeleteMessageBatchRequestEntry struct {
 	// A receipt handle.
 	ReceiptHandle *string `type:"string" required:"true"`
 
-	metadataDeleteMessageBatchRequestEntry `json:"-" xml:"-"`
-}
-
-type metadataDeleteMessageBatchRequestEntry struct {
-	SDKShapeTraits bool `type:"structure"`
+	_ struct{} `type:"structure"`
 }
 
 // String returns the string representation
@@ -1143,11 +1087,7 @@ type DeleteMessageBatchResultEntry struct {
 	// Represents a successfully deleted message.
 	Id *string `type:"string" required:"true"`
 
-	metadataDeleteMessageBatchResultEntry `json:"-" xml:"-"`
-}
-
-type metadataDeleteMessageBatchResultEntry struct {
-	SDKShapeTraits bool `type:"structure"`
+	_ struct{} `type:"structure"`
 }
 
 // String returns the string representation
@@ -1167,11 +1107,7 @@ type DeleteMessageInput struct {
 	// The receipt handle associated with the message to delete.
 	ReceiptHandle *string `type:"string" required:"true"`
 
-	metadataDeleteMessageInput `json:"-" xml:"-"`
-}
-
-type metadataDeleteMessageInput struct {
-	SDKShapeTraits bool `type:"structure"`
+	_ struct{} `type:"structure"`
 }
 
 // String returns the string representation
@@ -1185,11 +1121,7 @@ func (s DeleteMessageInput) GoString() string {
 }
 
 type DeleteMessageOutput struct {
-	metadataDeleteMessageOutput `json:"-" xml:"-"`
-}
-
-type metadataDeleteMessageOutput struct {
-	SDKShapeTraits bool `type:"structure"`
+	_ struct{} `type:"structure"`
 }
 
 // String returns the string representation
@@ -1206,11 +1138,7 @@ type DeleteQueueInput struct {
 	// The URL of the Amazon SQS queue to take action on.
 	QueueUrl *string `type:"string" required:"true"`
 
-	metadataDeleteQueueInput `json:"-" xml:"-"`
-}
-
-type metadataDeleteQueueInput struct {
-	SDKShapeTraits bool `type:"structure"`
+	_ struct{} `type:"structure"`
 }
 
 // String returns the string representation
@@ -1224,11 +1152,7 @@ func (s DeleteQueueInput) GoString() string {
 }
 
 type DeleteQueueOutput struct {
-	metadataDeleteQueueOutput `json:"-" xml:"-"`
-}
-
-type metadataDeleteQueueOutput struct {
-	SDKShapeTraits bool `type:"structure"`
+	_ struct{} `type:"structure"`
 }
 
 // String returns the string representation
@@ -1248,11 +1172,7 @@ type GetQueueAttributesInput struct {
 	// The URL of the Amazon SQS queue to take action on.
 	QueueUrl *string `type:"string" required:"true"`
 
-	metadataGetQueueAttributesInput `json:"-" xml:"-"`
-}
-
-type metadataGetQueueAttributesInput struct {
-	SDKShapeTraits bool `type:"structure"`
+	_ struct{} `type:"structure"`
 }
 
 // String returns the string representation
@@ -1270,11 +1190,7 @@ type GetQueueAttributesOutput struct {
 	// A map of attributes to the respective values.
 	Attributes map[string]*string `locationName:"Attribute" locationNameKey:"Name" locationNameValue:"Value" type:"map" flattened:"true"`
 
-	metadataGetQueueAttributesOutput `json:"-" xml:"-"`
-}
-
-type metadataGetQueueAttributesOutput struct {
-	SDKShapeTraits bool `type:"structure"`
+	_ struct{} `type:"structure"`
 }
 
 // String returns the string representation
@@ -1295,11 +1211,7 @@ type GetQueueUrlInput struct {
 	// The AWS account ID of the account that created the queue.
 	QueueOwnerAWSAccountId *string `type:"string"`
 
-	metadataGetQueueUrlInput `json:"-" xml:"-"`
-}
-
-type metadataGetQueueUrlInput struct {
-	SDKShapeTraits bool `type:"structure"`
+	_ struct{} `type:"structure"`
 }
 
 // String returns the string representation
@@ -1318,11 +1230,7 @@ type GetQueueUrlOutput struct {
 	// The URL for the queue.
 	QueueUrl *string `type:"string"`
 
-	metadataGetQueueUrlOutput `json:"-" xml:"-"`
-}
-
-type metadataGetQueueUrlOutput struct {
-	SDKShapeTraits bool `type:"structure"`
+	_ struct{} `type:"structure"`
 }
 
 // String returns the string representation
@@ -1339,11 +1247,7 @@ type ListDeadLetterSourceQueuesInput struct {
 	// The queue URL of a dead letter queue.
 	QueueUrl *string `type:"string" required:"true"`
 
-	metadataListDeadLetterSourceQueuesInput `json:"-" xml:"-"`
-}
-
-type metadataListDeadLetterSourceQueuesInput struct {
-	SDKShapeTraits bool `type:"structure"`
+	_ struct{} `type:"structure"`
 }
 
 // String returns the string representation
@@ -1362,11 +1266,7 @@ type ListDeadLetterSourceQueuesOutput struct {
 	// with a dead letter queue.
 	QueueUrls []*string `locationName:"queueUrls" locationNameList:"QueueUrl" type:"list" flattened:"true" required:"true"`
 
-	metadataListDeadLetterSourceQueuesOutput `json:"-" xml:"-"`
-}
-
-type metadataListDeadLetterSourceQueuesOutput struct {
-	SDKShapeTraits bool `type:"structure"`
+	_ struct{} `type:"structure"`
 }
 
 // String returns the string representation
@@ -1384,11 +1284,7 @@ type ListQueuesInput struct {
 	// begins with the specified string are returned.
 	QueueNamePrefix *string `type:"string"`
 
-	metadataListQueuesInput `json:"-" xml:"-"`
-}
-
-type metadataListQueuesInput struct {
-	SDKShapeTraits bool `type:"structure"`
+	_ struct{} `type:"structure"`
 }
 
 // String returns the string representation
@@ -1406,11 +1302,7 @@ type ListQueuesOutput struct {
 	// A list of queue URLs, up to 1000 entries.
 	QueueUrls []*string `locationNameList:"QueueUrl" type:"list" flattened:"true"`
 
-	metadataListQueuesOutput `json:"-" xml:"-"`
-}
-
-type metadataListQueuesOutput struct {
-	SDKShapeTraits bool `type:"structure"`
+	_ struct{} `type:"structure"`
 }
 
 // String returns the string representation
@@ -1456,11 +1348,7 @@ type Message struct {
 	// you provide the last received receipt handle to delete the message.
 	ReceiptHandle *string `type:"string"`
 
-	metadataMessage `json:"-" xml:"-"`
-}
-
-type metadataMessage struct {
-	SDKShapeTraits bool `type:"structure"`
+	_ struct{} `type:"structure"`
 }
 
 // String returns the string representation
@@ -1501,11 +1389,7 @@ type MessageAttributeValue struct {
 	// see http://en.wikipedia.org/wiki/ASCII#ASCII_printable_characters (http://en.wikipedia.org/wiki/ASCII#ASCII_printable_characters).
 	StringValue *string `type:"string"`
 
-	metadataMessageAttributeValue `json:"-" xml:"-"`
-}
-
-type metadataMessageAttributeValue struct {
-	SDKShapeTraits bool `type:"structure"`
+	_ struct{} `type:"structure"`
 }
 
 // String returns the string representation
@@ -1523,11 +1407,7 @@ type PurgeQueueInput struct {
 	// API.
 	QueueUrl *string `type:"string" required:"true"`
 
-	metadataPurgeQueueInput `json:"-" xml:"-"`
-}
-
-type metadataPurgeQueueInput struct {
-	SDKShapeTraits bool `type:"structure"`
+	_ struct{} `type:"structure"`
 }
 
 // String returns the string representation
@@ -1541,11 +1421,7 @@ func (s PurgeQueueInput) GoString() string {
 }
 
 type PurgeQueueOutput struct {
-	metadataPurgeQueueOutput `json:"-" xml:"-"`
-}
-
-type metadataPurgeQueueOutput struct {
-	SDKShapeTraits bool `type:"structure"`
+	_ struct{} `type:"structure"`
 }
 
 // String returns the string representation
@@ -1607,11 +1483,7 @@ type ReceiveMessageInput struct {
 	// sooner than WaitTimeSeconds.
 	WaitTimeSeconds *int64 `type:"integer"`
 
-	metadataReceiveMessageInput `json:"-" xml:"-"`
-}
-
-type metadataReceiveMessageInput struct {
-	SDKShapeTraits bool `type:"structure"`
+	_ struct{} `type:"structure"`
 }
 
 // String returns the string representation
@@ -1629,11 +1501,7 @@ type ReceiveMessageOutput struct {
 	// A list of messages.
 	Messages []*Message `locationNameList:"Message" type:"list" flattened:"true"`
 
-	metadataReceiveMessageOutput `json:"-" xml:"-"`
-}
-
-type metadataReceiveMessageOutput struct {
-	SDKShapeTraits bool `type:"structure"`
+	_ struct{} `type:"structure"`
 }
 
 // String returns the string representation
@@ -1654,11 +1522,7 @@ type RemovePermissionInput struct {
 	// The URL of the Amazon SQS queue to take action on.
 	QueueUrl *string `type:"string" required:"true"`
 
-	metadataRemovePermissionInput `json:"-" xml:"-"`
-}
-
-type metadataRemovePermissionInput struct {
-	SDKShapeTraits bool `type:"structure"`
+	_ struct{} `type:"structure"`
 }
 
 // String returns the string representation
@@ -1672,11 +1536,7 @@ func (s RemovePermissionInput) GoString() string {
 }
 
 type RemovePermissionOutput struct {
-	metadataRemovePermissionOutput `json:"-" xml:"-"`
-}
-
-type metadataRemovePermissionOutput struct {
-	SDKShapeTraits bool `type:"structure"`
+	_ struct{} `type:"structure"`
 }
 
 // String returns the string representation
@@ -1696,11 +1556,7 @@ type SendMessageBatchInput struct {
 	// The URL of the Amazon SQS queue to take action on.
 	QueueUrl *string `type:"string" required:"true"`
 
-	metadataSendMessageBatchInput `json:"-" xml:"-"`
-}
-
-type metadataSendMessageBatchInput struct {
-	SDKShapeTraits bool `type:"structure"`
+	_ struct{} `type:"structure"`
 }
 
 // String returns the string representation
@@ -1724,11 +1580,7 @@ type SendMessageBatchOutput struct {
 	// A list of SendMessageBatchResultEntry items.
 	Successful []*SendMessageBatchResultEntry `locationNameList:"SendMessageBatchResultEntry" type:"list" flattened:"true" required:"true"`
 
-	metadataSendMessageBatchOutput `json:"-" xml:"-"`
-}
-
-type metadataSendMessageBatchOutput struct {
-	SDKShapeTraits bool `type:"structure"`
+	_ struct{} `type:"structure"`
 }
 
 // String returns the string representation
@@ -1758,11 +1610,7 @@ type SendMessageBatchRequestEntry struct {
 	// Body of the message.
 	MessageBody *string `type:"string" required:"true"`
 
-	metadataSendMessageBatchRequestEntry `json:"-" xml:"-"`
-}
-
-type metadataSendMessageBatchRequestEntry struct {
-	SDKShapeTraits bool `type:"structure"`
+	_ struct{} `type:"structure"`
 }
 
 // String returns the string representation
@@ -1795,11 +1643,7 @@ type SendMessageBatchResultEntry struct {
 	// An identifier for the message.
 	MessageId *string `type:"string" required:"true"`
 
-	metadataSendMessageBatchResultEntry `json:"-" xml:"-"`
-}
-
-type metadataSendMessageBatchResultEntry struct {
-	SDKShapeTraits bool `type:"structure"`
+	_ struct{} `type:"structure"`
 }
 
 // String returns the string representation
@@ -1830,11 +1674,7 @@ type SendMessageInput struct {
 	// The URL of the Amazon SQS queue to take action on.
 	QueueUrl *string `type:"string" required:"true"`
 
-	metadataSendMessageInput `json:"-" xml:"-"`
-}
-
-type metadataSendMessageInput struct {
-	SDKShapeTraits bool `type:"structure"`
+	_ struct{} `type:"structure"`
 }
 
 // String returns the string representation
@@ -1866,11 +1706,7 @@ type SendMessageOutput struct {
 	// in the Amazon SQS Developer Guide.
 	MessageId *string `type:"string"`
 
-	metadataSendMessageOutput `json:"-" xml:"-"`
-}
-
-type metadataSendMessageOutput struct {
-	SDKShapeTraits bool `type:"structure"`
+	_ struct{} `type:"structure"`
 }
 
 // String returns the string representation
@@ -1913,11 +1749,7 @@ type SetQueueAttributesInput struct {
 	// The URL of the Amazon SQS queue to take action on.
 	QueueUrl *string `type:"string" required:"true"`
 
-	metadataSetQueueAttributesInput `json:"-" xml:"-"`
-}
-
-type metadataSetQueueAttributesInput struct {
-	SDKShapeTraits bool `type:"structure"`
+	_ struct{} `type:"structure"`
 }
 
 // String returns the string representation
@@ -1931,11 +1763,7 @@ func (s SetQueueAttributesInput) GoString() string {
 }
 
 type SetQueueAttributesOutput struct {
-	metadataSetQueueAttributesOutput `json:"-" xml:"-"`
-}
-
-type metadataSetQueueAttributesOutput struct {
-	SDKShapeTraits bool `type:"structure"`
+	_ struct{} `type:"structure"`
 }
 
 // String returns the string representation

--- a/service/ssm/api.go
+++ b/service/ssm/api.go
@@ -483,11 +483,7 @@ type Association struct {
 	// The name of the SSM document.
 	Name *string `type:"string"`
 
-	metadataAssociation `json:"-" xml:"-"`
-}
-
-type metadataAssociation struct {
-	SDKShapeTraits bool `type:"structure"`
+	_ struct{} `type:"structure"`
 }
 
 // String returns the string representation
@@ -517,11 +513,7 @@ type AssociationDescription struct {
 	// The association status.
 	Status *AssociationStatus `type:"structure"`
 
-	metadataAssociationDescription `json:"-" xml:"-"`
-}
-
-type metadataAssociationDescription struct {
-	SDKShapeTraits bool `type:"structure"`
+	_ struct{} `type:"structure"`
 }
 
 // String returns the string representation
@@ -542,11 +534,7 @@ type AssociationFilter struct {
 	// The filter value.
 	Value *string `locationName:"value" min:"1" type:"string" required:"true"`
 
-	metadataAssociationFilter `json:"-" xml:"-"`
-}
-
-type metadataAssociationFilter struct {
-	SDKShapeTraits bool `type:"structure"`
+	_ struct{} `type:"structure"`
 }
 
 // String returns the string representation
@@ -573,11 +561,7 @@ type AssociationStatus struct {
 	// The status.
 	Name *string `type:"string" required:"true" enum:"AssociationStatusName"`
 
-	metadataAssociationStatus `json:"-" xml:"-"`
-}
-
-type metadataAssociationStatus struct {
-	SDKShapeTraits bool `type:"structure"`
+	_ struct{} `type:"structure"`
 }
 
 // String returns the string representation
@@ -599,11 +583,7 @@ type CancelCommandInput struct {
 	// requested.
 	InstanceIds []*string `min:"1" type:"list"`
 
-	metadataCancelCommandInput `json:"-" xml:"-"`
-}
-
-type metadataCancelCommandInput struct {
-	SDKShapeTraits bool `type:"structure"`
+	_ struct{} `type:"structure"`
 }
 
 // String returns the string representation
@@ -619,11 +599,7 @@ func (s CancelCommandInput) GoString() string {
 // Whether or not the command was successfully canceled. There is no guarantee
 // that a request can be canceled.
 type CancelCommandOutput struct {
-	metadataCancelCommandOutput `json:"-" xml:"-"`
-}
-
-type metadataCancelCommandOutput struct {
-	SDKShapeTraits bool `type:"structure"`
+	_ struct{} `type:"structure"`
 }
 
 // String returns the string representation
@@ -674,11 +650,7 @@ type Command struct {
 	// The status of the command.
 	Status *string `type:"string" enum:"CommandStatus"`
 
-	metadataCommand `json:"-" xml:"-"`
-}
-
-type metadataCommand struct {
-	SDKShapeTraits bool `type:"structure"`
+	_ struct{} `type:"structure"`
 }
 
 // String returns the string representation
@@ -699,11 +671,7 @@ type CommandFilter struct {
 	// The filter value. For example: June 30, 2015.
 	Value *string `locationName:"value" min:"1" type:"string" required:"true"`
 
-	metadataCommandFilter `json:"-" xml:"-"`
-}
-
-type metadataCommandFilter struct {
-	SDKShapeTraits bool `type:"structure"`
+	_ struct{} `type:"structure"`
 }
 
 // String returns the string representation
@@ -746,11 +714,7 @@ type CommandInvocation struct {
 	// Gets the trace output sent by the agent.
 	TraceOutput *string `type:"string"`
 
-	metadataCommandInvocation `json:"-" xml:"-"`
-}
-
-type metadataCommandInvocation struct {
-	SDKShapeTraits bool `type:"structure"`
+	_ struct{} `type:"structure"`
 }
 
 // String returns the string representation
@@ -794,11 +758,7 @@ type CommandPlugin struct {
 	// The status of this plugin. You can execute a document with multiple plugins.
 	Status *string `type:"string" enum:"CommandPluginStatus"`
 
-	metadataCommandPlugin `json:"-" xml:"-"`
-}
-
-type metadataCommandPlugin struct {
-	SDKShapeTraits bool `type:"structure"`
+	_ struct{} `type:"structure"`
 }
 
 // String returns the string representation
@@ -815,11 +775,7 @@ type CreateAssociationBatchInput struct {
 	// One or more associations.
 	Entries []*CreateAssociationBatchRequestEntry `locationNameList:"entries" type:"list" required:"true"`
 
-	metadataCreateAssociationBatchInput `json:"-" xml:"-"`
-}
-
-type metadataCreateAssociationBatchInput struct {
-	SDKShapeTraits bool `type:"structure"`
+	_ struct{} `type:"structure"`
 }
 
 // String returns the string representation
@@ -839,11 +795,7 @@ type CreateAssociationBatchOutput struct {
 	// Information about the associations that succeeded.
 	Successful []*AssociationDescription `locationNameList:"AssociationDescription" type:"list"`
 
-	metadataCreateAssociationBatchOutput `json:"-" xml:"-"`
-}
-
-type metadataCreateAssociationBatchOutput struct {
-	SDKShapeTraits bool `type:"structure"`
+	_ struct{} `type:"structure"`
 }
 
 // String returns the string representation
@@ -867,11 +819,7 @@ type CreateAssociationBatchRequestEntry struct {
 	// A description of the parameters for a document.
 	Parameters map[string][]*string `type:"map"`
 
-	metadataCreateAssociationBatchRequestEntry `json:"-" xml:"-"`
-}
-
-type metadataCreateAssociationBatchRequestEntry struct {
-	SDKShapeTraits bool `type:"structure"`
+	_ struct{} `type:"structure"`
 }
 
 // String returns the string representation
@@ -894,11 +842,7 @@ type CreateAssociationInput struct {
 	// The parameters for the document’s runtime configuration.
 	Parameters map[string][]*string `type:"map"`
 
-	metadataCreateAssociationInput `json:"-" xml:"-"`
-}
-
-type metadataCreateAssociationInput struct {
-	SDKShapeTraits bool `type:"structure"`
+	_ struct{} `type:"structure"`
 }
 
 // String returns the string representation
@@ -915,11 +859,7 @@ type CreateAssociationOutput struct {
 	// Information about the association.
 	AssociationDescription *AssociationDescription `type:"structure"`
 
-	metadataCreateAssociationOutput `json:"-" xml:"-"`
-}
-
-type metadataCreateAssociationOutput struct {
-	SDKShapeTraits bool `type:"structure"`
+	_ struct{} `type:"structure"`
 }
 
 // String returns the string representation
@@ -940,11 +880,7 @@ type CreateDocumentInput struct {
 	// A name for the SSM document.
 	Name *string `type:"string" required:"true"`
 
-	metadataCreateDocumentInput `json:"-" xml:"-"`
-}
-
-type metadataCreateDocumentInput struct {
-	SDKShapeTraits bool `type:"structure"`
+	_ struct{} `type:"structure"`
 }
 
 // String returns the string representation
@@ -961,11 +897,7 @@ type CreateDocumentOutput struct {
 	// Information about the SSM document.
 	DocumentDescription *DocumentDescription `type:"structure"`
 
-	metadataCreateDocumentOutput `json:"-" xml:"-"`
-}
-
-type metadataCreateDocumentOutput struct {
-	SDKShapeTraits bool `type:"structure"`
+	_ struct{} `type:"structure"`
 }
 
 // String returns the string representation
@@ -985,11 +917,7 @@ type DeleteAssociationInput struct {
 	// The name of the SSM document.
 	Name *string `type:"string" required:"true"`
 
-	metadataDeleteAssociationInput `json:"-" xml:"-"`
-}
-
-type metadataDeleteAssociationInput struct {
-	SDKShapeTraits bool `type:"structure"`
+	_ struct{} `type:"structure"`
 }
 
 // String returns the string representation
@@ -1003,11 +931,7 @@ func (s DeleteAssociationInput) GoString() string {
 }
 
 type DeleteAssociationOutput struct {
-	metadataDeleteAssociationOutput `json:"-" xml:"-"`
-}
-
-type metadataDeleteAssociationOutput struct {
-	SDKShapeTraits bool `type:"structure"`
+	_ struct{} `type:"structure"`
 }
 
 // String returns the string representation
@@ -1024,11 +948,7 @@ type DeleteDocumentInput struct {
 	// The name of the SSM document.
 	Name *string `type:"string" required:"true"`
 
-	metadataDeleteDocumentInput `json:"-" xml:"-"`
-}
-
-type metadataDeleteDocumentInput struct {
-	SDKShapeTraits bool `type:"structure"`
+	_ struct{} `type:"structure"`
 }
 
 // String returns the string representation
@@ -1042,11 +962,7 @@ func (s DeleteDocumentInput) GoString() string {
 }
 
 type DeleteDocumentOutput struct {
-	metadataDeleteDocumentOutput `json:"-" xml:"-"`
-}
-
-type metadataDeleteDocumentOutput struct {
-	SDKShapeTraits bool `type:"structure"`
+	_ struct{} `type:"structure"`
 }
 
 // String returns the string representation
@@ -1066,11 +982,7 @@ type DescribeAssociationInput struct {
 	// The name of the SSM document.
 	Name *string `type:"string" required:"true"`
 
-	metadataDescribeAssociationInput `json:"-" xml:"-"`
-}
-
-type metadataDescribeAssociationInput struct {
-	SDKShapeTraits bool `type:"structure"`
+	_ struct{} `type:"structure"`
 }
 
 // String returns the string representation
@@ -1087,11 +999,7 @@ type DescribeAssociationOutput struct {
 	// Information about the association.
 	AssociationDescription *AssociationDescription `type:"structure"`
 
-	metadataDescribeAssociationOutput `json:"-" xml:"-"`
-}
-
-type metadataDescribeAssociationOutput struct {
-	SDKShapeTraits bool `type:"structure"`
+	_ struct{} `type:"structure"`
 }
 
 // String returns the string representation
@@ -1108,11 +1016,7 @@ type DescribeDocumentInput struct {
 	// The name of the SSM document.
 	Name *string `type:"string" required:"true"`
 
-	metadataDescribeDocumentInput `json:"-" xml:"-"`
-}
-
-type metadataDescribeDocumentInput struct {
-	SDKShapeTraits bool `type:"structure"`
+	_ struct{} `type:"structure"`
 }
 
 // String returns the string representation
@@ -1129,11 +1033,7 @@ type DescribeDocumentOutput struct {
 	// Information about the SSM document.
 	Document *DocumentDescription `type:"structure"`
 
-	metadataDescribeDocumentOutput `json:"-" xml:"-"`
-}
-
-type metadataDescribeDocumentOutput struct {
-	SDKShapeTraits bool `type:"structure"`
+	_ struct{} `type:"structure"`
 }
 
 // String returns the string representation
@@ -1159,11 +1059,7 @@ type DescribeInstanceInformationInput struct {
 	// a previous call.)
 	NextToken *string `type:"string"`
 
-	metadataDescribeInstanceInformationInput `json:"-" xml:"-"`
-}
-
-type metadataDescribeInstanceInformationInput struct {
-	SDKShapeTraits bool `type:"structure"`
+	_ struct{} `type:"structure"`
 }
 
 // String returns the string representation
@@ -1184,11 +1080,7 @@ type DescribeInstanceInformationOutput struct {
 	// items to return, the string is empty.
 	NextToken *string `type:"string"`
 
-	metadataDescribeInstanceInformationOutput `json:"-" xml:"-"`
-}
-
-type metadataDescribeInstanceInformationOutput struct {
-	SDKShapeTraits bool `type:"structure"`
+	_ struct{} `type:"structure"`
 }
 
 // String returns the string representation
@@ -1224,11 +1116,7 @@ type DocumentDescription struct {
 	// The status of the SSM document.
 	Status *string `type:"string" enum:"DocumentStatus"`
 
-	metadataDocumentDescription `json:"-" xml:"-"`
-}
-
-type metadataDocumentDescription struct {
-	SDKShapeTraits bool `type:"structure"`
+	_ struct{} `type:"structure"`
 }
 
 // String returns the string representation
@@ -1249,11 +1137,7 @@ type DocumentFilter struct {
 	// The value of the filter.
 	Value *string `locationName:"value" min:"1" type:"string" required:"true"`
 
-	metadataDocumentFilter `json:"-" xml:"-"`
-}
-
-type metadataDocumentFilter struct {
-	SDKShapeTraits bool `type:"structure"`
+	_ struct{} `type:"structure"`
 }
 
 // String returns the string representation
@@ -1274,11 +1158,7 @@ type DocumentIdentifier struct {
 	// The operating system platform.
 	PlatformTypes []*string `locationNameList:"PlatformType" type:"list"`
 
-	metadataDocumentIdentifier `json:"-" xml:"-"`
-}
-
-type metadataDocumentIdentifier struct {
-	SDKShapeTraits bool `type:"structure"`
+	_ struct{} `type:"structure"`
 }
 
 // String returns the string representation
@@ -1306,11 +1186,7 @@ type DocumentParameter struct {
 	// The type of parameter. The type can be either “String” or “StringList”.
 	Type *string `type:"string" enum:"DocumentParameterType"`
 
-	metadataDocumentParameter `json:"-" xml:"-"`
-}
-
-type metadataDocumentParameter struct {
-	SDKShapeTraits bool `type:"structure"`
+	_ struct{} `type:"structure"`
 }
 
 // String returns the string representation
@@ -1334,11 +1210,7 @@ type FailedCreateAssociation struct {
 	// A description of the failure.
 	Message *string `type:"string"`
 
-	metadataFailedCreateAssociation `json:"-" xml:"-"`
-}
-
-type metadataFailedCreateAssociation struct {
-	SDKShapeTraits bool `type:"structure"`
+	_ struct{} `type:"structure"`
 }
 
 // String returns the string representation
@@ -1355,11 +1227,7 @@ type GetDocumentInput struct {
 	// The name of the SSM document.
 	Name *string `type:"string" required:"true"`
 
-	metadataGetDocumentInput `json:"-" xml:"-"`
-}
-
-type metadataGetDocumentInput struct {
-	SDKShapeTraits bool `type:"structure"`
+	_ struct{} `type:"structure"`
 }
 
 // String returns the string representation
@@ -1379,11 +1247,7 @@ type GetDocumentOutput struct {
 	// The name of the SSM document.
 	Name *string `type:"string"`
 
-	metadataGetDocumentOutput `json:"-" xml:"-"`
-}
-
-type metadataGetDocumentOutput struct {
-	SDKShapeTraits bool `type:"structure"`
+	_ struct{} `type:"structure"`
 }
 
 // String returns the string representation
@@ -1422,11 +1286,7 @@ type InstanceInformation struct {
 	// The version of the OS platform running on your instance.
 	PlatformVersion *string `type:"string"`
 
-	metadataInstanceInformation `json:"-" xml:"-"`
-}
-
-type metadataInstanceInformation struct {
-	SDKShapeTraits bool `type:"structure"`
+	_ struct{} `type:"structure"`
 }
 
 // String returns the string representation
@@ -1447,11 +1307,7 @@ type InstanceInformationFilter struct {
 	// The filter values.
 	ValueSet []*string `locationName:"valueSet" locationNameList:"InstanceInformationFilterValue" min:"1" type:"list" required:"true"`
 
-	metadataInstanceInformationFilter `json:"-" xml:"-"`
-}
-
-type metadataInstanceInformationFilter struct {
-	SDKShapeTraits bool `type:"structure"`
+	_ struct{} `type:"structure"`
 }
 
 // String returns the string representation
@@ -1477,11 +1333,7 @@ type ListAssociationsInput struct {
 	// a previous call.)
 	NextToken *string `type:"string"`
 
-	metadataListAssociationsInput `json:"-" xml:"-"`
-}
-
-type metadataListAssociationsInput struct {
-	SDKShapeTraits bool `type:"structure"`
+	_ struct{} `type:"structure"`
 }
 
 // String returns the string representation
@@ -1502,11 +1354,7 @@ type ListAssociationsOutput struct {
 	// items to return, the string is empty.
 	NextToken *string `type:"string"`
 
-	metadataListAssociationsOutput `json:"-" xml:"-"`
-}
-
-type metadataListAssociationsOutput struct {
-	SDKShapeTraits bool `type:"structure"`
+	_ struct{} `type:"structure"`
 }
 
 // String returns the string representation
@@ -1543,11 +1391,7 @@ type ListCommandInvocationsInput struct {
 	// token from a previous call.)
 	NextToken *string `type:"string"`
 
-	metadataListCommandInvocationsInput `json:"-" xml:"-"`
-}
-
-type metadataListCommandInvocationsInput struct {
-	SDKShapeTraits bool `type:"structure"`
+	_ struct{} `type:"structure"`
 }
 
 // String returns the string representation
@@ -1568,11 +1412,7 @@ type ListCommandInvocationsOutput struct {
 	// token from a previous call.)
 	NextToken *string `type:"string"`
 
-	metadataListCommandInvocationsOutput `json:"-" xml:"-"`
-}
-
-type metadataListCommandInvocationsOutput struct {
-	SDKShapeTraits bool `type:"structure"`
+	_ struct{} `type:"structure"`
 }
 
 // String returns the string representation
@@ -1605,11 +1445,7 @@ type ListCommandsInput struct {
 	// token from a previous call.)
 	NextToken *string `type:"string"`
 
-	metadataListCommandsInput `json:"-" xml:"-"`
-}
-
-type metadataListCommandsInput struct {
-	SDKShapeTraits bool `type:"structure"`
+	_ struct{} `type:"structure"`
 }
 
 // String returns the string representation
@@ -1630,11 +1466,7 @@ type ListCommandsOutput struct {
 	// token from a previous call.)
 	NextToken *string `type:"string"`
 
-	metadataListCommandsOutput `json:"-" xml:"-"`
-}
-
-type metadataListCommandsOutput struct {
-	SDKShapeTraits bool `type:"structure"`
+	_ struct{} `type:"structure"`
 }
 
 // String returns the string representation
@@ -1660,11 +1492,7 @@ type ListDocumentsInput struct {
 	// a previous call.)
 	NextToken *string `type:"string"`
 
-	metadataListDocumentsInput `json:"-" xml:"-"`
-}
-
-type metadataListDocumentsInput struct {
-	SDKShapeTraits bool `type:"structure"`
+	_ struct{} `type:"structure"`
 }
 
 // String returns the string representation
@@ -1685,11 +1513,7 @@ type ListDocumentsOutput struct {
 	// items to return, the string is empty.
 	NextToken *string `type:"string"`
 
-	metadataListDocumentsOutput `json:"-" xml:"-"`
-}
-
-type metadataListDocumentsOutput struct {
-	SDKShapeTraits bool `type:"structure"`
+	_ struct{} `type:"structure"`
 }
 
 // String returns the string representation
@@ -1729,11 +1553,7 @@ type SendCommandInput struct {
 	// it will not execute.
 	TimeoutSeconds *int64 `min:"30" type:"integer"`
 
-	metadataSendCommandInput `json:"-" xml:"-"`
-}
-
-type metadataSendCommandInput struct {
-	SDKShapeTraits bool `type:"structure"`
+	_ struct{} `type:"structure"`
 }
 
 // String returns the string representation
@@ -1751,11 +1571,7 @@ type SendCommandOutput struct {
 	// can be used future references to this request.
 	Command *Command `type:"structure"`
 
-	metadataSendCommandOutput `json:"-" xml:"-"`
-}
-
-type metadataSendCommandOutput struct {
-	SDKShapeTraits bool `type:"structure"`
+	_ struct{} `type:"structure"`
 }
 
 // String returns the string representation
@@ -1778,11 +1594,7 @@ type UpdateAssociationStatusInput struct {
 	// The name of the SSM document.
 	Name *string `type:"string" required:"true"`
 
-	metadataUpdateAssociationStatusInput `json:"-" xml:"-"`
-}
-
-type metadataUpdateAssociationStatusInput struct {
-	SDKShapeTraits bool `type:"structure"`
+	_ struct{} `type:"structure"`
 }
 
 // String returns the string representation
@@ -1799,11 +1611,7 @@ type UpdateAssociationStatusOutput struct {
 	// Information about the association.
 	AssociationDescription *AssociationDescription `type:"structure"`
 
-	metadataUpdateAssociationStatusOutput `json:"-" xml:"-"`
-}
-
-type metadataUpdateAssociationStatusOutput struct {
-	SDKShapeTraits bool `type:"structure"`
+	_ struct{} `type:"structure"`
 }
 
 // String returns the string representation

--- a/service/ssm/api.go
+++ b/service/ssm/api.go
@@ -477,13 +477,13 @@ func (c *SSM) UpdateAssociationStatus(input *UpdateAssociationStatusInput) (*Upd
 
 // Describes an association of an SSM document and an instance.
 type Association struct {
+	_ struct{} `type:"structure"`
+
 	// The ID of the instance.
 	InstanceId *string `min:"10" type:"string"`
 
 	// The name of the SSM document.
 	Name *string `type:"string"`
-
-	_ struct{} `type:"structure"`
 }
 
 // String returns the string representation
@@ -498,6 +498,8 @@ func (s Association) GoString() string {
 
 // Describes the parameters for a document.
 type AssociationDescription struct {
+	_ struct{} `type:"structure"`
+
 	// The date when the association was made.
 	Date *time.Time `type:"timestamp" timestampFormat:"unix"`
 
@@ -512,8 +514,6 @@ type AssociationDescription struct {
 
 	// The association status.
 	Status *AssociationStatus `type:"structure"`
-
-	_ struct{} `type:"structure"`
 }
 
 // String returns the string representation
@@ -528,13 +528,13 @@ func (s AssociationDescription) GoString() string {
 
 // Describes a filter.
 type AssociationFilter struct {
+	_ struct{} `type:"structure"`
+
 	// The name of the filter.
 	Key *string `locationName:"key" type:"string" required:"true" enum:"AssociationFilterKey"`
 
 	// The filter value.
 	Value *string `locationName:"value" min:"1" type:"string" required:"true"`
-
-	_ struct{} `type:"structure"`
 }
 
 // String returns the string representation
@@ -549,6 +549,8 @@ func (s AssociationFilter) GoString() string {
 
 // Describes an association status.
 type AssociationStatus struct {
+	_ struct{} `type:"structure"`
+
 	// A user-defined string.
 	AdditionalInfo *string `type:"string"`
 
@@ -560,8 +562,6 @@ type AssociationStatus struct {
 
 	// The status.
 	Name *string `type:"string" required:"true" enum:"AssociationStatusName"`
-
-	_ struct{} `type:"structure"`
 }
 
 // String returns the string representation
@@ -575,6 +575,8 @@ func (s AssociationStatus) GoString() string {
 }
 
 type CancelCommandInput struct {
+	_ struct{} `type:"structure"`
+
 	// The ID of the command you want to cancel.
 	CommandId *string `min:"36" type:"string" required:"true"`
 
@@ -582,8 +584,6 @@ type CancelCommandInput struct {
 	// If not provided, the command is canceled on every instance on which it was
 	// requested.
 	InstanceIds []*string `min:"1" type:"list"`
-
-	_ struct{} `type:"structure"`
 }
 
 // String returns the string representation
@@ -614,6 +614,8 @@ func (s CancelCommandOutput) GoString() string {
 
 // Describes a command request.
 type Command struct {
+	_ struct{} `type:"structure"`
+
 	// A unique identifier for this command.
 	CommandId *string `min:"36" type:"string"`
 
@@ -649,8 +651,6 @@ type Command struct {
 
 	// The status of the command.
 	Status *string `type:"string" enum:"CommandStatus"`
-
-	_ struct{} `type:"structure"`
 }
 
 // String returns the string representation
@@ -665,13 +665,13 @@ func (s Command) GoString() string {
 
 // Describes a command filter.
 type CommandFilter struct {
+	_ struct{} `type:"structure"`
+
 	// The name of the filter. For example, requested date and time.
 	Key *string `locationName:"key" type:"string" required:"true" enum:"CommandFilterKey"`
 
 	// The filter value. For example: June 30, 2015.
 	Value *string `locationName:"value" min:"1" type:"string" required:"true"`
-
-	_ struct{} `type:"structure"`
 }
 
 // String returns the string representation
@@ -690,6 +690,8 @@ func (s CommandFilter) GoString() string {
 // a command invocation is created for each requested instance ID. A command
 // invocation returns status and detail information about a command you executed.
 type CommandInvocation struct {
+	_ struct{} `type:"structure"`
+
 	// The command against which this invocation was requested.
 	CommandId *string `min:"36" type:"string"`
 
@@ -713,8 +715,6 @@ type CommandInvocation struct {
 
 	// Gets the trace output sent by the agent.
 	TraceOutput *string `type:"string"`
-
-	_ struct{} `type:"structure"`
 }
 
 // String returns the string representation
@@ -729,6 +729,8 @@ func (s CommandInvocation) GoString() string {
 
 // Describes plugin details.
 type CommandPlugin struct {
+	_ struct{} `type:"structure"`
+
 	// The name of the plugin. Must be one of the following: AWS-JoinDirectoryServiceDomain,
 	// AWS-InstallApplication, AWS-RunPowerShellScript, AWS-InstallPowerShellModule,
 	// AWS-ConfigureCloudWatch.
@@ -757,8 +759,6 @@ type CommandPlugin struct {
 
 	// The status of this plugin. You can execute a document with multiple plugins.
 	Status *string `type:"string" enum:"CommandPluginStatus"`
-
-	_ struct{} `type:"structure"`
 }
 
 // String returns the string representation
@@ -772,10 +772,10 @@ func (s CommandPlugin) GoString() string {
 }
 
 type CreateAssociationBatchInput struct {
+	_ struct{} `type:"structure"`
+
 	// One or more associations.
 	Entries []*CreateAssociationBatchRequestEntry `locationNameList:"entries" type:"list" required:"true"`
-
-	_ struct{} `type:"structure"`
 }
 
 // String returns the string representation
@@ -789,13 +789,13 @@ func (s CreateAssociationBatchInput) GoString() string {
 }
 
 type CreateAssociationBatchOutput struct {
+	_ struct{} `type:"structure"`
+
 	// Information about the associations that failed.
 	Failed []*FailedCreateAssociation `locationNameList:"FailedCreateAssociationEntry" type:"list"`
 
 	// Information about the associations that succeeded.
 	Successful []*AssociationDescription `locationNameList:"AssociationDescription" type:"list"`
-
-	_ struct{} `type:"structure"`
 }
 
 // String returns the string representation
@@ -810,6 +810,8 @@ func (s CreateAssociationBatchOutput) GoString() string {
 
 // Describes the association of an SSM document and an instance.
 type CreateAssociationBatchRequestEntry struct {
+	_ struct{} `type:"structure"`
+
 	// The ID of the instance.
 	InstanceId *string `min:"10" type:"string"`
 
@@ -818,8 +820,6 @@ type CreateAssociationBatchRequestEntry struct {
 
 	// A description of the parameters for a document.
 	Parameters map[string][]*string `type:"map"`
-
-	_ struct{} `type:"structure"`
 }
 
 // String returns the string representation
@@ -833,6 +833,8 @@ func (s CreateAssociationBatchRequestEntry) GoString() string {
 }
 
 type CreateAssociationInput struct {
+	_ struct{} `type:"structure"`
+
 	// The instance ID.
 	InstanceId *string `min:"10" type:"string" required:"true"`
 
@@ -841,8 +843,6 @@ type CreateAssociationInput struct {
 
 	// The parameters for the document’s runtime configuration.
 	Parameters map[string][]*string `type:"map"`
-
-	_ struct{} `type:"structure"`
 }
 
 // String returns the string representation
@@ -856,10 +856,10 @@ func (s CreateAssociationInput) GoString() string {
 }
 
 type CreateAssociationOutput struct {
+	_ struct{} `type:"structure"`
+
 	// Information about the association.
 	AssociationDescription *AssociationDescription `type:"structure"`
-
-	_ struct{} `type:"structure"`
 }
 
 // String returns the string representation
@@ -873,14 +873,14 @@ func (s CreateAssociationOutput) GoString() string {
 }
 
 type CreateDocumentInput struct {
+	_ struct{} `type:"structure"`
+
 	// A valid JSON string. For more information about the contents of this string,
 	// see SSM Document (http://docs.aws.amazon.com/ssm/latest/APIReference/aws-ssm-document.html).
 	Content *string `min:"1" type:"string" required:"true"`
 
 	// A name for the SSM document.
 	Name *string `type:"string" required:"true"`
-
-	_ struct{} `type:"structure"`
 }
 
 // String returns the string representation
@@ -894,10 +894,10 @@ func (s CreateDocumentInput) GoString() string {
 }
 
 type CreateDocumentOutput struct {
+	_ struct{} `type:"structure"`
+
 	// Information about the SSM document.
 	DocumentDescription *DocumentDescription `type:"structure"`
-
-	_ struct{} `type:"structure"`
 }
 
 // String returns the string representation
@@ -911,13 +911,13 @@ func (s CreateDocumentOutput) GoString() string {
 }
 
 type DeleteAssociationInput struct {
+	_ struct{} `type:"structure"`
+
 	// The ID of the instance.
 	InstanceId *string `min:"10" type:"string" required:"true"`
 
 	// The name of the SSM document.
 	Name *string `type:"string" required:"true"`
-
-	_ struct{} `type:"structure"`
 }
 
 // String returns the string representation
@@ -945,10 +945,10 @@ func (s DeleteAssociationOutput) GoString() string {
 }
 
 type DeleteDocumentInput struct {
+	_ struct{} `type:"structure"`
+
 	// The name of the SSM document.
 	Name *string `type:"string" required:"true"`
-
-	_ struct{} `type:"structure"`
 }
 
 // String returns the string representation
@@ -976,13 +976,13 @@ func (s DeleteDocumentOutput) GoString() string {
 }
 
 type DescribeAssociationInput struct {
+	_ struct{} `type:"structure"`
+
 	// The ID of the instance.
 	InstanceId *string `min:"10" type:"string" required:"true"`
 
 	// The name of the SSM document.
 	Name *string `type:"string" required:"true"`
-
-	_ struct{} `type:"structure"`
 }
 
 // String returns the string representation
@@ -996,10 +996,10 @@ func (s DescribeAssociationInput) GoString() string {
 }
 
 type DescribeAssociationOutput struct {
+	_ struct{} `type:"structure"`
+
 	// Information about the association.
 	AssociationDescription *AssociationDescription `type:"structure"`
-
-	_ struct{} `type:"structure"`
 }
 
 // String returns the string representation
@@ -1013,10 +1013,10 @@ func (s DescribeAssociationOutput) GoString() string {
 }
 
 type DescribeDocumentInput struct {
+	_ struct{} `type:"structure"`
+
 	// The name of the SSM document.
 	Name *string `type:"string" required:"true"`
-
-	_ struct{} `type:"structure"`
 }
 
 // String returns the string representation
@@ -1030,10 +1030,10 @@ func (s DescribeDocumentInput) GoString() string {
 }
 
 type DescribeDocumentOutput struct {
+	_ struct{} `type:"structure"`
+
 	// Information about the SSM document.
 	Document *DocumentDescription `type:"structure"`
-
-	_ struct{} `type:"structure"`
 }
 
 // String returns the string representation
@@ -1047,6 +1047,8 @@ func (s DescribeDocumentOutput) GoString() string {
 }
 
 type DescribeInstanceInformationInput struct {
+	_ struct{} `type:"structure"`
+
 	// One or more filters. Use a filter to return a more specific list of instances.
 	InstanceInformationFilterList []*InstanceInformationFilter `locationNameList:"InstanceInformationFilter" min:"1" type:"list"`
 
@@ -1058,8 +1060,6 @@ type DescribeInstanceInformationInput struct {
 	// The token for the next set of items to return. (You received this token from
 	// a previous call.)
 	NextToken *string `type:"string"`
-
-	_ struct{} `type:"structure"`
 }
 
 // String returns the string representation
@@ -1073,14 +1073,14 @@ func (s DescribeInstanceInformationInput) GoString() string {
 }
 
 type DescribeInstanceInformationOutput struct {
+	_ struct{} `type:"structure"`
+
 	// The instance information list.
 	InstanceInformationList []*InstanceInformation `locationNameList:"InstanceInformation" type:"list"`
 
 	// The token to use when requesting the next set of items. If there are no additional
 	// items to return, the string is empty.
 	NextToken *string `type:"string"`
-
-	_ struct{} `type:"structure"`
 }
 
 // String returns the string representation
@@ -1095,6 +1095,8 @@ func (s DescribeInstanceInformationOutput) GoString() string {
 
 // Describes an SSM document.
 type DocumentDescription struct {
+	_ struct{} `type:"structure"`
+
 	// The date when the SSM document was created.
 	CreatedDate *time.Time `type:"timestamp" timestampFormat:"unix"`
 
@@ -1115,8 +1117,6 @@ type DocumentDescription struct {
 
 	// The status of the SSM document.
 	Status *string `type:"string" enum:"DocumentStatus"`
-
-	_ struct{} `type:"structure"`
 }
 
 // String returns the string representation
@@ -1131,13 +1131,13 @@ func (s DocumentDescription) GoString() string {
 
 // Describes a filter.
 type DocumentFilter struct {
+	_ struct{} `type:"structure"`
+
 	// The name of the filter.
 	Key *string `locationName:"key" type:"string" required:"true" enum:"DocumentFilterKey"`
 
 	// The value of the filter.
 	Value *string `locationName:"value" min:"1" type:"string" required:"true"`
-
-	_ struct{} `type:"structure"`
 }
 
 // String returns the string representation
@@ -1152,13 +1152,13 @@ func (s DocumentFilter) GoString() string {
 
 // Describes the name of an SSM document.
 type DocumentIdentifier struct {
+	_ struct{} `type:"structure"`
+
 	// The name of the SSM document.
 	Name *string `type:"string"`
 
 	// The operating system platform.
 	PlatformTypes []*string `locationNameList:"PlatformType" type:"list"`
-
-	_ struct{} `type:"structure"`
 }
 
 // String returns the string representation
@@ -1172,6 +1172,8 @@ func (s DocumentIdentifier) GoString() string {
 }
 
 type DocumentParameter struct {
+	_ struct{} `type:"structure"`
+
 	// If specified, the default values for the parameters. Parameters without a
 	// default value are required. Parameters with a default value are optional.
 	DefaultValue *string `type:"string"`
@@ -1185,8 +1187,6 @@ type DocumentParameter struct {
 
 	// The type of parameter. The type can be either “String” or “StringList”.
 	Type *string `type:"string" enum:"DocumentParameterType"`
-
-	_ struct{} `type:"structure"`
 }
 
 // String returns the string representation
@@ -1201,6 +1201,8 @@ func (s DocumentParameter) GoString() string {
 
 // Describes a failed association.
 type FailedCreateAssociation struct {
+	_ struct{} `type:"structure"`
+
 	// The association.
 	Entry *CreateAssociationBatchRequestEntry `type:"structure"`
 
@@ -1209,8 +1211,6 @@ type FailedCreateAssociation struct {
 
 	// A description of the failure.
 	Message *string `type:"string"`
-
-	_ struct{} `type:"structure"`
 }
 
 // String returns the string representation
@@ -1224,10 +1224,10 @@ func (s FailedCreateAssociation) GoString() string {
 }
 
 type GetDocumentInput struct {
+	_ struct{} `type:"structure"`
+
 	// The name of the SSM document.
 	Name *string `type:"string" required:"true"`
-
-	_ struct{} `type:"structure"`
 }
 
 // String returns the string representation
@@ -1241,13 +1241,13 @@ func (s GetDocumentInput) GoString() string {
 }
 
 type GetDocumentOutput struct {
+	_ struct{} `type:"structure"`
+
 	// The contents of the SSM document.
 	Content *string `min:"1" type:"string"`
 
 	// The name of the SSM document.
 	Name *string `type:"string"`
-
-	_ struct{} `type:"structure"`
 }
 
 // String returns the string representation
@@ -1262,6 +1262,8 @@ func (s GetDocumentOutput) GoString() string {
 
 // Describes a filter for a specific list of instances.
 type InstanceInformation struct {
+	_ struct{} `type:"structure"`
+
 	// The version of the SSM agent running on your instance.
 	AgentVersion *string `type:"string"`
 
@@ -1285,8 +1287,6 @@ type InstanceInformation struct {
 
 	// The version of the OS platform running on your instance.
 	PlatformVersion *string `type:"string"`
-
-	_ struct{} `type:"structure"`
 }
 
 // String returns the string representation
@@ -1301,13 +1301,13 @@ func (s InstanceInformation) GoString() string {
 
 // Describes a filter for a specific list of instances.
 type InstanceInformationFilter struct {
+	_ struct{} `type:"structure"`
+
 	// The name of the filter.
 	Key *string `locationName:"key" type:"string" required:"true" enum:"InstanceInformationFilterKey"`
 
 	// The filter values.
 	ValueSet []*string `locationName:"valueSet" locationNameList:"InstanceInformationFilterValue" min:"1" type:"list" required:"true"`
-
-	_ struct{} `type:"structure"`
 }
 
 // String returns the string representation
@@ -1321,6 +1321,8 @@ func (s InstanceInformationFilter) GoString() string {
 }
 
 type ListAssociationsInput struct {
+	_ struct{} `type:"structure"`
+
 	// One or more filters. Use a filter to return a more specific list of results.
 	AssociationFilterList []*AssociationFilter `locationNameList:"AssociationFilter" min:"1" type:"list" required:"true"`
 
@@ -1332,8 +1334,6 @@ type ListAssociationsInput struct {
 	// The token for the next set of items to return. (You received this token from
 	// a previous call.)
 	NextToken *string `type:"string"`
-
-	_ struct{} `type:"structure"`
 }
 
 // String returns the string representation
@@ -1347,14 +1347,14 @@ func (s ListAssociationsInput) GoString() string {
 }
 
 type ListAssociationsOutput struct {
+	_ struct{} `type:"structure"`
+
 	// The associations.
 	Associations []*Association `locationNameList:"Association" type:"list"`
 
 	// The token to use when requesting the next set of items. If there are no additional
 	// items to return, the string is empty.
 	NextToken *string `type:"string"`
-
-	_ struct{} `type:"structure"`
 }
 
 // String returns the string representation
@@ -1368,6 +1368,8 @@ func (s ListAssociationsOutput) GoString() string {
 }
 
 type ListCommandInvocationsInput struct {
+	_ struct{} `type:"structure"`
+
 	// (Optional) The invocations for a specific command ID.
 	CommandId *string `min:"36" type:"string"`
 
@@ -1390,8 +1392,6 @@ type ListCommandInvocationsInput struct {
 	// (Optional) The token for the next set of items to return. (You received this
 	// token from a previous call.)
 	NextToken *string `type:"string"`
-
-	_ struct{} `type:"structure"`
 }
 
 // String returns the string representation
@@ -1405,14 +1405,14 @@ func (s ListCommandInvocationsInput) GoString() string {
 }
 
 type ListCommandInvocationsOutput struct {
+	_ struct{} `type:"structure"`
+
 	// (Optional) A list of all invocations.
 	CommandInvocations []*CommandInvocation `type:"list"`
 
 	// (Optional) The token for the next set of items to return. (You received this
 	// token from a previous call.)
 	NextToken *string `type:"string"`
-
-	_ struct{} `type:"structure"`
 }
 
 // String returns the string representation
@@ -1426,6 +1426,8 @@ func (s ListCommandInvocationsOutput) GoString() string {
 }
 
 type ListCommandsInput struct {
+	_ struct{} `type:"structure"`
+
 	// (Optional) If provided, lists only the specified command.
 	CommandId *string `min:"36" type:"string"`
 
@@ -1444,8 +1446,6 @@ type ListCommandsInput struct {
 	// (Optional) The token for the next set of items to return. (You received this
 	// token from a previous call.)
 	NextToken *string `type:"string"`
-
-	_ struct{} `type:"structure"`
 }
 
 // String returns the string representation
@@ -1459,14 +1459,14 @@ func (s ListCommandsInput) GoString() string {
 }
 
 type ListCommandsOutput struct {
+	_ struct{} `type:"structure"`
+
 	// (Optional) The list of commands requested by the user.
 	Commands []*Command `type:"list"`
 
 	// (Optional) The token for the next set of items to return. (You received this
 	// token from a previous call.)
 	NextToken *string `type:"string"`
-
-	_ struct{} `type:"structure"`
 }
 
 // String returns the string representation
@@ -1480,6 +1480,8 @@ func (s ListCommandsOutput) GoString() string {
 }
 
 type ListDocumentsInput struct {
+	_ struct{} `type:"structure"`
+
 	// One or more filters. Use a filter to return a more specific list of results.
 	DocumentFilterList []*DocumentFilter `locationNameList:"DocumentFilter" min:"1" type:"list"`
 
@@ -1491,8 +1493,6 @@ type ListDocumentsInput struct {
 	// The token for the next set of items to return. (You received this token from
 	// a previous call.)
 	NextToken *string `type:"string"`
-
-	_ struct{} `type:"structure"`
 }
 
 // String returns the string representation
@@ -1506,14 +1506,14 @@ func (s ListDocumentsInput) GoString() string {
 }
 
 type ListDocumentsOutput struct {
+	_ struct{} `type:"structure"`
+
 	// The names of the SSM documents.
 	DocumentIdentifiers []*DocumentIdentifier `locationNameList:"DocumentIdentifier" type:"list"`
 
 	// The token to use when requesting the next set of items. If there are no additional
 	// items to return, the string is empty.
 	NextToken *string `type:"string"`
-
-	_ struct{} `type:"structure"`
 }
 
 // String returns the string representation
@@ -1527,6 +1527,8 @@ func (s ListDocumentsOutput) GoString() string {
 }
 
 type SendCommandInput struct {
+	_ struct{} `type:"structure"`
+
 	// User-specified information about the command, such as a brief description
 	// of what the command should do.
 	Comment *string `type:"string"`
@@ -1552,8 +1554,6 @@ type SendCommandInput struct {
 	// If this time is reached and the command has not already started executing,
 	// it will not execute.
 	TimeoutSeconds *int64 `min:"30" type:"integer"`
-
-	_ struct{} `type:"structure"`
 }
 
 // String returns the string representation
@@ -1567,11 +1567,11 @@ func (s SendCommandInput) GoString() string {
 }
 
 type SendCommandOutput struct {
+	_ struct{} `type:"structure"`
+
 	// The request as it was received by SSM. Also provides the command ID which
 	// can be used future references to this request.
 	Command *Command `type:"structure"`
-
-	_ struct{} `type:"structure"`
 }
 
 // String returns the string representation
@@ -1585,6 +1585,8 @@ func (s SendCommandOutput) GoString() string {
 }
 
 type UpdateAssociationStatusInput struct {
+	_ struct{} `type:"structure"`
+
 	// The association status.
 	AssociationStatus *AssociationStatus `type:"structure" required:"true"`
 
@@ -1593,8 +1595,6 @@ type UpdateAssociationStatusInput struct {
 
 	// The name of the SSM document.
 	Name *string `type:"string" required:"true"`
-
-	_ struct{} `type:"structure"`
 }
 
 // String returns the string representation
@@ -1608,10 +1608,10 @@ func (s UpdateAssociationStatusInput) GoString() string {
 }
 
 type UpdateAssociationStatusOutput struct {
+	_ struct{} `type:"structure"`
+
 	// Information about the association.
 	AssociationDescription *AssociationDescription `type:"structure"`
-
-	_ struct{} `type:"structure"`
 }
 
 // String returns the string representation

--- a/service/storagegateway/api.go
+++ b/service/storagegateway/api.go
@@ -1873,6 +1873,8 @@ func (c *StorageGateway) UpdateVTLDeviceType(input *UpdateVTLDeviceTypeInput) (*
 //   ActivateGatewayInput$GatewayTimezone   ActivateGatewayInput$GatewayType
 //   ActivateGatewayInput$TapeDriveType   ActivateGatewayInput$MediumChangerType
 type ActivateGatewayInput struct {
+	_ struct{} `type:"structure"`
+
 	// Your gateway activation key. You can obtain the activation key by sending
 	// an HTTP GET request with redirects enabled to the gateway IP address (port
 	// 80). The redirect URL returned in the response provides you the activation
@@ -1918,8 +1920,6 @@ type ActivateGatewayInput struct {
 	//
 	// Valid Values: "IBM-ULT3580-TD5"
 	TapeDriveType *string `min:"2" type:"string"`
-
-	_ struct{} `type:"structure"`
 }
 
 // String returns the string representation
@@ -1937,11 +1937,11 @@ func (s ActivateGatewayInput) GoString() string {
 // name, and region. This ARN is used to reference the gateway in other API
 // operations as well as resource-based authorization.
 type ActivateGatewayOutput struct {
+	_ struct{} `type:"structure"`
+
 	// The Amazon Resource Name (ARN) of the gateway. Use the ListGateways operation
 	// to return a list of gateways for your account and region.
 	GatewayARN *string `min:"50" type:"string"`
-
-	_ struct{} `type:"structure"`
 }
 
 // String returns the string representation
@@ -1955,13 +1955,13 @@ func (s ActivateGatewayOutput) GoString() string {
 }
 
 type AddCacheInput struct {
+	_ struct{} `type:"structure"`
+
 	DiskIds []*string `type:"list" required:"true"`
 
 	// The Amazon Resource Name (ARN) of the gateway. Use the ListGateways operation
 	// to return a list of gateways for your account and region.
 	GatewayARN *string `min:"50" type:"string" required:"true"`
-
-	_ struct{} `type:"structure"`
 }
 
 // String returns the string representation
@@ -1975,11 +1975,11 @@ func (s AddCacheInput) GoString() string {
 }
 
 type AddCacheOutput struct {
+	_ struct{} `type:"structure"`
+
 	// The Amazon Resource Name (ARN) of the gateway. Use the ListGateways operation
 	// to return a list of gateways for your account and region.
 	GatewayARN *string `min:"50" type:"string"`
-
-	_ struct{} `type:"structure"`
 }
 
 // String returns the string representation
@@ -1994,6 +1994,8 @@ func (s AddCacheOutput) GoString() string {
 
 // AddTagsToResourceInput
 type AddTagsToResourceInput struct {
+	_ struct{} `type:"structure"`
+
 	// The Amazon Resource Name (ARN) of the resource you want to add tags to.
 	ResourceARN *string `min:"50" type:"string" required:"true"`
 
@@ -2003,8 +2005,6 @@ type AddTagsToResourceInput struct {
 	// Valid characters for key and value are letters, spaces, and numbers representable
 	// in UTF-8 format, and the following special characters: + - = . _ : / @.
 	Tags []*Tag `type:"list" required:"true"`
-
-	_ struct{} `type:"structure"`
 }
 
 // String returns the string representation
@@ -2019,10 +2019,10 @@ func (s AddTagsToResourceInput) GoString() string {
 
 // AddTagsToResourceOutput
 type AddTagsToResourceOutput struct {
+	_ struct{} `type:"structure"`
+
 	// The Amazon Resource Name (ARN) of the resource you want to add tags to.
 	ResourceARN *string `min:"50" type:"string"`
-
-	_ struct{} `type:"structure"`
 }
 
 // String returns the string representation
@@ -2036,13 +2036,13 @@ func (s AddTagsToResourceOutput) GoString() string {
 }
 
 type AddUploadBufferInput struct {
+	_ struct{} `type:"structure"`
+
 	DiskIds []*string `type:"list" required:"true"`
 
 	// The Amazon Resource Name (ARN) of the gateway. Use the ListGateways operation
 	// to return a list of gateways for your account and region.
 	GatewayARN *string `min:"50" type:"string" required:"true"`
-
-	_ struct{} `type:"structure"`
 }
 
 // String returns the string representation
@@ -2056,11 +2056,11 @@ func (s AddUploadBufferInput) GoString() string {
 }
 
 type AddUploadBufferOutput struct {
+	_ struct{} `type:"structure"`
+
 	// The Amazon Resource Name (ARN) of the gateway. Use the ListGateways operation
 	// to return a list of gateways for your account and region.
 	GatewayARN *string `min:"50" type:"string"`
-
-	_ struct{} `type:"structure"`
 }
 
 // String returns the string representation
@@ -2077,6 +2077,8 @@ func (s AddUploadBufferOutput) GoString() string {
 //
 //   AddWorkingStorageInput$DiskIds
 type AddWorkingStorageInput struct {
+	_ struct{} `type:"structure"`
+
 	// An array of strings that identify disks that are to be configured as working
 	// storage. Each string have a minimum length of 1 and maximum length of 300.
 	// You can get the disk IDs from the ListLocalDisks API.
@@ -2085,8 +2087,6 @@ type AddWorkingStorageInput struct {
 	// The Amazon Resource Name (ARN) of the gateway. Use the ListGateways operation
 	// to return a list of gateways for your account and region.
 	GatewayARN *string `min:"50" type:"string" required:"true"`
-
-	_ struct{} `type:"structure"`
 }
 
 // String returns the string representation
@@ -2102,11 +2102,11 @@ func (s AddWorkingStorageInput) GoString() string {
 // A JSON object containing the of the gateway for which working storage was
 // configured.
 type AddWorkingStorageOutput struct {
+	_ struct{} `type:"structure"`
+
 	// The Amazon Resource Name (ARN) of the gateway. Use the ListGateways operation
 	// to return a list of gateways for your account and region.
 	GatewayARN *string `min:"50" type:"string"`
-
-	_ struct{} `type:"structure"`
 }
 
 // String returns the string representation
@@ -2120,6 +2120,8 @@ func (s AddWorkingStorageOutput) GoString() string {
 }
 
 type CachediSCSIVolume struct {
+	_ struct{} `type:"structure"`
+
 	SourceSnapshotId *string `type:"string"`
 
 	VolumeARN *string `min:"50" type:"string"`
@@ -2136,8 +2138,6 @@ type CachediSCSIVolume struct {
 
 	// Lists iSCSI information about a volume.
 	VolumeiSCSIAttributes *VolumeiSCSIAttributes `type:"structure"`
-
-	_ struct{} `type:"structure"`
 }
 
 // String returns the string representation
@@ -2152,6 +2152,8 @@ func (s CachediSCSIVolume) GoString() string {
 
 // CancelArchivalInput
 type CancelArchivalInput struct {
+	_ struct{} `type:"structure"`
+
 	// The Amazon Resource Name (ARN) of the gateway. Use the ListGateways operation
 	// to return a list of gateways for your account and region.
 	GatewayARN *string `min:"50" type:"string" required:"true"`
@@ -2159,8 +2161,6 @@ type CancelArchivalInput struct {
 	// The Amazon Resource Name (ARN) of the virtual tape you want to cancel archiving
 	// for.
 	TapeARN *string `min:"50" type:"string" required:"true"`
-
-	_ struct{} `type:"structure"`
 }
 
 // String returns the string representation
@@ -2175,11 +2175,11 @@ func (s CancelArchivalInput) GoString() string {
 
 // CancelArchivalOutput
 type CancelArchivalOutput struct {
+	_ struct{} `type:"structure"`
+
 	// The Amazon Resource Name (ARN) of the virtual tape for which archiving was
 	// canceled.
 	TapeARN *string `min:"50" type:"string"`
-
-	_ struct{} `type:"structure"`
 }
 
 // String returns the string representation
@@ -2194,6 +2194,8 @@ func (s CancelArchivalOutput) GoString() string {
 
 // CancelRetrievalInput
 type CancelRetrievalInput struct {
+	_ struct{} `type:"structure"`
+
 	// The Amazon Resource Name (ARN) of the gateway. Use the ListGateways operation
 	// to return a list of gateways for your account and region.
 	GatewayARN *string `min:"50" type:"string" required:"true"`
@@ -2201,8 +2203,6 @@ type CancelRetrievalInput struct {
 	// The Amazon Resource Name (ARN) of the virtual tape you want to cancel retrieval
 	// for.
 	TapeARN *string `min:"50" type:"string" required:"true"`
-
-	_ struct{} `type:"structure"`
 }
 
 // String returns the string representation
@@ -2217,11 +2217,11 @@ func (s CancelRetrievalInput) GoString() string {
 
 // CancelRetrievalOutput
 type CancelRetrievalOutput struct {
+	_ struct{} `type:"structure"`
+
 	// The Amazon Resource Name (ARN) of the virtual tape for which retrieval was
 	// canceled.
 	TapeARN *string `min:"50" type:"string"`
-
-	_ struct{} `type:"structure"`
 }
 
 // String returns the string representation
@@ -2237,6 +2237,8 @@ func (s CancelRetrievalOutput) GoString() string {
 // Describes Challenge-Handshake Authentication Protocol (CHAP) information
 // that supports authentication between your gateway and iSCSI initiators.
 type ChapInfo struct {
+	_ struct{} `type:"structure"`
+
 	// The iSCSI initiator that connects to the target.
 	InitiatorName *string `min:"1" type:"string"`
 
@@ -2253,8 +2255,6 @@ type ChapInfo struct {
 	// Valid Values: 50 to 500 lowercase letters, numbers, periods (.), and hyphens
 	// (-).
 	TargetARN *string `min:"50" type:"string"`
-
-	_ struct{} `type:"structure"`
 }
 
 // String returns the string representation
@@ -2268,6 +2268,8 @@ func (s ChapInfo) GoString() string {
 }
 
 type CreateCachediSCSIVolumeInput struct {
+	_ struct{} `type:"structure"`
+
 	ClientToken *string `min:"5" type:"string" required:"true"`
 
 	// The Amazon Resource Name (ARN) of the gateway. Use the ListGateways operation
@@ -2281,8 +2283,6 @@ type CreateCachediSCSIVolumeInput struct {
 	TargetName *string `min:"1" type:"string" required:"true"`
 
 	VolumeSizeInBytes *int64 `type:"long" required:"true"`
-
-	_ struct{} `type:"structure"`
 }
 
 // String returns the string representation
@@ -2296,11 +2296,11 @@ func (s CreateCachediSCSIVolumeInput) GoString() string {
 }
 
 type CreateCachediSCSIVolumeOutput struct {
+	_ struct{} `type:"structure"`
+
 	TargetARN *string `min:"50" type:"string"`
 
 	VolumeARN *string `min:"50" type:"string"`
-
-	_ struct{} `type:"structure"`
 }
 
 // String returns the string representation
@@ -2314,11 +2314,11 @@ func (s CreateCachediSCSIVolumeOutput) GoString() string {
 }
 
 type CreateSnapshotFromVolumeRecoveryPointInput struct {
+	_ struct{} `type:"structure"`
+
 	SnapshotDescription *string `min:"1" type:"string" required:"true"`
 
 	VolumeARN *string `min:"50" type:"string" required:"true"`
-
-	_ struct{} `type:"structure"`
 }
 
 // String returns the string representation
@@ -2332,13 +2332,13 @@ func (s CreateSnapshotFromVolumeRecoveryPointInput) GoString() string {
 }
 
 type CreateSnapshotFromVolumeRecoveryPointOutput struct {
+	_ struct{} `type:"structure"`
+
 	SnapshotId *string `type:"string"`
 
 	VolumeARN *string `min:"50" type:"string"`
 
 	VolumeRecoveryPointTime *string `type:"string"`
-
-	_ struct{} `type:"structure"`
 }
 
 // String returns the string representation
@@ -2355,6 +2355,8 @@ func (s CreateSnapshotFromVolumeRecoveryPointOutput) GoString() string {
 //
 //   CreateSnapshotInput$SnapshotDescription   CreateSnapshotInput$VolumeARN
 type CreateSnapshotInput struct {
+	_ struct{} `type:"structure"`
+
 	// Textual description of the snapshot that appears in the Amazon EC2 console,
 	// Elastic Block Store snapshots panel in the Description field, and in the
 	// AWS Storage Gateway snapshot Details pane, Description field
@@ -2363,8 +2365,6 @@ type CreateSnapshotInput struct {
 	// The Amazon Resource Name (ARN) of the volume. Use the ListVolumes operation
 	// to return a list of gateway volumes.
 	VolumeARN *string `min:"50" type:"string" required:"true"`
-
-	_ struct{} `type:"structure"`
 }
 
 // String returns the string representation
@@ -2379,6 +2379,8 @@ func (s CreateSnapshotInput) GoString() string {
 
 // A JSON object containing the following fields:
 type CreateSnapshotOutput struct {
+	_ struct{} `type:"structure"`
+
 	// The snapshot ID that is used to refer to the snapshot in future operations
 	// such as describing snapshots (Amazon Elastic Compute Cloud API DescribeSnapshots)
 	// or creating a volume from a snapshot (CreateStorediSCSIVolume).
@@ -2386,8 +2388,6 @@ type CreateSnapshotOutput struct {
 
 	// The Amazon Resource Name (ARN) of the volume of which the snapshot was taken.
 	VolumeARN *string `min:"50" type:"string"`
-
-	_ struct{} `type:"structure"`
 }
 
 // String returns the string representation
@@ -2406,6 +2406,8 @@ func (s CreateSnapshotOutput) GoString() string {
 //   CreateStorediSCSIVolumeInput$PreserveExistingData   CreateStorediSCSIVolumeInput$SnapshotId
 //   CreateStorediSCSIVolumeInput$TargetName
 type CreateStorediSCSIVolumeInput struct {
+	_ struct{} `type:"structure"`
+
 	// The unique identifier for the gateway local disk that is configured as a
 	// stored volume. Use ListLocalDisks (http://docs.aws.amazon.com/storagegateway/latest/userguide/API_ListLocalDisks.html)
 	// to list disk IDs for a gateway.
@@ -2440,8 +2442,6 @@ type CreateStorediSCSIVolumeInput struct {
 	// myvolume results in the target ARN of arn:aws:storagegateway:us-east-1:111122223333:gateway/mygateway/target/iqn.1997-05.com.amazon:myvolume.
 	// The target name must be unique across all volumes of a gateway.
 	TargetName *string `min:"1" type:"string" required:"true"`
-
-	_ struct{} `type:"structure"`
 }
 
 // String returns the string representation
@@ -2456,6 +2456,8 @@ func (s CreateStorediSCSIVolumeInput) GoString() string {
 
 // A JSON object containing the following fields:
 type CreateStorediSCSIVolumeOutput struct {
+	_ struct{} `type:"structure"`
+
 	// he Amazon Resource Name (ARN) of the volume target that includes the iSCSI
 	// name that initiators can use to connect to the target.
 	TargetARN *string `min:"50" type:"string"`
@@ -2465,8 +2467,6 @@ type CreateStorediSCSIVolumeOutput struct {
 
 	// The size of the volume in bytes.
 	VolumeSizeInBytes *int64 `type:"long"`
-
-	_ struct{} `type:"structure"`
 }
 
 // String returns the string representation
@@ -2481,6 +2481,8 @@ func (s CreateStorediSCSIVolumeOutput) GoString() string {
 
 // CreateTapesInput
 type CreateTapesInput struct {
+	_ struct{} `type:"structure"`
+
 	// A unique identifier that you use to retry a request. If you retry a request,
 	// use the same ClientToken you specified in the initial request.
 	//
@@ -2506,8 +2508,6 @@ type CreateTapesInput struct {
 	//
 	// The size must be gigabyte (1024*1024*1024 byte) aligned.
 	TapeSizeInBytes *int64 `type:"long" required:"true"`
-
-	_ struct{} `type:"structure"`
 }
 
 // String returns the string representation
@@ -2522,11 +2522,11 @@ func (s CreateTapesInput) GoString() string {
 
 // CreateTapeOutput
 type CreateTapesOutput struct {
+	_ struct{} `type:"structure"`
+
 	// A list of unique Amazon Resource Named (ARN) that represents the virtual
 	// tapes that were created.
 	TapeARNs []*string `type:"list"`
-
-	_ struct{} `type:"structure"`
 }
 
 // String returns the string representation
@@ -2540,13 +2540,13 @@ func (s CreateTapesOutput) GoString() string {
 }
 
 type DeleteBandwidthRateLimitInput struct {
+	_ struct{} `type:"structure"`
+
 	BandwidthType *string `min:"3" type:"string" required:"true"`
 
 	// The Amazon Resource Name (ARN) of the gateway. Use the ListGateways operation
 	// to return a list of gateways for your account and region.
 	GatewayARN *string `min:"50" type:"string" required:"true"`
-
-	_ struct{} `type:"structure"`
 }
 
 // String returns the string representation
@@ -2562,11 +2562,11 @@ func (s DeleteBandwidthRateLimitInput) GoString() string {
 // A JSON object containing the of the gateway whose bandwidth rate information
 // was deleted.
 type DeleteBandwidthRateLimitOutput struct {
+	_ struct{} `type:"structure"`
+
 	// The Amazon Resource Name (ARN) of the gateway. Use the ListGateways operation
 	// to return a list of gateways for your account and region.
 	GatewayARN *string `min:"50" type:"string"`
-
-	_ struct{} `type:"structure"`
 }
 
 // String returns the string representation
@@ -2583,14 +2583,14 @@ func (s DeleteBandwidthRateLimitOutput) GoString() string {
 //
 //   DeleteChapCredentialsInput$InitiatorName   DeleteChapCredentialsInput$TargetARN
 type DeleteChapCredentialsInput struct {
+	_ struct{} `type:"structure"`
+
 	// The iSCSI initiator that connects to the target.
 	InitiatorName *string `min:"1" type:"string" required:"true"`
 
 	// The Amazon Resource Name (ARN) of the iSCSI volume target. Use the DescribeStorediSCSIVolumes
 	// operation to return to retrieve the TargetARN for specified VolumeARN.
 	TargetARN *string `min:"50" type:"string" required:"true"`
-
-	_ struct{} `type:"structure"`
 }
 
 // String returns the string representation
@@ -2605,13 +2605,13 @@ func (s DeleteChapCredentialsInput) GoString() string {
 
 // A JSON object containing the following fields:
 type DeleteChapCredentialsOutput struct {
+	_ struct{} `type:"structure"`
+
 	// The iSCSI initiator that connects to the target.
 	InitiatorName *string `min:"1" type:"string"`
 
 	// The Amazon Resource Name (ARN) of the target.
 	TargetARN *string `min:"50" type:"string"`
-
-	_ struct{} `type:"structure"`
 }
 
 // String returns the string representation
@@ -2626,11 +2626,11 @@ func (s DeleteChapCredentialsOutput) GoString() string {
 
 // A JSON object containing the id of the gateway to delete.
 type DeleteGatewayInput struct {
+	_ struct{} `type:"structure"`
+
 	// The Amazon Resource Name (ARN) of the gateway. Use the ListGateways operation
 	// to return a list of gateways for your account and region.
 	GatewayARN *string `min:"50" type:"string" required:"true"`
-
-	_ struct{} `type:"structure"`
 }
 
 // String returns the string representation
@@ -2645,11 +2645,11 @@ func (s DeleteGatewayInput) GoString() string {
 
 // A JSON object containing the id of the deleted gateway.
 type DeleteGatewayOutput struct {
+	_ struct{} `type:"structure"`
+
 	// The Amazon Resource Name (ARN) of the gateway. Use the ListGateways operation
 	// to return a list of gateways for your account and region.
 	GatewayARN *string `min:"50" type:"string"`
-
-	_ struct{} `type:"structure"`
 }
 
 // String returns the string representation
@@ -2663,9 +2663,9 @@ func (s DeleteGatewayOutput) GoString() string {
 }
 
 type DeleteSnapshotScheduleInput struct {
-	VolumeARN *string `min:"50" type:"string" required:"true"`
-
 	_ struct{} `type:"structure"`
+
+	VolumeARN *string `min:"50" type:"string" required:"true"`
 }
 
 // String returns the string representation
@@ -2679,9 +2679,9 @@ func (s DeleteSnapshotScheduleInput) GoString() string {
 }
 
 type DeleteSnapshotScheduleOutput struct {
-	VolumeARN *string `min:"50" type:"string"`
-
 	_ struct{} `type:"structure"`
+
+	VolumeARN *string `min:"50" type:"string"`
 }
 
 // String returns the string representation
@@ -2696,11 +2696,11 @@ func (s DeleteSnapshotScheduleOutput) GoString() string {
 
 // DeleteTapeArchiveInput
 type DeleteTapeArchiveInput struct {
+	_ struct{} `type:"structure"`
+
 	// The Amazon Resource Name (ARN) of the virtual tape to delete from the virtual
 	// tape shelf (VTS).
 	TapeARN *string `min:"50" type:"string" required:"true"`
-
-	_ struct{} `type:"structure"`
 }
 
 // String returns the string representation
@@ -2715,11 +2715,11 @@ func (s DeleteTapeArchiveInput) GoString() string {
 
 // DeleteTapeArchiveOutput
 type DeleteTapeArchiveOutput struct {
+	_ struct{} `type:"structure"`
+
 	// The Amazon Resource Name (ARN) of the virtual tape that was deleted from
 	// the virtual tape shelf (VTS).
 	TapeARN *string `min:"50" type:"string"`
-
-	_ struct{} `type:"structure"`
 }
 
 // String returns the string representation
@@ -2734,6 +2734,8 @@ func (s DeleteTapeArchiveOutput) GoString() string {
 
 // DeleteTapeInput
 type DeleteTapeInput struct {
+	_ struct{} `type:"structure"`
+
 	// The unique Amazon Resource Name (ARN) of the gateway that the virtual tape
 	// to delete is associated with. Use the ListGateways operation to return a
 	// list of gateways for your account and region.
@@ -2741,8 +2743,6 @@ type DeleteTapeInput struct {
 
 	// The Amazon Resource Name (ARN) of the virtual tape to delete.
 	TapeARN *string `min:"50" type:"string" required:"true"`
-
-	_ struct{} `type:"structure"`
 }
 
 // String returns the string representation
@@ -2757,10 +2757,10 @@ func (s DeleteTapeInput) GoString() string {
 
 // DeleteTapeOutput
 type DeleteTapeOutput struct {
+	_ struct{} `type:"structure"`
+
 	// The Amazon Resource Name (ARN) of the deleted virtual tape.
 	TapeARN *string `min:"50" type:"string"`
-
-	_ struct{} `type:"structure"`
 }
 
 // String returns the string representation
@@ -2775,11 +2775,11 @@ func (s DeleteTapeOutput) GoString() string {
 
 // A JSON object containing the DeleteVolumeInput$VolumeARN to delete.
 type DeleteVolumeInput struct {
+	_ struct{} `type:"structure"`
+
 	// The Amazon Resource Name (ARN) of the volume. Use the ListVolumes operation
 	// to return a list of gateway volumes.
 	VolumeARN *string `min:"50" type:"string" required:"true"`
-
-	_ struct{} `type:"structure"`
 }
 
 // String returns the string representation
@@ -2794,11 +2794,11 @@ func (s DeleteVolumeInput) GoString() string {
 
 // A JSON object containing the of the storage volume that was deleted
 type DeleteVolumeOutput struct {
+	_ struct{} `type:"structure"`
+
 	// The Amazon Resource Name (ARN) of the storage volume that was deleted. It
 	// is the same ARN you provided in the request.
 	VolumeARN *string `min:"50" type:"string"`
-
-	_ struct{} `type:"structure"`
 }
 
 // String returns the string representation
@@ -2813,11 +2813,11 @@ func (s DeleteVolumeOutput) GoString() string {
 
 // A JSON object containing the of the gateway.
 type DescribeBandwidthRateLimitInput struct {
+	_ struct{} `type:"structure"`
+
 	// The Amazon Resource Name (ARN) of the gateway. Use the ListGateways operation
 	// to return a list of gateways for your account and region.
 	GatewayARN *string `min:"50" type:"string" required:"true"`
-
-	_ struct{} `type:"structure"`
 }
 
 // String returns the string representation
@@ -2832,6 +2832,8 @@ func (s DescribeBandwidthRateLimitInput) GoString() string {
 
 // A JSON object containing the following fields:
 type DescribeBandwidthRateLimitOutput struct {
+	_ struct{} `type:"structure"`
+
 	// The average download bandwidth rate limit in bits per second. This field
 	// does not appear in the response if the download rate limit is not set.
 	AverageDownloadRateLimitInBitsPerSec *int64 `min:"102400" type:"long"`
@@ -2843,8 +2845,6 @@ type DescribeBandwidthRateLimitOutput struct {
 	// The Amazon Resource Name (ARN) of the gateway. Use the ListGateways operation
 	// to return a list of gateways for your account and region.
 	GatewayARN *string `min:"50" type:"string"`
-
-	_ struct{} `type:"structure"`
 }
 
 // String returns the string representation
@@ -2858,11 +2858,11 @@ func (s DescribeBandwidthRateLimitOutput) GoString() string {
 }
 
 type DescribeCacheInput struct {
+	_ struct{} `type:"structure"`
+
 	// The Amazon Resource Name (ARN) of the gateway. Use the ListGateways operation
 	// to return a list of gateways for your account and region.
 	GatewayARN *string `min:"50" type:"string" required:"true"`
-
-	_ struct{} `type:"structure"`
 }
 
 // String returns the string representation
@@ -2876,6 +2876,8 @@ func (s DescribeCacheInput) GoString() string {
 }
 
 type DescribeCacheOutput struct {
+	_ struct{} `type:"structure"`
+
 	CacheAllocatedInBytes *int64 `type:"long"`
 
 	CacheDirtyPercentage *float64 `type:"double"`
@@ -2891,8 +2893,6 @@ type DescribeCacheOutput struct {
 	// The Amazon Resource Name (ARN) of the gateway. Use the ListGateways operation
 	// to return a list of gateways for your account and region.
 	GatewayARN *string `min:"50" type:"string"`
-
-	_ struct{} `type:"structure"`
 }
 
 // String returns the string representation
@@ -2906,9 +2906,9 @@ func (s DescribeCacheOutput) GoString() string {
 }
 
 type DescribeCachediSCSIVolumesInput struct {
-	VolumeARNs []*string `type:"list" required:"true"`
-
 	_ struct{} `type:"structure"`
+
+	VolumeARNs []*string `type:"list" required:"true"`
 }
 
 // String returns the string representation
@@ -2923,11 +2923,11 @@ func (s DescribeCachediSCSIVolumesInput) GoString() string {
 
 // A JSON object containing the following fields:
 type DescribeCachediSCSIVolumesOutput struct {
+	_ struct{} `type:"structure"`
+
 	// An array of objects where each object contains metadata about one cached
 	// volume.
 	CachediSCSIVolumes []*CachediSCSIVolume `type:"list"`
-
-	_ struct{} `type:"structure"`
 }
 
 // String returns the string representation
@@ -2943,11 +2943,11 @@ func (s DescribeCachediSCSIVolumesOutput) GoString() string {
 // A JSON object containing the Amazon Resource Name (ARN) of the iSCSI volume
 // target.
 type DescribeChapCredentialsInput struct {
+	_ struct{} `type:"structure"`
+
 	// The Amazon Resource Name (ARN) of the iSCSI volume target. Use the DescribeStorediSCSIVolumes
 	// operation to return to retrieve the TargetARN for specified VolumeARN.
 	TargetARN *string `min:"50" type:"string" required:"true"`
-
-	_ struct{} `type:"structure"`
 }
 
 // String returns the string representation
@@ -2962,6 +2962,8 @@ func (s DescribeChapCredentialsInput) GoString() string {
 
 // A JSON object containing a .
 type DescribeChapCredentialsOutput struct {
+	_ struct{} `type:"structure"`
+
 	// An array of ChapInfo objects that represent CHAP credentials. Each object
 	// in the array contains CHAP credential information for one target-initiator
 	// pair. If no CHAP credentials are set, an empty array is returned. CHAP credential
@@ -2978,8 +2980,6 @@ type DescribeChapCredentialsOutput struct {
 	//
 	//   TargetARN: The Amazon Resource Name (ARN) of the storage volume.
 	ChapCredentials []*ChapInfo `type:"list"`
-
-	_ struct{} `type:"structure"`
 }
 
 // String returns the string representation
@@ -2994,11 +2994,11 @@ func (s DescribeChapCredentialsOutput) GoString() string {
 
 // A JSON object containing the id of the gateway.
 type DescribeGatewayInformationInput struct {
+	_ struct{} `type:"structure"`
+
 	// The Amazon Resource Name (ARN) of the gateway. Use the ListGateways operation
 	// to return a list of gateways for your account and region.
 	GatewayARN *string `min:"50" type:"string" required:"true"`
-
-	_ struct{} `type:"structure"`
 }
 
 // String returns the string representation
@@ -3013,6 +3013,8 @@ func (s DescribeGatewayInformationInput) GoString() string {
 
 // A JSON object containing the following fields:
 type DescribeGatewayInformationOutput struct {
+	_ struct{} `type:"structure"`
+
 	// The Amazon Resource Name (ARN) of the gateway. Use the ListGateways operation
 	// to return a list of gateways for your account and region.
 	GatewayARN *string `min:"50" type:"string"`
@@ -3045,8 +3047,6 @@ type DescribeGatewayInformationOutput struct {
 	// the time zone of the gateway. If the gateway is not available for an update
 	// this field is not returned in the response.
 	NextUpdateAvailabilityDate *string `min:"1" type:"string"`
-
-	_ struct{} `type:"structure"`
 }
 
 // String returns the string representation
@@ -3061,11 +3061,11 @@ func (s DescribeGatewayInformationOutput) GoString() string {
 
 // A JSON object containing the of the gateway.
 type DescribeMaintenanceStartTimeInput struct {
+	_ struct{} `type:"structure"`
+
 	// The Amazon Resource Name (ARN) of the gateway. Use the ListGateways operation
 	// to return a list of gateways for your account and region.
 	GatewayARN *string `min:"50" type:"string" required:"true"`
-
-	_ struct{} `type:"structure"`
 }
 
 // String returns the string representation
@@ -3079,6 +3079,8 @@ func (s DescribeMaintenanceStartTimeInput) GoString() string {
 }
 
 type DescribeMaintenanceStartTimeOutput struct {
+	_ struct{} `type:"structure"`
+
 	DayOfWeek *int64 `type:"integer"`
 
 	// The Amazon Resource Name (ARN) of the gateway. Use the ListGateways operation
@@ -3090,8 +3092,6 @@ type DescribeMaintenanceStartTimeOutput struct {
 	MinuteOfHour *int64 `type:"integer"`
 
 	Timezone *string `min:"3" type:"string"`
-
-	_ struct{} `type:"structure"`
 }
 
 // String returns the string representation
@@ -3107,11 +3107,11 @@ func (s DescribeMaintenanceStartTimeOutput) GoString() string {
 // A JSON object containing the DescribeSnapshotScheduleInput$VolumeARN of the
 // volume.
 type DescribeSnapshotScheduleInput struct {
+	_ struct{} `type:"structure"`
+
 	// The Amazon Resource Name (ARN) of the volume. Use the ListVolumes operation
 	// to return a list of gateway volumes.
 	VolumeARN *string `min:"50" type:"string" required:"true"`
-
-	_ struct{} `type:"structure"`
 }
 
 // String returns the string representation
@@ -3125,6 +3125,8 @@ func (s DescribeSnapshotScheduleInput) GoString() string {
 }
 
 type DescribeSnapshotScheduleOutput struct {
+	_ struct{} `type:"structure"`
+
 	Description *string `min:"1" type:"string"`
 
 	RecurrenceInHours *int64 `min:"1" type:"integer"`
@@ -3134,8 +3136,6 @@ type DescribeSnapshotScheduleOutput struct {
 	Timezone *string `min:"3" type:"string"`
 
 	VolumeARN *string `min:"50" type:"string"`
-
-	_ struct{} `type:"structure"`
 }
 
 // String returns the string representation
@@ -3150,12 +3150,12 @@ func (s DescribeSnapshotScheduleOutput) GoString() string {
 
 // A JSON Object containing a list of DescribeStorediSCSIVolumesInput$VolumeARNs.
 type DescribeStorediSCSIVolumesInput struct {
+	_ struct{} `type:"structure"`
+
 	// An array of strings where each string represents the Amazon Resource Name
 	// (ARN) of a stored volume. All of the specified stored volumes must from the
 	// same gateway. Use ListVolumes to get volume ARNs for a gateway.
 	VolumeARNs []*string `type:"list" required:"true"`
-
-	_ struct{} `type:"structure"`
 }
 
 // String returns the string representation
@@ -3169,9 +3169,9 @@ func (s DescribeStorediSCSIVolumesInput) GoString() string {
 }
 
 type DescribeStorediSCSIVolumesOutput struct {
-	StorediSCSIVolumes []*StorediSCSIVolume `type:"list"`
-
 	_ struct{} `type:"structure"`
+
+	StorediSCSIVolumes []*StorediSCSIVolume `type:"list"`
 }
 
 // String returns the string representation
@@ -3186,6 +3186,8 @@ func (s DescribeStorediSCSIVolumesOutput) GoString() string {
 
 // DescribeTapeArchivesInput
 type DescribeTapeArchivesInput struct {
+	_ struct{} `type:"structure"`
+
 	// Specifies that the number of virtual tapes descried be limited to the specified
 	// number.
 	Limit *int64 `min:"1" type:"integer"`
@@ -3197,8 +3199,6 @@ type DescribeTapeArchivesInput struct {
 	// Specifies one or more unique Amazon Resource Names (ARNs) that represent
 	// the virtual tapes you want to describe.
 	TapeARNs []*string `type:"list"`
-
-	_ struct{} `type:"structure"`
 }
 
 // String returns the string representation
@@ -3213,6 +3213,8 @@ func (s DescribeTapeArchivesInput) GoString() string {
 
 // DescribeTapeArchivesOutput
 type DescribeTapeArchivesOutput struct {
+	_ struct{} `type:"structure"`
+
 	// An opaque string that indicates the position at which the virtual tapes that
 	// were fetched for description ended. Use this marker in your next request
 	// to fetch the next set of virtual tapes in the virtual tape shelf (VTS). If
@@ -3225,8 +3227,6 @@ type DescribeTapeArchivesOutput struct {
 	// returned includes the Amazon Resource Names (ARNs) of the tapes, size of
 	// the tapes, status of the tapes, progress of the description and tape barcode.
 	TapeArchives []*TapeArchive `type:"list"`
-
-	_ struct{} `type:"structure"`
 }
 
 // String returns the string representation
@@ -3241,6 +3241,8 @@ func (s DescribeTapeArchivesOutput) GoString() string {
 
 // DescribeTapeRecoveryPointsInput
 type DescribeTapeRecoveryPointsInput struct {
+	_ struct{} `type:"structure"`
+
 	// The Amazon Resource Name (ARN) of the gateway. Use the ListGateways operation
 	// to return a list of gateways for your account and region.
 	GatewayARN *string `min:"50" type:"string" required:"true"`
@@ -3252,8 +3254,6 @@ type DescribeTapeRecoveryPointsInput struct {
 	// An opaque string that indicates the position at which to begin describing
 	// the virtual tape recovery points.
 	Marker *string `min:"1" type:"string"`
-
-	_ struct{} `type:"structure"`
 }
 
 // String returns the string representation
@@ -3268,6 +3268,8 @@ func (s DescribeTapeRecoveryPointsInput) GoString() string {
 
 // DescribeTapeRecoveryPointsOutput
 type DescribeTapeRecoveryPointsOutput struct {
+	_ struct{} `type:"structure"`
+
 	// The Amazon Resource Name (ARN) of the gateway. Use the ListGateways operation
 	// to return a list of gateways for your account and region.
 	GatewayARN *string `min:"50" type:"string"`
@@ -3282,8 +3284,6 @@ type DescribeTapeRecoveryPointsOutput struct {
 
 	// An array of TapeRecoveryPointInfos that are available for the specified gateway.
 	TapeRecoveryPointInfos []*TapeRecoveryPointInfo `type:"list"`
-
-	_ struct{} `type:"structure"`
 }
 
 // String returns the string representation
@@ -3298,6 +3298,8 @@ func (s DescribeTapeRecoveryPointsOutput) GoString() string {
 
 // DescribeTapesInput
 type DescribeTapesInput struct {
+	_ struct{} `type:"structure"`
+
 	// The Amazon Resource Name (ARN) of the gateway. Use the ListGateways operation
 	// to return a list of gateways for your account and region.
 	GatewayARN *string `min:"50" type:"string" required:"true"`
@@ -3319,8 +3321,6 @@ type DescribeTapesInput struct {
 	// AWS Storage Gateway returns a description of all virtual tapes associated
 	// with the specified gateway.
 	TapeARNs []*string `type:"list"`
-
-	_ struct{} `type:"structure"`
 }
 
 // String returns the string representation
@@ -3335,6 +3335,8 @@ func (s DescribeTapesInput) GoString() string {
 
 // DescribeTapesOutput
 type DescribeTapesOutput struct {
+	_ struct{} `type:"structure"`
+
 	// An opaque string which can be used as part of a subsequent DescribeTapes
 	// call to retrieve the next page of results.
 	//
@@ -3344,8 +3346,6 @@ type DescribeTapesOutput struct {
 
 	// An array of virtual tape descriptions.
 	Tapes []*Tape `type:"list"`
-
-	_ struct{} `type:"structure"`
 }
 
 // String returns the string representation
@@ -3359,11 +3359,11 @@ func (s DescribeTapesOutput) GoString() string {
 }
 
 type DescribeUploadBufferInput struct {
+	_ struct{} `type:"structure"`
+
 	// The Amazon Resource Name (ARN) of the gateway. Use the ListGateways operation
 	// to return a list of gateways for your account and region.
 	GatewayARN *string `min:"50" type:"string" required:"true"`
-
-	_ struct{} `type:"structure"`
 }
 
 // String returns the string representation
@@ -3377,6 +3377,8 @@ func (s DescribeUploadBufferInput) GoString() string {
 }
 
 type DescribeUploadBufferOutput struct {
+	_ struct{} `type:"structure"`
+
 	DiskIds []*string `type:"list"`
 
 	// The Amazon Resource Name (ARN) of the gateway. Use the ListGateways operation
@@ -3386,8 +3388,6 @@ type DescribeUploadBufferOutput struct {
 	UploadBufferAllocatedInBytes *int64 `type:"long"`
 
 	UploadBufferUsedInBytes *int64 `type:"long"`
-
-	_ struct{} `type:"structure"`
 }
 
 // String returns the string representation
@@ -3402,6 +3402,8 @@ func (s DescribeUploadBufferOutput) GoString() string {
 
 // DescribeVTLDevicesInput
 type DescribeVTLDevicesInput struct {
+	_ struct{} `type:"structure"`
+
 	// The Amazon Resource Name (ARN) of the gateway. Use the ListGateways operation
 	// to return a list of gateways for your account and region.
 	GatewayARN *string `min:"50" type:"string" required:"true"`
@@ -3421,8 +3423,6 @@ type DescribeVTLDevicesInput struct {
 	// devices are specified, the result will contain all devices on the specified
 	// gateway.
 	VTLDeviceARNs []*string `type:"list"`
-
-	_ struct{} `type:"structure"`
 }
 
 // String returns the string representation
@@ -3437,6 +3437,8 @@ func (s DescribeVTLDevicesInput) GoString() string {
 
 // DescribeVTLDevicesOutput
 type DescribeVTLDevicesOutput struct {
+	_ struct{} `type:"structure"`
+
 	// The Amazon Resource Name (ARN) of the gateway. Use the ListGateways operation
 	// to return a list of gateways for your account and region.
 	GatewayARN *string `min:"50" type:"string"`
@@ -3450,8 +3452,6 @@ type DescribeVTLDevicesOutput struct {
 	// An array of VTL device objects composed of the Amazon Resource Name(ARN)
 	// of the VTL devices.
 	VTLDevices []*VTLDevice `type:"list"`
-
-	_ struct{} `type:"structure"`
 }
 
 // String returns the string representation
@@ -3466,11 +3466,11 @@ func (s DescribeVTLDevicesOutput) GoString() string {
 
 // A JSON object containing the of the gateway.
 type DescribeWorkingStorageInput struct {
+	_ struct{} `type:"structure"`
+
 	// The Amazon Resource Name (ARN) of the gateway. Use the ListGateways operation
 	// to return a list of gateways for your account and region.
 	GatewayARN *string `min:"50" type:"string" required:"true"`
-
-	_ struct{} `type:"structure"`
 }
 
 // String returns the string representation
@@ -3485,6 +3485,8 @@ func (s DescribeWorkingStorageInput) GoString() string {
 
 // A JSON object containing the following fields:
 type DescribeWorkingStorageOutput struct {
+	_ struct{} `type:"structure"`
+
 	// An array of the gateway's local disk IDs that are configured as working storage.
 	// Each local disk ID is specified as a string (minimum length of 1 and maximum
 	// length of 300). If no local disks are configured as working storage, then
@@ -3502,8 +3504,6 @@ type DescribeWorkingStorageOutput struct {
 	// The total working storage in bytes in use by the gateway. If no working storage
 	// is configured for the gateway, this field returns 0.
 	WorkingStorageUsedInBytes *int64 `type:"long"`
-
-	_ struct{} `type:"structure"`
 }
 
 // String returns the string representation
@@ -3518,6 +3518,8 @@ func (s DescribeWorkingStorageOutput) GoString() string {
 
 // Lists iSCSI information about a VTL device.
 type DeviceiSCSIAttributes struct {
+	_ struct{} `type:"structure"`
+
 	// Indicates whether mutual CHAP is enabled for the iSCSI target.
 	ChapEnabled *bool `type:"boolean"`
 
@@ -3530,8 +3532,6 @@ type DeviceiSCSIAttributes struct {
 	// Specifies the unique Amazon Resource Name(ARN) that encodes the iSCSI qualified
 	// name(iqn) of a tape drive or media changer target.
 	TargetARN *string `min:"50" type:"string"`
-
-	_ struct{} `type:"structure"`
 }
 
 // String returns the string representation
@@ -3546,11 +3546,11 @@ func (s DeviceiSCSIAttributes) GoString() string {
 
 // DisableGatewayInput
 type DisableGatewayInput struct {
+	_ struct{} `type:"structure"`
+
 	// The Amazon Resource Name (ARN) of the gateway. Use the ListGateways operation
 	// to return a list of gateways for your account and region.
 	GatewayARN *string `min:"50" type:"string" required:"true"`
-
-	_ struct{} `type:"structure"`
 }
 
 // String returns the string representation
@@ -3565,10 +3565,10 @@ func (s DisableGatewayInput) GoString() string {
 
 // DisableGatewayOutput
 type DisableGatewayOutput struct {
+	_ struct{} `type:"structure"`
+
 	// The unique Amazon Resource Name of the disabled gateway.
 	GatewayARN *string `min:"50" type:"string"`
-
-	_ struct{} `type:"structure"`
 }
 
 // String returns the string representation
@@ -3582,6 +3582,8 @@ func (s DisableGatewayOutput) GoString() string {
 }
 
 type Disk struct {
+	_ struct{} `type:"structure"`
+
 	DiskAllocationResource *string `type:"string"`
 
 	DiskAllocationType *string `min:"3" type:"string"`
@@ -3595,8 +3597,6 @@ type Disk struct {
 	DiskSizeInBytes *int64 `type:"long"`
 
 	DiskStatus *string `type:"string"`
-
-	_ struct{} `type:"structure"`
 }
 
 // String returns the string representation
@@ -3613,13 +3613,13 @@ func (s Disk) GoString() string {
 // as an or. See the errorCode and errorDetails members for more information
 // about the error.
 type Error struct {
+	_ struct{} `type:"structure"`
+
 	// Additional information about the error.
 	ErrorCode *string `locationName:"errorCode" type:"string" enum:"ErrorCode"`
 
 	// Human-readable text that provides detail about the error that occurred.
 	ErrorDetails map[string]*string `locationName:"errorDetails" type:"map"`
-
-	_ struct{} `type:"structure"`
 }
 
 // String returns the string representation
@@ -3633,6 +3633,8 @@ func (s Error) GoString() string {
 }
 
 type GatewayInfo struct {
+	_ struct{} `type:"structure"`
+
 	// The Amazon Resource Name (ARN) of the gateway. Use the ListGateways operation
 	// to return a list of gateways for your account and region.
 	GatewayARN *string `min:"50" type:"string"`
@@ -3642,8 +3644,6 @@ type GatewayInfo struct {
 	GatewayOperationalState *string `min:"2" type:"string"`
 
 	GatewayType *string `min:"2" type:"string"`
-
-	_ struct{} `type:"structure"`
 }
 
 // String returns the string representation
@@ -3660,6 +3660,8 @@ func (s GatewayInfo) GoString() string {
 //
 //   ListGatewaysInput$Limit   ListGatewaysInput$Marker
 type ListGatewaysInput struct {
+	_ struct{} `type:"structure"`
+
 	// Specifies that the list of gateways returned be limited to the specified
 	// number of items.
 	Limit *int64 `min:"1" type:"integer"`
@@ -3667,8 +3669,6 @@ type ListGatewaysInput struct {
 	// An opaque string that indicates the position at which to begin the returned
 	// list of gateways.
 	Marker *string `min:"1" type:"string"`
-
-	_ struct{} `type:"structure"`
 }
 
 // String returns the string representation
@@ -3682,11 +3682,11 @@ func (s ListGatewaysInput) GoString() string {
 }
 
 type ListGatewaysOutput struct {
+	_ struct{} `type:"structure"`
+
 	Gateways []*GatewayInfo `type:"list"`
 
 	Marker *string `min:"1" type:"string"`
-
-	_ struct{} `type:"structure"`
 }
 
 // String returns the string representation
@@ -3701,11 +3701,11 @@ func (s ListGatewaysOutput) GoString() string {
 
 // A JSON object containing the of the gateway.
 type ListLocalDisksInput struct {
+	_ struct{} `type:"structure"`
+
 	// The Amazon Resource Name (ARN) of the gateway. Use the ListGateways operation
 	// to return a list of gateways for your account and region.
 	GatewayARN *string `min:"50" type:"string" required:"true"`
-
-	_ struct{} `type:"structure"`
 }
 
 // String returns the string representation
@@ -3719,13 +3719,13 @@ func (s ListLocalDisksInput) GoString() string {
 }
 
 type ListLocalDisksOutput struct {
+	_ struct{} `type:"structure"`
+
 	Disks []*Disk `type:"list"`
 
 	// The Amazon Resource Name (ARN) of the gateway. Use the ListGateways operation
 	// to return a list of gateways for your account and region.
 	GatewayARN *string `min:"50" type:"string"`
-
-	_ struct{} `type:"structure"`
 }
 
 // String returns the string representation
@@ -3740,6 +3740,8 @@ func (s ListLocalDisksOutput) GoString() string {
 
 // ListTagsForResourceInput
 type ListTagsForResourceInput struct {
+	_ struct{} `type:"structure"`
+
 	// Specifies that the list of tags returned be limited to the specified number
 	// of items.
 	Limit *int64 `min:"1" type:"integer"`
@@ -3751,8 +3753,6 @@ type ListTagsForResourceInput struct {
 	// The Amazon Resource Name (ARN) of the resource for which you want to list
 	// tags.
 	ResourceARN *string `min:"50" type:"string"`
-
-	_ struct{} `type:"structure"`
 }
 
 // String returns the string representation
@@ -3767,6 +3767,8 @@ func (s ListTagsForResourceInput) GoString() string {
 
 // ListTagsForResourceOutput
 type ListTagsForResourceOutput struct {
+	_ struct{} `type:"structure"`
+
 	// An opaque string that indicates the position at which to stop returning the
 	// list of tags.
 	Marker *string `min:"1" type:"string"`
@@ -3777,8 +3779,6 @@ type ListTagsForResourceOutput struct {
 
 	// An array that contains the tags for the specified resource.
 	Tags []*Tag `type:"list"`
-
-	_ struct{} `type:"structure"`
 }
 
 // String returns the string representation
@@ -3793,11 +3793,11 @@ func (s ListTagsForResourceOutput) GoString() string {
 
 // ListVolumeInitiatorsInput
 type ListVolumeInitiatorsInput struct {
+	_ struct{} `type:"structure"`
+
 	// The Amazon Resource Name (ARN) of the volume. Use the ListVolumes operation
 	// to return a list of gateway volumes for the gateway.
 	VolumeARN *string `min:"50" type:"string" required:"true"`
-
-	_ struct{} `type:"structure"`
 }
 
 // String returns the string representation
@@ -3812,11 +3812,11 @@ func (s ListVolumeInitiatorsInput) GoString() string {
 
 // ListVolumeInitiatorsOutput
 type ListVolumeInitiatorsOutput struct {
+	_ struct{} `type:"structure"`
+
 	// The host names and port numbers of all iSCSI initiators that are connected
 	// to the gateway.
 	Initiators []*string `type:"list"`
-
-	_ struct{} `type:"structure"`
 }
 
 // String returns the string representation
@@ -3830,11 +3830,11 @@ func (s ListVolumeInitiatorsOutput) GoString() string {
 }
 
 type ListVolumeRecoveryPointsInput struct {
+	_ struct{} `type:"structure"`
+
 	// The Amazon Resource Name (ARN) of the gateway. Use the ListGateways operation
 	// to return a list of gateways for your account and region.
 	GatewayARN *string `min:"50" type:"string" required:"true"`
-
-	_ struct{} `type:"structure"`
 }
 
 // String returns the string representation
@@ -3848,13 +3848,13 @@ func (s ListVolumeRecoveryPointsInput) GoString() string {
 }
 
 type ListVolumeRecoveryPointsOutput struct {
+	_ struct{} `type:"structure"`
+
 	// The Amazon Resource Name (ARN) of the gateway. Use the ListGateways operation
 	// to return a list of gateways for your account and region.
 	GatewayARN *string `min:"50" type:"string"`
 
 	VolumeRecoveryPointInfos []*VolumeRecoveryPointInfo `type:"list"`
-
-	_ struct{} `type:"structure"`
 }
 
 // String returns the string representation
@@ -3871,6 +3871,8 @@ func (s ListVolumeRecoveryPointsOutput) GoString() string {
 //
 //   ListVolumesInput$Limit   ListVolumesInput$Marker
 type ListVolumesInput struct {
+	_ struct{} `type:"structure"`
+
 	// The Amazon Resource Name (ARN) of the gateway. Use the ListGateways operation
 	// to return a list of gateways for your account and region.
 	GatewayARN *string `min:"50" type:"string" required:"true"`
@@ -3883,8 +3885,6 @@ type ListVolumesInput struct {
 	// of volumes. Obtain the marker from the response of a previous List iSCSI
 	// Volumes request.
 	Marker *string `min:"1" type:"string"`
-
-	_ struct{} `type:"structure"`
 }
 
 // String returns the string representation
@@ -3898,6 +3898,8 @@ func (s ListVolumesInput) GoString() string {
 }
 
 type ListVolumesOutput struct {
+	_ struct{} `type:"structure"`
+
 	// The Amazon Resource Name (ARN) of the gateway. Use the ListGateways operation
 	// to return a list of gateways for your account and region.
 	GatewayARN *string `min:"50" type:"string"`
@@ -3905,8 +3907,6 @@ type ListVolumesOutput struct {
 	Marker *string `min:"1" type:"string"`
 
 	VolumeInfos []*VolumeInfo `type:"list"`
-
-	_ struct{} `type:"structure"`
 }
 
 // String returns the string representation
@@ -3921,6 +3921,8 @@ func (s ListVolumesOutput) GoString() string {
 
 // Describes a gateway's network interface.
 type NetworkInterface struct {
+	_ struct{} `type:"structure"`
+
 	// The Internet Protocol version 4 (IPv4) address of the interface.
 	Ipv4Address *string `type:"string"`
 
@@ -3932,8 +3934,6 @@ type NetworkInterface struct {
 	//
 	// This is currently unsupported and will not be returned in output.
 	MacAddress *string `type:"string"`
-
-	_ struct{} `type:"structure"`
 }
 
 // String returns the string representation
@@ -3948,6 +3948,8 @@ func (s NetworkInterface) GoString() string {
 
 // RemoveTagsFromResourceInput
 type RemoveTagsFromResourceInput struct {
+	_ struct{} `type:"structure"`
+
 	// The Amazon Resource Name (ARN) of the resource you want to remove the tags
 	// from.
 	ResourceARN *string `min:"50" type:"string"`
@@ -3955,8 +3957,6 @@ type RemoveTagsFromResourceInput struct {
 	// The keys of the tags you want to remove from the specified resource. A tag
 	// is composed of a key/value pair.
 	TagKeys []*string `type:"list"`
-
-	_ struct{} `type:"structure"`
 }
 
 // String returns the string representation
@@ -3971,11 +3971,11 @@ func (s RemoveTagsFromResourceInput) GoString() string {
 
 // RemoveTagsFromResourceOutput
 type RemoveTagsFromResourceOutput struct {
+	_ struct{} `type:"structure"`
+
 	// The Amazon Resource Name (ARN) of the resource that the tags were removed
 	// from.
 	ResourceARN *string `min:"50" type:"string"`
-
-	_ struct{} `type:"structure"`
 }
 
 // String returns the string representation
@@ -3989,11 +3989,11 @@ func (s RemoveTagsFromResourceOutput) GoString() string {
 }
 
 type ResetCacheInput struct {
+	_ struct{} `type:"structure"`
+
 	// The Amazon Resource Name (ARN) of the gateway. Use the ListGateways operation
 	// to return a list of gateways for your account and region.
 	GatewayARN *string `min:"50" type:"string" required:"true"`
-
-	_ struct{} `type:"structure"`
 }
 
 // String returns the string representation
@@ -4007,11 +4007,11 @@ func (s ResetCacheInput) GoString() string {
 }
 
 type ResetCacheOutput struct {
+	_ struct{} `type:"structure"`
+
 	// The Amazon Resource Name (ARN) of the gateway. Use the ListGateways operation
 	// to return a list of gateways for your account and region.
 	GatewayARN *string `min:"50" type:"string"`
-
-	_ struct{} `type:"structure"`
 }
 
 // String returns the string representation
@@ -4026,6 +4026,8 @@ func (s ResetCacheOutput) GoString() string {
 
 // RetrieveTapeArchiveInput
 type RetrieveTapeArchiveInput struct {
+	_ struct{} `type:"structure"`
+
 	// The Amazon Resource Name (ARN) of the gateway you want to retrieve the virtual
 	// tape to. Use the ListGateways operation to return a list of gateways for
 	// your account and region.
@@ -4037,8 +4039,6 @@ type RetrieveTapeArchiveInput struct {
 	// The Amazon Resource Name (ARN) of the virtual tape you want to retrieve from
 	// the virtual tape shelf (VTS).
 	TapeARN *string `min:"50" type:"string" required:"true"`
-
-	_ struct{} `type:"structure"`
 }
 
 // String returns the string representation
@@ -4053,10 +4053,10 @@ func (s RetrieveTapeArchiveInput) GoString() string {
 
 // RetrieveTapeArchiveOutput
 type RetrieveTapeArchiveOutput struct {
+	_ struct{} `type:"structure"`
+
 	// The Amazon Resource Name (ARN) of the retrieved virtual tape.
 	TapeARN *string `min:"50" type:"string"`
-
-	_ struct{} `type:"structure"`
 }
 
 // String returns the string representation
@@ -4071,6 +4071,8 @@ func (s RetrieveTapeArchiveOutput) GoString() string {
 
 // RetrieveTapeRecoveryPointInput
 type RetrieveTapeRecoveryPointInput struct {
+	_ struct{} `type:"structure"`
+
 	// The Amazon Resource Name (ARN) of the gateway. Use the ListGateways operation
 	// to return a list of gateways for your account and region.
 	GatewayARN *string `min:"50" type:"string" required:"true"`
@@ -4078,8 +4080,6 @@ type RetrieveTapeRecoveryPointInput struct {
 	// The Amazon Resource Name (ARN) of the virtual tape for which you want to
 	// retrieve the recovery point.
 	TapeARN *string `min:"50" type:"string" required:"true"`
-
-	_ struct{} `type:"structure"`
 }
 
 // String returns the string representation
@@ -4094,11 +4094,11 @@ func (s RetrieveTapeRecoveryPointInput) GoString() string {
 
 // RetrieveTapeRecoveryPointOutput
 type RetrieveTapeRecoveryPointOutput struct {
+	_ struct{} `type:"structure"`
+
 	// The Amazon Resource Name (ARN) of the virtual tape for which the recovery
 	// point was retrieved.
 	TapeARN *string `min:"50" type:"string"`
-
-	_ struct{} `type:"structure"`
 }
 
 // String returns the string representation
@@ -4113,11 +4113,11 @@ func (s RetrieveTapeRecoveryPointOutput) GoString() string {
 
 // A JSON object containing the of the gateway to shut down.
 type ShutdownGatewayInput struct {
+	_ struct{} `type:"structure"`
+
 	// The Amazon Resource Name (ARN) of the gateway. Use the ListGateways operation
 	// to return a list of gateways for your account and region.
 	GatewayARN *string `min:"50" type:"string" required:"true"`
-
-	_ struct{} `type:"structure"`
 }
 
 // String returns the string representation
@@ -4132,11 +4132,11 @@ func (s ShutdownGatewayInput) GoString() string {
 
 // A JSON object containing the of the gateway that was shut down.
 type ShutdownGatewayOutput struct {
+	_ struct{} `type:"structure"`
+
 	// The Amazon Resource Name (ARN) of the gateway. Use the ListGateways operation
 	// to return a list of gateways for your account and region.
 	GatewayARN *string `min:"50" type:"string"`
-
-	_ struct{} `type:"structure"`
 }
 
 // String returns the string representation
@@ -4151,11 +4151,11 @@ func (s ShutdownGatewayOutput) GoString() string {
 
 // A JSON object containing the of the gateway to start.
 type StartGatewayInput struct {
+	_ struct{} `type:"structure"`
+
 	// The Amazon Resource Name (ARN) of the gateway. Use the ListGateways operation
 	// to return a list of gateways for your account and region.
 	GatewayARN *string `min:"50" type:"string" required:"true"`
-
-	_ struct{} `type:"structure"`
 }
 
 // String returns the string representation
@@ -4170,11 +4170,11 @@ func (s StartGatewayInput) GoString() string {
 
 // A JSON object containing the of the gateway that was restarted.
 type StartGatewayOutput struct {
+	_ struct{} `type:"structure"`
+
 	// The Amazon Resource Name (ARN) of the gateway. Use the ListGateways operation
 	// to return a list of gateways for your account and region.
 	GatewayARN *string `min:"50" type:"string"`
-
-	_ struct{} `type:"structure"`
 }
 
 // String returns the string representation
@@ -4188,6 +4188,8 @@ func (s StartGatewayOutput) GoString() string {
 }
 
 type StorediSCSIVolume struct {
+	_ struct{} `type:"structure"`
+
 	PreservedExistingData *bool `type:"boolean"`
 
 	SourceSnapshotId *string `type:"string"`
@@ -4208,8 +4210,6 @@ type StorediSCSIVolume struct {
 
 	// Lists iSCSI information about a volume.
 	VolumeiSCSIAttributes *VolumeiSCSIAttributes `type:"structure"`
-
-	_ struct{} `type:"structure"`
 }
 
 // String returns the string representation
@@ -4223,11 +4223,11 @@ func (s StorediSCSIVolume) GoString() string {
 }
 
 type Tag struct {
+	_ struct{} `type:"structure"`
+
 	Key *string `min:"1" type:"string" required:"true"`
 
 	Value *string `type:"string" required:"true"`
-
-	_ struct{} `type:"structure"`
 }
 
 // String returns the string representation
@@ -4242,6 +4242,8 @@ func (s Tag) GoString() string {
 
 // Describes a virtual tape object.
 type Tape struct {
+	_ struct{} `type:"structure"`
+
 	// For archiving virtual tapes, indicates how much data remains to be uploaded
 	// before archiving is complete.
 	//
@@ -4263,8 +4265,6 @@ type Tape struct {
 	// The virtual tape library (VTL) device that the virtual tape is associated
 	// with.
 	VTLDevice *string `min:"50" type:"string"`
-
-	_ struct{} `type:"structure"`
 }
 
 // String returns the string representation
@@ -4279,6 +4279,8 @@ func (s Tape) GoString() string {
 
 // Represents a virtual tape that is archived in the virtual tape shelf (VTS).
 type TapeArchive struct {
+	_ struct{} `type:"structure"`
+
 	// The time that the archiving of the virtual tape was completed.
 	//
 	// The string format of the completion time is in the ISO8601 extended YYYY-MM-DD'T'HH:MM:SS'Z'
@@ -4302,8 +4304,6 @@ type TapeArchive struct {
 
 	// The current state of the archived virtual tape.
 	TapeStatus *string `type:"string"`
-
-	_ struct{} `type:"structure"`
 }
 
 // String returns the string representation
@@ -4318,6 +4318,8 @@ func (s TapeArchive) GoString() string {
 
 // Describes a recovery point.
 type TapeRecoveryPointInfo struct {
+	_ struct{} `type:"structure"`
+
 	// The Amazon Resource Name (ARN) of the virtual tape.
 	TapeARN *string `min:"50" type:"string"`
 
@@ -4332,8 +4334,6 @@ type TapeRecoveryPointInfo struct {
 	TapeSizeInBytes *int64 `type:"long"`
 
 	TapeStatus *string `type:"string"`
-
-	_ struct{} `type:"structure"`
 }
 
 // String returns the string representation
@@ -4350,6 +4350,8 @@ func (s TapeRecoveryPointInfo) GoString() string {
 //
 //   UpdateBandwidthRateLimitInput$AverageDownloadRateLimitInBitsPerSec   UpdateBandwidthRateLimitInput$AverageUploadRateLimitInBitsPerSec
 type UpdateBandwidthRateLimitInput struct {
+	_ struct{} `type:"structure"`
+
 	// The average download bandwidth rate limit in bits per second.
 	AverageDownloadRateLimitInBitsPerSec *int64 `min:"102400" type:"long"`
 
@@ -4359,8 +4361,6 @@ type UpdateBandwidthRateLimitInput struct {
 	// The Amazon Resource Name (ARN) of the gateway. Use the ListGateways operation
 	// to return a list of gateways for your account and region.
 	GatewayARN *string `min:"50" type:"string" required:"true"`
-
-	_ struct{} `type:"structure"`
 }
 
 // String returns the string representation
@@ -4376,11 +4376,11 @@ func (s UpdateBandwidthRateLimitInput) GoString() string {
 // A JSON object containing the of the gateway whose throttle information was
 // updated.
 type UpdateBandwidthRateLimitOutput struct {
+	_ struct{} `type:"structure"`
+
 	// The Amazon Resource Name (ARN) of the gateway. Use the ListGateways operation
 	// to return a list of gateways for your account and region.
 	GatewayARN *string `min:"50" type:"string"`
-
-	_ struct{} `type:"structure"`
 }
 
 // String returns the string representation
@@ -4398,6 +4398,8 @@ func (s UpdateBandwidthRateLimitOutput) GoString() string {
 //   UpdateChapCredentialsInput$InitiatorName   UpdateChapCredentialsInput$SecretToAuthenticateInitiator
 //   UpdateChapCredentialsInput$SecretToAuthenticateTarget   UpdateChapCredentialsInput$TargetARN
 type UpdateChapCredentialsInput struct {
+	_ struct{} `type:"structure"`
+
 	// The iSCSI initiator that connects to the target.
 	InitiatorName *string `min:"1" type:"string" required:"true"`
 
@@ -4418,8 +4420,6 @@ type UpdateChapCredentialsInput struct {
 	// The Amazon Resource Name (ARN) of the iSCSI volume target. Use the DescribeStorediSCSIVolumes
 	// operation to return the TargetARN for specified VolumeARN.
 	TargetARN *string `min:"50" type:"string" required:"true"`
-
-	_ struct{} `type:"structure"`
 }
 
 // String returns the string representation
@@ -4434,6 +4434,8 @@ func (s UpdateChapCredentialsInput) GoString() string {
 
 // A JSON object containing the following fields:
 type UpdateChapCredentialsOutput struct {
+	_ struct{} `type:"structure"`
+
 	// The iSCSI initiator that connects to the target. This is the same initiator
 	// name specified in the request.
 	InitiatorName *string `min:"1" type:"string"`
@@ -4441,8 +4443,6 @@ type UpdateChapCredentialsOutput struct {
 	// The Amazon Resource Name (ARN) of the target. This is the same target specified
 	// in the request.
 	TargetARN *string `min:"50" type:"string"`
-
-	_ struct{} `type:"structure"`
 }
 
 // String returns the string representation
@@ -4456,6 +4456,8 @@ func (s UpdateChapCredentialsOutput) GoString() string {
 }
 
 type UpdateGatewayInformationInput struct {
+	_ struct{} `type:"structure"`
+
 	// The Amazon Resource Name (ARN) of the gateway. Use the ListGateways operation
 	// to return a list of gateways for your account and region.
 	GatewayARN *string `min:"50" type:"string" required:"true"`
@@ -4465,8 +4467,6 @@ type UpdateGatewayInformationInput struct {
 	GatewayName *string `min:"2" type:"string"`
 
 	GatewayTimezone *string `min:"3" type:"string"`
-
-	_ struct{} `type:"structure"`
 }
 
 // String returns the string representation
@@ -4481,13 +4481,13 @@ func (s UpdateGatewayInformationInput) GoString() string {
 
 // A JSON object containing the of the gateway that was updated.
 type UpdateGatewayInformationOutput struct {
+	_ struct{} `type:"structure"`
+
 	// The Amazon Resource Name (ARN) of the gateway. Use the ListGateways operation
 	// to return a list of gateways for your account and region.
 	GatewayARN *string `min:"50" type:"string"`
 
 	GatewayName *string `type:"string"`
-
-	_ struct{} `type:"structure"`
 }
 
 // String returns the string representation
@@ -4502,11 +4502,11 @@ func (s UpdateGatewayInformationOutput) GoString() string {
 
 // A JSON object containing the of the gateway to update.
 type UpdateGatewaySoftwareNowInput struct {
+	_ struct{} `type:"structure"`
+
 	// The Amazon Resource Name (ARN) of the gateway. Use the ListGateways operation
 	// to return a list of gateways for your account and region.
 	GatewayARN *string `min:"50" type:"string" required:"true"`
-
-	_ struct{} `type:"structure"`
 }
 
 // String returns the string representation
@@ -4521,11 +4521,11 @@ func (s UpdateGatewaySoftwareNowInput) GoString() string {
 
 // A JSON object containing the of the gateway that was updated.
 type UpdateGatewaySoftwareNowOutput struct {
+	_ struct{} `type:"structure"`
+
 	// The Amazon Resource Name (ARN) of the gateway. Use the ListGateways operation
 	// to return a list of gateways for your account and region.
 	GatewayARN *string `min:"50" type:"string"`
-
-	_ struct{} `type:"structure"`
 }
 
 // String returns the string representation
@@ -4543,6 +4543,8 @@ func (s UpdateGatewaySoftwareNowOutput) GoString() string {
 //   UpdateMaintenanceStartTimeInput$DayOfWeek   UpdateMaintenanceStartTimeInput$HourOfDay
 //   UpdateMaintenanceStartTimeInput$MinuteOfHour
 type UpdateMaintenanceStartTimeInput struct {
+	_ struct{} `type:"structure"`
+
 	// The maintenance start time day of the week.
 	DayOfWeek *int64 `type:"integer" required:"true"`
 
@@ -4559,8 +4561,6 @@ type UpdateMaintenanceStartTimeInput struct {
 	// mm is the minute (00 to 59). The minute of the hour is in the time zone of
 	// the gateway.
 	MinuteOfHour *int64 `type:"integer" required:"true"`
-
-	_ struct{} `type:"structure"`
 }
 
 // String returns the string representation
@@ -4576,11 +4576,11 @@ func (s UpdateMaintenanceStartTimeInput) GoString() string {
 // A JSON object containing the of the gateway whose maintenance start time
 // is updated.
 type UpdateMaintenanceStartTimeOutput struct {
+	_ struct{} `type:"structure"`
+
 	// The Amazon Resource Name (ARN) of the gateway. Use the ListGateways operation
 	// to return a list of gateways for your account and region.
 	GatewayARN *string `min:"50" type:"string"`
-
-	_ struct{} `type:"structure"`
 }
 
 // String returns the string representation
@@ -4598,6 +4598,8 @@ func (s UpdateMaintenanceStartTimeOutput) GoString() string {
 //   UpdateSnapshotScheduleInput$Description   UpdateSnapshotScheduleInput$RecurrenceInHours
 //   UpdateSnapshotScheduleInput$StartAt   UpdateSnapshotScheduleInput$VolumeARN
 type UpdateSnapshotScheduleInput struct {
+	_ struct{} `type:"structure"`
+
 	// Optional description of the snapshot that overwrites the existing description.
 	Description *string `min:"1" type:"string"`
 
@@ -4612,8 +4614,6 @@ type UpdateSnapshotScheduleInput struct {
 	// The Amazon Resource Name (ARN) of the volume. Use the ListVolumes operation
 	// to return a list of gateway volumes.
 	VolumeARN *string `min:"50" type:"string" required:"true"`
-
-	_ struct{} `type:"structure"`
 }
 
 // String returns the string representation
@@ -4628,9 +4628,9 @@ func (s UpdateSnapshotScheduleInput) GoString() string {
 
 // A JSON object containing the of the updated storage volume.
 type UpdateSnapshotScheduleOutput struct {
-	VolumeARN *string `min:"50" type:"string"`
-
 	_ struct{} `type:"structure"`
+
+	VolumeARN *string `min:"50" type:"string"`
 }
 
 // String returns the string representation
@@ -4645,6 +4645,8 @@ func (s UpdateSnapshotScheduleOutput) GoString() string {
 
 // UpdateVTLDeviceTypeInput
 type UpdateVTLDeviceTypeInput struct {
+	_ struct{} `type:"structure"`
+
 	// The type of medium changer you want to select.
 	//
 	// Valid Values: "STK-L700", "AWS-Gateway-VTL"
@@ -4652,8 +4654,6 @@ type UpdateVTLDeviceTypeInput struct {
 
 	// The Amazon Resource Name (ARN) of the medium changer you want to select.
 	VTLDeviceARN *string `min:"50" type:"string" required:"true"`
-
-	_ struct{} `type:"structure"`
 }
 
 // String returns the string representation
@@ -4668,10 +4668,10 @@ func (s UpdateVTLDeviceTypeInput) GoString() string {
 
 // UpdateVTLDeviceTypeOutput
 type UpdateVTLDeviceTypeOutput struct {
+	_ struct{} `type:"structure"`
+
 	// The Amazon Resource Name (ARN) of the medium changer you have selected.
 	VTLDeviceARN *string `min:"50" type:"string"`
-
-	_ struct{} `type:"structure"`
 }
 
 // String returns the string representation
@@ -4686,6 +4686,8 @@ func (s UpdateVTLDeviceTypeOutput) GoString() string {
 
 // Represents a device object associated with a gateway-VTL.
 type VTLDevice struct {
+	_ struct{} `type:"structure"`
+
 	// A list of iSCSI information about a VTL device.
 	DeviceiSCSIAttributes *DeviceiSCSIAttributes `type:"structure"`
 
@@ -4698,8 +4700,6 @@ type VTLDevice struct {
 	VTLDeviceType *string `type:"string"`
 
 	VTLDeviceVendor *string `type:"string"`
-
-	_ struct{} `type:"structure"`
 }
 
 // String returns the string representation
@@ -4713,11 +4713,11 @@ func (s VTLDevice) GoString() string {
 }
 
 type VolumeInfo struct {
+	_ struct{} `type:"structure"`
+
 	VolumeARN *string `min:"50" type:"string"`
 
 	VolumeType *string `min:"3" type:"string"`
-
-	_ struct{} `type:"structure"`
 }
 
 // String returns the string representation
@@ -4731,6 +4731,8 @@ func (s VolumeInfo) GoString() string {
 }
 
 type VolumeRecoveryPointInfo struct {
+	_ struct{} `type:"structure"`
+
 	VolumeARN *string `min:"50" type:"string"`
 
 	VolumeRecoveryPointTime *string `type:"string"`
@@ -4738,8 +4740,6 @@ type VolumeRecoveryPointInfo struct {
 	VolumeSizeInBytes *int64 `type:"long"`
 
 	VolumeUsageInBytes *int64 `type:"long"`
-
-	_ struct{} `type:"structure"`
 }
 
 // String returns the string representation
@@ -4754,6 +4754,8 @@ func (s VolumeRecoveryPointInfo) GoString() string {
 
 // Lists iSCSI information about a volume.
 type VolumeiSCSIAttributes struct {
+	_ struct{} `type:"structure"`
+
 	// Indicates whether mutual CHAP is enabled for the iSCSI target.
 	ChapEnabled *bool `type:"boolean"`
 
@@ -4768,8 +4770,6 @@ type VolumeiSCSIAttributes struct {
 
 	// The Amazon Resource Name (ARN) of the volume target.
 	TargetARN *string `min:"50" type:"string"`
-
-	_ struct{} `type:"structure"`
 }
 
 // String returns the string representation

--- a/service/storagegateway/api.go
+++ b/service/storagegateway/api.go
@@ -1919,11 +1919,7 @@ type ActivateGatewayInput struct {
 	// Valid Values: "IBM-ULT3580-TD5"
 	TapeDriveType *string `min:"2" type:"string"`
 
-	metadataActivateGatewayInput `json:"-" xml:"-"`
-}
-
-type metadataActivateGatewayInput struct {
-	SDKShapeTraits bool `type:"structure"`
+	_ struct{} `type:"structure"`
 }
 
 // String returns the string representation
@@ -1945,11 +1941,7 @@ type ActivateGatewayOutput struct {
 	// to return a list of gateways for your account and region.
 	GatewayARN *string `min:"50" type:"string"`
 
-	metadataActivateGatewayOutput `json:"-" xml:"-"`
-}
-
-type metadataActivateGatewayOutput struct {
-	SDKShapeTraits bool `type:"structure"`
+	_ struct{} `type:"structure"`
 }
 
 // String returns the string representation
@@ -1969,11 +1961,7 @@ type AddCacheInput struct {
 	// to return a list of gateways for your account and region.
 	GatewayARN *string `min:"50" type:"string" required:"true"`
 
-	metadataAddCacheInput `json:"-" xml:"-"`
-}
-
-type metadataAddCacheInput struct {
-	SDKShapeTraits bool `type:"structure"`
+	_ struct{} `type:"structure"`
 }
 
 // String returns the string representation
@@ -1991,11 +1979,7 @@ type AddCacheOutput struct {
 	// to return a list of gateways for your account and region.
 	GatewayARN *string `min:"50" type:"string"`
 
-	metadataAddCacheOutput `json:"-" xml:"-"`
-}
-
-type metadataAddCacheOutput struct {
-	SDKShapeTraits bool `type:"structure"`
+	_ struct{} `type:"structure"`
 }
 
 // String returns the string representation
@@ -2020,11 +2004,7 @@ type AddTagsToResourceInput struct {
 	// in UTF-8 format, and the following special characters: + - = . _ : / @.
 	Tags []*Tag `type:"list" required:"true"`
 
-	metadataAddTagsToResourceInput `json:"-" xml:"-"`
-}
-
-type metadataAddTagsToResourceInput struct {
-	SDKShapeTraits bool `type:"structure"`
+	_ struct{} `type:"structure"`
 }
 
 // String returns the string representation
@@ -2042,11 +2022,7 @@ type AddTagsToResourceOutput struct {
 	// The Amazon Resource Name (ARN) of the resource you want to add tags to.
 	ResourceARN *string `min:"50" type:"string"`
 
-	metadataAddTagsToResourceOutput `json:"-" xml:"-"`
-}
-
-type metadataAddTagsToResourceOutput struct {
-	SDKShapeTraits bool `type:"structure"`
+	_ struct{} `type:"structure"`
 }
 
 // String returns the string representation
@@ -2066,11 +2042,7 @@ type AddUploadBufferInput struct {
 	// to return a list of gateways for your account and region.
 	GatewayARN *string `min:"50" type:"string" required:"true"`
 
-	metadataAddUploadBufferInput `json:"-" xml:"-"`
-}
-
-type metadataAddUploadBufferInput struct {
-	SDKShapeTraits bool `type:"structure"`
+	_ struct{} `type:"structure"`
 }
 
 // String returns the string representation
@@ -2088,11 +2060,7 @@ type AddUploadBufferOutput struct {
 	// to return a list of gateways for your account and region.
 	GatewayARN *string `min:"50" type:"string"`
 
-	metadataAddUploadBufferOutput `json:"-" xml:"-"`
-}
-
-type metadataAddUploadBufferOutput struct {
-	SDKShapeTraits bool `type:"structure"`
+	_ struct{} `type:"structure"`
 }
 
 // String returns the string representation
@@ -2118,11 +2086,7 @@ type AddWorkingStorageInput struct {
 	// to return a list of gateways for your account and region.
 	GatewayARN *string `min:"50" type:"string" required:"true"`
 
-	metadataAddWorkingStorageInput `json:"-" xml:"-"`
-}
-
-type metadataAddWorkingStorageInput struct {
-	SDKShapeTraits bool `type:"structure"`
+	_ struct{} `type:"structure"`
 }
 
 // String returns the string representation
@@ -2142,11 +2106,7 @@ type AddWorkingStorageOutput struct {
 	// to return a list of gateways for your account and region.
 	GatewayARN *string `min:"50" type:"string"`
 
-	metadataAddWorkingStorageOutput `json:"-" xml:"-"`
-}
-
-type metadataAddWorkingStorageOutput struct {
-	SDKShapeTraits bool `type:"structure"`
+	_ struct{} `type:"structure"`
 }
 
 // String returns the string representation
@@ -2177,11 +2137,7 @@ type CachediSCSIVolume struct {
 	// Lists iSCSI information about a volume.
 	VolumeiSCSIAttributes *VolumeiSCSIAttributes `type:"structure"`
 
-	metadataCachediSCSIVolume `json:"-" xml:"-"`
-}
-
-type metadataCachediSCSIVolume struct {
-	SDKShapeTraits bool `type:"structure"`
+	_ struct{} `type:"structure"`
 }
 
 // String returns the string representation
@@ -2204,11 +2160,7 @@ type CancelArchivalInput struct {
 	// for.
 	TapeARN *string `min:"50" type:"string" required:"true"`
 
-	metadataCancelArchivalInput `json:"-" xml:"-"`
-}
-
-type metadataCancelArchivalInput struct {
-	SDKShapeTraits bool `type:"structure"`
+	_ struct{} `type:"structure"`
 }
 
 // String returns the string representation
@@ -2227,11 +2179,7 @@ type CancelArchivalOutput struct {
 	// canceled.
 	TapeARN *string `min:"50" type:"string"`
 
-	metadataCancelArchivalOutput `json:"-" xml:"-"`
-}
-
-type metadataCancelArchivalOutput struct {
-	SDKShapeTraits bool `type:"structure"`
+	_ struct{} `type:"structure"`
 }
 
 // String returns the string representation
@@ -2254,11 +2202,7 @@ type CancelRetrievalInput struct {
 	// for.
 	TapeARN *string `min:"50" type:"string" required:"true"`
 
-	metadataCancelRetrievalInput `json:"-" xml:"-"`
-}
-
-type metadataCancelRetrievalInput struct {
-	SDKShapeTraits bool `type:"structure"`
+	_ struct{} `type:"structure"`
 }
 
 // String returns the string representation
@@ -2277,11 +2221,7 @@ type CancelRetrievalOutput struct {
 	// canceled.
 	TapeARN *string `min:"50" type:"string"`
 
-	metadataCancelRetrievalOutput `json:"-" xml:"-"`
-}
-
-type metadataCancelRetrievalOutput struct {
-	SDKShapeTraits bool `type:"structure"`
+	_ struct{} `type:"structure"`
 }
 
 // String returns the string representation
@@ -2314,11 +2254,7 @@ type ChapInfo struct {
 	// (-).
 	TargetARN *string `min:"50" type:"string"`
 
-	metadataChapInfo `json:"-" xml:"-"`
-}
-
-type metadataChapInfo struct {
-	SDKShapeTraits bool `type:"structure"`
+	_ struct{} `type:"structure"`
 }
 
 // String returns the string representation
@@ -2346,11 +2282,7 @@ type CreateCachediSCSIVolumeInput struct {
 
 	VolumeSizeInBytes *int64 `type:"long" required:"true"`
 
-	metadataCreateCachediSCSIVolumeInput `json:"-" xml:"-"`
-}
-
-type metadataCreateCachediSCSIVolumeInput struct {
-	SDKShapeTraits bool `type:"structure"`
+	_ struct{} `type:"structure"`
 }
 
 // String returns the string representation
@@ -2368,11 +2300,7 @@ type CreateCachediSCSIVolumeOutput struct {
 
 	VolumeARN *string `min:"50" type:"string"`
 
-	metadataCreateCachediSCSIVolumeOutput `json:"-" xml:"-"`
-}
-
-type metadataCreateCachediSCSIVolumeOutput struct {
-	SDKShapeTraits bool `type:"structure"`
+	_ struct{} `type:"structure"`
 }
 
 // String returns the string representation
@@ -2390,11 +2318,7 @@ type CreateSnapshotFromVolumeRecoveryPointInput struct {
 
 	VolumeARN *string `min:"50" type:"string" required:"true"`
 
-	metadataCreateSnapshotFromVolumeRecoveryPointInput `json:"-" xml:"-"`
-}
-
-type metadataCreateSnapshotFromVolumeRecoveryPointInput struct {
-	SDKShapeTraits bool `type:"structure"`
+	_ struct{} `type:"structure"`
 }
 
 // String returns the string representation
@@ -2414,11 +2338,7 @@ type CreateSnapshotFromVolumeRecoveryPointOutput struct {
 
 	VolumeRecoveryPointTime *string `type:"string"`
 
-	metadataCreateSnapshotFromVolumeRecoveryPointOutput `json:"-" xml:"-"`
-}
-
-type metadataCreateSnapshotFromVolumeRecoveryPointOutput struct {
-	SDKShapeTraits bool `type:"structure"`
+	_ struct{} `type:"structure"`
 }
 
 // String returns the string representation
@@ -2444,11 +2364,7 @@ type CreateSnapshotInput struct {
 	// to return a list of gateway volumes.
 	VolumeARN *string `min:"50" type:"string" required:"true"`
 
-	metadataCreateSnapshotInput `json:"-" xml:"-"`
-}
-
-type metadataCreateSnapshotInput struct {
-	SDKShapeTraits bool `type:"structure"`
+	_ struct{} `type:"structure"`
 }
 
 // String returns the string representation
@@ -2471,11 +2387,7 @@ type CreateSnapshotOutput struct {
 	// The Amazon Resource Name (ARN) of the volume of which the snapshot was taken.
 	VolumeARN *string `min:"50" type:"string"`
 
-	metadataCreateSnapshotOutput `json:"-" xml:"-"`
-}
-
-type metadataCreateSnapshotOutput struct {
-	SDKShapeTraits bool `type:"structure"`
+	_ struct{} `type:"structure"`
 }
 
 // String returns the string representation
@@ -2529,11 +2441,7 @@ type CreateStorediSCSIVolumeInput struct {
 	// The target name must be unique across all volumes of a gateway.
 	TargetName *string `min:"1" type:"string" required:"true"`
 
-	metadataCreateStorediSCSIVolumeInput `json:"-" xml:"-"`
-}
-
-type metadataCreateStorediSCSIVolumeInput struct {
-	SDKShapeTraits bool `type:"structure"`
+	_ struct{} `type:"structure"`
 }
 
 // String returns the string representation
@@ -2558,11 +2466,7 @@ type CreateStorediSCSIVolumeOutput struct {
 	// The size of the volume in bytes.
 	VolumeSizeInBytes *int64 `type:"long"`
 
-	metadataCreateStorediSCSIVolumeOutput `json:"-" xml:"-"`
-}
-
-type metadataCreateStorediSCSIVolumeOutput struct {
-	SDKShapeTraits bool `type:"structure"`
+	_ struct{} `type:"structure"`
 }
 
 // String returns the string representation
@@ -2603,11 +2507,7 @@ type CreateTapesInput struct {
 	// The size must be gigabyte (1024*1024*1024 byte) aligned.
 	TapeSizeInBytes *int64 `type:"long" required:"true"`
 
-	metadataCreateTapesInput `json:"-" xml:"-"`
-}
-
-type metadataCreateTapesInput struct {
-	SDKShapeTraits bool `type:"structure"`
+	_ struct{} `type:"structure"`
 }
 
 // String returns the string representation
@@ -2626,11 +2526,7 @@ type CreateTapesOutput struct {
 	// tapes that were created.
 	TapeARNs []*string `type:"list"`
 
-	metadataCreateTapesOutput `json:"-" xml:"-"`
-}
-
-type metadataCreateTapesOutput struct {
-	SDKShapeTraits bool `type:"structure"`
+	_ struct{} `type:"structure"`
 }
 
 // String returns the string representation
@@ -2650,11 +2546,7 @@ type DeleteBandwidthRateLimitInput struct {
 	// to return a list of gateways for your account and region.
 	GatewayARN *string `min:"50" type:"string" required:"true"`
 
-	metadataDeleteBandwidthRateLimitInput `json:"-" xml:"-"`
-}
-
-type metadataDeleteBandwidthRateLimitInput struct {
-	SDKShapeTraits bool `type:"structure"`
+	_ struct{} `type:"structure"`
 }
 
 // String returns the string representation
@@ -2674,11 +2566,7 @@ type DeleteBandwidthRateLimitOutput struct {
 	// to return a list of gateways for your account and region.
 	GatewayARN *string `min:"50" type:"string"`
 
-	metadataDeleteBandwidthRateLimitOutput `json:"-" xml:"-"`
-}
-
-type metadataDeleteBandwidthRateLimitOutput struct {
-	SDKShapeTraits bool `type:"structure"`
+	_ struct{} `type:"structure"`
 }
 
 // String returns the string representation
@@ -2702,11 +2590,7 @@ type DeleteChapCredentialsInput struct {
 	// operation to return to retrieve the TargetARN for specified VolumeARN.
 	TargetARN *string `min:"50" type:"string" required:"true"`
 
-	metadataDeleteChapCredentialsInput `json:"-" xml:"-"`
-}
-
-type metadataDeleteChapCredentialsInput struct {
-	SDKShapeTraits bool `type:"structure"`
+	_ struct{} `type:"structure"`
 }
 
 // String returns the string representation
@@ -2727,11 +2611,7 @@ type DeleteChapCredentialsOutput struct {
 	// The Amazon Resource Name (ARN) of the target.
 	TargetARN *string `min:"50" type:"string"`
 
-	metadataDeleteChapCredentialsOutput `json:"-" xml:"-"`
-}
-
-type metadataDeleteChapCredentialsOutput struct {
-	SDKShapeTraits bool `type:"structure"`
+	_ struct{} `type:"structure"`
 }
 
 // String returns the string representation
@@ -2750,11 +2630,7 @@ type DeleteGatewayInput struct {
 	// to return a list of gateways for your account and region.
 	GatewayARN *string `min:"50" type:"string" required:"true"`
 
-	metadataDeleteGatewayInput `json:"-" xml:"-"`
-}
-
-type metadataDeleteGatewayInput struct {
-	SDKShapeTraits bool `type:"structure"`
+	_ struct{} `type:"structure"`
 }
 
 // String returns the string representation
@@ -2773,11 +2649,7 @@ type DeleteGatewayOutput struct {
 	// to return a list of gateways for your account and region.
 	GatewayARN *string `min:"50" type:"string"`
 
-	metadataDeleteGatewayOutput `json:"-" xml:"-"`
-}
-
-type metadataDeleteGatewayOutput struct {
-	SDKShapeTraits bool `type:"structure"`
+	_ struct{} `type:"structure"`
 }
 
 // String returns the string representation
@@ -2793,11 +2665,7 @@ func (s DeleteGatewayOutput) GoString() string {
 type DeleteSnapshotScheduleInput struct {
 	VolumeARN *string `min:"50" type:"string" required:"true"`
 
-	metadataDeleteSnapshotScheduleInput `json:"-" xml:"-"`
-}
-
-type metadataDeleteSnapshotScheduleInput struct {
-	SDKShapeTraits bool `type:"structure"`
+	_ struct{} `type:"structure"`
 }
 
 // String returns the string representation
@@ -2813,11 +2681,7 @@ func (s DeleteSnapshotScheduleInput) GoString() string {
 type DeleteSnapshotScheduleOutput struct {
 	VolumeARN *string `min:"50" type:"string"`
 
-	metadataDeleteSnapshotScheduleOutput `json:"-" xml:"-"`
-}
-
-type metadataDeleteSnapshotScheduleOutput struct {
-	SDKShapeTraits bool `type:"structure"`
+	_ struct{} `type:"structure"`
 }
 
 // String returns the string representation
@@ -2836,11 +2700,7 @@ type DeleteTapeArchiveInput struct {
 	// tape shelf (VTS).
 	TapeARN *string `min:"50" type:"string" required:"true"`
 
-	metadataDeleteTapeArchiveInput `json:"-" xml:"-"`
-}
-
-type metadataDeleteTapeArchiveInput struct {
-	SDKShapeTraits bool `type:"structure"`
+	_ struct{} `type:"structure"`
 }
 
 // String returns the string representation
@@ -2859,11 +2719,7 @@ type DeleteTapeArchiveOutput struct {
 	// the virtual tape shelf (VTS).
 	TapeARN *string `min:"50" type:"string"`
 
-	metadataDeleteTapeArchiveOutput `json:"-" xml:"-"`
-}
-
-type metadataDeleteTapeArchiveOutput struct {
-	SDKShapeTraits bool `type:"structure"`
+	_ struct{} `type:"structure"`
 }
 
 // String returns the string representation
@@ -2886,11 +2742,7 @@ type DeleteTapeInput struct {
 	// The Amazon Resource Name (ARN) of the virtual tape to delete.
 	TapeARN *string `min:"50" type:"string" required:"true"`
 
-	metadataDeleteTapeInput `json:"-" xml:"-"`
-}
-
-type metadataDeleteTapeInput struct {
-	SDKShapeTraits bool `type:"structure"`
+	_ struct{} `type:"structure"`
 }
 
 // String returns the string representation
@@ -2908,11 +2760,7 @@ type DeleteTapeOutput struct {
 	// The Amazon Resource Name (ARN) of the deleted virtual tape.
 	TapeARN *string `min:"50" type:"string"`
 
-	metadataDeleteTapeOutput `json:"-" xml:"-"`
-}
-
-type metadataDeleteTapeOutput struct {
-	SDKShapeTraits bool `type:"structure"`
+	_ struct{} `type:"structure"`
 }
 
 // String returns the string representation
@@ -2931,11 +2779,7 @@ type DeleteVolumeInput struct {
 	// to return a list of gateway volumes.
 	VolumeARN *string `min:"50" type:"string" required:"true"`
 
-	metadataDeleteVolumeInput `json:"-" xml:"-"`
-}
-
-type metadataDeleteVolumeInput struct {
-	SDKShapeTraits bool `type:"structure"`
+	_ struct{} `type:"structure"`
 }
 
 // String returns the string representation
@@ -2954,11 +2798,7 @@ type DeleteVolumeOutput struct {
 	// is the same ARN you provided in the request.
 	VolumeARN *string `min:"50" type:"string"`
 
-	metadataDeleteVolumeOutput `json:"-" xml:"-"`
-}
-
-type metadataDeleteVolumeOutput struct {
-	SDKShapeTraits bool `type:"structure"`
+	_ struct{} `type:"structure"`
 }
 
 // String returns the string representation
@@ -2977,11 +2817,7 @@ type DescribeBandwidthRateLimitInput struct {
 	// to return a list of gateways for your account and region.
 	GatewayARN *string `min:"50" type:"string" required:"true"`
 
-	metadataDescribeBandwidthRateLimitInput `json:"-" xml:"-"`
-}
-
-type metadataDescribeBandwidthRateLimitInput struct {
-	SDKShapeTraits bool `type:"structure"`
+	_ struct{} `type:"structure"`
 }
 
 // String returns the string representation
@@ -3008,11 +2844,7 @@ type DescribeBandwidthRateLimitOutput struct {
 	// to return a list of gateways for your account and region.
 	GatewayARN *string `min:"50" type:"string"`
 
-	metadataDescribeBandwidthRateLimitOutput `json:"-" xml:"-"`
-}
-
-type metadataDescribeBandwidthRateLimitOutput struct {
-	SDKShapeTraits bool `type:"structure"`
+	_ struct{} `type:"structure"`
 }
 
 // String returns the string representation
@@ -3030,11 +2862,7 @@ type DescribeCacheInput struct {
 	// to return a list of gateways for your account and region.
 	GatewayARN *string `min:"50" type:"string" required:"true"`
 
-	metadataDescribeCacheInput `json:"-" xml:"-"`
-}
-
-type metadataDescribeCacheInput struct {
-	SDKShapeTraits bool `type:"structure"`
+	_ struct{} `type:"structure"`
 }
 
 // String returns the string representation
@@ -3064,11 +2892,7 @@ type DescribeCacheOutput struct {
 	// to return a list of gateways for your account and region.
 	GatewayARN *string `min:"50" type:"string"`
 
-	metadataDescribeCacheOutput `json:"-" xml:"-"`
-}
-
-type metadataDescribeCacheOutput struct {
-	SDKShapeTraits bool `type:"structure"`
+	_ struct{} `type:"structure"`
 }
 
 // String returns the string representation
@@ -3084,11 +2908,7 @@ func (s DescribeCacheOutput) GoString() string {
 type DescribeCachediSCSIVolumesInput struct {
 	VolumeARNs []*string `type:"list" required:"true"`
 
-	metadataDescribeCachediSCSIVolumesInput `json:"-" xml:"-"`
-}
-
-type metadataDescribeCachediSCSIVolumesInput struct {
-	SDKShapeTraits bool `type:"structure"`
+	_ struct{} `type:"structure"`
 }
 
 // String returns the string representation
@@ -3107,11 +2927,7 @@ type DescribeCachediSCSIVolumesOutput struct {
 	// volume.
 	CachediSCSIVolumes []*CachediSCSIVolume `type:"list"`
 
-	metadataDescribeCachediSCSIVolumesOutput `json:"-" xml:"-"`
-}
-
-type metadataDescribeCachediSCSIVolumesOutput struct {
-	SDKShapeTraits bool `type:"structure"`
+	_ struct{} `type:"structure"`
 }
 
 // String returns the string representation
@@ -3131,11 +2947,7 @@ type DescribeChapCredentialsInput struct {
 	// operation to return to retrieve the TargetARN for specified VolumeARN.
 	TargetARN *string `min:"50" type:"string" required:"true"`
 
-	metadataDescribeChapCredentialsInput `json:"-" xml:"-"`
-}
-
-type metadataDescribeChapCredentialsInput struct {
-	SDKShapeTraits bool `type:"structure"`
+	_ struct{} `type:"structure"`
 }
 
 // String returns the string representation
@@ -3167,11 +2979,7 @@ type DescribeChapCredentialsOutput struct {
 	//   TargetARN: The Amazon Resource Name (ARN) of the storage volume.
 	ChapCredentials []*ChapInfo `type:"list"`
 
-	metadataDescribeChapCredentialsOutput `json:"-" xml:"-"`
-}
-
-type metadataDescribeChapCredentialsOutput struct {
-	SDKShapeTraits bool `type:"structure"`
+	_ struct{} `type:"structure"`
 }
 
 // String returns the string representation
@@ -3190,11 +2998,7 @@ type DescribeGatewayInformationInput struct {
 	// to return a list of gateways for your account and region.
 	GatewayARN *string `min:"50" type:"string" required:"true"`
 
-	metadataDescribeGatewayInformationInput `json:"-" xml:"-"`
-}
-
-type metadataDescribeGatewayInformationInput struct {
-	SDKShapeTraits bool `type:"structure"`
+	_ struct{} `type:"structure"`
 }
 
 // String returns the string representation
@@ -3242,11 +3046,7 @@ type DescribeGatewayInformationOutput struct {
 	// this field is not returned in the response.
 	NextUpdateAvailabilityDate *string `min:"1" type:"string"`
 
-	metadataDescribeGatewayInformationOutput `json:"-" xml:"-"`
-}
-
-type metadataDescribeGatewayInformationOutput struct {
-	SDKShapeTraits bool `type:"structure"`
+	_ struct{} `type:"structure"`
 }
 
 // String returns the string representation
@@ -3265,11 +3065,7 @@ type DescribeMaintenanceStartTimeInput struct {
 	// to return a list of gateways for your account and region.
 	GatewayARN *string `min:"50" type:"string" required:"true"`
 
-	metadataDescribeMaintenanceStartTimeInput `json:"-" xml:"-"`
-}
-
-type metadataDescribeMaintenanceStartTimeInput struct {
-	SDKShapeTraits bool `type:"structure"`
+	_ struct{} `type:"structure"`
 }
 
 // String returns the string representation
@@ -3295,11 +3091,7 @@ type DescribeMaintenanceStartTimeOutput struct {
 
 	Timezone *string `min:"3" type:"string"`
 
-	metadataDescribeMaintenanceStartTimeOutput `json:"-" xml:"-"`
-}
-
-type metadataDescribeMaintenanceStartTimeOutput struct {
-	SDKShapeTraits bool `type:"structure"`
+	_ struct{} `type:"structure"`
 }
 
 // String returns the string representation
@@ -3319,11 +3111,7 @@ type DescribeSnapshotScheduleInput struct {
 	// to return a list of gateway volumes.
 	VolumeARN *string `min:"50" type:"string" required:"true"`
 
-	metadataDescribeSnapshotScheduleInput `json:"-" xml:"-"`
-}
-
-type metadataDescribeSnapshotScheduleInput struct {
-	SDKShapeTraits bool `type:"structure"`
+	_ struct{} `type:"structure"`
 }
 
 // String returns the string representation
@@ -3347,11 +3135,7 @@ type DescribeSnapshotScheduleOutput struct {
 
 	VolumeARN *string `min:"50" type:"string"`
 
-	metadataDescribeSnapshotScheduleOutput `json:"-" xml:"-"`
-}
-
-type metadataDescribeSnapshotScheduleOutput struct {
-	SDKShapeTraits bool `type:"structure"`
+	_ struct{} `type:"structure"`
 }
 
 // String returns the string representation
@@ -3371,11 +3155,7 @@ type DescribeStorediSCSIVolumesInput struct {
 	// same gateway. Use ListVolumes to get volume ARNs for a gateway.
 	VolumeARNs []*string `type:"list" required:"true"`
 
-	metadataDescribeStorediSCSIVolumesInput `json:"-" xml:"-"`
-}
-
-type metadataDescribeStorediSCSIVolumesInput struct {
-	SDKShapeTraits bool `type:"structure"`
+	_ struct{} `type:"structure"`
 }
 
 // String returns the string representation
@@ -3391,11 +3171,7 @@ func (s DescribeStorediSCSIVolumesInput) GoString() string {
 type DescribeStorediSCSIVolumesOutput struct {
 	StorediSCSIVolumes []*StorediSCSIVolume `type:"list"`
 
-	metadataDescribeStorediSCSIVolumesOutput `json:"-" xml:"-"`
-}
-
-type metadataDescribeStorediSCSIVolumesOutput struct {
-	SDKShapeTraits bool `type:"structure"`
+	_ struct{} `type:"structure"`
 }
 
 // String returns the string representation
@@ -3422,11 +3198,7 @@ type DescribeTapeArchivesInput struct {
 	// the virtual tapes you want to describe.
 	TapeARNs []*string `type:"list"`
 
-	metadataDescribeTapeArchivesInput `json:"-" xml:"-"`
-}
-
-type metadataDescribeTapeArchivesInput struct {
-	SDKShapeTraits bool `type:"structure"`
+	_ struct{} `type:"structure"`
 }
 
 // String returns the string representation
@@ -3454,11 +3226,7 @@ type DescribeTapeArchivesOutput struct {
 	// the tapes, status of the tapes, progress of the description and tape barcode.
 	TapeArchives []*TapeArchive `type:"list"`
 
-	metadataDescribeTapeArchivesOutput `json:"-" xml:"-"`
-}
-
-type metadataDescribeTapeArchivesOutput struct {
-	SDKShapeTraits bool `type:"structure"`
+	_ struct{} `type:"structure"`
 }
 
 // String returns the string representation
@@ -3485,11 +3253,7 @@ type DescribeTapeRecoveryPointsInput struct {
 	// the virtual tape recovery points.
 	Marker *string `min:"1" type:"string"`
 
-	metadataDescribeTapeRecoveryPointsInput `json:"-" xml:"-"`
-}
-
-type metadataDescribeTapeRecoveryPointsInput struct {
-	SDKShapeTraits bool `type:"structure"`
+	_ struct{} `type:"structure"`
 }
 
 // String returns the string representation
@@ -3519,11 +3283,7 @@ type DescribeTapeRecoveryPointsOutput struct {
 	// An array of TapeRecoveryPointInfos that are available for the specified gateway.
 	TapeRecoveryPointInfos []*TapeRecoveryPointInfo `type:"list"`
 
-	metadataDescribeTapeRecoveryPointsOutput `json:"-" xml:"-"`
-}
-
-type metadataDescribeTapeRecoveryPointsOutput struct {
-	SDKShapeTraits bool `type:"structure"`
+	_ struct{} `type:"structure"`
 }
 
 // String returns the string representation
@@ -3560,11 +3320,7 @@ type DescribeTapesInput struct {
 	// with the specified gateway.
 	TapeARNs []*string `type:"list"`
 
-	metadataDescribeTapesInput `json:"-" xml:"-"`
-}
-
-type metadataDescribeTapesInput struct {
-	SDKShapeTraits bool `type:"structure"`
+	_ struct{} `type:"structure"`
 }
 
 // String returns the string representation
@@ -3589,11 +3345,7 @@ type DescribeTapesOutput struct {
 	// An array of virtual tape descriptions.
 	Tapes []*Tape `type:"list"`
 
-	metadataDescribeTapesOutput `json:"-" xml:"-"`
-}
-
-type metadataDescribeTapesOutput struct {
-	SDKShapeTraits bool `type:"structure"`
+	_ struct{} `type:"structure"`
 }
 
 // String returns the string representation
@@ -3611,11 +3363,7 @@ type DescribeUploadBufferInput struct {
 	// to return a list of gateways for your account and region.
 	GatewayARN *string `min:"50" type:"string" required:"true"`
 
-	metadataDescribeUploadBufferInput `json:"-" xml:"-"`
-}
-
-type metadataDescribeUploadBufferInput struct {
-	SDKShapeTraits bool `type:"structure"`
+	_ struct{} `type:"structure"`
 }
 
 // String returns the string representation
@@ -3639,11 +3387,7 @@ type DescribeUploadBufferOutput struct {
 
 	UploadBufferUsedInBytes *int64 `type:"long"`
 
-	metadataDescribeUploadBufferOutput `json:"-" xml:"-"`
-}
-
-type metadataDescribeUploadBufferOutput struct {
-	SDKShapeTraits bool `type:"structure"`
+	_ struct{} `type:"structure"`
 }
 
 // String returns the string representation
@@ -3678,11 +3422,7 @@ type DescribeVTLDevicesInput struct {
 	// gateway.
 	VTLDeviceARNs []*string `type:"list"`
 
-	metadataDescribeVTLDevicesInput `json:"-" xml:"-"`
-}
-
-type metadataDescribeVTLDevicesInput struct {
-	SDKShapeTraits bool `type:"structure"`
+	_ struct{} `type:"structure"`
 }
 
 // String returns the string representation
@@ -3711,11 +3451,7 @@ type DescribeVTLDevicesOutput struct {
 	// of the VTL devices.
 	VTLDevices []*VTLDevice `type:"list"`
 
-	metadataDescribeVTLDevicesOutput `json:"-" xml:"-"`
-}
-
-type metadataDescribeVTLDevicesOutput struct {
-	SDKShapeTraits bool `type:"structure"`
+	_ struct{} `type:"structure"`
 }
 
 // String returns the string representation
@@ -3734,11 +3470,7 @@ type DescribeWorkingStorageInput struct {
 	// to return a list of gateways for your account and region.
 	GatewayARN *string `min:"50" type:"string" required:"true"`
 
-	metadataDescribeWorkingStorageInput `json:"-" xml:"-"`
-}
-
-type metadataDescribeWorkingStorageInput struct {
-	SDKShapeTraits bool `type:"structure"`
+	_ struct{} `type:"structure"`
 }
 
 // String returns the string representation
@@ -3771,11 +3503,7 @@ type DescribeWorkingStorageOutput struct {
 	// is configured for the gateway, this field returns 0.
 	WorkingStorageUsedInBytes *int64 `type:"long"`
 
-	metadataDescribeWorkingStorageOutput `json:"-" xml:"-"`
-}
-
-type metadataDescribeWorkingStorageOutput struct {
-	SDKShapeTraits bool `type:"structure"`
+	_ struct{} `type:"structure"`
 }
 
 // String returns the string representation
@@ -3803,11 +3531,7 @@ type DeviceiSCSIAttributes struct {
 	// name(iqn) of a tape drive or media changer target.
 	TargetARN *string `min:"50" type:"string"`
 
-	metadataDeviceiSCSIAttributes `json:"-" xml:"-"`
-}
-
-type metadataDeviceiSCSIAttributes struct {
-	SDKShapeTraits bool `type:"structure"`
+	_ struct{} `type:"structure"`
 }
 
 // String returns the string representation
@@ -3826,11 +3550,7 @@ type DisableGatewayInput struct {
 	// to return a list of gateways for your account and region.
 	GatewayARN *string `min:"50" type:"string" required:"true"`
 
-	metadataDisableGatewayInput `json:"-" xml:"-"`
-}
-
-type metadataDisableGatewayInput struct {
-	SDKShapeTraits bool `type:"structure"`
+	_ struct{} `type:"structure"`
 }
 
 // String returns the string representation
@@ -3848,11 +3568,7 @@ type DisableGatewayOutput struct {
 	// The unique Amazon Resource Name of the disabled gateway.
 	GatewayARN *string `min:"50" type:"string"`
 
-	metadataDisableGatewayOutput `json:"-" xml:"-"`
-}
-
-type metadataDisableGatewayOutput struct {
-	SDKShapeTraits bool `type:"structure"`
+	_ struct{} `type:"structure"`
 }
 
 // String returns the string representation
@@ -3880,11 +3596,7 @@ type Disk struct {
 
 	DiskStatus *string `type:"string"`
 
-	metadataDisk `json:"-" xml:"-"`
-}
-
-type metadataDisk struct {
-	SDKShapeTraits bool `type:"structure"`
+	_ struct{} `type:"structure"`
 }
 
 // String returns the string representation
@@ -3907,11 +3619,7 @@ type Error struct {
 	// Human-readable text that provides detail about the error that occurred.
 	ErrorDetails map[string]*string `locationName:"errorDetails" type:"map"`
 
-	metadataError `json:"-" xml:"-"`
-}
-
-type metadataError struct {
-	SDKShapeTraits bool `type:"structure"`
+	_ struct{} `type:"structure"`
 }
 
 // String returns the string representation
@@ -3935,11 +3643,7 @@ type GatewayInfo struct {
 
 	GatewayType *string `min:"2" type:"string"`
 
-	metadataGatewayInfo `json:"-" xml:"-"`
-}
-
-type metadataGatewayInfo struct {
-	SDKShapeTraits bool `type:"structure"`
+	_ struct{} `type:"structure"`
 }
 
 // String returns the string representation
@@ -3964,11 +3668,7 @@ type ListGatewaysInput struct {
 	// list of gateways.
 	Marker *string `min:"1" type:"string"`
 
-	metadataListGatewaysInput `json:"-" xml:"-"`
-}
-
-type metadataListGatewaysInput struct {
-	SDKShapeTraits bool `type:"structure"`
+	_ struct{} `type:"structure"`
 }
 
 // String returns the string representation
@@ -3986,11 +3686,7 @@ type ListGatewaysOutput struct {
 
 	Marker *string `min:"1" type:"string"`
 
-	metadataListGatewaysOutput `json:"-" xml:"-"`
-}
-
-type metadataListGatewaysOutput struct {
-	SDKShapeTraits bool `type:"structure"`
+	_ struct{} `type:"structure"`
 }
 
 // String returns the string representation
@@ -4009,11 +3705,7 @@ type ListLocalDisksInput struct {
 	// to return a list of gateways for your account and region.
 	GatewayARN *string `min:"50" type:"string" required:"true"`
 
-	metadataListLocalDisksInput `json:"-" xml:"-"`
-}
-
-type metadataListLocalDisksInput struct {
-	SDKShapeTraits bool `type:"structure"`
+	_ struct{} `type:"structure"`
 }
 
 // String returns the string representation
@@ -4033,11 +3725,7 @@ type ListLocalDisksOutput struct {
 	// to return a list of gateways for your account and region.
 	GatewayARN *string `min:"50" type:"string"`
 
-	metadataListLocalDisksOutput `json:"-" xml:"-"`
-}
-
-type metadataListLocalDisksOutput struct {
-	SDKShapeTraits bool `type:"structure"`
+	_ struct{} `type:"structure"`
 }
 
 // String returns the string representation
@@ -4064,11 +3752,7 @@ type ListTagsForResourceInput struct {
 	// tags.
 	ResourceARN *string `min:"50" type:"string"`
 
-	metadataListTagsForResourceInput `json:"-" xml:"-"`
-}
-
-type metadataListTagsForResourceInput struct {
-	SDKShapeTraits bool `type:"structure"`
+	_ struct{} `type:"structure"`
 }
 
 // String returns the string representation
@@ -4094,11 +3778,7 @@ type ListTagsForResourceOutput struct {
 	// An array that contains the tags for the specified resource.
 	Tags []*Tag `type:"list"`
 
-	metadataListTagsForResourceOutput `json:"-" xml:"-"`
-}
-
-type metadataListTagsForResourceOutput struct {
-	SDKShapeTraits bool `type:"structure"`
+	_ struct{} `type:"structure"`
 }
 
 // String returns the string representation
@@ -4117,11 +3797,7 @@ type ListVolumeInitiatorsInput struct {
 	// to return a list of gateway volumes for the gateway.
 	VolumeARN *string `min:"50" type:"string" required:"true"`
 
-	metadataListVolumeInitiatorsInput `json:"-" xml:"-"`
-}
-
-type metadataListVolumeInitiatorsInput struct {
-	SDKShapeTraits bool `type:"structure"`
+	_ struct{} `type:"structure"`
 }
 
 // String returns the string representation
@@ -4140,11 +3816,7 @@ type ListVolumeInitiatorsOutput struct {
 	// to the gateway.
 	Initiators []*string `type:"list"`
 
-	metadataListVolumeInitiatorsOutput `json:"-" xml:"-"`
-}
-
-type metadataListVolumeInitiatorsOutput struct {
-	SDKShapeTraits bool `type:"structure"`
+	_ struct{} `type:"structure"`
 }
 
 // String returns the string representation
@@ -4162,11 +3834,7 @@ type ListVolumeRecoveryPointsInput struct {
 	// to return a list of gateways for your account and region.
 	GatewayARN *string `min:"50" type:"string" required:"true"`
 
-	metadataListVolumeRecoveryPointsInput `json:"-" xml:"-"`
-}
-
-type metadataListVolumeRecoveryPointsInput struct {
-	SDKShapeTraits bool `type:"structure"`
+	_ struct{} `type:"structure"`
 }
 
 // String returns the string representation
@@ -4186,11 +3854,7 @@ type ListVolumeRecoveryPointsOutput struct {
 
 	VolumeRecoveryPointInfos []*VolumeRecoveryPointInfo `type:"list"`
 
-	metadataListVolumeRecoveryPointsOutput `json:"-" xml:"-"`
-}
-
-type metadataListVolumeRecoveryPointsOutput struct {
-	SDKShapeTraits bool `type:"structure"`
+	_ struct{} `type:"structure"`
 }
 
 // String returns the string representation
@@ -4220,11 +3884,7 @@ type ListVolumesInput struct {
 	// Volumes request.
 	Marker *string `min:"1" type:"string"`
 
-	metadataListVolumesInput `json:"-" xml:"-"`
-}
-
-type metadataListVolumesInput struct {
-	SDKShapeTraits bool `type:"structure"`
+	_ struct{} `type:"structure"`
 }
 
 // String returns the string representation
@@ -4246,11 +3906,7 @@ type ListVolumesOutput struct {
 
 	VolumeInfos []*VolumeInfo `type:"list"`
 
-	metadataListVolumesOutput `json:"-" xml:"-"`
-}
-
-type metadataListVolumesOutput struct {
-	SDKShapeTraits bool `type:"structure"`
+	_ struct{} `type:"structure"`
 }
 
 // String returns the string representation
@@ -4277,11 +3933,7 @@ type NetworkInterface struct {
 	// This is currently unsupported and will not be returned in output.
 	MacAddress *string `type:"string"`
 
-	metadataNetworkInterface `json:"-" xml:"-"`
-}
-
-type metadataNetworkInterface struct {
-	SDKShapeTraits bool `type:"structure"`
+	_ struct{} `type:"structure"`
 }
 
 // String returns the string representation
@@ -4304,11 +3956,7 @@ type RemoveTagsFromResourceInput struct {
 	// is composed of a key/value pair.
 	TagKeys []*string `type:"list"`
 
-	metadataRemoveTagsFromResourceInput `json:"-" xml:"-"`
-}
-
-type metadataRemoveTagsFromResourceInput struct {
-	SDKShapeTraits bool `type:"structure"`
+	_ struct{} `type:"structure"`
 }
 
 // String returns the string representation
@@ -4327,11 +3975,7 @@ type RemoveTagsFromResourceOutput struct {
 	// from.
 	ResourceARN *string `min:"50" type:"string"`
 
-	metadataRemoveTagsFromResourceOutput `json:"-" xml:"-"`
-}
-
-type metadataRemoveTagsFromResourceOutput struct {
-	SDKShapeTraits bool `type:"structure"`
+	_ struct{} `type:"structure"`
 }
 
 // String returns the string representation
@@ -4349,11 +3993,7 @@ type ResetCacheInput struct {
 	// to return a list of gateways for your account and region.
 	GatewayARN *string `min:"50" type:"string" required:"true"`
 
-	metadataResetCacheInput `json:"-" xml:"-"`
-}
-
-type metadataResetCacheInput struct {
-	SDKShapeTraits bool `type:"structure"`
+	_ struct{} `type:"structure"`
 }
 
 // String returns the string representation
@@ -4371,11 +4011,7 @@ type ResetCacheOutput struct {
 	// to return a list of gateways for your account and region.
 	GatewayARN *string `min:"50" type:"string"`
 
-	metadataResetCacheOutput `json:"-" xml:"-"`
-}
-
-type metadataResetCacheOutput struct {
-	SDKShapeTraits bool `type:"structure"`
+	_ struct{} `type:"structure"`
 }
 
 // String returns the string representation
@@ -4402,11 +4038,7 @@ type RetrieveTapeArchiveInput struct {
 	// the virtual tape shelf (VTS).
 	TapeARN *string `min:"50" type:"string" required:"true"`
 
-	metadataRetrieveTapeArchiveInput `json:"-" xml:"-"`
-}
-
-type metadataRetrieveTapeArchiveInput struct {
-	SDKShapeTraits bool `type:"structure"`
+	_ struct{} `type:"structure"`
 }
 
 // String returns the string representation
@@ -4424,11 +4056,7 @@ type RetrieveTapeArchiveOutput struct {
 	// The Amazon Resource Name (ARN) of the retrieved virtual tape.
 	TapeARN *string `min:"50" type:"string"`
 
-	metadataRetrieveTapeArchiveOutput `json:"-" xml:"-"`
-}
-
-type metadataRetrieveTapeArchiveOutput struct {
-	SDKShapeTraits bool `type:"structure"`
+	_ struct{} `type:"structure"`
 }
 
 // String returns the string representation
@@ -4451,11 +4079,7 @@ type RetrieveTapeRecoveryPointInput struct {
 	// retrieve the recovery point.
 	TapeARN *string `min:"50" type:"string" required:"true"`
 
-	metadataRetrieveTapeRecoveryPointInput `json:"-" xml:"-"`
-}
-
-type metadataRetrieveTapeRecoveryPointInput struct {
-	SDKShapeTraits bool `type:"structure"`
+	_ struct{} `type:"structure"`
 }
 
 // String returns the string representation
@@ -4474,11 +4098,7 @@ type RetrieveTapeRecoveryPointOutput struct {
 	// point was retrieved.
 	TapeARN *string `min:"50" type:"string"`
 
-	metadataRetrieveTapeRecoveryPointOutput `json:"-" xml:"-"`
-}
-
-type metadataRetrieveTapeRecoveryPointOutput struct {
-	SDKShapeTraits bool `type:"structure"`
+	_ struct{} `type:"structure"`
 }
 
 // String returns the string representation
@@ -4497,11 +4117,7 @@ type ShutdownGatewayInput struct {
 	// to return a list of gateways for your account and region.
 	GatewayARN *string `min:"50" type:"string" required:"true"`
 
-	metadataShutdownGatewayInput `json:"-" xml:"-"`
-}
-
-type metadataShutdownGatewayInput struct {
-	SDKShapeTraits bool `type:"structure"`
+	_ struct{} `type:"structure"`
 }
 
 // String returns the string representation
@@ -4520,11 +4136,7 @@ type ShutdownGatewayOutput struct {
 	// to return a list of gateways for your account and region.
 	GatewayARN *string `min:"50" type:"string"`
 
-	metadataShutdownGatewayOutput `json:"-" xml:"-"`
-}
-
-type metadataShutdownGatewayOutput struct {
-	SDKShapeTraits bool `type:"structure"`
+	_ struct{} `type:"structure"`
 }
 
 // String returns the string representation
@@ -4543,11 +4155,7 @@ type StartGatewayInput struct {
 	// to return a list of gateways for your account and region.
 	GatewayARN *string `min:"50" type:"string" required:"true"`
 
-	metadataStartGatewayInput `json:"-" xml:"-"`
-}
-
-type metadataStartGatewayInput struct {
-	SDKShapeTraits bool `type:"structure"`
+	_ struct{} `type:"structure"`
 }
 
 // String returns the string representation
@@ -4566,11 +4174,7 @@ type StartGatewayOutput struct {
 	// to return a list of gateways for your account and region.
 	GatewayARN *string `min:"50" type:"string"`
 
-	metadataStartGatewayOutput `json:"-" xml:"-"`
-}
-
-type metadataStartGatewayOutput struct {
-	SDKShapeTraits bool `type:"structure"`
+	_ struct{} `type:"structure"`
 }
 
 // String returns the string representation
@@ -4605,11 +4209,7 @@ type StorediSCSIVolume struct {
 	// Lists iSCSI information about a volume.
 	VolumeiSCSIAttributes *VolumeiSCSIAttributes `type:"structure"`
 
-	metadataStorediSCSIVolume `json:"-" xml:"-"`
-}
-
-type metadataStorediSCSIVolume struct {
-	SDKShapeTraits bool `type:"structure"`
+	_ struct{} `type:"structure"`
 }
 
 // String returns the string representation
@@ -4627,11 +4227,7 @@ type Tag struct {
 
 	Value *string `type:"string" required:"true"`
 
-	metadataTag `json:"-" xml:"-"`
-}
-
-type metadataTag struct {
-	SDKShapeTraits bool `type:"structure"`
+	_ struct{} `type:"structure"`
 }
 
 // String returns the string representation
@@ -4668,11 +4264,7 @@ type Tape struct {
 	// with.
 	VTLDevice *string `min:"50" type:"string"`
 
-	metadataTape `json:"-" xml:"-"`
-}
-
-type metadataTape struct {
-	SDKShapeTraits bool `type:"structure"`
+	_ struct{} `type:"structure"`
 }
 
 // String returns the string representation
@@ -4711,11 +4303,7 @@ type TapeArchive struct {
 	// The current state of the archived virtual tape.
 	TapeStatus *string `type:"string"`
 
-	metadataTapeArchive `json:"-" xml:"-"`
-}
-
-type metadataTapeArchive struct {
-	SDKShapeTraits bool `type:"structure"`
+	_ struct{} `type:"structure"`
 }
 
 // String returns the string representation
@@ -4745,11 +4333,7 @@ type TapeRecoveryPointInfo struct {
 
 	TapeStatus *string `type:"string"`
 
-	metadataTapeRecoveryPointInfo `json:"-" xml:"-"`
-}
-
-type metadataTapeRecoveryPointInfo struct {
-	SDKShapeTraits bool `type:"structure"`
+	_ struct{} `type:"structure"`
 }
 
 // String returns the string representation
@@ -4776,11 +4360,7 @@ type UpdateBandwidthRateLimitInput struct {
 	// to return a list of gateways for your account and region.
 	GatewayARN *string `min:"50" type:"string" required:"true"`
 
-	metadataUpdateBandwidthRateLimitInput `json:"-" xml:"-"`
-}
-
-type metadataUpdateBandwidthRateLimitInput struct {
-	SDKShapeTraits bool `type:"structure"`
+	_ struct{} `type:"structure"`
 }
 
 // String returns the string representation
@@ -4800,11 +4380,7 @@ type UpdateBandwidthRateLimitOutput struct {
 	// to return a list of gateways for your account and region.
 	GatewayARN *string `min:"50" type:"string"`
 
-	metadataUpdateBandwidthRateLimitOutput `json:"-" xml:"-"`
-}
-
-type metadataUpdateBandwidthRateLimitOutput struct {
-	SDKShapeTraits bool `type:"structure"`
+	_ struct{} `type:"structure"`
 }
 
 // String returns the string representation
@@ -4843,11 +4419,7 @@ type UpdateChapCredentialsInput struct {
 	// operation to return the TargetARN for specified VolumeARN.
 	TargetARN *string `min:"50" type:"string" required:"true"`
 
-	metadataUpdateChapCredentialsInput `json:"-" xml:"-"`
-}
-
-type metadataUpdateChapCredentialsInput struct {
-	SDKShapeTraits bool `type:"structure"`
+	_ struct{} `type:"structure"`
 }
 
 // String returns the string representation
@@ -4870,11 +4442,7 @@ type UpdateChapCredentialsOutput struct {
 	// in the request.
 	TargetARN *string `min:"50" type:"string"`
 
-	metadataUpdateChapCredentialsOutput `json:"-" xml:"-"`
-}
-
-type metadataUpdateChapCredentialsOutput struct {
-	SDKShapeTraits bool `type:"structure"`
+	_ struct{} `type:"structure"`
 }
 
 // String returns the string representation
@@ -4898,11 +4466,7 @@ type UpdateGatewayInformationInput struct {
 
 	GatewayTimezone *string `min:"3" type:"string"`
 
-	metadataUpdateGatewayInformationInput `json:"-" xml:"-"`
-}
-
-type metadataUpdateGatewayInformationInput struct {
-	SDKShapeTraits bool `type:"structure"`
+	_ struct{} `type:"structure"`
 }
 
 // String returns the string representation
@@ -4923,11 +4487,7 @@ type UpdateGatewayInformationOutput struct {
 
 	GatewayName *string `type:"string"`
 
-	metadataUpdateGatewayInformationOutput `json:"-" xml:"-"`
-}
-
-type metadataUpdateGatewayInformationOutput struct {
-	SDKShapeTraits bool `type:"structure"`
+	_ struct{} `type:"structure"`
 }
 
 // String returns the string representation
@@ -4946,11 +4506,7 @@ type UpdateGatewaySoftwareNowInput struct {
 	// to return a list of gateways for your account and region.
 	GatewayARN *string `min:"50" type:"string" required:"true"`
 
-	metadataUpdateGatewaySoftwareNowInput `json:"-" xml:"-"`
-}
-
-type metadataUpdateGatewaySoftwareNowInput struct {
-	SDKShapeTraits bool `type:"structure"`
+	_ struct{} `type:"structure"`
 }
 
 // String returns the string representation
@@ -4969,11 +4525,7 @@ type UpdateGatewaySoftwareNowOutput struct {
 	// to return a list of gateways for your account and region.
 	GatewayARN *string `min:"50" type:"string"`
 
-	metadataUpdateGatewaySoftwareNowOutput `json:"-" xml:"-"`
-}
-
-type metadataUpdateGatewaySoftwareNowOutput struct {
-	SDKShapeTraits bool `type:"structure"`
+	_ struct{} `type:"structure"`
 }
 
 // String returns the string representation
@@ -5008,11 +4560,7 @@ type UpdateMaintenanceStartTimeInput struct {
 	// the gateway.
 	MinuteOfHour *int64 `type:"integer" required:"true"`
 
-	metadataUpdateMaintenanceStartTimeInput `json:"-" xml:"-"`
-}
-
-type metadataUpdateMaintenanceStartTimeInput struct {
-	SDKShapeTraits bool `type:"structure"`
+	_ struct{} `type:"structure"`
 }
 
 // String returns the string representation
@@ -5032,11 +4580,7 @@ type UpdateMaintenanceStartTimeOutput struct {
 	// to return a list of gateways for your account and region.
 	GatewayARN *string `min:"50" type:"string"`
 
-	metadataUpdateMaintenanceStartTimeOutput `json:"-" xml:"-"`
-}
-
-type metadataUpdateMaintenanceStartTimeOutput struct {
-	SDKShapeTraits bool `type:"structure"`
+	_ struct{} `type:"structure"`
 }
 
 // String returns the string representation
@@ -5069,11 +4613,7 @@ type UpdateSnapshotScheduleInput struct {
 	// to return a list of gateway volumes.
 	VolumeARN *string `min:"50" type:"string" required:"true"`
 
-	metadataUpdateSnapshotScheduleInput `json:"-" xml:"-"`
-}
-
-type metadataUpdateSnapshotScheduleInput struct {
-	SDKShapeTraits bool `type:"structure"`
+	_ struct{} `type:"structure"`
 }
 
 // String returns the string representation
@@ -5090,11 +4630,7 @@ func (s UpdateSnapshotScheduleInput) GoString() string {
 type UpdateSnapshotScheduleOutput struct {
 	VolumeARN *string `min:"50" type:"string"`
 
-	metadataUpdateSnapshotScheduleOutput `json:"-" xml:"-"`
-}
-
-type metadataUpdateSnapshotScheduleOutput struct {
-	SDKShapeTraits bool `type:"structure"`
+	_ struct{} `type:"structure"`
 }
 
 // String returns the string representation
@@ -5117,11 +4653,7 @@ type UpdateVTLDeviceTypeInput struct {
 	// The Amazon Resource Name (ARN) of the medium changer you want to select.
 	VTLDeviceARN *string `min:"50" type:"string" required:"true"`
 
-	metadataUpdateVTLDeviceTypeInput `json:"-" xml:"-"`
-}
-
-type metadataUpdateVTLDeviceTypeInput struct {
-	SDKShapeTraits bool `type:"structure"`
+	_ struct{} `type:"structure"`
 }
 
 // String returns the string representation
@@ -5139,11 +4671,7 @@ type UpdateVTLDeviceTypeOutput struct {
 	// The Amazon Resource Name (ARN) of the medium changer you have selected.
 	VTLDeviceARN *string `min:"50" type:"string"`
 
-	metadataUpdateVTLDeviceTypeOutput `json:"-" xml:"-"`
-}
-
-type metadataUpdateVTLDeviceTypeOutput struct {
-	SDKShapeTraits bool `type:"structure"`
+	_ struct{} `type:"structure"`
 }
 
 // String returns the string representation
@@ -5171,11 +4699,7 @@ type VTLDevice struct {
 
 	VTLDeviceVendor *string `type:"string"`
 
-	metadataVTLDevice `json:"-" xml:"-"`
-}
-
-type metadataVTLDevice struct {
-	SDKShapeTraits bool `type:"structure"`
+	_ struct{} `type:"structure"`
 }
 
 // String returns the string representation
@@ -5193,11 +4717,7 @@ type VolumeInfo struct {
 
 	VolumeType *string `min:"3" type:"string"`
 
-	metadataVolumeInfo `json:"-" xml:"-"`
-}
-
-type metadataVolumeInfo struct {
-	SDKShapeTraits bool `type:"structure"`
+	_ struct{} `type:"structure"`
 }
 
 // String returns the string representation
@@ -5219,11 +4739,7 @@ type VolumeRecoveryPointInfo struct {
 
 	VolumeUsageInBytes *int64 `type:"long"`
 
-	metadataVolumeRecoveryPointInfo `json:"-" xml:"-"`
-}
-
-type metadataVolumeRecoveryPointInfo struct {
-	SDKShapeTraits bool `type:"structure"`
+	_ struct{} `type:"structure"`
 }
 
 // String returns the string representation
@@ -5253,11 +4769,7 @@ type VolumeiSCSIAttributes struct {
 	// The Amazon Resource Name (ARN) of the volume target.
 	TargetARN *string `min:"50" type:"string"`
 
-	metadataVolumeiSCSIAttributes `json:"-" xml:"-"`
-}
-
-type metadataVolumeiSCSIAttributes struct {
-	SDKShapeTraits bool `type:"structure"`
+	_ struct{} `type:"structure"`
 }
 
 // String returns the string representation

--- a/service/sts/api.go
+++ b/service/sts/api.go
@@ -534,11 +534,7 @@ type AssumeRoleInput struct {
 	// is missing or expired, the AssumeRole call returns an "access denied" error.
 	TokenCode *string `min:"6" type:"string"`
 
-	metadataAssumeRoleInput `json:"-" xml:"-"`
-}
-
-type metadataAssumeRoleInput struct {
-	SDKShapeTraits bool `type:"structure"`
+	_ struct{} `type:"structure"`
 }
 
 // String returns the string representation
@@ -570,11 +566,7 @@ type AssumeRoleOutput struct {
 	// which means the policy exceeded the allowed space.
 	PackedPolicySize *int64 `type:"integer"`
 
-	metadataAssumeRoleOutput `json:"-" xml:"-"`
-}
-
-type metadataAssumeRoleOutput struct {
-	SDKShapeTraits bool `type:"structure"`
+	_ struct{} `type:"structure"`
 }
 
 // String returns the string representation
@@ -632,11 +624,7 @@ type AssumeRoleWithSAMLInput struct {
 	// in the Using IAM guide.
 	SAMLAssertion *string `min:"4" type:"string" required:"true"`
 
-	metadataAssumeRoleWithSAMLInput `json:"-" xml:"-"`
-}
-
-type metadataAssumeRoleWithSAMLInput struct {
-	SDKShapeTraits bool `type:"structure"`
+	_ struct{} `type:"structure"`
 }
 
 // String returns the string representation
@@ -695,11 +683,7 @@ type AssumeRoleWithSAMLOutput struct {
 	// is returned with no modifications.
 	SubjectType *string `type:"string"`
 
-	metadataAssumeRoleWithSAMLOutput `json:"-" xml:"-"`
-}
-
-type metadataAssumeRoleWithSAMLOutput struct {
-	SDKShapeTraits bool `type:"structure"`
+	_ struct{} `type:"structure"`
 }
 
 // String returns the string representation
@@ -762,11 +746,7 @@ type AssumeRoleWithWebIdentityInput struct {
 	// the application makes an AssumeRoleWithWebIdentity call.
 	WebIdentityToken *string `min:"4" type:"string" required:"true"`
 
-	metadataAssumeRoleWithWebIdentityInput `json:"-" xml:"-"`
-}
-
-type metadataAssumeRoleWithWebIdentityInput struct {
-	SDKShapeTraits bool `type:"structure"`
+	_ struct{} `type:"structure"`
 }
 
 // String returns the string representation
@@ -817,11 +797,7 @@ type AssumeRoleWithWebIdentityOutput struct {
 	// returned by the identity provider as the token's sub (Subject) claim.
 	SubjectFromWebIdentityToken *string `min:"6" type:"string"`
 
-	metadataAssumeRoleWithWebIdentityOutput `json:"-" xml:"-"`
-}
-
-type metadataAssumeRoleWithWebIdentityOutput struct {
-	SDKShapeTraits bool `type:"structure"`
+	_ struct{} `type:"structure"`
 }
 
 // String returns the string representation
@@ -848,11 +824,7 @@ type AssumedRoleUser struct {
 	// role is created.
 	AssumedRoleId *string `min:"2" type:"string" required:"true"`
 
-	metadataAssumedRoleUser `json:"-" xml:"-"`
-}
-
-type metadataAssumedRoleUser struct {
-	SDKShapeTraits bool `type:"structure"`
+	_ struct{} `type:"structure"`
 }
 
 // String returns the string representation
@@ -879,11 +851,7 @@ type Credentials struct {
 	// The token that users must pass to the service API to use the temporary credentials.
 	SessionToken *string `type:"string" required:"true"`
 
-	metadataCredentials `json:"-" xml:"-"`
-}
-
-type metadataCredentials struct {
-	SDKShapeTraits bool `type:"structure"`
+	_ struct{} `type:"structure"`
 }
 
 // String returns the string representation
@@ -900,11 +868,7 @@ type DecodeAuthorizationMessageInput struct {
 	// The encoded message that was returned with the response.
 	EncodedMessage *string `min:"1" type:"string" required:"true"`
 
-	metadataDecodeAuthorizationMessageInput `json:"-" xml:"-"`
-}
-
-type metadataDecodeAuthorizationMessageInput struct {
-	SDKShapeTraits bool `type:"structure"`
+	_ struct{} `type:"structure"`
 }
 
 // String returns the string representation
@@ -925,11 +889,7 @@ type DecodeAuthorizationMessageOutput struct {
 	// see DecodeAuthorizationMessage.
 	DecodedMessage *string `type:"string"`
 
-	metadataDecodeAuthorizationMessageOutput `json:"-" xml:"-"`
-}
-
-type metadataDecodeAuthorizationMessageOutput struct {
-	SDKShapeTraits bool `type:"structure"`
+	_ struct{} `type:"structure"`
 }
 
 // String returns the string representation
@@ -954,11 +914,7 @@ type FederatedUser struct {
 	// similar to the unique ID of an IAM user.
 	FederatedUserId *string `min:"2" type:"string" required:"true"`
 
-	metadataFederatedUser `json:"-" xml:"-"`
-}
-
-type metadataFederatedUser struct {
-	SDKShapeTraits bool `type:"structure"`
+	_ struct{} `type:"structure"`
 }
 
 // String returns the string representation
@@ -1010,11 +966,7 @@ type GetFederationTokenInput struct {
 	// GetFederationToken (http://docs.aws.amazon.com/IAM/latest/UserGuide/id_credentials_temp_control-access_getfederationtoken.html).
 	Policy *string `min:"1" type:"string"`
 
-	metadataGetFederationTokenInput `json:"-" xml:"-"`
-}
-
-type metadataGetFederationTokenInput struct {
-	SDKShapeTraits bool `type:"structure"`
+	_ struct{} `type:"structure"`
 }
 
 // String returns the string representation
@@ -1044,11 +996,7 @@ type GetFederationTokenOutput struct {
 	// of the allowed value.
 	PackedPolicySize *int64 `type:"integer"`
 
-	metadataGetFederationTokenOutput `json:"-" xml:"-"`
-}
-
-type metadataGetFederationTokenOutput struct {
-	SDKShapeTraits bool `type:"structure"`
+	_ struct{} `type:"structure"`
 }
 
 // String returns the string representation
@@ -1086,11 +1034,7 @@ type GetSessionTokenInput struct {
 	// response when requesting resources that require MFA authentication.
 	TokenCode *string `min:"6" type:"string"`
 
-	metadataGetSessionTokenInput `json:"-" xml:"-"`
-}
-
-type metadataGetSessionTokenInput struct {
-	SDKShapeTraits bool `type:"structure"`
+	_ struct{} `type:"structure"`
 }
 
 // String returns the string representation
@@ -1109,11 +1053,7 @@ type GetSessionTokenOutput struct {
 	// The session credentials for API authentication.
 	Credentials *Credentials `type:"structure"`
 
-	metadataGetSessionTokenOutput `json:"-" xml:"-"`
-}
-
-type metadataGetSessionTokenOutput struct {
-	SDKShapeTraits bool `type:"structure"`
+	_ struct{} `type:"structure"`
 }
 
 // String returns the string representation

--- a/service/sts/api.go
+++ b/service/sts/api.go
@@ -471,6 +471,8 @@ func (c *STS) GetSessionToken(input *GetSessionTokenInput) (*GetSessionTokenOutp
 }
 
 type AssumeRoleInput struct {
+	_ struct{} `type:"structure"`
+
 	// The duration, in seconds, of the role session. The value can range from 900
 	// seconds (15 minutes) to 3600 seconds (1 hour). By default, the value is set
 	// to 3600 seconds.
@@ -533,8 +535,6 @@ type AssumeRoleInput struct {
 	// for MFA). If the role being assumed requires MFA and if the TokenCode value
 	// is missing or expired, the AssumeRole call returns an "access denied" error.
 	TokenCode *string `min:"6" type:"string"`
-
-	_ struct{} `type:"structure"`
 }
 
 // String returns the string representation
@@ -550,6 +550,8 @@ func (s AssumeRoleInput) GoString() string {
 // Contains the response to a successful AssumeRole request, including temporary
 // AWS credentials that can be used to make AWS requests.
 type AssumeRoleOutput struct {
+	_ struct{} `type:"structure"`
+
 	// The Amazon Resource Name (ARN) and the assumed role ID, which are identifiers
 	// that you can use to refer to the resulting temporary security credentials.
 	// For example, you can reference these credentials as a principal in a resource-based
@@ -565,8 +567,6 @@ type AssumeRoleOutput struct {
 	// The service rejects any policy with a packed size greater than 100 percent,
 	// which means the policy exceeded the allowed space.
 	PackedPolicySize *int64 `type:"integer"`
-
-	_ struct{} `type:"structure"`
 }
 
 // String returns the string representation
@@ -580,6 +580,8 @@ func (s AssumeRoleOutput) GoString() string {
 }
 
 type AssumeRoleWithSAMLInput struct {
+	_ struct{} `type:"structure"`
+
 	// The duration, in seconds, of the role session. The value can range from 900
 	// seconds (15 minutes) to 3600 seconds (1 hour). By default, the value is set
 	// to 3600 seconds. An expiration can also be specified in the SAML authentication
@@ -623,8 +625,6 @@ type AssumeRoleWithSAMLInput struct {
 	// (http://docs.aws.amazon.com/IAM/latest/UserGuide/create-role-saml-IdP-tasks.html)
 	// in the Using IAM guide.
 	SAMLAssertion *string `min:"4" type:"string" required:"true"`
-
-	_ struct{} `type:"structure"`
 }
 
 // String returns the string representation
@@ -640,6 +640,8 @@ func (s AssumeRoleWithSAMLInput) GoString() string {
 // Contains the response to a successful AssumeRoleWithSAML request, including
 // temporary AWS credentials that can be used to make AWS requests.
 type AssumeRoleWithSAMLOutput struct {
+	_ struct{} `type:"structure"`
+
 	// The identifiers for the temporary security credentials that the operation
 	// returns.
 	AssumedRoleUser *AssumedRoleUser `type:"structure"`
@@ -682,8 +684,6 @@ type AssumeRoleWithSAMLOutput struct {
 	// is returned as transient. If the format includes any other prefix, the format
 	// is returned with no modifications.
 	SubjectType *string `type:"string"`
-
-	_ struct{} `type:"structure"`
 }
 
 // String returns the string representation
@@ -697,6 +697,8 @@ func (s AssumeRoleWithSAMLOutput) GoString() string {
 }
 
 type AssumeRoleWithWebIdentityInput struct {
+	_ struct{} `type:"structure"`
+
 	// The duration, in seconds, of the role session. The value can range from 900
 	// seconds (15 minutes) to 3600 seconds (1 hour). By default, the value is set
 	// to 3600 seconds.
@@ -745,8 +747,6 @@ type AssumeRoleWithWebIdentityInput struct {
 	// the user who is using your application with a web identity provider before
 	// the application makes an AssumeRoleWithWebIdentity call.
 	WebIdentityToken *string `min:"4" type:"string" required:"true"`
-
-	_ struct{} `type:"structure"`
 }
 
 // String returns the string representation
@@ -762,6 +762,8 @@ func (s AssumeRoleWithWebIdentityInput) GoString() string {
 // Contains the response to a successful AssumeRoleWithWebIdentity request,
 // including temporary AWS credentials that can be used to make AWS requests.
 type AssumeRoleWithWebIdentityOutput struct {
+	_ struct{} `type:"structure"`
+
 	// The Amazon Resource Name (ARN) and the assumed role ID, which are identifiers
 	// that you can use to refer to the resulting temporary security credentials.
 	// For example, you can reference these credentials as a principal in a resource-based
@@ -796,8 +798,6 @@ type AssumeRoleWithWebIdentityOutput struct {
 	// identifier). For OpenID Connect ID tokens, this field contains the value
 	// returned by the identity provider as the token's sub (Subject) claim.
 	SubjectFromWebIdentityToken *string `min:"6" type:"string"`
-
-	_ struct{} `type:"structure"`
 }
 
 // String returns the string representation
@@ -813,6 +813,8 @@ func (s AssumeRoleWithWebIdentityOutput) GoString() string {
 // The identifiers for the temporary security credentials that the operation
 // returns.
 type AssumedRoleUser struct {
+	_ struct{} `type:"structure"`
+
 	// The ARN of the temporary security credentials that are returned from the
 	// AssumeRole action. For more information about ARNs and how to use them in
 	// policies, see IAM Identifiers (http://docs.aws.amazon.com/IAM/latest/UserGuide/reference_identifiers.html)
@@ -823,8 +825,6 @@ type AssumedRoleUser struct {
 	// the role that is being assumed. The role ID is generated by AWS when the
 	// role is created.
 	AssumedRoleId *string `min:"2" type:"string" required:"true"`
-
-	_ struct{} `type:"structure"`
 }
 
 // String returns the string representation
@@ -839,6 +839,8 @@ func (s AssumedRoleUser) GoString() string {
 
 // AWS credentials for API authentication.
 type Credentials struct {
+	_ struct{} `type:"structure"`
+
 	// The access key ID that identifies the temporary security credentials.
 	AccessKeyId *string `min:"16" type:"string" required:"true"`
 
@@ -850,8 +852,6 @@ type Credentials struct {
 
 	// The token that users must pass to the service API to use the temporary credentials.
 	SessionToken *string `type:"string" required:"true"`
-
-	_ struct{} `type:"structure"`
 }
 
 // String returns the string representation
@@ -865,10 +865,10 @@ func (s Credentials) GoString() string {
 }
 
 type DecodeAuthorizationMessageInput struct {
+	_ struct{} `type:"structure"`
+
 	// The encoded message that was returned with the response.
 	EncodedMessage *string `min:"1" type:"string" required:"true"`
-
-	_ struct{} `type:"structure"`
 }
 
 // String returns the string representation
@@ -885,11 +885,11 @@ func (s DecodeAuthorizationMessageInput) GoString() string {
 // of a request from an encoded message that is returned in response to an AWS
 // request.
 type DecodeAuthorizationMessageOutput struct {
+	_ struct{} `type:"structure"`
+
 	// An XML document that contains the decoded message. For more information,
 	// see DecodeAuthorizationMessage.
 	DecodedMessage *string `type:"string"`
-
-	_ struct{} `type:"structure"`
 }
 
 // String returns the string representation
@@ -904,6 +904,8 @@ func (s DecodeAuthorizationMessageOutput) GoString() string {
 
 // Identifiers for the federated user that is associated with the credentials.
 type FederatedUser struct {
+	_ struct{} `type:"structure"`
+
 	// The ARN that specifies the federated user that is associated with the credentials.
 	// For more information about ARNs and how to use them in policies, see IAM
 	// Identifiers (http://docs.aws.amazon.com/IAM/latest/UserGuide/reference_identifiers.html)
@@ -913,8 +915,6 @@ type FederatedUser struct {
 	// The string that identifies the federated user associated with the credentials,
 	// similar to the unique ID of an IAM user.
 	FederatedUserId *string `min:"2" type:"string" required:"true"`
-
-	_ struct{} `type:"structure"`
 }
 
 // String returns the string representation
@@ -928,6 +928,8 @@ func (s FederatedUser) GoString() string {
 }
 
 type GetFederationTokenInput struct {
+	_ struct{} `type:"structure"`
+
 	// The duration, in seconds, that the session should last. Acceptable durations
 	// for federation sessions range from 900 seconds (15 minutes) to 129600 seconds
 	// (36 hours), with 43200 seconds (12 hours) as the default. Sessions obtained
@@ -965,8 +967,6 @@ type GetFederationTokenInput struct {
 	// size.  For more information about how permissions work, see Permissions for
 	// GetFederationToken (http://docs.aws.amazon.com/IAM/latest/UserGuide/id_credentials_temp_control-access_getfederationtoken.html).
 	Policy *string `min:"1" type:"string"`
-
-	_ struct{} `type:"structure"`
 }
 
 // String returns the string representation
@@ -982,6 +982,8 @@ func (s GetFederationTokenInput) GoString() string {
 // Contains the response to a successful GetFederationToken request, including
 // temporary AWS credentials that can be used to make AWS requests.
 type GetFederationTokenOutput struct {
+	_ struct{} `type:"structure"`
+
 	// Credentials for the service API authentication.
 	Credentials *Credentials `type:"structure"`
 
@@ -995,8 +997,6 @@ type GetFederationTokenOutput struct {
 	// service rejects policies for which the packed size is greater than 100 percent
 	// of the allowed value.
 	PackedPolicySize *int64 `type:"integer"`
-
-	_ struct{} `type:"structure"`
 }
 
 // String returns the string representation
@@ -1010,6 +1010,8 @@ func (s GetFederationTokenOutput) GoString() string {
 }
 
 type GetSessionTokenInput struct {
+	_ struct{} `type:"structure"`
+
 	// The duration, in seconds, that the credentials should remain valid. Acceptable
 	// durations for IAM user sessions range from 900 seconds (15 minutes) to 129600
 	// seconds (36 hours), with 43200 seconds (12 hours) as the default. Sessions
@@ -1033,8 +1035,6 @@ type GetSessionTokenInput struct {
 	// temporary security credentials, the user will receive an "access denied"
 	// response when requesting resources that require MFA authentication.
 	TokenCode *string `min:"6" type:"string"`
-
-	_ struct{} `type:"structure"`
 }
 
 // String returns the string representation
@@ -1050,10 +1050,10 @@ func (s GetSessionTokenInput) GoString() string {
 // Contains the response to a successful GetSessionToken request, including
 // temporary AWS credentials that can be used to make AWS requests.
 type GetSessionTokenOutput struct {
+	_ struct{} `type:"structure"`
+
 	// The session credentials for API authentication.
 	Credentials *Credentials `type:"structure"`
-
-	_ struct{} `type:"structure"`
 }
 
 // String returns the string representation

--- a/service/support/api.go
+++ b/service/support/api.go
@@ -525,6 +525,8 @@ func (c *Support) ResolveCase(input *ResolveCaseInput) (*ResolveCaseOutput, erro
 }
 
 type AddAttachmentsToSetInput struct {
+	_ struct{} `type:"structure"`
+
 	// The ID of the attachment set. If an AttachmentSetId is not specified, a new
 	// attachment set is created, and the ID of the set is returned in the response.
 	// If an AttachmentSetId is specified, the attachments are added to the specified
@@ -534,8 +536,6 @@ type AddAttachmentsToSetInput struct {
 	// One or more attachments to add to the set. The limit is 3 attachments per
 	// set, and the size limit is 5 MB per attachment.
 	Attachments []*Attachment `locationName:"attachments" type:"list" required:"true"`
-
-	_ struct{} `type:"structure"`
 }
 
 // String returns the string representation
@@ -551,6 +551,8 @@ func (s AddAttachmentsToSetInput) GoString() string {
 // The ID and expiry time of the attachment set returned by the AddAttachmentsToSet
 // operation.
 type AddAttachmentsToSetOutput struct {
+	_ struct{} `type:"structure"`
+
 	// The ID of the attachment set. If an AttachmentSetId was not specified, a
 	// new attachment set is created, and the ID of the set is returned in the response.
 	// If an AttachmentSetId was specified, the attachments are added to the specified
@@ -559,8 +561,6 @@ type AddAttachmentsToSetOutput struct {
 
 	// The time and date when the attachment set expires.
 	ExpiryTime *string `locationName:"expiryTime" type:"string"`
-
-	_ struct{} `type:"structure"`
 }
 
 // String returns the string representation
@@ -575,6 +575,8 @@ func (s AddAttachmentsToSetOutput) GoString() string {
 
 // To be written.
 type AddCommunicationToCaseInput struct {
+	_ struct{} `type:"structure"`
+
 	// The ID of a set of one or more attachments for the communication to add to
 	// the case. Create the set by calling AddAttachmentsToSet
 	AttachmentSetId *string `locationName:"attachmentSetId" type:"string"`
@@ -589,8 +591,6 @@ type AddCommunicationToCaseInput struct {
 
 	// The body of an email communication to add to the support case.
 	CommunicationBody *string `locationName:"communicationBody" type:"string" required:"true"`
-
-	_ struct{} `type:"structure"`
 }
 
 // String returns the string representation
@@ -605,10 +605,10 @@ func (s AddCommunicationToCaseInput) GoString() string {
 
 // The result of the AddCommunicationToCase operation.
 type AddCommunicationToCaseOutput struct {
+	_ struct{} `type:"structure"`
+
 	// True if AddCommunicationToCase succeeds. Otherwise, returns an error.
 	Result *bool `locationName:"result" type:"boolean"`
-
-	_ struct{} `type:"structure"`
 }
 
 // String returns the string representation
@@ -624,13 +624,13 @@ func (s AddCommunicationToCaseOutput) GoString() string {
 // An attachment to a case communication. The attachment consists of the file
 // name and the content of the file.
 type Attachment struct {
+	_ struct{} `type:"structure"`
+
 	// The content of the attachment file.
 	Data []byte `locationName:"data" type:"blob"`
 
 	// The name of the attachment file.
 	FileName *string `locationName:"fileName" type:"string"`
-
-	_ struct{} `type:"structure"`
 }
 
 // String returns the string representation
@@ -646,13 +646,13 @@ func (s Attachment) GoString() string {
 // The file name and ID of an attachment to a case communication. You can use
 // the ID to retrieve the attachment with the DescribeAttachment operation.
 type AttachmentDetails struct {
+	_ struct{} `type:"structure"`
+
 	// The ID of the attachment.
 	AttachmentId *string `locationName:"attachmentId" type:"string"`
 
 	// The file name of the attachment.
 	FileName *string `locationName:"fileName" type:"string"`
-
-	_ struct{} `type:"structure"`
 }
 
 // String returns the string representation
@@ -687,6 +687,8 @@ func (s AttachmentDetails) GoString() string {
 // The email address of the account that submitted the case.  TimeCreated. The
 // time the case was created, in ISO-8601 format.
 type CaseDetails struct {
+	_ struct{} `type:"structure"`
+
 	// The AWS Support case ID requested or returned in the call. The case ID is
 	// an alphanumeric string formatted as shown in this example: case-12345678910-2013-c4c1d2bf33c5cf47
 	CaseId *string `locationName:"caseId" type:"string"`
@@ -728,8 +730,6 @@ type CaseDetails struct {
 
 	// The time that the case was case created in the AWS Support Center.
 	TimeCreated *string `locationName:"timeCreated" type:"string"`
-
-	_ struct{} `type:"structure"`
 }
 
 // String returns the string representation
@@ -746,13 +746,13 @@ func (s CaseDetails) GoString() string {
 // code of the problem, selected from the DescribeServices response for each
 // AWS service.
 type Category struct {
+	_ struct{} `type:"structure"`
+
 	// The category code for the support case.
 	Code *string `locationName:"code" type:"string"`
 
 	// The category name for the support case.
 	Name *string `locationName:"name" type:"string"`
-
-	_ struct{} `type:"structure"`
 }
 
 // String returns the string representation
@@ -769,6 +769,8 @@ func (s Category) GoString() string {
 // of the case ID, the message body, attachment information, the account email
 // address, and the date and time of the communication.
 type Communication struct {
+	_ struct{} `type:"structure"`
+
 	// Information about the attachments to the case communication.
 	AttachmentSet []*AttachmentDetails `locationName:"attachmentSet" type:"list"`
 
@@ -784,8 +786,6 @@ type Communication struct {
 
 	// The time the communication was created.
 	TimeCreated *string `locationName:"timeCreated" type:"string"`
-
-	_ struct{} `type:"structure"`
 }
 
 // String returns the string representation
@@ -799,6 +799,8 @@ func (s Communication) GoString() string {
 }
 
 type CreateCaseInput struct {
+	_ struct{} `type:"structure"`
+
 	// The ID of a set of one or more attachments for the case. Create the set by
 	// using AddAttachmentsToSet.
 	AttachmentSetId *string `locationName:"attachmentSetId" type:"string"`
@@ -834,8 +836,6 @@ type CreateCaseInput struct {
 
 	// The title of the AWS Support case.
 	Subject *string `locationName:"subject" type:"string" required:"true"`
-
-	_ struct{} `type:"structure"`
 }
 
 // String returns the string representation
@@ -851,11 +851,11 @@ func (s CreateCaseInput) GoString() string {
 // The AWS Support case ID returned by a successful completion of the CreateCase
 // operation.
 type CreateCaseOutput struct {
+	_ struct{} `type:"structure"`
+
 	// The AWS Support case ID requested or returned in the call. The case ID is
 	// an alphanumeric string formatted as shown in this example: case-12345678910-2013-c4c1d2bf33c5cf47
 	CaseId *string `locationName:"caseId" type:"string"`
-
-	_ struct{} `type:"structure"`
 }
 
 // String returns the string representation
@@ -869,11 +869,11 @@ func (s CreateCaseOutput) GoString() string {
 }
 
 type DescribeAttachmentInput struct {
+	_ struct{} `type:"structure"`
+
 	// The ID of the attachment to return. Attachment IDs are returned by the DescribeCommunications
 	// operation.
 	AttachmentId *string `locationName:"attachmentId" type:"string" required:"true"`
-
-	_ struct{} `type:"structure"`
 }
 
 // String returns the string representation
@@ -889,10 +889,10 @@ func (s DescribeAttachmentInput) GoString() string {
 // The content and file name of the attachment returned by the DescribeAttachment
 // operation.
 type DescribeAttachmentOutput struct {
+	_ struct{} `type:"structure"`
+
 	// The attachment content and file name.
 	Attachment *Attachment `locationName:"attachment" type:"structure"`
-
-	_ struct{} `type:"structure"`
 }
 
 // String returns the string representation
@@ -906,6 +906,8 @@ func (s DescribeAttachmentOutput) GoString() string {
 }
 
 type DescribeCasesInput struct {
+	_ struct{} `type:"structure"`
+
 	// The start date for a filtered date search on support case communications.
 	// Case communications are available for 12 months after creation.
 	AfterTime *string `locationName:"afterTime" type:"string"`
@@ -939,8 +941,6 @@ type DescribeCasesInput struct {
 
 	// A resumption point for pagination.
 	NextToken *string `locationName:"nextToken" type:"string"`
-
-	_ struct{} `type:"structure"`
 }
 
 // String returns the string representation
@@ -956,13 +956,13 @@ func (s DescribeCasesInput) GoString() string {
 // Returns an array of CaseDetails objects and a NextToken that defines a point
 // for pagination in the result set.
 type DescribeCasesOutput struct {
+	_ struct{} `type:"structure"`
+
 	// The details for the cases that match the request.
 	Cases []*CaseDetails `locationName:"cases" type:"list"`
 
 	// A resumption point for pagination.
 	NextToken *string `locationName:"nextToken" type:"string"`
-
-	_ struct{} `type:"structure"`
 }
 
 // String returns the string representation
@@ -976,6 +976,8 @@ func (s DescribeCasesOutput) GoString() string {
 }
 
 type DescribeCommunicationsInput struct {
+	_ struct{} `type:"structure"`
+
 	// The start date for a filtered date search on support case communications.
 	// Case communications are available for 12 months after creation.
 	AfterTime *string `locationName:"afterTime" type:"string"`
@@ -993,8 +995,6 @@ type DescribeCommunicationsInput struct {
 
 	// A resumption point for pagination.
 	NextToken *string `locationName:"nextToken" type:"string"`
-
-	_ struct{} `type:"structure"`
 }
 
 // String returns the string representation
@@ -1009,13 +1009,13 @@ func (s DescribeCommunicationsInput) GoString() string {
 
 // The communications returned by the DescribeCommunications operation.
 type DescribeCommunicationsOutput struct {
+	_ struct{} `type:"structure"`
+
 	// The communications for the case.
 	Communications []*Communication `locationName:"communications" type:"list"`
 
 	// A resumption point for pagination.
 	NextToken *string `locationName:"nextToken" type:"string"`
-
-	_ struct{} `type:"structure"`
 }
 
 // String returns the string representation
@@ -1029,6 +1029,8 @@ func (s DescribeCommunicationsOutput) GoString() string {
 }
 
 type DescribeServicesInput struct {
+	_ struct{} `type:"structure"`
+
 	// The ISO 639-1 code for the language in which AWS provides support. AWS Support
 	// currently supports English ("en") and Japanese ("ja"). Language parameters
 	// must be passed explicitly for operations that take them.
@@ -1036,8 +1038,6 @@ type DescribeServicesInput struct {
 
 	// A JSON-formatted list of service codes available for AWS services.
 	ServiceCodeList []*string `locationName:"serviceCodeList" type:"list"`
-
-	_ struct{} `type:"structure"`
 }
 
 // String returns the string representation
@@ -1052,10 +1052,10 @@ func (s DescribeServicesInput) GoString() string {
 
 // The list of AWS services returned by the DescribeServices operation.
 type DescribeServicesOutput struct {
+	_ struct{} `type:"structure"`
+
 	// A JSON-formatted list of AWS services.
 	Services []*Service `locationName:"services" type:"list"`
-
-	_ struct{} `type:"structure"`
 }
 
 // String returns the string representation
@@ -1069,12 +1069,12 @@ func (s DescribeServicesOutput) GoString() string {
 }
 
 type DescribeSeverityLevelsInput struct {
+	_ struct{} `type:"structure"`
+
 	// The ISO 639-1 code for the language in which AWS provides support. AWS Support
 	// currently supports English ("en") and Japanese ("ja"). Language parameters
 	// must be passed explicitly for operations that take them.
 	Language *string `locationName:"language" type:"string"`
-
-	_ struct{} `type:"structure"`
 }
 
 // String returns the string representation
@@ -1089,11 +1089,11 @@ func (s DescribeSeverityLevelsInput) GoString() string {
 
 // The list of severity levels returned by the DescribeSeverityLevels operation.
 type DescribeSeverityLevelsOutput struct {
+	_ struct{} `type:"structure"`
+
 	// The available severity levels for the support case. Available severity levels
 	// are defined by your service level agreement with AWS.
 	SeverityLevels []*SeverityLevel `locationName:"severityLevels" type:"list"`
-
-	_ struct{} `type:"structure"`
 }
 
 // String returns the string representation
@@ -1107,10 +1107,10 @@ func (s DescribeSeverityLevelsOutput) GoString() string {
 }
 
 type DescribeTrustedAdvisorCheckRefreshStatusesInput struct {
+	_ struct{} `type:"structure"`
+
 	// The IDs of the Trusted Advisor checks.
 	CheckIds []*string `locationName:"checkIds" type:"list" required:"true"`
-
-	_ struct{} `type:"structure"`
 }
 
 // String returns the string representation
@@ -1126,10 +1126,10 @@ func (s DescribeTrustedAdvisorCheckRefreshStatusesInput) GoString() string {
 // The statuses of the Trusted Advisor checks returned by the DescribeTrustedAdvisorCheckRefreshStatuses
 // operation.
 type DescribeTrustedAdvisorCheckRefreshStatusesOutput struct {
+	_ struct{} `type:"structure"`
+
 	// The refresh status of the specified Trusted Advisor checks.
 	Statuses []*TrustedAdvisorCheckRefreshStatus `locationName:"statuses" type:"list" required:"true"`
-
-	_ struct{} `type:"structure"`
 }
 
 // String returns the string representation
@@ -1143,6 +1143,8 @@ func (s DescribeTrustedAdvisorCheckRefreshStatusesOutput) GoString() string {
 }
 
 type DescribeTrustedAdvisorCheckResultInput struct {
+	_ struct{} `type:"structure"`
+
 	// The unique identifier for the Trusted Advisor check.
 	CheckId *string `locationName:"checkId" type:"string" required:"true"`
 
@@ -1150,8 +1152,6 @@ type DescribeTrustedAdvisorCheckResultInput struct {
 	// currently supports English ("en") and Japanese ("ja"). Language parameters
 	// must be passed explicitly for operations that take them.
 	Language *string `locationName:"language" type:"string"`
-
-	_ struct{} `type:"structure"`
 }
 
 // String returns the string representation
@@ -1167,10 +1167,10 @@ func (s DescribeTrustedAdvisorCheckResultInput) GoString() string {
 // The result of the Trusted Advisor check returned by the DescribeTrustedAdvisorCheckResult
 // operation.
 type DescribeTrustedAdvisorCheckResultOutput struct {
+	_ struct{} `type:"structure"`
+
 	// The detailed results of the Trusted Advisor check.
 	Result *TrustedAdvisorCheckResult `locationName:"result" type:"structure"`
-
-	_ struct{} `type:"structure"`
 }
 
 // String returns the string representation
@@ -1184,10 +1184,10 @@ func (s DescribeTrustedAdvisorCheckResultOutput) GoString() string {
 }
 
 type DescribeTrustedAdvisorCheckSummariesInput struct {
+	_ struct{} `type:"structure"`
+
 	// The IDs of the Trusted Advisor checks.
 	CheckIds []*string `locationName:"checkIds" type:"list" required:"true"`
-
-	_ struct{} `type:"structure"`
 }
 
 // String returns the string representation
@@ -1203,10 +1203,10 @@ func (s DescribeTrustedAdvisorCheckSummariesInput) GoString() string {
 // The summaries of the Trusted Advisor checks returned by the DescribeTrustedAdvisorCheckSummaries
 // operation.
 type DescribeTrustedAdvisorCheckSummariesOutput struct {
+	_ struct{} `type:"structure"`
+
 	// The summary information for the requested Trusted Advisor checks.
 	Summaries []*TrustedAdvisorCheckSummary `locationName:"summaries" type:"list" required:"true"`
-
-	_ struct{} `type:"structure"`
 }
 
 // String returns the string representation
@@ -1220,12 +1220,12 @@ func (s DescribeTrustedAdvisorCheckSummariesOutput) GoString() string {
 }
 
 type DescribeTrustedAdvisorChecksInput struct {
+	_ struct{} `type:"structure"`
+
 	// The ISO 639-1 code for the language in which AWS provides support. AWS Support
 	// currently supports English ("en") and Japanese ("ja"). Language parameters
 	// must be passed explicitly for operations that take them.
 	Language *string `locationName:"language" type:"string" required:"true"`
-
-	_ struct{} `type:"structure"`
 }
 
 // String returns the string representation
@@ -1241,10 +1241,10 @@ func (s DescribeTrustedAdvisorChecksInput) GoString() string {
 // Information about the Trusted Advisor checks returned by the DescribeTrustedAdvisorChecks
 // operation.
 type DescribeTrustedAdvisorChecksOutput struct {
+	_ struct{} `type:"structure"`
+
 	// Information about all available Trusted Advisor checks.
 	Checks []*TrustedAdvisorCheckDescription `locationName:"checks" type:"list" required:"true"`
-
-	_ struct{} `type:"structure"`
 }
 
 // String returns the string representation
@@ -1259,13 +1259,13 @@ func (s DescribeTrustedAdvisorChecksOutput) GoString() string {
 
 // The five most recent communications associated with the case.
 type RecentCaseCommunications struct {
+	_ struct{} `type:"structure"`
+
 	// The five most recent communications associated with the case.
 	Communications []*Communication `locationName:"communications" type:"list"`
 
 	// A resumption point for pagination.
 	NextToken *string `locationName:"nextToken" type:"string"`
-
-	_ struct{} `type:"structure"`
 }
 
 // String returns the string representation
@@ -1279,10 +1279,10 @@ func (s RecentCaseCommunications) GoString() string {
 }
 
 type RefreshTrustedAdvisorCheckInput struct {
+	_ struct{} `type:"structure"`
+
 	// The unique identifier for the Trusted Advisor check.
 	CheckId *string `locationName:"checkId" type:"string" required:"true"`
-
-	_ struct{} `type:"structure"`
 }
 
 // String returns the string representation
@@ -1297,11 +1297,11 @@ func (s RefreshTrustedAdvisorCheckInput) GoString() string {
 
 // The current refresh status of a Trusted Advisor check.
 type RefreshTrustedAdvisorCheckOutput struct {
+	_ struct{} `type:"structure"`
+
 	// The current refresh status for a check, including the amount of time until
 	// the check is eligible for refresh.
 	Status *TrustedAdvisorCheckRefreshStatus `locationName:"status" type:"structure" required:"true"`
-
-	_ struct{} `type:"structure"`
 }
 
 // String returns the string representation
@@ -1315,11 +1315,11 @@ func (s RefreshTrustedAdvisorCheckOutput) GoString() string {
 }
 
 type ResolveCaseInput struct {
+	_ struct{} `type:"structure"`
+
 	// The AWS Support case ID requested or returned in the call. The case ID is
 	// an alphanumeric string formatted as shown in this example: case-12345678910-2013-c4c1d2bf33c5cf47
 	CaseId *string `locationName:"caseId" type:"string"`
-
-	_ struct{} `type:"structure"`
 }
 
 // String returns the string representation
@@ -1334,13 +1334,13 @@ func (s ResolveCaseInput) GoString() string {
 
 // The status of the case returned by the ResolveCase operation.
 type ResolveCaseOutput struct {
+	_ struct{} `type:"structure"`
+
 	// The status of the case after the ResolveCase request was processed.
 	FinalCaseStatus *string `locationName:"finalCaseStatus" type:"string"`
 
 	// The status of the case when the ResolveCase request was sent.
 	InitialCaseStatus *string `locationName:"initialCaseStatus" type:"string"`
-
-	_ struct{} `type:"structure"`
 }
 
 // String returns the string representation
@@ -1355,6 +1355,8 @@ func (s ResolveCaseOutput) GoString() string {
 
 // Information about an AWS service returned by the DescribeServices operation.
 type Service struct {
+	_ struct{} `type:"structure"`
+
 	// A list of categories that describe the type of support issue a case describes.
 	// Categories consist of a category name and a category code. Category names
 	// and codes are passed to AWS Support when you call CreateCase.
@@ -1367,8 +1369,6 @@ type Service struct {
 	// The friendly name for an AWS service. The Code element contains the corresponding
 	// code.
 	Name *string `locationName:"name" type:"string"`
-
-	_ struct{} `type:"structure"`
 }
 
 // String returns the string representation
@@ -1384,14 +1384,14 @@ func (s Service) GoString() string {
 // A code and name pair that represent a severity level that can be applied
 // to a support case.
 type SeverityLevel struct {
+	_ struct{} `type:"structure"`
+
 	// One of four values: "low," "medium," "high," and "urgent". These values correspond
 	// to response times returned to the caller in SeverityLevel.name.
 	Code *string `locationName:"code" type:"string"`
 
 	// The name of the severity level that corresponds to the severity level code.
 	Name *string `locationName:"name" type:"string"`
-
-	_ struct{} `type:"structure"`
 }
 
 // String returns the string representation
@@ -1407,11 +1407,11 @@ func (s SeverityLevel) GoString() string {
 // The container for summary information that relates to the category of the
 // Trusted Advisor check.
 type TrustedAdvisorCategorySpecificSummary struct {
+	_ struct{} `type:"structure"`
+
 	// The summary information about cost savings for a Trusted Advisor check that
 	// is in the Cost Optimizing category.
 	CostOptimizing *TrustedAdvisorCostOptimizingSummary `locationName:"costOptimizing" type:"structure"`
-
-	_ struct{} `type:"structure"`
 }
 
 // String returns the string representation
@@ -1426,6 +1426,8 @@ func (s TrustedAdvisorCategorySpecificSummary) GoString() string {
 
 // The description and metadata for a Trusted Advisor check.
 type TrustedAdvisorCheckDescription struct {
+	_ struct{} `type:"structure"`
+
 	// The category of the Trusted Advisor check.
 	Category *string `locationName:"category" type:"string" required:"true"`
 
@@ -1445,8 +1447,6 @@ type TrustedAdvisorCheckDescription struct {
 
 	// The display name for the Trusted Advisor check.
 	Name *string `locationName:"name" type:"string" required:"true"`
-
-	_ struct{} `type:"structure"`
 }
 
 // String returns the string representation
@@ -1461,6 +1461,8 @@ func (s TrustedAdvisorCheckDescription) GoString() string {
 
 // The refresh status of a Trusted Advisor check.
 type TrustedAdvisorCheckRefreshStatus struct {
+	_ struct{} `type:"structure"`
+
 	// The unique identifier for the Trusted Advisor check.
 	CheckId *string `locationName:"checkId" type:"string" required:"true"`
 
@@ -1471,8 +1473,6 @@ type TrustedAdvisorCheckRefreshStatus struct {
 	// The status of the Trusted Advisor check for which a refresh has been requested:
 	// "none", "enqueued", "processing", "success", or "abandoned".
 	Status *string `locationName:"status" type:"string" required:"true"`
-
-	_ struct{} `type:"structure"`
 }
 
 // String returns the string representation
@@ -1487,6 +1487,8 @@ func (s TrustedAdvisorCheckRefreshStatus) GoString() string {
 
 // The results of a Trusted Advisor check returned by DescribeTrustedAdvisorCheckResult.
 type TrustedAdvisorCheckResult struct {
+	_ struct{} `type:"structure"`
+
 	// Summary information that relates to the category of the check. Cost Optimizing
 	// is the only category that is currently supported.
 	CategorySpecificSummary *TrustedAdvisorCategorySpecificSummary `locationName:"categorySpecificSummary" type:"structure" required:"true"`
@@ -1507,8 +1509,6 @@ type TrustedAdvisorCheckResult struct {
 
 	// The time of the last refresh of the check.
 	Timestamp *string `locationName:"timestamp" type:"string" required:"true"`
-
-	_ struct{} `type:"structure"`
 }
 
 // String returns the string representation
@@ -1524,6 +1524,8 @@ func (s TrustedAdvisorCheckResult) GoString() string {
 // A summary of a Trusted Advisor check result, including the alert status,
 // last refresh, and number of resources examined.
 type TrustedAdvisorCheckSummary struct {
+	_ struct{} `type:"structure"`
+
 	// Summary information that relates to the category of the check. Cost Optimizing
 	// is the only category that is currently supported.
 	CategorySpecificSummary *TrustedAdvisorCategorySpecificSummary `locationName:"categorySpecificSummary" type:"structure" required:"true"`
@@ -1544,8 +1546,6 @@ type TrustedAdvisorCheckSummary struct {
 
 	// The time of the last refresh of the check.
 	Timestamp *string `locationName:"timestamp" type:"string" required:"true"`
-
-	_ struct{} `type:"structure"`
 }
 
 // String returns the string representation
@@ -1561,6 +1561,8 @@ func (s TrustedAdvisorCheckSummary) GoString() string {
 // The estimated cost savings that might be realized if the recommended actions
 // are taken.
 type TrustedAdvisorCostOptimizingSummary struct {
+	_ struct{} `type:"structure"`
+
 	// The estimated monthly savings that might be realized if the recommended actions
 	// are taken.
 	EstimatedMonthlySavings *float64 `locationName:"estimatedMonthlySavings" type:"double" required:"true"`
@@ -1568,8 +1570,6 @@ type TrustedAdvisorCostOptimizingSummary struct {
 	// The estimated percentage of savings that might be realized if the recommended
 	// actions are taken.
 	EstimatedPercentMonthlySavings *float64 `locationName:"estimatedPercentMonthlySavings" type:"double" required:"true"`
-
-	_ struct{} `type:"structure"`
 }
 
 // String returns the string representation
@@ -1584,6 +1584,8 @@ func (s TrustedAdvisorCostOptimizingSummary) GoString() string {
 
 // Contains information about a resource identified by a Trusted Advisor check.
 type TrustedAdvisorResourceDetail struct {
+	_ struct{} `type:"structure"`
+
 	// Specifies whether the AWS resource was ignored by Trusted Advisor because
 	// it was marked as suppressed by the user.
 	IsSuppressed *bool `locationName:"isSuppressed" type:"boolean"`
@@ -1603,8 +1605,6 @@ type TrustedAdvisorResourceDetail struct {
 
 	// The status code for the resource identified in the Trusted Advisor check.
 	Status *string `locationName:"status" type:"string" required:"true"`
-
-	_ struct{} `type:"structure"`
 }
 
 // String returns the string representation
@@ -1620,6 +1620,8 @@ func (s TrustedAdvisorResourceDetail) GoString() string {
 // Details about AWS resources that were analyzed in a call to Trusted Advisor
 // DescribeTrustedAdvisorCheckSummaries.
 type TrustedAdvisorResourcesSummary struct {
+	_ struct{} `type:"structure"`
+
 	// The number of AWS resources that were flagged (listed) by the Trusted Advisor
 	// check.
 	ResourcesFlagged *int64 `locationName:"resourcesFlagged" type:"long" required:"true"`
@@ -1634,8 +1636,6 @@ type TrustedAdvisorResourcesSummary struct {
 	// The number of AWS resources ignored by Trusted Advisor because they were
 	// marked as suppressed by the user.
 	ResourcesSuppressed *int64 `locationName:"resourcesSuppressed" type:"long" required:"true"`
-
-	_ struct{} `type:"structure"`
 }
 
 // String returns the string representation

--- a/service/support/api.go
+++ b/service/support/api.go
@@ -535,11 +535,7 @@ type AddAttachmentsToSetInput struct {
 	// set, and the size limit is 5 MB per attachment.
 	Attachments []*Attachment `locationName:"attachments" type:"list" required:"true"`
 
-	metadataAddAttachmentsToSetInput `json:"-" xml:"-"`
-}
-
-type metadataAddAttachmentsToSetInput struct {
-	SDKShapeTraits bool `type:"structure"`
+	_ struct{} `type:"structure"`
 }
 
 // String returns the string representation
@@ -564,11 +560,7 @@ type AddAttachmentsToSetOutput struct {
 	// The time and date when the attachment set expires.
 	ExpiryTime *string `locationName:"expiryTime" type:"string"`
 
-	metadataAddAttachmentsToSetOutput `json:"-" xml:"-"`
-}
-
-type metadataAddAttachmentsToSetOutput struct {
-	SDKShapeTraits bool `type:"structure"`
+	_ struct{} `type:"structure"`
 }
 
 // String returns the string representation
@@ -598,11 +590,7 @@ type AddCommunicationToCaseInput struct {
 	// The body of an email communication to add to the support case.
 	CommunicationBody *string `locationName:"communicationBody" type:"string" required:"true"`
 
-	metadataAddCommunicationToCaseInput `json:"-" xml:"-"`
-}
-
-type metadataAddCommunicationToCaseInput struct {
-	SDKShapeTraits bool `type:"structure"`
+	_ struct{} `type:"structure"`
 }
 
 // String returns the string representation
@@ -620,11 +608,7 @@ type AddCommunicationToCaseOutput struct {
 	// True if AddCommunicationToCase succeeds. Otherwise, returns an error.
 	Result *bool `locationName:"result" type:"boolean"`
 
-	metadataAddCommunicationToCaseOutput `json:"-" xml:"-"`
-}
-
-type metadataAddCommunicationToCaseOutput struct {
-	SDKShapeTraits bool `type:"structure"`
+	_ struct{} `type:"structure"`
 }
 
 // String returns the string representation
@@ -646,11 +630,7 @@ type Attachment struct {
 	// The name of the attachment file.
 	FileName *string `locationName:"fileName" type:"string"`
 
-	metadataAttachment `json:"-" xml:"-"`
-}
-
-type metadataAttachment struct {
-	SDKShapeTraits bool `type:"structure"`
+	_ struct{} `type:"structure"`
 }
 
 // String returns the string representation
@@ -672,11 +652,7 @@ type AttachmentDetails struct {
 	// The file name of the attachment.
 	FileName *string `locationName:"fileName" type:"string"`
 
-	metadataAttachmentDetails `json:"-" xml:"-"`
-}
-
-type metadataAttachmentDetails struct {
-	SDKShapeTraits bool `type:"structure"`
+	_ struct{} `type:"structure"`
 }
 
 // String returns the string representation
@@ -753,11 +729,7 @@ type CaseDetails struct {
 	// The time that the case was case created in the AWS Support Center.
 	TimeCreated *string `locationName:"timeCreated" type:"string"`
 
-	metadataCaseDetails `json:"-" xml:"-"`
-}
-
-type metadataCaseDetails struct {
-	SDKShapeTraits bool `type:"structure"`
+	_ struct{} `type:"structure"`
 }
 
 // String returns the string representation
@@ -780,11 +752,7 @@ type Category struct {
 	// The category name for the support case.
 	Name *string `locationName:"name" type:"string"`
 
-	metadataCategory `json:"-" xml:"-"`
-}
-
-type metadataCategory struct {
-	SDKShapeTraits bool `type:"structure"`
+	_ struct{} `type:"structure"`
 }
 
 // String returns the string representation
@@ -817,11 +785,7 @@ type Communication struct {
 	// The time the communication was created.
 	TimeCreated *string `locationName:"timeCreated" type:"string"`
 
-	metadataCommunication `json:"-" xml:"-"`
-}
-
-type metadataCommunication struct {
-	SDKShapeTraits bool `type:"structure"`
+	_ struct{} `type:"structure"`
 }
 
 // String returns the string representation
@@ -871,11 +835,7 @@ type CreateCaseInput struct {
 	// The title of the AWS Support case.
 	Subject *string `locationName:"subject" type:"string" required:"true"`
 
-	metadataCreateCaseInput `json:"-" xml:"-"`
-}
-
-type metadataCreateCaseInput struct {
-	SDKShapeTraits bool `type:"structure"`
+	_ struct{} `type:"structure"`
 }
 
 // String returns the string representation
@@ -895,11 +855,7 @@ type CreateCaseOutput struct {
 	// an alphanumeric string formatted as shown in this example: case-12345678910-2013-c4c1d2bf33c5cf47
 	CaseId *string `locationName:"caseId" type:"string"`
 
-	metadataCreateCaseOutput `json:"-" xml:"-"`
-}
-
-type metadataCreateCaseOutput struct {
-	SDKShapeTraits bool `type:"structure"`
+	_ struct{} `type:"structure"`
 }
 
 // String returns the string representation
@@ -917,11 +873,7 @@ type DescribeAttachmentInput struct {
 	// operation.
 	AttachmentId *string `locationName:"attachmentId" type:"string" required:"true"`
 
-	metadataDescribeAttachmentInput `json:"-" xml:"-"`
-}
-
-type metadataDescribeAttachmentInput struct {
-	SDKShapeTraits bool `type:"structure"`
+	_ struct{} `type:"structure"`
 }
 
 // String returns the string representation
@@ -940,11 +892,7 @@ type DescribeAttachmentOutput struct {
 	// The attachment content and file name.
 	Attachment *Attachment `locationName:"attachment" type:"structure"`
 
-	metadataDescribeAttachmentOutput `json:"-" xml:"-"`
-}
-
-type metadataDescribeAttachmentOutput struct {
-	SDKShapeTraits bool `type:"structure"`
+	_ struct{} `type:"structure"`
 }
 
 // String returns the string representation
@@ -992,11 +940,7 @@ type DescribeCasesInput struct {
 	// A resumption point for pagination.
 	NextToken *string `locationName:"nextToken" type:"string"`
 
-	metadataDescribeCasesInput `json:"-" xml:"-"`
-}
-
-type metadataDescribeCasesInput struct {
-	SDKShapeTraits bool `type:"structure"`
+	_ struct{} `type:"structure"`
 }
 
 // String returns the string representation
@@ -1018,11 +962,7 @@ type DescribeCasesOutput struct {
 	// A resumption point for pagination.
 	NextToken *string `locationName:"nextToken" type:"string"`
 
-	metadataDescribeCasesOutput `json:"-" xml:"-"`
-}
-
-type metadataDescribeCasesOutput struct {
-	SDKShapeTraits bool `type:"structure"`
+	_ struct{} `type:"structure"`
 }
 
 // String returns the string representation
@@ -1054,11 +994,7 @@ type DescribeCommunicationsInput struct {
 	// A resumption point for pagination.
 	NextToken *string `locationName:"nextToken" type:"string"`
 
-	metadataDescribeCommunicationsInput `json:"-" xml:"-"`
-}
-
-type metadataDescribeCommunicationsInput struct {
-	SDKShapeTraits bool `type:"structure"`
+	_ struct{} `type:"structure"`
 }
 
 // String returns the string representation
@@ -1079,11 +1015,7 @@ type DescribeCommunicationsOutput struct {
 	// A resumption point for pagination.
 	NextToken *string `locationName:"nextToken" type:"string"`
 
-	metadataDescribeCommunicationsOutput `json:"-" xml:"-"`
-}
-
-type metadataDescribeCommunicationsOutput struct {
-	SDKShapeTraits bool `type:"structure"`
+	_ struct{} `type:"structure"`
 }
 
 // String returns the string representation
@@ -1105,11 +1037,7 @@ type DescribeServicesInput struct {
 	// A JSON-formatted list of service codes available for AWS services.
 	ServiceCodeList []*string `locationName:"serviceCodeList" type:"list"`
 
-	metadataDescribeServicesInput `json:"-" xml:"-"`
-}
-
-type metadataDescribeServicesInput struct {
-	SDKShapeTraits bool `type:"structure"`
+	_ struct{} `type:"structure"`
 }
 
 // String returns the string representation
@@ -1127,11 +1055,7 @@ type DescribeServicesOutput struct {
 	// A JSON-formatted list of AWS services.
 	Services []*Service `locationName:"services" type:"list"`
 
-	metadataDescribeServicesOutput `json:"-" xml:"-"`
-}
-
-type metadataDescribeServicesOutput struct {
-	SDKShapeTraits bool `type:"structure"`
+	_ struct{} `type:"structure"`
 }
 
 // String returns the string representation
@@ -1150,11 +1074,7 @@ type DescribeSeverityLevelsInput struct {
 	// must be passed explicitly for operations that take them.
 	Language *string `locationName:"language" type:"string"`
 
-	metadataDescribeSeverityLevelsInput `json:"-" xml:"-"`
-}
-
-type metadataDescribeSeverityLevelsInput struct {
-	SDKShapeTraits bool `type:"structure"`
+	_ struct{} `type:"structure"`
 }
 
 // String returns the string representation
@@ -1173,11 +1093,7 @@ type DescribeSeverityLevelsOutput struct {
 	// are defined by your service level agreement with AWS.
 	SeverityLevels []*SeverityLevel `locationName:"severityLevels" type:"list"`
 
-	metadataDescribeSeverityLevelsOutput `json:"-" xml:"-"`
-}
-
-type metadataDescribeSeverityLevelsOutput struct {
-	SDKShapeTraits bool `type:"structure"`
+	_ struct{} `type:"structure"`
 }
 
 // String returns the string representation
@@ -1194,11 +1110,7 @@ type DescribeTrustedAdvisorCheckRefreshStatusesInput struct {
 	// The IDs of the Trusted Advisor checks.
 	CheckIds []*string `locationName:"checkIds" type:"list" required:"true"`
 
-	metadataDescribeTrustedAdvisorCheckRefreshStatusesInput `json:"-" xml:"-"`
-}
-
-type metadataDescribeTrustedAdvisorCheckRefreshStatusesInput struct {
-	SDKShapeTraits bool `type:"structure"`
+	_ struct{} `type:"structure"`
 }
 
 // String returns the string representation
@@ -1217,11 +1129,7 @@ type DescribeTrustedAdvisorCheckRefreshStatusesOutput struct {
 	// The refresh status of the specified Trusted Advisor checks.
 	Statuses []*TrustedAdvisorCheckRefreshStatus `locationName:"statuses" type:"list" required:"true"`
 
-	metadataDescribeTrustedAdvisorCheckRefreshStatusesOutput `json:"-" xml:"-"`
-}
-
-type metadataDescribeTrustedAdvisorCheckRefreshStatusesOutput struct {
-	SDKShapeTraits bool `type:"structure"`
+	_ struct{} `type:"structure"`
 }
 
 // String returns the string representation
@@ -1243,11 +1151,7 @@ type DescribeTrustedAdvisorCheckResultInput struct {
 	// must be passed explicitly for operations that take them.
 	Language *string `locationName:"language" type:"string"`
 
-	metadataDescribeTrustedAdvisorCheckResultInput `json:"-" xml:"-"`
-}
-
-type metadataDescribeTrustedAdvisorCheckResultInput struct {
-	SDKShapeTraits bool `type:"structure"`
+	_ struct{} `type:"structure"`
 }
 
 // String returns the string representation
@@ -1266,11 +1170,7 @@ type DescribeTrustedAdvisorCheckResultOutput struct {
 	// The detailed results of the Trusted Advisor check.
 	Result *TrustedAdvisorCheckResult `locationName:"result" type:"structure"`
 
-	metadataDescribeTrustedAdvisorCheckResultOutput `json:"-" xml:"-"`
-}
-
-type metadataDescribeTrustedAdvisorCheckResultOutput struct {
-	SDKShapeTraits bool `type:"structure"`
+	_ struct{} `type:"structure"`
 }
 
 // String returns the string representation
@@ -1287,11 +1187,7 @@ type DescribeTrustedAdvisorCheckSummariesInput struct {
 	// The IDs of the Trusted Advisor checks.
 	CheckIds []*string `locationName:"checkIds" type:"list" required:"true"`
 
-	metadataDescribeTrustedAdvisorCheckSummariesInput `json:"-" xml:"-"`
-}
-
-type metadataDescribeTrustedAdvisorCheckSummariesInput struct {
-	SDKShapeTraits bool `type:"structure"`
+	_ struct{} `type:"structure"`
 }
 
 // String returns the string representation
@@ -1310,11 +1206,7 @@ type DescribeTrustedAdvisorCheckSummariesOutput struct {
 	// The summary information for the requested Trusted Advisor checks.
 	Summaries []*TrustedAdvisorCheckSummary `locationName:"summaries" type:"list" required:"true"`
 
-	metadataDescribeTrustedAdvisorCheckSummariesOutput `json:"-" xml:"-"`
-}
-
-type metadataDescribeTrustedAdvisorCheckSummariesOutput struct {
-	SDKShapeTraits bool `type:"structure"`
+	_ struct{} `type:"structure"`
 }
 
 // String returns the string representation
@@ -1333,11 +1225,7 @@ type DescribeTrustedAdvisorChecksInput struct {
 	// must be passed explicitly for operations that take them.
 	Language *string `locationName:"language" type:"string" required:"true"`
 
-	metadataDescribeTrustedAdvisorChecksInput `json:"-" xml:"-"`
-}
-
-type metadataDescribeTrustedAdvisorChecksInput struct {
-	SDKShapeTraits bool `type:"structure"`
+	_ struct{} `type:"structure"`
 }
 
 // String returns the string representation
@@ -1356,11 +1244,7 @@ type DescribeTrustedAdvisorChecksOutput struct {
 	// Information about all available Trusted Advisor checks.
 	Checks []*TrustedAdvisorCheckDescription `locationName:"checks" type:"list" required:"true"`
 
-	metadataDescribeTrustedAdvisorChecksOutput `json:"-" xml:"-"`
-}
-
-type metadataDescribeTrustedAdvisorChecksOutput struct {
-	SDKShapeTraits bool `type:"structure"`
+	_ struct{} `type:"structure"`
 }
 
 // String returns the string representation
@@ -1381,11 +1265,7 @@ type RecentCaseCommunications struct {
 	// A resumption point for pagination.
 	NextToken *string `locationName:"nextToken" type:"string"`
 
-	metadataRecentCaseCommunications `json:"-" xml:"-"`
-}
-
-type metadataRecentCaseCommunications struct {
-	SDKShapeTraits bool `type:"structure"`
+	_ struct{} `type:"structure"`
 }
 
 // String returns the string representation
@@ -1402,11 +1282,7 @@ type RefreshTrustedAdvisorCheckInput struct {
 	// The unique identifier for the Trusted Advisor check.
 	CheckId *string `locationName:"checkId" type:"string" required:"true"`
 
-	metadataRefreshTrustedAdvisorCheckInput `json:"-" xml:"-"`
-}
-
-type metadataRefreshTrustedAdvisorCheckInput struct {
-	SDKShapeTraits bool `type:"structure"`
+	_ struct{} `type:"structure"`
 }
 
 // String returns the string representation
@@ -1425,11 +1301,7 @@ type RefreshTrustedAdvisorCheckOutput struct {
 	// the check is eligible for refresh.
 	Status *TrustedAdvisorCheckRefreshStatus `locationName:"status" type:"structure" required:"true"`
 
-	metadataRefreshTrustedAdvisorCheckOutput `json:"-" xml:"-"`
-}
-
-type metadataRefreshTrustedAdvisorCheckOutput struct {
-	SDKShapeTraits bool `type:"structure"`
+	_ struct{} `type:"structure"`
 }
 
 // String returns the string representation
@@ -1447,11 +1319,7 @@ type ResolveCaseInput struct {
 	// an alphanumeric string formatted as shown in this example: case-12345678910-2013-c4c1d2bf33c5cf47
 	CaseId *string `locationName:"caseId" type:"string"`
 
-	metadataResolveCaseInput `json:"-" xml:"-"`
-}
-
-type metadataResolveCaseInput struct {
-	SDKShapeTraits bool `type:"structure"`
+	_ struct{} `type:"structure"`
 }
 
 // String returns the string representation
@@ -1472,11 +1340,7 @@ type ResolveCaseOutput struct {
 	// The status of the case when the ResolveCase request was sent.
 	InitialCaseStatus *string `locationName:"initialCaseStatus" type:"string"`
 
-	metadataResolveCaseOutput `json:"-" xml:"-"`
-}
-
-type metadataResolveCaseOutput struct {
-	SDKShapeTraits bool `type:"structure"`
+	_ struct{} `type:"structure"`
 }
 
 // String returns the string representation
@@ -1504,11 +1368,7 @@ type Service struct {
 	// code.
 	Name *string `locationName:"name" type:"string"`
 
-	metadataService `json:"-" xml:"-"`
-}
-
-type metadataService struct {
-	SDKShapeTraits bool `type:"structure"`
+	_ struct{} `type:"structure"`
 }
 
 // String returns the string representation
@@ -1531,11 +1391,7 @@ type SeverityLevel struct {
 	// The name of the severity level that corresponds to the severity level code.
 	Name *string `locationName:"name" type:"string"`
 
-	metadataSeverityLevel `json:"-" xml:"-"`
-}
-
-type metadataSeverityLevel struct {
-	SDKShapeTraits bool `type:"structure"`
+	_ struct{} `type:"structure"`
 }
 
 // String returns the string representation
@@ -1555,11 +1411,7 @@ type TrustedAdvisorCategorySpecificSummary struct {
 	// is in the Cost Optimizing category.
 	CostOptimizing *TrustedAdvisorCostOptimizingSummary `locationName:"costOptimizing" type:"structure"`
 
-	metadataTrustedAdvisorCategorySpecificSummary `json:"-" xml:"-"`
-}
-
-type metadataTrustedAdvisorCategorySpecificSummary struct {
-	SDKShapeTraits bool `type:"structure"`
+	_ struct{} `type:"structure"`
 }
 
 // String returns the string representation
@@ -1594,11 +1446,7 @@ type TrustedAdvisorCheckDescription struct {
 	// The display name for the Trusted Advisor check.
 	Name *string `locationName:"name" type:"string" required:"true"`
 
-	metadataTrustedAdvisorCheckDescription `json:"-" xml:"-"`
-}
-
-type metadataTrustedAdvisorCheckDescription struct {
-	SDKShapeTraits bool `type:"structure"`
+	_ struct{} `type:"structure"`
 }
 
 // String returns the string representation
@@ -1624,11 +1472,7 @@ type TrustedAdvisorCheckRefreshStatus struct {
 	// "none", "enqueued", "processing", "success", or "abandoned".
 	Status *string `locationName:"status" type:"string" required:"true"`
 
-	metadataTrustedAdvisorCheckRefreshStatus `json:"-" xml:"-"`
-}
-
-type metadataTrustedAdvisorCheckRefreshStatus struct {
-	SDKShapeTraits bool `type:"structure"`
+	_ struct{} `type:"structure"`
 }
 
 // String returns the string representation
@@ -1664,11 +1508,7 @@ type TrustedAdvisorCheckResult struct {
 	// The time of the last refresh of the check.
 	Timestamp *string `locationName:"timestamp" type:"string" required:"true"`
 
-	metadataTrustedAdvisorCheckResult `json:"-" xml:"-"`
-}
-
-type metadataTrustedAdvisorCheckResult struct {
-	SDKShapeTraits bool `type:"structure"`
+	_ struct{} `type:"structure"`
 }
 
 // String returns the string representation
@@ -1705,11 +1545,7 @@ type TrustedAdvisorCheckSummary struct {
 	// The time of the last refresh of the check.
 	Timestamp *string `locationName:"timestamp" type:"string" required:"true"`
 
-	metadataTrustedAdvisorCheckSummary `json:"-" xml:"-"`
-}
-
-type metadataTrustedAdvisorCheckSummary struct {
-	SDKShapeTraits bool `type:"structure"`
+	_ struct{} `type:"structure"`
 }
 
 // String returns the string representation
@@ -1733,11 +1569,7 @@ type TrustedAdvisorCostOptimizingSummary struct {
 	// actions are taken.
 	EstimatedPercentMonthlySavings *float64 `locationName:"estimatedPercentMonthlySavings" type:"double" required:"true"`
 
-	metadataTrustedAdvisorCostOptimizingSummary `json:"-" xml:"-"`
-}
-
-type metadataTrustedAdvisorCostOptimizingSummary struct {
-	SDKShapeTraits bool `type:"structure"`
+	_ struct{} `type:"structure"`
 }
 
 // String returns the string representation
@@ -1772,11 +1604,7 @@ type TrustedAdvisorResourceDetail struct {
 	// The status code for the resource identified in the Trusted Advisor check.
 	Status *string `locationName:"status" type:"string" required:"true"`
 
-	metadataTrustedAdvisorResourceDetail `json:"-" xml:"-"`
-}
-
-type metadataTrustedAdvisorResourceDetail struct {
-	SDKShapeTraits bool `type:"structure"`
+	_ struct{} `type:"structure"`
 }
 
 // String returns the string representation
@@ -1807,11 +1635,7 @@ type TrustedAdvisorResourcesSummary struct {
 	// marked as suppressed by the user.
 	ResourcesSuppressed *int64 `locationName:"resourcesSuppressed" type:"long" required:"true"`
 
-	metadataTrustedAdvisorResourcesSummary `json:"-" xml:"-"`
-}
-
-type metadataTrustedAdvisorResourcesSummary struct {
-	SDKShapeTraits bool `type:"structure"`
+	_ struct{} `type:"structure"`
 }
 
 // String returns the string representation

--- a/service/swf/api.go
+++ b/service/swf/api.go
@@ -1593,11 +1593,7 @@ type ActivityTaskCancelRequestedEventAttributes struct {
 	// back the chain of events leading up to this event.
 	DecisionTaskCompletedEventId *int64 `locationName:"decisionTaskCompletedEventId" type:"long" required:"true"`
 
-	metadataActivityTaskCancelRequestedEventAttributes `json:"-" xml:"-"`
-}
-
-type metadataActivityTaskCancelRequestedEventAttributes struct {
-	SDKShapeTraits bool `type:"structure"`
+	_ struct{} `type:"structure"`
 }
 
 // String returns the string representation
@@ -1630,11 +1626,7 @@ type ActivityTaskCanceledEventAttributes struct {
 	// back the chain of events leading up to this event.
 	StartedEventId *int64 `locationName:"startedEventId" type:"long" required:"true"`
 
-	metadataActivityTaskCanceledEventAttributes `json:"-" xml:"-"`
-}
-
-type metadataActivityTaskCanceledEventAttributes struct {
-	SDKShapeTraits bool `type:"structure"`
+	_ struct{} `type:"structure"`
 }
 
 // String returns the string representation
@@ -1662,11 +1654,7 @@ type ActivityTaskCompletedEventAttributes struct {
 	// back the chain of events leading up to this event.
 	StartedEventId *int64 `locationName:"startedEventId" type:"long" required:"true"`
 
-	metadataActivityTaskCompletedEventAttributes `json:"-" xml:"-"`
-}
-
-type metadataActivityTaskCompletedEventAttributes struct {
-	SDKShapeTraits bool `type:"structure"`
+	_ struct{} `type:"structure"`
 }
 
 // String returns the string representation
@@ -1697,11 +1685,7 @@ type ActivityTaskFailedEventAttributes struct {
 	// back the chain of events leading up to this event.
 	StartedEventId *int64 `locationName:"startedEventId" type:"long" required:"true"`
 
-	metadataActivityTaskFailedEventAttributes `json:"-" xml:"-"`
-}
-
-type metadataActivityTaskFailedEventAttributes struct {
-	SDKShapeTraits bool `type:"structure"`
+	_ struct{} `type:"structure"`
 }
 
 // String returns the string representation
@@ -1766,11 +1750,7 @@ type ActivityTaskScheduledEventAttributes struct {
 	// in the Amazon Simple Workflow Developer Guide.
 	TaskPriority *string `locationName:"taskPriority" type:"string"`
 
-	metadataActivityTaskScheduledEventAttributes `json:"-" xml:"-"`
-}
-
-type metadataActivityTaskScheduledEventAttributes struct {
-	SDKShapeTraits bool `type:"structure"`
+	_ struct{} `type:"structure"`
 }
 
 // String returns the string representation
@@ -1794,11 +1774,7 @@ type ActivityTaskStartedEventAttributes struct {
 	// by tracing back the chain of events leading up to this event.
 	ScheduledEventId *int64 `locationName:"scheduledEventId" type:"long" required:"true"`
 
-	metadataActivityTaskStartedEventAttributes `json:"-" xml:"-"`
-}
-
-type metadataActivityTaskStartedEventAttributes struct {
-	SDKShapeTraits bool `type:"structure"`
+	_ struct{} `type:"structure"`
 }
 
 // String returns the string representation
@@ -1830,11 +1806,7 @@ type ActivityTaskTimedOutEventAttributes struct {
 	// The type of the timeout that caused this event.
 	TimeoutType *string `locationName:"timeoutType" type:"string" required:"true" enum:"ActivityTaskTimeoutType"`
 
-	metadataActivityTaskTimedOutEventAttributes `json:"-" xml:"-"`
-}
-
-type metadataActivityTaskTimedOutEventAttributes struct {
-	SDKShapeTraits bool `type:"structure"`
+	_ struct{} `type:"structure"`
 }
 
 // String returns the string representation
@@ -1861,11 +1833,7 @@ type ActivityType struct {
 	// a domain.
 	Version *string `locationName:"version" min:"1" type:"string" required:"true"`
 
-	metadataActivityType `json:"-" xml:"-"`
-}
-
-type metadataActivityType struct {
-	SDKShapeTraits bool `type:"structure"`
+	_ struct{} `type:"structure"`
 }
 
 // String returns the string representation
@@ -1937,11 +1905,7 @@ type ActivityTypeConfiguration struct {
 	// 0. The value "NONE" can be used to specify unlimited duration.
 	DefaultTaskStartToCloseTimeout *string `locationName:"defaultTaskStartToCloseTimeout" type:"string"`
 
-	metadataActivityTypeConfiguration `json:"-" xml:"-"`
-}
-
-type metadataActivityTypeConfiguration struct {
-	SDKShapeTraits bool `type:"structure"`
+	_ struct{} `type:"structure"`
 }
 
 // String returns the string representation
@@ -1971,11 +1935,7 @@ type ActivityTypeInfo struct {
 	// The current status of the activity type.
 	Status *string `locationName:"status" type:"string" required:"true" enum:"RegistrationStatus"`
 
-	metadataActivityTypeInfo `json:"-" xml:"-"`
-}
-
-type metadataActivityTypeInfo struct {
-	SDKShapeTraits bool `type:"structure"`
+	_ struct{} `type:"structure"`
 }
 
 // String returns the string representation
@@ -2007,11 +1967,7 @@ type CancelTimerDecisionAttributes struct {
 	// Required. The unique ID of the timer to cancel.
 	TimerId *string `locationName:"timerId" min:"1" type:"string" required:"true"`
 
-	metadataCancelTimerDecisionAttributes `json:"-" xml:"-"`
-}
-
-type metadataCancelTimerDecisionAttributes struct {
-	SDKShapeTraits bool `type:"structure"`
+	_ struct{} `type:"structure"`
 }
 
 // String returns the string representation
@@ -2043,11 +1999,7 @@ type CancelTimerFailedEventAttributes struct {
 	// The timerId provided in the CancelTimer decision that failed.
 	TimerId *string `locationName:"timerId" min:"1" type:"string" required:"true"`
 
-	metadataCancelTimerFailedEventAttributes `json:"-" xml:"-"`
-}
-
-type metadataCancelTimerFailedEventAttributes struct {
-	SDKShapeTraits bool `type:"structure"`
+	_ struct{} `type:"structure"`
 }
 
 // String returns the string representation
@@ -2079,11 +2031,7 @@ type CancelWorkflowExecutionDecisionAttributes struct {
 	// Optional. details of the cancellation.
 	Details *string `locationName:"details" type:"string"`
 
-	metadataCancelWorkflowExecutionDecisionAttributes `json:"-" xml:"-"`
-}
-
-type metadataCancelWorkflowExecutionDecisionAttributes struct {
-	SDKShapeTraits bool `type:"structure"`
+	_ struct{} `type:"structure"`
 }
 
 // String returns the string representation
@@ -2112,11 +2060,7 @@ type CancelWorkflowExecutionFailedEventAttributes struct {
 	// back the chain of events leading up to this event.
 	DecisionTaskCompletedEventId *int64 `locationName:"decisionTaskCompletedEventId" type:"long" required:"true"`
 
-	metadataCancelWorkflowExecutionFailedEventAttributes `json:"-" xml:"-"`
-}
-
-type metadataCancelWorkflowExecutionFailedEventAttributes struct {
-	SDKShapeTraits bool `type:"structure"`
+	_ struct{} `type:"structure"`
 }
 
 // String returns the string representation
@@ -2151,11 +2095,7 @@ type ChildWorkflowExecutionCanceledEventAttributes struct {
 	// The type of the child workflow execution.
 	WorkflowType *WorkflowType `locationName:"workflowType" type:"structure" required:"true"`
 
-	metadataChildWorkflowExecutionCanceledEventAttributes `json:"-" xml:"-"`
-}
-
-type metadataChildWorkflowExecutionCanceledEventAttributes struct {
-	SDKShapeTraits bool `type:"structure"`
+	_ struct{} `type:"structure"`
 }
 
 // String returns the string representation
@@ -2190,11 +2130,7 @@ type ChildWorkflowExecutionCompletedEventAttributes struct {
 	// The type of the child workflow execution.
 	WorkflowType *WorkflowType `locationName:"workflowType" type:"structure" required:"true"`
 
-	metadataChildWorkflowExecutionCompletedEventAttributes `json:"-" xml:"-"`
-}
-
-type metadataChildWorkflowExecutionCompletedEventAttributes struct {
-	SDKShapeTraits bool `type:"structure"`
+	_ struct{} `type:"structure"`
 }
 
 // String returns the string representation
@@ -2232,11 +2168,7 @@ type ChildWorkflowExecutionFailedEventAttributes struct {
 	// The type of the child workflow execution.
 	WorkflowType *WorkflowType `locationName:"workflowType" type:"structure" required:"true"`
 
-	metadataChildWorkflowExecutionFailedEventAttributes `json:"-" xml:"-"`
-}
-
-type metadataChildWorkflowExecutionFailedEventAttributes struct {
-	SDKShapeTraits bool `type:"structure"`
+	_ struct{} `type:"structure"`
 }
 
 // String returns the string representation
@@ -2263,11 +2195,7 @@ type ChildWorkflowExecutionStartedEventAttributes struct {
 	// The type of the child workflow execution.
 	WorkflowType *WorkflowType `locationName:"workflowType" type:"structure" required:"true"`
 
-	metadataChildWorkflowExecutionStartedEventAttributes `json:"-" xml:"-"`
-}
-
-type metadataChildWorkflowExecutionStartedEventAttributes struct {
-	SDKShapeTraits bool `type:"structure"`
+	_ struct{} `type:"structure"`
 }
 
 // String returns the string representation
@@ -2299,11 +2227,7 @@ type ChildWorkflowExecutionTerminatedEventAttributes struct {
 	// The type of the child workflow execution.
 	WorkflowType *WorkflowType `locationName:"workflowType" type:"structure" required:"true"`
 
-	metadataChildWorkflowExecutionTerminatedEventAttributes `json:"-" xml:"-"`
-}
-
-type metadataChildWorkflowExecutionTerminatedEventAttributes struct {
-	SDKShapeTraits bool `type:"structure"`
+	_ struct{} `type:"structure"`
 }
 
 // String returns the string representation
@@ -2339,11 +2263,7 @@ type ChildWorkflowExecutionTimedOutEventAttributes struct {
 	// The type of the child workflow execution.
 	WorkflowType *WorkflowType `locationName:"workflowType" type:"structure" required:"true"`
 
-	metadataChildWorkflowExecutionTimedOutEventAttributes `json:"-" xml:"-"`
-}
-
-type metadataChildWorkflowExecutionTimedOutEventAttributes struct {
-	SDKShapeTraits bool `type:"structure"`
+	_ struct{} `type:"structure"`
 }
 
 // String returns the string representation
@@ -2363,11 +2283,7 @@ type CloseStatusFilter struct {
 	// for it to meet the criteria of this filter.
 	Status *string `locationName:"status" type:"string" required:"true" enum:"CloseStatus"`
 
-	metadataCloseStatusFilter `json:"-" xml:"-"`
-}
-
-type metadataCloseStatusFilter struct {
-	SDKShapeTraits bool `type:"structure"`
+	_ struct{} `type:"structure"`
 }
 
 // String returns the string representation
@@ -2400,11 +2316,7 @@ type CompleteWorkflowExecutionDecisionAttributes struct {
 	// defined.
 	Result *string `locationName:"result" type:"string"`
 
-	metadataCompleteWorkflowExecutionDecisionAttributes `json:"-" xml:"-"`
-}
-
-type metadataCompleteWorkflowExecutionDecisionAttributes struct {
-	SDKShapeTraits bool `type:"structure"`
+	_ struct{} `type:"structure"`
 }
 
 // String returns the string representation
@@ -2433,11 +2345,7 @@ type CompleteWorkflowExecutionFailedEventAttributes struct {
 	// back the chain of events leading up to this event.
 	DecisionTaskCompletedEventId *int64 `locationName:"decisionTaskCompletedEventId" type:"long" required:"true"`
 
-	metadataCompleteWorkflowExecutionFailedEventAttributes `json:"-" xml:"-"`
-}
-
-type metadataCompleteWorkflowExecutionFailedEventAttributes struct {
-	SDKShapeTraits bool `type:"structure"`
+	_ struct{} `type:"structure"`
 }
 
 // String returns the string representation
@@ -2545,11 +2453,7 @@ type ContinueAsNewWorkflowExecutionDecisionAttributes struct {
 
 	WorkflowTypeVersion *string `locationName:"workflowTypeVersion" min:"1" type:"string"`
 
-	metadataContinueAsNewWorkflowExecutionDecisionAttributes `json:"-" xml:"-"`
-}
-
-type metadataContinueAsNewWorkflowExecutionDecisionAttributes struct {
-	SDKShapeTraits bool `type:"structure"`
+	_ struct{} `type:"structure"`
 }
 
 // String returns the string representation
@@ -2578,11 +2482,7 @@ type ContinueAsNewWorkflowExecutionFailedEventAttributes struct {
 	// tracing back the chain of events leading up to this event.
 	DecisionTaskCompletedEventId *int64 `locationName:"decisionTaskCompletedEventId" type:"long" required:"true"`
 
-	metadataContinueAsNewWorkflowExecutionFailedEventAttributes `json:"-" xml:"-"`
-}
-
-type metadataContinueAsNewWorkflowExecutionFailedEventAttributes struct {
-	SDKShapeTraits bool `type:"structure"`
+	_ struct{} `type:"structure"`
 }
 
 // String returns the string representation
@@ -2640,11 +2540,7 @@ type CountClosedWorkflowExecutionsInput struct {
 	// exclusive. You can specify at most one of these in a request.
 	TypeFilter *WorkflowTypeFilter `locationName:"typeFilter" type:"structure"`
 
-	metadataCountClosedWorkflowExecutionsInput `json:"-" xml:"-"`
-}
-
-type metadataCountClosedWorkflowExecutionsInput struct {
-	SDKShapeTraits bool `type:"structure"`
+	_ struct{} `type:"structure"`
 }
 
 // String returns the string representation
@@ -2685,11 +2581,7 @@ type CountOpenWorkflowExecutionsInput struct {
 	// specify at most one of these in a request.
 	TypeFilter *WorkflowTypeFilter `locationName:"typeFilter" type:"structure"`
 
-	metadataCountOpenWorkflowExecutionsInput `json:"-" xml:"-"`
-}
-
-type metadataCountOpenWorkflowExecutionsInput struct {
-	SDKShapeTraits bool `type:"structure"`
+	_ struct{} `type:"structure"`
 }
 
 // String returns the string representation
@@ -2709,11 +2601,7 @@ type CountPendingActivityTasksInput struct {
 	// The name of the task list.
 	TaskList *TaskList `locationName:"taskList" type:"structure" required:"true"`
 
-	metadataCountPendingActivityTasksInput `json:"-" xml:"-"`
-}
-
-type metadataCountPendingActivityTasksInput struct {
-	SDKShapeTraits bool `type:"structure"`
+	_ struct{} `type:"structure"`
 }
 
 // String returns the string representation
@@ -2733,11 +2621,7 @@ type CountPendingDecisionTasksInput struct {
 	// The name of the task list.
 	TaskList *TaskList `locationName:"taskList" type:"structure" required:"true"`
 
-	metadataCountPendingDecisionTasksInput `json:"-" xml:"-"`
-}
-
-type metadataCountPendingDecisionTasksInput struct {
-	SDKShapeTraits bool `type:"structure"`
+	_ struct{} `type:"structure"`
 }
 
 // String returns the string representation
@@ -2929,11 +2813,7 @@ type Decision struct {
 	// types.
 	StartTimerDecisionAttributes *StartTimerDecisionAttributes `locationName:"startTimerDecisionAttributes" type:"structure"`
 
-	metadataDecision `json:"-" xml:"-"`
-}
-
-type metadataDecision struct {
-	SDKShapeTraits bool `type:"structure"`
+	_ struct{} `type:"structure"`
 }
 
 // String returns the string representation
@@ -2961,11 +2841,7 @@ type DecisionTaskCompletedEventAttributes struct {
 	// back the chain of events leading up to this event.
 	StartedEventId *int64 `locationName:"startedEventId" type:"long" required:"true"`
 
-	metadataDecisionTaskCompletedEventAttributes `json:"-" xml:"-"`
-}
-
-type metadataDecisionTaskCompletedEventAttributes struct {
-	SDKShapeTraits bool `type:"structure"`
+	_ struct{} `type:"structure"`
 }
 
 // String returns the string representation
@@ -3000,11 +2876,7 @@ type DecisionTaskScheduledEventAttributes struct {
 	// in the Amazon Simple Workflow Developer Guide.
 	TaskPriority *string `locationName:"taskPriority" type:"string"`
 
-	metadataDecisionTaskScheduledEventAttributes `json:"-" xml:"-"`
-}
-
-type metadataDecisionTaskScheduledEventAttributes struct {
-	SDKShapeTraits bool `type:"structure"`
+	_ struct{} `type:"structure"`
 }
 
 // String returns the string representation
@@ -3028,11 +2900,7 @@ type DecisionTaskStartedEventAttributes struct {
 	// by tracing back the chain of events leading up to this event.
 	ScheduledEventId *int64 `locationName:"scheduledEventId" type:"long" required:"true"`
 
-	metadataDecisionTaskStartedEventAttributes `json:"-" xml:"-"`
-}
-
-type metadataDecisionTaskStartedEventAttributes struct {
-	SDKShapeTraits bool `type:"structure"`
+	_ struct{} `type:"structure"`
 }
 
 // String returns the string representation
@@ -3060,11 +2928,7 @@ type DecisionTaskTimedOutEventAttributes struct {
 	// The type of timeout that expired before the decision task could be completed.
 	TimeoutType *string `locationName:"timeoutType" type:"string" required:"true" enum:"DecisionTaskTimeoutType"`
 
-	metadataDecisionTaskTimedOutEventAttributes `json:"-" xml:"-"`
-}
-
-type metadataDecisionTaskTimedOutEventAttributes struct {
-	SDKShapeTraits bool `type:"structure"`
+	_ struct{} `type:"structure"`
 }
 
 // String returns the string representation
@@ -3084,11 +2948,7 @@ type DeprecateActivityTypeInput struct {
 	// The name of the domain in which the activity type is registered.
 	Domain *string `locationName:"domain" min:"1" type:"string" required:"true"`
 
-	metadataDeprecateActivityTypeInput `json:"-" xml:"-"`
-}
-
-type metadataDeprecateActivityTypeInput struct {
-	SDKShapeTraits bool `type:"structure"`
+	_ struct{} `type:"structure"`
 }
 
 // String returns the string representation
@@ -3102,11 +2962,7 @@ func (s DeprecateActivityTypeInput) GoString() string {
 }
 
 type DeprecateActivityTypeOutput struct {
-	metadataDeprecateActivityTypeOutput `json:"-" xml:"-"`
-}
-
-type metadataDeprecateActivityTypeOutput struct {
-	SDKShapeTraits bool `type:"structure"`
+	_ struct{} `type:"structure"`
 }
 
 // String returns the string representation
@@ -3123,11 +2979,7 @@ type DeprecateDomainInput struct {
 	// The name of the domain to deprecate.
 	Name *string `locationName:"name" min:"1" type:"string" required:"true"`
 
-	metadataDeprecateDomainInput `json:"-" xml:"-"`
-}
-
-type metadataDeprecateDomainInput struct {
-	SDKShapeTraits bool `type:"structure"`
+	_ struct{} `type:"structure"`
 }
 
 // String returns the string representation
@@ -3141,11 +2993,7 @@ func (s DeprecateDomainInput) GoString() string {
 }
 
 type DeprecateDomainOutput struct {
-	metadataDeprecateDomainOutput `json:"-" xml:"-"`
-}
-
-type metadataDeprecateDomainOutput struct {
-	SDKShapeTraits bool `type:"structure"`
+	_ struct{} `type:"structure"`
 }
 
 // String returns the string representation
@@ -3165,11 +3013,7 @@ type DeprecateWorkflowTypeInput struct {
 	// The workflow type to deprecate.
 	WorkflowType *WorkflowType `locationName:"workflowType" type:"structure" required:"true"`
 
-	metadataDeprecateWorkflowTypeInput `json:"-" xml:"-"`
-}
-
-type metadataDeprecateWorkflowTypeInput struct {
-	SDKShapeTraits bool `type:"structure"`
+	_ struct{} `type:"structure"`
 }
 
 // String returns the string representation
@@ -3183,11 +3027,7 @@ func (s DeprecateWorkflowTypeInput) GoString() string {
 }
 
 type DeprecateWorkflowTypeOutput struct {
-	metadataDeprecateWorkflowTypeOutput `json:"-" xml:"-"`
-}
-
-type metadataDeprecateWorkflowTypeOutput struct {
-	SDKShapeTraits bool `type:"structure"`
+	_ struct{} `type:"structure"`
 }
 
 // String returns the string representation
@@ -3208,11 +3048,7 @@ type DescribeActivityTypeInput struct {
 	// The name of the domain in which the activity type is registered.
 	Domain *string `locationName:"domain" min:"1" type:"string" required:"true"`
 
-	metadataDescribeActivityTypeInput `json:"-" xml:"-"`
-}
-
-type metadataDescribeActivityTypeInput struct {
-	SDKShapeTraits bool `type:"structure"`
+	_ struct{} `type:"structure"`
 }
 
 // String returns the string representation
@@ -3241,11 +3077,7 @@ type DescribeActivityTypeOutput struct {
 	// You cannot create new tasks of this type.
 	TypeInfo *ActivityTypeInfo `locationName:"typeInfo" type:"structure" required:"true"`
 
-	metadataDescribeActivityTypeOutput `json:"-" xml:"-"`
-}
-
-type metadataDescribeActivityTypeOutput struct {
-	SDKShapeTraits bool `type:"structure"`
+	_ struct{} `type:"structure"`
 }
 
 // String returns the string representation
@@ -3262,11 +3094,7 @@ type DescribeDomainInput struct {
 	// The name of the domain to describe.
 	Name *string `locationName:"name" min:"1" type:"string" required:"true"`
 
-	metadataDescribeDomainInput `json:"-" xml:"-"`
-}
-
-type metadataDescribeDomainInput struct {
-	SDKShapeTraits bool `type:"structure"`
+	_ struct{} `type:"structure"`
 }
 
 // String returns the string representation
@@ -3287,11 +3115,7 @@ type DescribeDomainOutput struct {
 	// Contains general information about a domain.
 	DomainInfo *DomainInfo `locationName:"domainInfo" type:"structure" required:"true"`
 
-	metadataDescribeDomainOutput `json:"-" xml:"-"`
-}
-
-type metadataDescribeDomainOutput struct {
-	SDKShapeTraits bool `type:"structure"`
+	_ struct{} `type:"structure"`
 }
 
 // String returns the string representation
@@ -3311,11 +3135,7 @@ type DescribeWorkflowExecutionInput struct {
 	// The workflow execution to describe.
 	Execution *WorkflowExecution `locationName:"execution" type:"structure" required:"true"`
 
-	metadataDescribeWorkflowExecutionInput `json:"-" xml:"-"`
-}
-
-type metadataDescribeWorkflowExecutionInput struct {
-	SDKShapeTraits bool `type:"structure"`
+	_ struct{} `type:"structure"`
 }
 
 // String returns the string representation
@@ -3351,11 +3171,7 @@ type DescribeWorkflowExecutionOutput struct {
 	// tasks of all types.
 	OpenCounts *WorkflowExecutionOpenCounts `locationName:"openCounts" type:"structure" required:"true"`
 
-	metadataDescribeWorkflowExecutionOutput `json:"-" xml:"-"`
-}
-
-type metadataDescribeWorkflowExecutionOutput struct {
-	SDKShapeTraits bool `type:"structure"`
+	_ struct{} `type:"structure"`
 }
 
 // String returns the string representation
@@ -3375,11 +3191,7 @@ type DescribeWorkflowTypeInput struct {
 	// The workflow type to describe.
 	WorkflowType *WorkflowType `locationName:"workflowType" type:"structure" required:"true"`
 
-	metadataDescribeWorkflowTypeInput `json:"-" xml:"-"`
-}
-
-type metadataDescribeWorkflowTypeInput struct {
-	SDKShapeTraits bool `type:"structure"`
+	_ struct{} `type:"structure"`
 }
 
 // String returns the string representation
@@ -3408,11 +3220,7 @@ type DescribeWorkflowTypeOutput struct {
 	// You cannot create new workflow executions of this type.
 	TypeInfo *WorkflowTypeInfo `locationName:"typeInfo" type:"structure" required:"true"`
 
-	metadataDescribeWorkflowTypeOutput `json:"-" xml:"-"`
-}
-
-type metadataDescribeWorkflowTypeOutput struct {
-	SDKShapeTraits bool `type:"structure"`
+	_ struct{} `type:"structure"`
 }
 
 // String returns the string representation
@@ -3430,11 +3238,7 @@ type DomainConfiguration struct {
 	// The retention period for workflow executions in this domain.
 	WorkflowExecutionRetentionPeriodInDays *string `locationName:"workflowExecutionRetentionPeriodInDays" min:"1" type:"string" required:"true"`
 
-	metadataDomainConfiguration `json:"-" xml:"-"`
-}
-
-type metadataDomainConfiguration struct {
-	SDKShapeTraits bool `type:"structure"`
+	_ struct{} `type:"structure"`
 }
 
 // String returns the string representation
@@ -3463,11 +3267,7 @@ type DomainInfo struct {
 	// in use. You should not create new workflow executions in this domain.
 	Status *string `locationName:"status" type:"string" required:"true" enum:"RegistrationStatus"`
 
-	metadataDomainInfo `json:"-" xml:"-"`
-}
-
-type metadataDomainInfo struct {
-	SDKShapeTraits bool `type:"structure"`
+	_ struct{} `type:"structure"`
 }
 
 // String returns the string representation
@@ -3492,11 +3292,7 @@ type ExecutionTimeFilter struct {
 	// Specifies the oldest start or close date and time to return.
 	OldestDate *time.Time `locationName:"oldestDate" type:"timestamp" timestampFormat:"unix" required:"true"`
 
-	metadataExecutionTimeFilter `json:"-" xml:"-"`
-}
-
-type metadataExecutionTimeFilter struct {
-	SDKShapeTraits bool `type:"structure"`
+	_ struct{} `type:"structure"`
 }
 
 // String returns the string representation
@@ -3520,11 +3316,7 @@ type ExternalWorkflowExecutionCancelRequestedEventAttributes struct {
 	// The external workflow execution to which the cancellation request was delivered.
 	WorkflowExecution *WorkflowExecution `locationName:"workflowExecution" type:"structure" required:"true"`
 
-	metadataExternalWorkflowExecutionCancelRequestedEventAttributes `json:"-" xml:"-"`
-}
-
-type metadataExternalWorkflowExecutionCancelRequestedEventAttributes struct {
-	SDKShapeTraits bool `type:"structure"`
+	_ struct{} `type:"structure"`
 }
 
 // String returns the string representation
@@ -3548,11 +3340,7 @@ type ExternalWorkflowExecutionSignaledEventAttributes struct {
 	// The external workflow execution that the signal was delivered to.
 	WorkflowExecution *WorkflowExecution `locationName:"workflowExecution" type:"structure" required:"true"`
 
-	metadataExternalWorkflowExecutionSignaledEventAttributes `json:"-" xml:"-"`
-}
-
-type metadataExternalWorkflowExecutionSignaledEventAttributes struct {
-	SDKShapeTraits bool `type:"structure"`
+	_ struct{} `type:"structure"`
 }
 
 // String returns the string representation
@@ -3587,11 +3375,7 @@ type FailWorkflowExecutionDecisionAttributes struct {
 	// A descriptive reason for the failure that may help in diagnostics.
 	Reason *string `locationName:"reason" type:"string"`
 
-	metadataFailWorkflowExecutionDecisionAttributes `json:"-" xml:"-"`
-}
-
-type metadataFailWorkflowExecutionDecisionAttributes struct {
-	SDKShapeTraits bool `type:"structure"`
+	_ struct{} `type:"structure"`
 }
 
 // String returns the string representation
@@ -3620,11 +3404,7 @@ type FailWorkflowExecutionFailedEventAttributes struct {
 	// chain of events leading up to this event.
 	DecisionTaskCompletedEventId *int64 `locationName:"decisionTaskCompletedEventId" type:"long" required:"true"`
 
-	metadataFailWorkflowExecutionFailedEventAttributes `json:"-" xml:"-"`
-}
-
-type metadataFailWorkflowExecutionFailedEventAttributes struct {
-	SDKShapeTraits bool `type:"structure"`
+	_ struct{} `type:"structure"`
 }
 
 // String returns the string representation
@@ -3665,11 +3445,7 @@ type GetWorkflowExecutionHistoryInput struct {
 	// are returned in ascending order of the eventTimeStamp of the events.
 	ReverseOrder *bool `locationName:"reverseOrder" type:"boolean"`
 
-	metadataGetWorkflowExecutionHistoryInput `json:"-" xml:"-"`
-}
-
-type metadataGetWorkflowExecutionHistoryInput struct {
-	SDKShapeTraits bool `type:"structure"`
+	_ struct{} `type:"structure"`
 }
 
 // String returns the string representation
@@ -3697,11 +3473,7 @@ type GetWorkflowExecutionHistoryOutput struct {
 	// in a single call.
 	NextPageToken *string `locationName:"nextPageToken" type:"string"`
 
-	metadataGetWorkflowExecutionHistoryOutput `json:"-" xml:"-"`
-}
-
-type metadataGetWorkflowExecutionHistoryOutput struct {
-	SDKShapeTraits bool `type:"structure"`
+	_ struct{} `type:"structure"`
 }
 
 // String returns the string representation
@@ -4040,11 +3812,7 @@ type HistoryEvent struct {
 	// event types.
 	WorkflowExecutionTimedOutEventAttributes *WorkflowExecutionTimedOutEventAttributes `locationName:"workflowExecutionTimedOutEventAttributes" type:"structure"`
 
-	metadataHistoryEvent `json:"-" xml:"-"`
-}
-
-type metadataHistoryEvent struct {
-	SDKShapeTraits bool `type:"structure"`
+	_ struct{} `type:"structure"`
 }
 
 // String returns the string representation
@@ -4070,11 +3838,7 @@ type LambdaFunctionCompletedEventAttributes struct {
 	// The ID of the LambdaFunctionStarted event recorded in the history.
 	StartedEventId *int64 `locationName:"startedEventId" type:"long" required:"true"`
 
-	metadataLambdaFunctionCompletedEventAttributes `json:"-" xml:"-"`
-}
-
-type metadataLambdaFunctionCompletedEventAttributes struct {
-	SDKShapeTraits bool `type:"structure"`
+	_ struct{} `type:"structure"`
 }
 
 // String returns the string representation
@@ -4103,11 +3867,7 @@ type LambdaFunctionFailedEventAttributes struct {
 	// The ID of the LambdaFunctionStarted event recorded in the history.
 	StartedEventId *int64 `locationName:"startedEventId" type:"long" required:"true"`
 
-	metadataLambdaFunctionFailedEventAttributes `json:"-" xml:"-"`
-}
-
-type metadataLambdaFunctionFailedEventAttributes struct {
-	SDKShapeTraits bool `type:"structure"`
+	_ struct{} `type:"structure"`
 }
 
 // String returns the string representation
@@ -4141,11 +3901,7 @@ type LambdaFunctionScheduledEventAttributes struct {
 	// from start to close before it is marked as failed.
 	StartToCloseTimeout *string `locationName:"startToCloseTimeout" type:"string"`
 
-	metadataLambdaFunctionScheduledEventAttributes `json:"-" xml:"-"`
-}
-
-type metadataLambdaFunctionScheduledEventAttributes struct {
-	SDKShapeTraits bool `type:"structure"`
+	_ struct{} `type:"structure"`
 }
 
 // String returns the string representation
@@ -4165,11 +3921,7 @@ type LambdaFunctionStartedEventAttributes struct {
 	// problems by tracing back the chain of events leading up to this event.
 	ScheduledEventId *int64 `locationName:"scheduledEventId" type:"long" required:"true"`
 
-	metadataLambdaFunctionStartedEventAttributes `json:"-" xml:"-"`
-}
-
-type metadataLambdaFunctionStartedEventAttributes struct {
-	SDKShapeTraits bool `type:"structure"`
+	_ struct{} `type:"structure"`
 }
 
 // String returns the string representation
@@ -4195,11 +3947,7 @@ type LambdaFunctionTimedOutEventAttributes struct {
 	// The type of the timeout that caused this event.
 	TimeoutType *string `locationName:"timeoutType" type:"string" enum:"LambdaFunctionTimeoutType"`
 
-	metadataLambdaFunctionTimedOutEventAttributes `json:"-" xml:"-"`
-}
-
-type metadataLambdaFunctionTimedOutEventAttributes struct {
-	SDKShapeTraits bool `type:"structure"`
+	_ struct{} `type:"structure"`
 }
 
 // String returns the string representation
@@ -4243,11 +3991,7 @@ type ListActivityTypesInput struct {
 	// are returned in ascending alphabetical order by name of the activity types.
 	ReverseOrder *bool `locationName:"reverseOrder" type:"boolean"`
 
-	metadataListActivityTypesInput `json:"-" xml:"-"`
-}
-
-type metadataListActivityTypesInput struct {
-	SDKShapeTraits bool `type:"structure"`
+	_ struct{} `type:"structure"`
 }
 
 // String returns the string representation
@@ -4273,11 +4017,7 @@ type ListActivityTypesOutput struct {
 	// List of activity type information.
 	TypeInfos []*ActivityTypeInfo `locationName:"typeInfos" type:"list" required:"true"`
 
-	metadataListActivityTypesOutput `json:"-" xml:"-"`
-}
-
-type metadataListActivityTypesOutput struct {
-	SDKShapeTraits bool `type:"structure"`
+	_ struct{} `type:"structure"`
 }
 
 // String returns the string representation
@@ -4360,11 +4100,7 @@ type ListClosedWorkflowExecutionsInput struct {
 	// exclusive. You can specify at most one of these in a request.
 	TypeFilter *WorkflowTypeFilter `locationName:"typeFilter" type:"structure"`
 
-	metadataListClosedWorkflowExecutionsInput `json:"-" xml:"-"`
-}
-
-type metadataListClosedWorkflowExecutionsInput struct {
-	SDKShapeTraits bool `type:"structure"`
+	_ struct{} `type:"structure"`
 }
 
 // String returns the string representation
@@ -4402,11 +4138,7 @@ type ListDomainsInput struct {
 	// are returned in ascending alphabetical order by name of the domains.
 	ReverseOrder *bool `locationName:"reverseOrder" type:"boolean"`
 
-	metadataListDomainsInput `json:"-" xml:"-"`
-}
-
-type metadataListDomainsInput struct {
-	SDKShapeTraits bool `type:"structure"`
+	_ struct{} `type:"structure"`
 }
 
 // String returns the string representation
@@ -4432,11 +4164,7 @@ type ListDomainsOutput struct {
 	// in a single call.
 	NextPageToken *string `locationName:"nextPageToken" type:"string"`
 
-	metadataListDomainsOutput `json:"-" xml:"-"`
-}
-
-type metadataListDomainsOutput struct {
-	SDKShapeTraits bool `type:"structure"`
+	_ struct{} `type:"structure"`
 }
 
 // String returns the string representation
@@ -4497,11 +4225,7 @@ type ListOpenWorkflowExecutionsInput struct {
 	// specify at most one of these in a request.
 	TypeFilter *WorkflowTypeFilter `locationName:"typeFilter" type:"structure"`
 
-	metadataListOpenWorkflowExecutionsInput `json:"-" xml:"-"`
-}
-
-type metadataListOpenWorkflowExecutionsInput struct {
-	SDKShapeTraits bool `type:"structure"`
+	_ struct{} `type:"structure"`
 }
 
 // String returns the string representation
@@ -4546,11 +4270,7 @@ type ListWorkflowTypesInput struct {
 	// types.
 	ReverseOrder *bool `locationName:"reverseOrder" type:"boolean"`
 
-	metadataListWorkflowTypesInput `json:"-" xml:"-"`
-}
-
-type metadataListWorkflowTypesInput struct {
-	SDKShapeTraits bool `type:"structure"`
+	_ struct{} `type:"structure"`
 }
 
 // String returns the string representation
@@ -4576,11 +4296,7 @@ type ListWorkflowTypesOutput struct {
 	// The list of workflow type information.
 	TypeInfos []*WorkflowTypeInfo `locationName:"typeInfos" type:"list" required:"true"`
 
-	metadataListWorkflowTypesOutput `json:"-" xml:"-"`
-}
-
-type metadataListWorkflowTypesOutput struct {
-	SDKShapeTraits bool `type:"structure"`
+	_ struct{} `type:"structure"`
 }
 
 // String returns the string representation
@@ -4607,11 +4323,7 @@ type MarkerRecordedEventAttributes struct {
 	// The name of the marker.
 	MarkerName *string `locationName:"markerName" min:"1" type:"string" required:"true"`
 
-	metadataMarkerRecordedEventAttributes `json:"-" xml:"-"`
-}
-
-type metadataMarkerRecordedEventAttributes struct {
-	SDKShapeTraits bool `type:"structure"`
+	_ struct{} `type:"structure"`
 }
 
 // String returns the string representation
@@ -4633,11 +4345,7 @@ type PendingTaskCount struct {
 	// supported by this API and the count returned is the truncated value.
 	Truncated *bool `locationName:"truncated" type:"boolean"`
 
-	metadataPendingTaskCount `json:"-" xml:"-"`
-}
-
-type metadataPendingTaskCount struct {
-	SDKShapeTraits bool `type:"structure"`
+	_ struct{} `type:"structure"`
 }
 
 // String returns the string representation
@@ -4667,11 +4375,7 @@ type PollForActivityTaskInput struct {
 	// string quotarnquot.
 	TaskList *TaskList `locationName:"taskList" type:"structure" required:"true"`
 
-	metadataPollForActivityTaskInput `json:"-" xml:"-"`
-}
-
-type metadataPollForActivityTaskInput struct {
-	SDKShapeTraits bool `type:"structure"`
+	_ struct{} `type:"structure"`
 }
 
 // String returns the string representation
@@ -4707,11 +4411,7 @@ type PollForActivityTaskOutput struct {
 	// The workflow execution that started this activity task.
 	WorkflowExecution *WorkflowExecution `locationName:"workflowExecution" type:"structure" required:"true"`
 
-	metadataPollForActivityTaskOutput `json:"-" xml:"-"`
-}
-
-type metadataPollForActivityTaskOutput struct {
-	SDKShapeTraits bool `type:"structure"`
+	_ struct{} `type:"structure"`
 }
 
 // String returns the string representation
@@ -4767,11 +4467,7 @@ type PollForDecisionTaskInput struct {
 	// string quotarnquot.
 	TaskList *TaskList `locationName:"taskList" type:"structure" required:"true"`
 
-	metadataPollForDecisionTaskInput `json:"-" xml:"-"`
-}
-
-type metadataPollForDecisionTaskInput struct {
-	SDKShapeTraits bool `type:"structure"`
+	_ struct{} `type:"structure"`
 }
 
 // String returns the string representation
@@ -4819,11 +4515,7 @@ type PollForDecisionTaskOutput struct {
 	// The type of the workflow execution for which this decision task was created.
 	WorkflowType *WorkflowType `locationName:"workflowType" type:"structure" required:"true"`
 
-	metadataPollForDecisionTaskOutput `json:"-" xml:"-"`
-}
-
-type metadataPollForDecisionTaskOutput struct {
-	SDKShapeTraits bool `type:"structure"`
+	_ struct{} `type:"structure"`
 }
 
 // String returns the string representation
@@ -4847,11 +4539,7 @@ type RecordActivityTaskHeartbeatInput struct {
 	// be passed. This enables it to provide its progress and respond with results.
 	TaskToken *string `locationName:"taskToken" min:"1" type:"string" required:"true"`
 
-	metadataRecordActivityTaskHeartbeatInput `json:"-" xml:"-"`
-}
-
-type metadataRecordActivityTaskHeartbeatInput struct {
-	SDKShapeTraits bool `type:"structure"`
+	_ struct{} `type:"structure"`
 }
 
 // String returns the string representation
@@ -4869,11 +4557,7 @@ type RecordActivityTaskHeartbeatOutput struct {
 	// Set to true if cancellation of the task is requested.
 	CancelRequested *bool `locationName:"cancelRequested" type:"boolean" required:"true"`
 
-	metadataRecordActivityTaskHeartbeatOutput `json:"-" xml:"-"`
-}
-
-type metadataRecordActivityTaskHeartbeatOutput struct {
-	SDKShapeTraits bool `type:"structure"`
+	_ struct{} `type:"structure"`
 }
 
 // String returns the string representation
@@ -4908,11 +4592,7 @@ type RecordMarkerDecisionAttributes struct {
 	// Required. The name of the marker.
 	MarkerName *string `locationName:"markerName" min:"1" type:"string" required:"true"`
 
-	metadataRecordMarkerDecisionAttributes `json:"-" xml:"-"`
-}
-
-type metadataRecordMarkerDecisionAttributes struct {
-	SDKShapeTraits bool `type:"structure"`
+	_ struct{} `type:"structure"`
 }
 
 // String returns the string representation
@@ -4944,11 +4624,7 @@ type RecordMarkerFailedEventAttributes struct {
 	// The marker's name.
 	MarkerName *string `locationName:"markerName" min:"1" type:"string" required:"true"`
 
-	metadataRecordMarkerFailedEventAttributes `json:"-" xml:"-"`
-}
-
-type metadataRecordMarkerFailedEventAttributes struct {
-	SDKShapeTraits bool `type:"structure"`
+	_ struct{} `type:"structure"`
 }
 
 // String returns the string representation
@@ -5037,11 +4713,7 @@ type RegisterActivityTypeInput struct {
 	// it must not contain the literal string quotarnquot.
 	Version *string `locationName:"version" min:"1" type:"string" required:"true"`
 
-	metadataRegisterActivityTypeInput `json:"-" xml:"-"`
-}
-
-type metadataRegisterActivityTypeInput struct {
-	SDKShapeTraits bool `type:"structure"`
+	_ struct{} `type:"structure"`
 }
 
 // String returns the string representation
@@ -5055,11 +4727,7 @@ func (s RegisterActivityTypeInput) GoString() string {
 }
 
 type RegisterActivityTypeOutput struct {
-	metadataRegisterActivityTypeOutput `json:"-" xml:"-"`
-}
-
-type metadataRegisterActivityTypeOutput struct {
-	SDKShapeTraits bool `type:"structure"`
+	_ struct{} `type:"structure"`
 }
 
 // String returns the string representation
@@ -5098,11 +4766,7 @@ type RegisterDomainInput struct {
 	// in the Amazon SWF Developer Guide.
 	WorkflowExecutionRetentionPeriodInDays *string `locationName:"workflowExecutionRetentionPeriodInDays" min:"1" type:"string" required:"true"`
 
-	metadataRegisterDomainInput `json:"-" xml:"-"`
-}
-
-type metadataRegisterDomainInput struct {
-	SDKShapeTraits bool `type:"structure"`
+	_ struct{} `type:"structure"`
 }
 
 // String returns the string representation
@@ -5116,11 +4780,7 @@ func (s RegisterDomainInput) GoString() string {
 }
 
 type RegisterDomainOutput struct {
-	metadataRegisterDomainOutput `json:"-" xml:"-"`
-}
-
-type metadataRegisterDomainOutput struct {
-	SDKShapeTraits bool `type:"structure"`
+	_ struct{} `type:"structure"`
 }
 
 // String returns the string representation
@@ -5217,11 +4877,7 @@ type RegisterWorkflowTypeInput struct {
 	// Also, it must not contain the literal string quotarnquot.
 	Version *string `locationName:"version" min:"1" type:"string" required:"true"`
 
-	metadataRegisterWorkflowTypeInput `json:"-" xml:"-"`
-}
-
-type metadataRegisterWorkflowTypeInput struct {
-	SDKShapeTraits bool `type:"structure"`
+	_ struct{} `type:"structure"`
 }
 
 // String returns the string representation
@@ -5235,11 +4891,7 @@ func (s RegisterWorkflowTypeInput) GoString() string {
 }
 
 type RegisterWorkflowTypeOutput struct {
-	metadataRegisterWorkflowTypeOutput `json:"-" xml:"-"`
-}
-
-type metadataRegisterWorkflowTypeOutput struct {
-	SDKShapeTraits bool `type:"structure"`
+	_ struct{} `type:"structure"`
 }
 
 // String returns the string representation
@@ -5271,11 +4923,7 @@ type RequestCancelActivityTaskDecisionAttributes struct {
 	// The activityId of the activity task to be canceled.
 	ActivityId *string `locationName:"activityId" min:"1" type:"string" required:"true"`
 
-	metadataRequestCancelActivityTaskDecisionAttributes `json:"-" xml:"-"`
-}
-
-type metadataRequestCancelActivityTaskDecisionAttributes struct {
-	SDKShapeTraits bool `type:"structure"`
+	_ struct{} `type:"structure"`
 }
 
 // String returns the string representation
@@ -5307,11 +4955,7 @@ type RequestCancelActivityTaskFailedEventAttributes struct {
 	// back the chain of events leading up to this event.
 	DecisionTaskCompletedEventId *int64 `locationName:"decisionTaskCompletedEventId" type:"long" required:"true"`
 
-	metadataRequestCancelActivityTaskFailedEventAttributes `json:"-" xml:"-"`
-}
-
-type metadataRequestCancelActivityTaskFailedEventAttributes struct {
-	SDKShapeTraits bool `type:"structure"`
+	_ struct{} `type:"structure"`
 }
 
 // String returns the string representation
@@ -5350,11 +4994,7 @@ type RequestCancelExternalWorkflowExecutionDecisionAttributes struct {
 	// Required. The workflowId of the external workflow execution to cancel.
 	WorkflowId *string `locationName:"workflowId" min:"1" type:"string" required:"true"`
 
-	metadataRequestCancelExternalWorkflowExecutionDecisionAttributes `json:"-" xml:"-"`
-}
-
-type metadataRequestCancelExternalWorkflowExecutionDecisionAttributes struct {
-	SDKShapeTraits bool `type:"structure"`
+	_ struct{} `type:"structure"`
 }
 
 // String returns the string representation
@@ -5398,11 +5038,7 @@ type RequestCancelExternalWorkflowExecutionFailedEventAttributes struct {
 	// be delivered.
 	WorkflowId *string `locationName:"workflowId" min:"1" type:"string" required:"true"`
 
-	metadataRequestCancelExternalWorkflowExecutionFailedEventAttributes `json:"-" xml:"-"`
-}
-
-type metadataRequestCancelExternalWorkflowExecutionFailedEventAttributes struct {
-	SDKShapeTraits bool `type:"structure"`
+	_ struct{} `type:"structure"`
 }
 
 // String returns the string representation
@@ -5433,11 +5069,7 @@ type RequestCancelExternalWorkflowExecutionInitiatedEventAttributes struct {
 	// The workflowId of the external workflow execution to be canceled.
 	WorkflowId *string `locationName:"workflowId" min:"1" type:"string" required:"true"`
 
-	metadataRequestCancelExternalWorkflowExecutionInitiatedEventAttributes `json:"-" xml:"-"`
-}
-
-type metadataRequestCancelExternalWorkflowExecutionInitiatedEventAttributes struct {
-	SDKShapeTraits bool `type:"structure"`
+	_ struct{} `type:"structure"`
 }
 
 // String returns the string representation
@@ -5460,11 +5092,7 @@ type RequestCancelWorkflowExecutionInput struct {
 	// The workflowId of the workflow execution to cancel.
 	WorkflowId *string `locationName:"workflowId" min:"1" type:"string" required:"true"`
 
-	metadataRequestCancelWorkflowExecutionInput `json:"-" xml:"-"`
-}
-
-type metadataRequestCancelWorkflowExecutionInput struct {
-	SDKShapeTraits bool `type:"structure"`
+	_ struct{} `type:"structure"`
 }
 
 // String returns the string representation
@@ -5478,11 +5106,7 @@ func (s RequestCancelWorkflowExecutionInput) GoString() string {
 }
 
 type RequestCancelWorkflowExecutionOutput struct {
-	metadataRequestCancelWorkflowExecutionOutput `json:"-" xml:"-"`
-}
-
-type metadataRequestCancelWorkflowExecutionOutput struct {
-	SDKShapeTraits bool `type:"structure"`
+	_ struct{} `type:"structure"`
 }
 
 // String returns the string representation
@@ -5506,11 +5130,7 @@ type RespondActivityTaskCanceledInput struct {
 	// be passed. This enables it to provide its progress and respond with results.
 	TaskToken *string `locationName:"taskToken" min:"1" type:"string" required:"true"`
 
-	metadataRespondActivityTaskCanceledInput `json:"-" xml:"-"`
-}
-
-type metadataRespondActivityTaskCanceledInput struct {
-	SDKShapeTraits bool `type:"structure"`
+	_ struct{} `type:"structure"`
 }
 
 // String returns the string representation
@@ -5524,11 +5144,7 @@ func (s RespondActivityTaskCanceledInput) GoString() string {
 }
 
 type RespondActivityTaskCanceledOutput struct {
-	metadataRespondActivityTaskCanceledOutput `json:"-" xml:"-"`
-}
-
-type metadataRespondActivityTaskCanceledOutput struct {
-	SDKShapeTraits bool `type:"structure"`
+	_ struct{} `type:"structure"`
 }
 
 // String returns the string representation
@@ -5553,11 +5169,7 @@ type RespondActivityTaskCompletedInput struct {
 	// be passed. This enables it to provide its progress and respond with results.
 	TaskToken *string `locationName:"taskToken" min:"1" type:"string" required:"true"`
 
-	metadataRespondActivityTaskCompletedInput `json:"-" xml:"-"`
-}
-
-type metadataRespondActivityTaskCompletedInput struct {
-	SDKShapeTraits bool `type:"structure"`
+	_ struct{} `type:"structure"`
 }
 
 // String returns the string representation
@@ -5571,11 +5183,7 @@ func (s RespondActivityTaskCompletedInput) GoString() string {
 }
 
 type RespondActivityTaskCompletedOutput struct {
-	metadataRespondActivityTaskCompletedOutput `json:"-" xml:"-"`
-}
-
-type metadataRespondActivityTaskCompletedOutput struct {
-	SDKShapeTraits bool `type:"structure"`
+	_ struct{} `type:"structure"`
 }
 
 // String returns the string representation
@@ -5602,11 +5210,7 @@ type RespondActivityTaskFailedInput struct {
 	// be passed. This enables it to provide its progress and respond with results.
 	TaskToken *string `locationName:"taskToken" min:"1" type:"string" required:"true"`
 
-	metadataRespondActivityTaskFailedInput `json:"-" xml:"-"`
-}
-
-type metadataRespondActivityTaskFailedInput struct {
-	SDKShapeTraits bool `type:"structure"`
+	_ struct{} `type:"structure"`
 }
 
 // String returns the string representation
@@ -5620,11 +5224,7 @@ func (s RespondActivityTaskFailedInput) GoString() string {
 }
 
 type RespondActivityTaskFailedOutput struct {
-	metadataRespondActivityTaskFailedOutput `json:"-" xml:"-"`
-}
-
-type metadataRespondActivityTaskFailedOutput struct {
-	SDKShapeTraits bool `type:"structure"`
+	_ struct{} `type:"structure"`
 }
 
 // String returns the string representation
@@ -5652,11 +5252,7 @@ type RespondDecisionTaskCompletedInput struct {
 	// be passed. This enables it to provide its progress and respond with results.
 	TaskToken *string `locationName:"taskToken" min:"1" type:"string" required:"true"`
 
-	metadataRespondDecisionTaskCompletedInput `json:"-" xml:"-"`
-}
-
-type metadataRespondDecisionTaskCompletedInput struct {
-	SDKShapeTraits bool `type:"structure"`
+	_ struct{} `type:"structure"`
 }
 
 // String returns the string representation
@@ -5670,11 +5266,7 @@ func (s RespondDecisionTaskCompletedInput) GoString() string {
 }
 
 type RespondDecisionTaskCompletedOutput struct {
-	metadataRespondDecisionTaskCompletedOutput `json:"-" xml:"-"`
-}
-
-type metadataRespondDecisionTaskCompletedOutput struct {
-	SDKShapeTraits bool `type:"structure"`
+	_ struct{} `type:"structure"`
 }
 
 // String returns the string representation
@@ -5796,11 +5388,7 @@ type ScheduleActivityTaskDecisionAttributes struct {
 	// in the Amazon Simple Workflow Developer Guide.
 	TaskPriority *string `locationName:"taskPriority" type:"string"`
 
-	metadataScheduleActivityTaskDecisionAttributes `json:"-" xml:"-"`
-}
-
-type metadataScheduleActivityTaskDecisionAttributes struct {
-	SDKShapeTraits bool `type:"structure"`
+	_ struct{} `type:"structure"`
 }
 
 // String returns the string representation
@@ -5835,11 +5423,7 @@ type ScheduleActivityTaskFailedEventAttributes struct {
 	// up to this event.
 	DecisionTaskCompletedEventId *int64 `locationName:"decisionTaskCompletedEventId" type:"long" required:"true"`
 
-	metadataScheduleActivityTaskFailedEventAttributes `json:"-" xml:"-"`
-}
-
-type metadataScheduleActivityTaskFailedEventAttributes struct {
-	SDKShapeTraits bool `type:"structure"`
+	_ struct{} `type:"structure"`
 }
 
 // String returns the string representation
@@ -5888,11 +5472,7 @@ type ScheduleLambdaFunctionDecisionAttributes struct {
 	// If set, specifies the maximum duration the function may take to execute.
 	StartToCloseTimeout *string `locationName:"startToCloseTimeout" type:"string"`
 
-	metadataScheduleLambdaFunctionDecisionAttributes `json:"-" xml:"-"`
-}
-
-type metadataScheduleLambdaFunctionDecisionAttributes struct {
-	SDKShapeTraits bool `type:"structure"`
+	_ struct{} `type:"structure"`
 }
 
 // String returns the string representation
@@ -5927,11 +5507,7 @@ type ScheduleLambdaFunctionFailedEventAttributes struct {
 	// The name of the scheduled AWS Lambda function.
 	Name *string `locationName:"name" min:"1" type:"string" required:"true"`
 
-	metadataScheduleLambdaFunctionFailedEventAttributes `json:"-" xml:"-"`
-}
-
-type metadataScheduleLambdaFunctionFailedEventAttributes struct {
-	SDKShapeTraits bool `type:"structure"`
+	_ struct{} `type:"structure"`
 }
 
 // String returns the string representation
@@ -5978,11 +5554,7 @@ type SignalExternalWorkflowExecutionDecisionAttributes struct {
 	// Required. The workflowId of the workflow execution to be signaled.
 	WorkflowId *string `locationName:"workflowId" min:"1" type:"string" required:"true"`
 
-	metadataSignalExternalWorkflowExecutionDecisionAttributes `json:"-" xml:"-"`
-}
-
-type metadataSignalExternalWorkflowExecutionDecisionAttributes struct {
-	SDKShapeTraits bool `type:"structure"`
+	_ struct{} `type:"structure"`
 }
 
 // String returns the string representation
@@ -6027,11 +5599,7 @@ type SignalExternalWorkflowExecutionFailedEventAttributes struct {
 	// delivered to.
 	WorkflowId *string `locationName:"workflowId" min:"1" type:"string" required:"true"`
 
-	metadataSignalExternalWorkflowExecutionFailedEventAttributes `json:"-" xml:"-"`
-}
-
-type metadataSignalExternalWorkflowExecutionFailedEventAttributes struct {
-	SDKShapeTraits bool `type:"structure"`
+	_ struct{} `type:"structure"`
 }
 
 // String returns the string representation
@@ -6068,11 +5636,7 @@ type SignalExternalWorkflowExecutionInitiatedEventAttributes struct {
 	// The workflowId of the external workflow execution.
 	WorkflowId *string `locationName:"workflowId" min:"1" type:"string" required:"true"`
 
-	metadataSignalExternalWorkflowExecutionInitiatedEventAttributes `json:"-" xml:"-"`
-}
-
-type metadataSignalExternalWorkflowExecutionInitiatedEventAttributes struct {
-	SDKShapeTraits bool `type:"structure"`
+	_ struct{} `type:"structure"`
 }
 
 // String returns the string representation
@@ -6102,11 +5666,7 @@ type SignalWorkflowExecutionInput struct {
 	// The workflowId of the workflow execution to signal.
 	WorkflowId *string `locationName:"workflowId" min:"1" type:"string" required:"true"`
 
-	metadataSignalWorkflowExecutionInput `json:"-" xml:"-"`
-}
-
-type metadataSignalWorkflowExecutionInput struct {
-	SDKShapeTraits bool `type:"structure"`
+	_ struct{} `type:"structure"`
 }
 
 // String returns the string representation
@@ -6120,11 +5680,7 @@ func (s SignalWorkflowExecutionInput) GoString() string {
 }
 
 type SignalWorkflowExecutionOutput struct {
-	metadataSignalWorkflowExecutionOutput `json:"-" xml:"-"`
-}
-
-type metadataSignalWorkflowExecutionOutput struct {
-	SDKShapeTraits bool `type:"structure"`
+	_ struct{} `type:"structure"`
 }
 
 // String returns the string representation
@@ -6254,11 +5810,7 @@ type StartChildWorkflowExecutionDecisionAttributes struct {
 	// Required. The type of the workflow execution to be started.
 	WorkflowType *WorkflowType `locationName:"workflowType" type:"structure" required:"true"`
 
-	metadataStartChildWorkflowExecutionDecisionAttributes `json:"-" xml:"-"`
-}
-
-type metadataStartChildWorkflowExecutionDecisionAttributes struct {
-	SDKShapeTraits bool `type:"structure"`
+	_ struct{} `type:"structure"`
 }
 
 // String returns the string representation
@@ -6302,11 +5854,7 @@ type StartChildWorkflowExecutionFailedEventAttributes struct {
 	// failed.
 	WorkflowType *WorkflowType `locationName:"workflowType" type:"structure" required:"true"`
 
-	metadataStartChildWorkflowExecutionFailedEventAttributes `json:"-" xml:"-"`
-}
-
-type metadataStartChildWorkflowExecutionFailedEventAttributes struct {
-	SDKShapeTraits bool `type:"structure"`
+	_ struct{} `type:"structure"`
 }
 
 // String returns the string representation
@@ -6387,11 +5935,7 @@ type StartChildWorkflowExecutionInitiatedEventAttributes struct {
 	// The type of the child workflow execution.
 	WorkflowType *WorkflowType `locationName:"workflowType" type:"structure" required:"true"`
 
-	metadataStartChildWorkflowExecutionInitiatedEventAttributes `json:"-" xml:"-"`
-}
-
-type metadataStartChildWorkflowExecutionInitiatedEventAttributes struct {
-	SDKShapeTraits bool `type:"structure"`
+	_ struct{} `type:"structure"`
 }
 
 // String returns the string representation
@@ -6422,11 +5966,7 @@ type StartLambdaFunctionFailedEventAttributes struct {
 	// problems by tracing back the chain of events leading up to this event.
 	ScheduledEventId *int64 `locationName:"scheduledEventId" type:"long"`
 
-	metadataStartLambdaFunctionFailedEventAttributes `json:"-" xml:"-"`
-}
-
-type metadataStartLambdaFunctionFailedEventAttributes struct {
-	SDKShapeTraits bool `type:"structure"`
+	_ struct{} `type:"structure"`
 }
 
 // String returns the string representation
@@ -6473,11 +6013,7 @@ type StartTimerDecisionAttributes struct {
 	// string quotarnquot.
 	TimerId *string `locationName:"timerId" min:"1" type:"string" required:"true"`
 
-	metadataStartTimerDecisionAttributes `json:"-" xml:"-"`
-}
-
-type metadataStartTimerDecisionAttributes struct {
-	SDKShapeTraits bool `type:"structure"`
+	_ struct{} `type:"structure"`
 }
 
 // String returns the string representation
@@ -6509,11 +6045,7 @@ type StartTimerFailedEventAttributes struct {
 	// The timerId provided in the StartTimer decision that failed.
 	TimerId *string `locationName:"timerId" min:"1" type:"string" required:"true"`
 
-	metadataStartTimerFailedEventAttributes `json:"-" xml:"-"`
-}
-
-type metadataStartTimerFailedEventAttributes struct {
-	SDKShapeTraits bool `type:"structure"`
+	_ struct{} `type:"structure"`
 }
 
 // String returns the string representation
@@ -6634,11 +6166,7 @@ type StartWorkflowExecutionInput struct {
 	// The type of the workflow to start.
 	WorkflowType *WorkflowType `locationName:"workflowType" type:"structure" required:"true"`
 
-	metadataStartWorkflowExecutionInput `json:"-" xml:"-"`
-}
-
-type metadataStartWorkflowExecutionInput struct {
-	SDKShapeTraits bool `type:"structure"`
+	_ struct{} `type:"structure"`
 }
 
 // String returns the string representation
@@ -6657,11 +6185,7 @@ type StartWorkflowExecutionOutput struct {
 	// can be used to uniquely identify the workflow execution within a domain.
 	RunId *string `locationName:"runId" min:"1" type:"string"`
 
-	metadataStartWorkflowExecutionOutput `json:"-" xml:"-"`
-}
-
-type metadataStartWorkflowExecutionOutput struct {
-	SDKShapeTraits bool `type:"structure"`
+	_ struct{} `type:"structure"`
 }
 
 // String returns the string representation
@@ -6680,11 +6204,7 @@ type TagFilter struct {
 	// it to meet the filter criteria.
 	Tag *string `locationName:"tag" min:"1" type:"string" required:"true"`
 
-	metadataTagFilter `json:"-" xml:"-"`
-}
-
-type metadataTagFilter struct {
-	SDKShapeTraits bool `type:"structure"`
+	_ struct{} `type:"structure"`
 }
 
 // String returns the string representation
@@ -6702,11 +6222,7 @@ type TaskList struct {
 	// The name of the task list.
 	Name *string `locationName:"name" min:"1" type:"string" required:"true"`
 
-	metadataTaskList `json:"-" xml:"-"`
-}
-
-type metadataTaskList struct {
-	SDKShapeTraits bool `type:"structure"`
+	_ struct{} `type:"structure"`
 }
 
 // String returns the string representation
@@ -6753,11 +6269,7 @@ type TerminateWorkflowExecutionInput struct {
 	// The workflowId of the workflow execution to terminate.
 	WorkflowId *string `locationName:"workflowId" min:"1" type:"string" required:"true"`
 
-	metadataTerminateWorkflowExecutionInput `json:"-" xml:"-"`
-}
-
-type metadataTerminateWorkflowExecutionInput struct {
-	SDKShapeTraits bool `type:"structure"`
+	_ struct{} `type:"structure"`
 }
 
 // String returns the string representation
@@ -6771,11 +6283,7 @@ func (s TerminateWorkflowExecutionInput) GoString() string {
 }
 
 type TerminateWorkflowExecutionOutput struct {
-	metadataTerminateWorkflowExecutionOutput `json:"-" xml:"-"`
-}
-
-type metadataTerminateWorkflowExecutionOutput struct {
-	SDKShapeTraits bool `type:"structure"`
+	_ struct{} `type:"structure"`
 }
 
 // String returns the string representation
@@ -6804,11 +6312,7 @@ type TimerCanceledEventAttributes struct {
 	// The unique ID of the timer that was canceled.
 	TimerId *string `locationName:"timerId" min:"1" type:"string" required:"true"`
 
-	metadataTimerCanceledEventAttributes `json:"-" xml:"-"`
-}
-
-type metadataTimerCanceledEventAttributes struct {
-	SDKShapeTraits bool `type:"structure"`
+	_ struct{} `type:"structure"`
 }
 
 // String returns the string representation
@@ -6831,11 +6335,7 @@ type TimerFiredEventAttributes struct {
 	// The unique ID of the timer that fired.
 	TimerId *string `locationName:"timerId" min:"1" type:"string" required:"true"`
 
-	metadataTimerFiredEventAttributes `json:"-" xml:"-"`
-}
-
-type metadataTimerFiredEventAttributes struct {
-	SDKShapeTraits bool `type:"structure"`
+	_ struct{} `type:"structure"`
 }
 
 // String returns the string representation
@@ -6869,11 +6369,7 @@ type TimerStartedEventAttributes struct {
 	// The unique ID of the timer that was started.
 	TimerId *string `locationName:"timerId" min:"1" type:"string" required:"true"`
 
-	metadataTimerStartedEventAttributes `json:"-" xml:"-"`
-}
-
-type metadataTimerStartedEventAttributes struct {
-	SDKShapeTraits bool `type:"structure"`
+	_ struct{} `type:"structure"`
 }
 
 // String returns the string representation
@@ -6894,11 +6390,7 @@ type WorkflowExecution struct {
 	// The user defined identifier associated with the workflow execution.
 	WorkflowId *string `locationName:"workflowId" min:"1" type:"string" required:"true"`
 
-	metadataWorkflowExecution `json:"-" xml:"-"`
-}
-
-type metadataWorkflowExecution struct {
-	SDKShapeTraits bool `type:"structure"`
+	_ struct{} `type:"structure"`
 }
 
 // String returns the string representation
@@ -6928,11 +6420,7 @@ type WorkflowExecutionCancelRequestedEventAttributes struct {
 	// The external workflow execution for which the cancellation was requested.
 	ExternalWorkflowExecution *WorkflowExecution `locationName:"externalWorkflowExecution" type:"structure"`
 
-	metadataWorkflowExecutionCancelRequestedEventAttributes `json:"-" xml:"-"`
-}
-
-type metadataWorkflowExecutionCancelRequestedEventAttributes struct {
-	SDKShapeTraits bool `type:"structure"`
+	_ struct{} `type:"structure"`
 }
 
 // String returns the string representation
@@ -6956,11 +6444,7 @@ type WorkflowExecutionCanceledEventAttributes struct {
 	// Details for the cancellation (if any).
 	Details *string `locationName:"details" type:"string"`
 
-	metadataWorkflowExecutionCanceledEventAttributes `json:"-" xml:"-"`
-}
-
-type metadataWorkflowExecutionCanceledEventAttributes struct {
-	SDKShapeTraits bool `type:"structure"`
+	_ struct{} `type:"structure"`
 }
 
 // String returns the string representation
@@ -6984,11 +6468,7 @@ type WorkflowExecutionCompletedEventAttributes struct {
 	// The result produced by the workflow execution upon successful completion.
 	Result *string `locationName:"result" type:"string"`
 
-	metadataWorkflowExecutionCompletedEventAttributes `json:"-" xml:"-"`
-}
-
-type metadataWorkflowExecutionCompletedEventAttributes struct {
-	SDKShapeTraits bool `type:"structure"`
+	_ struct{} `type:"structure"`
 }
 
 // String returns the string representation
@@ -7046,11 +6526,7 @@ type WorkflowExecutionConfiguration struct {
 	// 0. The value "NONE" can be used to specify unlimited duration.
 	TaskStartToCloseTimeout *string `locationName:"taskStartToCloseTimeout" min:"1" type:"string" required:"true"`
 
-	metadataWorkflowExecutionConfiguration `json:"-" xml:"-"`
-}
-
-type metadataWorkflowExecutionConfiguration struct {
-	SDKShapeTraits bool `type:"structure"`
+	_ struct{} `type:"structure"`
 }
 
 // String returns the string representation
@@ -7117,11 +6593,7 @@ type WorkflowExecutionContinuedAsNewEventAttributes struct {
 	// Represents a workflow type.
 	WorkflowType *WorkflowType `locationName:"workflowType" type:"structure" required:"true"`
 
-	metadataWorkflowExecutionContinuedAsNewEventAttributes `json:"-" xml:"-"`
-}
-
-type metadataWorkflowExecutionContinuedAsNewEventAttributes struct {
-	SDKShapeTraits bool `type:"structure"`
+	_ struct{} `type:"structure"`
 }
 
 // String returns the string representation
@@ -7144,11 +6616,7 @@ type WorkflowExecutionCount struct {
 	// supported by this API and the count returned is the truncated value.
 	Truncated *bool `locationName:"truncated" type:"boolean"`
 
-	metadataWorkflowExecutionCount `json:"-" xml:"-"`
-}
-
-type metadataWorkflowExecutionCount struct {
-	SDKShapeTraits bool `type:"structure"`
+	_ struct{} `type:"structure"`
 }
 
 // String returns the string representation
@@ -7175,11 +6643,7 @@ type WorkflowExecutionFailedEventAttributes struct {
 	// The descriptive reason provided for the failure (if any).
 	Reason *string `locationName:"reason" type:"string"`
 
-	metadataWorkflowExecutionFailedEventAttributes `json:"-" xml:"-"`
-}
-
-type metadataWorkflowExecutionFailedEventAttributes struct {
-	SDKShapeTraits bool `type:"structure"`
+	_ struct{} `type:"structure"`
 }
 
 // String returns the string representation
@@ -7197,11 +6661,7 @@ type WorkflowExecutionFilter struct {
 	// The workflowId to pass of match the criteria of this filter.
 	WorkflowId *string `locationName:"workflowId" min:"1" type:"string" required:"true"`
 
-	metadataWorkflowExecutionFilter `json:"-" xml:"-"`
-}
-
-type metadataWorkflowExecutionFilter struct {
-	SDKShapeTraits bool `type:"structure"`
+	_ struct{} `type:"structure"`
 }
 
 // String returns the string representation
@@ -7256,11 +6716,7 @@ type WorkflowExecutionInfo struct {
 	// The type of the workflow execution.
 	WorkflowType *WorkflowType `locationName:"workflowType" type:"structure" required:"true"`
 
-	metadataWorkflowExecutionInfo `json:"-" xml:"-"`
-}
-
-type metadataWorkflowExecutionInfo struct {
-	SDKShapeTraits bool `type:"structure"`
+	_ struct{} `type:"structure"`
 }
 
 // String returns the string representation
@@ -7286,11 +6742,7 @@ type WorkflowExecutionInfos struct {
 	// in a single call.
 	NextPageToken *string `locationName:"nextPageToken" type:"string"`
 
-	metadataWorkflowExecutionInfos `json:"-" xml:"-"`
-}
-
-type metadataWorkflowExecutionInfos struct {
-	SDKShapeTraits bool `type:"structure"`
+	_ struct{} `type:"structure"`
 }
 
 // String returns the string representation
@@ -7323,11 +6775,7 @@ type WorkflowExecutionOpenCounts struct {
 	// yet.
 	OpenTimers *int64 `locationName:"openTimers" type:"integer" required:"true"`
 
-	metadataWorkflowExecutionOpenCounts `json:"-" xml:"-"`
-}
-
-type metadataWorkflowExecutionOpenCounts struct {
-	SDKShapeTraits bool `type:"structure"`
+	_ struct{} `type:"structure"`
 }
 
 // String returns the string representation
@@ -7362,11 +6810,7 @@ type WorkflowExecutionSignaledEventAttributes struct {
 	// inputs to determine how to the process the signal.
 	SignalName *string `locationName:"signalName" min:"1" type:"string" required:"true"`
 
-	metadataWorkflowExecutionSignaledEventAttributes `json:"-" xml:"-"`
-}
-
-type metadataWorkflowExecutionSignaledEventAttributes struct {
-	SDKShapeTraits bool `type:"structure"`
+	_ struct{} `type:"structure"`
 }
 
 // String returns the string representation
@@ -7442,11 +6886,7 @@ type WorkflowExecutionStartedEventAttributes struct {
 	// The workflow type of this execution.
 	WorkflowType *WorkflowType `locationName:"workflowType" type:"structure" required:"true"`
 
-	metadataWorkflowExecutionStartedEventAttributes `json:"-" xml:"-"`
-}
-
-type metadataWorkflowExecutionStartedEventAttributes struct {
-	SDKShapeTraits bool `type:"structure"`
+	_ struct{} `type:"structure"`
 }
 
 // String returns the string representation
@@ -7483,11 +6923,7 @@ type WorkflowExecutionTerminatedEventAttributes struct {
 	// The reason provided for the termination (if any).
 	Reason *string `locationName:"reason" type:"string"`
 
-	metadataWorkflowExecutionTerminatedEventAttributes `json:"-" xml:"-"`
-}
-
-type metadataWorkflowExecutionTerminatedEventAttributes struct {
-	SDKShapeTraits bool `type:"structure"`
+	_ struct{} `type:"structure"`
 }
 
 // String returns the string representation
@@ -7516,11 +6952,7 @@ type WorkflowExecutionTimedOutEventAttributes struct {
 	// The type of timeout that caused this event.
 	TimeoutType *string `locationName:"timeoutType" type:"string" required:"true" enum:"WorkflowExecutionTimeoutType"`
 
-	metadataWorkflowExecutionTimedOutEventAttributes `json:"-" xml:"-"`
-}
-
-type metadataWorkflowExecutionTimedOutEventAttributes struct {
-	SDKShapeTraits bool `type:"structure"`
+	_ struct{} `type:"structure"`
 }
 
 // String returns the string representation
@@ -7547,11 +6979,7 @@ type WorkflowType struct {
 	// a domain.
 	Version *string `locationName:"version" min:"1" type:"string" required:"true"`
 
-	metadataWorkflowType `json:"-" xml:"-"`
-}
-
-type metadataWorkflowType struct {
-	SDKShapeTraits bool `type:"structure"`
+	_ struct{} `type:"structure"`
 }
 
 // String returns the string representation
@@ -7625,11 +7053,7 @@ type WorkflowTypeConfiguration struct {
 	// 0. The value "NONE" can be used to specify unlimited duration.
 	DefaultTaskStartToCloseTimeout *string `locationName:"defaultTaskStartToCloseTimeout" type:"string"`
 
-	metadataWorkflowTypeConfiguration `json:"-" xml:"-"`
-}
-
-type metadataWorkflowTypeConfiguration struct {
-	SDKShapeTraits bool `type:"structure"`
+	_ struct{} `type:"structure"`
 }
 
 // String returns the string representation
@@ -7651,11 +7075,7 @@ type WorkflowTypeFilter struct {
 	// Version of the workflow type.
 	Version *string `locationName:"version" type:"string"`
 
-	metadataWorkflowTypeFilter `json:"-" xml:"-"`
-}
-
-type metadataWorkflowTypeFilter struct {
-	SDKShapeTraits bool `type:"structure"`
+	_ struct{} `type:"structure"`
 }
 
 // String returns the string representation
@@ -7686,11 +7106,7 @@ type WorkflowTypeInfo struct {
 	// The workflow type this information is about.
 	WorkflowType *WorkflowType `locationName:"workflowType" type:"structure" required:"true"`
 
-	metadataWorkflowTypeInfo `json:"-" xml:"-"`
-}
-
-type metadataWorkflowTypeInfo struct {
-	SDKShapeTraits bool `type:"structure"`
+	_ struct{} `type:"structure"`
 }
 
 // String returns the string representation

--- a/service/swf/api.go
+++ b/service/swf/api.go
@@ -1584,6 +1584,8 @@ func (c *SWF) TerminateWorkflowExecution(input *TerminateWorkflowExecutionInput)
 
 // Provides details of the ActivityTaskCancelRequested event.
 type ActivityTaskCancelRequestedEventAttributes struct {
+	_ struct{} `type:"structure"`
+
 	// The unique ID of the task.
 	ActivityId *string `locationName:"activityId" min:"1" type:"string" required:"true"`
 
@@ -1592,8 +1594,6 @@ type ActivityTaskCancelRequestedEventAttributes struct {
 	// request. This information can be useful for diagnosing problems by tracing
 	// back the chain of events leading up to this event.
 	DecisionTaskCompletedEventId *int64 `locationName:"decisionTaskCompletedEventId" type:"long" required:"true"`
-
-	_ struct{} `type:"structure"`
 }
 
 // String returns the string representation
@@ -1608,6 +1608,8 @@ func (s ActivityTaskCancelRequestedEventAttributes) GoString() string {
 
 // Provides details of the ActivityTaskCanceled event.
 type ActivityTaskCanceledEventAttributes struct {
+	_ struct{} `type:"structure"`
+
 	// Details of the cancellation (if any).
 	Details *string `locationName:"details" type:"string"`
 
@@ -1625,8 +1627,6 @@ type ActivityTaskCanceledEventAttributes struct {
 	// was started. This information can be useful for diagnosing problems by tracing
 	// back the chain of events leading up to this event.
 	StartedEventId *int64 `locationName:"startedEventId" type:"long" required:"true"`
-
-	_ struct{} `type:"structure"`
 }
 
 // String returns the string representation
@@ -1641,6 +1641,8 @@ func (s ActivityTaskCanceledEventAttributes) GoString() string {
 
 // Provides details of the ActivityTaskCompleted event.
 type ActivityTaskCompletedEventAttributes struct {
+	_ struct{} `type:"structure"`
+
 	// The results of the activity task (if any).
 	Result *string `locationName:"result" type:"string"`
 
@@ -1653,8 +1655,6 @@ type ActivityTaskCompletedEventAttributes struct {
 	// was started. This information can be useful for diagnosing problems by tracing
 	// back the chain of events leading up to this event.
 	StartedEventId *int64 `locationName:"startedEventId" type:"long" required:"true"`
-
-	_ struct{} `type:"structure"`
 }
 
 // String returns the string representation
@@ -1669,6 +1669,8 @@ func (s ActivityTaskCompletedEventAttributes) GoString() string {
 
 // Provides details of the ActivityTaskFailed event.
 type ActivityTaskFailedEventAttributes struct {
+	_ struct{} `type:"structure"`
+
 	// The details of the failure (if any).
 	Details *string `locationName:"details" type:"string"`
 
@@ -1684,8 +1686,6 @@ type ActivityTaskFailedEventAttributes struct {
 	// was started. This information can be useful for diagnosing problems by tracing
 	// back the chain of events leading up to this event.
 	StartedEventId *int64 `locationName:"startedEventId" type:"long" required:"true"`
-
-	_ struct{} `type:"structure"`
 }
 
 // String returns the string representation
@@ -1700,6 +1700,8 @@ func (s ActivityTaskFailedEventAttributes) GoString() string {
 
 // Provides details of the ActivityTaskScheduled event.
 type ActivityTaskScheduledEventAttributes struct {
+	_ struct{} `type:"structure"`
+
 	// The unique ID of the activity task.
 	ActivityId *string `locationName:"activityId" min:"1" type:"string" required:"true"`
 
@@ -1749,8 +1751,6 @@ type ActivityTaskScheduledEventAttributes struct {
 	// (http://docs.aws.amazon.com/amazonswf/latest/developerguide/programming-priority.html)
 	// in the Amazon Simple Workflow Developer Guide.
 	TaskPriority *string `locationName:"taskPriority" type:"string"`
-
-	_ struct{} `type:"structure"`
 }
 
 // String returns the string representation
@@ -1765,6 +1765,8 @@ func (s ActivityTaskScheduledEventAttributes) GoString() string {
 
 // Provides details of the ActivityTaskStarted event.
 type ActivityTaskStartedEventAttributes struct {
+	_ struct{} `type:"structure"`
+
 	// Identity of the worker that was assigned this task. This aids diagnostics
 	// when problems arise. The form of this identity is user defined.
 	Identity *string `locationName:"identity" type:"string"`
@@ -1773,8 +1775,6 @@ type ActivityTaskStartedEventAttributes struct {
 	// task was scheduled. This information can be useful for diagnosing problems
 	// by tracing back the chain of events leading up to this event.
 	ScheduledEventId *int64 `locationName:"scheduledEventId" type:"long" required:"true"`
-
-	_ struct{} `type:"structure"`
 }
 
 // String returns the string representation
@@ -1789,6 +1789,8 @@ func (s ActivityTaskStartedEventAttributes) GoString() string {
 
 // Provides details of the ActivityTaskTimedOut event.
 type ActivityTaskTimedOutEventAttributes struct {
+	_ struct{} `type:"structure"`
+
 	// Contains the content of the details parameter for the last call made by the
 	// activity to RecordActivityTaskHeartbeat.
 	Details *string `locationName:"details" type:"string"`
@@ -1805,8 +1807,6 @@ type ActivityTaskTimedOutEventAttributes struct {
 
 	// The type of the timeout that caused this event.
 	TimeoutType *string `locationName:"timeoutType" type:"string" required:"true" enum:"ActivityTaskTimeoutType"`
-
-	_ struct{} `type:"structure"`
 }
 
 // String returns the string representation
@@ -1821,6 +1821,8 @@ func (s ActivityTaskTimedOutEventAttributes) GoString() string {
 
 // Represents an activity type.
 type ActivityType struct {
+	_ struct{} `type:"structure"`
+
 	// The name of this activity.
 	//
 	// The combination of activity type name and version must be unique within
@@ -1832,8 +1834,6 @@ type ActivityType struct {
 	// The combination of activity type name and version must be unique with in
 	// a domain.
 	Version *string `locationName:"version" min:"1" type:"string" required:"true"`
-
-	_ struct{} `type:"structure"`
 }
 
 // String returns the string representation
@@ -1848,6 +1848,8 @@ func (s ActivityType) GoString() string {
 
 // Configuration settings registered with the activity type.
 type ActivityTypeConfiguration struct {
+	_ struct{} `type:"structure"`
+
 	// Optional. The default maximum time, in seconds, before which a worker processing
 	// a task must report progress by calling RecordActivityTaskHeartbeat.
 	//
@@ -1904,8 +1906,6 @@ type ActivityTypeConfiguration struct {
 	// The duration is specified in seconds; an integer greater than or equal to
 	// 0. The value "NONE" can be used to specify unlimited duration.
 	DefaultTaskStartToCloseTimeout *string `locationName:"defaultTaskStartToCloseTimeout" type:"string"`
-
-	_ struct{} `type:"structure"`
 }
 
 // String returns the string representation
@@ -1920,6 +1920,8 @@ func (s ActivityTypeConfiguration) GoString() string {
 
 // Detailed information about an activity type.
 type ActivityTypeInfo struct {
+	_ struct{} `type:"structure"`
+
 	// The ActivityType type structure representing the activity type.
 	ActivityType *ActivityType `locationName:"activityType" type:"structure" required:"true"`
 
@@ -1934,8 +1936,6 @@ type ActivityTypeInfo struct {
 
 	// The current status of the activity type.
 	Status *string `locationName:"status" type:"string" required:"true" enum:"RegistrationStatus"`
-
-	_ struct{} `type:"structure"`
 }
 
 // String returns the string representation
@@ -1964,10 +1964,10 @@ func (s ActivityTypeInfo) GoString() string {
 // For details and example IAM policies, see Using IAM to Manage Access to Amazon
 // SWF Workflows (http://docs.aws.amazon.com/amazonswf/latest/developerguide/swf-dev-iam.html).
 type CancelTimerDecisionAttributes struct {
+	_ struct{} `type:"structure"`
+
 	// Required. The unique ID of the timer to cancel.
 	TimerId *string `locationName:"timerId" min:"1" type:"string" required:"true"`
-
-	_ struct{} `type:"structure"`
 }
 
 // String returns the string representation
@@ -1982,6 +1982,8 @@ func (s CancelTimerDecisionAttributes) GoString() string {
 
 // Provides details of the CancelTimerFailed event.
 type CancelTimerFailedEventAttributes struct {
+	_ struct{} `type:"structure"`
+
 	// The cause of the failure. This information is generated by the system and
 	// can be useful for diagnostic purposes.
 	//
@@ -1998,8 +2000,6 @@ type CancelTimerFailedEventAttributes struct {
 
 	// The timerId provided in the CancelTimer decision that failed.
 	TimerId *string `locationName:"timerId" min:"1" type:"string" required:"true"`
-
-	_ struct{} `type:"structure"`
 }
 
 // String returns the string representation
@@ -2028,10 +2028,10 @@ func (s CancelTimerFailedEventAttributes) GoString() string {
 // For details and example IAM policies, see Using IAM to Manage Access to Amazon
 // SWF Workflows (http://docs.aws.amazon.com/amazonswf/latest/developerguide/swf-dev-iam.html).
 type CancelWorkflowExecutionDecisionAttributes struct {
+	_ struct{} `type:"structure"`
+
 	// Optional. details of the cancellation.
 	Details *string `locationName:"details" type:"string"`
-
-	_ struct{} `type:"structure"`
 }
 
 // String returns the string representation
@@ -2046,6 +2046,8 @@ func (s CancelWorkflowExecutionDecisionAttributes) GoString() string {
 
 // Provides details of the CancelWorkflowExecutionFailed event.
 type CancelWorkflowExecutionFailedEventAttributes struct {
+	_ struct{} `type:"structure"`
+
 	// The cause of the failure. This information is generated by the system and
 	// can be useful for diagnostic purposes.
 	//
@@ -2059,8 +2061,6 @@ type CancelWorkflowExecutionFailedEventAttributes struct {
 	// request. This information can be useful for diagnosing problems by tracing
 	// back the chain of events leading up to this event.
 	DecisionTaskCompletedEventId *int64 `locationName:"decisionTaskCompletedEventId" type:"long" required:"true"`
-
-	_ struct{} `type:"structure"`
 }
 
 // String returns the string representation
@@ -2075,6 +2075,8 @@ func (s CancelWorkflowExecutionFailedEventAttributes) GoString() string {
 
 // Provide details of the ChildWorkflowExecutionCanceled event.
 type ChildWorkflowExecutionCanceledEventAttributes struct {
+	_ struct{} `type:"structure"`
+
 	// Details of the cancellation (if provided).
 	Details *string `locationName:"details" type:"string"`
 
@@ -2094,8 +2096,6 @@ type ChildWorkflowExecutionCanceledEventAttributes struct {
 
 	// The type of the child workflow execution.
 	WorkflowType *WorkflowType `locationName:"workflowType" type:"structure" required:"true"`
-
-	_ struct{} `type:"structure"`
 }
 
 // String returns the string representation
@@ -2110,6 +2110,8 @@ func (s ChildWorkflowExecutionCanceledEventAttributes) GoString() string {
 
 // Provides details of the ChildWorkflowExecutionCompleted event.
 type ChildWorkflowExecutionCompletedEventAttributes struct {
+	_ struct{} `type:"structure"`
+
 	// The ID of the StartChildWorkflowExecutionInitiated event corresponding to
 	// the StartChildWorkflowExecution decision to start this child workflow execution.
 	// This information can be useful for diagnosing problems by tracing back the
@@ -2129,8 +2131,6 @@ type ChildWorkflowExecutionCompletedEventAttributes struct {
 
 	// The type of the child workflow execution.
 	WorkflowType *WorkflowType `locationName:"workflowType" type:"structure" required:"true"`
-
-	_ struct{} `type:"structure"`
 }
 
 // String returns the string representation
@@ -2145,6 +2145,8 @@ func (s ChildWorkflowExecutionCompletedEventAttributes) GoString() string {
 
 // Provides details of the ChildWorkflowExecutionFailed event.
 type ChildWorkflowExecutionFailedEventAttributes struct {
+	_ struct{} `type:"structure"`
+
 	// The details of the failure (if provided).
 	Details *string `locationName:"details" type:"string"`
 
@@ -2167,8 +2169,6 @@ type ChildWorkflowExecutionFailedEventAttributes struct {
 
 	// The type of the child workflow execution.
 	WorkflowType *WorkflowType `locationName:"workflowType" type:"structure" required:"true"`
-
-	_ struct{} `type:"structure"`
 }
 
 // String returns the string representation
@@ -2183,6 +2183,8 @@ func (s ChildWorkflowExecutionFailedEventAttributes) GoString() string {
 
 // Provides details of the ChildWorkflowExecutionStarted event.
 type ChildWorkflowExecutionStartedEventAttributes struct {
+	_ struct{} `type:"structure"`
+
 	// The ID of the StartChildWorkflowExecutionInitiated event corresponding to
 	// the StartChildWorkflowExecution decision to start this child workflow execution.
 	// This information can be useful for diagnosing problems by tracing back the
@@ -2194,8 +2196,6 @@ type ChildWorkflowExecutionStartedEventAttributes struct {
 
 	// The type of the child workflow execution.
 	WorkflowType *WorkflowType `locationName:"workflowType" type:"structure" required:"true"`
-
-	_ struct{} `type:"structure"`
 }
 
 // String returns the string representation
@@ -2210,6 +2210,8 @@ func (s ChildWorkflowExecutionStartedEventAttributes) GoString() string {
 
 // Provides details of the ChildWorkflowExecutionTerminated event.
 type ChildWorkflowExecutionTerminatedEventAttributes struct {
+	_ struct{} `type:"structure"`
+
 	// The ID of the StartChildWorkflowExecutionInitiated event corresponding to
 	// the StartChildWorkflowExecution decision to start this child workflow execution.
 	// This information can be useful for diagnosing problems by tracing back the
@@ -2226,8 +2228,6 @@ type ChildWorkflowExecutionTerminatedEventAttributes struct {
 
 	// The type of the child workflow execution.
 	WorkflowType *WorkflowType `locationName:"workflowType" type:"structure" required:"true"`
-
-	_ struct{} `type:"structure"`
 }
 
 // String returns the string representation
@@ -2242,6 +2242,8 @@ func (s ChildWorkflowExecutionTerminatedEventAttributes) GoString() string {
 
 // Provides details of the ChildWorkflowExecutionTimedOut event.
 type ChildWorkflowExecutionTimedOutEventAttributes struct {
+	_ struct{} `type:"structure"`
+
 	// The ID of the StartChildWorkflowExecutionInitiated event corresponding to
 	// the StartChildWorkflowExecution decision to start this child workflow execution.
 	// This information can be useful for diagnosing problems by tracing back the
@@ -2262,8 +2264,6 @@ type ChildWorkflowExecutionTimedOutEventAttributes struct {
 
 	// The type of the child workflow execution.
 	WorkflowType *WorkflowType `locationName:"workflowType" type:"structure" required:"true"`
-
-	_ struct{} `type:"structure"`
 }
 
 // String returns the string representation
@@ -2279,11 +2279,11 @@ func (s ChildWorkflowExecutionTimedOutEventAttributes) GoString() string {
 // Used to filter the closed workflow executions in visibility APIs by their
 // close status.
 type CloseStatusFilter struct {
+	_ struct{} `type:"structure"`
+
 	// Required. The close status that must match the close status of an execution
 	// for it to meet the criteria of this filter.
 	Status *string `locationName:"status" type:"string" required:"true" enum:"CloseStatus"`
-
-	_ struct{} `type:"structure"`
 }
 
 // String returns the string representation
@@ -2312,11 +2312,11 @@ func (s CloseStatusFilter) GoString() string {
 // For details and example IAM policies, see Using IAM to Manage Access to Amazon
 // SWF Workflows (http://docs.aws.amazon.com/amazonswf/latest/developerguide/swf-dev-iam.html).
 type CompleteWorkflowExecutionDecisionAttributes struct {
+	_ struct{} `type:"structure"`
+
 	// The result of the workflow execution. The form of the result is implementation
 	// defined.
 	Result *string `locationName:"result" type:"string"`
-
-	_ struct{} `type:"structure"`
 }
 
 // String returns the string representation
@@ -2331,6 +2331,8 @@ func (s CompleteWorkflowExecutionDecisionAttributes) GoString() string {
 
 // Provides details of the CompleteWorkflowExecutionFailed event.
 type CompleteWorkflowExecutionFailedEventAttributes struct {
+	_ struct{} `type:"structure"`
+
 	// The cause of the failure. This information is generated by the system and
 	// can be useful for diagnostic purposes.
 	//
@@ -2344,8 +2346,6 @@ type CompleteWorkflowExecutionFailedEventAttributes struct {
 	// execution. This information can be useful for diagnosing problems by tracing
 	// back the chain of events leading up to this event.
 	DecisionTaskCompletedEventId *int64 `locationName:"decisionTaskCompletedEventId" type:"long" required:"true"`
-
-	_ struct{} `type:"structure"`
 }
 
 // String returns the string representation
@@ -2377,6 +2377,8 @@ func (s CompleteWorkflowExecutionFailedEventAttributes) GoString() string {
 // For details and example IAM policies, see Using IAM to Manage Access to Amazon
 // SWF Workflows (http://docs.aws.amazon.com/amazonswf/latest/developerguide/swf-dev-iam.html).
 type ContinueAsNewWorkflowExecutionDecisionAttributes struct {
+	_ struct{} `type:"structure"`
+
 	// If set, specifies the policy to use for the child workflow executions of
 	// the new execution if it is terminated by calling the TerminateWorkflowExecution
 	// action explicitly or due to an expired timeout. This policy overrides the
@@ -2452,8 +2454,6 @@ type ContinueAsNewWorkflowExecutionDecisionAttributes struct {
 	TaskStartToCloseTimeout *string `locationName:"taskStartToCloseTimeout" type:"string"`
 
 	WorkflowTypeVersion *string `locationName:"workflowTypeVersion" min:"1" type:"string"`
-
-	_ struct{} `type:"structure"`
 }
 
 // String returns the string representation
@@ -2468,6 +2468,8 @@ func (s ContinueAsNewWorkflowExecutionDecisionAttributes) GoString() string {
 
 // Provides details of the ContinueAsNewWorkflowExecutionFailed event.
 type ContinueAsNewWorkflowExecutionFailedEventAttributes struct {
+	_ struct{} `type:"structure"`
+
 	// The cause of the failure. This information is generated by the system and
 	// can be useful for diagnostic purposes.
 	//
@@ -2481,8 +2483,6 @@ type ContinueAsNewWorkflowExecutionFailedEventAttributes struct {
 	// this execution. This information can be useful for diagnosing problems by
 	// tracing back the chain of events leading up to this event.
 	DecisionTaskCompletedEventId *int64 `locationName:"decisionTaskCompletedEventId" type:"long" required:"true"`
-
-	_ struct{} `type:"structure"`
 }
 
 // String returns the string representation
@@ -2496,6 +2496,8 @@ func (s ContinueAsNewWorkflowExecutionFailedEventAttributes) GoString() string {
 }
 
 type CountClosedWorkflowExecutionsInput struct {
+	_ struct{} `type:"structure"`
+
 	// If specified, only workflow executions that match this close status are counted.
 	// This filter has an affect only if executionStatus is specified as CLOSED.
 	//
@@ -2539,8 +2541,6 @@ type CountClosedWorkflowExecutionsInput struct {
 	// closeStatusFilter, executionFilter, typeFilter and tagFilter are mutually
 	// exclusive. You can specify at most one of these in a request.
 	TypeFilter *WorkflowTypeFilter `locationName:"typeFilter" type:"structure"`
-
-	_ struct{} `type:"structure"`
 }
 
 // String returns the string representation
@@ -2554,6 +2554,8 @@ func (s CountClosedWorkflowExecutionsInput) GoString() string {
 }
 
 type CountOpenWorkflowExecutionsInput struct {
+	_ struct{} `type:"structure"`
+
 	// The name of the domain containing the workflow executions to count.
 	Domain *string `locationName:"domain" min:"1" type:"string" required:"true"`
 
@@ -2580,8 +2582,6 @@ type CountOpenWorkflowExecutionsInput struct {
 	// executionFilter, typeFilter and tagFilter are mutually exclusive. You can
 	// specify at most one of these in a request.
 	TypeFilter *WorkflowTypeFilter `locationName:"typeFilter" type:"structure"`
-
-	_ struct{} `type:"structure"`
 }
 
 // String returns the string representation
@@ -2595,13 +2595,13 @@ func (s CountOpenWorkflowExecutionsInput) GoString() string {
 }
 
 type CountPendingActivityTasksInput struct {
+	_ struct{} `type:"structure"`
+
 	// The name of the domain that contains the task list.
 	Domain *string `locationName:"domain" min:"1" type:"string" required:"true"`
 
 	// The name of the task list.
 	TaskList *TaskList `locationName:"taskList" type:"structure" required:"true"`
-
-	_ struct{} `type:"structure"`
 }
 
 // String returns the string representation
@@ -2615,13 +2615,13 @@ func (s CountPendingActivityTasksInput) GoString() string {
 }
 
 type CountPendingDecisionTasksInput struct {
+	_ struct{} `type:"structure"`
+
 	// The name of the domain that contains the task list.
 	Domain *string `locationName:"domain" min:"1" type:"string" required:"true"`
 
 	// The name of the task list.
 	TaskList *TaskList `locationName:"taskList" type:"structure" required:"true"`
-
-	_ struct{} `type:"structure"`
 }
 
 // String returns the string representation
@@ -2742,6 +2742,8 @@ func (s CountPendingDecisionTasksInput) GoString() string {
 //   StartTimerDecisionAttributes   CancelTimerDecisionAttributes   SignalExternalWorkflowExecutionDecisionAttributes
 //   RequestCancelExternalWorkflowExecutionDecisionAttributes   StartChildWorkflowExecutionDecisionAttributes
 type Decision struct {
+	_ struct{} `type:"structure"`
+
 	// Provides details of the CancelTimer decision. It is not set for other decision
 	// types.
 	CancelTimerDecisionAttributes *CancelTimerDecisionAttributes `locationName:"cancelTimerDecisionAttributes" type:"structure"`
@@ -2812,8 +2814,6 @@ type Decision struct {
 	// Provides details of the StartTimer decision. It is not set for other decision
 	// types.
 	StartTimerDecisionAttributes *StartTimerDecisionAttributes `locationName:"startTimerDecisionAttributes" type:"structure"`
-
-	_ struct{} `type:"structure"`
 }
 
 // String returns the string representation
@@ -2828,6 +2828,8 @@ func (s Decision) GoString() string {
 
 // Provides details of the DecisionTaskCompleted event.
 type DecisionTaskCompletedEventAttributes struct {
+	_ struct{} `type:"structure"`
+
 	// User defined context for the workflow execution.
 	ExecutionContext *string `locationName:"executionContext" type:"string"`
 
@@ -2840,8 +2842,6 @@ type DecisionTaskCompletedEventAttributes struct {
 	// was started. This information can be useful for diagnosing problems by tracing
 	// back the chain of events leading up to this event.
 	StartedEventId *int64 `locationName:"startedEventId" type:"long" required:"true"`
-
-	_ struct{} `type:"structure"`
 }
 
 // String returns the string representation
@@ -2856,6 +2856,8 @@ func (s DecisionTaskCompletedEventAttributes) GoString() string {
 
 // Provides details about the DecisionTaskScheduled event.
 type DecisionTaskScheduledEventAttributes struct {
+	_ struct{} `type:"structure"`
+
 	// The maximum duration for this decision task. The task is considered timed
 	// out if it does not completed within this duration.
 	//
@@ -2875,8 +2877,6 @@ type DecisionTaskScheduledEventAttributes struct {
 	// (http://docs.aws.amazon.com/amazonswf/latest/developerguide/programming-priority.html)
 	// in the Amazon Simple Workflow Developer Guide.
 	TaskPriority *string `locationName:"taskPriority" type:"string"`
-
-	_ struct{} `type:"structure"`
 }
 
 // String returns the string representation
@@ -2891,6 +2891,8 @@ func (s DecisionTaskScheduledEventAttributes) GoString() string {
 
 // Provides details of the DecisionTaskStarted event.
 type DecisionTaskStartedEventAttributes struct {
+	_ struct{} `type:"structure"`
+
 	// Identity of the decider making the request. This enables diagnostic tracing
 	// when problems arise. The form of this identity is user defined.
 	Identity *string `locationName:"identity" type:"string"`
@@ -2899,8 +2901,6 @@ type DecisionTaskStartedEventAttributes struct {
 	// task was scheduled. This information can be useful for diagnosing problems
 	// by tracing back the chain of events leading up to this event.
 	ScheduledEventId *int64 `locationName:"scheduledEventId" type:"long" required:"true"`
-
-	_ struct{} `type:"structure"`
 }
 
 // String returns the string representation
@@ -2915,6 +2915,8 @@ func (s DecisionTaskStartedEventAttributes) GoString() string {
 
 // Provides details of the DecisionTaskTimedOut event.
 type DecisionTaskTimedOutEventAttributes struct {
+	_ struct{} `type:"structure"`
+
 	// The ID of the DecisionTaskScheduled event that was recorded when this decision
 	// task was scheduled. This information can be useful for diagnosing problems
 	// by tracing back the chain of events leading up to this event.
@@ -2927,8 +2929,6 @@ type DecisionTaskTimedOutEventAttributes struct {
 
 	// The type of timeout that expired before the decision task could be completed.
 	TimeoutType *string `locationName:"timeoutType" type:"string" required:"true" enum:"DecisionTaskTimeoutType"`
-
-	_ struct{} `type:"structure"`
 }
 
 // String returns the string representation
@@ -2942,13 +2942,13 @@ func (s DecisionTaskTimedOutEventAttributes) GoString() string {
 }
 
 type DeprecateActivityTypeInput struct {
+	_ struct{} `type:"structure"`
+
 	// The activity type to deprecate.
 	ActivityType *ActivityType `locationName:"activityType" type:"structure" required:"true"`
 
 	// The name of the domain in which the activity type is registered.
 	Domain *string `locationName:"domain" min:"1" type:"string" required:"true"`
-
-	_ struct{} `type:"structure"`
 }
 
 // String returns the string representation
@@ -2976,10 +2976,10 @@ func (s DeprecateActivityTypeOutput) GoString() string {
 }
 
 type DeprecateDomainInput struct {
+	_ struct{} `type:"structure"`
+
 	// The name of the domain to deprecate.
 	Name *string `locationName:"name" min:"1" type:"string" required:"true"`
-
-	_ struct{} `type:"structure"`
 }
 
 // String returns the string representation
@@ -3007,13 +3007,13 @@ func (s DeprecateDomainOutput) GoString() string {
 }
 
 type DeprecateWorkflowTypeInput struct {
+	_ struct{} `type:"structure"`
+
 	// The name of the domain in which the workflow type is registered.
 	Domain *string `locationName:"domain" min:"1" type:"string" required:"true"`
 
 	// The workflow type to deprecate.
 	WorkflowType *WorkflowType `locationName:"workflowType" type:"structure" required:"true"`
-
-	_ struct{} `type:"structure"`
 }
 
 // String returns the string representation
@@ -3041,14 +3041,14 @@ func (s DeprecateWorkflowTypeOutput) GoString() string {
 }
 
 type DescribeActivityTypeInput struct {
+	_ struct{} `type:"structure"`
+
 	// The activity type to get information about. Activity types are identified
 	// by the name and version that were supplied when the activity was registered.
 	ActivityType *ActivityType `locationName:"activityType" type:"structure" required:"true"`
 
 	// The name of the domain in which the activity type is registered.
 	Domain *string `locationName:"domain" min:"1" type:"string" required:"true"`
-
-	_ struct{} `type:"structure"`
 }
 
 // String returns the string representation
@@ -3063,6 +3063,8 @@ func (s DescribeActivityTypeInput) GoString() string {
 
 // Detailed information about an activity type.
 type DescribeActivityTypeOutput struct {
+	_ struct{} `type:"structure"`
+
 	// The configuration settings registered with the activity type.
 	Configuration *ActivityTypeConfiguration `locationName:"configuration" type:"structure" required:"true"`
 
@@ -3076,8 +3078,6 @@ type DescribeActivityTypeOutput struct {
 	// but is still in use. You should keep workers supporting this type running.
 	// You cannot create new tasks of this type.
 	TypeInfo *ActivityTypeInfo `locationName:"typeInfo" type:"structure" required:"true"`
-
-	_ struct{} `type:"structure"`
 }
 
 // String returns the string representation
@@ -3091,10 +3091,10 @@ func (s DescribeActivityTypeOutput) GoString() string {
 }
 
 type DescribeDomainInput struct {
+	_ struct{} `type:"structure"`
+
 	// The name of the domain to describe.
 	Name *string `locationName:"name" min:"1" type:"string" required:"true"`
-
-	_ struct{} `type:"structure"`
 }
 
 // String returns the string representation
@@ -3109,13 +3109,13 @@ func (s DescribeDomainInput) GoString() string {
 
 // Contains details of a domain.
 type DescribeDomainOutput struct {
+	_ struct{} `type:"structure"`
+
 	// Contains the configuration settings of a domain.
 	Configuration *DomainConfiguration `locationName:"configuration" type:"structure" required:"true"`
 
 	// Contains general information about a domain.
 	DomainInfo *DomainInfo `locationName:"domainInfo" type:"structure" required:"true"`
-
-	_ struct{} `type:"structure"`
 }
 
 // String returns the string representation
@@ -3129,13 +3129,13 @@ func (s DescribeDomainOutput) GoString() string {
 }
 
 type DescribeWorkflowExecutionInput struct {
+	_ struct{} `type:"structure"`
+
 	// The name of the domain containing the workflow execution.
 	Domain *string `locationName:"domain" min:"1" type:"string" required:"true"`
 
 	// The workflow execution to describe.
 	Execution *WorkflowExecution `locationName:"execution" type:"structure" required:"true"`
-
-	_ struct{} `type:"structure"`
 }
 
 // String returns the string representation
@@ -3150,6 +3150,8 @@ func (s DescribeWorkflowExecutionInput) GoString() string {
 
 // Contains details about a workflow execution.
 type DescribeWorkflowExecutionOutput struct {
+	_ struct{} `type:"structure"`
+
 	// The configuration settings for this workflow execution including timeout
 	// values, tasklist etc.
 	ExecutionConfiguration *WorkflowExecutionConfiguration `locationName:"executionConfiguration" type:"structure" required:"true"`
@@ -3170,8 +3172,6 @@ type DescribeWorkflowExecutionOutput struct {
 	// The number of tasks for this workflow execution. This includes open and closed
 	// tasks of all types.
 	OpenCounts *WorkflowExecutionOpenCounts `locationName:"openCounts" type:"structure" required:"true"`
-
-	_ struct{} `type:"structure"`
 }
 
 // String returns the string representation
@@ -3185,13 +3185,13 @@ func (s DescribeWorkflowExecutionOutput) GoString() string {
 }
 
 type DescribeWorkflowTypeInput struct {
+	_ struct{} `type:"structure"`
+
 	// The name of the domain in which this workflow type is registered.
 	Domain *string `locationName:"domain" min:"1" type:"string" required:"true"`
 
 	// The workflow type to describe.
 	WorkflowType *WorkflowType `locationName:"workflowType" type:"structure" required:"true"`
-
-	_ struct{} `type:"structure"`
 }
 
 // String returns the string representation
@@ -3206,6 +3206,8 @@ func (s DescribeWorkflowTypeInput) GoString() string {
 
 // Contains details about a workflow type.
 type DescribeWorkflowTypeOutput struct {
+	_ struct{} `type:"structure"`
+
 	// Configuration settings of the workflow type registered through RegisterWorkflowType
 	Configuration *WorkflowTypeConfiguration `locationName:"configuration" type:"structure" required:"true"`
 
@@ -3219,8 +3221,6 @@ type DescribeWorkflowTypeOutput struct {
 	// but is still in use. You should keep workers supporting this type running.
 	// You cannot create new workflow executions of this type.
 	TypeInfo *WorkflowTypeInfo `locationName:"typeInfo" type:"structure" required:"true"`
-
-	_ struct{} `type:"structure"`
 }
 
 // String returns the string representation
@@ -3235,10 +3235,10 @@ func (s DescribeWorkflowTypeOutput) GoString() string {
 
 // Contains the configuration settings of a domain.
 type DomainConfiguration struct {
+	_ struct{} `type:"structure"`
+
 	// The retention period for workflow executions in this domain.
 	WorkflowExecutionRetentionPeriodInDays *string `locationName:"workflowExecutionRetentionPeriodInDays" min:"1" type:"string" required:"true"`
-
-	_ struct{} `type:"structure"`
 }
 
 // String returns the string representation
@@ -3253,6 +3253,8 @@ func (s DomainConfiguration) GoString() string {
 
 // Contains general information about a domain.
 type DomainInfo struct {
+	_ struct{} `type:"structure"`
+
 	// The description of the domain provided through RegisterDomain.
 	Description *string `locationName:"description" type:"string"`
 
@@ -3266,8 +3268,6 @@ type DomainInfo struct {
 	//  DEPRECATED: The domain was deprecated using DeprecateDomain, but is still
 	// in use. You should not create new workflow executions in this domain.
 	Status *string `locationName:"status" type:"string" required:"true" enum:"RegistrationStatus"`
-
-	_ struct{} `type:"structure"`
 }
 
 // String returns the string representation
@@ -3286,13 +3286,13 @@ func (s DomainInfo) GoString() string {
 // format (https://en.wikipedia.org/wiki/Unix_time). For example: "oldestDate":
 // 1325376070.
 type ExecutionTimeFilter struct {
+	_ struct{} `type:"structure"`
+
 	// Specifies the latest start or close date and time to return.
 	LatestDate *time.Time `locationName:"latestDate" type:"timestamp" timestampFormat:"unix"`
 
 	// Specifies the oldest start or close date and time to return.
 	OldestDate *time.Time `locationName:"oldestDate" type:"timestamp" timestampFormat:"unix" required:"true"`
-
-	_ struct{} `type:"structure"`
 }
 
 // String returns the string representation
@@ -3307,6 +3307,8 @@ func (s ExecutionTimeFilter) GoString() string {
 
 // Provides details of the ExternalWorkflowExecutionCancelRequested event.
 type ExternalWorkflowExecutionCancelRequestedEventAttributes struct {
+	_ struct{} `type:"structure"`
+
 	// The ID of the RequestCancelExternalWorkflowExecutionInitiated event corresponding
 	// to the RequestCancelExternalWorkflowExecution decision to cancel this external
 	// workflow execution. This information can be useful for diagnosing problems
@@ -3315,8 +3317,6 @@ type ExternalWorkflowExecutionCancelRequestedEventAttributes struct {
 
 	// The external workflow execution to which the cancellation request was delivered.
 	WorkflowExecution *WorkflowExecution `locationName:"workflowExecution" type:"structure" required:"true"`
-
-	_ struct{} `type:"structure"`
 }
 
 // String returns the string representation
@@ -3331,6 +3331,8 @@ func (s ExternalWorkflowExecutionCancelRequestedEventAttributes) GoString() stri
 
 // Provides details of the ExternalWorkflowExecutionSignaled event.
 type ExternalWorkflowExecutionSignaledEventAttributes struct {
+	_ struct{} `type:"structure"`
+
 	// The ID of the SignalExternalWorkflowExecutionInitiated event corresponding
 	// to the SignalExternalWorkflowExecution decision to request this signal. This
 	// information can be useful for diagnosing problems by tracing back the chain
@@ -3339,8 +3341,6 @@ type ExternalWorkflowExecutionSignaledEventAttributes struct {
 
 	// The external workflow execution that the signal was delivered to.
 	WorkflowExecution *WorkflowExecution `locationName:"workflowExecution" type:"structure" required:"true"`
-
-	_ struct{} `type:"structure"`
 }
 
 // String returns the string representation
@@ -3369,13 +3369,13 @@ func (s ExternalWorkflowExecutionSignaledEventAttributes) GoString() string {
 // For details and example IAM policies, see Using IAM to Manage Access to Amazon
 // SWF Workflows (http://docs.aws.amazon.com/amazonswf/latest/developerguide/swf-dev-iam.html).
 type FailWorkflowExecutionDecisionAttributes struct {
+	_ struct{} `type:"structure"`
+
 	// Optional. Details of the failure.
 	Details *string `locationName:"details" type:"string"`
 
 	// A descriptive reason for the failure that may help in diagnostics.
 	Reason *string `locationName:"reason" type:"string"`
-
-	_ struct{} `type:"structure"`
 }
 
 // String returns the string representation
@@ -3390,6 +3390,8 @@ func (s FailWorkflowExecutionDecisionAttributes) GoString() string {
 
 // Provides details of the FailWorkflowExecutionFailed event.
 type FailWorkflowExecutionFailedEventAttributes struct {
+	_ struct{} `type:"structure"`
+
 	// The cause of the failure. This information is generated by the system and
 	// can be useful for diagnostic purposes.
 	//
@@ -3403,8 +3405,6 @@ type FailWorkflowExecutionFailedEventAttributes struct {
 	// This information can be useful for diagnosing problems by tracing back the
 	// chain of events leading up to this event.
 	DecisionTaskCompletedEventId *int64 `locationName:"decisionTaskCompletedEventId" type:"long" required:"true"`
-
-	_ struct{} `type:"structure"`
 }
 
 // String returns the string representation
@@ -3418,6 +3418,8 @@ func (s FailWorkflowExecutionFailedEventAttributes) GoString() string {
 }
 
 type GetWorkflowExecutionHistoryInput struct {
+	_ struct{} `type:"structure"`
+
 	// The name of the domain containing the workflow execution.
 	Domain *string `locationName:"domain" min:"1" type:"string" required:"true"`
 
@@ -3444,8 +3446,6 @@ type GetWorkflowExecutionHistoryInput struct {
 	// When set to true, returns the events in reverse order. By default the results
 	// are returned in ascending order of the eventTimeStamp of the events.
 	ReverseOrder *bool `locationName:"reverseOrder" type:"boolean"`
-
-	_ struct{} `type:"structure"`
 }
 
 // String returns the string representation
@@ -3462,6 +3462,8 @@ func (s GetWorkflowExecutionHistoryInput) GoString() string {
 // This is the up to date, complete and authoritative record of the events related
 // to all tasks and events in the life of the workflow execution.
 type GetWorkflowExecutionHistoryOutput struct {
+	_ struct{} `type:"structure"`
+
 	// The list of history events.
 	Events []*HistoryEvent `locationName:"events" type:"list" required:"true"`
 
@@ -3472,8 +3474,6 @@ type GetWorkflowExecutionHistoryOutput struct {
 	// The configured maximumPageSize determines how many results can be returned
 	// in a single call.
 	NextPageToken *string `locationName:"nextPageToken" type:"string"`
-
-	_ struct{} `type:"structure"`
 }
 
 // String returns the string representation
@@ -3556,6 +3556,8 @@ func (s GetWorkflowExecutionHistoryOutput) GoString() string {
 // AWS Lambda service. This happens when the AWS Lambda service is not available
 // in the current region, or received too many requests.
 type HistoryEvent struct {
+	_ struct{} `type:"structure"`
+
 	// If the event is of type ActivityTaskcancelRequested then this member is set
 	// and provides detailed information about the event. It is not set for other
 	// event types.
@@ -3811,8 +3813,6 @@ type HistoryEvent struct {
 	// and provides detailed information about the event. It is not set for other
 	// event types.
 	WorkflowExecutionTimedOutEventAttributes *WorkflowExecutionTimedOutEventAttributes `locationName:"workflowExecutionTimedOutEventAttributes" type:"structure"`
-
-	_ struct{} `type:"structure"`
 }
 
 // String returns the string representation
@@ -3827,6 +3827,8 @@ func (s HistoryEvent) GoString() string {
 
 // Provides details for the LambdaFunctionCompleted event.
 type LambdaFunctionCompletedEventAttributes struct {
+	_ struct{} `type:"structure"`
+
 	// The result of the function execution (if any).
 	Result *string `locationName:"result" type:"string"`
 
@@ -3837,8 +3839,6 @@ type LambdaFunctionCompletedEventAttributes struct {
 
 	// The ID of the LambdaFunctionStarted event recorded in the history.
 	StartedEventId *int64 `locationName:"startedEventId" type:"long" required:"true"`
-
-	_ struct{} `type:"structure"`
 }
 
 // String returns the string representation
@@ -3853,6 +3853,8 @@ func (s LambdaFunctionCompletedEventAttributes) GoString() string {
 
 // Provides details for the LambdaFunctionFailed event.
 type LambdaFunctionFailedEventAttributes struct {
+	_ struct{} `type:"structure"`
+
 	// The details of the failure (if any).
 	Details *string `locationName:"details" type:"string"`
 
@@ -3866,8 +3868,6 @@ type LambdaFunctionFailedEventAttributes struct {
 
 	// The ID of the LambdaFunctionStarted event recorded in the history.
 	StartedEventId *int64 `locationName:"startedEventId" type:"long" required:"true"`
-
-	_ struct{} `type:"structure"`
 }
 
 // String returns the string representation
@@ -3882,6 +3882,8 @@ func (s LambdaFunctionFailedEventAttributes) GoString() string {
 
 // Provides details for the LambdaFunctionScheduled event.
 type LambdaFunctionScheduledEventAttributes struct {
+	_ struct{} `type:"structure"`
+
 	// The ID of the DecisionTaskCompleted event for the decision that resulted
 	// in the scheduling of this AWS Lambda function. This information can be useful
 	// for diagnosing problems by tracing back the chain of events leading up to
@@ -3900,8 +3902,6 @@ type LambdaFunctionScheduledEventAttributes struct {
 	// The maximum time, in seconds, that the AWS Lambda function can take to execute
 	// from start to close before it is marked as failed.
 	StartToCloseTimeout *string `locationName:"startToCloseTimeout" type:"string"`
-
-	_ struct{} `type:"structure"`
 }
 
 // String returns the string representation
@@ -3916,12 +3916,12 @@ func (s LambdaFunctionScheduledEventAttributes) GoString() string {
 
 // Provides details for the LambdaFunctionStarted event.
 type LambdaFunctionStartedEventAttributes struct {
+	_ struct{} `type:"structure"`
+
 	// The ID of the LambdaFunctionScheduled event that was recorded when this AWS
 	// Lambda function was scheduled. This information can be useful for diagnosing
 	// problems by tracing back the chain of events leading up to this event.
 	ScheduledEventId *int64 `locationName:"scheduledEventId" type:"long" required:"true"`
-
-	_ struct{} `type:"structure"`
 }
 
 // String returns the string representation
@@ -3936,6 +3936,8 @@ func (s LambdaFunctionStartedEventAttributes) GoString() string {
 
 // Provides details for the LambdaFunctionTimedOut event.
 type LambdaFunctionTimedOutEventAttributes struct {
+	_ struct{} `type:"structure"`
+
 	// The ID of the LambdaFunctionScheduled event that was recorded when this AWS
 	// Lambda function was scheduled. This information can be useful for diagnosing
 	// problems by tracing back the chain of events leading up to this event.
@@ -3946,8 +3948,6 @@ type LambdaFunctionTimedOutEventAttributes struct {
 
 	// The type of the timeout that caused this event.
 	TimeoutType *string `locationName:"timeoutType" type:"string" enum:"LambdaFunctionTimeoutType"`
-
-	_ struct{} `type:"structure"`
 }
 
 // String returns the string representation
@@ -3961,6 +3961,8 @@ func (s LambdaFunctionTimedOutEventAttributes) GoString() string {
 }
 
 type ListActivityTypesInput struct {
+	_ struct{} `type:"structure"`
+
 	// The name of the domain in which the activity types have been registered.
 	Domain *string `locationName:"domain" min:"1" type:"string" required:"true"`
 
@@ -3990,8 +3992,6 @@ type ListActivityTypesInput struct {
 	// When set to true, returns the results in reverse order. By default, the results
 	// are returned in ascending alphabetical order by name of the activity types.
 	ReverseOrder *bool `locationName:"reverseOrder" type:"boolean"`
-
-	_ struct{} `type:"structure"`
 }
 
 // String returns the string representation
@@ -4006,6 +4006,8 @@ func (s ListActivityTypesInput) GoString() string {
 
 // Contains a paginated list of activity type information structures.
 type ListActivityTypesOutput struct {
+	_ struct{} `type:"structure"`
+
 	// If a NextPageToken was returned by a previous call, there are more results
 	// available. To retrieve the next page of results, make the call again using
 	// the returned token in nextPageToken. Keep all other arguments unchanged.
@@ -4016,8 +4018,6 @@ type ListActivityTypesOutput struct {
 
 	// List of activity type information.
 	TypeInfos []*ActivityTypeInfo `locationName:"typeInfos" type:"list" required:"true"`
-
-	_ struct{} `type:"structure"`
 }
 
 // String returns the string representation
@@ -4031,6 +4031,8 @@ func (s ListActivityTypesOutput) GoString() string {
 }
 
 type ListClosedWorkflowExecutionsInput struct {
+	_ struct{} `type:"structure"`
+
 	// If specified, only workflow executions that match this close status are listed.
 	// For example, if TERMINATED is specified, then only TERMINATED workflow executions
 	// are listed.
@@ -4099,8 +4101,6 @@ type ListClosedWorkflowExecutionsInput struct {
 	// closeStatusFilter, executionFilter, typeFilter and tagFilter are mutually
 	// exclusive. You can specify at most one of these in a request.
 	TypeFilter *WorkflowTypeFilter `locationName:"typeFilter" type:"structure"`
-
-	_ struct{} `type:"structure"`
 }
 
 // String returns the string representation
@@ -4114,6 +4114,8 @@ func (s ListClosedWorkflowExecutionsInput) GoString() string {
 }
 
 type ListDomainsInput struct {
+	_ struct{} `type:"structure"`
+
 	// The maximum number of results that will be returned per call. nextPageToken
 	// can be used to obtain futher pages of results. The default is 1000, which
 	// is the maximum allowed page size. You can, however, specify a page size smaller
@@ -4137,8 +4139,6 @@ type ListDomainsInput struct {
 	// When set to true, returns the results in reverse order. By default, the results
 	// are returned in ascending alphabetical order by name of the domains.
 	ReverseOrder *bool `locationName:"reverseOrder" type:"boolean"`
-
-	_ struct{} `type:"structure"`
 }
 
 // String returns the string representation
@@ -4153,6 +4153,8 @@ func (s ListDomainsInput) GoString() string {
 
 // Contains a paginated collection of DomainInfo structures.
 type ListDomainsOutput struct {
+	_ struct{} `type:"structure"`
+
 	// A list of DomainInfo structures.
 	DomainInfos []*DomainInfo `locationName:"domainInfos" type:"list" required:"true"`
 
@@ -4163,8 +4165,6 @@ type ListDomainsOutput struct {
 	// The configured maximumPageSize determines how many results can be returned
 	// in a single call.
 	NextPageToken *string `locationName:"nextPageToken" type:"string"`
-
-	_ struct{} `type:"structure"`
 }
 
 // String returns the string representation
@@ -4178,6 +4178,8 @@ func (s ListDomainsOutput) GoString() string {
 }
 
 type ListOpenWorkflowExecutionsInput struct {
+	_ struct{} `type:"structure"`
+
 	// The name of the domain that contains the workflow executions to list.
 	Domain *string `locationName:"domain" min:"1" type:"string" required:"true"`
 
@@ -4224,8 +4226,6 @@ type ListOpenWorkflowExecutionsInput struct {
 	// executionFilter, typeFilter and tagFilter are mutually exclusive. You can
 	// specify at most one of these in a request.
 	TypeFilter *WorkflowTypeFilter `locationName:"typeFilter" type:"structure"`
-
-	_ struct{} `type:"structure"`
 }
 
 // String returns the string representation
@@ -4239,6 +4239,8 @@ func (s ListOpenWorkflowExecutionsInput) GoString() string {
 }
 
 type ListWorkflowTypesInput struct {
+	_ struct{} `type:"structure"`
+
 	// The name of the domain in which the workflow types have been registered.
 	Domain *string `locationName:"domain" min:"1" type:"string" required:"true"`
 
@@ -4269,8 +4271,6 @@ type ListWorkflowTypesInput struct {
 	// are returned in ascending alphabetical order of the name of the workflow
 	// types.
 	ReverseOrder *bool `locationName:"reverseOrder" type:"boolean"`
-
-	_ struct{} `type:"structure"`
 }
 
 // String returns the string representation
@@ -4285,6 +4285,8 @@ func (s ListWorkflowTypesInput) GoString() string {
 
 // Contains a paginated list of information structures about workflow types.
 type ListWorkflowTypesOutput struct {
+	_ struct{} `type:"structure"`
+
 	// If a NextPageToken was returned by a previous call, there are more results
 	// available. To retrieve the next page of results, make the call again using
 	// the returned token in nextPageToken. Keep all other arguments unchanged.
@@ -4295,8 +4297,6 @@ type ListWorkflowTypesOutput struct {
 
 	// The list of workflow type information.
 	TypeInfos []*WorkflowTypeInfo `locationName:"typeInfos" type:"list" required:"true"`
-
-	_ struct{} `type:"structure"`
 }
 
 // String returns the string representation
@@ -4311,6 +4311,8 @@ func (s ListWorkflowTypesOutput) GoString() string {
 
 // Provides details of the MarkerRecorded event.
 type MarkerRecordedEventAttributes struct {
+	_ struct{} `type:"structure"`
+
 	// The ID of the DecisionTaskCompleted event corresponding to the decision task
 	// that resulted in the RecordMarker decision that requested this marker. This
 	// information can be useful for diagnosing problems by tracing back the chain
@@ -4322,8 +4324,6 @@ type MarkerRecordedEventAttributes struct {
 
 	// The name of the marker.
 	MarkerName *string `locationName:"markerName" min:"1" type:"string" required:"true"`
-
-	_ struct{} `type:"structure"`
 }
 
 // String returns the string representation
@@ -4338,14 +4338,14 @@ func (s MarkerRecordedEventAttributes) GoString() string {
 
 // Contains the count of tasks in a task list.
 type PendingTaskCount struct {
+	_ struct{} `type:"structure"`
+
 	// The number of tasks in the task list.
 	Count *int64 `locationName:"count" type:"integer" required:"true"`
 
 	// If set to true, indicates that the actual count was more than the maximum
 	// supported by this API and the count returned is the truncated value.
 	Truncated *bool `locationName:"truncated" type:"boolean"`
-
-	_ struct{} `type:"structure"`
 }
 
 // String returns the string representation
@@ -4359,6 +4359,8 @@ func (s PendingTaskCount) GoString() string {
 }
 
 type PollForActivityTaskInput struct {
+	_ struct{} `type:"structure"`
+
 	// The name of the domain that contains the task lists being polled.
 	Domain *string `locationName:"domain" min:"1" type:"string" required:"true"`
 
@@ -4374,8 +4376,6 @@ type PollForActivityTaskInput struct {
 	// (\u0000-\u001f | \u007f - \u009f). Also, it must not contain the literal
 	// string quotarnquot.
 	TaskList *TaskList `locationName:"taskList" type:"structure" required:"true"`
-
-	_ struct{} `type:"structure"`
 }
 
 // String returns the string representation
@@ -4390,6 +4390,8 @@ func (s PollForActivityTaskInput) GoString() string {
 
 // Unit of work sent to an activity worker.
 type PollForActivityTaskOutput struct {
+	_ struct{} `type:"structure"`
+
 	// The unique ID of the task.
 	ActivityId *string `locationName:"activityId" min:"1" type:"string" required:"true"`
 
@@ -4410,8 +4412,6 @@ type PollForActivityTaskOutput struct {
 
 	// The workflow execution that started this activity task.
 	WorkflowExecution *WorkflowExecution `locationName:"workflowExecution" type:"structure" required:"true"`
-
-	_ struct{} `type:"structure"`
 }
 
 // String returns the string representation
@@ -4425,6 +4425,8 @@ func (s PollForActivityTaskOutput) GoString() string {
 }
 
 type PollForDecisionTaskInput struct {
+	_ struct{} `type:"structure"`
+
 	// The name of the domain containing the task lists to poll.
 	Domain *string `locationName:"domain" min:"1" type:"string" required:"true"`
 
@@ -4466,8 +4468,6 @@ type PollForDecisionTaskInput struct {
 	// (\u0000-\u001f | \u007f - \u009f). Also, it must not contain the literal
 	// string quotarnquot.
 	TaskList *TaskList `locationName:"taskList" type:"structure" required:"true"`
-
-	_ struct{} `type:"structure"`
 }
 
 // String returns the string representation
@@ -4483,6 +4483,8 @@ func (s PollForDecisionTaskInput) GoString() string {
 // A structure that represents a decision task. Decision tasks are sent to deciders
 // in order for them to make decisions.
 type PollForDecisionTaskOutput struct {
+	_ struct{} `type:"structure"`
+
 	// A paginated list of history events of the workflow execution. The decider
 	// uses this during the processing of the decision task.
 	Events []*HistoryEvent `locationName:"events" type:"list" required:"true"`
@@ -4514,8 +4516,6 @@ type PollForDecisionTaskOutput struct {
 
 	// The type of the workflow execution for which this decision task was created.
 	WorkflowType *WorkflowType `locationName:"workflowType" type:"structure" required:"true"`
-
-	_ struct{} `type:"structure"`
 }
 
 // String returns the string representation
@@ -4529,6 +4529,8 @@ func (s PollForDecisionTaskOutput) GoString() string {
 }
 
 type RecordActivityTaskHeartbeatInput struct {
+	_ struct{} `type:"structure"`
+
 	// If specified, contains details about the progress of the task.
 	Details *string `locationName:"details" type:"string"`
 
@@ -4538,8 +4540,6 @@ type RecordActivityTaskHeartbeatInput struct {
 	// value. If the task is passed to another process, its taskToken must also
 	// be passed. This enables it to provide its progress and respond with results.
 	TaskToken *string `locationName:"taskToken" min:"1" type:"string" required:"true"`
-
-	_ struct{} `type:"structure"`
 }
 
 // String returns the string representation
@@ -4554,10 +4554,10 @@ func (s RecordActivityTaskHeartbeatInput) GoString() string {
 
 // Status information about an activity task.
 type RecordActivityTaskHeartbeatOutput struct {
+	_ struct{} `type:"structure"`
+
 	// Set to true if cancellation of the task is requested.
 	CancelRequested *bool `locationName:"cancelRequested" type:"boolean" required:"true"`
-
-	_ struct{} `type:"structure"`
 }
 
 // String returns the string representation
@@ -4586,13 +4586,13 @@ func (s RecordActivityTaskHeartbeatOutput) GoString() string {
 // For details and example IAM policies, see Using IAM to Manage Access to Amazon
 // SWF Workflows (http://docs.aws.amazon.com/amazonswf/latest/developerguide/swf-dev-iam.html).
 type RecordMarkerDecisionAttributes struct {
+	_ struct{} `type:"structure"`
+
 	// Optional. details of the marker.
 	Details *string `locationName:"details" type:"string"`
 
 	// Required. The name of the marker.
 	MarkerName *string `locationName:"markerName" min:"1" type:"string" required:"true"`
-
-	_ struct{} `type:"structure"`
 }
 
 // String returns the string representation
@@ -4607,6 +4607,8 @@ func (s RecordMarkerDecisionAttributes) GoString() string {
 
 // Provides details of the RecordMarkerFailed event.
 type RecordMarkerFailedEventAttributes struct {
+	_ struct{} `type:"structure"`
+
 	// The cause of the failure. This information is generated by the system and
 	// can be useful for diagnostic purposes.
 	//
@@ -4623,8 +4625,6 @@ type RecordMarkerFailedEventAttributes struct {
 
 	// The marker's name.
 	MarkerName *string `locationName:"markerName" min:"1" type:"string" required:"true"`
-
-	_ struct{} `type:"structure"`
 }
 
 // String returns the string representation
@@ -4638,6 +4638,8 @@ func (s RecordMarkerFailedEventAttributes) GoString() string {
 }
 
 type RegisterActivityTypeInput struct {
+	_ struct{} `type:"structure"`
+
 	// If set, specifies the default maximum time before which a worker processing
 	// a task of this type must report progress by calling RecordActivityTaskHeartbeat.
 	// If the timeout is exceeded, the activity task is automatically timed out.
@@ -4712,8 +4714,6 @@ type RegisterActivityTypeInput struct {
 	// bar), or any control characters (\u0000-\u001f | \u007f - \u009f). Also,
 	// it must not contain the literal string quotarnquot.
 	Version *string `locationName:"version" min:"1" type:"string" required:"true"`
-
-	_ struct{} `type:"structure"`
 }
 
 // String returns the string representation
@@ -4741,6 +4741,8 @@ func (s RegisterActivityTypeOutput) GoString() string {
 }
 
 type RegisterDomainInput struct {
+	_ struct{} `type:"structure"`
+
 	// A text description of the domain.
 	Description *string `locationName:"description" type:"string"`
 
@@ -4765,8 +4767,6 @@ type RegisterDomainInput struct {
 	// about Amazon SWF service limits, see: Amazon SWF Service Limits (http://docs.aws.amazon.com/amazonswf/latest/developerguide/swf-dg-limits.html)
 	// in the Amazon SWF Developer Guide.
 	WorkflowExecutionRetentionPeriodInDays *string `locationName:"workflowExecutionRetentionPeriodInDays" min:"1" type:"string" required:"true"`
-
-	_ struct{} `type:"structure"`
 }
 
 // String returns the string representation
@@ -4794,6 +4794,8 @@ func (s RegisterDomainOutput) GoString() string {
 }
 
 type RegisterWorkflowTypeInput struct {
+	_ struct{} `type:"structure"`
+
 	// If set, specifies the default policy to use for the child workflow executions
 	// when a workflow execution of this type is terminated, by calling the TerminateWorkflowExecution
 	// action explicitly or due to an expired timeout. This default can be overridden
@@ -4876,8 +4878,6 @@ type RegisterWorkflowTypeInput struct {
 	// | (vertical bar), or any control characters (\u0000-\u001f | \u007f - \u009f).
 	// Also, it must not contain the literal string quotarnquot.
 	Version *string `locationName:"version" min:"1" type:"string" required:"true"`
-
-	_ struct{} `type:"structure"`
 }
 
 // String returns the string representation
@@ -4920,10 +4920,10 @@ func (s RegisterWorkflowTypeOutput) GoString() string {
 // For details and example IAM policies, see Using IAM to Manage Access to Amazon
 // SWF Workflows (http://docs.aws.amazon.com/amazonswf/latest/developerguide/swf-dev-iam.html).
 type RequestCancelActivityTaskDecisionAttributes struct {
+	_ struct{} `type:"structure"`
+
 	// The activityId of the activity task to be canceled.
 	ActivityId *string `locationName:"activityId" min:"1" type:"string" required:"true"`
-
-	_ struct{} `type:"structure"`
 }
 
 // String returns the string representation
@@ -4938,6 +4938,8 @@ func (s RequestCancelActivityTaskDecisionAttributes) GoString() string {
 
 // Provides details of the RequestCancelActivityTaskFailed event.
 type RequestCancelActivityTaskFailedEventAttributes struct {
+	_ struct{} `type:"structure"`
+
 	// The activityId provided in the RequestCancelActivityTask decision that failed.
 	ActivityId *string `locationName:"activityId" min:"1" type:"string" required:"true"`
 
@@ -4954,8 +4956,6 @@ type RequestCancelActivityTaskFailedEventAttributes struct {
 	// request. This information can be useful for diagnosing problems by tracing
 	// back the chain of events leading up to this event.
 	DecisionTaskCompletedEventId *int64 `locationName:"decisionTaskCompletedEventId" type:"long" required:"true"`
-
-	_ struct{} `type:"structure"`
 }
 
 // String returns the string representation
@@ -4984,6 +4984,8 @@ func (s RequestCancelActivityTaskFailedEventAttributes) GoString() string {
 // For details and example IAM policies, see Using IAM to Manage Access to Amazon
 // SWF Workflows (http://docs.aws.amazon.com/amazonswf/latest/developerguide/swf-dev-iam.html).
 type RequestCancelExternalWorkflowExecutionDecisionAttributes struct {
+	_ struct{} `type:"structure"`
+
 	// Optional. Data attached to the event that can be used by the decider in subsequent
 	// workflow tasks.
 	Control *string `locationName:"control" type:"string"`
@@ -4993,8 +4995,6 @@ type RequestCancelExternalWorkflowExecutionDecisionAttributes struct {
 
 	// Required. The workflowId of the external workflow execution to cancel.
 	WorkflowId *string `locationName:"workflowId" min:"1" type:"string" required:"true"`
-
-	_ struct{} `type:"structure"`
 }
 
 // String returns the string representation
@@ -5009,6 +5009,8 @@ func (s RequestCancelExternalWorkflowExecutionDecisionAttributes) GoString() str
 
 // Provides details of the RequestCancelExternalWorkflowExecutionFailed event.
 type RequestCancelExternalWorkflowExecutionFailedEventAttributes struct {
+	_ struct{} `type:"structure"`
+
 	// The cause of the failure. This information is generated by the system and
 	// can be useful for diagnostic purposes.
 	//
@@ -5037,8 +5039,6 @@ type RequestCancelExternalWorkflowExecutionFailedEventAttributes struct {
 	// The workflowId of the external workflow to which the cancel request was to
 	// be delivered.
 	WorkflowId *string `locationName:"workflowId" min:"1" type:"string" required:"true"`
-
-	_ struct{} `type:"structure"`
 }
 
 // String returns the string representation
@@ -5053,6 +5053,8 @@ func (s RequestCancelExternalWorkflowExecutionFailedEventAttributes) GoString() 
 
 // Provides details of the RequestCancelExternalWorkflowExecutionInitiated event.
 type RequestCancelExternalWorkflowExecutionInitiatedEventAttributes struct {
+	_ struct{} `type:"structure"`
+
 	// Optional. Data attached to the event that can be used by the decider in subsequent
 	// workflow tasks.
 	Control *string `locationName:"control" type:"string"`
@@ -5068,8 +5070,6 @@ type RequestCancelExternalWorkflowExecutionInitiatedEventAttributes struct {
 
 	// The workflowId of the external workflow execution to be canceled.
 	WorkflowId *string `locationName:"workflowId" min:"1" type:"string" required:"true"`
-
-	_ struct{} `type:"structure"`
 }
 
 // String returns the string representation
@@ -5083,6 +5083,8 @@ func (s RequestCancelExternalWorkflowExecutionInitiatedEventAttributes) GoString
 }
 
 type RequestCancelWorkflowExecutionInput struct {
+	_ struct{} `type:"structure"`
+
 	// The name of the domain containing the workflow execution to cancel.
 	Domain *string `locationName:"domain" min:"1" type:"string" required:"true"`
 
@@ -5091,8 +5093,6 @@ type RequestCancelWorkflowExecutionInput struct {
 
 	// The workflowId of the workflow execution to cancel.
 	WorkflowId *string `locationName:"workflowId" min:"1" type:"string" required:"true"`
-
-	_ struct{} `type:"structure"`
 }
 
 // String returns the string representation
@@ -5120,6 +5120,8 @@ func (s RequestCancelWorkflowExecutionOutput) GoString() string {
 }
 
 type RespondActivityTaskCanceledInput struct {
+	_ struct{} `type:"structure"`
+
 	// Optional. Information about the cancellation.
 	Details *string `locationName:"details" type:"string"`
 
@@ -5129,8 +5131,6 @@ type RespondActivityTaskCanceledInput struct {
 	// value. If the task is passed to another process, its taskToken must also
 	// be passed. This enables it to provide its progress and respond with results.
 	TaskToken *string `locationName:"taskToken" min:"1" type:"string" required:"true"`
-
-	_ struct{} `type:"structure"`
 }
 
 // String returns the string representation
@@ -5158,6 +5158,8 @@ func (s RespondActivityTaskCanceledOutput) GoString() string {
 }
 
 type RespondActivityTaskCompletedInput struct {
+	_ struct{} `type:"structure"`
+
 	// The result of the activity task. It is a free form string that is implementation
 	// specific.
 	Result *string `locationName:"result" type:"string"`
@@ -5168,8 +5170,6 @@ type RespondActivityTaskCompletedInput struct {
 	// value. If the task is passed to another process, its taskToken must also
 	// be passed. This enables it to provide its progress and respond with results.
 	TaskToken *string `locationName:"taskToken" min:"1" type:"string" required:"true"`
-
-	_ struct{} `type:"structure"`
 }
 
 // String returns the string representation
@@ -5197,6 +5197,8 @@ func (s RespondActivityTaskCompletedOutput) GoString() string {
 }
 
 type RespondActivityTaskFailedInput struct {
+	_ struct{} `type:"structure"`
+
 	// Optional. Detailed information about the failure.
 	Details *string `locationName:"details" type:"string"`
 
@@ -5209,8 +5211,6 @@ type RespondActivityTaskFailedInput struct {
 	// value. If the task is passed to another process, its taskToken must also
 	// be passed. This enables it to provide its progress and respond with results.
 	TaskToken *string `locationName:"taskToken" min:"1" type:"string" required:"true"`
-
-	_ struct{} `type:"structure"`
 }
 
 // String returns the string representation
@@ -5238,6 +5238,8 @@ func (s RespondActivityTaskFailedOutput) GoString() string {
 }
 
 type RespondDecisionTaskCompletedInput struct {
+	_ struct{} `type:"structure"`
+
 	// The list of decisions (possibly empty) made by the decider while processing
 	// this decision task. See the docs for the decision structure for details.
 	Decisions []*Decision `locationName:"decisions" type:"list"`
@@ -5251,8 +5253,6 @@ type RespondDecisionTaskCompletedInput struct {
 	// value. If the task is passed to another process, its taskToken must also
 	// be passed. This enables it to provide its progress and respond with results.
 	TaskToken *string `locationName:"taskToken" min:"1" type:"string" required:"true"`
-
-	_ struct{} `type:"structure"`
 }
 
 // String returns the string representation
@@ -5298,6 +5298,8 @@ func (s RespondDecisionTaskCompletedOutput) GoString() string {
 // For details and example IAM policies, see Using IAM to Manage Access to Amazon
 // SWF Workflows (http://docs.aws.amazon.com/amazonswf/latest/developerguide/swf-dev-iam.html).
 type ScheduleActivityTaskDecisionAttributes struct {
+	_ struct{} `type:"structure"`
+
 	// Required. The activityId of the activity task.
 	//
 	// The specified string must not start or end with whitespace. It must not
@@ -5387,8 +5389,6 @@ type ScheduleActivityTaskDecisionAttributes struct {
 	// (http://docs.aws.amazon.com/amazonswf/latest/developerguide/programming-priority.html)
 	// in the Amazon Simple Workflow Developer Guide.
 	TaskPriority *string `locationName:"taskPriority" type:"string"`
-
-	_ struct{} `type:"structure"`
 }
 
 // String returns the string representation
@@ -5403,6 +5403,8 @@ func (s ScheduleActivityTaskDecisionAttributes) GoString() string {
 
 // Provides details of the ScheduleActivityTaskFailed event.
 type ScheduleActivityTaskFailedEventAttributes struct {
+	_ struct{} `type:"structure"`
+
 	// The activityId provided in the ScheduleActivityTask decision that failed.
 	ActivityId *string `locationName:"activityId" min:"1" type:"string" required:"true"`
 
@@ -5422,8 +5424,6 @@ type ScheduleActivityTaskFailedEventAttributes struct {
 	// useful for diagnosing problems by tracing back the chain of events leading
 	// up to this event.
 	DecisionTaskCompletedEventId *int64 `locationName:"decisionTaskCompletedEventId" type:"long" required:"true"`
-
-	_ struct{} `type:"structure"`
 }
 
 // String returns the string representation
@@ -5455,6 +5455,8 @@ func (s ScheduleActivityTaskFailedEventAttributes) GoString() string {
 // For details and example IAM policies, see Using IAM to Manage Access to Amazon
 // SWF Workflows (http://docs.aws.amazon.com/amazonswf/latest/developerguide/swf-dev-iam.html).
 type ScheduleLambdaFunctionDecisionAttributes struct {
+	_ struct{} `type:"structure"`
+
 	// Required. The SWF id of the AWS Lambda task.
 	//
 	// The specified string must not start or end with whitespace. It must not
@@ -5471,8 +5473,6 @@ type ScheduleLambdaFunctionDecisionAttributes struct {
 
 	// If set, specifies the maximum duration the function may take to execute.
 	StartToCloseTimeout *string `locationName:"startToCloseTimeout" type:"string"`
-
-	_ struct{} `type:"structure"`
 }
 
 // String returns the string representation
@@ -5487,6 +5487,8 @@ func (s ScheduleLambdaFunctionDecisionAttributes) GoString() string {
 
 // Provides details for the ScheduleLambdaFunctionFailed event.
 type ScheduleLambdaFunctionFailedEventAttributes struct {
+	_ struct{} `type:"structure"`
+
 	// The cause of the failure. This information is generated by the system and
 	// can be useful for diagnostic purposes.
 	//
@@ -5506,8 +5508,6 @@ type ScheduleLambdaFunctionFailedEventAttributes struct {
 
 	// The name of the scheduled AWS Lambda function.
 	Name *string `locationName:"name" min:"1" type:"string" required:"true"`
-
-	_ struct{} `type:"structure"`
 }
 
 // String returns the string representation
@@ -5536,6 +5536,8 @@ func (s ScheduleLambdaFunctionFailedEventAttributes) GoString() string {
 // For details and example IAM policies, see Using IAM to Manage Access to Amazon
 // SWF Workflows (http://docs.aws.amazon.com/amazonswf/latest/developerguide/swf-dev-iam.html).
 type SignalExternalWorkflowExecutionDecisionAttributes struct {
+	_ struct{} `type:"structure"`
+
 	// Optional. Data attached to the event that can be used by the decider in subsequent
 	// decision tasks.
 	Control *string `locationName:"control" type:"string"`
@@ -5553,8 +5555,6 @@ type SignalExternalWorkflowExecutionDecisionAttributes struct {
 
 	// Required. The workflowId of the workflow execution to be signaled.
 	WorkflowId *string `locationName:"workflowId" min:"1" type:"string" required:"true"`
-
-	_ struct{} `type:"structure"`
 }
 
 // String returns the string representation
@@ -5569,6 +5569,8 @@ func (s SignalExternalWorkflowExecutionDecisionAttributes) GoString() string {
 
 // Provides details of the SignalExternalWorkflowExecutionFailed event.
 type SignalExternalWorkflowExecutionFailedEventAttributes struct {
+	_ struct{} `type:"structure"`
+
 	// The cause of the failure. This information is generated by the system and
 	// can be useful for diagnostic purposes.
 	//
@@ -5598,8 +5600,6 @@ type SignalExternalWorkflowExecutionFailedEventAttributes struct {
 	// The workflowId of the external workflow execution that the signal was being
 	// delivered to.
 	WorkflowId *string `locationName:"workflowId" min:"1" type:"string" required:"true"`
-
-	_ struct{} `type:"structure"`
 }
 
 // String returns the string representation
@@ -5614,6 +5614,8 @@ func (s SignalExternalWorkflowExecutionFailedEventAttributes) GoString() string 
 
 // Provides details of the SignalExternalWorkflowExecutionInitiated event.
 type SignalExternalWorkflowExecutionInitiatedEventAttributes struct {
+	_ struct{} `type:"structure"`
+
 	// Optional. data attached to the event that can be used by the decider in subsequent
 	// decision tasks.
 	Control *string `locationName:"control" type:"string"`
@@ -5635,8 +5637,6 @@ type SignalExternalWorkflowExecutionInitiatedEventAttributes struct {
 
 	// The workflowId of the external workflow execution.
 	WorkflowId *string `locationName:"workflowId" min:"1" type:"string" required:"true"`
-
-	_ struct{} `type:"structure"`
 }
 
 // String returns the string representation
@@ -5650,6 +5650,8 @@ func (s SignalExternalWorkflowExecutionInitiatedEventAttributes) GoString() stri
 }
 
 type SignalWorkflowExecutionInput struct {
+	_ struct{} `type:"structure"`
+
 	// The name of the domain containing the workflow execution to signal.
 	Domain *string `locationName:"domain" min:"1" type:"string" required:"true"`
 
@@ -5665,8 +5667,6 @@ type SignalWorkflowExecutionInput struct {
 
 	// The workflowId of the workflow execution to signal.
 	WorkflowId *string `locationName:"workflowId" min:"1" type:"string" required:"true"`
-
-	_ struct{} `type:"structure"`
 }
 
 // String returns the string representation
@@ -5713,6 +5713,8 @@ func (s SignalWorkflowExecutionOutput) GoString() string {
 // will be set to OPERATION_NOT_PERMITTED. For details and example IAM policies,
 // see Using IAM to Manage Access to Amazon SWF Workflows (http://docs.aws.amazon.com/amazonswf/latest/developerguide/swf-dev-iam.html).
 type StartChildWorkflowExecutionDecisionAttributes struct {
+	_ struct{} `type:"structure"`
+
 	// Optional. If set, specifies the policy to use for the child workflow executions
 	// if the workflow execution being started is terminated by calling the TerminateWorkflowExecution
 	// action explicitly or due to an expired timeout. This policy overrides the
@@ -5809,8 +5811,6 @@ type StartChildWorkflowExecutionDecisionAttributes struct {
 
 	// Required. The type of the workflow execution to be started.
 	WorkflowType *WorkflowType `locationName:"workflowType" type:"structure" required:"true"`
-
-	_ struct{} `type:"structure"`
 }
 
 // String returns the string representation
@@ -5825,6 +5825,8 @@ func (s StartChildWorkflowExecutionDecisionAttributes) GoString() string {
 
 // Provides details of the StartChildWorkflowExecutionFailed event.
 type StartChildWorkflowExecutionFailedEventAttributes struct {
+	_ struct{} `type:"structure"`
+
 	// The cause of the failure. This information is generated by the system and
 	// can be useful for diagnostic purposes.
 	//
@@ -5853,8 +5855,6 @@ type StartChildWorkflowExecutionFailedEventAttributes struct {
 	// The workflow type provided in the StartChildWorkflowExecution decision that
 	// failed.
 	WorkflowType *WorkflowType `locationName:"workflowType" type:"structure" required:"true"`
-
-	_ struct{} `type:"structure"`
 }
 
 // String returns the string representation
@@ -5869,6 +5869,8 @@ func (s StartChildWorkflowExecutionFailedEventAttributes) GoString() string {
 
 // Provides details of the StartChildWorkflowExecutionInitiated event.
 type StartChildWorkflowExecutionInitiatedEventAttributes struct {
+	_ struct{} `type:"structure"`
+
 	// The policy to use for the child workflow executions if this execution gets
 	// terminated by explicitly calling the TerminateWorkflowExecution action or
 	// due to an expired timeout.
@@ -5934,8 +5936,6 @@ type StartChildWorkflowExecutionInitiatedEventAttributes struct {
 
 	// The type of the child workflow execution.
 	WorkflowType *WorkflowType `locationName:"workflowType" type:"structure" required:"true"`
-
-	_ struct{} `type:"structure"`
 }
 
 // String returns the string representation
@@ -5950,6 +5950,8 @@ func (s StartChildWorkflowExecutionInitiatedEventAttributes) GoString() string {
 
 // Provides details for the StartLambdaFunctionFailed event.
 type StartLambdaFunctionFailedEventAttributes struct {
+	_ struct{} `type:"structure"`
+
 	// The cause of the failure. This information is generated by the system and
 	// can be useful for diagnostic purposes.
 	//
@@ -5965,8 +5967,6 @@ type StartLambdaFunctionFailedEventAttributes struct {
 	// Lambda function was scheduled. This information can be useful for diagnosing
 	// problems by tracing back the chain of events leading up to this event.
 	ScheduledEventId *int64 `locationName:"scheduledEventId" type:"long"`
-
-	_ struct{} `type:"structure"`
 }
 
 // String returns the string representation
@@ -5995,6 +5995,8 @@ func (s StartLambdaFunctionFailedEventAttributes) GoString() string {
 // For details and example IAM policies, see Using IAM to Manage Access to Amazon
 // SWF Workflows (http://docs.aws.amazon.com/amazonswf/latest/developerguide/swf-dev-iam.html).
 type StartTimerDecisionAttributes struct {
+	_ struct{} `type:"structure"`
+
 	// Optional. Data attached to the event that can be used by the decider in subsequent
 	// workflow tasks.
 	Control *string `locationName:"control" type:"string"`
@@ -6012,8 +6014,6 @@ type StartTimerDecisionAttributes struct {
 	// (\u0000-\u001f | \u007f - \u009f). Also, it must not contain the literal
 	// string quotarnquot.
 	TimerId *string `locationName:"timerId" min:"1" type:"string" required:"true"`
-
-	_ struct{} `type:"structure"`
 }
 
 // String returns the string representation
@@ -6028,6 +6028,8 @@ func (s StartTimerDecisionAttributes) GoString() string {
 
 // Provides details of the StartTimerFailed event.
 type StartTimerFailedEventAttributes struct {
+	_ struct{} `type:"structure"`
+
 	// The cause of the failure. This information is generated by the system and
 	// can be useful for diagnostic purposes.
 	//
@@ -6044,8 +6046,6 @@ type StartTimerFailedEventAttributes struct {
 
 	// The timerId provided in the StartTimer decision that failed.
 	TimerId *string `locationName:"timerId" min:"1" type:"string" required:"true"`
-
-	_ struct{} `type:"structure"`
 }
 
 // String returns the string representation
@@ -6059,6 +6059,8 @@ func (s StartTimerFailedEventAttributes) GoString() string {
 }
 
 type StartWorkflowExecutionInput struct {
+	_ struct{} `type:"structure"`
+
 	// If set, specifies the policy to use for the child workflow executions of
 	// this workflow execution if it is terminated, by calling the TerminateWorkflowExecution
 	// action explicitly or due to an expired timeout. This policy overrides the
@@ -6165,8 +6167,6 @@ type StartWorkflowExecutionInput struct {
 
 	// The type of the workflow to start.
 	WorkflowType *WorkflowType `locationName:"workflowType" type:"structure" required:"true"`
-
-	_ struct{} `type:"structure"`
 }
 
 // String returns the string representation
@@ -6181,11 +6181,11 @@ func (s StartWorkflowExecutionInput) GoString() string {
 
 // Specifies the runId of a workflow execution.
 type StartWorkflowExecutionOutput struct {
+	_ struct{} `type:"structure"`
+
 	// The runId of a workflow execution. This ID is generated by the service and
 	// can be used to uniquely identify the workflow execution within a domain.
 	RunId *string `locationName:"runId" min:"1" type:"string"`
-
-	_ struct{} `type:"structure"`
 }
 
 // String returns the string representation
@@ -6200,11 +6200,11 @@ func (s StartWorkflowExecutionOutput) GoString() string {
 
 // Used to filter the workflow executions in visibility APIs based on a tag.
 type TagFilter struct {
+	_ struct{} `type:"structure"`
+
 	// Required. Specifies the tag that must be associated with the execution for
 	// it to meet the filter criteria.
 	Tag *string `locationName:"tag" min:"1" type:"string" required:"true"`
-
-	_ struct{} `type:"structure"`
 }
 
 // String returns the string representation
@@ -6219,10 +6219,10 @@ func (s TagFilter) GoString() string {
 
 // Represents a task list.
 type TaskList struct {
+	_ struct{} `type:"structure"`
+
 	// The name of the task list.
 	Name *string `locationName:"name" min:"1" type:"string" required:"true"`
-
-	_ struct{} `type:"structure"`
 }
 
 // String returns the string representation
@@ -6236,6 +6236,8 @@ func (s TaskList) GoString() string {
 }
 
 type TerminateWorkflowExecutionInput struct {
+	_ struct{} `type:"structure"`
+
 	// If set, specifies the policy to use for the child workflow executions of
 	// the workflow execution being terminated. This policy overrides the child
 	// policy specified for the workflow execution at registration time or when
@@ -6268,8 +6270,6 @@ type TerminateWorkflowExecutionInput struct {
 
 	// The workflowId of the workflow execution to terminate.
 	WorkflowId *string `locationName:"workflowId" min:"1" type:"string" required:"true"`
-
-	_ struct{} `type:"structure"`
 }
 
 // String returns the string representation
@@ -6298,6 +6298,8 @@ func (s TerminateWorkflowExecutionOutput) GoString() string {
 
 // Provides details of the TimerCanceled event.
 type TimerCanceledEventAttributes struct {
+	_ struct{} `type:"structure"`
+
 	// The ID of the DecisionTaskCompleted event corresponding to the decision task
 	// that resulted in the CancelTimer decision to cancel this timer. This information
 	// can be useful for diagnosing problems by tracing back the chain of events
@@ -6311,8 +6313,6 @@ type TimerCanceledEventAttributes struct {
 
 	// The unique ID of the timer that was canceled.
 	TimerId *string `locationName:"timerId" min:"1" type:"string" required:"true"`
-
-	_ struct{} `type:"structure"`
 }
 
 // String returns the string representation
@@ -6327,6 +6327,8 @@ func (s TimerCanceledEventAttributes) GoString() string {
 
 // Provides details of the TimerFired event.
 type TimerFiredEventAttributes struct {
+	_ struct{} `type:"structure"`
+
 	// The ID of the TimerStarted event that was recorded when this timer was started.
 	// This information can be useful for diagnosing problems by tracing back the
 	// chain of events leading up to this event.
@@ -6334,8 +6336,6 @@ type TimerFiredEventAttributes struct {
 
 	// The unique ID of the timer that fired.
 	TimerId *string `locationName:"timerId" min:"1" type:"string" required:"true"`
-
-	_ struct{} `type:"structure"`
 }
 
 // String returns the string representation
@@ -6350,6 +6350,8 @@ func (s TimerFiredEventAttributes) GoString() string {
 
 // Provides details of the TimerStarted event.
 type TimerStartedEventAttributes struct {
+	_ struct{} `type:"structure"`
+
 	// Optional. Data attached to the event that can be used by the decider in subsequent
 	// workflow tasks.
 	Control *string `locationName:"control" type:"string"`
@@ -6368,8 +6370,6 @@ type TimerStartedEventAttributes struct {
 
 	// The unique ID of the timer that was started.
 	TimerId *string `locationName:"timerId" min:"1" type:"string" required:"true"`
-
-	_ struct{} `type:"structure"`
 }
 
 // String returns the string representation
@@ -6384,13 +6384,13 @@ func (s TimerStartedEventAttributes) GoString() string {
 
 // Represents a workflow execution.
 type WorkflowExecution struct {
+	_ struct{} `type:"structure"`
+
 	// A system-generated unique identifier for the workflow execution.
 	RunId *string `locationName:"runId" min:"1" type:"string" required:"true"`
 
 	// The user defined identifier associated with the workflow execution.
 	WorkflowId *string `locationName:"workflowId" min:"1" type:"string" required:"true"`
-
-	_ struct{} `type:"structure"`
 }
 
 // String returns the string representation
@@ -6405,6 +6405,8 @@ func (s WorkflowExecution) GoString() string {
 
 // Provides details of the WorkflowExecutionCancelRequested event.
 type WorkflowExecutionCancelRequestedEventAttributes struct {
+	_ struct{} `type:"structure"`
+
 	// If set, indicates that the request to cancel the workflow execution was automatically
 	// generated, and specifies the cause. This happens if the parent workflow execution
 	// times out or is terminated, and the child policy is set to cancel child executions.
@@ -6419,8 +6421,6 @@ type WorkflowExecutionCancelRequestedEventAttributes struct {
 
 	// The external workflow execution for which the cancellation was requested.
 	ExternalWorkflowExecution *WorkflowExecution `locationName:"externalWorkflowExecution" type:"structure"`
-
-	_ struct{} `type:"structure"`
 }
 
 // String returns the string representation
@@ -6435,6 +6435,8 @@ func (s WorkflowExecutionCancelRequestedEventAttributes) GoString() string {
 
 // Provides details of the WorkflowExecutionCanceled event.
 type WorkflowExecutionCanceledEventAttributes struct {
+	_ struct{} `type:"structure"`
+
 	// The ID of the DecisionTaskCompleted event corresponding to the decision task
 	// that resulted in the CancelWorkflowExecution decision for this cancellation
 	// request. This information can be useful for diagnosing problems by tracing
@@ -6443,8 +6445,6 @@ type WorkflowExecutionCanceledEventAttributes struct {
 
 	// Details for the cancellation (if any).
 	Details *string `locationName:"details" type:"string"`
-
-	_ struct{} `type:"structure"`
 }
 
 // String returns the string representation
@@ -6459,6 +6459,8 @@ func (s WorkflowExecutionCanceledEventAttributes) GoString() string {
 
 // Provides details of the WorkflowExecutionCompleted event.
 type WorkflowExecutionCompletedEventAttributes struct {
+	_ struct{} `type:"structure"`
+
 	// The ID of the DecisionTaskCompleted event corresponding to the decision task
 	// that resulted in the CompleteWorkflowExecution decision to complete this
 	// execution. This information can be useful for diagnosing problems by tracing
@@ -6467,8 +6469,6 @@ type WorkflowExecutionCompletedEventAttributes struct {
 
 	// The result produced by the workflow execution upon successful completion.
 	Result *string `locationName:"result" type:"string"`
-
-	_ struct{} `type:"structure"`
 }
 
 // String returns the string representation
@@ -6486,6 +6486,8 @@ func (s WorkflowExecutionCompletedEventAttributes) GoString() string {
 // specified when registering the workflow type and those specified when starting
 // the workflow execution.
 type WorkflowExecutionConfiguration struct {
+	_ struct{} `type:"structure"`
+
 	// The policy to use for the child workflow executions if this workflow execution
 	// is terminated, by calling the TerminateWorkflowExecution action explicitly
 	// or due to an expired timeout.
@@ -6525,8 +6527,6 @@ type WorkflowExecutionConfiguration struct {
 	// The duration is specified in seconds; an integer greater than or equal to
 	// 0. The value "NONE" can be used to specify unlimited duration.
 	TaskStartToCloseTimeout *string `locationName:"taskStartToCloseTimeout" min:"1" type:"string" required:"true"`
-
-	_ struct{} `type:"structure"`
 }
 
 // String returns the string representation
@@ -6541,6 +6541,8 @@ func (s WorkflowExecutionConfiguration) GoString() string {
 
 // Provides details of the WorkflowExecutionContinuedAsNew event.
 type WorkflowExecutionContinuedAsNewEventAttributes struct {
+	_ struct{} `type:"structure"`
+
 	// The policy to use for the child workflow executions of the new execution
 	// if it is terminated by calling the TerminateWorkflowExecution action explicitly
 	// or due to an expired timeout.
@@ -6592,8 +6594,6 @@ type WorkflowExecutionContinuedAsNewEventAttributes struct {
 
 	// Represents a workflow type.
 	WorkflowType *WorkflowType `locationName:"workflowType" type:"structure" required:"true"`
-
-	_ struct{} `type:"structure"`
 }
 
 // String returns the string representation
@@ -6609,14 +6609,14 @@ func (s WorkflowExecutionContinuedAsNewEventAttributes) GoString() string {
 // Contains the count of workflow executions returned from CountOpenWorkflowExecutions
 // or CountClosedWorkflowExecutions
 type WorkflowExecutionCount struct {
+	_ struct{} `type:"structure"`
+
 	// The number of workflow executions.
 	Count *int64 `locationName:"count" type:"integer" required:"true"`
 
 	// If set to true, indicates that the actual count was more than the maximum
 	// supported by this API and the count returned is the truncated value.
 	Truncated *bool `locationName:"truncated" type:"boolean"`
-
-	_ struct{} `type:"structure"`
 }
 
 // String returns the string representation
@@ -6631,6 +6631,8 @@ func (s WorkflowExecutionCount) GoString() string {
 
 // Provides details of the WorkflowExecutionFailed event.
 type WorkflowExecutionFailedEventAttributes struct {
+	_ struct{} `type:"structure"`
+
 	// The ID of the DecisionTaskCompleted event corresponding to the decision task
 	// that resulted in the FailWorkflowExecution decision to fail this execution.
 	// This information can be useful for diagnosing problems by tracing back the
@@ -6642,8 +6644,6 @@ type WorkflowExecutionFailedEventAttributes struct {
 
 	// The descriptive reason provided for the failure (if any).
 	Reason *string `locationName:"reason" type:"string"`
-
-	_ struct{} `type:"structure"`
 }
 
 // String returns the string representation
@@ -6658,10 +6658,10 @@ func (s WorkflowExecutionFailedEventAttributes) GoString() string {
 
 // Used to filter the workflow executions in visibility APIs by their workflowId.
 type WorkflowExecutionFilter struct {
+	_ struct{} `type:"structure"`
+
 	// The workflowId to pass of match the criteria of this filter.
 	WorkflowId *string `locationName:"workflowId" min:"1" type:"string" required:"true"`
-
-	_ struct{} `type:"structure"`
 }
 
 // String returns the string representation
@@ -6676,6 +6676,8 @@ func (s WorkflowExecutionFilter) GoString() string {
 
 // Contains information about a workflow execution.
 type WorkflowExecutionInfo struct {
+	_ struct{} `type:"structure"`
+
 	// Set to true if a cancellation is requested for this workflow execution.
 	CancelRequested *bool `locationName:"cancelRequested" type:"boolean"`
 
@@ -6715,8 +6717,6 @@ type WorkflowExecutionInfo struct {
 
 	// The type of the workflow execution.
 	WorkflowType *WorkflowType `locationName:"workflowType" type:"structure" required:"true"`
-
-	_ struct{} `type:"structure"`
 }
 
 // String returns the string representation
@@ -6731,6 +6731,8 @@ func (s WorkflowExecutionInfo) GoString() string {
 
 // Contains a paginated list of information about workflow executions.
 type WorkflowExecutionInfos struct {
+	_ struct{} `type:"structure"`
+
 	// The list of workflow information structures.
 	ExecutionInfos []*WorkflowExecutionInfo `locationName:"executionInfos" type:"list" required:"true"`
 
@@ -6741,8 +6743,6 @@ type WorkflowExecutionInfos struct {
 	// The configured maximumPageSize determines how many results can be returned
 	// in a single call.
 	NextPageToken *string `locationName:"nextPageToken" type:"string"`
-
-	_ struct{} `type:"structure"`
 }
 
 // String returns the string representation
@@ -6758,6 +6758,8 @@ func (s WorkflowExecutionInfos) GoString() string {
 // Contains the counts of open tasks, child workflow executions and timers for
 // a workflow execution.
 type WorkflowExecutionOpenCounts struct {
+	_ struct{} `type:"structure"`
+
 	// The count of activity tasks whose status is OPEN.
 	OpenActivityTasks *int64 `locationName:"openActivityTasks" type:"integer" required:"true"`
 
@@ -6774,8 +6776,6 @@ type WorkflowExecutionOpenCounts struct {
 	// The count of timers started by this workflow execution that have not fired
 	// yet.
 	OpenTimers *int64 `locationName:"openTimers" type:"integer" required:"true"`
-
-	_ struct{} `type:"structure"`
 }
 
 // String returns the string representation
@@ -6790,6 +6790,8 @@ func (s WorkflowExecutionOpenCounts) GoString() string {
 
 // Provides details of the WorkflowExecutionSignaled event.
 type WorkflowExecutionSignaledEventAttributes struct {
+	_ struct{} `type:"structure"`
+
 	// The ID of the SignalExternalWorkflowExecutionInitiated event corresponding
 	// to the SignalExternalWorkflow decision to signal this workflow execution.The
 	// source event with this ID can be found in the history of the source workflow
@@ -6809,8 +6811,6 @@ type WorkflowExecutionSignaledEventAttributes struct {
 	// The name of the signal received. The decider can use the signal name and
 	// inputs to determine how to the process the signal.
 	SignalName *string `locationName:"signalName" min:"1" type:"string" required:"true"`
-
-	_ struct{} `type:"structure"`
 }
 
 // String returns the string representation
@@ -6825,6 +6825,8 @@ func (s WorkflowExecutionSignaledEventAttributes) GoString() string {
 
 // Provides details of WorkflowExecutionStarted event.
 type WorkflowExecutionStartedEventAttributes struct {
+	_ struct{} `type:"structure"`
+
 	// The policy to use for the child workflow executions if this workflow execution
 	// is terminated, by calling the TerminateWorkflowExecution action explicitly
 	// or due to an expired timeout.
@@ -6885,8 +6887,6 @@ type WorkflowExecutionStartedEventAttributes struct {
 
 	// The workflow type of this execution.
 	WorkflowType *WorkflowType `locationName:"workflowType" type:"structure" required:"true"`
-
-	_ struct{} `type:"structure"`
 }
 
 // String returns the string representation
@@ -6901,6 +6901,8 @@ func (s WorkflowExecutionStartedEventAttributes) GoString() string {
 
 // Provides details of the WorkflowExecutionTerminated event.
 type WorkflowExecutionTerminatedEventAttributes struct {
+	_ struct{} `type:"structure"`
+
 	// If set, indicates that the workflow execution was automatically terminated,
 	// and specifies the cause. This happens if the parent workflow execution times
 	// out or is terminated and the child policy is set to terminate child executions.
@@ -6922,8 +6924,6 @@ type WorkflowExecutionTerminatedEventAttributes struct {
 
 	// The reason provided for the termination (if any).
 	Reason *string `locationName:"reason" type:"string"`
-
-	_ struct{} `type:"structure"`
 }
 
 // String returns the string representation
@@ -6938,6 +6938,8 @@ func (s WorkflowExecutionTerminatedEventAttributes) GoString() string {
 
 // Provides details of the WorkflowExecutionTimedOut event.
 type WorkflowExecutionTimedOutEventAttributes struct {
+	_ struct{} `type:"structure"`
+
 	// The policy used for the child workflow executions of this workflow execution.
 	//
 	// The supported child policies are:
@@ -6951,8 +6953,6 @@ type WorkflowExecutionTimedOutEventAttributes struct {
 
 	// The type of timeout that caused this event.
 	TimeoutType *string `locationName:"timeoutType" type:"string" required:"true" enum:"WorkflowExecutionTimeoutType"`
-
-	_ struct{} `type:"structure"`
 }
 
 // String returns the string representation
@@ -6967,6 +6967,8 @@ func (s WorkflowExecutionTimedOutEventAttributes) GoString() string {
 
 // Represents a workflow type.
 type WorkflowType struct {
+	_ struct{} `type:"structure"`
+
 	// Required. The name of the workflow type.
 	//
 	// The combination of workflow type name and version must be unique with in
@@ -6978,8 +6980,6 @@ type WorkflowType struct {
 	// The combination of workflow type name and version must be unique with in
 	// a domain.
 	Version *string `locationName:"version" min:"1" type:"string" required:"true"`
-
-	_ struct{} `type:"structure"`
 }
 
 // String returns the string representation
@@ -6994,6 +6994,8 @@ func (s WorkflowType) GoString() string {
 
 // The configuration settings of a workflow type.
 type WorkflowTypeConfiguration struct {
+	_ struct{} `type:"structure"`
+
 	// Optional. The default policy to use for the child workflow executions when
 	// a workflow execution of this type is terminated, by calling the TerminateWorkflowExecution
 	// action explicitly or due to an expired timeout. This default can be overridden
@@ -7052,8 +7054,6 @@ type WorkflowTypeConfiguration struct {
 	// The duration is specified in seconds; an integer greater than or equal to
 	// 0. The value "NONE" can be used to specify unlimited duration.
 	DefaultTaskStartToCloseTimeout *string `locationName:"defaultTaskStartToCloseTimeout" type:"string"`
-
-	_ struct{} `type:"structure"`
 }
 
 // String returns the string representation
@@ -7069,13 +7069,13 @@ func (s WorkflowTypeConfiguration) GoString() string {
 // Used to filter workflow execution query results by type. Each parameter,
 // if specified, defines a rule that must be satisfied by each returned result.
 type WorkflowTypeFilter struct {
+	_ struct{} `type:"structure"`
+
 	// Required. Name of the workflow type.
 	Name *string `locationName:"name" min:"1" type:"string" required:"true"`
 
 	// Version of the workflow type.
 	Version *string `locationName:"version" type:"string"`
-
-	_ struct{} `type:"structure"`
 }
 
 // String returns the string representation
@@ -7090,6 +7090,8 @@ func (s WorkflowTypeFilter) GoString() string {
 
 // Contains information about a workflow type.
 type WorkflowTypeInfo struct {
+	_ struct{} `type:"structure"`
+
 	// The date when this type was registered.
 	CreationDate *time.Time `locationName:"creationDate" type:"timestamp" timestampFormat:"unix" required:"true"`
 
@@ -7105,8 +7107,6 @@ type WorkflowTypeInfo struct {
 
 	// The workflow type this information is about.
 	WorkflowType *WorkflowType `locationName:"workflowType" type:"structure" required:"true"`
-
-	_ struct{} `type:"structure"`
 }
 
 // String returns the string representation

--- a/service/waf/api.go
+++ b/service/waf/api.go
@@ -1070,6 +1070,8 @@ func (c *WAF) UpdateWebACL(input *UpdateWebACLInput) (*UpdateWebACLOutput, error
 // To specify whether to insert or delete a Rule, use the Action parameter
 // in the WebACLUpdate data type.
 type ActivatedRule struct {
+	_ struct{} `type:"structure"`
+
 	// Specifies the action that CloudFront or AWS WAF takes when a web request
 	// matches the conditions in the Rule. Valid values for Action include the following:
 	//
@@ -1092,8 +1094,6 @@ type ActivatedRule struct {
 	//
 	// RuleId is returned by CreateRule and by ListRules.
 	RuleId *string `min:"1" type:"string" required:"true"`
-
-	_ struct{} `type:"structure"`
 }
 
 // String returns the string representation
@@ -1116,6 +1116,8 @@ func (s ActivatedRule) GoString() string {
 // object, a request needs to match the settings in only one ByteMatchTuple
 // to be considered a match.
 type ByteMatchSet struct {
+	_ struct{} `type:"structure"`
+
 	// The ByteMatchSetId for a ByteMatchSet. You use ByteMatchSetId to get information
 	// about a ByteMatchSet (see GetByteMatchSet), update a ByteMatchSet (see UpdateByteMatchSet,
 	// insert a ByteMatchSet into a Rule or delete one from a Rule (see UpdateRule),
@@ -1132,8 +1134,6 @@ type ByteMatchSet struct {
 	// A friendly name or description of the ByteMatchSet. You can't change Name
 	// after you create a ByteMatchSet.
 	Name *string `min:"1" type:"string"`
-
-	_ struct{} `type:"structure"`
 }
 
 // String returns the string representation
@@ -1149,6 +1149,8 @@ func (s ByteMatchSet) GoString() string {
 // Returned by ListByteMatchSets. Each ByteMatchSetSummary object includes the
 // Name and ByteMatchSetId for one ByteMatchSet.
 type ByteMatchSetSummary struct {
+	_ struct{} `type:"structure"`
+
 	// The ByteMatchSetId for a ByteMatchSet. You use ByteMatchSetId to get information
 	// about a ByteMatchSet, update a ByteMatchSet, remove a ByteMatchSet from a
 	// Rule, and delete a ByteMatchSet from AWS WAF.
@@ -1159,8 +1161,6 @@ type ByteMatchSetSummary struct {
 	// A friendly name or description of the ByteMatchSet. You can't change Name
 	// after you create a ByteMatchSet.
 	Name *string `min:"1" type:"string" required:"true"`
-
-	_ struct{} `type:"structure"`
 }
 
 // String returns the string representation
@@ -1176,6 +1176,8 @@ func (s ByteMatchSetSummary) GoString() string {
 // In an UpdateByteMatchSet request, ByteMatchSetUpdate specifies whether to
 // insert or delete a ByteMatchTuple and includes the settings for the ByteMatchTuple.
 type ByteMatchSetUpdate struct {
+	_ struct{} `type:"structure"`
+
 	// Specifies whether to insert or delete a ByteMatchTuple.
 	Action *string `type:"string" required:"true" enum:"ChangeAction"`
 
@@ -1184,8 +1186,6 @@ type ByteMatchSetUpdate struct {
 	// for the value of Action, the ByteMatchTuple values must exactly match the
 	// values in the ByteMatchTuple that you want to delete from the ByteMatchSet.
 	ByteMatchTuple *ByteMatchTuple `type:"structure" required:"true"`
-
-	_ struct{} `type:"structure"`
 }
 
 // String returns the string representation
@@ -1202,6 +1202,8 @@ func (s ByteMatchSetUpdate) GoString() string {
 // you want AWS WAF to search for in web requests, the location in requests
 // that you want AWS WAF to search, and other settings.
 type ByteMatchTuple struct {
+	_ struct{} `type:"structure"`
+
 	// The part of a web request that you want AWS WAF to search, such as a specified
 	// header or a query string. For more information, see FieldToMatch.
 	FieldToMatch *FieldToMatch `type:"structure" required:"true"`
@@ -1325,8 +1327,6 @@ type ByteMatchTuple struct {
 	//
 	// Specify NONE if you don't want to perform any text transformations.
 	TextTransformation *string `type:"string" required:"true" enum:"TextTransformation"`
-
-	_ struct{} `type:"structure"`
 }
 
 // String returns the string representation
@@ -1340,14 +1340,14 @@ func (s ByteMatchTuple) GoString() string {
 }
 
 type CreateByteMatchSetInput struct {
+	_ struct{} `type:"structure"`
+
 	// The value returned by the most recent call to GetChangeToken.
 	ChangeToken *string `type:"string" required:"true"`
 
 	// A friendly name or description of the ByteMatchSet. You can't change Name
 	// after you create a ByteMatchSet.
 	Name *string `min:"1" type:"string" required:"true"`
-
-	_ struct{} `type:"structure"`
 }
 
 // String returns the string representation
@@ -1361,6 +1361,8 @@ func (s CreateByteMatchSetInput) GoString() string {
 }
 
 type CreateByteMatchSetOutput struct {
+	_ struct{} `type:"structure"`
+
 	// A ByteMatchSet that contains no ByteMatchTuple objects.
 	ByteMatchSet *ByteMatchSet `type:"structure"`
 
@@ -1368,8 +1370,6 @@ type CreateByteMatchSetOutput struct {
 	// can also use this value to query the status of the request. For more information,
 	// see GetChangeTokenStatus.
 	ChangeToken *string `type:"string"`
-
-	_ struct{} `type:"structure"`
 }
 
 // String returns the string representation
@@ -1383,14 +1383,14 @@ func (s CreateByteMatchSetOutput) GoString() string {
 }
 
 type CreateIPSetInput struct {
+	_ struct{} `type:"structure"`
+
 	// The value returned by the most recent call to GetChangeToken.
 	ChangeToken *string `type:"string" required:"true"`
 
 	// A friendly name or description of the IPSet. You can't change Name after
 	// you create the IPSet.
 	Name *string `min:"1" type:"string" required:"true"`
-
-	_ struct{} `type:"structure"`
 }
 
 // String returns the string representation
@@ -1404,6 +1404,8 @@ func (s CreateIPSetInput) GoString() string {
 }
 
 type CreateIPSetOutput struct {
+	_ struct{} `type:"structure"`
+
 	// The ChangeToken that you used to submit the CreateIPSet request. You can
 	// also use this value to query the status of the request. For more information,
 	// see GetChangeTokenStatus.
@@ -1411,8 +1413,6 @@ type CreateIPSetOutput struct {
 
 	// The IPSet returned in the CreateIPSet response.
 	IPSet *IPSet `type:"structure"`
-
-	_ struct{} `type:"structure"`
 }
 
 // String returns the string representation
@@ -1426,6 +1426,8 @@ func (s CreateIPSetOutput) GoString() string {
 }
 
 type CreateRuleInput struct {
+	_ struct{} `type:"structure"`
+
 	// The value returned by the most recent call to GetChangeToken.
 	ChangeToken *string `type:"string" required:"true"`
 
@@ -1438,8 +1440,6 @@ type CreateRuleInput struct {
 	// A friendly name or description of the Rule. You can't change the name of
 	// a Rule after you create it.
 	Name *string `min:"1" type:"string" required:"true"`
-
-	_ struct{} `type:"structure"`
 }
 
 // String returns the string representation
@@ -1453,6 +1453,8 @@ func (s CreateRuleInput) GoString() string {
 }
 
 type CreateRuleOutput struct {
+	_ struct{} `type:"structure"`
+
 	// The ChangeToken that you used to submit the CreateRule request. You can also
 	// use this value to query the status of the request. For more information,
 	// see GetChangeTokenStatus.
@@ -1460,8 +1462,6 @@ type CreateRuleOutput struct {
 
 	// The Rule returned in the CreateRule response.
 	Rule *Rule `type:"structure"`
-
-	_ struct{} `type:"structure"`
 }
 
 // String returns the string representation
@@ -1476,14 +1476,14 @@ func (s CreateRuleOutput) GoString() string {
 
 // A request to create a SqlInjectionMatchSet.
 type CreateSqlInjectionMatchSetInput struct {
+	_ struct{} `type:"structure"`
+
 	// The value returned by the most recent call to GetChangeToken.
 	ChangeToken *string `type:"string" required:"true"`
 
 	// A friendly name or description for the SqlInjectionMatchSet that you're creating.
 	// You can't change Name after you create the SqlInjectionMatchSet.
 	Name *string `min:"1" type:"string" required:"true"`
-
-	_ struct{} `type:"structure"`
 }
 
 // String returns the string representation
@@ -1498,6 +1498,8 @@ func (s CreateSqlInjectionMatchSetInput) GoString() string {
 
 // The response to a CreateSqlInjectionMatchSet request.
 type CreateSqlInjectionMatchSetOutput struct {
+	_ struct{} `type:"structure"`
+
 	// The ChangeToken that you used to submit the CreateSqlInjectionMatchSet request.
 	// You can also use this value to query the status of the request. For more
 	// information, see GetChangeTokenStatus.
@@ -1505,8 +1507,6 @@ type CreateSqlInjectionMatchSetOutput struct {
 
 	// A SqlInjectionMatchSet.
 	SqlInjectionMatchSet *SqlInjectionMatchSet `type:"structure"`
-
-	_ struct{} `type:"structure"`
 }
 
 // String returns the string representation
@@ -1520,6 +1520,8 @@ func (s CreateSqlInjectionMatchSetOutput) GoString() string {
 }
 
 type CreateWebACLInput struct {
+	_ struct{} `type:"structure"`
+
 	// The value returned by the most recent call to GetChangeToken.
 	ChangeToken *string `type:"string" required:"true"`
 
@@ -1536,8 +1538,6 @@ type CreateWebACLInput struct {
 	// A friendly name or description of the WebACL. You can't change Name after
 	// you create the WebACL.
 	Name *string `min:"1" type:"string" required:"true"`
-
-	_ struct{} `type:"structure"`
 }
 
 // String returns the string representation
@@ -1551,6 +1551,8 @@ func (s CreateWebACLInput) GoString() string {
 }
 
 type CreateWebACLOutput struct {
+	_ struct{} `type:"structure"`
+
 	// The ChangeToken that you used to submit the CreateWebACL request. You can
 	// also use this value to query the status of the request. For more information,
 	// see GetChangeTokenStatus.
@@ -1558,8 +1560,6 @@ type CreateWebACLOutput struct {
 
 	// The WebACL returned in the CreateWebACL response.
 	WebACL *WebACL `type:"structure"`
-
-	_ struct{} `type:"structure"`
 }
 
 // String returns the string representation
@@ -1573,14 +1573,14 @@ func (s CreateWebACLOutput) GoString() string {
 }
 
 type DeleteByteMatchSetInput struct {
+	_ struct{} `type:"structure"`
+
 	// The ByteMatchSetId of the ByteMatchSet that you want to delete. ByteMatchSetId
 	// is returned by CreateByteMatchSet and by ListByteMatchSets.
 	ByteMatchSetId *string `min:"1" type:"string" required:"true"`
 
 	// The value returned by the most recent call to GetChangeToken.
 	ChangeToken *string `type:"string" required:"true"`
-
-	_ struct{} `type:"structure"`
 }
 
 // String returns the string representation
@@ -1594,12 +1594,12 @@ func (s DeleteByteMatchSetInput) GoString() string {
 }
 
 type DeleteByteMatchSetOutput struct {
+	_ struct{} `type:"structure"`
+
 	// The ChangeToken that you used to submit the DeleteByteMatchSet request. You
 	// can also use this value to query the status of the request. For more information,
 	// see GetChangeTokenStatus.
 	ChangeToken *string `type:"string"`
-
-	_ struct{} `type:"structure"`
 }
 
 // String returns the string representation
@@ -1613,14 +1613,14 @@ func (s DeleteByteMatchSetOutput) GoString() string {
 }
 
 type DeleteIPSetInput struct {
+	_ struct{} `type:"structure"`
+
 	// The value returned by the most recent call to GetChangeToken.
 	ChangeToken *string `type:"string" required:"true"`
 
 	// The IPSetId of the IPSet that you want to delete. IPSetId is returned by
 	// CreateIPSet and by ListIPSets.
 	IPSetId *string `min:"1" type:"string" required:"true"`
-
-	_ struct{} `type:"structure"`
 }
 
 // String returns the string representation
@@ -1634,12 +1634,12 @@ func (s DeleteIPSetInput) GoString() string {
 }
 
 type DeleteIPSetOutput struct {
+	_ struct{} `type:"structure"`
+
 	// The ChangeToken that you used to submit the DeleteIPSet request. You can
 	// also use this value to query the status of the request. For more information,
 	// see GetChangeTokenStatus.
 	ChangeToken *string `type:"string"`
-
-	_ struct{} `type:"structure"`
 }
 
 // String returns the string representation
@@ -1653,14 +1653,14 @@ func (s DeleteIPSetOutput) GoString() string {
 }
 
 type DeleteRuleInput struct {
+	_ struct{} `type:"structure"`
+
 	// The value returned by the most recent call to GetChangeToken.
 	ChangeToken *string `type:"string" required:"true"`
 
 	// The RuleId of the Rule that you want to delete. RuleId is returned by CreateRule
 	// and by ListRules.
 	RuleId *string `min:"1" type:"string" required:"true"`
-
-	_ struct{} `type:"structure"`
 }
 
 // String returns the string representation
@@ -1674,12 +1674,12 @@ func (s DeleteRuleInput) GoString() string {
 }
 
 type DeleteRuleOutput struct {
+	_ struct{} `type:"structure"`
+
 	// The ChangeToken that you used to submit the DeleteRule request. You can also
 	// use this value to query the status of the request. For more information,
 	// see GetChangeTokenStatus.
 	ChangeToken *string `type:"string"`
-
-	_ struct{} `type:"structure"`
 }
 
 // String returns the string representation
@@ -1694,14 +1694,14 @@ func (s DeleteRuleOutput) GoString() string {
 
 // A request to delete a SqlInjectionMatchSet from AWS WAF.
 type DeleteSqlInjectionMatchSetInput struct {
+	_ struct{} `type:"structure"`
+
 	// The value returned by the most recent call to GetChangeToken.
 	ChangeToken *string `type:"string" required:"true"`
 
 	// The SqlInjectionMatchSetId of the SqlInjectionMatchSet that you want to delete.
 	// SqlInjectionMatchSetId is returned by CreateSqlInjectionMatchSet and by ListSqlInjectionMatchSets.
 	SqlInjectionMatchSetId *string `min:"1" type:"string" required:"true"`
-
-	_ struct{} `type:"structure"`
 }
 
 // String returns the string representation
@@ -1716,12 +1716,12 @@ func (s DeleteSqlInjectionMatchSetInput) GoString() string {
 
 // The response to a request to delete a SqlInjectionMatchSet from AWS WAF.
 type DeleteSqlInjectionMatchSetOutput struct {
+	_ struct{} `type:"structure"`
+
 	// The ChangeToken that you used to submit the DeleteSqlInjectionMatchSet request.
 	// You can also use this value to query the status of the request. For more
 	// information, see GetChangeTokenStatus.
 	ChangeToken *string `type:"string"`
-
-	_ struct{} `type:"structure"`
 }
 
 // String returns the string representation
@@ -1735,14 +1735,14 @@ func (s DeleteSqlInjectionMatchSetOutput) GoString() string {
 }
 
 type DeleteWebACLInput struct {
+	_ struct{} `type:"structure"`
+
 	// The value returned by the most recent call to GetChangeToken.
 	ChangeToken *string `type:"string" required:"true"`
 
 	// The WebACLId of the WebACL that you want to delete. WebACLId is returned
 	// by CreateWebACL and by ListWebACLs.
 	WebACLId *string `min:"1" type:"string" required:"true"`
-
-	_ struct{} `type:"structure"`
 }
 
 // String returns the string representation
@@ -1756,12 +1756,12 @@ func (s DeleteWebACLInput) GoString() string {
 }
 
 type DeleteWebACLOutput struct {
+	_ struct{} `type:"structure"`
+
 	// The ChangeToken that you used to submit the DeleteWebACL request. You can
 	// also use this value to query the status of the request. For more information,
 	// see GetChangeTokenStatus.
 	ChangeToken *string `type:"string"`
-
-	_ struct{} `type:"structure"`
 }
 
 // String returns the string representation
@@ -1776,6 +1776,8 @@ func (s DeleteWebACLOutput) GoString() string {
 
 // Specifies where in a web request to look for TargetString.
 type FieldToMatch struct {
+	_ struct{} `type:"structure"`
+
 	// When the value of Type is HEADER, enter the name of the header that you want
 	// AWS WAF to search, for example, User-Agent or Referer. If the value of Type
 	// is any other value, omit Data.
@@ -1795,8 +1797,6 @@ type FieldToMatch struct {
 	// after a ? character, if any.  URI: The part of a web request that identifies
 	// a resource, for example, /images/daily-ad.jpg.
 	Type *string `type:"string" required:"true" enum:"MatchFieldType"`
-
-	_ struct{} `type:"structure"`
 }
 
 // String returns the string representation
@@ -1810,11 +1810,11 @@ func (s FieldToMatch) GoString() string {
 }
 
 type GetByteMatchSetInput struct {
+	_ struct{} `type:"structure"`
+
 	// The ByteMatchSetId of the ByteMatchSet that you want to get. ByteMatchSetId
 	// is returned by CreateByteMatchSet and by ListByteMatchSets.
 	ByteMatchSetId *string `min:"1" type:"string" required:"true"`
-
-	_ struct{} `type:"structure"`
 }
 
 // String returns the string representation
@@ -1828,6 +1828,8 @@ func (s GetByteMatchSetInput) GoString() string {
 }
 
 type GetByteMatchSetOutput struct {
+	_ struct{} `type:"structure"`
+
 	// Information about the ByteMatchSet that you specified in the GetByteMatchSet
 	// request. For more information, see the following topics:
 	//
@@ -1836,8 +1838,6 @@ type GetByteMatchSetOutput struct {
 	// FieldToMatch, PositionalConstraint, TargetString, and TextTransformation
 	//   FieldToMatch: Contains Data and Type
 	ByteMatchSet *ByteMatchSet `type:"structure"`
-
-	_ struct{} `type:"structure"`
 }
 
 // String returns the string representation
@@ -1865,11 +1865,11 @@ func (s GetChangeTokenInput) GoString() string {
 }
 
 type GetChangeTokenOutput struct {
+	_ struct{} `type:"structure"`
+
 	// The ChangeToken that you used in the request. Use this value in a GetChangeTokenStatus
 	// request to get the current status of the request.
 	ChangeToken *string `type:"string"`
-
-	_ struct{} `type:"structure"`
 }
 
 // String returns the string representation
@@ -1883,11 +1883,11 @@ func (s GetChangeTokenOutput) GoString() string {
 }
 
 type GetChangeTokenStatusInput struct {
+	_ struct{} `type:"structure"`
+
 	// The change token for which you want to get the status. This change token
 	// was previously returned in the GetChangeToken response.
 	ChangeToken *string `type:"string" required:"true"`
-
-	_ struct{} `type:"structure"`
 }
 
 // String returns the string representation
@@ -1901,10 +1901,10 @@ func (s GetChangeTokenStatusInput) GoString() string {
 }
 
 type GetChangeTokenStatusOutput struct {
+	_ struct{} `type:"structure"`
+
 	// The status of the change token.
 	ChangeTokenStatus *string `type:"string" enum:"ChangeTokenStatus"`
-
-	_ struct{} `type:"structure"`
 }
 
 // String returns the string representation
@@ -1918,11 +1918,11 @@ func (s GetChangeTokenStatusOutput) GoString() string {
 }
 
 type GetIPSetInput struct {
+	_ struct{} `type:"structure"`
+
 	// The IPSetId of the IPSet that you want to get. IPSetId is returned by CreateIPSet
 	// and by ListIPSets.
 	IPSetId *string `min:"1" type:"string" required:"true"`
-
-	_ struct{} `type:"structure"`
 }
 
 // String returns the string representation
@@ -1936,6 +1936,8 @@ func (s GetIPSetInput) GoString() string {
 }
 
 type GetIPSetOutput struct {
+	_ struct{} `type:"structure"`
+
 	// Information about the IPSet that you specified in the GetIPSet request. For
 	// more information, see the following topics:
 	//
@@ -1943,8 +1945,6 @@ type GetIPSetOutput struct {
 	// Contains an array of IPSetDescriptor objects. Each IPSetDescriptor object
 	// contains Type and Value
 	IPSet *IPSet `type:"structure"`
-
-	_ struct{} `type:"structure"`
 }
 
 // String returns the string representation
@@ -1958,11 +1958,11 @@ func (s GetIPSetOutput) GoString() string {
 }
 
 type GetRuleInput struct {
+	_ struct{} `type:"structure"`
+
 	// The RuleId of the Rule that you want to get. RuleId is returned by CreateRule
 	// and by ListRules.
 	RuleId *string `min:"1" type:"string" required:"true"`
-
-	_ struct{} `type:"structure"`
 }
 
 // String returns the string representation
@@ -1976,14 +1976,14 @@ func (s GetRuleInput) GoString() string {
 }
 
 type GetRuleOutput struct {
+	_ struct{} `type:"structure"`
+
 	// Information about the Rule that you specified in the GetRule request. For
 	// more information, see the following topics:
 	//
 	//   Rule: Contains MetricName, Name, an array of Predicate objects, and RuleId
 	//   Predicate: Each Predicate object contains DataId, Negated, and Type
 	Rule *Rule `type:"structure"`
-
-	_ struct{} `type:"structure"`
 }
 
 // String returns the string representation
@@ -1997,6 +1997,8 @@ func (s GetRuleOutput) GoString() string {
 }
 
 type GetSampledRequestsInput struct {
+	_ struct{} `type:"structure"`
+
 	// The number of requests that you want AWS WAF to return from among the first
 	// 5,000 requests that your AWS resource received during the time range. If
 	// your resource received fewer requests than the value of MaxItems, GetSampledRequests
@@ -2020,8 +2022,6 @@ type GetSampledRequestsInput struct {
 	// The WebACLId of the WebACL for which you want GetSampledRequests to return
 	// a sample of requests.
 	WebAclId *string `min:"1" type:"string" required:"true"`
-
-	_ struct{} `type:"structure"`
 }
 
 // String returns the string representation
@@ -2035,6 +2035,8 @@ func (s GetSampledRequestsInput) GoString() string {
 }
 
 type GetSampledRequestsOutput struct {
+	_ struct{} `type:"structure"`
+
 	// The total number of requests from which GetSampledRequests got a sample of
 	// MaxItems requests. If PopulationSize is less than MaxItems, the sample includes
 	// every request that your AWS resource received during the specified time range.
@@ -2049,8 +2051,6 @@ type GetSampledRequestsOutput struct {
 	// during the time range that you specified in the request, GetSampledRequests
 	// returns the time range for the first 5,000 requests.
 	TimeWindow *TimeWindow `type:"structure"`
-
-	_ struct{} `type:"structure"`
 }
 
 // String returns the string representation
@@ -2065,11 +2065,11 @@ func (s GetSampledRequestsOutput) GoString() string {
 
 // A request to get a SqlInjectionMatchSet.
 type GetSqlInjectionMatchSetInput struct {
+	_ struct{} `type:"structure"`
+
 	// The SqlInjectionMatchSetId of the SqlInjectionMatchSet that you want to get.
 	// SqlInjectionMatchSetId is returned by CreateSqlInjectionMatchSet and by ListSqlInjectionMatchSets.
 	SqlInjectionMatchSetId *string `min:"1" type:"string" required:"true"`
-
-	_ struct{} `type:"structure"`
 }
 
 // String returns the string representation
@@ -2084,6 +2084,8 @@ func (s GetSqlInjectionMatchSetInput) GoString() string {
 
 // The response to a GetSqlInjectionMatchSet request.
 type GetSqlInjectionMatchSetOutput struct {
+	_ struct{} `type:"structure"`
+
 	// Information about the SqlInjectionMatchSet that you specified in the GetSqlInjectionMatchSet
 	// request. For more information, see the following topics:
 	//
@@ -2092,8 +2094,6 @@ type GetSqlInjectionMatchSetOutput struct {
 	// object contains FieldToMatch and TextTransformation   FieldToMatch: Contains
 	// Data and Type
 	SqlInjectionMatchSet *SqlInjectionMatchSet `type:"structure"`
-
-	_ struct{} `type:"structure"`
 }
 
 // String returns the string representation
@@ -2107,11 +2107,11 @@ func (s GetSqlInjectionMatchSetOutput) GoString() string {
 }
 
 type GetWebACLInput struct {
+	_ struct{} `type:"structure"`
+
 	// The WebACLId of the WebACL that you want to get. WebACLId is returned by
 	// CreateWebACL and by ListWebACLs.
 	WebACLId *string `min:"1" type:"string" required:"true"`
-
-	_ struct{} `type:"structure"`
 }
 
 // String returns the string representation
@@ -2125,6 +2125,8 @@ func (s GetWebACLInput) GoString() string {
 }
 
 type GetWebACLOutput struct {
+	_ struct{} `type:"structure"`
+
 	// Information about the WebACL that you specified in the GetWebACL request.
 	// For more information, see the following topics:
 	//
@@ -2133,8 +2135,6 @@ type GetWebACLOutput struct {
 	// Contains an array of ActivatedRule objects, which contain Action, Priority,
 	// and RuleId   Action: Contains Type
 	WebACL *WebACL `type:"structure"`
-
-	_ struct{} `type:"structure"`
 }
 
 // String returns the string representation
@@ -2152,13 +2152,13 @@ func (s GetWebACLOutput) GoString() string {
 // the names and values of all of the headers that appear in one of the web
 // requests that were returned by GetSampledRequests.
 type HTTPHeader struct {
+	_ struct{} `type:"structure"`
+
 	// The name of one of the headers in the sampled web request.
 	Name *string `type:"string"`
 
 	// The value of one of the headers in the sampled web request.
 	Value *string `type:"string"`
-
-	_ struct{} `type:"structure"`
 }
 
 // String returns the string representation
@@ -2175,6 +2175,8 @@ func (s HTTPHeader) GoString() string {
 // type that appears as Request in the response syntax. HTTPRequest contains
 // information about one of the web requests that were returned by GetSampledRequests.
 type HTTPRequest struct {
+	_ struct{} `type:"structure"`
+
 	// The IP address that the request originated from. If the WebACL is associated
 	// with a CloudFront distribution, this is the value of one of the following
 	// fields in CloudFront access logs:
@@ -2202,8 +2204,6 @@ type HTTPRequest struct {
 
 	// The part of a web request that identifies the resource, for example, /images/daily-ad.jpg.
 	URI *string `type:"string"`
-
-	_ struct{} `type:"structure"`
 }
 
 // String returns the string representation
@@ -2223,6 +2223,8 @@ func (s HTTPRequest) GoString() string {
 // /16, or a /8 CIDR. For more information about CIDR notation, perform an Internet
 // search on cidr notation.
 type IPSet struct {
+	_ struct{} `type:"structure"`
+
 	// The IP address type (IPV4) and the IP address range (in CIDR notation) that
 	// web requests originate from. If the WebACL is associated with a CloudFront
 	// distribution, this is the value of one of the following fields in CloudFront
@@ -2244,8 +2246,6 @@ type IPSet struct {
 	// A friendly name or description of the IPSet. You can't change the name of
 	// an IPSet after you create it.
 	Name *string `min:"1" type:"string"`
-
-	_ struct{} `type:"structure"`
 }
 
 // String returns the string representation
@@ -2261,6 +2261,8 @@ func (s IPSet) GoString() string {
 // Specifies the IP address type (IPV4) and the IP address range (in CIDR format)
 // that web requests originate from.
 type IPSetDescriptor struct {
+	_ struct{} `type:"structure"`
+
 	// Specify IPV4.
 	Type *string `type:"string" required:"true" enum:"IPSetDescriptorType"`
 
@@ -2275,8 +2277,6 @@ type IPSetDescriptor struct {
 	// For more information about CIDR notation, see the Wikipedia entry Classless
 	// Inter-Domain Routing (https://en.wikipedia.org/wiki/Classless_Inter-Domain_Routing).
 	Value *string `type:"string" required:"true"`
-
-	_ struct{} `type:"structure"`
 }
 
 // String returns the string representation
@@ -2291,6 +2291,8 @@ func (s IPSetDescriptor) GoString() string {
 
 // Contains the identifier and the name of the IPSet.
 type IPSetSummary struct {
+	_ struct{} `type:"structure"`
+
 	// The IPSetId for an IPSet. You can use IPSetId in a GetIPSet request to get
 	// detailed information about an IPSet.
 	IPSetId *string `min:"1" type:"string" required:"true"`
@@ -2298,8 +2300,6 @@ type IPSetSummary struct {
 	// A friendly name or description of the IPSet. You can't change the name of
 	// an IPSet after you create it.
 	Name *string `min:"1" type:"string" required:"true"`
-
-	_ struct{} `type:"structure"`
 }
 
 // String returns the string representation
@@ -2314,14 +2314,14 @@ func (s IPSetSummary) GoString() string {
 
 // Specifies the type of update to perform to an IPSet with UpdateIPSet.
 type IPSetUpdate struct {
+	_ struct{} `type:"structure"`
+
 	// Specifies whether to insert or delete an IP address with UpdateIPSet.
 	Action *string `type:"string" required:"true" enum:"ChangeAction"`
 
 	// The IP address type (IPV4) and the IP address range (in CIDR notation) that
 	// web requests originate from.
 	IPSetDescriptor *IPSetDescriptor `type:"structure" required:"true"`
-
-	_ struct{} `type:"structure"`
 }
 
 // String returns the string representation
@@ -2335,6 +2335,8 @@ func (s IPSetUpdate) GoString() string {
 }
 
 type ListByteMatchSetsInput struct {
+	_ struct{} `type:"structure"`
+
 	// Specifies the number of ByteMatchSet objects that you want AWS WAF to return
 	// for this request. If you have more ByteMatchSets objects than the number
 	// you specify for Limit, the response includes a NextMarker value that you
@@ -2347,8 +2349,6 @@ type ListByteMatchSetsInput struct {
 	// ListByteMatchSets requests, specify the value of NextMarker from the previous
 	// response to get information about another batch of ByteMatchSets.
 	NextMarker *string `min:"1" type:"string"`
-
-	_ struct{} `type:"structure"`
 }
 
 // String returns the string representation
@@ -2362,6 +2362,8 @@ func (s ListByteMatchSetsInput) GoString() string {
 }
 
 type ListByteMatchSetsOutput struct {
+	_ struct{} `type:"structure"`
+
 	// An array of ByteMatchSetSummary objects.
 	ByteMatchSets []*ByteMatchSetSummary `type:"list"`
 
@@ -2371,8 +2373,6 @@ type ListByteMatchSetsOutput struct {
 	// specify the NextMarker value from the response in the NextMarker value in
 	// the next request.
 	NextMarker *string `min:"1" type:"string"`
-
-	_ struct{} `type:"structure"`
 }
 
 // String returns the string representation
@@ -2386,6 +2386,8 @@ func (s ListByteMatchSetsOutput) GoString() string {
 }
 
 type ListIPSetsInput struct {
+	_ struct{} `type:"structure"`
+
 	// Specifies the number of IPSet objects that you want AWS WAF to return for
 	// this request. If you have more IPSet objects than the number you specify
 	// for Limit, the response includes a NextMarker value that you can use to get
@@ -2398,8 +2400,6 @@ type ListIPSetsInput struct {
 	// requests, specify the value of NextMarker from the previous response to get
 	// information about another batch of ByteMatchSets.
 	NextMarker *string `min:"1" type:"string"`
-
-	_ struct{} `type:"structure"`
 }
 
 // String returns the string representation
@@ -2413,6 +2413,8 @@ func (s ListIPSetsInput) GoString() string {
 }
 
 type ListIPSetsOutput struct {
+	_ struct{} `type:"structure"`
+
 	// An array of IPSetSummary objects.
 	IPSets []*IPSetSummary `type:"list"`
 
@@ -2421,8 +2423,6 @@ type ListIPSetsOutput struct {
 	// objects, submit another ListIPSets request, and specify the NextMarker value
 	// from the response in the NextMarker value in the next request.
 	NextMarker *string `min:"1" type:"string"`
-
-	_ struct{} `type:"structure"`
 }
 
 // String returns the string representation
@@ -2436,6 +2436,8 @@ func (s ListIPSetsOutput) GoString() string {
 }
 
 type ListRulesInput struct {
+	_ struct{} `type:"structure"`
+
 	// Specifies the number of Rules that you want AWS WAF to return for this request.
 	// If you have more Rules than the number that you specify for Limit, the response
 	// includes a NextMarker value that you can use to get another batch of Rules.
@@ -2447,8 +2449,6 @@ type ListRulesInput struct {
 	// specify the value of NextMarker from the previous response to get information
 	// about another batch of Rules.
 	NextMarker *string `min:"1" type:"string"`
-
-	_ struct{} `type:"structure"`
 }
 
 // String returns the string representation
@@ -2462,6 +2462,8 @@ func (s ListRulesInput) GoString() string {
 }
 
 type ListRulesOutput struct {
+	_ struct{} `type:"structure"`
+
 	// If you have more Rules than the number that you specified for Limit in the
 	// request, the response includes a NextMarker value. To list more Rules, submit
 	// another ListRules request, and specify the NextMarker value from the response
@@ -2470,8 +2472,6 @@ type ListRulesOutput struct {
 
 	// An array of RuleSummary objects.
 	Rules []*RuleSummary `type:"list"`
-
-	_ struct{} `type:"structure"`
 }
 
 // String returns the string representation
@@ -2487,6 +2487,8 @@ func (s ListRulesOutput) GoString() string {
 // A request to list the SqlInjectionMatchSet objects created by the current
 // AWS account.
 type ListSqlInjectionMatchSetsInput struct {
+	_ struct{} `type:"structure"`
+
 	// Specifies the number of SqlInjectionMatchSet objects that you want AWS WAF
 	// to return for this request. If you have more SqlInjectionMatchSet objects
 	// than the number you specify for Limit, the response includes a NextMarker
@@ -2499,8 +2501,6 @@ type ListSqlInjectionMatchSetsInput struct {
 	// and subsequent ListSqlInjectionMatchSets requests, specify the value of NextMarker
 	// from the previous response to get information about another batch of SqlInjectionMatchSets.
 	NextMarker *string `min:"1" type:"string"`
-
-	_ struct{} `type:"structure"`
 }
 
 // String returns the string representation
@@ -2515,6 +2515,8 @@ func (s ListSqlInjectionMatchSetsInput) GoString() string {
 
 // The response to a ListSqlInjectionMatchSets request.
 type ListSqlInjectionMatchSetsOutput struct {
+	_ struct{} `type:"structure"`
+
 	// If you have more SqlInjectionMatchSet objects than the number that you specified
 	// for Limit in the request, the response includes a NextMarker value. To list
 	// more SqlInjectionMatchSet objects, submit another ListSqlInjectionMatchSets
@@ -2524,8 +2526,6 @@ type ListSqlInjectionMatchSetsOutput struct {
 
 	// An array of SqlInjectionMatchSetSummary objects.
 	SqlInjectionMatchSets []*SqlInjectionMatchSetSummary `type:"list"`
-
-	_ struct{} `type:"structure"`
 }
 
 // String returns the string representation
@@ -2539,6 +2539,8 @@ func (s ListSqlInjectionMatchSetsOutput) GoString() string {
 }
 
 type ListWebACLsInput struct {
+	_ struct{} `type:"structure"`
+
 	// Specifies the number of WebACL objects that you want AWS WAF to return for
 	// this request. If you have more WebACL objects than the number that you specify
 	// for Limit, the response includes a NextMarker value that you can use to get
@@ -2552,8 +2554,6 @@ type ListWebACLsInput struct {
 	// from the previous response to get information about another batch of WebACL
 	// objects.
 	NextMarker *string `min:"1" type:"string"`
-
-	_ struct{} `type:"structure"`
 }
 
 // String returns the string representation
@@ -2567,6 +2567,8 @@ func (s ListWebACLsInput) GoString() string {
 }
 
 type ListWebACLsOutput struct {
+	_ struct{} `type:"structure"`
+
 	// If you have more WebACL objects than the number that you specified for Limit
 	// in the request, the response includes a NextMarker value. To list more WebACL
 	// objects, submit another ListWebACLs request, and specify the NextMarker value
@@ -2575,8 +2577,6 @@ type ListWebACLsOutput struct {
 
 	// An array of WebACLSummary objects.
 	WebACLs []*WebACLSummary `type:"list"`
-
-	_ struct{} `type:"structure"`
 }
 
 // String returns the string representation
@@ -2594,6 +2594,8 @@ func (s ListWebACLsOutput) GoString() string {
 // to negate the settings, for example, requests that do NOT originate from
 // the IP address 192.0.2.44.
 type Predicate struct {
+	_ struct{} `type:"structure"`
+
 	// A unique identifier for a predicate in a Rule, such as ByteMatchSetId or
 	// IPSetId. The ID is returned by the corresponding Create or List command.
 	DataId *string `type:"string" required:"true"`
@@ -2611,8 +2613,6 @@ type Predicate struct {
 
 	// The type of predicate in a Rule, such as ByteMatchSet or IPSet.
 	Type *string `type:"string" required:"true" enum:"PredicateType"`
-
-	_ struct{} `type:"structure"`
 }
 
 // String returns the string representation
@@ -2635,6 +2635,8 @@ func (s Predicate) GoString() string {
 //  To match the settings in this Rule, a request must originate from 192.0.2.44
 // AND include a User-Agent header for which the value is BadBot.
 type Rule struct {
+	_ struct{} `type:"structure"`
+
 	MetricName *string `type:"string"`
 
 	// The friendly name or description for the Rule. You can't change the name
@@ -2652,8 +2654,6 @@ type Rule struct {
 	//
 	// RuleId is returned by CreateRule and by ListRules.
 	RuleId *string `min:"1" type:"string" required:"true"`
-
-	_ struct{} `type:"structure"`
 }
 
 // String returns the string representation
@@ -2668,6 +2668,8 @@ func (s Rule) GoString() string {
 
 // Contains the identifier and the friendly name or description of the Rule.
 type RuleSummary struct {
+	_ struct{} `type:"structure"`
+
 	// A friendly name or description of the Rule. You can't change the name of
 	// a Rule after you create it.
 	Name *string `min:"1" type:"string" required:"true"`
@@ -2679,8 +2681,6 @@ type RuleSummary struct {
 	//
 	// RuleId is returned by CreateRule and by ListRules.
 	RuleId *string `min:"1" type:"string" required:"true"`
-
-	_ struct{} `type:"structure"`
 }
 
 // String returns the string representation
@@ -2696,14 +2696,14 @@ func (s RuleSummary) GoString() string {
 // Specifies a Predicate (such as an IPSet) and indicates whether you want to
 // add it to a Rule or delete it from a Rule.
 type RuleUpdate struct {
+	_ struct{} `type:"structure"`
+
 	// Specify INSERT to add a Predicate to a Rule. Use DELETE to remove a Predicate
 	// from a Rule.
 	Action *string `type:"string" required:"true" enum:"ChangeAction"`
 
 	// The ID of the Predicate (such as an IPSet) that you want to add to a Rule.
 	Predicate *Predicate `type:"structure" required:"true"`
-
-	_ struct{} `type:"structure"`
 }
 
 // String returns the string representation
@@ -2721,6 +2721,8 @@ func (s RuleUpdate) GoString() string {
 // contains one SampledHTTPRequest object for each web request that is returned
 // by GetSampledRequests.
 type SampledHTTPRequest struct {
+	_ struct{} `type:"structure"`
+
 	// The action for the Rule that the request matched: ALLOW, BLOCK, or COUNT.
 	Action *string `type:"string"`
 
@@ -2736,8 +2738,6 @@ type SampledHTTPRequest struct {
 	// roughly twice as many CloudFront web requests as a result that has a weight
 	// of 1.
 	Weight *int64 `type:"long" required:"true"`
-
-	_ struct{} `type:"structure"`
 }
 
 // String returns the string representation
@@ -2757,6 +2757,8 @@ func (s SampledHTTPRequest) GoString() string {
 // object, a request needs to include snippets of SQL code in only one of the
 // specified parts of the request to be considered a match.
 type SqlInjectionMatchSet struct {
+	_ struct{} `type:"structure"`
+
 	// The name, if any, of the SqlInjectionMatchSet.
 	Name *string `min:"1" type:"string"`
 
@@ -2773,8 +2775,6 @@ type SqlInjectionMatchSet struct {
 	// Specifies the parts of web requests that you want to inspect for snippets
 	// of malicious SQL code.
 	SqlInjectionMatchTuples []*SqlInjectionMatchTuple `type:"list" required:"true"`
-
-	_ struct{} `type:"structure"`
 }
 
 // String returns the string representation
@@ -2789,6 +2789,8 @@ func (s SqlInjectionMatchSet) GoString() string {
 
 // The Id and Name of a SqlInjectionMatchSet.
 type SqlInjectionMatchSetSummary struct {
+	_ struct{} `type:"structure"`
+
 	// The name of the SqlInjectionMatchSet, if any, specified by Id.
 	Name *string `min:"1" type:"string" required:"true"`
 
@@ -2801,8 +2803,6 @@ type SqlInjectionMatchSetSummary struct {
 	// SqlInjectionMatchSetId is returned by CreateSqlInjectionMatchSet and by
 	// ListSqlInjectionMatchSets.
 	SqlInjectionMatchSetId *string `min:"1" type:"string" required:"true"`
-
-	_ struct{} `type:"structure"`
 }
 
 // String returns the string representation
@@ -2819,6 +2819,8 @@ func (s SqlInjectionMatchSetSummary) GoString() string {
 // of malicious SQL code and indicates whether you want to add the specification
 // to a SqlInjectionMatchSet or delete it from a SqlInjectionMatchSet.
 type SqlInjectionMatchSetUpdate struct {
+	_ struct{} `type:"structure"`
+
 	// Specify INSERT to add a SqlInjectionMatchSetUpdate to a SqlInjectionMatchSet.
 	// Use DELETE to remove a SqlInjectionMatchSetUpdate from a SqlInjectionMatchSet.
 	Action *string `type:"string" required:"true" enum:"ChangeAction"`
@@ -2827,8 +2829,6 @@ type SqlInjectionMatchSetUpdate struct {
 	// snippets of malicious SQL code and, if you want AWS WAF to inspect a header,
 	// the name of the header.
 	SqlInjectionMatchTuple *SqlInjectionMatchTuple `type:"structure" required:"true"`
-
-	_ struct{} `type:"structure"`
 }
 
 // String returns the string representation
@@ -2845,6 +2845,8 @@ func (s SqlInjectionMatchSetUpdate) GoString() string {
 // snippets of malicious SQL code and, if you want AWS WAF to inspect a header,
 // the name of the header.
 type SqlInjectionMatchTuple struct {
+	_ struct{} `type:"structure"`
+
 	// Specifies where in a web request to look for TargetString.
 	FieldToMatch *FieldToMatch `type:"structure" required:"true"`
 
@@ -2894,8 +2896,6 @@ type SqlInjectionMatchTuple struct {
 	//
 	// Specify NONE if you don't want to perform any text transformations.
 	TextTransformation *string `type:"string" required:"true" enum:"TextTransformation"`
-
-	_ struct{} `type:"structure"`
 }
 
 // String returns the string representation
@@ -2919,6 +2919,8 @@ func (s SqlInjectionMatchTuple) GoString() string {
 // WAF stops sampling after the 5,000th request. In that case, EndTime is the
 // time that AWS WAF received the 5,000th request.
 type TimeWindow struct {
+	_ struct{} `type:"structure"`
+
 	// The end of the time range from which you want GetSampledRequests to return
 	// a sample of the requests that your AWS resource received. You can specify
 	// any time range in the previous three hours.
@@ -2928,8 +2930,6 @@ type TimeWindow struct {
 	// return a sample of the requests that your AWS resource received. You can
 	// specify any time range in the previous three hours.
 	StartTime *time.Time `type:"timestamp" timestampFormat:"unix" required:"true"`
-
-	_ struct{} `type:"structure"`
 }
 
 // String returns the string representation
@@ -2943,6 +2943,8 @@ func (s TimeWindow) GoString() string {
 }
 
 type UpdateByteMatchSetInput struct {
+	_ struct{} `type:"structure"`
+
 	// The ByteMatchSetId of the ByteMatchSet that you want to update. ByteMatchSetId
 	// is returned by CreateByteMatchSet and by ListByteMatchSets.
 	ByteMatchSetId *string `min:"1" type:"string" required:"true"`
@@ -2957,8 +2959,6 @@ type UpdateByteMatchSetInput struct {
 	// Contains FieldToMatch, PositionalConstraint, TargetString, and TextTransformation
 	//   FieldToMatch: Contains Data and Type
 	Updates []*ByteMatchSetUpdate `type:"list" required:"true"`
-
-	_ struct{} `type:"structure"`
 }
 
 // String returns the string representation
@@ -2972,12 +2972,12 @@ func (s UpdateByteMatchSetInput) GoString() string {
 }
 
 type UpdateByteMatchSetOutput struct {
+	_ struct{} `type:"structure"`
+
 	// The ChangeToken that you used to submit the UpdateByteMatchSet request. You
 	// can also use this value to query the status of the request. For more information,
 	// see GetChangeTokenStatus.
 	ChangeToken *string `type:"string"`
-
-	_ struct{} `type:"structure"`
 }
 
 // String returns the string representation
@@ -2991,6 +2991,8 @@ func (s UpdateByteMatchSetOutput) GoString() string {
 }
 
 type UpdateIPSetInput struct {
+	_ struct{} `type:"structure"`
+
 	// The value returned by the most recent call to GetChangeToken.
 	ChangeToken *string `type:"string" required:"true"`
 
@@ -3004,8 +3006,6 @@ type UpdateIPSetInput struct {
 	//   IPSetUpdate: Contains Action and IPSetDescriptor   IPSetDescriptor: Contains
 	// Type and Value
 	Updates []*IPSetUpdate `type:"list" required:"true"`
-
-	_ struct{} `type:"structure"`
 }
 
 // String returns the string representation
@@ -3019,12 +3019,12 @@ func (s UpdateIPSetInput) GoString() string {
 }
 
 type UpdateIPSetOutput struct {
+	_ struct{} `type:"structure"`
+
 	// The ChangeToken that you used to submit the UpdateIPSet request. You can
 	// also use this value to query the status of the request. For more information,
 	// see GetChangeTokenStatus.
 	ChangeToken *string `type:"string"`
-
-	_ struct{} `type:"structure"`
 }
 
 // String returns the string representation
@@ -3038,6 +3038,8 @@ func (s UpdateIPSetOutput) GoString() string {
 }
 
 type UpdateRuleInput struct {
+	_ struct{} `type:"structure"`
+
 	// The value returned by the most recent call to GetChangeToken.
 	ChangeToken *string `type:"string" required:"true"`
 
@@ -3051,8 +3053,6 @@ type UpdateRuleInput struct {
 	//   RuleUpdate: Contains Action and Predicate   Predicate: Contains DataId,
 	// Negated, and Type   FieldToMatch: Contains Data and Type
 	Updates []*RuleUpdate `type:"list" required:"true"`
-
-	_ struct{} `type:"structure"`
 }
 
 // String returns the string representation
@@ -3066,12 +3066,12 @@ func (s UpdateRuleInput) GoString() string {
 }
 
 type UpdateRuleOutput struct {
+	_ struct{} `type:"structure"`
+
 	// The ChangeToken that you used to submit the UpdateRule request. You can also
 	// use this value to query the status of the request. For more information,
 	// see GetChangeTokenStatus.
 	ChangeToken *string `type:"string"`
-
-	_ struct{} `type:"structure"`
 }
 
 // String returns the string representation
@@ -3086,6 +3086,8 @@ func (s UpdateRuleOutput) GoString() string {
 
 // A request to update a SqlInjectionMatchSet.
 type UpdateSqlInjectionMatchSetInput struct {
+	_ struct{} `type:"structure"`
+
 	// The value returned by the most recent call to GetChangeToken.
 	ChangeToken *string `type:"string" required:"true"`
 
@@ -3101,8 +3103,6 @@ type UpdateSqlInjectionMatchSetInput struct {
 	//   SqlInjectionMatchTuple: Contains FieldToMatch and TextTransformation
 	// FieldToMatch: Contains Data and Type
 	Updates []*SqlInjectionMatchSetUpdate `type:"list" required:"true"`
-
-	_ struct{} `type:"structure"`
 }
 
 // String returns the string representation
@@ -3117,12 +3117,12 @@ func (s UpdateSqlInjectionMatchSetInput) GoString() string {
 
 // The response to an UpdateSqlInjectionMatchSets request.
 type UpdateSqlInjectionMatchSetOutput struct {
+	_ struct{} `type:"structure"`
+
 	// The ChangeToken that you used to submit the UpdateSqlInjectionMatchSet request.
 	// You can also use this value to query the status of the request. For more
 	// information, see GetChangeTokenStatus.
 	ChangeToken *string `type:"string"`
-
-	_ struct{} `type:"structure"`
 }
 
 // String returns the string representation
@@ -3136,6 +3136,8 @@ func (s UpdateSqlInjectionMatchSetOutput) GoString() string {
 }
 
 type UpdateWebACLInput struct {
+	_ struct{} `type:"structure"`
+
 	// The value returned by the most recent call to GetChangeToken.
 	ChangeToken *string `type:"string" required:"true"`
 
@@ -3158,8 +3160,6 @@ type UpdateWebACLInput struct {
 	// The WebACLId of the WebACL that you want to update. WebACLId is returned
 	// by CreateWebACL and by ListWebACLs.
 	WebACLId *string `min:"1" type:"string" required:"true"`
-
-	_ struct{} `type:"structure"`
 }
 
 // String returns the string representation
@@ -3173,12 +3173,12 @@ func (s UpdateWebACLInput) GoString() string {
 }
 
 type UpdateWebACLOutput struct {
+	_ struct{} `type:"structure"`
+
 	// The ChangeToken that you used to submit the UpdateWebACL request. You can
 	// also use this value to query the status of the request. For more information,
 	// see GetChangeTokenStatus.
 	ChangeToken *string `type:"string"`
-
-	_ struct{} `type:"structure"`
 }
 
 // String returns the string representation
@@ -3197,6 +3197,8 @@ func (s UpdateWebACLOutput) GoString() string {
 // action that you want AWS WAF to take when a web request doesn't match all
 // of the conditions in any of the rules in a WebACL.
 type WafAction struct {
+	_ struct{} `type:"structure"`
+
 	// Specifies how you want AWS WAF to respond to requests that match the settings
 	// in a Rule. Valid settings include the following:
 	//
@@ -3206,8 +3208,6 @@ type WafAction struct {
 	// remaining rules in the web ACL. You can't specify COUNT for the default action
 	// for a WebACL.
 	Type *string `type:"string" required:"true" enum:"WafActionType"`
-
-	_ struct{} `type:"structure"`
 }
 
 // String returns the string representation
@@ -3229,6 +3229,8 @@ func (s WafAction) GoString() string {
 // to a WebACL, a request needs to match only one of the specifications to be
 // allowed, blocked, or counted. For more information, see UpdateWebACL.
 type WebACL struct {
+	_ struct{} `type:"structure"`
+
 	// The action to perform if none of the Rules contained in the WebACL match.
 	// The action is specified by the WafAction object.
 	DefaultAction *WafAction `type:"structure" required:"true"`
@@ -3249,8 +3251,6 @@ type WebACL struct {
 	//
 	// WebACLId is returned by CreateWebACL and by ListWebACLs.
 	WebACLId *string `min:"1" type:"string" required:"true"`
-
-	_ struct{} `type:"structure"`
 }
 
 // String returns the string representation
@@ -3265,6 +3265,8 @@ func (s WebACL) GoString() string {
 
 // Contains the identifier and the name or description of the WebACL.
 type WebACLSummary struct {
+	_ struct{} `type:"structure"`
+
 	// A friendly name or description of the WebACL. You can't change the name of
 	// a WebACL after you create it.
 	Name *string `min:"1" type:"string" required:"true"`
@@ -3275,8 +3277,6 @@ type WebACLSummary struct {
 	//
 	// WebACLId is returned by CreateWebACL and by ListWebACLs.
 	WebACLId *string `min:"1" type:"string" required:"true"`
-
-	_ struct{} `type:"structure"`
 }
 
 // String returns the string representation
@@ -3291,6 +3291,8 @@ func (s WebACLSummary) GoString() string {
 
 // Specifies whether to insert a Rule into or delete a Rule from a WebACL.
 type WebACLUpdate struct {
+	_ struct{} `type:"structure"`
+
 	// Specifies whether to insert a Rule into or delete a Rule from a WebACL.
 	Action *string `type:"string" required:"true" enum:"ChangeAction"`
 
@@ -3302,8 +3304,6 @@ type WebACLUpdate struct {
 	// To specify whether to insert or delete a Rule, use the Action parameter
 	// in the WebACLUpdate data type.
 	ActivatedRule *ActivatedRule `type:"structure" required:"true"`
-
-	_ struct{} `type:"structure"`
 }
 
 // String returns the string representation

--- a/service/waf/api.go
+++ b/service/waf/api.go
@@ -1093,11 +1093,7 @@ type ActivatedRule struct {
 	// RuleId is returned by CreateRule and by ListRules.
 	RuleId *string `min:"1" type:"string" required:"true"`
 
-	metadataActivatedRule `json:"-" xml:"-"`
-}
-
-type metadataActivatedRule struct {
-	SDKShapeTraits bool `type:"structure"`
+	_ struct{} `type:"structure"`
 }
 
 // String returns the string representation
@@ -1137,11 +1133,7 @@ type ByteMatchSet struct {
 	// after you create a ByteMatchSet.
 	Name *string `min:"1" type:"string"`
 
-	metadataByteMatchSet `json:"-" xml:"-"`
-}
-
-type metadataByteMatchSet struct {
-	SDKShapeTraits bool `type:"structure"`
+	_ struct{} `type:"structure"`
 }
 
 // String returns the string representation
@@ -1168,11 +1160,7 @@ type ByteMatchSetSummary struct {
 	// after you create a ByteMatchSet.
 	Name *string `min:"1" type:"string" required:"true"`
 
-	metadataByteMatchSetSummary `json:"-" xml:"-"`
-}
-
-type metadataByteMatchSetSummary struct {
-	SDKShapeTraits bool `type:"structure"`
+	_ struct{} `type:"structure"`
 }
 
 // String returns the string representation
@@ -1197,11 +1185,7 @@ type ByteMatchSetUpdate struct {
 	// values in the ByteMatchTuple that you want to delete from the ByteMatchSet.
 	ByteMatchTuple *ByteMatchTuple `type:"structure" required:"true"`
 
-	metadataByteMatchSetUpdate `json:"-" xml:"-"`
-}
-
-type metadataByteMatchSetUpdate struct {
-	SDKShapeTraits bool `type:"structure"`
+	_ struct{} `type:"structure"`
 }
 
 // String returns the string representation
@@ -1342,11 +1326,7 @@ type ByteMatchTuple struct {
 	// Specify NONE if you don't want to perform any text transformations.
 	TextTransformation *string `type:"string" required:"true" enum:"TextTransformation"`
 
-	metadataByteMatchTuple `json:"-" xml:"-"`
-}
-
-type metadataByteMatchTuple struct {
-	SDKShapeTraits bool `type:"structure"`
+	_ struct{} `type:"structure"`
 }
 
 // String returns the string representation
@@ -1367,11 +1347,7 @@ type CreateByteMatchSetInput struct {
 	// after you create a ByteMatchSet.
 	Name *string `min:"1" type:"string" required:"true"`
 
-	metadataCreateByteMatchSetInput `json:"-" xml:"-"`
-}
-
-type metadataCreateByteMatchSetInput struct {
-	SDKShapeTraits bool `type:"structure"`
+	_ struct{} `type:"structure"`
 }
 
 // String returns the string representation
@@ -1393,11 +1369,7 @@ type CreateByteMatchSetOutput struct {
 	// see GetChangeTokenStatus.
 	ChangeToken *string `type:"string"`
 
-	metadataCreateByteMatchSetOutput `json:"-" xml:"-"`
-}
-
-type metadataCreateByteMatchSetOutput struct {
-	SDKShapeTraits bool `type:"structure"`
+	_ struct{} `type:"structure"`
 }
 
 // String returns the string representation
@@ -1418,11 +1390,7 @@ type CreateIPSetInput struct {
 	// you create the IPSet.
 	Name *string `min:"1" type:"string" required:"true"`
 
-	metadataCreateIPSetInput `json:"-" xml:"-"`
-}
-
-type metadataCreateIPSetInput struct {
-	SDKShapeTraits bool `type:"structure"`
+	_ struct{} `type:"structure"`
 }
 
 // String returns the string representation
@@ -1444,11 +1412,7 @@ type CreateIPSetOutput struct {
 	// The IPSet returned in the CreateIPSet response.
 	IPSet *IPSet `type:"structure"`
 
-	metadataCreateIPSetOutput `json:"-" xml:"-"`
-}
-
-type metadataCreateIPSetOutput struct {
-	SDKShapeTraits bool `type:"structure"`
+	_ struct{} `type:"structure"`
 }
 
 // String returns the string representation
@@ -1475,11 +1439,7 @@ type CreateRuleInput struct {
 	// a Rule after you create it.
 	Name *string `min:"1" type:"string" required:"true"`
 
-	metadataCreateRuleInput `json:"-" xml:"-"`
-}
-
-type metadataCreateRuleInput struct {
-	SDKShapeTraits bool `type:"structure"`
+	_ struct{} `type:"structure"`
 }
 
 // String returns the string representation
@@ -1501,11 +1461,7 @@ type CreateRuleOutput struct {
 	// The Rule returned in the CreateRule response.
 	Rule *Rule `type:"structure"`
 
-	metadataCreateRuleOutput `json:"-" xml:"-"`
-}
-
-type metadataCreateRuleOutput struct {
-	SDKShapeTraits bool `type:"structure"`
+	_ struct{} `type:"structure"`
 }
 
 // String returns the string representation
@@ -1527,11 +1483,7 @@ type CreateSqlInjectionMatchSetInput struct {
 	// You can't change Name after you create the SqlInjectionMatchSet.
 	Name *string `min:"1" type:"string" required:"true"`
 
-	metadataCreateSqlInjectionMatchSetInput `json:"-" xml:"-"`
-}
-
-type metadataCreateSqlInjectionMatchSetInput struct {
-	SDKShapeTraits bool `type:"structure"`
+	_ struct{} `type:"structure"`
 }
 
 // String returns the string representation
@@ -1554,11 +1506,7 @@ type CreateSqlInjectionMatchSetOutput struct {
 	// A SqlInjectionMatchSet.
 	SqlInjectionMatchSet *SqlInjectionMatchSet `type:"structure"`
 
-	metadataCreateSqlInjectionMatchSetOutput `json:"-" xml:"-"`
-}
-
-type metadataCreateSqlInjectionMatchSetOutput struct {
-	SDKShapeTraits bool `type:"structure"`
+	_ struct{} `type:"structure"`
 }
 
 // String returns the string representation
@@ -1589,11 +1537,7 @@ type CreateWebACLInput struct {
 	// you create the WebACL.
 	Name *string `min:"1" type:"string" required:"true"`
 
-	metadataCreateWebACLInput `json:"-" xml:"-"`
-}
-
-type metadataCreateWebACLInput struct {
-	SDKShapeTraits bool `type:"structure"`
+	_ struct{} `type:"structure"`
 }
 
 // String returns the string representation
@@ -1615,11 +1559,7 @@ type CreateWebACLOutput struct {
 	// The WebACL returned in the CreateWebACL response.
 	WebACL *WebACL `type:"structure"`
 
-	metadataCreateWebACLOutput `json:"-" xml:"-"`
-}
-
-type metadataCreateWebACLOutput struct {
-	SDKShapeTraits bool `type:"structure"`
+	_ struct{} `type:"structure"`
 }
 
 // String returns the string representation
@@ -1640,11 +1580,7 @@ type DeleteByteMatchSetInput struct {
 	// The value returned by the most recent call to GetChangeToken.
 	ChangeToken *string `type:"string" required:"true"`
 
-	metadataDeleteByteMatchSetInput `json:"-" xml:"-"`
-}
-
-type metadataDeleteByteMatchSetInput struct {
-	SDKShapeTraits bool `type:"structure"`
+	_ struct{} `type:"structure"`
 }
 
 // String returns the string representation
@@ -1663,11 +1599,7 @@ type DeleteByteMatchSetOutput struct {
 	// see GetChangeTokenStatus.
 	ChangeToken *string `type:"string"`
 
-	metadataDeleteByteMatchSetOutput `json:"-" xml:"-"`
-}
-
-type metadataDeleteByteMatchSetOutput struct {
-	SDKShapeTraits bool `type:"structure"`
+	_ struct{} `type:"structure"`
 }
 
 // String returns the string representation
@@ -1688,11 +1620,7 @@ type DeleteIPSetInput struct {
 	// CreateIPSet and by ListIPSets.
 	IPSetId *string `min:"1" type:"string" required:"true"`
 
-	metadataDeleteIPSetInput `json:"-" xml:"-"`
-}
-
-type metadataDeleteIPSetInput struct {
-	SDKShapeTraits bool `type:"structure"`
+	_ struct{} `type:"structure"`
 }
 
 // String returns the string representation
@@ -1711,11 +1639,7 @@ type DeleteIPSetOutput struct {
 	// see GetChangeTokenStatus.
 	ChangeToken *string `type:"string"`
 
-	metadataDeleteIPSetOutput `json:"-" xml:"-"`
-}
-
-type metadataDeleteIPSetOutput struct {
-	SDKShapeTraits bool `type:"structure"`
+	_ struct{} `type:"structure"`
 }
 
 // String returns the string representation
@@ -1736,11 +1660,7 @@ type DeleteRuleInput struct {
 	// and by ListRules.
 	RuleId *string `min:"1" type:"string" required:"true"`
 
-	metadataDeleteRuleInput `json:"-" xml:"-"`
-}
-
-type metadataDeleteRuleInput struct {
-	SDKShapeTraits bool `type:"structure"`
+	_ struct{} `type:"structure"`
 }
 
 // String returns the string representation
@@ -1759,11 +1679,7 @@ type DeleteRuleOutput struct {
 	// see GetChangeTokenStatus.
 	ChangeToken *string `type:"string"`
 
-	metadataDeleteRuleOutput `json:"-" xml:"-"`
-}
-
-type metadataDeleteRuleOutput struct {
-	SDKShapeTraits bool `type:"structure"`
+	_ struct{} `type:"structure"`
 }
 
 // String returns the string representation
@@ -1785,11 +1701,7 @@ type DeleteSqlInjectionMatchSetInput struct {
 	// SqlInjectionMatchSetId is returned by CreateSqlInjectionMatchSet and by ListSqlInjectionMatchSets.
 	SqlInjectionMatchSetId *string `min:"1" type:"string" required:"true"`
 
-	metadataDeleteSqlInjectionMatchSetInput `json:"-" xml:"-"`
-}
-
-type metadataDeleteSqlInjectionMatchSetInput struct {
-	SDKShapeTraits bool `type:"structure"`
+	_ struct{} `type:"structure"`
 }
 
 // String returns the string representation
@@ -1809,11 +1721,7 @@ type DeleteSqlInjectionMatchSetOutput struct {
 	// information, see GetChangeTokenStatus.
 	ChangeToken *string `type:"string"`
 
-	metadataDeleteSqlInjectionMatchSetOutput `json:"-" xml:"-"`
-}
-
-type metadataDeleteSqlInjectionMatchSetOutput struct {
-	SDKShapeTraits bool `type:"structure"`
+	_ struct{} `type:"structure"`
 }
 
 // String returns the string representation
@@ -1834,11 +1742,7 @@ type DeleteWebACLInput struct {
 	// by CreateWebACL and by ListWebACLs.
 	WebACLId *string `min:"1" type:"string" required:"true"`
 
-	metadataDeleteWebACLInput `json:"-" xml:"-"`
-}
-
-type metadataDeleteWebACLInput struct {
-	SDKShapeTraits bool `type:"structure"`
+	_ struct{} `type:"structure"`
 }
 
 // String returns the string representation
@@ -1857,11 +1761,7 @@ type DeleteWebACLOutput struct {
 	// see GetChangeTokenStatus.
 	ChangeToken *string `type:"string"`
 
-	metadataDeleteWebACLOutput `json:"-" xml:"-"`
-}
-
-type metadataDeleteWebACLOutput struct {
-	SDKShapeTraits bool `type:"structure"`
+	_ struct{} `type:"structure"`
 }
 
 // String returns the string representation
@@ -1896,11 +1796,7 @@ type FieldToMatch struct {
 	// a resource, for example, /images/daily-ad.jpg.
 	Type *string `type:"string" required:"true" enum:"MatchFieldType"`
 
-	metadataFieldToMatch `json:"-" xml:"-"`
-}
-
-type metadataFieldToMatch struct {
-	SDKShapeTraits bool `type:"structure"`
+	_ struct{} `type:"structure"`
 }
 
 // String returns the string representation
@@ -1918,11 +1814,7 @@ type GetByteMatchSetInput struct {
 	// is returned by CreateByteMatchSet and by ListByteMatchSets.
 	ByteMatchSetId *string `min:"1" type:"string" required:"true"`
 
-	metadataGetByteMatchSetInput `json:"-" xml:"-"`
-}
-
-type metadataGetByteMatchSetInput struct {
-	SDKShapeTraits bool `type:"structure"`
+	_ struct{} `type:"structure"`
 }
 
 // String returns the string representation
@@ -1945,11 +1837,7 @@ type GetByteMatchSetOutput struct {
 	//   FieldToMatch: Contains Data and Type
 	ByteMatchSet *ByteMatchSet `type:"structure"`
 
-	metadataGetByteMatchSetOutput `json:"-" xml:"-"`
-}
-
-type metadataGetByteMatchSetOutput struct {
-	SDKShapeTraits bool `type:"structure"`
+	_ struct{} `type:"structure"`
 }
 
 // String returns the string representation
@@ -1963,11 +1851,7 @@ func (s GetByteMatchSetOutput) GoString() string {
 }
 
 type GetChangeTokenInput struct {
-	metadataGetChangeTokenInput `json:"-" xml:"-"`
-}
-
-type metadataGetChangeTokenInput struct {
-	SDKShapeTraits bool `type:"structure"`
+	_ struct{} `type:"structure"`
 }
 
 // String returns the string representation
@@ -1985,11 +1869,7 @@ type GetChangeTokenOutput struct {
 	// request to get the current status of the request.
 	ChangeToken *string `type:"string"`
 
-	metadataGetChangeTokenOutput `json:"-" xml:"-"`
-}
-
-type metadataGetChangeTokenOutput struct {
-	SDKShapeTraits bool `type:"structure"`
+	_ struct{} `type:"structure"`
 }
 
 // String returns the string representation
@@ -2007,11 +1887,7 @@ type GetChangeTokenStatusInput struct {
 	// was previously returned in the GetChangeToken response.
 	ChangeToken *string `type:"string" required:"true"`
 
-	metadataGetChangeTokenStatusInput `json:"-" xml:"-"`
-}
-
-type metadataGetChangeTokenStatusInput struct {
-	SDKShapeTraits bool `type:"structure"`
+	_ struct{} `type:"structure"`
 }
 
 // String returns the string representation
@@ -2028,11 +1904,7 @@ type GetChangeTokenStatusOutput struct {
 	// The status of the change token.
 	ChangeTokenStatus *string `type:"string" enum:"ChangeTokenStatus"`
 
-	metadataGetChangeTokenStatusOutput `json:"-" xml:"-"`
-}
-
-type metadataGetChangeTokenStatusOutput struct {
-	SDKShapeTraits bool `type:"structure"`
+	_ struct{} `type:"structure"`
 }
 
 // String returns the string representation
@@ -2050,11 +1922,7 @@ type GetIPSetInput struct {
 	// and by ListIPSets.
 	IPSetId *string `min:"1" type:"string" required:"true"`
 
-	metadataGetIPSetInput `json:"-" xml:"-"`
-}
-
-type metadataGetIPSetInput struct {
-	SDKShapeTraits bool `type:"structure"`
+	_ struct{} `type:"structure"`
 }
 
 // String returns the string representation
@@ -2076,11 +1944,7 @@ type GetIPSetOutput struct {
 	// contains Type and Value
 	IPSet *IPSet `type:"structure"`
 
-	metadataGetIPSetOutput `json:"-" xml:"-"`
-}
-
-type metadataGetIPSetOutput struct {
-	SDKShapeTraits bool `type:"structure"`
+	_ struct{} `type:"structure"`
 }
 
 // String returns the string representation
@@ -2098,11 +1962,7 @@ type GetRuleInput struct {
 	// and by ListRules.
 	RuleId *string `min:"1" type:"string" required:"true"`
 
-	metadataGetRuleInput `json:"-" xml:"-"`
-}
-
-type metadataGetRuleInput struct {
-	SDKShapeTraits bool `type:"structure"`
+	_ struct{} `type:"structure"`
 }
 
 // String returns the string representation
@@ -2123,11 +1983,7 @@ type GetRuleOutput struct {
 	//   Predicate: Each Predicate object contains DataId, Negated, and Type
 	Rule *Rule `type:"structure"`
 
-	metadataGetRuleOutput `json:"-" xml:"-"`
-}
-
-type metadataGetRuleOutput struct {
-	SDKShapeTraits bool `type:"structure"`
+	_ struct{} `type:"structure"`
 }
 
 // String returns the string representation
@@ -2165,11 +2021,7 @@ type GetSampledRequestsInput struct {
 	// a sample of requests.
 	WebAclId *string `min:"1" type:"string" required:"true"`
 
-	metadataGetSampledRequestsInput `json:"-" xml:"-"`
-}
-
-type metadataGetSampledRequestsInput struct {
-	SDKShapeTraits bool `type:"structure"`
+	_ struct{} `type:"structure"`
 }
 
 // String returns the string representation
@@ -2198,11 +2050,7 @@ type GetSampledRequestsOutput struct {
 	// returns the time range for the first 5,000 requests.
 	TimeWindow *TimeWindow `type:"structure"`
 
-	metadataGetSampledRequestsOutput `json:"-" xml:"-"`
-}
-
-type metadataGetSampledRequestsOutput struct {
-	SDKShapeTraits bool `type:"structure"`
+	_ struct{} `type:"structure"`
 }
 
 // String returns the string representation
@@ -2221,11 +2069,7 @@ type GetSqlInjectionMatchSetInput struct {
 	// SqlInjectionMatchSetId is returned by CreateSqlInjectionMatchSet and by ListSqlInjectionMatchSets.
 	SqlInjectionMatchSetId *string `min:"1" type:"string" required:"true"`
 
-	metadataGetSqlInjectionMatchSetInput `json:"-" xml:"-"`
-}
-
-type metadataGetSqlInjectionMatchSetInput struct {
-	SDKShapeTraits bool `type:"structure"`
+	_ struct{} `type:"structure"`
 }
 
 // String returns the string representation
@@ -2249,11 +2093,7 @@ type GetSqlInjectionMatchSetOutput struct {
 	// Data and Type
 	SqlInjectionMatchSet *SqlInjectionMatchSet `type:"structure"`
 
-	metadataGetSqlInjectionMatchSetOutput `json:"-" xml:"-"`
-}
-
-type metadataGetSqlInjectionMatchSetOutput struct {
-	SDKShapeTraits bool `type:"structure"`
+	_ struct{} `type:"structure"`
 }
 
 // String returns the string representation
@@ -2271,11 +2111,7 @@ type GetWebACLInput struct {
 	// CreateWebACL and by ListWebACLs.
 	WebACLId *string `min:"1" type:"string" required:"true"`
 
-	metadataGetWebACLInput `json:"-" xml:"-"`
-}
-
-type metadataGetWebACLInput struct {
-	SDKShapeTraits bool `type:"structure"`
+	_ struct{} `type:"structure"`
 }
 
 // String returns the string representation
@@ -2298,11 +2134,7 @@ type GetWebACLOutput struct {
 	// and RuleId   Action: Contains Type
 	WebACL *WebACL `type:"structure"`
 
-	metadataGetWebACLOutput `json:"-" xml:"-"`
-}
-
-type metadataGetWebACLOutput struct {
-	SDKShapeTraits bool `type:"structure"`
+	_ struct{} `type:"structure"`
 }
 
 // String returns the string representation
@@ -2326,11 +2158,7 @@ type HTTPHeader struct {
 	// The value of one of the headers in the sampled web request.
 	Value *string `type:"string"`
 
-	metadataHTTPHeader `json:"-" xml:"-"`
-}
-
-type metadataHTTPHeader struct {
-	SDKShapeTraits bool `type:"structure"`
+	_ struct{} `type:"structure"`
 }
 
 // String returns the string representation
@@ -2375,11 +2203,7 @@ type HTTPRequest struct {
 	// The part of a web request that identifies the resource, for example, /images/daily-ad.jpg.
 	URI *string `type:"string"`
 
-	metadataHTTPRequest `json:"-" xml:"-"`
-}
-
-type metadataHTTPRequest struct {
-	SDKShapeTraits bool `type:"structure"`
+	_ struct{} `type:"structure"`
 }
 
 // String returns the string representation
@@ -2421,11 +2245,7 @@ type IPSet struct {
 	// an IPSet after you create it.
 	Name *string `min:"1" type:"string"`
 
-	metadataIPSet `json:"-" xml:"-"`
-}
-
-type metadataIPSet struct {
-	SDKShapeTraits bool `type:"structure"`
+	_ struct{} `type:"structure"`
 }
 
 // String returns the string representation
@@ -2456,11 +2276,7 @@ type IPSetDescriptor struct {
 	// Inter-Domain Routing (https://en.wikipedia.org/wiki/Classless_Inter-Domain_Routing).
 	Value *string `type:"string" required:"true"`
 
-	metadataIPSetDescriptor `json:"-" xml:"-"`
-}
-
-type metadataIPSetDescriptor struct {
-	SDKShapeTraits bool `type:"structure"`
+	_ struct{} `type:"structure"`
 }
 
 // String returns the string representation
@@ -2483,11 +2299,7 @@ type IPSetSummary struct {
 	// an IPSet after you create it.
 	Name *string `min:"1" type:"string" required:"true"`
 
-	metadataIPSetSummary `json:"-" xml:"-"`
-}
-
-type metadataIPSetSummary struct {
-	SDKShapeTraits bool `type:"structure"`
+	_ struct{} `type:"structure"`
 }
 
 // String returns the string representation
@@ -2509,11 +2321,7 @@ type IPSetUpdate struct {
 	// web requests originate from.
 	IPSetDescriptor *IPSetDescriptor `type:"structure" required:"true"`
 
-	metadataIPSetUpdate `json:"-" xml:"-"`
-}
-
-type metadataIPSetUpdate struct {
-	SDKShapeTraits bool `type:"structure"`
+	_ struct{} `type:"structure"`
 }
 
 // String returns the string representation
@@ -2540,11 +2348,7 @@ type ListByteMatchSetsInput struct {
 	// response to get information about another batch of ByteMatchSets.
 	NextMarker *string `min:"1" type:"string"`
 
-	metadataListByteMatchSetsInput `json:"-" xml:"-"`
-}
-
-type metadataListByteMatchSetsInput struct {
-	SDKShapeTraits bool `type:"structure"`
+	_ struct{} `type:"structure"`
 }
 
 // String returns the string representation
@@ -2568,11 +2372,7 @@ type ListByteMatchSetsOutput struct {
 	// the next request.
 	NextMarker *string `min:"1" type:"string"`
 
-	metadataListByteMatchSetsOutput `json:"-" xml:"-"`
-}
-
-type metadataListByteMatchSetsOutput struct {
-	SDKShapeTraits bool `type:"structure"`
+	_ struct{} `type:"structure"`
 }
 
 // String returns the string representation
@@ -2599,11 +2399,7 @@ type ListIPSetsInput struct {
 	// information about another batch of ByteMatchSets.
 	NextMarker *string `min:"1" type:"string"`
 
-	metadataListIPSetsInput `json:"-" xml:"-"`
-}
-
-type metadataListIPSetsInput struct {
-	SDKShapeTraits bool `type:"structure"`
+	_ struct{} `type:"structure"`
 }
 
 // String returns the string representation
@@ -2626,11 +2422,7 @@ type ListIPSetsOutput struct {
 	// from the response in the NextMarker value in the next request.
 	NextMarker *string `min:"1" type:"string"`
 
-	metadataListIPSetsOutput `json:"-" xml:"-"`
-}
-
-type metadataListIPSetsOutput struct {
-	SDKShapeTraits bool `type:"structure"`
+	_ struct{} `type:"structure"`
 }
 
 // String returns the string representation
@@ -2656,11 +2448,7 @@ type ListRulesInput struct {
 	// about another batch of Rules.
 	NextMarker *string `min:"1" type:"string"`
 
-	metadataListRulesInput `json:"-" xml:"-"`
-}
-
-type metadataListRulesInput struct {
-	SDKShapeTraits bool `type:"structure"`
+	_ struct{} `type:"structure"`
 }
 
 // String returns the string representation
@@ -2683,11 +2471,7 @@ type ListRulesOutput struct {
 	// An array of RuleSummary objects.
 	Rules []*RuleSummary `type:"list"`
 
-	metadataListRulesOutput `json:"-" xml:"-"`
-}
-
-type metadataListRulesOutput struct {
-	SDKShapeTraits bool `type:"structure"`
+	_ struct{} `type:"structure"`
 }
 
 // String returns the string representation
@@ -2716,11 +2500,7 @@ type ListSqlInjectionMatchSetsInput struct {
 	// from the previous response to get information about another batch of SqlInjectionMatchSets.
 	NextMarker *string `min:"1" type:"string"`
 
-	metadataListSqlInjectionMatchSetsInput `json:"-" xml:"-"`
-}
-
-type metadataListSqlInjectionMatchSetsInput struct {
-	SDKShapeTraits bool `type:"structure"`
+	_ struct{} `type:"structure"`
 }
 
 // String returns the string representation
@@ -2745,11 +2525,7 @@ type ListSqlInjectionMatchSetsOutput struct {
 	// An array of SqlInjectionMatchSetSummary objects.
 	SqlInjectionMatchSets []*SqlInjectionMatchSetSummary `type:"list"`
 
-	metadataListSqlInjectionMatchSetsOutput `json:"-" xml:"-"`
-}
-
-type metadataListSqlInjectionMatchSetsOutput struct {
-	SDKShapeTraits bool `type:"structure"`
+	_ struct{} `type:"structure"`
 }
 
 // String returns the string representation
@@ -2777,11 +2553,7 @@ type ListWebACLsInput struct {
 	// objects.
 	NextMarker *string `min:"1" type:"string"`
 
-	metadataListWebACLsInput `json:"-" xml:"-"`
-}
-
-type metadataListWebACLsInput struct {
-	SDKShapeTraits bool `type:"structure"`
+	_ struct{} `type:"structure"`
 }
 
 // String returns the string representation
@@ -2804,11 +2576,7 @@ type ListWebACLsOutput struct {
 	// An array of WebACLSummary objects.
 	WebACLs []*WebACLSummary `type:"list"`
 
-	metadataListWebACLsOutput `json:"-" xml:"-"`
-}
-
-type metadataListWebACLsOutput struct {
-	SDKShapeTraits bool `type:"structure"`
+	_ struct{} `type:"structure"`
 }
 
 // String returns the string representation
@@ -2844,11 +2612,7 @@ type Predicate struct {
 	// The type of predicate in a Rule, such as ByteMatchSet or IPSet.
 	Type *string `type:"string" required:"true" enum:"PredicateType"`
 
-	metadataPredicate `json:"-" xml:"-"`
-}
-
-type metadataPredicate struct {
-	SDKShapeTraits bool `type:"structure"`
+	_ struct{} `type:"structure"`
 }
 
 // String returns the string representation
@@ -2889,11 +2653,7 @@ type Rule struct {
 	// RuleId is returned by CreateRule and by ListRules.
 	RuleId *string `min:"1" type:"string" required:"true"`
 
-	metadataRule `json:"-" xml:"-"`
-}
-
-type metadataRule struct {
-	SDKShapeTraits bool `type:"structure"`
+	_ struct{} `type:"structure"`
 }
 
 // String returns the string representation
@@ -2920,11 +2680,7 @@ type RuleSummary struct {
 	// RuleId is returned by CreateRule and by ListRules.
 	RuleId *string `min:"1" type:"string" required:"true"`
 
-	metadataRuleSummary `json:"-" xml:"-"`
-}
-
-type metadataRuleSummary struct {
-	SDKShapeTraits bool `type:"structure"`
+	_ struct{} `type:"structure"`
 }
 
 // String returns the string representation
@@ -2947,11 +2703,7 @@ type RuleUpdate struct {
 	// The ID of the Predicate (such as an IPSet) that you want to add to a Rule.
 	Predicate *Predicate `type:"structure" required:"true"`
 
-	metadataRuleUpdate `json:"-" xml:"-"`
-}
-
-type metadataRuleUpdate struct {
-	SDKShapeTraits bool `type:"structure"`
+	_ struct{} `type:"structure"`
 }
 
 // String returns the string representation
@@ -2985,11 +2737,7 @@ type SampledHTTPRequest struct {
 	// of 1.
 	Weight *int64 `type:"long" required:"true"`
 
-	metadataSampledHTTPRequest `json:"-" xml:"-"`
-}
-
-type metadataSampledHTTPRequest struct {
-	SDKShapeTraits bool `type:"structure"`
+	_ struct{} `type:"structure"`
 }
 
 // String returns the string representation
@@ -3026,11 +2774,7 @@ type SqlInjectionMatchSet struct {
 	// of malicious SQL code.
 	SqlInjectionMatchTuples []*SqlInjectionMatchTuple `type:"list" required:"true"`
 
-	metadataSqlInjectionMatchSet `json:"-" xml:"-"`
-}
-
-type metadataSqlInjectionMatchSet struct {
-	SDKShapeTraits bool `type:"structure"`
+	_ struct{} `type:"structure"`
 }
 
 // String returns the string representation
@@ -3058,11 +2802,7 @@ type SqlInjectionMatchSetSummary struct {
 	// ListSqlInjectionMatchSets.
 	SqlInjectionMatchSetId *string `min:"1" type:"string" required:"true"`
 
-	metadataSqlInjectionMatchSetSummary `json:"-" xml:"-"`
-}
-
-type metadataSqlInjectionMatchSetSummary struct {
-	SDKShapeTraits bool `type:"structure"`
+	_ struct{} `type:"structure"`
 }
 
 // String returns the string representation
@@ -3088,11 +2828,7 @@ type SqlInjectionMatchSetUpdate struct {
 	// the name of the header.
 	SqlInjectionMatchTuple *SqlInjectionMatchTuple `type:"structure" required:"true"`
 
-	metadataSqlInjectionMatchSetUpdate `json:"-" xml:"-"`
-}
-
-type metadataSqlInjectionMatchSetUpdate struct {
-	SDKShapeTraits bool `type:"structure"`
+	_ struct{} `type:"structure"`
 }
 
 // String returns the string representation
@@ -3159,11 +2895,7 @@ type SqlInjectionMatchTuple struct {
 	// Specify NONE if you don't want to perform any text transformations.
 	TextTransformation *string `type:"string" required:"true" enum:"TextTransformation"`
 
-	metadataSqlInjectionMatchTuple `json:"-" xml:"-"`
-}
-
-type metadataSqlInjectionMatchTuple struct {
-	SDKShapeTraits bool `type:"structure"`
+	_ struct{} `type:"structure"`
 }
 
 // String returns the string representation
@@ -3197,11 +2929,7 @@ type TimeWindow struct {
 	// specify any time range in the previous three hours.
 	StartTime *time.Time `type:"timestamp" timestampFormat:"unix" required:"true"`
 
-	metadataTimeWindow `json:"-" xml:"-"`
-}
-
-type metadataTimeWindow struct {
-	SDKShapeTraits bool `type:"structure"`
+	_ struct{} `type:"structure"`
 }
 
 // String returns the string representation
@@ -3230,11 +2958,7 @@ type UpdateByteMatchSetInput struct {
 	//   FieldToMatch: Contains Data and Type
 	Updates []*ByteMatchSetUpdate `type:"list" required:"true"`
 
-	metadataUpdateByteMatchSetInput `json:"-" xml:"-"`
-}
-
-type metadataUpdateByteMatchSetInput struct {
-	SDKShapeTraits bool `type:"structure"`
+	_ struct{} `type:"structure"`
 }
 
 // String returns the string representation
@@ -3253,11 +2977,7 @@ type UpdateByteMatchSetOutput struct {
 	// see GetChangeTokenStatus.
 	ChangeToken *string `type:"string"`
 
-	metadataUpdateByteMatchSetOutput `json:"-" xml:"-"`
-}
-
-type metadataUpdateByteMatchSetOutput struct {
-	SDKShapeTraits bool `type:"structure"`
+	_ struct{} `type:"structure"`
 }
 
 // String returns the string representation
@@ -3285,11 +3005,7 @@ type UpdateIPSetInput struct {
 	// Type and Value
 	Updates []*IPSetUpdate `type:"list" required:"true"`
 
-	metadataUpdateIPSetInput `json:"-" xml:"-"`
-}
-
-type metadataUpdateIPSetInput struct {
-	SDKShapeTraits bool `type:"structure"`
+	_ struct{} `type:"structure"`
 }
 
 // String returns the string representation
@@ -3308,11 +3024,7 @@ type UpdateIPSetOutput struct {
 	// see GetChangeTokenStatus.
 	ChangeToken *string `type:"string"`
 
-	metadataUpdateIPSetOutput `json:"-" xml:"-"`
-}
-
-type metadataUpdateIPSetOutput struct {
-	SDKShapeTraits bool `type:"structure"`
+	_ struct{} `type:"structure"`
 }
 
 // String returns the string representation
@@ -3340,11 +3052,7 @@ type UpdateRuleInput struct {
 	// Negated, and Type   FieldToMatch: Contains Data and Type
 	Updates []*RuleUpdate `type:"list" required:"true"`
 
-	metadataUpdateRuleInput `json:"-" xml:"-"`
-}
-
-type metadataUpdateRuleInput struct {
-	SDKShapeTraits bool `type:"structure"`
+	_ struct{} `type:"structure"`
 }
 
 // String returns the string representation
@@ -3363,11 +3071,7 @@ type UpdateRuleOutput struct {
 	// see GetChangeTokenStatus.
 	ChangeToken *string `type:"string"`
 
-	metadataUpdateRuleOutput `json:"-" xml:"-"`
-}
-
-type metadataUpdateRuleOutput struct {
-	SDKShapeTraits bool `type:"structure"`
+	_ struct{} `type:"structure"`
 }
 
 // String returns the string representation
@@ -3398,11 +3102,7 @@ type UpdateSqlInjectionMatchSetInput struct {
 	// FieldToMatch: Contains Data and Type
 	Updates []*SqlInjectionMatchSetUpdate `type:"list" required:"true"`
 
-	metadataUpdateSqlInjectionMatchSetInput `json:"-" xml:"-"`
-}
-
-type metadataUpdateSqlInjectionMatchSetInput struct {
-	SDKShapeTraits bool `type:"structure"`
+	_ struct{} `type:"structure"`
 }
 
 // String returns the string representation
@@ -3422,11 +3122,7 @@ type UpdateSqlInjectionMatchSetOutput struct {
 	// information, see GetChangeTokenStatus.
 	ChangeToken *string `type:"string"`
 
-	metadataUpdateSqlInjectionMatchSetOutput `json:"-" xml:"-"`
-}
-
-type metadataUpdateSqlInjectionMatchSetOutput struct {
-	SDKShapeTraits bool `type:"structure"`
+	_ struct{} `type:"structure"`
 }
 
 // String returns the string representation
@@ -3463,11 +3159,7 @@ type UpdateWebACLInput struct {
 	// by CreateWebACL and by ListWebACLs.
 	WebACLId *string `min:"1" type:"string" required:"true"`
 
-	metadataUpdateWebACLInput `json:"-" xml:"-"`
-}
-
-type metadataUpdateWebACLInput struct {
-	SDKShapeTraits bool `type:"structure"`
+	_ struct{} `type:"structure"`
 }
 
 // String returns the string representation
@@ -3486,11 +3178,7 @@ type UpdateWebACLOutput struct {
 	// see GetChangeTokenStatus.
 	ChangeToken *string `type:"string"`
 
-	metadataUpdateWebACLOutput `json:"-" xml:"-"`
-}
-
-type metadataUpdateWebACLOutput struct {
-	SDKShapeTraits bool `type:"structure"`
+	_ struct{} `type:"structure"`
 }
 
 // String returns the string representation
@@ -3519,11 +3207,7 @@ type WafAction struct {
 	// for a WebACL.
 	Type *string `type:"string" required:"true" enum:"WafActionType"`
 
-	metadataWafAction `json:"-" xml:"-"`
-}
-
-type metadataWafAction struct {
-	SDKShapeTraits bool `type:"structure"`
+	_ struct{} `type:"structure"`
 }
 
 // String returns the string representation
@@ -3566,11 +3250,7 @@ type WebACL struct {
 	// WebACLId is returned by CreateWebACL and by ListWebACLs.
 	WebACLId *string `min:"1" type:"string" required:"true"`
 
-	metadataWebACL `json:"-" xml:"-"`
-}
-
-type metadataWebACL struct {
-	SDKShapeTraits bool `type:"structure"`
+	_ struct{} `type:"structure"`
 }
 
 // String returns the string representation
@@ -3596,11 +3276,7 @@ type WebACLSummary struct {
 	// WebACLId is returned by CreateWebACL and by ListWebACLs.
 	WebACLId *string `min:"1" type:"string" required:"true"`
 
-	metadataWebACLSummary `json:"-" xml:"-"`
-}
-
-type metadataWebACLSummary struct {
-	SDKShapeTraits bool `type:"structure"`
+	_ struct{} `type:"structure"`
 }
 
 // String returns the string representation
@@ -3627,11 +3303,7 @@ type WebACLUpdate struct {
 	// in the WebACLUpdate data type.
 	ActivatedRule *ActivatedRule `type:"structure" required:"true"`
 
-	metadataWebACLUpdate `json:"-" xml:"-"`
-}
-
-type metadataWebACLUpdate struct {
-	SDKShapeTraits bool `type:"structure"`
+	_ struct{} `type:"structure"`
 }
 
 // String returns the string representation

--- a/service/workspaces/api.go
+++ b/service/workspaces/api.go
@@ -297,10 +297,10 @@ func (c *WorkSpaces) TerminateWorkspaces(input *TerminateWorkspacesInput) (*Term
 
 // Contains information about the compute type of a WorkSpace bundle.
 type ComputeType struct {
+	_ struct{} `type:"structure"`
+
 	// The name of the compute type for the bundle.
 	Name *string `type:"string" enum:"Compute"`
-
-	_ struct{} `type:"structure"`
 }
 
 // String returns the string representation
@@ -315,10 +315,10 @@ func (s ComputeType) GoString() string {
 
 // Contains the inputs for the CreateWorkspaces operation.
 type CreateWorkspacesInput struct {
+	_ struct{} `type:"structure"`
+
 	// An array of structures that specify the WorkSpaces to create.
 	Workspaces []*WorkspaceRequest `min:"1" type:"list" required:"true"`
-
-	_ struct{} `type:"structure"`
 }
 
 // String returns the string representation
@@ -333,6 +333,8 @@ func (s CreateWorkspacesInput) GoString() string {
 
 // Contains the result of the CreateWorkspaces operation.
 type CreateWorkspacesOutput struct {
+	_ struct{} `type:"structure"`
+
 	// An array of structures that represent the WorkSpaces that could not be created.
 	FailedRequests []*FailedCreateWorkspaceRequest `type:"list"`
 
@@ -342,8 +344,6 @@ type CreateWorkspacesOutput struct {
 	// not immediately available. If you immediately call DescribeWorkspaces with
 	// this identifier, no information will be returned.
 	PendingRequests []*Workspace `type:"list"`
-
-	_ struct{} `type:"structure"`
 }
 
 // String returns the string representation
@@ -358,6 +358,8 @@ func (s CreateWorkspacesOutput) GoString() string {
 
 // Contains default WorkSpace creation information.
 type DefaultWorkspaceCreationProperties struct {
+	_ struct{} `type:"structure"`
+
 	// The identifier of any custom security groups that are applied to the WorkSpaces
 	// when they are created.
 	CustomSecurityGroupId *string `type:"string"`
@@ -375,8 +377,6 @@ type DefaultWorkspaceCreationProperties struct {
 
 	// The WorkSpace user is an administrator on the WorkSpace.
 	UserEnabledAsLocalAdministrator *bool `type:"boolean"`
-
-	_ struct{} `type:"structure"`
 }
 
 // String returns the string representation
@@ -391,6 +391,8 @@ func (s DefaultWorkspaceCreationProperties) GoString() string {
 
 // Contains the inputs for the DescribeWorkspaceBundles operation.
 type DescribeWorkspaceBundlesInput struct {
+	_ struct{} `type:"structure"`
+
 	// An array of strings that contains the identifiers of the bundles to retrieve.
 	// This parameter cannot be combined with any other filter parameter.
 	BundleIds []*string `min:"1" type:"list"`
@@ -407,8 +409,6 @@ type DescribeWorkspaceBundlesInput struct {
 	//  null - Retrieves the bundles that belong to the account making the call.
 	//  AMAZON - Retrieves the bundles that are provided by AWS.
 	Owner *string `type:"string"`
-
-	_ struct{} `type:"structure"`
 }
 
 // String returns the string representation
@@ -423,6 +423,8 @@ func (s DescribeWorkspaceBundlesInput) GoString() string {
 
 // Contains the results of the DescribeWorkspaceBundles operation.
 type DescribeWorkspaceBundlesOutput struct {
+	_ struct{} `type:"structure"`
+
 	// An array of structures that contain information about the bundles.
 	Bundles []*WorkspaceBundle `type:"list"`
 
@@ -430,8 +432,6 @@ type DescribeWorkspaceBundlesOutput struct {
 	// parameter in a subsequent call to this operation to retrieve the next set
 	// of items. This token is valid for one day and must be used within that timeframe.
 	NextToken *string `min:"1" type:"string"`
-
-	_ struct{} `type:"structure"`
 }
 
 // String returns the string representation
@@ -446,6 +446,8 @@ func (s DescribeWorkspaceBundlesOutput) GoString() string {
 
 // Contains the inputs for the DescribeWorkspaceDirectories operation.
 type DescribeWorkspaceDirectoriesInput struct {
+	_ struct{} `type:"structure"`
+
 	// An array of strings that contains the directory identifiers to retrieve information
 	// for. If this member is null, all directories are retrieved.
 	DirectoryIds []*string `min:"1" type:"list"`
@@ -453,8 +455,6 @@ type DescribeWorkspaceDirectoriesInput struct {
 	// The NextToken value from a previous call to this operation. Pass null if
 	// this is the first call.
 	NextToken *string `min:"1" type:"string"`
-
-	_ struct{} `type:"structure"`
 }
 
 // String returns the string representation
@@ -469,6 +469,8 @@ func (s DescribeWorkspaceDirectoriesInput) GoString() string {
 
 // Contains the results of the DescribeWorkspaceDirectories operation.
 type DescribeWorkspaceDirectoriesOutput struct {
+	_ struct{} `type:"structure"`
+
 	// An array of structures that contain information about the directories.
 	Directories []*WorkspaceDirectory `type:"list"`
 
@@ -476,8 +478,6 @@ type DescribeWorkspaceDirectoriesOutput struct {
 	// parameter in a subsequent call to this operation to retrieve the next set
 	// of items. This token is valid for one day and must be used within that timeframe.
 	NextToken *string `min:"1" type:"string"`
-
-	_ struct{} `type:"structure"`
 }
 
 // String returns the string representation
@@ -492,6 +492,8 @@ func (s DescribeWorkspaceDirectoriesOutput) GoString() string {
 
 // Contains the inputs for the DescribeWorkspaces operation.
 type DescribeWorkspacesInput struct {
+	_ struct{} `type:"structure"`
+
 	// The identifier of a bundle to obtain the WorkSpaces for. All WorkSpaces that
 	// are created from this bundle will be retrieved. This parameter cannot be
 	// combined with any other filter parameter.
@@ -521,8 +523,6 @@ type DescribeWorkspacesInput struct {
 	// by CreateWorkspaces is not immediately available. If you immediately call
 	// DescribeWorkspaces with this identifier, no information will be returned.
 	WorkspaceIds []*string `min:"1" type:"list"`
-
-	_ struct{} `type:"structure"`
 }
 
 // String returns the string representation
@@ -537,6 +537,8 @@ func (s DescribeWorkspacesInput) GoString() string {
 
 // Contains the results for the DescribeWorkspaces operation.
 type DescribeWorkspacesOutput struct {
+	_ struct{} `type:"structure"`
+
 	// If not null, more results are available. Pass this value for the NextToken
 	// parameter in a subsequent call to this operation to retrieve the next set
 	// of items. This token is valid for one day and must be used within that timeframe.
@@ -547,8 +549,6 @@ type DescribeWorkspacesOutput struct {
 	// Because the CreateWorkspaces operation is asynchronous, some of this information
 	// may be incomplete for a newly-created WorkSpace.
 	Workspaces []*Workspace `type:"list"`
-
-	_ struct{} `type:"structure"`
 }
 
 // String returns the string representation
@@ -563,6 +563,8 @@ func (s DescribeWorkspacesOutput) GoString() string {
 
 // Contains information about a WorkSpace that could not be created.
 type FailedCreateWorkspaceRequest struct {
+	_ struct{} `type:"structure"`
+
 	// The error code.
 	ErrorCode *string `type:"string"`
 
@@ -572,8 +574,6 @@ type FailedCreateWorkspaceRequest struct {
 	// A WorkspaceRequest object that contains the information about the WorkSpace
 	// that could not be created.
 	WorkspaceRequest *WorkspaceRequest `type:"structure"`
-
-	_ struct{} `type:"structure"`
 }
 
 // String returns the string representation
@@ -589,6 +589,8 @@ func (s FailedCreateWorkspaceRequest) GoString() string {
 // Contains information about a WorkSpace that could not be rebooted (RebootWorkspaces),
 // rebuilt (RebuildWorkspaces), or terminated (TerminateWorkspaces).
 type FailedWorkspaceChangeRequest struct {
+	_ struct{} `type:"structure"`
+
 	// The error code.
 	ErrorCode *string `type:"string"`
 
@@ -597,8 +599,6 @@ type FailedWorkspaceChangeRequest struct {
 
 	// The identifier of the WorkSpace.
 	WorkspaceId *string `type:"string"`
-
-	_ struct{} `type:"structure"`
 }
 
 // String returns the string representation
@@ -614,10 +614,10 @@ func (s FailedWorkspaceChangeRequest) GoString() string {
 // Contains information used with the RebootWorkspaces operation to reboot a
 // WorkSpace.
 type RebootRequest struct {
+	_ struct{} `type:"structure"`
+
 	// The identifier of the WorkSpace to reboot.
 	WorkspaceId *string `type:"string" required:"true"`
-
-	_ struct{} `type:"structure"`
 }
 
 // String returns the string representation
@@ -632,10 +632,10 @@ func (s RebootRequest) GoString() string {
 
 // Contains the inputs for the RebootWorkspaces operation.
 type RebootWorkspacesInput struct {
+	_ struct{} `type:"structure"`
+
 	// An array of structures that specify the WorkSpaces to reboot.
 	RebootWorkspaceRequests []*RebootRequest `min:"1" type:"list" required:"true"`
-
-	_ struct{} `type:"structure"`
 }
 
 // String returns the string representation
@@ -650,10 +650,10 @@ func (s RebootWorkspacesInput) GoString() string {
 
 // Contains the results of the RebootWorkspaces operation.
 type RebootWorkspacesOutput struct {
+	_ struct{} `type:"structure"`
+
 	// An array of structures that represent any WorkSpaces that could not be rebooted.
 	FailedRequests []*FailedWorkspaceChangeRequest `type:"list"`
-
-	_ struct{} `type:"structure"`
 }
 
 // String returns the string representation
@@ -669,10 +669,10 @@ func (s RebootWorkspacesOutput) GoString() string {
 // Contains information used with the RebuildWorkspaces operation to rebuild
 // a WorkSpace.
 type RebuildRequest struct {
+	_ struct{} `type:"structure"`
+
 	// The identifier of the WorkSpace to rebuild.
 	WorkspaceId *string `type:"string" required:"true"`
-
-	_ struct{} `type:"structure"`
 }
 
 // String returns the string representation
@@ -687,10 +687,10 @@ func (s RebuildRequest) GoString() string {
 
 // Contains the inputs for the RebuildWorkspaces operation.
 type RebuildWorkspacesInput struct {
+	_ struct{} `type:"structure"`
+
 	// An array of structures that specify the WorkSpaces to rebuild.
 	RebuildWorkspaceRequests []*RebuildRequest `min:"1" type:"list" required:"true"`
-
-	_ struct{} `type:"structure"`
 }
 
 // String returns the string representation
@@ -705,10 +705,10 @@ func (s RebuildWorkspacesInput) GoString() string {
 
 // Contains the results of the RebuildWorkspaces operation.
 type RebuildWorkspacesOutput struct {
+	_ struct{} `type:"structure"`
+
 	// An array of structures that represent any WorkSpaces that could not be rebuilt.
 	FailedRequests []*FailedWorkspaceChangeRequest `type:"list"`
-
-	_ struct{} `type:"structure"`
 }
 
 // String returns the string representation
@@ -724,10 +724,10 @@ func (s RebuildWorkspacesOutput) GoString() string {
 // Contains information used with the TerminateWorkspaces operation to terminate
 // a WorkSpace.
 type TerminateRequest struct {
+	_ struct{} `type:"structure"`
+
 	// The identifier of the WorkSpace to terminate.
 	WorkspaceId *string `type:"string" required:"true"`
-
-	_ struct{} `type:"structure"`
 }
 
 // String returns the string representation
@@ -742,10 +742,10 @@ func (s TerminateRequest) GoString() string {
 
 // Contains the inputs for the TerminateWorkspaces operation.
 type TerminateWorkspacesInput struct {
+	_ struct{} `type:"structure"`
+
 	// An array of structures that specify the WorkSpaces to terminate.
 	TerminateWorkspaceRequests []*TerminateRequest `min:"1" type:"list" required:"true"`
-
-	_ struct{} `type:"structure"`
 }
 
 // String returns the string representation
@@ -760,10 +760,10 @@ func (s TerminateWorkspacesInput) GoString() string {
 
 // Contains the results of the TerminateWorkspaces operation.
 type TerminateWorkspacesOutput struct {
+	_ struct{} `type:"structure"`
+
 	// An array of structures that represent any WorkSpaces that could not be terminated.
 	FailedRequests []*FailedWorkspaceChangeRequest `type:"list"`
-
-	_ struct{} `type:"structure"`
 }
 
 // String returns the string representation
@@ -778,10 +778,10 @@ func (s TerminateWorkspacesOutput) GoString() string {
 
 // Contains information about the user storage for a WorkSpace bundle.
 type UserStorage struct {
+	_ struct{} `type:"structure"`
+
 	// The amount of user storage for the bundle.
 	Capacity *string `min:"1" type:"string"`
-
-	_ struct{} `type:"structure"`
 }
 
 // String returns the string representation
@@ -796,6 +796,8 @@ func (s UserStorage) GoString() string {
 
 // Contains information about a WorkSpace.
 type Workspace struct {
+	_ struct{} `type:"structure"`
+
 	// The identifier of the bundle that the WorkSpace was created from.
 	BundleId *string `type:"string"`
 
@@ -836,8 +838,6 @@ type Workspace struct {
 
 	// The identifier of the WorkSpace.
 	WorkspaceId *string `type:"string"`
-
-	_ struct{} `type:"structure"`
 }
 
 // String returns the string representation
@@ -852,6 +852,8 @@ func (s Workspace) GoString() string {
 
 // Contains information about a WorkSpace bundle.
 type WorkspaceBundle struct {
+	_ struct{} `type:"structure"`
+
 	// The bundle identifier.
 	BundleId *string `type:"string"`
 
@@ -871,8 +873,6 @@ type WorkspaceBundle struct {
 	// A UserStorage object that specifies the amount of user storage that the bundle
 	// contains.
 	UserStorage *UserStorage `type:"structure"`
-
-	_ struct{} `type:"structure"`
 }
 
 // String returns the string representation
@@ -888,6 +888,8 @@ func (s WorkspaceBundle) GoString() string {
 // Contains information about an AWS Directory Service directory for use with
 // Amazon WorkSpaces.
 type WorkspaceDirectory struct {
+	_ struct{} `type:"structure"`
+
 	// The directory alias.
 	Alias *string `type:"string"`
 
@@ -928,8 +930,6 @@ type WorkspaceDirectory struct {
 
 	// The identifier of the security group that is assigned to new WorkSpaces.
 	WorkspaceSecurityGroupId *string `type:"string"`
-
-	_ struct{} `type:"structure"`
 }
 
 // String returns the string representation
@@ -944,6 +944,8 @@ func (s WorkspaceDirectory) GoString() string {
 
 // Contains information about a WorkSpace creation request.
 type WorkspaceRequest struct {
+	_ struct{} `type:"structure"`
+
 	// The identifier of the bundle to create the WorkSpace from. You can use the
 	// DescribeWorkspaceBundles operation to obtain a list of the bundles that are
 	// available.
@@ -966,8 +968,6 @@ type WorkspaceRequest struct {
 
 	// The KMS key used to encrypt data stored on your WorkSpace.
 	VolumeEncryptionKey *string `type:"string"`
-
-	_ struct{} `type:"structure"`
 }
 
 // String returns the string representation

--- a/service/workspaces/api.go
+++ b/service/workspaces/api.go
@@ -300,11 +300,7 @@ type ComputeType struct {
 	// The name of the compute type for the bundle.
 	Name *string `type:"string" enum:"Compute"`
 
-	metadataComputeType `json:"-" xml:"-"`
-}
-
-type metadataComputeType struct {
-	SDKShapeTraits bool `type:"structure"`
+	_ struct{} `type:"structure"`
 }
 
 // String returns the string representation
@@ -322,11 +318,7 @@ type CreateWorkspacesInput struct {
 	// An array of structures that specify the WorkSpaces to create.
 	Workspaces []*WorkspaceRequest `min:"1" type:"list" required:"true"`
 
-	metadataCreateWorkspacesInput `json:"-" xml:"-"`
-}
-
-type metadataCreateWorkspacesInput struct {
-	SDKShapeTraits bool `type:"structure"`
+	_ struct{} `type:"structure"`
 }
 
 // String returns the string representation
@@ -351,11 +343,7 @@ type CreateWorkspacesOutput struct {
 	// this identifier, no information will be returned.
 	PendingRequests []*Workspace `type:"list"`
 
-	metadataCreateWorkspacesOutput `json:"-" xml:"-"`
-}
-
-type metadataCreateWorkspacesOutput struct {
-	SDKShapeTraits bool `type:"structure"`
+	_ struct{} `type:"structure"`
 }
 
 // String returns the string representation
@@ -388,11 +376,7 @@ type DefaultWorkspaceCreationProperties struct {
 	// The WorkSpace user is an administrator on the WorkSpace.
 	UserEnabledAsLocalAdministrator *bool `type:"boolean"`
 
-	metadataDefaultWorkspaceCreationProperties `json:"-" xml:"-"`
-}
-
-type metadataDefaultWorkspaceCreationProperties struct {
-	SDKShapeTraits bool `type:"structure"`
+	_ struct{} `type:"structure"`
 }
 
 // String returns the string representation
@@ -424,11 +408,7 @@ type DescribeWorkspaceBundlesInput struct {
 	//  AMAZON - Retrieves the bundles that are provided by AWS.
 	Owner *string `type:"string"`
 
-	metadataDescribeWorkspaceBundlesInput `json:"-" xml:"-"`
-}
-
-type metadataDescribeWorkspaceBundlesInput struct {
-	SDKShapeTraits bool `type:"structure"`
+	_ struct{} `type:"structure"`
 }
 
 // String returns the string representation
@@ -451,11 +431,7 @@ type DescribeWorkspaceBundlesOutput struct {
 	// of items. This token is valid for one day and must be used within that timeframe.
 	NextToken *string `min:"1" type:"string"`
 
-	metadataDescribeWorkspaceBundlesOutput `json:"-" xml:"-"`
-}
-
-type metadataDescribeWorkspaceBundlesOutput struct {
-	SDKShapeTraits bool `type:"structure"`
+	_ struct{} `type:"structure"`
 }
 
 // String returns the string representation
@@ -478,11 +454,7 @@ type DescribeWorkspaceDirectoriesInput struct {
 	// this is the first call.
 	NextToken *string `min:"1" type:"string"`
 
-	metadataDescribeWorkspaceDirectoriesInput `json:"-" xml:"-"`
-}
-
-type metadataDescribeWorkspaceDirectoriesInput struct {
-	SDKShapeTraits bool `type:"structure"`
+	_ struct{} `type:"structure"`
 }
 
 // String returns the string representation
@@ -505,11 +477,7 @@ type DescribeWorkspaceDirectoriesOutput struct {
 	// of items. This token is valid for one day and must be used within that timeframe.
 	NextToken *string `min:"1" type:"string"`
 
-	metadataDescribeWorkspaceDirectoriesOutput `json:"-" xml:"-"`
-}
-
-type metadataDescribeWorkspaceDirectoriesOutput struct {
-	SDKShapeTraits bool `type:"structure"`
+	_ struct{} `type:"structure"`
 }
 
 // String returns the string representation
@@ -554,11 +522,7 @@ type DescribeWorkspacesInput struct {
 	// DescribeWorkspaces with this identifier, no information will be returned.
 	WorkspaceIds []*string `min:"1" type:"list"`
 
-	metadataDescribeWorkspacesInput `json:"-" xml:"-"`
-}
-
-type metadataDescribeWorkspacesInput struct {
-	SDKShapeTraits bool `type:"structure"`
+	_ struct{} `type:"structure"`
 }
 
 // String returns the string representation
@@ -584,11 +548,7 @@ type DescribeWorkspacesOutput struct {
 	// may be incomplete for a newly-created WorkSpace.
 	Workspaces []*Workspace `type:"list"`
 
-	metadataDescribeWorkspacesOutput `json:"-" xml:"-"`
-}
-
-type metadataDescribeWorkspacesOutput struct {
-	SDKShapeTraits bool `type:"structure"`
+	_ struct{} `type:"structure"`
 }
 
 // String returns the string representation
@@ -613,11 +573,7 @@ type FailedCreateWorkspaceRequest struct {
 	// that could not be created.
 	WorkspaceRequest *WorkspaceRequest `type:"structure"`
 
-	metadataFailedCreateWorkspaceRequest `json:"-" xml:"-"`
-}
-
-type metadataFailedCreateWorkspaceRequest struct {
-	SDKShapeTraits bool `type:"structure"`
+	_ struct{} `type:"structure"`
 }
 
 // String returns the string representation
@@ -642,11 +598,7 @@ type FailedWorkspaceChangeRequest struct {
 	// The identifier of the WorkSpace.
 	WorkspaceId *string `type:"string"`
 
-	metadataFailedWorkspaceChangeRequest `json:"-" xml:"-"`
-}
-
-type metadataFailedWorkspaceChangeRequest struct {
-	SDKShapeTraits bool `type:"structure"`
+	_ struct{} `type:"structure"`
 }
 
 // String returns the string representation
@@ -665,11 +617,7 @@ type RebootRequest struct {
 	// The identifier of the WorkSpace to reboot.
 	WorkspaceId *string `type:"string" required:"true"`
 
-	metadataRebootRequest `json:"-" xml:"-"`
-}
-
-type metadataRebootRequest struct {
-	SDKShapeTraits bool `type:"structure"`
+	_ struct{} `type:"structure"`
 }
 
 // String returns the string representation
@@ -687,11 +635,7 @@ type RebootWorkspacesInput struct {
 	// An array of structures that specify the WorkSpaces to reboot.
 	RebootWorkspaceRequests []*RebootRequest `min:"1" type:"list" required:"true"`
 
-	metadataRebootWorkspacesInput `json:"-" xml:"-"`
-}
-
-type metadataRebootWorkspacesInput struct {
-	SDKShapeTraits bool `type:"structure"`
+	_ struct{} `type:"structure"`
 }
 
 // String returns the string representation
@@ -709,11 +653,7 @@ type RebootWorkspacesOutput struct {
 	// An array of structures that represent any WorkSpaces that could not be rebooted.
 	FailedRequests []*FailedWorkspaceChangeRequest `type:"list"`
 
-	metadataRebootWorkspacesOutput `json:"-" xml:"-"`
-}
-
-type metadataRebootWorkspacesOutput struct {
-	SDKShapeTraits bool `type:"structure"`
+	_ struct{} `type:"structure"`
 }
 
 // String returns the string representation
@@ -732,11 +672,7 @@ type RebuildRequest struct {
 	// The identifier of the WorkSpace to rebuild.
 	WorkspaceId *string `type:"string" required:"true"`
 
-	metadataRebuildRequest `json:"-" xml:"-"`
-}
-
-type metadataRebuildRequest struct {
-	SDKShapeTraits bool `type:"structure"`
+	_ struct{} `type:"structure"`
 }
 
 // String returns the string representation
@@ -754,11 +690,7 @@ type RebuildWorkspacesInput struct {
 	// An array of structures that specify the WorkSpaces to rebuild.
 	RebuildWorkspaceRequests []*RebuildRequest `min:"1" type:"list" required:"true"`
 
-	metadataRebuildWorkspacesInput `json:"-" xml:"-"`
-}
-
-type metadataRebuildWorkspacesInput struct {
-	SDKShapeTraits bool `type:"structure"`
+	_ struct{} `type:"structure"`
 }
 
 // String returns the string representation
@@ -776,11 +708,7 @@ type RebuildWorkspacesOutput struct {
 	// An array of structures that represent any WorkSpaces that could not be rebuilt.
 	FailedRequests []*FailedWorkspaceChangeRequest `type:"list"`
 
-	metadataRebuildWorkspacesOutput `json:"-" xml:"-"`
-}
-
-type metadataRebuildWorkspacesOutput struct {
-	SDKShapeTraits bool `type:"structure"`
+	_ struct{} `type:"structure"`
 }
 
 // String returns the string representation
@@ -799,11 +727,7 @@ type TerminateRequest struct {
 	// The identifier of the WorkSpace to terminate.
 	WorkspaceId *string `type:"string" required:"true"`
 
-	metadataTerminateRequest `json:"-" xml:"-"`
-}
-
-type metadataTerminateRequest struct {
-	SDKShapeTraits bool `type:"structure"`
+	_ struct{} `type:"structure"`
 }
 
 // String returns the string representation
@@ -821,11 +745,7 @@ type TerminateWorkspacesInput struct {
 	// An array of structures that specify the WorkSpaces to terminate.
 	TerminateWorkspaceRequests []*TerminateRequest `min:"1" type:"list" required:"true"`
 
-	metadataTerminateWorkspacesInput `json:"-" xml:"-"`
-}
-
-type metadataTerminateWorkspacesInput struct {
-	SDKShapeTraits bool `type:"structure"`
+	_ struct{} `type:"structure"`
 }
 
 // String returns the string representation
@@ -843,11 +763,7 @@ type TerminateWorkspacesOutput struct {
 	// An array of structures that represent any WorkSpaces that could not be terminated.
 	FailedRequests []*FailedWorkspaceChangeRequest `type:"list"`
 
-	metadataTerminateWorkspacesOutput `json:"-" xml:"-"`
-}
-
-type metadataTerminateWorkspacesOutput struct {
-	SDKShapeTraits bool `type:"structure"`
+	_ struct{} `type:"structure"`
 }
 
 // String returns the string representation
@@ -865,11 +781,7 @@ type UserStorage struct {
 	// The amount of user storage for the bundle.
 	Capacity *string `min:"1" type:"string"`
 
-	metadataUserStorage `json:"-" xml:"-"`
-}
-
-type metadataUserStorage struct {
-	SDKShapeTraits bool `type:"structure"`
+	_ struct{} `type:"structure"`
 }
 
 // String returns the string representation
@@ -925,11 +837,7 @@ type Workspace struct {
 	// The identifier of the WorkSpace.
 	WorkspaceId *string `type:"string"`
 
-	metadataWorkspace `json:"-" xml:"-"`
-}
-
-type metadataWorkspace struct {
-	SDKShapeTraits bool `type:"structure"`
+	_ struct{} `type:"structure"`
 }
 
 // String returns the string representation
@@ -964,11 +872,7 @@ type WorkspaceBundle struct {
 	// contains.
 	UserStorage *UserStorage `type:"structure"`
 
-	metadataWorkspaceBundle `json:"-" xml:"-"`
-}
-
-type metadataWorkspaceBundle struct {
-	SDKShapeTraits bool `type:"structure"`
+	_ struct{} `type:"structure"`
 }
 
 // String returns the string representation
@@ -1025,11 +929,7 @@ type WorkspaceDirectory struct {
 	// The identifier of the security group that is assigned to new WorkSpaces.
 	WorkspaceSecurityGroupId *string `type:"string"`
 
-	metadataWorkspaceDirectory `json:"-" xml:"-"`
-}
-
-type metadataWorkspaceDirectory struct {
-	SDKShapeTraits bool `type:"structure"`
+	_ struct{} `type:"structure"`
 }
 
 // String returns the string representation
@@ -1067,11 +967,7 @@ type WorkspaceRequest struct {
 	// The KMS key used to encrypt data stored on your WorkSpace.
 	VolumeEncryptionKey *string `type:"string"`
 
-	metadataWorkspaceRequest `json:"-" xml:"-"`
-}
-
-type metadataWorkspaceRequest struct {
-	SDKShapeTraits bool `type:"structure"`
+	_ struct{} `type:"structure"`
 }
 
 // String returns the string representation


### PR DESCRIPTION
As far as I can tell this retains the current behavior with the following advantages:

1. The zero-width field has no overhead on instances of the struct. I think SDKShapeTraits is costing us up to 8 bytes on each struct instance (depending on packing/padding).
1. Cheaper to fetch via reflection. Benchmarks below.
1. More succinct.

One downside is that `_` is less descriptive than `SDKShapeTraits` but since it's an internal detail that doesn't seem like too big of a deal.

As mentioned in https://github.com/aws/aws-sdk-go/issues/377#issuecomment-157496324

## Example

### Old Style

```go
type InvokeAsyncInput struct {
  // The Lambda function name.
  FunctionName *string `location:"uri" locationName:"FunctionName" min:"1" type:"string" required:"true"`

  // JSON that you want to provide to your Lambda function as input.
  InvokeArgs io.ReadSeeker `type:"blob" required:"true"`

  metadataInvokeAsyncInput `json:"-" xml:"-"`
}

type metadataInvokeAsyncInput struct {
  SDKShapeTraits bool `type:"structure" payload:"InvokeArgs"`
}
```

### New Style
```go
type InvokeAsyncInput struct {
  _ struct{} `type:"structure" payload:"InvokeArgs"`

  // The Lambda function name.
  FunctionName *string `location:"uri" locationName:"FunctionName" min:"1" type:"string" required:"true"`

  // JSON that you want to provide to your Lambda function as input.
  InvokeArgs io.ReadSeeker `type:"blob" required:"true"`
}
```

# Protocol Benchmarks (vs master)

```
benchmark                                                                      old ns/op     new ns/op     delta
BenchmarkEC2QueryBuild_Complex_ec2AuthorizeSecurityGroupEgress-4               48412         48456         +0.09%
BenchmarkEC2QueryBuild_Simple_ec2AttachNetworkInterface-4                      12853         12925         +0.56%
BenchmarkBuildJSON-4                                                           7597          7700          +1.36%
BenchmarkStdlibJSON-4                                                          7176          6914          -3.65%
BenchmarkJSONRPCBuild_Simple_dynamodbPutItem-4                                 16229         12028         -25.89%
BenchmarkJSONUtilBuild_Simple_dynamodbPutItem-4                                15871         11636         -26.68%
BenchmarkEncodingJSONMarshal_Simple_dynamodbPutItem-4                          6447          6393          -0.84%
BenchmarkRESTJSONBuild_Complex_elastictranscoderCreateJobInput-4               272536        213156        -21.79%
BenchmarkRESTBuild_Complex_elastictranscoderCreateJobInput-4                   9023          7757          -14.03%
BenchmarkEncodingJSONMarshal_Complex_elastictranscoderCreateJobInput-4         38727         37823         -2.33%
BenchmarkRESTJSONBuild_Simple_elastictranscoderListJobsByPipeline-4            14645         10682         -27.06%
BenchmarkRESTBuild_Simple_elastictranscoderListJobsByPipeline-4                10505         8934          -14.95%
BenchmarkEncodingJSONMarshal_Simple_elastictranscoderListJobsByPipeline-4      1073          1056          -1.58%
BenchmarkRESTXMLBuild_Complex_cloudfrontCreateDistribution-4                   428704        369790        -13.74%
BenchmarkRESTXMLBuild_Simple_cloudfrontDeleteStreamingDistribution-4           19239         15089         -21.57%
BenchmarkEncodingXMLMarshal_Simple_cloudfrontDeleteStreamingDistribution-4     5547          5447          -1.80%

benchmark                                                                old allocs     new allocs     delta
BenchmarkJSONRPCBuild_Simple_dynamodbPutItem-4                           79             55             -30.38%
BenchmarkJSONUtilBuild_Simple_dynamodbPutItem-4                          77             53             -31.17%
BenchmarkRESTJSONBuild_Complex_elastictranscoderCreateJobInput-4         1131           819            -27.59%
BenchmarkRESTBuild_Complex_elastictranscoderCreateJobInput-4             59             51             -13.56%
BenchmarkRESTJSONBuild_Simple_elastictranscoderListJobsByPipeline-4      80             56             -30.00%
BenchmarkRESTBuild_Simple_elastictranscoderListJobsByPipeline-4          57             49             -14.04%
BenchmarkRESTXMLBuild_Complex_cloudfrontCreateDistribution-4             1832           1584           -13.54%
BenchmarkRESTXMLBuild_Simple_cloudfrontDeleteStreamingDistribution-4     88             64             -27.27%

benchmark                                                                old bytes     new bytes     delta
BenchmarkEC2QueryBuild_Complex_ec2AuthorizeSecurityGroupEgress-4         10922         10920         -0.02%
BenchmarkJSONRPCBuild_Simple_dynamodbPutItem-4                           3873          2624          -32.25%
BenchmarkJSONUtilBuild_Simple_dynamodbPutItem-4                          3809          2560          -32.79%
BenchmarkRESTJSONBuild_Complex_elastictranscoderCreateJobInput-4         41276         25047         -39.32%
BenchmarkRESTBuild_Complex_elastictranscoderCreateJobInput-4             2800          2384          -14.86%
BenchmarkRESTJSONBuild_Simple_elastictranscoderListJobsByPipeline-4      4368          3120          -28.57%
BenchmarkRESTBuild_Simple_elastictranscoderListJobsByPipeline-4          3328          2912          -12.50%
BenchmarkRESTXMLBuild_Complex_cloudfrontCreateDistribution-4             103383        90447         -12.51%
BenchmarkRESTXMLBuild_Simple_cloudfrontDeleteStreamingDistribution-4     9104          7856          -13.71%
```