### PR TITLE
aws/request: Add support for logging and stopping handler lists

### DIFF
--- a/aws/defaults/defaults.go
+++ b/aws/defaults/defaults.go
@@ -67,6 +67,7 @@ func Handlers() request.Handlers {
 
 	handlers.Validate.PushBackNamed(corehandlers.ValidateEndpointHandler)
 	handlers.Build.PushBackNamed(corehandlers.SDKVersionUserAgentHandler)
+	handlers.Build.AfterEachFn = request.HandlerListStopOnError
 	handlers.Sign.PushBackNamed(corehandlers.BuildContentLengthHandler)
 	handlers.Send.PushBackNamed(corehandlers.SendHandler)
 	handlers.AfterRetry.PushBackNamed(corehandlers.AfterRetryHandler)

--- a/aws/logger.go
+++ b/aws/logger.go
@@ -79,6 +79,20 @@ type Logger interface {
 	Log(...interface{})
 }
 
+// A LoggerFunc is a convenience type to convert a function taking a variadic
+// list of arguments and wrap it so the Logger interface can be used.
+//
+// Example:
+//     s3.New(sess, &aws.Config{Logger: aws.LoggerFunc(func(args ...interface{}) {
+//         fmt.Fprintln(os.Stdout, args...)
+//     })})
+type LoggerFunc func(...interface{})
+
+// Log calls the wrapped function with the arguments provided
+func (f LoggerFunc) Log(args ...interface{}) {
+	f(args...)
+}
+
 // NewDefaultLogger returns a Logger which will write log messages to stdout, and
 // use same formatting runes as the stdlib log.Logger
 func NewDefaultLogger() Logger {

--- a/aws/request/handlers.go
+++ b/aws/request/handlers.go
@@ -50,9 +50,28 @@ func (h *Handlers) Clear() {
 	h.AfterRetry.Clear()
 }
 
+// A HandlerListRunItem represents an entry in the HandlerList which
+// is being run.
+type HandlerListRunItem struct {
+	Index   int
+	Handler NamedHandler
+	Request *Request
+}
+
 // A HandlerList manages zero or more handlers in a list.
 type HandlerList struct {
 	list []NamedHandler
+
+	// Called after each request handler in the list is called. If set
+	// and the func returns true the HandlerList will continue to iterate
+	// over the request handlers. If false is returned the HandlerList
+	// will stop iterating.
+	//
+	// Should be used if extra logic to be performed between each handler
+	// in the list. This can be used to terminate a list's iteration
+	// based on a condition such as error like, HandlerListStopOnError.
+	// Or for logging like HandlerListLogItem.
+	AfterEachFn func(item HandlerListRunItem) bool
 }
 
 // A NamedHandler is a struct that contains a name and function callback.
@@ -63,7 +82,9 @@ type NamedHandler struct {
 
 // copy creates a copy of the handler list.
 func (l *HandlerList) copy() HandlerList {
-	var n HandlerList
+	n := HandlerList{
+		AfterEachFn: l.AfterEachFn,
+	}
 	n.list = append([]NamedHandler{}, l.list...)
 	return n
 }
@@ -111,9 +132,35 @@ func (l *HandlerList) Remove(n NamedHandler) {
 
 // Run executes all handlers in the list with a given request object.
 func (l *HandlerList) Run(r *Request) {
-	for _, f := range l.list {
-		f.Fn(r)
+	for i, h := range l.list {
+		h.Fn(r)
+		item := HandlerListRunItem{
+			Index: i, Handler: h, Request: r,
+		}
+		if l.AfterEachFn != nil && !l.AfterEachFn(item) {
+			return
+		}
 	}
+}
+
+// HandlerListLogItem logs the request handler and the state of the
+// request's Error value. Always returns true to continue iterating
+// request handlers in a HandlerList.
+func HandlerListLogItem(item HandlerListRunItem) bool {
+	if item.Request.Config.Logger == nil {
+		return true
+	}
+	item.Request.Config.Logger.Log("DEBUG: RequestHandler",
+		item.Index, item.Handler.Name, item.Request.Error)
+
+	return true
+}
+
+// HandlerListStopOnError returns false to stop the HandlerList iterating
+// over request handlers if Request.Error is not nil. True otherwise
+// to continue iterating.
+func HandlerListStopOnError(item HandlerListRunItem) bool {
+	return item.Request.Error == nil
 }
 
 // MakeAddToUserAgentHandler will add the name/version pair to the User-Agent request

--- a/aws/request/handlers_test.go
+++ b/aws/request/handlers_test.go
@@ -45,3 +45,43 @@ func TestNamedHandlers(t *testing.T) {
 	l.Remove(named)
 	assert.Equal(t, 2, l.Len())
 }
+
+func TestLoggedHandlers(t *testing.T) {
+	expectedHandlers := []string{"name1", "name2"}
+	l := request.HandlerList{}
+	loggedHandlers := []string{}
+	l.AfterEachFn = request.HandlerListLogItem
+	cfg := aws.Config{Logger: aws.LoggerFunc(func(args ...interface{}) {
+		loggedHandlers = append(loggedHandlers, args[2].(string))
+	})}
+
+	named1 := request.NamedHandler{Name: "name1", Fn: func(r *request.Request) {}}
+	named2 := request.NamedHandler{Name: "name2", Fn: func(r *request.Request) {}}
+	l.PushBackNamed(named1)
+	l.PushBackNamed(named2)
+	l.Run(&request.Request{Config: cfg})
+
+	assert.Equal(t, expectedHandlers, loggedHandlers)
+}
+
+func TestStopHandlers(t *testing.T) {
+	l := request.HandlerList{}
+	stopAt := 1
+	l.AfterEachFn = func(item request.HandlerListRunItem) bool {
+		return item.Index != stopAt
+	}
+
+	called := 0
+	l.PushBackNamed(request.NamedHandler{Name: "name1", Fn: func(r *request.Request) {
+		called++
+	}})
+	l.PushBackNamed(request.NamedHandler{Name: "name2", Fn: func(r *request.Request) {
+		called++
+	}})
+	l.PushBackNamed(request.NamedHandler{Name: "name3", Fn: func(r *request.Request) {
+		assert.Fail(t, "thrid handler should not be called")
+	}})
+	l.Run(&request.Request{})
+
+	assert.Equal(t, 2, called, "Expect only two handlers to be called")
+}

--- a/aws/request/request.go
+++ b/aws/request/request.go
@@ -192,6 +192,10 @@ func (r *Request) Build() error {
 			return r.Error
 		}
 		r.Handlers.Build.Run(r)
+		if r.Error != nil {
+			debugLogReqError(r, "Build Request", false, r.Error)
+			return r.Error
+		}
 		r.built = true
 	}
 


### PR DESCRIPTION
Adds support for setting a logger on `request.Handlerlist` used by each
service client. This allows you to provide a debug logging function
which is called for each iteration in the handler list. A default
logging func is also provided, `LogHandlerListItems` which will log the
handler used, if named, and the current state of the request's Error.

Adds support for stopping a `request.HandlerList`'s iteration after a
request handler has been executed. A default `HandlerListStopOnError`
func is provided to stop iterating a handler list's request handlers if
any request error occurs. This is added to the default Build handler
list. To stop if the request fails to build.

