### PR TITLE
service/route53: Add batched error support for ChangeResourceRecordSets

### DIFF
--- a/aws/awserr/error.go
+++ b/aws/awserr/error.go
@@ -42,9 +42,12 @@ type Error interface {
 	OrigErr() error
 }
 
-// BatchError is a batch of errors which also wraps lower level errors with code, message,
-// and original errors. Calling Error() will only return the error that is at the end
-// of the list.
+// BatchError is a batch of errors which also wraps lower level errors with
+// code, message, and original errors. Calling Error() will include all errors
+// that occured in the batch.
+//
+// Deprecated: Replaced with BatchedErrors. Only defined for backwards
+// compatibility.
 type BatchError interface {
 	// Satisfy the generic error interface.
 	error
@@ -59,17 +62,35 @@ type BatchError interface {
 	OrigErrs() []error
 }
 
+// BatchedErrors is a batch of errors which also wraps lower level errors with
+// code, message, and original errors. Calling Error() will include all errors
+// that occured in the batch.
+//
+// Replaces BatchError
+type BatchedErrors interface {
+	// Satisfy the base Error interface.
+	Error
+
+	// Returns the original error if one was set.  Nil is returned if not set.
+	OrigErrs() []error
+}
+
 // New returns an Error object described by the code, message, and origErr.
 //
 // If origErr satisfies the Error interface it will not be wrapped within a new
 // Error object and will instead be returned.
 func New(code, message string, origErr error) Error {
-	return newBaseError(code, message, origErr)
+	var errs []error
+	if origErr != nil {
+		errs = append(errs, origErr)
+	}
+	return newBaseError(code, message, errs)
 }
 
-// NewBatchError returns an baseError with an expectation of an array of errors
-func NewBatchError(code, message string, errs []error) BatchError {
-	return newBaseErrors(code, message, errs)
+// NewBatchError returns an BatchedErrors with a collection of errors as an
+// array of errors.
+func NewBatchError(code, message string, errs []error) BatchedErrors {
+	return newBaseError(code, message, errs)
 }
 
 // A RequestFailure is an interface to extract request failure information from

--- a/aws/awserr/types.go
+++ b/aws/awserr/types.go
@@ -34,36 +34,17 @@ type baseError struct {
 	errs []error
 }
 
-// newBaseError returns an error object for the code, message, and err.
+// newBaseError returns an error object for the code, message, and errors.
 //
 // code is a short no whitespace phrase depicting the classification of
 // the error that is being created.
 //
-// message is the free flow string containing detailed information about the error.
+// message is the free flow string containing detailed information about the
+// error.
 //
-// origErr is the error object which will be nested under the new error to be returned.
-func newBaseError(code, message string, origErr error) *baseError {
-	b := &baseError{
-		code:    code,
-		message: message,
-	}
-
-	if origErr != nil {
-		b.errs = append(b.errs, origErr)
-	}
-
-	return b
-}
-
-// newBaseErrors returns an error object for the code, message, and errors.
-//
-// code is a short no whitespace phrase depicting the classification of
-// the error that is being created.
-//
-// message is the free flow string containing detailed information about the error.
-//
-// origErrs is the error objects which will be nested under the new errors to be returned.
-func newBaseErrors(code, message string, origErrs []error) *baseError {
+// origErrs is the error objects which will be nested under the new errors to
+// be returned.
+func newBaseError(code, message string, origErrs []error) *baseError {
 	b := &baseError{
 		code:    code,
 		message: message,
@@ -103,19 +84,26 @@ func (b baseError) Message() string {
 	return b.message
 }
 
-// OrigErr returns the original error if one was set. Nil is returned if no error
-// was set. This only returns the first element in the list. If the full list is
-// needed, use BatchError
+// OrigErr returns the original error if one was set. Nil is returned if no
+// error was set. This only returns the first element in the list. If the full
+// list is needed, use BatchedErrors.
 func (b baseError) OrigErr() error {
-	if size := len(b.errs); size > 0 {
+	switch len(b.errs) {
+	case 0:
+		return nil
+	case 1:
 		return b.errs[0]
+	default:
+		if err, ok := b.errs[0].(Error); ok {
+			return NewBatchError(err.Code(), err.Message(), b.errs[1:])
+		}
+		return NewBatchError("BatchedErrors",
+			"multiple errors occured", b.errs)
 	}
-
-	return nil
 }
 
-// OrigErrs returns the original errors if one was set. An empty slice is returned if
-// no error was set:w
+// OrigErrs returns the original errors if one was set. An empty slice is
+// returned if no error was set.
 func (b baseError) OrigErrs() []error {
 	return b.errs
 }
@@ -133,8 +121,8 @@ type requestError struct {
 	requestID  string
 }
 
-// newRequestError returns a wrapped error with additional information for request
-// status code, and service requestID.
+// newRequestError returns a wrapped error with additional information for
+// request status code, and service requestID.
 //
 // Should be used to wrap all request which involve service requests. Even if
 // the request failed without a service response, but had an HTTP status code
@@ -171,6 +159,15 @@ func (r requestError) StatusCode() int {
 // RequestID returns the wrapped requestID
 func (r requestError) RequestID() string {
 	return r.requestID
+}
+
+// OrigErrs returns the original errors if one was set. An empty slice is
+// returned if no error was set.
+func (r requestError) OrigErrs() []error {
+	if b, ok := r.awsError.(BatchedErrors); ok {
+		return b.OrigErrs()
+	}
+	return []error{r.OrigErr()}
 }
 
 // An error list that satisfies the golang interface

--- a/awstesting/integration/smoke/iotdataplane/iotdataplane.feature
+++ b/awstesting/integration/smoke/iotdataplane/iotdataplane.feature
@@ -4,9 +4,9 @@ Feature: AWS IoT Data Plane
 
   Scenario: Handling errors
     When I attempt to call the "GetThingShadow" API with:
-    | ThingName | "fake_thing" |
-    Then I expect the response error code to be "ResourceNotFoundException"
+    | ThingName | "fakeThing" |
+    Then I expect the response error code to be "InvalidRequestException"
     And I expect the response error message to include:
     """
-    Not Found
+    Invalid thing name
     """

--- a/awstesting/integration/smoke/kms/kms.feature
+++ b/awstesting/integration/smoke/kms/kms.feature
@@ -9,5 +9,5 @@ Feature: Amazon Key Management Service
   Scenario: Handling errors
     When I attempt to call the "GetKeyPolicy" API with:
     | KeyId      | fake-key    |
-    | PolicyName | fake-policy |
+    | PolicyName | fakepolicy |
     Then I expect the response error code to be "NotFoundException"

--- a/service/route53/service.go
+++ b/service/route53/service.go
@@ -62,7 +62,9 @@ func newClient(cfg aws.Config, handlers request.Handlers, endpoint, signingRegio
 	svc.Handlers.Build.PushBackNamed(restxml.BuildHandler)
 	svc.Handlers.Unmarshal.PushBackNamed(restxml.UnmarshalHandler)
 	svc.Handlers.UnmarshalMeta.PushBackNamed(restxml.UnmarshalMetaHandler)
-	svc.Handlers.UnmarshalError.PushBackNamed(restxml.UnmarshalErrorHandler)
+
+	// Route53 uses a custom error parser
+	svc.Handlers.UnmarshalError.PushBack(unmarshalError)
 
 	// Run custom client initialization if present
 	if initClient != nil {

--- a/service/route53/unmarshal_error.go
+++ b/service/route53/unmarshal_error.go
@@ -1,0 +1,86 @@
+package route53
+
+import (
+	"bytes"
+	"encoding/xml"
+	"io/ioutil"
+
+	"github.com/aws/aws-sdk-go/aws/awserr"
+	"github.com/aws/aws-sdk-go/aws/request"
+	"github.com/aws/aws-sdk-go/private/protocol/restxml"
+)
+
+type baseXMLErrorResponse struct {
+	XMLName xml.Name
+}
+
+type standardXMLErrorResponse struct {
+	XMLName   xml.Name `xml:"ErrorResponse"`
+	Code      string   `xml:"Error>Code"`
+	Message   string   `xml:"Error>Message"`
+	RequestID string   `xml:"RequestId"`
+}
+
+type invalidChangeBatchXMLErrorResponse struct {
+	XMLName  xml.Name `xml:"InvalidChangeBatch"`
+	Messages []string `xml:"Messages>Message"`
+}
+
+func unmarshalError(r *request.Request) {
+	switch r.Operation.Name {
+	case opChangeResourceRecordSets:
+		unmarshalChangeResourceRecordSetsError(r)
+	default:
+		restxml.UnmarshalError(r)
+	}
+}
+
+func unmarshalChangeResourceRecordSetsError(r *request.Request) {
+	defer r.HTTPResponse.Body.Close()
+
+	responseBody, err := ioutil.ReadAll(r.HTTPResponse.Body)
+
+	if err != nil {
+		r.Error = awserr.New("SerializationError", "failed to read Route53 XML error response", err)
+		return
+	}
+
+	baseError := &baseXMLErrorResponse{}
+
+	if err := xml.Unmarshal(responseBody, baseError); err != nil {
+		r.Error = awserr.New("SerializationError", "failed to decode Route53 XML error response", err)
+		return
+	}
+
+	switch baseError.XMLName.Local {
+	case "InvalidChangeBatch":
+		unmarshalInvalidChangeBatchError(r, responseBody)
+	default:
+		r.HTTPResponse.Body = ioutil.NopCloser(bytes.NewReader(responseBody))
+		restxml.UnmarshalError(r)
+	}
+}
+
+func unmarshalInvalidChangeBatchError(r *request.Request, requestBody []byte) {
+	resp := &invalidChangeBatchXMLErrorResponse{}
+	err := xml.Unmarshal(requestBody, resp)
+
+	if err != nil {
+		r.Error = awserr.New("SerializationError", "failed to decode query XML error response", err)
+		return
+	}
+
+	const errorCode = "InvalidChangeBatch"
+	errors := []error{}
+
+	for _, msg := range resp.Messages {
+		errors = append(errors, awserr.New(errorCode, msg, nil))
+	}
+
+	r.Error = awserr.NewRequestFailure(
+		awserr.NewBatchError(errorCode, "ChangeBatch errors occured", errors),
+		r.HTTPResponse.StatusCode,
+		r.RequestID,
+	)
+
+}

--- a/service/route53/unmarshal_error_leak_test.go
+++ b/service/route53/unmarshal_error_leak_test.go
@@ -1,0 +1,37 @@
+package route53
+
+import (
+	"net/http"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+
+	"github.com/aws/aws-sdk-go/aws/request"
+	"github.com/aws/aws-sdk-go/awstesting"
+)
+
+func TestUnmarhsalErrorLeak(t *testing.T) {
+	req := &request.Request{
+		Operation: &request.Operation{
+			Name: opChangeResourceRecordSets,
+		},
+		HTTPRequest: &http.Request{
+			Header: make(http.Header),
+			Body:   &awstesting.ReadCloser{Size: 2048},
+		},
+	}
+	req.HTTPResponse = &http.Response{
+		Body: &awstesting.ReadCloser{Size: 2048},
+		Header: http.Header{
+			"X-Amzn-Requestid": []string{"1"},
+		},
+		StatusCode: http.StatusOK,
+	}
+
+	reader := req.HTTPResponse.Body.(*awstesting.ReadCloser)
+	unmarshalError(req)
+
+	assert.NotNil(t, req.Error)
+	assert.Equal(t, reader.Closed, true)
+	assert.Equal(t, reader.Size, 0)
+}

--- a/service/route53/unmarshal_error_test.go
+++ b/service/route53/unmarshal_error_test.go
@@ -1,0 +1,111 @@
+package route53_test
+
+import (
+	"bytes"
+	"io/ioutil"
+	"net/http"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+
+	"github.com/aws/aws-sdk-go/aws"
+	"github.com/aws/aws-sdk-go/aws/awserr"
+	"github.com/aws/aws-sdk-go/aws/request"
+	"github.com/aws/aws-sdk-go/awstesting/unit"
+	"github.com/aws/aws-sdk-go/service/route53"
+)
+
+func makeClientWithResponse(response string) *route53.Route53 {
+	r := route53.New(unit.Session)
+	r.Handlers.Send.Clear()
+	r.Handlers.Send.PushBack(func(r *request.Request) {
+		body := ioutil.NopCloser(bytes.NewReader([]byte(response)))
+		r.HTTPResponse = &http.Response{
+			ContentLength: int64(len(response)),
+			StatusCode:    400,
+			Status:        "Bad Request",
+			Body:          body,
+		}
+	})
+
+	return r
+}
+
+func TestUnmarshalStandardError(t *testing.T) {
+	const errorResponse = `<?xml version="1.0" encoding="UTF-8"?>
+<ErrorResponse xmlns="https://route53.amazonaws.com/doc/2013-04-01/">
+  <Error>
+    <Code>InvalidDomainName</Code>
+    <Message>The domain name is invalid</Message>
+  </Error>
+  <RequestId>12345</RequestId>
+</ErrorResponse>
+`
+
+	r := makeClientWithResponse(errorResponse)
+
+	_, err := r.CreateHostedZone(&route53.CreateHostedZoneInput{
+		CallerReference: aws.String("test"),
+		Name:            aws.String("test_zone"),
+	})
+
+	assert.Error(t, err)
+	assert.Equal(t, "InvalidDomainName", err.(awserr.Error).Code())
+	assert.Equal(t, "The domain name is invalid", err.(awserr.Error).Message())
+}
+
+func TestUnmarshalInvalidChangeBatch(t *testing.T) {
+	const errorMessage = `
+Tried to create resource record set duplicate.example.com. type A,
+but it already exists
+`
+	const errorResponse = `<?xml version="1.0" encoding="UTF-8"?>
+<InvalidChangeBatch xmlns="https://route53.amazonaws.com/doc/2013-04-01/">
+  <Messages>
+    <Message>` + errorMessage + `</Message>
+  </Messages>
+</InvalidChangeBatch>
+`
+
+	r := makeClientWithResponse(errorResponse)
+
+	req := &route53.ChangeResourceRecordSetsInput{
+		HostedZoneId: aws.String("zoneId"),
+		ChangeBatch: &route53.ChangeBatch{
+			Changes: []*route53.Change{
+				&route53.Change{
+					Action: aws.String("CREATE"),
+					ResourceRecordSet: &route53.ResourceRecordSet{
+						Name: aws.String("domain"),
+						Type: aws.String("CNAME"),
+						TTL:  aws.Int64(120),
+						ResourceRecords: []*route53.ResourceRecord{
+							{
+								Value: aws.String("cname"),
+							},
+						},
+					},
+				},
+			},
+		},
+	}
+
+	_, err := r.ChangeResourceRecordSets(req)
+	assert.Error(t, err)
+
+	if reqErr, ok := err.(awserr.RequestFailure); ok {
+		assert.Error(t, reqErr)
+		assert.Equal(t, 400, reqErr.StatusCode())
+	} else {
+		assert.Fail(t, "returned error is not a RequestFailure")
+	}
+
+	if batchErr, ok := err.(awserr.BatchedErrors); ok {
+		errs := batchErr.OrigErrs()
+		assert.Len(t, errs, 1)
+		assert.Equal(t, "InvalidChangeBatch", errs[0].(awserr.Error).Code())
+		assert.Equal(t, errorMessage, errs[0].(awserr.Error).Message())
+	} else {
+		assert.Fail(t, "returned error is not a BatchedErrors")
+	}
+}


### PR DESCRIPTION
service/route53: Add batched error support for ChangeResourceRecordSets
Adds support for batched errors that ChangeResourceRecordSets can
optionally return.

Replaces PR #438

Also deprecate BatchError in favor of BatchedErrors
BatchError did not satisfy the awserr.Error interface like it should of. This
update adds a new type BatchedErrors which satisfies awserr.Error.