### PR TITLE
ec2rolecreds: Add method for getting instance identity doc

### DIFF
--- a/aws/ec2metadata/api.go
+++ b/aws/ec2metadata/api.go
@@ -1,8 +1,12 @@
 package ec2metadata
 
 import (
+	"encoding/json"
 	"path"
+	"strings"
+	"time"
 
+	"github.com/aws/aws-sdk-go/aws/awserr"
 	"github.com/aws/aws-sdk-go/aws/request"
 )
 
@@ -18,6 +22,39 @@ func (c *EC2Metadata) GetMetadata(p string) (string, error) {
 	req := c.NewRequest(op, nil, output)
 
 	return output.Content, req.Send()
+}
+
+// GetDynamicData uses the path provided to request
+func (c *EC2Metadata) GetDynamicData(p string) (string, error) {
+	op := &request.Operation{
+		Name:       "GetMetadata",
+		HTTPMethod: "GET",
+		HTTPPath:   path.Join("/", "dynamic", p),
+	}
+
+	output := &metadataOutput{}
+	req := c.NewRequest(op, nil, output)
+
+	return output.Content, req.Send()
+}
+
+// GetInstanceIdentityDocument retrieves an identity document describing an instance
+func (c *EC2Metadata) GetInstanceIdentityDocument() (EC2InstanceIdentityDocument, error) {
+	resp, err := c.GetDynamicData("instance-identity/document")
+	if err != nil {
+		return EC2InstanceIdentityDocument{},
+			awserr.New("EC2RoleRequestError",
+				"failed to get EC2 instance identity document", err)
+	}
+
+	doc := EC2InstanceIdentityDocument{}
+	if err := json.NewDecoder(strings.NewReader(resp)).Decode(&doc); err != nil {
+		return EC2InstanceIdentityDocument{},
+			awserr.New("SerializationError",
+				"failed to decode EC2 instance identity document", err)
+	}
+
+	return doc, nil
 }
 
 // Region returns the region the instance is running in.
@@ -40,4 +77,23 @@ func (c *EC2Metadata) Available() bool {
 	}
 
 	return true
+}
+
+// An EC2InstanceIdentityDocument provides the shape for unmarshalling
+// an instance identity document
+type EC2InstanceIdentityDocument struct {
+	DevpayProductCodes []string  `json:"devpayProductCodes"`
+	AvailabilityZone   string    `json:"availabilityZone"`
+	PrivateIP          string    `json:"privateIp"`
+	Version            string    `json:"version"`
+	Region             string    `json:"region"`
+	InstanceID         string    `json:"instanceId"`
+	BillingProducts    []string  `json:"billingProducts"`
+	InstanceType       string    `json:"instanceType"`
+	AccountID          string    `json:"accountId"`
+	PendingTime        time.Time `json:"pendingTime"`
+	ImageID            string    `json:"imageId"`
+	KernelID           string    `json:"kernelId"`
+	RamdiskID          string    `json:"ramdiskId"`
+	Architecture       string    `json:"architecture"`
 }


### PR DESCRIPTION
This is an implementation of a very basic check for "authenticity" of an EC2 metadata API as discussed in https://github.com/aws/aws-sdk-go/issues/543

This is how I'd expect people to use it:

```go
func getCreds(key, secret, token, profile, credsfile string) *awsCredentials.Credentials {
	providers := []awsCredentials.Provider{
		&awsCredentials.StaticProvider{Value: awsCredentials.Value{
			AccessKeyID:     key,
			SecretAccessKey: secret,
			SessionToken:    token,
		}},
		&awsCredentials.EnvProvider{},
		&awsCredentials.SharedCredentialsProvider{
			Filename: credsfile,
			Profile:  profile,
		},
	}

	cfg := &aws.Config{}
	endpoint := os.Getenv("AWS_METADATA_ENDPOINT")
	if endpoint != "" {
		cfg.Endpoint = aws.String(getMetadataEndpoint())
	}
	
	ec2Provider := &ec2rolecreds.EC2RoleProvider{
		Client: ec2metadata.New(session.New(cfg)),
	}

	// Unless custom endpoint was given, verify it
	if endpoint == "" {
		_, err := ec2Provider.GetIdentityDocument()
		if err == nil {
			providers = append(providers, ec2Provider)
		} else {
			log.Printf("Failed to get instance identity document: %s", err)
		}
	}

	return awsCredentials.NewChainCredentials(providers)
}
```

Is there any standardised name for the ENV variable (`AWS_METADATA_ENDPOINT`)?

The PKCS7 signature verification can be a next iteration in a separate PR - I tried to keep this simple for the beginning.