### PR TITLE
aws/credentials/stscreds/: Adds support for AssumeRole with MFA Auth

### DIFF
--- a/aws/credentials/stscreds/assume_role_provider.go
+++ b/aws/credentials/stscreds/assume_role_provider.go
@@ -47,6 +47,26 @@ type AssumeRoleProvider struct {
 	// Optional ExternalID to pass along, defaults to nil if not set.
 	ExternalID *string
 
+	// The policy plain text must be 2048 bytes or shorter. However, an internal
+	// conversion compresses it into a packed binary format with a separate limit.
+	// The PackedPolicySize response element indicates by percentage how close to
+	// the upper size limit the policy is, with 100% equaling the maximum allowed
+	// size.
+	Policy *string
+
+	// The identification number of the MFA device that is associated with the user
+	// who is making the AssumeRole call. Specify this value if the trust policy
+	// of the role being assumed includes a condition that requires MFA authentication.
+	// The value is either the serial number for a hardware device (such as GAHT12345678)
+	// or an Amazon Resource Name (ARN) for a virtual device (such as arn:aws:iam::123456789012:mfa/user).
+	SerialNumber *string
+
+	// The value provided by the MFA device, if the trust policy of the role being
+	// assumed requires MFA (that is, if the policy includes a condition that tests
+	// for MFA). If the role being assumed requires MFA and if the TokenCode value
+	// is missing or expired, the AssumeRole call returns an "access denied" error.
+	TokenCode *string
+
 	// ExpiryWindow will allow the credentials to trigger refreshing prior to
 	// the credentials actually expiring. This is beneficial so race conditions
 	// with expiring credentials do not cause request to fail unexpectedly
@@ -110,13 +130,20 @@ func (p *AssumeRoleProvider) Retrieve() (credentials.Value, error) {
 		// Expire as often as AWS permits.
 		p.Duration = DefaultDuration
 	}
-
-	roleOutput, err := p.Client.AssumeRole(&sts.AssumeRoleInput{
+	input := &sts.AssumeRoleInput{
 		DurationSeconds: aws.Int64(int64(p.Duration / time.Second)),
 		RoleArn:         aws.String(p.RoleARN),
 		RoleSessionName: aws.String(p.RoleSessionName),
 		ExternalId:      p.ExternalID,
-	})
+	}
+	if p.Policy != nil {
+		input.Policy = p.Policy
+	}
+	if p.SerialNumber != nil && p.TokenCode != nil {
+		input.SerialNumber = p.SerialNumber
+		input.TokenCode = p.TokenCode
+	}
+	roleOutput, err := p.Client.AssumeRole(input)
 
 	if err != nil {
 		return credentials.Value{ProviderName: ProviderName}, err


### PR DESCRIPTION
If a IAM policy requires a user to be authenticated with multi-factor authentication, we have to pass the `mfa-serial-number` and its `token-code`. This changes enable us to do it like following sample code in Python.
http://docs.aws.amazon.com/IAM/latest/UserGuide/id_credentials_mfa_sample-code.html#MFAProtectedAPI-example-assumerole