### PR TITLE
Fix data race in EC2Metadata client initialization

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -15,7 +15,7 @@ install:
   - make get-deps
 
 script:
-  - make unit
+  - make unit-with-race-cover
 
 matrix:
   allow_failures:

--- a/Makefile
+++ b/Makefile
@@ -49,6 +49,10 @@ unit: get-deps-unit build verify
 	@echo "go test SDK and vendor packages"
 	@go test $(SDK_WITH_VENDOR_PKGS)
 
+unit-with-race-cover: get-deps-unit build verify
+	@echo "go test SDK and vendor packages"
+	@go test -v -race -cpu=1,2,4 -covermode=atomic $(SDK_WITH_VENDOR_PKGS)
+
 integration: get-deps-integ
 	go test -tags=integration ./awstesting/integration/customizations/...
 	gucumber ./awstesting/integration/smoke

--- a/aws/config.go
+++ b/aws/config.go
@@ -95,6 +95,20 @@ type Config struct {
 	//   Amazon S3: Virtual Hosting of Buckets
 	S3ForcePathStyle *bool
 
+	// Set this to `true` to disable the EC2Metadata client from overriding the
+	// default http.Client's Timeout. This is helpful if you do not want the EC2Metadata
+	// client to create a new http.Client. This options is only meaningful if you're not
+	// already using a custom HTTP client with the SDK. Enabled by default.
+	//
+	// Must be set and provided to the session.New() in order to disable the EC2Metadata
+	// overriding the timeout for default credentials chain.
+	//
+	// Example:
+	//    sess := session.New(aws.NewConfig().WithEC2MetadataDiableTimeoutOverride(true))
+	//    svc := s3.New(sess)
+	//
+	EC2MetadataDisableTimeoutOverride *bool
+
 	SleepDelay func(time.Duration)
 }
 
@@ -184,6 +198,13 @@ func (c *Config) WithS3ForcePathStyle(force bool) *Config {
 	return c
 }
 
