### PR TITLE
Fixed data race in retry by adding our own custom io.Reader

### DIFF
--- a/aws/client/default_retryer.go
+++ b/aws/client/default_retryer.go
@@ -1,7 +1,6 @@
 package client
 
 import (
-	"math"
 	"math/rand"
 	"time"
 
@@ -32,7 +31,13 @@ func (d DefaultRetryer) MaxRetries() int {
 
 // RetryRules returns the delay duration before retrying this request again
 func (d DefaultRetryer) RetryRules(r *request.Request) time.Duration {
-	delay := int(math.Pow(2, float64(r.RetryCount))) * (rand.Intn(30) + 30)
+	// Set the upper limit of delay in retrying at ~five minutes
+	retryCount := r.RetryCount
+	if retryCount > 13 {
+		retryCount = 13
+	}
+
+	delay := (1 << uint(retryCount)) * (rand.Intn(30) + 30)
 	return time.Duration(delay) * time.Millisecond
 }
 

--- a/aws/request/offset_reader.go
+++ b/aws/request/offset_reader.go
@@ -1,0 +1,49 @@
+package request
+
+import (
+	"io"
+	"sync"
+)
+
+// offsetReader is a thread-safe io.ReadCloser to prevent racing
+// with retrying requests
+type offsetReader struct {
+	buf    io.ReadSeeker
+	lock   sync.RWMutex
+	closed bool
+}
+
+func newOffsetReader(buf io.ReadSeeker, offset int64) *offsetReader {
+	reader := &offsetReader{}
+	buf.Seek(offset, 0)
+
+	reader.buf = buf
+	return reader
+}
+
+// Close is a thread-safe close. Uses the write lock.
+func (o *offsetReader) Close() error {
+	o.lock.Lock()
+	defer o.lock.Unlock()
+	o.closed = true
+	return nil
+}
+
+// Read is a thread-safe read using a read lock.
+func (o *offsetReader) Read(p []byte) (int, error) {
+	o.lock.RLock()
+	defer o.lock.RUnlock()
+
+	if o.closed {
+		return 0, io.EOF
+	}
+
+	return o.buf.Read(p)
+}
+
+// CloseAndCopy will return a new offsetReader with a copy of the old buffer
+// and close the old buffer.
+func (o *offsetReader) CloseAndCopy(offset int64) *offsetReader {
+	o.Close()
+	return newOffsetReader(o.buf, offset)
+}

--- a/aws/request/offset_reader_test.go
+++ b/aws/request/offset_reader_test.go
@@ -1,0 +1,122 @@
+package request
+
+import (
+	"bytes"
+	"io"
+	"math/rand"
+	"sync"
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/assert"
+)
+
+func TestOffsetReaderRead(t *testing.T) {
+	buf := []byte("testData")
+	reader := &offsetReader{buf: bytes.NewReader(buf)}
+
+	tempBuf := make([]byte, len(buf))
+
+	n, err := reader.Read(tempBuf)
+
+	assert.Equal(t, n, len(buf))
+	assert.Nil(t, err)
+	assert.Equal(t, buf, tempBuf)
+}
+
+func TestOffsetReaderClose(t *testing.T) {
+	buf := []byte("testData")
+	reader := &offsetReader{buf: bytes.NewReader(buf)}
+
+	err := reader.Close()
+	assert.Nil(t, err)
+
+	tempBuf := make([]byte, len(buf))
+	n, err := reader.Read(tempBuf)
+	assert.Equal(t, n, 0)
+	assert.Equal(t, err, io.EOF)
+}
+
+func TestOffsetReaderCloseAndCopy(t *testing.T) {
+	buf := []byte("testData")
+	tempBuf := make([]byte, len(buf))
+	reader := &offsetReader{buf: bytes.NewReader(buf)}
+
+	newReader := reader.CloseAndCopy(0)
+
+	n, err := reader.Read(tempBuf)
+	assert.Equal(t, n, 0)
+	assert.Equal(t, err, io.EOF)
+
+	n, err = newReader.Read(tempBuf)
+	assert.Equal(t, n, len(buf))
+	assert.Nil(t, err)
+	assert.Equal(t, buf, tempBuf)
+}
+
+func TestOffsetReaderCloseAndCopyOffset(t *testing.T) {
+	buf := []byte("testData")
+	tempBuf := make([]byte, len(buf))
+	reader := &offsetReader{buf: bytes.NewReader(buf)}
+
+	newReader := reader.CloseAndCopy(4)
+	n, err := newReader.Read(tempBuf)
+	assert.Equal(t, n, len(buf)-4)
+	assert.Nil(t, err)
+
+	expected := []byte{'D', 'a', 't', 'a', 0, 0, 0, 0}
+	assert.Equal(t, expected, tempBuf)
+}
+
+func TestOffsetReaderRace(t *testing.T) {
+	wg := sync.WaitGroup{}
+
+	f := func(reader *offsetReader) {
+		defer wg.Done()
+		var err error
+		buf := make([]byte, 1)
+		_, err = reader.Read(buf)
+		for err != io.EOF {
+			_, err = reader.Read(buf)
+		}
+
+	}
+
+	closeFn := func(reader *offsetReader) {
+		defer wg.Done()
+		time.Sleep(time.Duration(rand.Intn(20)+1) * time.Millisecond)
+		reader.Close()
+	}
+	for i := 0; i < 50; i++ {
+		reader := &offsetReader{buf: bytes.NewReader(make([]byte, 1024*1024))}
+		wg.Add(1)
+		go f(reader)
+		wg.Add(1)
+		go closeFn(reader)
+	}
+	wg.Wait()
+}
+
+func BenchmarkOffsetReader(b *testing.B) {
+	bufSize := 1024 * 1024 * 100
+	buf := make([]byte, bufSize)
+	reader := &offsetReader{buf: bytes.NewReader(buf)}
+
+	tempBuf := make([]byte, 1024)
+
+	for i := 0; i < b.N; i++ {
+		reader.Read(tempBuf)
+	}
+}
+
+func BenchmarkBytesReader(b *testing.B) {
+	bufSize := 1024 * 1024 * 100
+	buf := make([]byte, bufSize)
+	reader := bytes.NewReader(buf)
+
+	tempBuf := make([]byte, 1024)
+
+	for i := 0; i < b.N; i++ {
+		reader.Read(tempBuf)
+	}
+}

--- a/aws/request/request.go
+++ b/aws/request/request.go
@@ -131,7 +131,7 @@ func (r *Request) SetStringBody(s string) {
 
 // SetReaderBody will set the request's body reader.
 func (r *Request) SetReaderBody(reader io.ReadSeeker) {
-	r.HTTPRequest.Body = ioutil.NopCloser(reader)
+	r.HTTPRequest.Body = newOffsetReader(reader, 0)
 	r.Body = reader
 }
 
@@ -223,26 +223,46 @@ func (r *Request) Sign() error {
 // be executed in the order they were set.
 func (r *Request) Send() error {
 	for {
-		r.Sign()
-		if r.Error != nil {
-			return r.Error
-		}
-
 		if aws.BoolValue(r.Retryable) {
 			if r.Config.LogLevel.Matches(aws.LogDebugWithRequestRetries) {
 				r.Config.Logger.Log(fmt.Sprintf("DEBUG: Retrying Request %s/%s, attempt %d",
 					r.ClientInfo.ServiceName, r.Operation.Name, r.RetryCount))
 			}
 
+			var body io.ReadCloser
+			if reader, ok := r.HTTPRequest.Body.(*offsetReader); ok {
+				body = reader.CloseAndCopy(r.BodyStart)
+			} else {
+				if r.Config.Logger != nil {
+					r.Config.Logger.Log("Request body type has been overwritten. May cause race conditions")
+				}
+				r.Body.Seek(r.BodyStart, 0)
+				body = ioutil.NopCloser(r.Body)
+			}
+
+			r.HTTPRequest = &http.Request{
+				URL:           r.HTTPRequest.URL,
+				Header:        r.HTTPRequest.Header,
+				Close:         r.HTTPRequest.Close,
+				Form:          r.HTTPRequest.Form,
+				PostForm:      r.HTTPRequest.PostForm,
+				Body:          body,
+				MultipartForm: r.HTTPRequest.MultipartForm,
+				Host:          r.HTTPRequest.Host,
+				Method:        r.HTTPRequest.Method,
+				Proto:         r.HTTPRequest.Proto,
+				ContentLength: r.HTTPRequest.ContentLength,
+			}
 			// Closing response body. Since we are setting a new request to send off, this
 			// response will get squashed and leaked.
 			r.HTTPResponse.Body.Close()
-
-			// Re-seek the body back to the original point in for a retry so that
-			// send will send the body's contents again in the upcoming request.
-			r.Body.Seek(r.BodyStart, 0)
-			r.HTTPRequest.Body = ioutil.NopCloser(r.Body)
 		}
+
+		r.Sign()
+		if r.Error != nil {
+			return r.Error
+		}
+
 		r.Retryable = nil
 
 		r.Handlers.Send.Run(r)


### PR DESCRIPTION
Fixes #569 

There was a possibility of a data race in retrying due to transport trying to manipulate HTTPRequest's body and the SDK trying to reuse the request by seeking on the body. To fix this we added a thread-safe `io.Reader`, that way the transport will be mutually exclusive with the SDK's retry.

Performance benchmarks of the `io.Reader` vs `offsetReader`:
```
BenchmarkBytesReader-4  1000000000               1.80 ns/op
ok      github.com/aws/aws-sdk-go/aws/request   1.978s
BenchmarkOffsetReader-4 20000000                91.3 ns/op
ok      github.com/aws/aws-sdk-go/aws/request   2.951s
```