### PR TITLE
aws/types: grow WriteAtBuffer capacity by 2m when growing to length m

### DIFF
--- a/aws/types_test.go
+++ b/aws/types_test.go
@@ -54,3 +54,22 @@ func BenchmarkWriteAtBufferParallel(b *testing.B) {
 		}
 	})
 }
+
+func BenchmarkWriteAtBufferOrderedWrites(b *testing.B) {
+	// test the performance of a WriteAtBuffer when written in an
+	// ordered fashion. This is similar to the behavior of the
+	// s3.Downloader, since downloads the first chunk of the file, then
+	// the second, and so on.
+	//
+	// This test simulates a 150MB file being written in 30 ordered 5MB chunks.
+	chunk := int64(5e6)
+	max := chunk * 30
+	// we'll write the same 5MB chunk every time
+	tmp := make([]byte, chunk)
+	for i := 0; i < b.N; i++ {
+		buf := &WriteAtBuffer{}
+		for i := int64(0); i < max; i += chunk {
+			buf.WriteAt(tmp, i)
+		}
+	}
+}

--- a/aws/types_test.go
+++ b/aws/types_test.go
@@ -41,20 +41,6 @@ func BenchmarkWriteAtBuffer(b *testing.B) {
 	}
 }
 
-func BenchmarkWriteAtBufferParallel(b *testing.B) {
-	buf := &WriteAtBuffer{}
-	r := rand.New(rand.NewSource(1))
-
-	b.ResetTimer()
-	b.RunParallel(func(pb *testing.PB) {
-		for pb.Next() {
-			to := r.Intn(10) * 4096
-			bs := make([]byte, to)
-			buf.WriteAt(bs, r.Int63n(10)*4096)
-		}
-	})
-}
-
 func BenchmarkWriteAtBufferOrderedWrites(b *testing.B) {
 	// test the performance of a WriteAtBuffer when written in an
 	// ordered fashion. This is similar to the behavior of the
@@ -72,4 +58,18 @@ func BenchmarkWriteAtBufferOrderedWrites(b *testing.B) {
 			buf.WriteAt(tmp, i)
 		}
 	}
+}
+
+func BenchmarkWriteAtBufferParallel(b *testing.B) {
+	buf := &WriteAtBuffer{}
+	r := rand.New(rand.NewSource(1))
+
+	b.ResetTimer()
+	b.RunParallel(func(pb *testing.PB) {
+		for pb.Next() {
+			to := r.Intn(10) * 4096
+			bs := make([]byte, to)
+			buf.WriteAt(bs, r.Int63n(10)*4096)
+		}
+	})
 }


### PR DESCRIPTION
If the WriteAtBuffer is given ordered calls to WriteAt, i.e. the
length of the internal buffer grows with each call, the WriteAtBuffer
significantly degrades in performance due to the internal buffer
allocating too slowly. This occurs when downloading an object from S3,
where the object is downloaded in ordered chunks. I included a new
test, BenchmarkWriteAtBufferOrderedWrites to test the performance
around this use case.

By growing the internal buffer's capacity by 2*expLen, we may
potentially use more memory, but we spend less time copying bytes and
reallocating the internal buffer.

This change allows a consumer of this library to use two new
mechanisms to control the allocation of the internal buffer:

1. .GrowthCoeff, which defines the growth rate of the internal
buffer. In cases where the final buffer size is unknown, setting this
to 1.5 or to 2 should significantly reduce allocations.

2. NewWriteAtBuffer, which the
caller can pass in an internal buffer of the expected size, skipping
re-allocation entirely.

If setting GrowthCoeff to 2, we have less allocations to do and get a
speedup with ordered writes:

```
benchmark                                 old ns/op     new ns/op     delta
BenchmarkWriteAtBuffer-8                  3820          3889          +1.81%
BenchmarkWriteAtBufferParallel-8          4634          4501          -2.87%
BenchmarkWriteAtBufferOrderedWrites-8     445769448     42031587      -90.57%

benchmark                                 old allocs     new allocs     delta
BenchmarkWriteAtBuffer-8                  0              0              +0.00%
BenchmarkWriteAtBufferParallel-8          0              0              +0.00%
BenchmarkWriteAtBufferOrderedWrites-8     540            44             -91.85%

benchmark                                 old bytes      new bytes     delta
BenchmarkWriteAtBuffer-8                  19227          19227         +0.00%
BenchmarkWriteAtBufferParallel-8          19210          19268         +0.30%
BenchmarkWriteAtBufferOrderedWrites-8     2326800405     260181350     -88.82%
```