### PR TITLE
Addressing #503 Validation and such

### DIFF
--- a/private/signer/v4/functional_test.go
+++ b/private/signer/v4/functional_test.go
@@ -32,7 +32,6 @@ func TestPresignHandler(t *testing.T) {
 
 	u, _ := url.Parse(urlstr)
 	urlQ := u.Query()
-	fmt.Println("URLQ: ", urlQ)
 	assert.Equal(t, expectedSig, urlQ.Get("X-Amz-Signature"))
 	assert.Equal(t, expectedCred, urlQ.Get("X-Amz-Credential"))
 	assert.Equal(t, expectedHeaders, urlQ.Get("X-Amz-SignedHeaders"))

--- a/private/signer/v4/functional_test.go
+++ b/private/signer/v4/functional_test.go
@@ -1,6 +1,7 @@
 package v4_test
 
 import (
+	"fmt"
 	"net/url"
 	"testing"
 	"time"
@@ -32,6 +33,7 @@ func TestPresignHandler(t *testing.T) {
 
 	u, _ := url.Parse(urlstr)
 	urlQ := u.Query()
+	fmt.Println("URLQ: ", urlQ)
 	assert.Equal(t, expectedSig, urlQ.Get("X-Amz-Signature"))
 	assert.Equal(t, expectedCred, urlQ.Get("X-Amz-Credential"))
 	assert.Equal(t, expectedHeaders, urlQ.Get("X-Amz-SignedHeaders"))

--- a/private/signer/v4/functional_test.go
+++ b/private/signer/v4/functional_test.go
@@ -1,7 +1,6 @@
 package v4_test
 
 import (
-	"fmt"
 	"net/url"
 	"testing"
 	"time"

--- a/private/signer/v4/v4.go
+++ b/private/signer/v4/v4.go
@@ -165,15 +165,39 @@ func (v4 *signer) logSigningInfo() {
 }
 
 func (v4 *signer) build() {
+	filters := make(map[string][]string)
+	urlValues := url.Values{}
+
 	v4.buildTime()             // no depends
 	v4.buildCredentialString() // no depends
-	if v4.isPresign {
-		v4.buildQuery() // no depends
+
+	var allowedSignedHeaders = map[string][]string{
+		"X-Amz-Acl":               nil,
+		"X-Amz-Content-Sha256":    nil,
+		"X-Amz-Date":              nil,
+		"X-Amz-Meta-Other-Header": nil,
+		"X-Amz-Security-Token":    nil,
+		"X-Amz-Target":            nil,
 	}
-	v4.buildCanonicalHeaders() // depends on cred string
-	v4.buildCanonicalString()  // depends on canon headers / signed headers
-	v4.buildStringToSign()     // depends on canon string
-	v4.buildSignature()        // depends on string to sign
+	filters = v4.buildCanonicalHeaders(allowedSignedHeaders, filters)
+
+	if v4.isPresign {
+		var allowedHoisting = map[string][]string{
+			"Content-Md5":         nil,
+			"Content-Disposition": nil,
+		}
+
+		urlValues, filters = buildQuery(allowedHoisting, v4.Request.Header, filters) // no depends
+		for k, _ := range urlValues {
+			v4.Request.Header.Del(k)
+			v4.Query.Del(k)
+			v4.Query[k] = append(v4.Query[k], urlValues[k]...)
+		}
+	}
+
+	v4.buildCanonicalString() // depends on canon headers / signed headers
+	v4.buildStringToSign()    // depends on canon string
+	v4.buildSignature()       // depends on string to sign
 
 	if v4.isPresign {
 		v4.Request.URL.RawQuery += "&X-Amz-Signature=" + v4.signature
@@ -213,30 +237,27 @@ func (v4 *signer) buildCredentialString() {
 	}
 }
 
-func (v4 *signer) buildQuery() {
-	for k, h := range v4.Request.Header {
-		if strings.HasPrefix(http.CanonicalHeaderKey(k), "X-Amz-") {
-			continue // never hoist x-amz-* headers, they must be signed
-		}
-		if _, ok := ignoredHeaders[http.CanonicalHeaderKey(k)]; ok {
-			continue // never hoist ignored headers
-		}
-
-		v4.Request.Header.Del(k)
-		v4.Query.Del(k)
-		for _, v := range h {
-			v4.Query.Add(k, v)
+func buildQuery(allowed, header, filters map[string][]string) (url.Values, map[string][]string) {
+	query := url.Values{}
+	for k, h := range header {
+		_, allow := allowed[k]
+		_, filter := filters[k]
+		if allow && !filter {
+			filters[k] = h
+			query[k] = append(query[k], h...)
 		}
 	}
-}
 
-func (v4 *signer) buildCanonicalHeaders() {
+	return query, filters
+}
+func (v4 *signer) buildCanonicalHeaders(allowed, filters map[string][]string) map[string][]string {
 	var headers []string
 	headers = append(headers, "host")
 	for k := range v4.Request.Header {
-		if _, ok := ignoredHeaders[http.CanonicalHeaderKey(k)]; ok {
+		if _, ok := allowed[http.CanonicalHeaderKey(k)]; !ok {
 			continue // ignored header
 		}
+		filters[k] = nil
 		headers = append(headers, strings.ToLower(k))
 	}
 	sort.Strings(headers)
@@ -258,6 +279,7 @@ func (v4 *signer) buildCanonicalHeaders() {
 	}
 
 	v4.canonicalHeaders = strings.Join(headerValues, "\n")
+	return filters
 }
 
 func (v4 *signer) buildCanonicalString() {


### PR DESCRIPTION
Fixes #503 
Uses new struct Validator instead of blacklists to check if something needs to be hoisted or signed in headers

New method, PresignRequest, hoists nothing, returns the URL and headers that were signed
More work needs to be done in seeing what of the x-amz-* can be hoisted