### PR TITLE
aws/request: Add support for logging and stopping handler lists

### DIFF
--- a/aws/defaults/defaults.go
+++ b/aws/defaults/defaults.go
@@ -67,6 +67,7 @@ func Handlers() request.Handlers {
 
 	handlers.Validate.PushBackNamed(corehandlers.ValidateEndpointHandler)
 	handlers.Build.PushBackNamed(corehandlers.SDKVersionUserAgentHandler)
+	handlers.Build.ShouldStopFn = request.HandlerListStopOnError
 	handlers.Sign.PushBackNamed(corehandlers.BuildContentLengthHandler)
 	handlers.Send.PushBackNamed(corehandlers.SendHandler)
 	handlers.AfterRetry.PushBackNamed(corehandlers.AfterRetryHandler)

--- a/aws/request/request.go
+++ b/aws/request/request.go
@@ -192,6 +192,10 @@ func (r *Request) Build() error {
 			return r.Error
 		}
 		r.Handlers.Build.Run(r)
+		if r.Error != nil {
+			debugLogReqError(r, "Build Request", false, r.Error)
+			return r.Error
+		}
 		r.built = true
 	}
 

--- a/private/endpoints/endpoints.json
+++ b/private/endpoints/endpoints.json
@@ -57,36 +57,14 @@
       "endpoint": "sdb.amazonaws.com",
       "signingRegion": "us-east-1"
     },
+    "*/s3": {
+      "endpoint": "s3-{region}.amazonaws.com"
+    },
     "us-east-1/s3": {
       "endpoint": "s3.amazonaws.com"
     },
-    "us-west-1/s3": {
-      "endpoint": "s3-{region}.amazonaws.com"
-    },
-    "us-west-2/s3": {
-      "endpoint": "s3-{region}.amazonaws.com"
-    },
-    "eu-west-1/s3": {
-      "endpoint": "s3-{region}.amazonaws.com"
-    },
-    "ap-southeast-1/s3": {
-      "endpoint": "s3-{region}.amazonaws.com"
-    },
-    "ap-southeast-2/s3": {
-      "endpoint": "s3-{region}.amazonaws.com"
-    },
-    "ap-northeast-1/s3": {
-      "endpoint": "s3-{region}.amazonaws.com"
-    },
-    "ap-northeast-2/s3": {
-      "endpoint": "s3-{region}.amazonaws.com"
-    },
-    "sa-east-1/s3": {
-      "endpoint": "s3-{region}.amazonaws.com"
-    },
     "eu-central-1/s3": {
-      "endpoint": "{service}.{region}.amazonaws.com",
-      "signatureVersion": "v4"
+      "endpoint": "{service}.{region}.amazonaws.com"
     }
   }
 }

--- a/private/endpoints/endpoints_map.go
+++ b/private/endpoints/endpoints_map.go
@@ -46,6 +46,9 @@ var endpointsMap = endpointStruct{
 			Endpoint:      "route53.amazonaws.com",
 			SigningRegion: "us-east-1",
 		},
+		"*/s3": {
+			Endpoint: "s3-{region}.amazonaws.com",
+		},
 		"*/sts": {
 			Endpoint:      "sts.amazonaws.com",
 			SigningRegion: "us-east-1",
@@ -54,29 +57,11 @@ var endpointsMap = endpointStruct{
 			Endpoint:      "waf.amazonaws.com",
 			SigningRegion: "us-east-1",
 		},
-		"ap-northeast-1/s3": {
-			Endpoint: "s3-{region}.amazonaws.com",
-		},
-		"ap-northeast-2/s3": {
-			Endpoint: "s3-{region}.amazonaws.com",
-		},
-		"ap-southeast-1/s3": {
-			Endpoint: "s3-{region}.amazonaws.com",
-		},
-		"ap-southeast-2/s3": {
-			Endpoint: "s3-{region}.amazonaws.com",
-		},
 		"cn-north-1/*": {
 			Endpoint: "{service}.{region}.amazonaws.com.cn",
 		},
 		"eu-central-1/s3": {
 			Endpoint: "{service}.{region}.amazonaws.com",
-		},
-		"eu-west-1/s3": {
-			Endpoint: "s3-{region}.amazonaws.com",
-		},
-		"sa-east-1/s3": {
-			Endpoint: "s3-{region}.amazonaws.com",
 		},
 		"us-east-1/s3": {
 			Endpoint: "s3.amazonaws.com",
@@ -93,12 +78,6 @@ var endpointsMap = endpointStruct{
 		},
 		"us-gov-west-1/sts": {
 			Endpoint: "sts.us-gov-west-1.amazonaws.com",
-		},
-		"us-west-1/s3": {
-			Endpoint: "s3-{region}.amazonaws.com",
-		},
-		"us-west-2/s3": {
-			Endpoint: "s3-{region}.amazonaws.com",
 		},
 	},
 }

