### PR TITLE
Fix SDK's usage of go/types in Go 1.5

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -8,7 +8,7 @@ LINTIGNOREDEPS='vendor/.+\.go'
 SDK_WITH_VENDOR_PKGS=$(shell go list ./... | grep -v "/vendor/src")
 SDK_ONLY_PKGS=$(shell go list ./... | grep -v "/vendor/")
 
-all: generate unit
+all: get-deps generate unit
 
 help:
 	@echo "Please use \`make <target>' where <target> is one of"

--- a/awsmigrate/awsmigrate-renamer/rename/rename14.go
+++ b/awsmigrate/awsmigrate-renamer/rename/rename14.go
@@ -1,4 +1,4 @@
-// +build go1.5
+// +build !go1.5
 
 package rename
 
@@ -9,10 +9,10 @@ import (
 	"go/format"
 	"go/parser"
 	"go/token"
-	"go/types"
 	"io/ioutil"
 
 	"golang.org/x/tools/go/loader"
+	"golang.org/x/tools/go/types"
 )
 
 var dryRun = flag.Bool("dryrun", false, "Dry run")


### PR DESCRIPTION
In golang/tools@542ffc7e7 the tools/go/types packages were updated to
use the import path `go/types` instead of `golang.org/x/tools/go/types`.
This cause the SDK to fail to build once retrieved due to the awsmigrate
package referencing x/tools/go/types.

Fix #488