### PR TITLE
aws/corehandlers: speed up validation of []byte

### DIFF
--- a/aws/corehandlers/param_validator.go
+++ b/aws/corehandlers/param_validator.go
@@ -42,6 +42,12 @@ func (v *validator) validateAny(value reflect.Value, path string) {
 	case reflect.Struct:
 		v.validateStruct(value, path)
 	case reflect.Slice:
+		if value.Type().Name() == "" && value.Type().Elem().Name() == "uint8" {
+			// unnamed type (i.e. with no methods) whose underlying type is a
+			// slice of uint8, aka []byte. We don't need to validate its
+			// contents.
+			return
+		}
 		for i := 0; i < value.Len(); i++ {
 			v.validateAny(value.Index(i), path+fmt.Sprintf("[%d]", i))
 		}

--- a/aws/corehandlers/param_validator.go
+++ b/aws/corehandlers/param_validator.go
@@ -30,6 +30,11 @@ type validator struct {
 	errors []string
 }
 
+// There's no validation to be done on the contents of []byte values. Prepare
+// to check validateAny arguments against that type so we can quickly skip
+// them.
+var byteSliceType = reflect.TypeOf([]byte(nil))
+
 // validateAny will validate any struct, slice or map type. All validations
 // are also performed recursively for nested types.
 func (v *validator) validateAny(value reflect.Value, path string) {
@@ -42,10 +47,8 @@ func (v *validator) validateAny(value reflect.Value, path string) {
 	case reflect.Struct:
 		v.validateStruct(value, path)
 	case reflect.Slice:
-		if value.Type().Name() == "" && value.Type().Elem().Name() == "uint8" {
-			// unnamed type (i.e. with no methods) whose underlying type is a
-			// slice of uint8, aka []byte. We don't need to validate its
-			// contents.
+		if value.Type() == byteSliceType {
+			// We don't need to validate the contents of []byte.
 			return
 		}
 		for i := 0; i < value.Len(); i++ {


### PR DESCRIPTION
Request validation logic ensures that struct fields have appropriate values.
When validating slices and maps, the goal is to find any structs they may
contain, since only struct fields have validation rules. Slices of uint8,
aka []byte, do not lead to structs and so cannot cause validation to fail.
Speed up validation of this (unnamed) type.

This is particularly important for APIs such as Kinesis which can contain
byte slices for megabytes of data - each byte does not need to be validated
individually.

The below output of golang.org/x/tools/cmd/benchcmp is for a Kinesis
PutRecords request including 100 Records of 10kB each.

benchmark                  old ns/op     new ns/op     delta
BenchmarkValidateAny-8     310052182     216116        -99.93%

benchmark                  old allocs     new allocs     delta
BenchmarkValidateAny-8     3002424        1909           -99.94%

benchmark                  old bytes     new bytes     delta
BenchmarkValidateAny-8     48079408      19274         -99.96%