### PR TITLE
Added Set of Strings to convertFrom AttributeValue

### DIFF
--- a/service/dynamodb/dynamodbattribute/converter.go
+++ b/service/dynamodb/dynamodbattribute/converter.go
@@ -439,5 +439,9 @@ func convertFrom(a *dynamodb.AttributeValue) interface{} {
 		return a.B
 	}
 
+	if a.SS != nil {
+		return a.SS
+	}
+
 	panic(fmt.Sprintf("%#v is not a supported dynamodb.AttributeValue", a))
 }


### PR DESCRIPTION
Used a Set of Strings in my database, which panicked when attempting to read this. Upon closer inspection it was found that this datatype was not present in the convertFrom method. 