### PR TITLE
credentials: Expose provider names

### DIFF
--- a/aws/corehandlers/handlers_test.go
+++ b/aws/corehandlers/handlers_test.go
@@ -50,7 +50,7 @@ type mockCredsProvider struct {
 
 func (m *mockCredsProvider) Retrieve() (credentials.Value, error) {
 	m.retrieveCalled = true
-	return credentials.Value{}, nil
+	return credentials.Value{ProviderName: "mockCredsProvider"}, nil
 }
 
 func (m *mockCredsProvider) IsExpired() bool {

--- a/aws/credentials/chain_provider_test.go
+++ b/aws/credentials/chain_provider_test.go
@@ -7,6 +7,54 @@ import (
 	"github.com/stretchr/testify/assert"
 )
 
+type secondStubProvider struct {
+	creds   Value
+	expired bool
+	err     error
+}
+
+func (s *secondStubProvider) Retrieve() (Value, error) {
+	s.expired = false
+	s.creds.ProviderName = "secondStubProvider"
+	return s.creds, s.err
+}
+func (s *secondStubProvider) IsExpired() bool {
+	return s.expired
+}
+
+func TestChainProviderWithNames(t *testing.T) {
+	p := &ChainProvider{
+		Providers: []Provider{
+			&stubProvider{err: awserr.New("FirstError", "first provider error", nil)},
+			&stubProvider{err: awserr.New("SecondError", "second provider error", nil)},
+			&secondStubProvider{
+				creds: Value{
+					AccessKeyID:     "AKIF",
+					SecretAccessKey: "NOSECRET",
+					SessionToken:    "",
+				},
+			},
+			&stubProvider{
+				creds: Value{
+					AccessKeyID:     "AKID",
+					SecretAccessKey: "SECRET",
+					SessionToken:    "",
+				},
+			},
+		},
+	}
+
+	creds, err := p.Retrieve()
+	assert.Nil(t, err, "Expect no error")
+	assert.Equal(t, "secondStubProvider", creds.ProviderName, "Expect provider name to match")
+
+	// Also check credentials
+	assert.Equal(t, "AKIF", creds.AccessKeyID, "Expect access key ID to match")
+	assert.Equal(t, "NOSECRET", creds.SecretAccessKey, "Expect secret access key to match")
+	assert.Empty(t, creds.SessionToken, "Expect session token to be empty")
+
+}
+
 func TestChainProviderGet(t *testing.T) {
 	p := &ChainProvider{
 		Providers: []Provider{

--- a/aws/credentials/credentials.go
+++ b/aws/credentials/credentials.go
@@ -76,6 +76,9 @@ type Value struct {
 
 	// AWS Session Token
 	SessionToken string
+
+	// Provider used to get credentials
+	ProviderName string
 }
 
 // A Provider is the interface for any component which will provide credentials

--- a/aws/credentials/credentials_test.go
+++ b/aws/credentials/credentials_test.go
@@ -15,6 +15,7 @@ type stubProvider struct {
 
 func (s *stubProvider) Retrieve() (Value, error) {
 	s.expired = false
+	s.creds.ProviderName = "stubProvider"
 	return s.creds, s.err
 }
 func (s *stubProvider) IsExpired() bool {

--- a/aws/credentials/credentials_test.go
+++ b/aws/credentials/credentials_test.go
@@ -61,3 +61,13 @@ func TestCredentialsExpire(t *testing.T) {
 	stub.expired = true
 	assert.True(t, c.IsExpired(), "Expected to be expired")
 }
+
+func TestCredentialsGetWithProviderName(t *testing.T) {
+	stub := &stubProvider{}
+
+	c := NewCredentials(stub)
+
+	creds, err := c.Get()
+	assert.Nil(t, err, "Expected no error")
+	assert.Equal(t, creds.ProviderName, "stubProvider", "Expected provider name to match")
+}

--- a/aws/credentials/ec2rolecreds/ec2_role_provider.go
+++ b/aws/credentials/ec2rolecreds/ec2_role_provider.go
@@ -14,6 +14,9 @@ import (
 	"github.com/aws/aws-sdk-go/aws/ec2metadata"
 )
 
+// ProviderName provides a name of EC2Role provider
+const ProviderName = "EC2RoleProvider"
+
 // A EC2RoleProvider retrieves credentials from the EC2 service, and keeps track if
 // those credentials are expired.
 //
@@ -85,17 +88,17 @@ func NewCredentialsWithClient(client *ec2metadata.EC2Metadata, options ...func(*
 func (m *EC2RoleProvider) Retrieve() (credentials.Value, error) {
 	credsList, err := requestCredList(m.Client)
 	if err != nil {
-		return credentials.Value{}, err
+		return credentials.Value{ProviderName: ProviderName}, err
 	}
 
 	if len(credsList) == 0 {
-		return credentials.Value{}, awserr.New("EmptyEC2RoleList", "empty EC2 Role list", nil)
+		return credentials.Value{ProviderName: ProviderName}, awserr.New("EmptyEC2RoleList", "empty EC2 Role list", nil)
 	}
 	credsName := credsList[0]
 
 	roleCreds, err := requestCred(m.Client, credsName)
 	if err != nil {
-		return credentials.Value{}, err
+		return credentials.Value{ProviderName: ProviderName}, err
 	}
 
 	m.SetExpiration(roleCreds.Expiration, m.ExpiryWindow)
@@ -104,6 +107,7 @@ func (m *EC2RoleProvider) Retrieve() (credentials.Value, error) {
 		AccessKeyID:     roleCreds.AccessKeyID,
 		SecretAccessKey: roleCreds.SecretAccessKey,
 		SessionToken:    roleCreds.Token,
+		ProviderName:    ProviderName,
 	}, nil
 }
 

--- a/aws/credentials/env_provider.go
+++ b/aws/credentials/env_provider.go
@@ -6,6 +6,9 @@ import (
 	"github.com/aws/aws-sdk-go/aws/awserr"
 )
 
+// EnvProviderName provides a name of Env provider
+const EnvProviderName = "EnvProvider"
+
 var (
 	// ErrAccessKeyIDNotFound is returned when the AWS Access Key ID can't be
 	// found in the process's environment.
@@ -52,11 +55,11 @@ func (e *EnvProvider) Retrieve() (Value, error) {
 	}
 
 	if id == "" {
-		return Value{}, ErrAccessKeyIDNotFound
+		return Value{ProviderName: EnvProviderName}, ErrAccessKeyIDNotFound
 	}
 
 	if secret == "" {
-		return Value{}, ErrSecretAccessKeyNotFound
+		return Value{ProviderName: EnvProviderName}, ErrSecretAccessKeyNotFound
 	}
 
 	e.retrieved = true
@@ -64,6 +67,7 @@ func (e *EnvProvider) Retrieve() (Value, error) {
 		AccessKeyID:     id,
 		SecretAccessKey: secret,
 		SessionToken:    os.Getenv("AWS_SESSION_TOKEN"),
+		ProviderName:    EnvProviderName,
 	}, nil
 }
 

--- a/aws/credentials/shared_credentials_provider.go
+++ b/aws/credentials/shared_credentials_provider.go
@@ -10,6 +10,9 @@ import (
 	"github.com/aws/aws-sdk-go/aws/awserr"
 )
 
+// SharedCredsProviderName provides a name of SharedCreds provider
+const SharedCredsProviderName = "SharedCredentialsProvider"
+
 var (
 	// ErrSharedCredentialsHomeNotFound is emitted when the user directory cannot be found.
 	//
@@ -55,12 +58,12 @@ func (p *SharedCredentialsProvider) Retrieve() (Value, error) {
 
 	filename, err := p.filename()
 	if err != nil {
-		return Value{}, err
+		return Value{ProviderName: SharedCredsProviderName}, err
 	}
 
 	creds, err := loadProfile(filename, p.profile())
 	if err != nil {
-		return Value{}, err
+		return Value{ProviderName: SharedCredsProviderName}, err
 	}
 
 	p.retrieved = true
@@ -78,23 +81,23 @@ func (p *SharedCredentialsProvider) IsExpired() bool {
 func loadProfile(filename, profile string) (Value, error) {
 	config, err := ini.Load(filename)
 	if err != nil {
-		return Value{}, awserr.New("SharedCredsLoad", "failed to load shared credentials file", err)
+		return Value{ProviderName: SharedCredsProviderName}, awserr.New("SharedCredsLoad", "failed to load shared credentials file", err)
 	}
 	iniProfile, err := config.GetSection(profile)
 	if err != nil {
-		return Value{}, awserr.New("SharedCredsLoad", "failed to get profile", err)
+		return Value{ProviderName: SharedCredsProviderName}, awserr.New("SharedCredsLoad", "failed to get profile", err)
 	}
 
 	id, err := iniProfile.GetKey("aws_access_key_id")
 	if err != nil {
-		return Value{}, awserr.New("SharedCredsAccessKey",
+		return Value{ProviderName: SharedCredsProviderName}, awserr.New("SharedCredsAccessKey",
 			fmt.Sprintf("shared credentials %s in %s did not contain aws_access_key_id", profile, filename),
 			err)
 	}
 
 	secret, err := iniProfile.GetKey("aws_secret_access_key")
 	if err != nil {
-		return Value{}, awserr.New("SharedCredsSecret",
+		return Value{ProviderName: SharedCredsProviderName}, awserr.New("SharedCredsSecret",
 			fmt.Sprintf("shared credentials %s in %s did not contain aws_secret_access_key", profile, filename),
 			nil)
 	}
@@ -106,6 +109,7 @@ func loadProfile(filename, profile string) (Value, error) {
 		AccessKeyID:     id.String(),
 		SecretAccessKey: secret.String(),
 		SessionToken:    token.String(),
+		ProviderName:    SharedCredsProviderName,
 	}, nil
 }
 

--- a/aws/credentials/static_provider.go
+++ b/aws/credentials/static_provider.go
@@ -4,6 +4,9 @@ import (
 	"github.com/aws/aws-sdk-go/aws/awserr"
 )
 
+// StaticProviderName provides a name of Static provider
+const StaticProviderName = "StaticProvider"
+
 var (
 	// ErrStaticCredentialsEmpty is emitted when static credentials are empty.
 	//
@@ -30,9 +33,10 @@ func NewStaticCredentials(id, secret, token string) *Credentials {
 // Retrieve returns the credentials or error if the credentials are invalid.
 func (s *StaticProvider) Retrieve() (Value, error) {
 	if s.AccessKeyID == "" || s.SecretAccessKey == "" {
-		return Value{}, ErrStaticCredentialsEmpty
+		return Value{ProviderName: StaticProviderName}, ErrStaticCredentialsEmpty
 	}
 
+	s.Value.ProviderName = StaticProviderName
 	return s.Value, nil
 }
 

--- a/aws/credentials/stscreds/assume_role_provider.go
+++ b/aws/credentials/stscreds/assume_role_provider.go
@@ -14,6 +14,9 @@ import (
 	"github.com/aws/aws-sdk-go/service/sts"
 )
 
+// ProviderName provides a name of AssumeRole provider
+const ProviderName = "AssumeRoleProvider"
+
 // AssumeRoler represents the minimal subset of the STS client API used by this provider.
 type AssumeRoler interface {
 	AssumeRole(input *sts.AssumeRoleInput) (*sts.AssumeRoleOutput, error)
@@ -116,7 +119,7 @@ func (p *AssumeRoleProvider) Retrieve() (credentials.Value, error) {
 	})
 
 	if err != nil {
-		return credentials.Value{}, err
+		return credentials.Value{ProviderName: ProviderName}, err
 	}
 
 	// We will proactively generate new credentials before they expire.
@@ -126,5 +129,6 @@ func (p *AssumeRoleProvider) Retrieve() (credentials.Value, error) {
 		AccessKeyID:     *roleOutput.Credentials.AccessKeyId,
 		SecretAccessKey: *roleOutput.Credentials.SecretAccessKey,
 		SessionToken:    *roleOutput.Credentials.SessionToken,
+		ProviderName:    ProviderName,
 	}, nil
 }


### PR DESCRIPTION
This should help in situations such as debugging the `ChainProvider` or even giving the user better idea of what's happening under the hood - i.e. where are the used credentials coming from.

This PR may introduce a breaking change for users having custom providers as these will be missing the new method per modified interface (`Name()`).