### PR TITLE
Fix EC2Metadata Client overriding http.DefaultClient incorrectly

### DIFF
--- a/aws/ec2metadata/service_test.go
+++ b/aws/ec2metadata/service_test.go
@@ -1,0 +1,40 @@
+package ec2metadata_test
+
+import (
+	"net/http"
+	"testing"
+
+	"github.com/aws/aws-sdk-go/aws/ec2metadata"
+	"github.com/aws/aws-sdk-go/aws/session"
+	"github.com/stretchr/testify/assert"
+)
+
+func TestClientOverrideDefaultHTTPClientDialTimeout(t *testing.T) {
+	svc := ec2metadata.New(session.New())
+
+	assert.NotEqual(t, http.DefaultClient, svc.Config.HTTPClient)
+
+	tr, ok := svc.Config.HTTPClient.Transport.(*http.Transport)
+	assert.True(t, ok)
+	assert.NotNil(t, tr)
+
+	assert.NotNil(t, tr.Dial)
+}
+
+func TestClientNotOverrideDefaultHTTPClientDialTimeout(t *testing.T) {
+	origClient := *http.DefaultClient
+	http.DefaultClient.Transport = &http.Transport{}
+	defer func() {
+		http.DefaultClient = &origClient
+	}()
+
+	svc := ec2metadata.New(session.New())
+
+	assert.Equal(t, http.DefaultClient, svc.Config.HTTPClient)
+
+	tr, ok := svc.Config.HTTPClient.Transport.(*http.Transport)
+	assert.True(t, ok)
+	assert.NotNil(t, tr)
+
+	assert.Nil(t, tr.Dial)
+}


### PR DESCRIPTION
The EC2Metadata Client was incorrectly overriding the http.DefaultClient
when users had modified the default client's parameters. The metadata
client will now only set its alternate dial timeout if no http client
was provided, or if the provided client was never modified from the
original http.Client{}.

Also updates the logic so DefaultTransport is reused instead of
hardcoded.

Addresses #504 