### PR TITLE
Close response body on retries and if a response was returned during an error in corehandler

### DIFF
--- a/aws/corehandlers/handlers.go
+++ b/aws/corehandlers/handlers.go
@@ -64,6 +64,11 @@ var SendHandler = request.NamedHandler{Name: "core.SendHandler", Fn: func(r *req
 	var err error
 	r.HTTPResponse, err = r.Config.HTTPClient.Do(r.HTTPRequest)
 	if err != nil {
+		// Prevent leaking if an HTTPResponse was returned. Clean up
+		// the body.
+		if r.HTTPResponse != nil {
+			r.HTTPResponse.Body.Close()
+		}
 		// Capture the case where url.Error is returned for error processing
 		// response. e.g. 301 without location header comes back as string
 		// error and r.HTTPResponse is nil. Other url redirect errors will

--- a/aws/corehandlers/handlers_test.go
+++ b/aws/corehandlers/handlers_test.go
@@ -1,7 +1,9 @@
 package corehandlers_test
 
 import (
+	"bytes"
 	"fmt"
+	"io/ioutil"
 	"net/http"
 	"os"
 	"testing"
@@ -69,7 +71,7 @@ func TestAfterRetryRefreshCreds(t *testing.T) {
 	svc.Handlers.Clear()
 	svc.Handlers.ValidateResponse.PushBack(func(r *request.Request) {
 		r.Error = awserr.New("UnknownError", "", nil)
-		r.HTTPResponse = &http.Response{StatusCode: 400}
+		r.HTTPResponse = &http.Response{StatusCode: 400, Body: ioutil.NopCloser(bytes.NewBuffer([]byte{}))}
 	})
 	svc.Handlers.UnmarshalError.PushBack(func(r *request.Request) {
 		r.Error = awserr.New("ExpiredTokenException", "", nil)

--- a/aws/request/request.go
+++ b/aws/request/request.go
@@ -234,6 +234,7 @@ func (r *Request) Send() error {
 					r.ClientInfo.ServiceName, r.Operation.Name, r.RetryCount))
 			}
 
+			r.HTTPResponse.Body.Close()
 			// Re-seek the body back to the original point in for a retry so that
 			// send will send the body's contents again in the upcoming request.
 			r.Body.Seek(r.BodyStart, 0)

--- a/aws/request/request.go
+++ b/aws/request/request.go
@@ -234,7 +234,10 @@ func (r *Request) Send() error {
 					r.ClientInfo.ServiceName, r.Operation.Name, r.RetryCount))
 			}
 
+			// Closing response body. Since we are setting a new request to send off, this
+			// response will get squashed and leaked.
 			r.HTTPResponse.Body.Close()
+
 			// Re-seek the body back to the original point in for a retry so that
 			// send will send the body's contents again in the upcoming request.
 			r.Body.Seek(r.BodyStart, 0)


### PR DESCRIPTION
Fixes #563 