### PR TITLE
Support AWS_DEFAULT_PROFILE

### DIFF
--- a/aws/credentials/shared_credentials_provider.go
+++ b/aws/credentials/shared_credentials_provider.go
@@ -141,6 +141,9 @@ func (p *SharedCredentialsProvider) filename() (string, error) {
 // return "default".
 func (p *SharedCredentialsProvider) profile() string {
 	if p.Profile == "" {
+		p.Profile = os.Getenv("AWS_DEFAULT_PROFILE")
+	}
+	if p.Profile == "" {
 		p.Profile = os.Getenv("AWS_PROFILE")
 	}
 	if p.Profile == "" {

--- a/aws/credentials/shared_credentials_provider_test.go
+++ b/aws/credentials/shared_credentials_provider_test.go
@@ -73,6 +73,33 @@ func TestSharedCredentialsProviderWithAWS_PROFILE(t *testing.T) {
 	assert.Empty(t, creds.SessionToken, "Expect no token")
 }
 
+func TestSharedCredentialsProviderWithAWS_DEFAULT_PROFILE(t *testing.T) {
+	os.Clearenv()
+	os.Setenv("AWS_DEFAULT_PROFILE", "no_token")
+
+	p := SharedCredentialsProvider{Filename: "example.ini", Profile: ""}
+	creds, err := p.Retrieve()
+	assert.Nil(t, err, "Expect no error")
+
+	assert.Equal(t, "accessKey", creds.AccessKeyID, "Expect access key ID to match")
+	assert.Equal(t, "secret", creds.SecretAccessKey, "Expect secret access key to match")
+	assert.Empty(t, creds.SessionToken, "Expect no token")
+}
+
+func TestSharedCredentialsProviderAWS_DEFAULT_PROFILEoverridesAWS_PROFILE(t *testing.T) {
+	os.Clearenv()
+	os.Setenv("AWS_PROFILE", "default")
+	os.Setenv("AWS_DEFAULT_PROFILE", "no_token")
+
+	p := SharedCredentialsProvider{Filename: "example.ini", Profile: ""}
+	creds, err := p.Retrieve()
+	assert.Nil(t, err, "Expect no error")
+
+	assert.Equal(t, "accessKey", creds.AccessKeyID, "Expect access key ID to match")
+	assert.Equal(t, "secret", creds.SecretAccessKey, "Expect secret access key to match")
+	assert.Empty(t, creds.SessionToken, "Expect no token")
+}
+
 func TestSharedCredentialsProviderWithoutTokenFromProfile(t *testing.T) {
 	os.Clearenv()
 


### PR DESCRIPTION
On the aws driver for `docker-machine` we have users trying to use non default profile in their `~/.aws/credentials` as reported in https://github.com/docker/machine/issues/3045. As we 100% rely on the code here, rather than monkey patch in `docker-machine` we would like to propose the following PR to solve the issue of the aws-skd-go ignoring the `AWS_DEFAULT_PROFILE`.

This will fix a part of the https://github.com/aws/aws-sdk-go/issues/384#issuecomment-148812184

