### PR TITLE
Fix status waiter with status code > 4xx

### DIFF
--- a/private/protocol/query/unmarshal_error.go
+++ b/private/protocol/query/unmarshal_error.go
@@ -24,10 +24,14 @@ func UnmarshalError(r *request.Request) {
 	if err != nil && err != io.EOF {
 		r.Error = awserr.New("SerializationError", "failed to decode query XML error response", err)
 	} else {
+		reqID := resp.RequestID
+		if reqID == "" {
+			reqID = r.RequestID
+		}
 		r.Error = awserr.NewRequestFailure(
 			awserr.New(resp.Code, resp.Message, nil),
 			r.HTTPResponse.StatusCode,
-			resp.RequestID,
+			reqID,
 		)
 	}
 }

--- a/private/protocol/rest/unmarshal.go
+++ b/private/protocol/rest/unmarshal.go
@@ -26,6 +26,10 @@ func Unmarshal(r *request.Request) {
 // UnmarshalMeta unmarshals the REST metadata of a response in a REST service
 func UnmarshalMeta(r *request.Request) {
 	r.RequestID = r.HTTPResponse.Header.Get("X-Amzn-Requestid")
+	if r.RequestID == "" {
+		// Alternative version of request id in the header
+		r.RequestID = r.HTTPResponse.Header.Get("X-Amz-Request-Id")
+	}
 	if r.DataFilled() {
 		v := reflect.Indirect(reflect.ValueOf(r.Data))
 		unmarshalLocationElements(r, v)

--- a/private/waiter/waiter.go
+++ b/private/waiter/waiter.go
@@ -51,17 +51,15 @@ func (w *Waiter) Wait() error {
 
 		err := req.Send()
 		for _, a := range w.Acceptors {
-			if err != nil && a.Matcher != "error" {
-				// Only matcher error is valid if there is a request error
-				continue
-			}
-
 			result := false
 			var vals []interface{}
 			switch a.Matcher {
 			case "pathAll", "path":
 				// Require all matches to be equal for result to match
 				vals, _ = awsutil.ValuesAtPath(req.Data, a.Argument)
+				if len(vals) == 0 {
+					break
+				}
 				result = true
 				for _, val := range vals {
 					if !awsutil.DeepEqual(val, a.Expected) {

--- a/service/s3/unmarshal_error.go
+++ b/service/s3/unmarshal_error.go
@@ -22,17 +22,23 @@ func unmarshalError(r *request.Request) {
 	defer r.HTTPResponse.Body.Close()
 
 	if r.HTTPResponse.StatusCode == http.StatusMovedPermanently {
-		r.Error = awserr.New("BucketRegionError",
-			fmt.Sprintf("incorrect region, the bucket is not in '%s' region", aws.StringValue(r.Config.Region)), nil)
+		r.Error = awserr.NewRequestFailure(
+			awserr.New("BucketRegionError",
+				fmt.Sprintf("incorrect region, the bucket is not in '%s' region",
+					aws.StringValue(r.Config.Region)),
+				nil),
+			r.HTTPResponse.StatusCode,
+			r.RequestID,
+		)
 		return
 	}
 
-	if r.HTTPResponse.ContentLength == int64(0) {
+	if r.HTTPResponse.ContentLength <= 1 {
 		// No body, use status code to generate an awserr.Error
 		r.Error = awserr.NewRequestFailure(
 			awserr.New(strings.Replace(r.HTTPResponse.Status, " ", "", -1), r.HTTPResponse.Status, nil),
 			r.HTTPResponse.StatusCode,
-			"",
+			r.RequestID,
 		)
 		return
 	}
@@ -45,7 +51,7 @@ func unmarshalError(r *request.Request) {
 		r.Error = awserr.NewRequestFailure(
 			awserr.New(resp.Code, resp.Message, nil),
 			r.HTTPResponse.StatusCode,
-			"",
+			r.RequestID,
 		)
 	}
 }


### PR DESCRIPTION
The waiters were ignoring any acceptor other than "error" if there was
any request error when polling for resource status. This caused waiters
like S3 WaitForObject to return immediately with an error because 404 not
found was returned. The waiters will now handle status acceptors with
errors.

Also fixed a bug with pathAll being too greedy and matching on empty
list when it should not.

Fix #497