### PR TITLE
Adding an interface package for s3manager.

### DIFF
--- a/service/s3/s3manager/s3manageriface/interface.go
+++ b/service/s3/s3manager/s3manageriface/interface.go
@@ -1,0 +1,23 @@
+// Package s3manageriface provides an interface for the s3manager package
+package s3manageriface
+
+import (
+	"io"
+
+	"github.com/aws/aws-sdk-go/service/s3"
+	"github.com/aws/aws-sdk-go/service/s3/s3manager"
+)
+
+// DownloaderAPI is the interface type for s3manager.Downloader.
+type DownloaderAPI interface {
+	Download(io.WriterAt, *s3.GetObjectInput, ...func(*s3manager.Downloader)) (int64, error)
+}
+
+var _ DownloaderAPI = (*s3manager.Downloader)(nil)
+
+// UploaderAPI is the interface type for s3manager.Uploader.
+type UploaderAPI interface {
+	Upload(*s3manager.UploadInput, ...func(*s3manager.Uploader)) (*s3manager.UploadOutput, error)
+}
+
+var _ UploaderAPI = (*s3manager.Uploader)(nil)


### PR DESCRIPTION
This adds interfaces for s3manager.Download & s3manager.Uploader.

Follows naming convention of the auto-generated interfaces and names the package s3managerinterface, and the interfaces DownloaderAPI & UploaderAPI.

See Issue #483 