### PR TITLE
Hex values that are lower than 0x10 are incorrectly URL-escaped

### DIFF
--- a/private/protocol/rest/build.go
+++ b/private/protocol/rest/build.go
@@ -222,8 +222,7 @@ func EscapePath(path string, encodeSep bool) string {
 		if noEscape[c] || (c == '/' && !encodeSep) {
 			buf.WriteByte(c)
 		} else {
-			buf.WriteByte('%')
-			buf.WriteString(strings.ToUpper(strconv.FormatUint(uint64(c), 16)))
+			fmt.Fprintf(&buf, "%%%02X", c)
 		}
 	}
 	return buf.String()


### PR DESCRIPTION
Example: linefeed `\n` charater is escaped to %A instead of %0A
