### PR TITLE
Correctly point to the credentials file

### DIFF
--- a/README.md
+++ b/README.md
@@ -42,7 +42,7 @@ AWS_SECRET_ACCESS_KEY=MY-SECRET-KEY
 ```
 
 ### AWS CLI config file (`~/aws/config`)
-The AWS SDK for Go does not support the AWS CLI's config file. The SDK will not use any contents from this file. The SDK only supports the shared credentials file (`~/aws/credentials`). #384 tracks this feature request discussion.
+The AWS SDK for Go does not support the AWS CLI's config file. The SDK will not use any contents from this file. The SDK only supports the shared credentials file (`~/.aws/credentials`). #384 tracks this feature request discussion.
 
 ## Using the Go SDK
 


### PR DESCRIPTION
Think this is a typo in the readme about credientials