+// WithEC2MetadataDisableTimeoutOverride sets a config EC2MetadataDisableTimeoutOverride value
+// returning a Config pointer for chaining.
+func (c *Config) WithEC2MetadataDisableTimeoutOverride(enable bool) *Config {
+	c.EC2MetadataDisableTimeoutOverride = &enable
+	return c
+}
+
 // WithSleepDelay overrides the function used to sleep while waiting for the
 // next retry. Defaults to time.Sleep.
 func (c *Config) WithSleepDelay(fn func(time.Duration)) *Config {
@@ -249,6 +270,10 @@ func mergeInConfig(dst *Config, other *Config) {
 
 	if other.S3ForcePathStyle != nil {
 		dst.S3ForcePathStyle = other.S3ForcePathStyle
+	}
+
+	if other.EC2MetadataDisableTimeoutOverride != nil {
+		dst.EC2MetadataDisableTimeoutOverride = other.EC2MetadataDisableTimeoutOverride
 	}
 
 	if other.SleepDelay != nil {

--- a/aws/ec2metadata/service.go
+++ b/aws/ec2metadata/service.go
@@ -5,7 +5,6 @@ package ec2metadata
 import (
 	"io/ioutil"
 	"net/http"
-	"reflect"
 	"time"
 
 	"github.com/aws/aws-sdk-go/aws"
@@ -46,7 +45,7 @@ func New(p client.ConfigProvider, cfgs ...*aws.Config) *EC2Metadata {
 // the EC2RoleProvider's EC2Metadata HTTP client's timeout will be shortened.
 // To disable this set Config.EC2MetadataDisableTimeoutOverride to false. Enabled by default.
 func NewClient(cfg aws.Config, handlers request.Handlers, endpoint, signingRegion string, opts ...func(*client.Client)) *EC2Metadata {
-	if !aws.BoolValue(cfg.EC2MetadataDisableTimeoutOverride) && (cfg.HTTPClient == nil || reflect.DeepEqual(*cfg.HTTPClient, http.Client{})) {
+	if !aws.BoolValue(cfg.EC2MetadataDisableTimeoutOverride) && httpClientZero(cfg.HTTPClient) {
 		// If the http client is unmodified and this feature is not disabled
 		// set custom timeouts for EC2Metadata requests.
 		cfg.HTTPClient = &http.Client{
@@ -80,6 +79,10 @@ func NewClient(cfg aws.Config, handlers request.Handlers, endpoint, signingRegio
 	}
 
 	return svc
+}
+
+func httpClientZero(c *http.Client) bool {
+	return c == nil || (c.Transport == nil && c.CheckRedirect == nil && c.Jar == nil && c.Timeout == 0)
 }
 
 type metadataOutput struct {

--- a/aws/ec2metadata/service.go
+++ b/aws/ec2metadata/service.go
@@ -4,7 +4,6 @@ package ec2metadata
 
 import (
 	"io/ioutil"
-	"net"
 	"net/http"
 	"reflect"
 	"time"
@@ -27,9 +26,6 @@ type EC2Metadata struct {
 // New creates a new instance of the EC2Metadata client with a session.
 // This client is safe to use across multiple goroutines.
 //
-// If an unmodified HTTP client is provided from the stdlib default, or no client
-// it is safe to override the dial's timeout and keep alive for shorter connections.
-// If any client is provided which is not equal to the original default.
 //
 // Example:
 //     // Create a EC2Metadata client from just a session.
@@ -45,23 +41,20 @@ func New(p client.ConfigProvider, cfgs ...*aws.Config) *EC2Metadata {
 // NewClient returns a new EC2Metadata client. Should be used to create
 // a client when not using a session. Generally using just New with a session
 // is preferred.
+//
+// If an unmodified HTTP client is provided from the stdlib default, or no client
+// the EC2RoleProvider's EC2Metadata HTTP client's timeout will be shortened.
+// To disable this set Config.EC2MetadataDisableTimeoutOverride to false. Enabled by default.
 func NewClient(cfg aws.Config, handlers request.Handlers, endpoint, signingRegion string, opts ...func(*client.Client)) *EC2Metadata {
-	if cfg.HTTPClient == nil || reflect.DeepEqual(*cfg.HTTPClient, http.Client{}) {
-		// If a unmodified default http client is provided it is safe to add
-		// custom timeouts.
-		httpClient := *http.DefaultClient
-		if t, ok := http.DefaultTransport.(*http.Transport); ok {
-			transport := *t
-			transport.Dial = (&net.Dialer{
-				// use a shorter timeout than default because the metadata
-				// service is local if it is running, and to fail faster
-				// if not running on an ec2 instance.
-				Timeout:   5 * time.Second,
-				KeepAlive: 30 * time.Second,
-			}).Dial
-			httpClient.Transport = &transport
+	if !aws.BoolValue(cfg.EC2MetadataDisableTimeoutOverride) && (cfg.HTTPClient == nil || reflect.DeepEqual(*cfg.HTTPClient, http.Client{})) {
+		// If the http client is unmodified and this feature is not disabled
+		// set custom timeouts for EC2Metadata requests.
+		cfg.HTTPClient = &http.Client{
+			// use a shorter timeout than default because the metadata
+			// service is local if it is running, and to fail faster
+			// if not running on an ec2 instance.
+			Timeout: 5 * time.Second,
 		}
-		cfg.HTTPClient = &httpClient
 	}
 
 	svc := &EC2Metadata{

--- a/aws/ec2metadata/service_test.go
+++ b/aws/ec2metadata/service_test.go
@@ -2,26 +2,25 @@ package ec2metadata_test
 
 import (
 	"net/http"
+	"net/http/httptest"
+	"sync"
 	"testing"
+	"time"
 
+	"github.com/aws/aws-sdk-go/aws"
 	"github.com/aws/aws-sdk-go/aws/ec2metadata"
 	"github.com/aws/aws-sdk-go/aws/session"
 	"github.com/stretchr/testify/assert"
 )
 
-func TestClientOverrideDefaultHTTPClientDialTimeout(t *testing.T) {
+func TestClientOverrideDefaultHTTPClientTimeout(t *testing.T) {
 	svc := ec2metadata.New(session.New())
 
 	assert.NotEqual(t, http.DefaultClient, svc.Config.HTTPClient)
-
-	tr, ok := svc.Config.HTTPClient.Transport.(*http.Transport)
-	assert.True(t, ok)
-	assert.NotNil(t, tr)
-
-	assert.NotNil(t, tr.Dial)
+	assert.Equal(t, 5*time.Second, svc.Config.HTTPClient.Timeout)
 }
 
-func TestClientNotOverrideDefaultHTTPClientDialTimeout(t *testing.T) {
+func TestClientNotOverrideDefaultHTTPClientTimeout(t *testing.T) {
 	origClient := *http.DefaultClient
 	http.DefaultClient.Transport = &http.Transport{}
 	defer func() {
@@ -35,6 +34,46 @@ func TestClientNotOverrideDefaultHTTPClientDialTimeout(t *testing.T) {
 	tr, ok := svc.Config.HTTPClient.Transport.(*http.Transport)
 	assert.True(t, ok)
 	assert.NotNil(t, tr)
-
 	assert.Nil(t, tr.Dial)
+}
+
+func TestClientDisableOverrideDefaultHTTPClientTimeout(t *testing.T) {
+	svc := ec2metadata.New(session.New(aws.NewConfig().WithEC2MetadataDisableTimeoutOverride(true)))
+
+	assert.Equal(t, http.DefaultClient, svc.Config.HTTPClient)
+}
+
+func TestClientOverrideDefaultHTTPClientTimeoutRace(t *testing.T) {
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.Write([]byte("us-east-1a"))
+	}))
+
+	cfg := aws.NewConfig().WithEndpoint(server.URL)
+	runEC2MetadataClients(t, cfg, 100)
+}
+
+func TestClientOverrideDefaultHTTPClientTimeoutRaceWithTransport(t *testing.T) {
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.Write([]byte("us-east-1a"))
+	}))
+
+	cfg := aws.NewConfig().WithEndpoint(server.URL).WithHTTPClient(&http.Client{
+		Transport: http.DefaultTransport,
+	})
+
+	runEC2MetadataClients(t, cfg, 100)
+}
+
+func runEC2MetadataClients(t *testing.T, cfg *aws.Config, atOnce int) {
+	var wg sync.WaitGroup
+	wg.Add(atOnce)
+	for i := 0; i < atOnce; i++ {
+		go func() {
+			svc := ec2metadata.New(session.New(), cfg)
+			_, err := svc.Region()
+			assert.NoError(t, err)
+			wg.Done()
+		}()
+	}
+	wg.Wait()
 }

--- a/aws/session/session.go
+++ b/aws/session/session.go
@@ -51,12 +51,21 @@ type Session struct {
 //     sess := session.New()
 //     svc := s3.New(sess)
 func New(cfgs ...*aws.Config) *Session {
-	def := defaults.Get()
+	cfg := defaults.Config()
+	handlers := defaults.Handlers()
+
+	// Apply the passed in configs so the configuration can be applied to the
+	// default credential chain
+	cfg.MergeIn(cfgs...)
+	cfg.Credentials = defaults.CredChain(cfg, handlers)
+
+	// Reapply any passed in configs to override credentials if set
+	cfg.MergeIn(cfgs...)
+
 	s := &Session{
-		Config:   def.Config,
-		Handlers: def.Handlers,
+		Config:   cfg,
+		Handlers: handlers,
 	}
-	s.Config.MergeIn(cfgs...)
 
 	initHandlers(s)
 


### PR DESCRIPTION
The EC2Metadata client was taking a copy of http.Client's Transporter
which is not safe. This also complicated the implementation preventing
custom configurations by users. This alternative implementation is
concurrency safe and is much more flexible with custom transports and
dialers.

The EC2Metadata Timeout override can also be disabled by setting the
EC2MetadataDisableTimeoutOverride `aws.Config` flag. This flag needs to
be passed into the Session or Config prior to creating the credentials
change and EC2RoleProvider.

Fix #509