### PR TITLE
service/dynamodb/dynamodbattribute: Fix struct tag documentation

### DIFF
--- a/service/dynamodb/dynamodbattribute/doc.go
+++ b/service/dynamodb/dynamodbattribute/doc.go
@@ -31,7 +31,8 @@
 //
 // Marshal Go value type for DynamoDB.PutItem:
 //
-//     svc := dynamodb.New(nil)
+//     sess := session.New()
+//     svc := dynamodb.New(sess)
 //     item, err := dynamodbattribute.MarshalMap(r)
 //     if err != nil {
 //         fmt.Println("Failed to convert", err)
@@ -51,8 +52,9 @@
 // binary data fields in structs as base64 strings.
 //
 // The Marshal and Unmarshal functions correct this behavior, and removes
-// the reliance on encoding.json. `json` struct tags are still supported.
-// Support for the  json.Marshaler nor json.Unmarshaler interfaces have
-// been removed and replaced with have been replaced with dynamodbattribute.Marshaler
-// and dynamodbattribute.Unmarshaler interfaces.
+// the reliance on encoding.json. `json` struct tags are still supported. In
+// addition support for a new struct tag `dynamodbav` was added. Support for
+// the json.Marshaler and json.Unmarshaler interfaces have been removed and
+// replaced with have been replaced with dynamodbattribute.Marshaler and
+// dynamodbattribute.Unmarshaler interfaces.
 package dynamodbattribute

--- a/service/dynamodb/dynamodbattribute/encode.go
+++ b/service/dynamodb/dynamodbattribute/encode.go
@@ -40,39 +40,39 @@ type Marshaler interface {
 // Binary data (B), and [][]byte will be marshaled as binary data set
 // (BS).
 //
-// `dynamodb` struct tag can be used to control how the value will be
+// `dynamodbav` struct tag can be used to control how the value will be
 // marshaled into a AttributeValue.
 //
 //		// Field is ignored
-//		Field int `dynamodb:"-"`
+//		Field int `dynamodbav:"-"`
 //
 //		// Field AttributeValue map key "myName"
-//		Field int `dynamodb:"myName"`
+//		Field int `dynamodbav:"myName"`
 //
 //		// Field AttributeValue map key "myName", and
 //		// Field is omitted if it is empty
-//		Field int `dynamodb:"myName,omitempty"`
+//		Field int `dynamodbav:"myName,omitempty"`
 //
 //		// Field AttributeValue map key "Field", and
 //		// Field is omitted if it is empty
-//		Field int `dynamodb:",omitempty"`
+//		Field int `dynamodbav:",omitempty"`
 //
 //		// Field's elems will be omitted if empty
 //		// only valid for slices, and maps.
-//		Field []string `dynamodb:",omitemptyelem"`
+//		Field []string `dynamodbav:",omitemptyelem"`
 //
 //		// Field will be marshaled as a AttributeValue string
 //		// only value for number types, (int,uint,float)
-//		Field int `dynamodb:",string"`
+//		Field int `dynamodbav:",string"`
 //
 //		// Field will be marshaled as a binary set
-//		Field [][]byte `dynamodb:",binaryset"`
+//		Field [][]byte `dynamodbav:",binaryset"`
 //
 //		// Field will be marshaled as a number set
-//		Field []int `dynamodb:",numberset"`
+//		Field []int `dynamodbav:",numberset"`
 //
 //		// Field will be marshaled as a string set
-//		Field []string `dynamodb:",stringset"`
+//		Field []string `dynamodbav:",stringset"`
 //
 // The omitempty tag is only used during Marshaling and is ignored for
 // Unmarshal. Any zero value or a value when marshaled results in a


### PR DESCRIPTION
Docs for the new struct tag`dynamodbav` was incorrectly referring to them as to `dynamodb`, which is
not a valid struct tag.