### PR TITLE
Add absolute path test for AWS_SHARED_CREDENTIALS_FILE

### DIFF
--- a/aws/credentials/shared_credentials_provider_test.go
+++ b/aws/credentials/shared_credentials_provider_test.go
@@ -1,9 +1,11 @@
 package credentials
 
 import (
-	"github.com/stretchr/testify/assert"
 	"os"
+	"path/filepath"
 	"testing"
+
+	"github.com/stretchr/testify/assert"
 )
 
 func TestSharedCredentialsProvider(t *testing.T) {
@@ -37,6 +39,20 @@ func TestSharedCredentialsProviderWithAWS_SHARED_CREDENTIALS_FILE(t *testing.T) 
 	p := SharedCredentialsProvider{}
 	creds, err := p.Retrieve()
 
+	assert.Nil(t, err, "Expect no error")
+
+	assert.Equal(t, "accessKey", creds.AccessKeyID, "Expect access key ID to match")
+	assert.Equal(t, "secret", creds.SecretAccessKey, "Expect secret access key to match")
+	assert.Equal(t, "token", creds.SessionToken, "Expect session token to match")
+}
+
+func TestSharedCredentialsProviderWithAWS_SHARED_CREDENTIALS_FILEAbsPath(t *testing.T) {
+	os.Clearenv()
+	wd, err := os.Getwd()
+	assert.NoError(t, err)
+	os.Setenv("AWS_SHARED_CREDENTIALS_FILE", filepath.Join(wd, "example.ini"))
+	p := SharedCredentialsProvider{}
+	creds, err := p.Retrieve()
 	assert.Nil(t, err, "Expect no error")
 
 	assert.Equal(t, "accessKey", creds.AccessKeyID, "Expect access key ID to match")


### PR DESCRIPTION
Adds test case for absolute path to shared credentials alternatively file handling. Ensures that both relative and absolute paths work as expected.