### PR TITLE
Add static opsworks endpoint

### DIFF
--- a/private/endpoints/endpoints.json
+++ b/private/endpoints/endpoints.json
@@ -37,6 +37,10 @@
       "endpoint": "iam.amazonaws.com",
       "signingRegion": "us-east-1"
     },
+    "*/opsworks": {
+      "endpoint": "opsworks.us-east-1.amazonaws.com",
+      "signingRegion": "us-east-1"
+    },
     "*/importexport": {
       "endpoint": "importexport.amazonaws.com",
       "signingRegion": "us-east-1"


### PR DESCRIPTION
AWS OpsWorks has a single endpoint: opsworks.us-east-1.amazonaws.com and
only supports HTTPS requests. While the region is a thing you can configure when you setup your session, setting it to anything _but_ `us-east-1` will fail. 

Given this script:

```go
package main

import (
	"log"

	"github.com/aws/aws-sdk-go/aws"
	"github.com/aws/aws-sdk-go/aws/session"
	"github.com/aws/aws-sdk-go/service/opsworks"
)

func main() {
	log.Println("OK start")
	svc := opsworks.New(session.New())
	req := &opsworks.AttachElasticLoadBalancerInput{
		ElasticLoadBalancerName: aws.String("terraform-asg-deployment-example"),
		LayerId:                 aws.String("c5d45635-4cde-4cb6-9f62-b48036cd5dd0"),
	}

	r, err := svc.AttachElasticLoadBalancer(req)

	if err != nil {
		log.Printf("\n\terr: %s\n", err)
	}

	if r != nil {
		log.Printf("R: %s\n", r)
	}
}
```

You'll get an error if `AWS_REGION` is anything but `us-east-1`:

```
	err: RequestError: send request failed
caused by: Post https://opsworks.us-west-2.amazonaws.com/: dial tcp: lookup opsworks.us-west-2.amazonaws.com: no such host
```

This PR adds opsworks to the `endpoints.json` so that by default you'll get the correct region. At least, in my limited testing it has.

I've ran the above script successfully after running `make gen-endpoints` and `make build` in the root of the SDK.

Suggestions for a better way welcome!