### PR TITLE
Remove spurious trailing slash in invoke-async and event-source-mappings request URIs

### DIFF
--- a/models/apis/lambda/2015-03-31/api-2.json
+++ b/models/apis/lambda/2015-03-31/api-2.json
@@ -465,7 +465,7 @@
       "name":"InvokeAsync",
       "http":{
         "method":"POST",
-        "requestUri":"/2014-11-13/functions/{FunctionName}/invoke-async/",
+        "requestUri":"/2014-11-13/functions/{FunctionName}/invoke-async",
         "responseCode":202
       },
       "input":{

--- a/models/apis/lambda/2015-03-31/api-2.json
+++ b/models/apis/lambda/2015-03-31/api-2.json
@@ -531,7 +531,7 @@
       "name":"ListEventSourceMappings",
       "http":{
         "method":"GET",
-        "requestUri":"/2015-03-31/event-source-mappings/",
+        "requestUri":"/2015-03-31/event-source-mappings",
         "responseCode":200
       },
       "input":{"shape":"ListEventSourceMappingsRequest"},


### PR DESCRIPTION
It doesn't match the other request URIs and I have to strip it off in https://github.com/jkakar/aws-elixir for request singing to work correctly.