--- a/private/signer/v4/functional_test.go
+++ b/private/signer/v4/functional_test.go
@@ -28,7 +28,7 @@ func TestPresignHandler(t *testing.T) {
 
 	expectedDate := "19700101T000000Z"
 	expectedHeaders := "content-disposition;host;x-amz-acl"
-	expectedSig := "2d76a414208c0eac2a23ef9c834db9635ecd5a0fbb447a00ad191f82d854f55b"
+	expectedSig := "b2754ba8ffeb74a40b94767017e24c4672107d6d5a894648d5d332ca61f5ffe4"
 	expectedCred := "AKID/19700101/mock-region/s3/aws4_request"
 
 	u, _ := url.Parse(urlstr)
@@ -57,7 +57,7 @@ func TestPresignRequest(t *testing.T) {
 
 	expectedDate := "19700101T000000Z"
 	expectedHeaders := "content-disposition;host;x-amz-acl"
-	expectedSig := "2d76a414208c0eac2a23ef9c834db9635ecd5a0fbb447a00ad191f82d854f55b"
+	expectedSig := "b2754ba8ffeb74a40b94767017e24c4672107d6d5a894648d5d332ca61f5ffe4"
 	expectedCred := "AKID/19700101/mock-region/s3/aws4_request"
 	expectedHeaderMap := http.Header{
 		"x-amz-acl":           []string{"public-read"},

--- a/service/s3/host_style_bucket_test.go
+++ b/service/s3/host_style_bucket_test.go
@@ -19,22 +19,22 @@ type s3BucketTest struct {
 
 var (
 	sslTests = []s3BucketTest{
-		{"abc", "https://abc.s3.mock-region.amazonaws.com/"},
-		{"a$b$c", "https://s3.mock-region.amazonaws.com/a%24b%24c"},
-		{"a.b.c", "https://s3.mock-region.amazonaws.com/a.b.c"},
-		{"a..bc", "https://s3.mock-region.amazonaws.com/a..bc"},
+		{"abc", "https://abc.s3-mock-region.amazonaws.com/"},
+		{"a$b$c", "https://s3-mock-region.amazonaws.com/a%24b%24c"},
+		{"a.b.c", "https://s3-mock-region.amazonaws.com/a.b.c"},
+		{"a..bc", "https://s3-mock-region.amazonaws.com/a..bc"},
 	}
 
 	nosslTests = []s3BucketTest{
-		{"a.b.c", "http://a.b.c.s3.mock-region.amazonaws.com/"},
-		{"a..bc", "http://s3.mock-region.amazonaws.com/a..bc"},
+		{"a.b.c", "http://a.b.c.s3-mock-region.amazonaws.com/"},
+		{"a..bc", "http://s3-mock-region.amazonaws.com/a..bc"},
 	}
 
 	forcepathTests = []s3BucketTest{
-		{"abc", "https://s3.mock-region.amazonaws.com/abc"},
-		{"a$b$c", "https://s3.mock-region.amazonaws.com/a%24b%24c"},
-		{"a.b.c", "https://s3.mock-region.amazonaws.com/a.b.c"},
-		{"a..bc", "https://s3.mock-region.amazonaws.com/a..bc"},
+		{"abc", "https://s3-mock-region.amazonaws.com/abc"},
+		{"a$b$c", "https://s3-mock-region.amazonaws.com/a%24b%24c"},
+		{"a.b.c", "https://s3-mock-region.amazonaws.com/a.b.c"},
+		{"a..bc", "https://s3-mock-region.amazonaws.com/a..bc"},
 	}
 )
 


### PR DESCRIPTION
Adds support for setting a logger on `request.Handlerlist` used by each
service client. This allows you to provide a debug logging function
which is called for each iteration in the handler list. A default
logging func is also provided, `LogHandlerListItems` which will log the
handler used, if named, and the current state of the request's Error.

Adds support for stopping a `request.HandlerList`'s iteration after a
request handler has been executed. A default `HandlerListStopOnError`
func is provided to stop iterating a handler list's request handlers if
any request error occurs. This is added to the default Build handler
list. To stop if the request fails to build.