### PR TITLE
Improve EC2 instance role and EC2Metadata client error messages

### DIFF
--- a/aws/awserr/error.go
+++ b/aws/awserr/error.go
@@ -64,9 +64,6 @@ type BatchError interface {
 // If origErr satisfies the Error interface it will not be wrapped within a new
 // Error object and will instead be returned.
 func New(code, message string, origErr error) Error {
-	if e, ok := origErr.(Error); ok && e != nil {
-		return e
-	}
 	return newBaseError(code, message, origErr)
 }
 

--- a/aws/credentials/ec2rolecreds/ec2_role_provider.go
+++ b/aws/credentials/ec2rolecreds/ec2_role_provider.go
@@ -132,7 +132,7 @@ const iamSecurityCredsPath = "/iam/security-credentials"
 func requestCredList(client *ec2metadata.EC2Metadata) ([]string, error) {
 	resp, err := client.GetMetadata(iamSecurityCredsPath)
 	if err != nil {
-		return nil, awserr.New("EC2RoleRequestError", "failed to list EC2 Roles", err)
+		return nil, awserr.New("EC2RoleRequestError", "no EC2 instance role found", err)
 	}
 
 	credsList := []string{}
@@ -142,7 +142,7 @@ func requestCredList(client *ec2metadata.EC2Metadata) ([]string, error) {
 	}
 
 	if err := s.Err(); err != nil {
-		return nil, awserr.New("SerializationError", "failed to read list of EC2 Roles", err)
+		return nil, awserr.New("SerializationError", "failed to read EC2 instance role from metadata service", err)
 	}
 
 	return credsList, nil
@@ -157,7 +157,7 @@ func requestCred(client *ec2metadata.EC2Metadata, credsName string) (ec2RoleCred
 	if err != nil {
 		return ec2RoleCredRespBody{},
 			awserr.New("EC2RoleRequestError",
-				fmt.Sprintf("failed to get %s EC2 Role credentials", credsName),
+				fmt.Sprintf("failed to get %s EC2 instance role credentials", credsName),
 				err)
 	}
 
@@ -165,7 +165,7 @@ func requestCred(client *ec2metadata.EC2Metadata, credsName string) (ec2RoleCred
 	if err := json.NewDecoder(strings.NewReader(resp)).Decode(&respCreds); err != nil {
 		return ec2RoleCredRespBody{},
 			awserr.New("SerializationError",
-				fmt.Sprintf("failed to decode %s EC2 Role credentials", credsName),
+				fmt.Sprintf("failed to decode %s EC2 instance role credentials", credsName),
 				err)
 	}
 

--- a/service/s3/s3manager/upload_test.go
+++ b/service/s3/s3manager/upload_test.go
@@ -378,8 +378,9 @@ func TestUploadOrderReadFail2(t *testing.T) {
 		Body:   &failreader{times: 2},
 	})
 
-	assert.Equal(t, "ReadRequestBody", err.(awserr.Error).Code())
-	assert.EqualError(t, err.(awserr.Error).OrigErr(), "random failure")
+	assert.Equal(t, "MultipartUpload", err.(awserr.Error).Code())
+	assert.Equal(t, "ReadRequestBody", err.(awserr.Error).OrigErr().(awserr.Error).Code())
+	assert.Contains(t, err.(awserr.Error).OrigErr().Error(), "random failure")
 	assert.Equal(t, []string{"CreateMultipartUpload", "AbortMultipartUpload"}, *ops)
 }
 
@@ -441,8 +442,9 @@ func TestUploadOrderMultiBufferedReaderExceedTotalParts(t *testing.T) {
 	assert.Equal(t, []string{"CreateMultipartUpload", "AbortMultipartUpload"}, *ops)
 
 	aerr := err.(awserr.Error)
-	assert.Equal(t, "TotalPartsExceeded", aerr.Code())
-	assert.Contains(t, aerr.Message(), "configured MaxUploadParts (2)")
+	assert.Equal(t, "MultipartUpload", aerr.Code())
+	assert.Equal(t, "TotalPartsExceeded", aerr.OrigErr().(awserr.Error).Code())
+	assert.Contains(t, aerr.Error(), "configured MaxUploadParts (2)")
 }
 
 func TestUploadOrderSingleBufferedReader(t *testing.T) {


### PR DESCRIPTION
Improves the error messages received for EC2Metadata client requests.
The error message bodies were being dropped by the SDK and are now
included in the error returned.

Also updates the SDK to returned errors to be chained in a stack so that
nested errors are not ignored. This change updates the SDK so that the
chain of errors which occurred are all included. Instead of just the first error.

Fix #545 