### PR TITLE
service/s3: Add Content-MD5 for PutBucketReplication

### DIFF
--- a/service/s3/customizations.go
+++ b/service/s3/customizations.go
@@ -21,7 +21,7 @@ func init() {
 
 	initRequest = func(r *request.Request) {
 		switch r.Operation.Name {
-		case opPutBucketCors, opPutBucketLifecycle, opPutBucketPolicy, opPutBucketTagging, opDeleteObjects, opPutBucketLifecycleConfiguration:
+		case opPutBucketCors, opPutBucketLifecycle, opPutBucketPolicy, opPutBucketTagging, opDeleteObjects, opPutBucketLifecycleConfiguration, opPutBucketReplication:
 			// These S3 operations require Content-MD5 to be set
 			r.Handlers.Build.PushBack(contentMD5)
 		case opGetBucketLocation:


### PR DESCRIPTION
Adds customizations to the S3 service client for generating MD5 for
the PutBucketReplication operation.

[Looks like](http://docs.aws.amazon.com/AmazonS3/latest/API/APIRest.html) this was the only operation missing the Content-MD5.

Fix #612