### PR TITLE
private/model/api: Add custom doc for blob type doc strings

### DIFF
--- a/private/protocol/ec2query/build_test.go
+++ b/private/protocol/ec2query/build_test.go
@@ -676,6 +676,7 @@ func (c *InputService7ProtocolTest) InputService7TestCaseOperation1(input *Input
 type InputService7TestShapeInputService7TestCaseOperation1Input struct {
 	_ struct{} `type:"structure"`
 
+	// BlobArg is automatically base64 encoded/decoded by the SDK.
 	BlobArg []byte `type:"blob"`
 }
 

--- a/private/protocol/ec2query/unmarshal_test.go
+++ b/private/protocol/ec2query/unmarshal_test.go
@@ -228,6 +228,7 @@ type OutputService2TestShapeOutputService2TestCaseOperation1Input struct {
 type OutputService2TestShapeOutputService2TestCaseOperation1Output struct {
 	_ struct{} `type:"structure"`
 
+	// Blob is automatically base64 encoded/decoded by the SDK.
 	Blob []byte `type:"blob"`
 }
 

--- a/private/protocol/jsonrpc/build_test.go
+++ b/private/protocol/jsonrpc/build_test.go
@@ -345,6 +345,7 @@ type InputService3TestShapeInputService3TestCaseOperation2Output struct {
 type InputService3TestShapeInputShape struct {
 	_ struct{} `type:"structure"`
 
+	// BlobArg is automatically base64 encoded/decoded by the SDK.
 	BlobArg []byte `type:"blob"`
 
 	BlobMap map[string][]byte `type:"map"`

--- a/private/protocol/jsonrpc/unmarshal_test.go
+++ b/private/protocol/jsonrpc/unmarshal_test.go
@@ -228,6 +228,7 @@ func (c *OutputService2ProtocolTest) OutputService2TestCaseOperation1(input *Out
 type OutputService2TestShapeBlobContainer struct {
 	_ struct{} `type:"structure"`
 
+	// Foo is automatically base64 encoded/decoded by the SDK.
 	Foo []byte `locationName:"foo" type:"blob"`
 }
 
@@ -238,6 +239,7 @@ type OutputService2TestShapeOutputService2TestCaseOperation1Input struct {
 type OutputService2TestShapeOutputService2TestCaseOperation1Output struct {
 	_ struct{} `type:"structure"`
 
+	// BlobMember is automatically base64 encoded/decoded by the SDK.
 	BlobMember []byte `type:"blob"`
 
 	StructMember *OutputService2TestShapeBlobContainer `type:"structure"`

--- a/private/protocol/query/build_test.go
+++ b/private/protocol/query/build_test.go
@@ -1070,6 +1070,7 @@ func (c *InputService10ProtocolTest) InputService10TestCaseOperation1(input *Inp
 type InputService10TestShapeInputService10TestCaseOperation1Input struct {
 	_ struct{} `type:"structure"`
 
+	// BlobArg is automatically base64 encoded/decoded by the SDK.
 	BlobArg []byte `type:"blob"`
 }
 

--- a/private/protocol/query/unmarshal_test.go
+++ b/private/protocol/query/unmarshal_test.go
@@ -320,6 +320,7 @@ type OutputService3TestShapeOutputService3TestCaseOperation1Input struct {
 type OutputService3TestShapeOutputService3TestCaseOperation1Output struct {
 	_ struct{} `type:"structure"`
 
+	// Blob is automatically base64 encoded/decoded by the SDK.
 	Blob []byte `type:"blob"`
 }
 

--- a/private/protocol/restjson/unmarshal_test.go
+++ b/private/protocol/restjson/unmarshal_test.go
@@ -230,6 +230,7 @@ func (c *OutputService2ProtocolTest) OutputService2TestCaseOperation1(input *Out
 type OutputService2TestShapeBlobContainer struct {
 	_ struct{} `type:"structure"`
 
+	// Foo is automatically base64 encoded/decoded by the SDK.
 	Foo []byte `locationName:"foo" type:"blob"`
 }
 
@@ -240,6 +241,7 @@ type OutputService2TestShapeOutputService2TestCaseOperation1Input struct {
 type OutputService2TestShapeOutputService2TestCaseOperation1Output struct {
 	_ struct{} `type:"structure"`
 
+	// BlobMember is automatically base64 encoded/decoded by the SDK.
 	BlobMember []byte `type:"blob"`
 
 	StructMember *OutputService2TestShapeBlobContainer `type:"structure"`

--- a/private/protocol/restxml/build_test.go
+++ b/private/protocol/restxml/build_test.go
@@ -1098,6 +1098,7 @@ type InputService10TestShapeInputService10TestCaseOperation1Output struct {
 type InputService10TestShapeStructureShape struct {
 	_ struct{} `type:"structure"`
 
+	// B is automatically base64 encoded/decoded by the SDK.
 	B []byte `locationName:"b" type:"blob"`
 
 	T *time.Time `locationName:"t" type:"timestamp" timestampFormat:"iso8601"`

--- a/private/protocol/restxml/unmarshal_test.go
+++ b/private/protocol/restxml/unmarshal_test.go
@@ -262,6 +262,7 @@ type OutputService2TestShapeOutputService2TestCaseOperation1Input struct {
 type OutputService2TestShapeOutputService2TestCaseOperation1Output struct {
 	_ struct{} `type:"structure"`
 
+	// Blob is automatically base64 encoded/decoded by the SDK.
 	Blob []byte `type:"blob"`
 }
 

--- a/service/cloudtrail/api.go
+++ b/service/cloudtrail/api.go
@@ -995,6 +995,8 @@ type PublicKey struct {
 	ValidityStartTime *time.Time `type:"timestamp" timestampFormat:"unix"`
 
 	// The DER encoded public key value in PKCS#1 format.
+	//
+	// Value is automatically base64 encoded/decoded by the SDK.
 	Value []byte `type:"blob"`
 }
 

--- a/service/dynamodb/api.go
+++ b/service/dynamodb/api.go
@@ -796,6 +796,8 @@ type AttributeValue struct {
 	_ struct{} `type:"structure"`
 
 	// A Binary data type.
+	//
+	// B is automatically base64 encoded/decoded by the SDK.
 	B []byte `type:"blob"`
 
 	// A Boolean data type.

--- a/service/ec2/api.go
+++ b/service/ec2/api.go
@@ -7983,6 +7983,7 @@ func (s AvailableCapacity) GoString() string {
 type BlobAttributeValue struct {
 	_ struct{} `type:"structure"`
 
+	// Value is automatically base64 encoded/decoded by the SDK.
 	Value []byte `locationName:"value" type:"blob"`
 }
 
@@ -17436,6 +17437,8 @@ type ImportKeyPairInput struct {
 
 	// The public key. You must base64 encode the public key material before sending
 	// it to AWS.
+	//
+	// PublicKeyMaterial is automatically base64 encoded/decoded by the SDK.
 	PublicKeyMaterial []byte `locationName:"publicKeyMaterial" type:"blob" required:"true"`
 }
 
@@ -21903,6 +21906,8 @@ type S3Storage struct {
 
 	// A Base64-encoded Amazon S3 upload policy that gives Amazon EC2 permission
 	// to upload items into Amazon S3 on your behalf.
+	//
+	// UploadPolicy is automatically base64 encoded/decoded by the SDK.
 	UploadPolicy []byte `locationName:"uploadPolicy" type:"blob"`
 
 	// The signature of the Base64 encoded JSON document.

--- a/service/ecr/api.go
+++ b/service/ecr/api.go
@@ -1349,6 +1349,8 @@ type UploadLayerPartInput struct {
 	_ struct{} `type:"structure"`
 
 	// The base64-encoded layer part payload.
+	//
+	// LayerPartBlob is automatically base64 encoded/decoded by the SDK.
 	LayerPartBlob []byte `locationName:"layerPartBlob" type:"blob" required:"true"`
 
 	// The integer value of the first byte of the layer part.

--- a/service/firehose/api.go
+++ b/service/firehose/api.go
@@ -841,6 +841,8 @@ type Record struct {
 
 	// The data blob, which is base64-encoded when the blob is serialized. The maximum
 	// size of the data blob, before base64-encoding, is 1,000 KB.
+	//
+	// Data is automatically base64 encoded/decoded by the SDK.
 	Data []byte `type:"blob" required:"true"`
 }
 

--- a/service/iam/api.go
+++ b/service/iam/api.go
@@ -6627,6 +6627,8 @@ type GetCredentialReportOutput struct {
 	_ struct{} `type:"structure"`
 
 	// Contains the credential report. The report is Base64-encoded.
+	//
+	// Content is automatically base64 encoded/decoded by the SDK.
 	Content []byte `type:"blob"`
 
 	// The date and time when the credential report was created, in ISO 8601 date-time
@@ -11105,6 +11107,8 @@ type VirtualMFADevice struct {
 
 	// The Base32 seed defined as specified in RFC3548 (http://www.ietf.org/rfc/rfc3548.txt).
 	// The Base32StringSeed is Base64-encoded.
+	//
+	// Base32StringSeed is automatically base64 encoded/decoded by the SDK.
 	Base32StringSeed []byte `type:"blob"`
 
 	// The date and time on which the virtual MFA device was enabled.
@@ -11114,6 +11118,8 @@ type VirtualMFADevice struct {
 	// where $virtualMFADeviceName is one of the create call arguments, AccountName
 	// is the user name if set (otherwise, the account ID otherwise), and Base32String
 	// is the seed in Base32 format. The Base32String value is Base64-encoded.
+	//
+	// QRCodePNG is automatically base64 encoded/decoded by the SDK.
 	QRCodePNG []byte `type:"blob"`
 
 	// The serial number associated with VirtualMFADevice.

--- a/service/kinesis/api.go
+++ b/service/kinesis/api.go
@@ -1333,6 +1333,8 @@ type PutRecordInput struct {
 	// is serialized. When the data blob (the payload before base64-encoding) is
 	// added to the partition key size, the total size must not exceed the maximum
 	// record size (1 MB).
+	//
+	// Data is automatically base64 encoded/decoded by the SDK.
 	Data []byte `type:"blob" required:"true"`
 
 	// The hash value used to explicitly determine the shard the data record is
@@ -1448,6 +1450,8 @@ type PutRecordsRequestEntry struct {
 	// is serialized. When the data blob (the payload before base64-encoding) is
 	// added to the partition key size, the total size must not exceed the maximum
 	// record size (1 MB).
+	//
+	// Data is automatically base64 encoded/decoded by the SDK.
 	Data []byte `type:"blob" required:"true"`
 
 	// The hash value used to determine explicitly the shard that the data record
@@ -1523,6 +1527,8 @@ type Record struct {
 	// the blob in any way. When the data blob (the payload before base64-encoding)
 	// is added to the partition key size, the total size must not exceed the maximum
 	// record size (1 MB).
+	//
+	// Data is automatically base64 encoded/decoded by the SDK.
 	Data []byte `type:"blob" required:"true"`
 
 	// Identifies which shard in the stream the data record is assigned to.

--- a/service/kms/api.go
+++ b/service/kms/api.go
@@ -1268,6 +1268,8 @@ type DecryptInput struct {
 	_ struct{} `type:"structure"`
 
 	// Ciphertext to be decrypted. The blob includes metadata.
+	//
+	// CiphertextBlob is automatically base64 encoded/decoded by the SDK.
 	CiphertextBlob []byte `min:"1" type:"blob" required:"true"`
 
 	// The encryption context. If this was specified in the Encrypt function, it
@@ -1301,6 +1303,8 @@ type DecryptOutput struct {
 
 	// Decrypted plaintext data. This value may not be returned if the customer
 	// master key is not available or if you didn't have permission to use it.
+	//
+	// Plaintext is automatically base64 encoded/decoded by the SDK.
 	Plaintext []byte `min:"1" type:"blob"`
 }
 
@@ -1551,6 +1555,8 @@ type EncryptInput struct {
 	KeyId *string `min:"1" type:"string" required:"true"`
 
 	// Data to be encrypted.
+	//
+	// Plaintext is automatically base64 encoded/decoded by the SDK.
 	Plaintext []byte `min:"1" type:"blob" required:"true"`
 }
 
@@ -1569,6 +1575,8 @@ type EncryptOutput struct {
 
 	// The encrypted plaintext. If you are using the CLI, the value is Base64 encoded.
 	// Otherwise, it is not encoded.
+	//
+	// CiphertextBlob is automatically base64 encoded/decoded by the SDK.
 	CiphertextBlob []byte `min:"1" type:"blob"`
 
 	// The ID of the key used during encryption.
@@ -1638,6 +1646,8 @@ type GenerateDataKeyOutput struct {
 	//
 	// If you are using the CLI, the value is Base64 encoded. Otherwise, it is
 	// not encoded.
+	//
+	// CiphertextBlob is automatically base64 encoded/decoded by the SDK.
 	CiphertextBlob []byte `min:"1" type:"blob"`
 
 	// System generated unique identifier of the key to be used to decrypt the encrypted
@@ -1646,6 +1656,8 @@ type GenerateDataKeyOutput struct {
 
 	// Plaintext that contains the data key. Use this for encryption and decryption
 	// and then remove it from memory as soon as possible.
+	//
+	// Plaintext is automatically base64 encoded/decoded by the SDK.
 	Plaintext []byte `min:"1" type:"blob"`
 }
 
@@ -1708,6 +1720,8 @@ type GenerateDataKeyWithoutPlaintextOutput struct {
 	//
 	// If you are using the CLI, the value is Base64 encoded. Otherwise, it is
 	// not encoded.
+	//
+	// CiphertextBlob is automatically base64 encoded/decoded by the SDK.
 	CiphertextBlob []byte `min:"1" type:"blob"`
 
 	// System generated unique identifier of the key to be used to decrypt the encrypted
@@ -1747,6 +1761,8 @@ type GenerateRandomOutput struct {
 	_ struct{} `type:"structure"`
 
 	// Plaintext that contains the unpredictable byte string.
+	//
+	// Plaintext is automatically base64 encoded/decoded by the SDK.
 	Plaintext []byte `min:"1" type:"blob"`
 }
 
@@ -2307,6 +2323,8 @@ type ReEncryptInput struct {
 	_ struct{} `type:"structure"`
 
 	// Ciphertext of the data to re-encrypt.
+	//
+	// CiphertextBlob is automatically base64 encoded/decoded by the SDK.
 	CiphertextBlob []byte `min:"1" type:"blob" required:"true"`
 
 	// Encryption context to be used when the data is re-encrypted.
@@ -2347,6 +2365,8 @@ type ReEncryptOutput struct {
 
 	// The re-encrypted data. If you are using the CLI, the value is Base64 encoded.
 	// Otherwise, it is not encoded.
+	//
+	// CiphertextBlob is automatically base64 encoded/decoded by the SDK.
 	CiphertextBlob []byte `min:"1" type:"blob"`
 
 	// Unique identifier of the key used to re-encrypt the data.

--- a/service/lambda/api.go
+++ b/service/lambda/api.go
@@ -1341,6 +1341,8 @@ type FunctionCode struct {
 	// AWS CLI, the SDKs or CLI will do the encoding for you). For more information
 	// about creating a .zip file, go to Execution Permissions (http://docs.aws.amazon.com/lambda/latest/dg/intro-permission-model.html#lambda-intro-execution-role.html)
 	// in the AWS Lambda Developer Guide.
+	//
+	// ZipFile is automatically base64 encoded/decoded by the SDK.
 	ZipFile []byte `type:"blob"`
 }
 
@@ -2126,6 +2128,8 @@ type UpdateFunctionCodeInput struct {
 	S3ObjectVersion *string `min:"1" type:"string"`
 
 	// Based64-encoded .zip file containing your packaged source code.
+	//
+	// ZipFile is automatically base64 encoded/decoded by the SDK.
 	ZipFile []byte `type:"blob"`
 }
 

--- a/service/ses/api.go
+++ b/service/ses/api.go
@@ -2706,6 +2706,8 @@ type RawMessage struct {
 	// Do not include these X-headers in the DKIM signature, because they are removed
 	// by Amazon SES before sending the email. For more information, go to the Amazon
 	// SES Developer Guide (http://docs.aws.amazon.com/ses/latest/DeveloperGuide/send-email-raw.html).
+	//
+	// Data is automatically base64 encoded/decoded by the SDK.
 	Data []byte `type:"blob" required:"true"`
 }
 

--- a/service/sns/api.go
+++ b/service/sns/api.go
@@ -1608,6 +1608,8 @@ type MessageAttributeValue struct {
 
 	// Binary type attributes can store any binary data, for example, compressed
 	// data, encrypted data, or images.
+	//
+	// BinaryValue is automatically base64 encoded/decoded by the SDK.
 	BinaryValue []byte `type:"blob"`
 
 	// Amazon SNS supports the following logical data types: String, Number, and

--- a/service/sqs/api.go
+++ b/service/sqs/api.go
@@ -1393,6 +1393,8 @@ type MessageAttributeValue struct {
 
 	// Binary type attributes can store any binary data, for example, compressed
 	// data, encrypted data, or images.
+	//
+	// BinaryValue is automatically base64 encoded/decoded by the SDK.
 	BinaryValue []byte `type:"blob"`
 
 	// Amazon SQS supports the following logical data types: String, Number, and

--- a/service/support/api.go
+++ b/service/support/api.go
@@ -627,6 +627,8 @@ type Attachment struct {
 	_ struct{} `type:"structure"`
 
 	// The content of the attachment file.
+	//
+	// Data is automatically base64 encoded/decoded by the SDK.
 	Data []byte `locationName:"data" type:"blob"`
 
 	// The name of the attachment file.

--- a/service/waf/api.go
+++ b/service/waf/api.go
@@ -1474,6 +1474,8 @@ type ByteMatchTuple struct {
 	//
 	// The value that you want AWS WAF to search for. The SDK automatically base64
 	// encodes the value.
+	//
+	// TargetString is automatically base64 encoded/decoded by the SDK.
 	TargetString []byte `type:"blob" required:"true"`
 
 	// Text transformations eliminate some of the unusual formatting that attackers


### PR DESCRIPTION
Adds custom doc string to blob types to document the fact the SDK will
automatically encode and decode the value as it goes across the wire.
Presenting the user with a raw binary []byte type. Without needing to
manually encode/decode the value.

Fix #559