### PR TITLE
private/endpoints: Fix CN and GovCloud EC2Metadata endpoint

### DIFF
--- a/private/endpoints/endpoints.json
+++ b/private/endpoints/endpoints.json
@@ -8,6 +8,9 @@
       "endpoint": "{service}.{region}.amazonaws.com.cn",
       "signatureVersion": "v4"
     },
+    "cn-north-1/ec2metadata": {
+      "endpoint": "http://169.254.169.254/latest"
+    },
     "us-gov-west-1/iam": {
       "endpoint": "iam.us-gov.amazonaws.com"
     },
@@ -16,6 +19,9 @@
     },
     "us-gov-west-1/s3": {
       "endpoint": "s3-{region}.amazonaws.com"
+    },
+    "us-gov-west-1/ec2metadata": {
+      "endpoint": "http://169.254.169.254/latest"
     },
     "*/cloudfront": {
       "endpoint": "cloudfront.amazonaws.com",
@@ -30,8 +36,7 @@
       "signingRegion": "us-east-1"
     },
     "*/ec2metadata": {
-      "endpoint": "http://169.254.169.254/latest",
-      "signingRegion": "us-east-1"
+      "endpoint": "http://169.254.169.254/latest"
     },
     "*/iam": {
       "endpoint": "iam.amazonaws.com",

--- a/private/endpoints/endpoints_map.go
+++ b/private/endpoints/endpoints_map.go
@@ -31,8 +31,7 @@ var endpointsMap = endpointStruct{
 			SigningRegion: "us-east-1",
 		},
 		"*/ec2metadata": {
-			Endpoint:      "http://169.254.169.254/latest",
-			SigningRegion: "us-east-1",
+			Endpoint: "http://169.254.169.254/latest",
 		},
 		"*/iam": {
 			Endpoint:      "iam.amazonaws.com",
@@ -60,6 +59,9 @@ var endpointsMap = endpointStruct{
 		"cn-north-1/*": {
 			Endpoint: "{service}.{region}.amazonaws.com.cn",
 		},
+		"cn-north-1/ec2metadata": {
+			Endpoint: "http://169.254.169.254/latest",
+		},
 		"eu-central-1/s3": {
 			Endpoint: "{service}.{region}.amazonaws.com",
 		},
@@ -69,6 +71,9 @@ var endpointsMap = endpointStruct{
 		"us-east-1/sdb": {
 			Endpoint:      "sdb.amazonaws.com",
 			SigningRegion: "us-east-1",
+		},
+		"us-gov-west-1/ec2metadata": {
+			Endpoint: "http://169.254.169.254/latest",
 		},
 		"us-gov-west-1/iam": {
 			Endpoint: "iam.us-gov.amazonaws.com",

--- a/private/endpoints/endpoints_test.go
+++ b/private/endpoints/endpoints_test.go
@@ -39,3 +39,13 @@ func TestServicesInCN(t *testing.T) {
 		assert.Empty(t, sr)
 	}
 }
+
+func TestEC2MetadataEndpoints(t *testing.T) {
+	regions := []string{"us-east-1", "us-gov-west-1", "cn-north-1", "mock-region-1"}
+
+	for _, region := range regions {
+		ep, sr := endpoints.EndpointForRegion("ec2metadata", region, false)
+		assert.Equal(t, "http://169.254.169.254/latest", ep)
+		assert.Equal(t, "", sr)
+	}
+}


### PR DESCRIPTION
EC2 Metadata endpoint was using the wrong endpoints.json configuration
causing the look up to return https://ec2metadata.cn-north-1.amazonaws.com.cn
as the endpoint instead of http://169.254.169.254/latest. This impacted
both CN and GovCloud regions.