### PR TITLE
Update for Go 1.6

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -5,6 +5,7 @@ sudo: false
 go:
   - 1.4
   - 1.5
+  - 1.6
   - tip
     
 # Use Go 1.5's vendoring experiment for 1.5 tests. 1.4 tests will use the tip of the dependencies repo.

--- a/Makefile
+++ b/Makefile
@@ -70,7 +70,7 @@ lint:
 	if [ "$$lint" != "" ]; then exit 1; fi
 
 vet:
-	go tool vet -all -shadow $(shell ls -d */ | grep -v vendor)
+	go tool vet -all -shadow $(shell if go version | grep -v 1.5 | grep -v 1.4 >> /dev/null; then echo "-example=false" | tr -d '\n'; fi) $(shell ls -d */ | grep -v vendor)
 
 get-deps: get-deps-tests get-deps-verify
 	@echo "go get SDK dependencies"


### PR DESCRIPTION
- Do not fail on example naming scheme because example code is within a `_test` package when running go vet
- Add Travis testing for Go 1.6