### PR TITLE
private/protocol/ec2query: Unmarshal correct error request id.

### DIFF
--- a/private/protocol/ec2query/unmarshal.go
+++ b/private/protocol/ec2query/unmarshal.go
@@ -42,7 +42,7 @@ type xmlErrorResponse struct {
 	XMLName   xml.Name `xml:"Response"`
 	Code      string   `xml:"Errors>Error>Code"`
 	Message   string   `xml:"Errors>Error>Message"`
-	RequestID string   `xml:"RequestId"`
+	RequestID string   `xml:"RequestID"`
 }
 
 // UnmarshalError unmarshals a response error for the EC2 protocol.


### PR DESCRIPTION
Query and EC2 query slightly differ in that the request id is sent as
RequestID not RequestID.