### PR TITLE
Implemented Signed Cookies into sign package

### DIFF
--- a/service/cloudfront/sign/sign_cookie.go
+++ b/service/cloudfront/sign/sign_cookie.go
@@ -78,23 +78,20 @@ type CookieSigner struct {
 // 	signer := sign.NewCookieSigner(keyID, privKey)
 
 // 	//provide an optional struct fields to specify other options
-//
-//
 // 	signer.Path:   "/",
 // 	signer.Domain: ".cNameAssociatedWithMyDistribution.com", //http://docs.aws.amazon.com/AmazonCloudFront/latest/DeveloperGuide/CNAMEs.html
 // 	signer.Secure: true, //make sure your app/site can handle https payloads, otherwise set this to false
 //
 // 	//avoid adding an Expire or MaxAge. See provided AWS Documentation for more info
 
-// 	cookies, err := signer.SignCookies(p)
+// 	cookies, err := signer.SignWithPolicy(p)
 // 	if err != nil {
 // 		fmt.Println("error", err)
 // 	}
 
-// 	http.SetCookie(w, cookie[0])
-// 	http.SetCookie(w, cookie[1])
-// 	http.SetCookie(w, cookie[2])
-
+//	for _, cookie := range cookies {
+//	  http.SetCookie(w, cookie)
+//  }
 // }
 
 // NewCookieSigner constructs and returns a new CookieSigner to be used to for signing

--- a/service/cloudfront/sign/sign_cookie.go
+++ b/service/cloudfront/sign/sign_cookie.go
@@ -1,0 +1,76 @@
+package sign
+
+import (
+	"crypto/rsa"
+	"net/http"
+)
+
+//the requirements for Cookie Signer is the same for the URL signer
+type CookieSigner struct {
+	*URLSigner
+}
+
+type Options struct {
+	Path   string
+	Domain string
+	Secure Bool
+}
+
+// NewCookieSigner constructs and returns a new CookieSigner to be used to for signing
+// Amazon CloudFront URL resources with.
+func NewCookieSigner(keyID string, privKey *rsa.PrivateKey) *CookieSigner {
+	return &CookieSigner{
+		keyID:   keyID,
+		privKey: privKey,
+	}
+}
+
+//prepares the cookies to be attached to the header. An options struct is provided
+//in case people don't want to manually edit their cookies
+
+func (c CookieSigner) CreateCookies(policy, signature []byte, o *Options) (cPolicy, cSignature, cKey *http.Cookie) {
+	cPolicy := &http.Cookie{
+		Name:   "CloudFront-Policy",
+		Value:  string(policy),
+		Path:   "/",
+		Domain: ".launchpadcentral.com",
+		// Secure:   true,
+		HttpOnly: true,
+	}
+
+	cSig := &http.Cookie{
+		Name:   "CloudFront-Signature",
+		Value:  string(signature),
+		Path:   "/",
+		Domain: ".launchpadcentral.com",
+		// Secure:   true,
+		HttpOnly: true,
+	}
+	cKey := &http.Cookie{
+		Name:   "CloudFront-Key-Pair-Id",
+		Value:  key,
+		Path:   "/",
+		Domain: ".launchpadcentral.com",
+		// Secure:   true,
+		HttpOnly: true,
+	}
+
+	if Options != nil {
+		if Options.Path != "" {
+			cPolicy.Path = Options.Path
+			cSignature.Path = Options.Path
+			cKey.Path = Options.Path
+		}
+		if Options.Domain != "" {
+			cPolicy.Domain = Options.Domain
+			cSignature.Domain = Options.Domain
+			cKey.Domain = Options.Domain
+		}
+		if Options.Secure != false {
+			cPolicy.Secure = Options.Secure
+			cSignature.Secure = Options.Secure
+			cKey.Secure = Options.Secure
+		}
+	}
+	return cPolicy, cSig, cKey
+}

--- a/service/cloudfront/sign/sign_cookie.go
+++ b/service/cloudfront/sign/sign_cookie.go
@@ -8,7 +8,7 @@
 // sign the URLs.
 //
 // Example:
-//
+//	func handler(w http.ResponseWriter) {
 //    // Sign Cookie to be valid for 1 hour from now.
 //    signer := sign.NewCookieSigner(keyID, privKey)
 //    cookies, err := signer.Sign(rawURL, time.Now().Add(1*time.Hour))
@@ -19,6 +19,7 @@
 //    http.SetCookie(w, cookie[0])
 // 	  http.SetCookie(w, cookie[1])
 // 	  http.SetCookie(w, cookie[2])
+//	}
 //
 package sign
 
@@ -28,7 +29,7 @@ import (
 	"time"
 )
 
-// A Cookie Signer provides Cookie signing utilities to sign Cookies for Amazon CloudFront
+// CookieSigner provides Cookie signing utilities to sign Cookies for Amazon CloudFront
 // resources.
 // Additional Options are provided and will be required depending on your set up
 type CookieSigner struct {

--- a/service/cloudfront/sign/sign_cookie.go
+++ b/service/cloudfront/sign/sign_cookie.go
@@ -29,8 +29,7 @@ type CookieSigner struct {
 
 //Example:
 //
-//   With Canned Policy
-//   // Sign Cookie to be valid for 1 hour from now.
+//   // Sign Cookie to be valid for 1 hour from now using Canned Policy.
 //   signer := sign.NewCookieSigner(keyID, privKey)
 //   cookies, err := signer.Sign(rawURL, time.Now().Add(1*time.Hour))
 //   if err != nil {
@@ -42,7 +41,7 @@ type CookieSigner struct {
 // 	 http.SetCookie(w, cookie[2])
 //
 
-// With Custom Policy
+//  // Sign Cookie to be valid for 1 hour from now using Canned Policy.
 // func handler(w http.ResponseWriter, r *http.Request) {
 
 //  // sign cookie to be valid for 30 minutes from now, expires one hour from now, and
@@ -107,7 +106,7 @@ func NewCookieSigner(keyID string, privKey *rsa.PrivateKey) *CookieSigner {
 // Amazon CloudFront default Canned Policy. The Cookie will be signed with the
 // private key and Credential Key Pair Key ID previously provided to CookieSigner.
 //
-//If extra policy conditions are need other than expiration use SignWithPolicy instead.
+// If extra policy conditions are need other than expiration use SignWithPolicy instead.
 func (c CookieSigner) Sign(url string, expires time.Time) ([]*http.Cookie, error) {
 	scheme, _, err := cleanURLScheme(url)
 	if err != nil {

--- a/service/cloudfront/sign/sign_cookie.go
+++ b/service/cloudfront/sign/sign_cookie.go
@@ -7,14 +7,72 @@ import (
 
 //the requirements for Cookie Signer is the same for the URL signer
 type CookieSigner struct {
-	*URLSigner
+	keyID   string
+	privKey *rsa.PrivateKey
 }
 
-type Options struct {
+type CookieOptions struct {
 	Path   string
 	Domain string
-	Secure Bool
+	Secure bool
 }
+
+//Example:
+//     // Sign URL to be valid for 30 minutes from now, expires one hour from now, and
+//     // restricted to the 192.0.2.0/24 IP address range.
+
+// func handler(w http.ResponseWriter, r *http.Request) {
+
+// 	//create a policy
+//  //http://docs.aws.amazon.com/AmazonCloudFront/latest/DeveloperGuide/private-content-setting-signed-cookie-custom-policy.html
+// 	p := &sign.Policy{
+// 		Statements: []sign.Statement{
+// 			{
+//				Resource: RawCloudFrontURL, //read the provided documentation on how to set this correctly, you'll probably want to use wildcards
+// 				Condition: sign.Condition{
+// 					// Optional IP source address range
+// 					IPAddress: &sign.IPAddress{SourceIP: "192.0.2.0/24"},
+// 					// Optional date URL is not valid until
+// 					DateGreaterThan: &sign.AWSEpochTime{time.Now().Add(30 * time.Minute)},
+// 					// Required date the URL will expire after
+// 					DateLessThan: &sign.AWSEpochTime{time.Now().Add(1 * time.Hour)},
+// 				},
+// 			},
+// 		},
+// 	}
+
+// 	//load your private key and convert it to type rsa.PrivateKey
+// 	privKey, err := sign.LoadPEMPrivKeyFile("privatekey.pem")
+// 	if err != nil {
+// 		fmt.Println("error", err)
+// 	}
+
+// 	//key ID that represents the key pair associated with the private key
+// 	keyID := "WOIERULSDLKEWRIU"
+
+// 	//set credentials to the cookiesigner
+// 	signer := sign.NewCookieSigner(keyID, privKey)
+
+// 	//creates 3 signed cookies, provide an optional Cookie Options struct to specify other options
+// 	//http://docs.aws.amazon.com/AmazonCloudFront/latest/DeveloperGuide/private-content-setting-signed-cookie-custom-policy.html#private-content-custom-policy-statement-signed-cookies-examples
+//  //http://docs.aws.amazon.com/AmazonCloudFront/latest/DeveloperGuide/CNAMEs.html
+// 	o := &CookieOptions{
+// 		Path:   "/",
+// 		Domain: ".cNameAssociatedWithMyDistribution.com",
+// 		Secure: true, //make sure your app/site can handle https payloads, otherwise set this to false
+// 	}
+
+// 	//avoid adding an Expire or MaxAge. See provided AWS Documentation for more info
+// 	policy, signature, key, err := signer.SignCookies(p)
+// 	if err != nil {
+// 		fmt.Println("error", err)
+// 	}
+
+// 	http.SetCookie(w, policy)
+// 	http.SetCookie(w, signature)
+// 	http.SetCookie(w, key)
+
+// }
 
 // NewCookieSigner constructs and returns a new CookieSigner to be used to for signing
 // Amazon CloudFront URL resources with.
@@ -25,52 +83,59 @@ func NewCookieSigner(keyID string, privKey *rsa.PrivateKey) *CookieSigner {
 	}
 }
 
-//prepares the cookies to be attached to the header. An options struct is provided
+//CookieOptions are optional
+func (c CookieSigner) SignCookies(p *Policy, o *CookieOptions) (cPolicy, cSignature, cKey *http.Cookie, err error) {
+	b64Sig, b64Policy, err := p.Sign(c.privKey)
+	if err != nil {
+		return nil, nil, nil, err
+	}
+
+	cPolicy, cSignature, cKey = c.CreateCookies(b64Policy, b64Sig, o)
+	return cPolicy, cSignature, cKey, nil
+
+}
+
+//prepares the cookies to be attached to the header. An (optional) options struct is provided
 //in case people don't want to manually edit their cookies
 
-func (c CookieSigner) CreateCookies(policy, signature []byte, o *Options) (cPolicy, cSignature, cKey *http.Cookie) {
-	cPolicy := &http.Cookie{
-		Name:   "CloudFront-Policy",
-		Value:  string(policy),
-		Path:   "/",
-		Domain: ".launchpadcentral.com",
-		// Secure:   true,
+func (c CookieSigner) CreateCookies(policy, signature []byte, o *CookieOptions) (cPolicy, cSignature, cKey *http.Cookie) {
+	//creates proper cookies
+	cPolicy = &http.Cookie{
+		Name:     "CloudFront-Policy",
+		Value:    string(policy),
 		HttpOnly: true,
 	}
 
-	cSig := &http.Cookie{
-		Name:   "CloudFront-Signature",
-		Value:  string(signature),
-		Path:   "/",
-		Domain: ".launchpadcentral.com",
-		// Secure:   true,
+	cSignature = &http.Cookie{
+		Name:     "CloudFront-Signature",
+		Value:    string(signature),
 		HttpOnly: true,
 	}
-	cKey := &http.Cookie{
-		Name:   "CloudFront-Key-Pair-Id",
-		Value:  key,
-		Path:   "/",
-		Domain: ".launchpadcentral.com",
-		// Secure:   true,
+	cKey = &http.Cookie{
+		Name:     "CloudFront-Key-Pair-Id",
+		Value:    c.keyID,
 		HttpOnly: true,
 	}
 
-	if Options != nil {
-		if Options.Path != "" {
-			cPolicy.Path = Options.Path
-			cSignature.Path = Options.Path
-			cKey.Path = Options.Path
+	//if options are included, assign them to the cookies
+	if o != nil {
+		if o.Path != "" {
+			cPolicy.Path = o.Path
+			cSignature.Path = o.Path
+			cKey.Path = o.Path
 		}
-		if Options.Domain != "" {
-			cPolicy.Domain = Options.Domain
-			cSignature.Domain = Options.Domain
-			cKey.Domain = Options.Domain
+		if o.Domain != "" {
+			cPolicy.Domain = o.Domain
+			cSignature.Domain = o.Domain
+			cKey.Domain = o.Domain
 		}
-		if Options.Secure != false {
-			cPolicy.Secure = Options.Secure
-			cSignature.Secure = Options.Secure
-			cKey.Secure = Options.Secure
+		if o.Secure != false {
+			cPolicy.Secure = o.Secure
+			cSignature.Secure = o.Secure
+			cKey.Secure = o.Secure
 		}
 	}
-	return cPolicy, cSig, cKey
+
+	//return 3 cookies to be attached to the response
+	return cPolicy, cSignature, cKey
 }

--- a/service/cloudfront/sign/sign_cookie.go
+++ b/service/cloudfront/sign/sign_cookie.go
@@ -1,6 +1,6 @@
 // Package sign provides utilities to generate signed Cookies and URLs for Amazon CloudFront.
 //
-// More information about signed Cokkies and their structure can be found at:
+// More information about signed Cookies and their structure can be found at:
 // http://docs.aws.amazon.com/AmazonCloudFront/latest/DeveloperGuide/private-content-setting-signed-cookie-custom-policy.html
 //
 // To sign a Cookie, create a CookieSigner with your private key and credential pair key ID.

--- a/service/cloudfront/sign/sign_cookie.go
+++ b/service/cloudfront/sign/sign_cookie.go
@@ -18,12 +18,12 @@ type CookieOptions struct {
 }
 
 //Example:
-//     // Sign URL to be valid for 30 minutes from now, expires one hour from now, and
-//     // restricted to the 192.0.2.0/24 IP address range.
 
 // func handler(w http.ResponseWriter, r *http.Request) {
 
-// 	//create a policy
+//  // sign cookie to be valid for 30 minutes from now, expires one hour from now, and
+//  // restricted to the 192.0.2.0/24 IP address range.
+
 //  //http://docs.aws.amazon.com/AmazonCloudFront/latest/DeveloperGuide/private-content-setting-signed-cookie-custom-policy.html
 // 	p := &sign.Policy{
 // 		Statements: []sign.Statement{
@@ -54,15 +54,15 @@ type CookieOptions struct {
 // 	signer := sign.NewCookieSigner(keyID, privKey)
 
 // 	//creates 3 signed cookies, provide an optional Cookie Options struct to specify other options
-// 	//http://docs.aws.amazon.com/AmazonCloudFront/latest/DeveloperGuide/private-content-setting-signed-cookie-custom-policy.html#private-content-custom-policy-statement-signed-cookies-examples
-//  //http://docs.aws.amazon.com/AmazonCloudFront/latest/DeveloperGuide/CNAMEs.html
-// 	o := &CookieOptions{
+// 	o := &sign.CookieOptions{
 // 		Path:   "/",
 // 		Domain: ".cNameAssociatedWithMyDistribution.com",
 // 		Secure: true, //make sure your app/site can handle https payloads, otherwise set this to false
 // 	}
-
+// 	//http://docs.aws.amazon.com/AmazonCloudFront/latest/DeveloperGuide/private-content-setting-signed-cookie-custom-policy.html#private-content-custom-policy-statement-signed-cookies-examples
+//  //http://docs.aws.amazon.com/AmazonCloudFront/latest/DeveloperGuide/CNAMEs.html
 // 	//avoid adding an Expire or MaxAge. See provided AWS Documentation for more info
+
 // 	policy, signature, key, err := signer.SignCookies(p)
 // 	if err != nil {
 // 		fmt.Println("error", err)

--- a/service/cloudfront/sign/sign_cookie.go
+++ b/service/cloudfront/sign/sign_cookie.go
@@ -7,20 +7,6 @@
 // Once you have a CookieSigner instance you can call Sign or SignWithPolicy to
 // sign the URLs.
 //
-// Example:
-//	func handler(w http.ResponseWriter) {
-//    // Sign Cookie to be valid for 1 hour from now.
-//    signer := sign.NewCookieSigner(keyID, privKey)
-//    cookies, err := signer.Sign(rawURL, time.Now().Add(1*time.Hour))
-//    if err != nil {
-//        log.Fatalf("Failed to sign cookies, err: %s\n", err.Error())
-//    }
-
-//    http.SetCookie(w, cookie[0])
-// 	  http.SetCookie(w, cookie[1])
-// 	  http.SetCookie(w, cookie[2])
-//	}
-//
 package sign
 
 import (
@@ -42,7 +28,21 @@ type CookieSigner struct {
 }
 
 //Example:
+//
+//   With Canned Policy
+//   // Sign Cookie to be valid for 1 hour from now.
+//   signer := sign.NewCookieSigner(keyID, privKey)
+//   cookies, err := signer.Sign(rawURL, time.Now().Add(1*time.Hour))
+//   if err != nil {
+//       log.Fatalf("Failed to sign cookies, err: %s\n", err.Error())
+//   }
 
+//   http.SetCookie(w, cookie[0])
+// 	 http.SetCookie(w, cookie[1])
+// 	 http.SetCookie(w, cookie[2])
+//
+
+// With Custom Policy
 // func handler(w http.ResponseWriter, r *http.Request) {
 
 //  // sign cookie to be valid for 30 minutes from now, expires one hour from now, and

--- a/service/cloudfront/sign/sign_cookie.go
+++ b/service/cloudfront/sign/sign_cookie.go
@@ -1,6 +1,6 @@
 // Package sign provides utilities to generate signed Cookies and URLs for Amazon CloudFront.
 //
-// More information about signed URLs and their structure can be found at:
+// More information about signed Cokkies and their structure can be found at:
 // http://docs.aws.amazon.com/AmazonCloudFront/latest/DeveloperGuide/private-content-setting-signed-cookie-custom-policy.html
 //
 // To sign a Cookie, create a CookieSigner with your private key and credential pair key ID.
@@ -56,9 +56,9 @@ type CookieSigner struct {
 // 				Condition: sign.Condition{
 // 					// Optional IP source address range
 // 					IPAddress: &sign.IPAddress{SourceIP: "192.0.2.0/24"},
-// 					// Optional date URL is not valid until
+// 					// Optional date Cookie is not valid until
 // 					DateGreaterThan: &sign.AWSEpochTime{time.Now().Add(30 * time.Minute)},
-// 					// Required date the URL will expire after
+// 					// Required date the Cookie will expire after
 // 					DateLessThan: &sign.AWSEpochTime{time.Now().Add(1 * time.Hour)},
 // 				},
 // 			},
@@ -95,7 +95,7 @@ type CookieSigner struct {
 // }
 
 // NewCookieSigner constructs and returns a new CookieSigner to be used to for signing
-// Amazon CloudFront URL resources with.
+// Amazon CloudFront Cookie resources with.
 func NewCookieSigner(keyID string, privKey *rsa.PrivateKey) *CookieSigner {
 	return &CookieSigner{
 		keyID:   keyID,
@@ -104,8 +104,8 @@ func NewCookieSigner(keyID string, privKey *rsa.PrivateKey) *CookieSigner {
 }
 
 // Sign will sign cookies to expire at the time of expires sign using the
-// Amazon CloudFront default Canned Policy. The URL will be signed with the
-// private key and Credential Key Pair Key ID previously provided to URLSigner.
+// Amazon CloudFront default Canned Policy. The Cookie will be signed with the
+// private key and Credential Key Pair Key ID previously provided to CookieSigner.
 //
 //If extra policy conditions are need other than expiration use SignWithPolicy instead.
 func (c CookieSigner) Sign(url string, expires time.Time) ([]*http.Cookie, error) {

--- a/service/cloudfront/sign/sign_cookie.go
+++ b/service/cloudfront/sign/sign_cookie.go
@@ -5,12 +5,13 @@ import (
 	"net/http"
 )
 
-//the requirements for Cookie Signer is the same for the URL signer
+//CookieSigner requirements are the same for the URL signer
 type CookieSigner struct {
 	keyID   string
 	privKey *rsa.PrivateKey
 }
 
+//CookieOptions optional settings for Cookie Definition, these can also be set manually
 type CookieOptions struct {
 	Path   string
 	Domain string
@@ -83,22 +84,21 @@ func NewCookieSigner(keyID string, privKey *rsa.PrivateKey) *CookieSigner {
 	}
 }
 
-//CookieOptions are optional
+//SignCookies CookieOptions are optional, if unused, just pass in nil
 func (c CookieSigner) SignCookies(p *Policy, o *CookieOptions) (cPolicy, cSignature, cKey *http.Cookie, err error) {
 	b64Sig, b64Policy, err := p.Sign(c.privKey)
 	if err != nil {
 		return nil, nil, nil, err
 	}
 
-	cPolicy, cSignature, cKey = c.CreateCookies(b64Policy, b64Sig, o)
+	cPolicy, cSignature, cKey = c.createCookies(b64Policy, b64Sig, o)
 	return cPolicy, cSignature, cKey, nil
 
 }
 
 //prepares the cookies to be attached to the header. An (optional) options struct is provided
 //in case people don't want to manually edit their cookies
-
-func (c CookieSigner) CreateCookies(policy, signature []byte, o *CookieOptions) (cPolicy, cSignature, cKey *http.Cookie) {
+func (c CookieSigner) createCookies(policy, signature []byte, o *CookieOptions) (cPolicy, cSignature, cKey *http.Cookie) {
 	//creates proper cookies
 	cPolicy = &http.Cookie{
 		Name:     "CloudFront-Policy",

--- a/service/cloudfront/sign/sign_cookie_example_test.go
+++ b/service/cloudfront/sign/sign_cookie_example_test.go
@@ -65,9 +65,8 @@ func HandlerExample(t *testing.T, w http.ResponseWriter) {
 			t.Fatalf("error %#v", err)
 		}
 
-		http.SetCookie(w, cookies[0])
-		http.SetCookie(w, cookies[1])
-		http.SetCookie(w, cookies[2])
-
+		for _, cookie := range cookies {
+			http.SetCookie(w, cookie)
+		}
 	})
 }

--- a/service/cloudfront/sign/sign_cookie_example_test.go
+++ b/service/cloudfront/sign/sign_cookie_example_test.go
@@ -2,75 +2,72 @@ package sign
 
 import (
 	"crypto/rsa"
-	"fmt"
 	"net/http"
 	"net/http/httptest"
 	"testing"
 	"time"
 )
 
-// /Example:
 func TestSignedCookie(t *testing.T) {
 	w := httptest.NewRecorder()
 
-	HandlerExample(w)
+	HandlerExample(t, w)
 
 	if len(w.HeaderMap["Set-Cookie"]) != 3 {
 		t.Fatalf("Cookies were not properly set, expected %d   \n got: %d", 3, len(w.HeaderMap["Set-Cookie"]))
 	}
 
 }
-func HandlerExample(w http.ResponseWriter) {
+func HandlerExample(t *testing.T, w http.ResponseWriter) {
+	RunCookieSetup(t, func(privKey *rsa.PrivateKey) {
 
-	// sign cookie to be valid for 30 minutes from now, expires one hour from now, and
-	// restricted to the 192.0.2.0/24 IP address range.
+		// sign cookie to be valid for 30 minutes from now, expires one hour from now, and
+		// restricted to the 192.0.2.0/24 IP address range.
 
-	//http://docs.aws.amazon.com/AmazonCloudFront/latest/DeveloperGuide/private-content-setting-signed-cookie-custom-policy.html
-	p := &Policy{
-		Statements: []Statement{
-			{
-				Resource: "http://sub.cloudfront.com", //read the provided documentation on how to set this correctly, you'll probably want to use wildcards
-				Condition: Condition{
-					// Optional IP source address range
-					IPAddress: &IPAddress{SourceIP: "192.0.2.0/24"},
-					// Optional date URL is not valid until
-					DateGreaterThan: &AWSEpochTime{time.Now().Add(30 * time.Minute)},
-					// Required date the URL will expire after
-					DateLessThan: &AWSEpochTime{time.Now().Add(1 * time.Hour)},
+		//http://docs.aws.amazon.com/AmazonCloudFront/latest/DeveloperGuide/private-content-setting-signed-cookie-custom-policy.html
+		p := &Policy{
+			Statements: []Statement{
+				{
+					Resource: "http://sub.cloudfront.com", //read the provided documentation on how to set this correctly, you'll probably want to use wildcards
+					Condition: Condition{
+						// Optional IP source address range
+						IPAddress: &IPAddress{SourceIP: "192.0.2.0/24"},
+						// Optional date URL is not valid until
+						DateGreaterThan: &AWSEpochTime{time.Now().Add(30 * time.Minute)},
+						// Required date the URL will expire after
+						DateLessThan: &AWSEpochTime{time.Now().Add(1 * time.Hour)},
+					},
 				},
 			},
-		},
-	}
+		}
 
-	//load your private key and convert it to type rsa.PrivateKey
-	// privKey, err := sign.LoadPEMPrivKeyFile("privatekey.pem")
-	// if err != nil {
-	// 	fmt.Println("error", err)
-	// }
+		//load your private key and convert it to type rsa.PrivateKey
+		// privKey, err := sign.LoadPEMPrivKeyFile("privatekey.pem")
+		// if err != nil {
+		// 	fmt.Println("error", err)
+		// }
 
-	//we create a random key for the example
-	privKey, err := rsa.GenerateKey(randReader, 1024)
+		//key ID that represents the key pair associated with the private key
+		keyID := "WOIERULSDLKEWRIU"
 
-	//key ID that represents the key pair associated with the private key
-	keyID := "WOIERULSDLKEWRIU"
+		//set credentials to the cookiesigner
+		signer := NewCookieSigner(keyID, privKey)
 
-	//set credentials to the cookiesigner
-	signer := NewCookieSigner(keyID, privKey)
+		//provide an optional struct fields to specify other options
+		signer.Path = "/"
+		signer.Domain = ".cNameAssociatedWithMyDistribution.com" //http://docs.aws.amazon.com/AmazonCloudFront/latest/DeveloperGuide/CNAMEs.html
+		signer.Secure = true                                     //make sure your app/site can handle https payloads, otherwise set this to false
 
-	//provide an optional struct fields to specify other options
-	signer.Path = "/"
-	signer.Domain = ".cNameAssociatedWithMyDistribution.com" //http://docs.aws.amazon.com/AmazonCloudFront/latest/DeveloperGuide/CNAMEs.html
-	signer.Secure = true                                     //make sure your app/site can handle https payloads, otherwise set this to false
+		//avoid adding an Expire or MaxAge. See provided AWS Documentation for more info
 
-	//avoid adding an Expire or MaxAge. See provided AWS Documentation for more info
+		cookies, err := signer.SignWithPolicy(p)
+		if err != nil {
+			t.Fatalf("error %#v", err)
+		}
 
-	cookies, err := signer.SignWithPolicy(p)
-	if err != nil {
-		fmt.Println("error", err)
-	}
+		http.SetCookie(w, cookies[0])
+		http.SetCookie(w, cookies[1])
+		http.SetCookie(w, cookies[2])
 
-	http.SetCookie(w, cookies[0])
-	http.SetCookie(w, cookies[1])
-	http.SetCookie(w, cookies[2])
-
+	})
 }

--- a/service/cloudfront/sign/sign_cookie_example_test.go
+++ b/service/cloudfront/sign/sign_cookie_example_test.go
@@ -48,7 +48,7 @@ func HandlerExample(w http.ResponseWriter) {
 	// 	fmt.Println("error", err)
 	// }
 
-	//we create a random key since we have no pem file
+	//we create a random key for the example
 	privKey, err := rsa.GenerateKey(randReader, 1024)
 
 	//key ID that represents the key pair associated with the private key

--- a/service/cloudfront/sign/sign_cookie_example_test.go
+++ b/service/cloudfront/sign/sign_cookie_example_test.go
@@ -1,0 +1,76 @@
+package sign
+
+import (
+	"crypto/rsa"
+	"fmt"
+	"net/http"
+	"net/http/httptest"
+	"testing"
+	"time"
+)
+
+// /Example:
+func TestSignedCookie(t *testing.T) {
+	w := httptest.NewRecorder()
+
+	HandlerExample(w)
+
+	if len(w.HeaderMap["Set-Cookie"]) != 3 {
+		t.Fatalf("Cookies were not properly set, expected %d   \n got: %d", 3, len(w.HeaderMap["Set-Cookie"]))
+	}
+
+}
+func HandlerExample(w http.ResponseWriter) {
+
+	// sign cookie to be valid for 30 minutes from now, expires one hour from now, and
+	// restricted to the 192.0.2.0/24 IP address range.
+
+	//http://docs.aws.amazon.com/AmazonCloudFront/latest/DeveloperGuide/private-content-setting-signed-cookie-custom-policy.html
+	p := &Policy{
+		Statements: []Statement{
+			{
+				Resource: "http://sub.cloudfront.com", //read the provided documentation on how to set this correctly, you'll probably want to use wildcards
+				Condition: Condition{
+					// Optional IP source address range
+					IPAddress: &IPAddress{SourceIP: "192.0.2.0/24"},
+					// Optional date URL is not valid until
+					DateGreaterThan: &AWSEpochTime{time.Now().Add(30 * time.Minute)},
+					// Required date the URL will expire after
+					DateLessThan: &AWSEpochTime{time.Now().Add(1 * time.Hour)},
+				},
+			},
+		},
+	}
+
+	//load your private key and convert it to type rsa.PrivateKey
+	// privKey, err := sign.LoadPEMPrivKeyFile("privatekey.pem")
+	// if err != nil {
+	// 	fmt.Println("error", err)
+	// }
+
+	//we create a random key since we have no pem file
+	privKey, err := rsa.GenerateKey(randReader, 1024)
+
+	//key ID that represents the key pair associated with the private key
+	keyID := "WOIERULSDLKEWRIU"
+
+	//set credentials to the cookiesigner
+	signer := NewCookieSigner(keyID, privKey)
+
+	//provide an optional struct fields to specify other options
+	signer.Path = "/"
+	signer.Domain = ".cNameAssociatedWithMyDistribution.com" //http://docs.aws.amazon.com/AmazonCloudFront/latest/DeveloperGuide/CNAMEs.html
+	signer.Secure = true                                     //make sure your app/site can handle https payloads, otherwise set this to false
+
+	//avoid adding an Expire or MaxAge. See provided AWS Documentation for more info
+
+	cookies, err := signer.SignWithPolicy(p)
+	if err != nil {
+		fmt.Println("error", err)
+	}
+
+	http.SetCookie(w, cookies[0])
+	http.SetCookie(w, cookies[1])
+	http.SetCookie(w, cookies[2])
+
+}

--- a/service/cloudfront/sign/sign_cookie_test.go
+++ b/service/cloudfront/sign/sign_cookie_test.go
@@ -1,0 +1,1 @@
+package sign

--- a/service/cloudfront/sign/sign_cookie_test.go
+++ b/service/cloudfront/sign/sign_cookie_test.go
@@ -15,7 +15,7 @@ const (
 	testDomain    = ".myexample.com"
 )
 
-func runCookieSetup(t *testing.T, f func(*rsa.PrivateKey)) {
+func RunCookieSetup(t *testing.T, f func(*rsa.PrivateKey)) {
 	origRandReader := randReader
 	randReader = newRandomReader(rand.New(rand.NewSource(1)))
 	defer func() {
@@ -29,7 +29,7 @@ func runCookieSetup(t *testing.T, f func(*rsa.PrivateKey)) {
 	f(privKey)
 }
 func TestCookieWithPolicy(t *testing.T) {
-	runCookieSetup(t, func(privKey *rsa.PrivateKey) {
+	RunCookieSetup(t, func(privKey *rsa.PrivateKey) {
 
 		signer := NewCookieSigner("keyID", privKey)
 
@@ -58,7 +58,7 @@ func TestCookieWithPolicy(t *testing.T) {
 
 //test cookie signer with additional options
 func TestCookieWithOptions(t *testing.T) {
-	runCookieSetup(t, func(privKey *rsa.PrivateKey) {
+	RunCookieSetup(t, func(privKey *rsa.PrivateKey) {
 
 		signer := NewCookieSigner("keyID", privKey)
 		signer.Path = "/"
@@ -90,7 +90,7 @@ func TestCookieWithOptions(t *testing.T) {
 }
 
 func TestCannedCookie(t *testing.T) {
-	runCookieSetup(t, func(privKey *rsa.PrivateKey) {
+	RunCookieSetup(t, func(privKey *rsa.PrivateKey) {
 		signer := NewCookieSigner("keyID", privKey)
 		cookies, err := signer.Sign("http://sub.cloudfront.com/path", time.Now().Add(1*time.Hour))
 		if err != nil {

--- a/service/cloudfront/sign/sign_cookie_test.go
+++ b/service/cloudfront/sign/sign_cookie_test.go
@@ -1,1 +1,85 @@
 package sign
+
+import (
+	"crypto/rsa"
+	"testing"
+	"time"
+)
+
+const (
+	policyName    = "CloudFront-Policy"
+	signatureName = "CloudFront-Signature"
+	keyName       = "CloudFront-Key-Pair-Id"
+)
+
+func TestSignCookie(t *testing.T) {
+	privKey, err := rsa.GenerateKey(randReader, 1024)
+	if err != nil {
+		t.Fatalf("Unexpected priv key error, %#v", err)
+	}
+
+	signer := NewCookieSigner("keyID", privKey)
+
+	if signer.keyID != "keyID" || signer.privKey != privKey {
+		t.Fatalf("NewCookieSigner does not properly assign values %+v", signer)
+	}
+
+	p := &Policy{
+		Statements: []Statement{
+			{
+				Resource: "*",
+				Condition: Condition{
+					DateLessThan: &AWSEpochTime{time.Now().Add(1 * time.Hour)},
+				},
+			},
+		},
+	}
+	//test cookie signer without any additional options
+	policy, signature, key, err := signer.SignCookies(p, nil)
+	if err != nil {
+		t.Fatalf("Error signing cookies %#v", err)
+	}
+
+	if policy.Name != policyName {
+		t.Fatalf("policy name is incorrect, expected: %s\n got: %s", policyName, policy.Name)
+	}
+	if signature.Name != signatureName {
+		t.Fatalf("signature name is incorrect, expected: %s\n got: %s", signatureName, signature.Name)
+	}
+	if key.Name != keyName {
+		t.Fatalf("key name is incorrect, expected: %s\n got: %s", keyName, key.Name)
+	}
+
+	//test cookie signer with additional options
+	o := &CookieOptions{
+		Path:   "/",
+		Domain: ".myexample.com",
+		Secure: true,
+	}
+
+	policy, signature, key, err = signer.SignCookies(p, o)
+	if err != nil {
+		t.Fatalf("Error signing cookies %#v", err)
+	}
+
+	if policy.Name != policyName {
+		t.Fatalf("policy name is incorrect, expected: %s\n got: %s", policyName, policy.Name)
+	}
+	if signature.Name != signatureName {
+		t.Fatalf("signature name is incorrect, expected: %s\n got: %s", signatureName, signature.Name)
+	}
+	if key.Name != keyName {
+		t.Fatalf("key name is incorrect, expected: %s\n got: %s", keyName, key.Name)
+	}
+
+	if policy.Domain != o.Domain || policy.Path != o.Path || policy.Secure != o.Secure {
+		t.Fatalf("extra options were not applied correctly, expected: %+v\n got: %+v", o, policy)
+	}
+	if signature.Domain != o.Domain || signature.Path != o.Path || signature.Secure != o.Secure {
+		t.Fatalf("extra options were not applied correctly, expected: %+v\n got: %+v", o, signature)
+	}
+	if key.Domain != o.Domain || key.Path != o.Path || key.Secure != o.Secure {
+		t.Fatalf("extra options were not applied correctly, expected: %+v\n got: %+v", o, key)
+	}
+
+}

--- a/service/cloudfront/sign/sign_cookie_test.go
+++ b/service/cloudfront/sign/sign_cookie_test.go
@@ -2,6 +2,8 @@ package sign
 
 import (
 	"crypto/rsa"
+	"math/rand"
+	"net/http"
 	"testing"
 	"time"
 )
@@ -10,76 +12,112 @@ const (
 	policyName    = "CloudFront-Policy"
 	signatureName = "CloudFront-Signature"
 	keyName       = "CloudFront-Key-Pair-Id"
+	testDomain    = ".myexample.com"
 )
 
-func TestSignCookie(t *testing.T) {
+func runCookieSetup(t *testing.T, f func(*rsa.PrivateKey)) {
+	origRandReader := randReader
+	randReader = newRandomReader(rand.New(rand.NewSource(1)))
+	defer func() {
+		randReader = origRandReader
+	}()
+
 	privKey, err := rsa.GenerateKey(randReader, 1024)
 	if err != nil {
 		t.Fatalf("Unexpected priv key error, %#v", err)
 	}
+	f(privKey)
+}
+func TestCookieWithPolicy(t *testing.T) {
+	runCookieSetup(t, func(privKey *rsa.PrivateKey) {
 
-	signer := NewCookieSigner("keyID", privKey)
+		signer := NewCookieSigner("keyID", privKey)
 
-	if signer.keyID != "keyID" || signer.privKey != privKey {
-		t.Fatalf("NewCookieSigner does not properly assign values %+v", signer)
-	}
+		if signer.keyID != "keyID" || signer.privKey != privKey {
+			t.Fatalf("NewCookieSigner does not properly assign values %+v", signer)
+		}
 
-	p := &Policy{
-		Statements: []Statement{
-			{
-				Resource: "*",
-				Condition: Condition{
-					DateLessThan: &AWSEpochTime{time.Now().Add(1 * time.Hour)},
+		p := &Policy{
+			Statements: []Statement{
+				{
+					Resource: "*",
+					Condition: Condition{
+						DateLessThan: &AWSEpochTime{time.Now().Add(1 * time.Hour)},
+					},
 				},
 			},
-		},
+		}
+		//test cookie signer without any additional options
+		cookies, err := signer.SignWithPolicy(p)
+		if err != nil {
+			t.Fatalf("Error signing cookies %#v", err)
+		}
+		validateCookies(t, cookies, signer)
+	})
+}
+
+//test cookie signer with additional options
+func TestCookieWithOptions(t *testing.T) {
+	runCookieSetup(t, func(privKey *rsa.PrivateKey) {
+
+		signer := NewCookieSigner("keyID", privKey)
+		signer.Path = "/"
+		signer.Domain = testDomain
+		signer.Secure = false
+
+		if signer.keyID != "keyID" || signer.privKey != privKey {
+			t.Fatalf("NewCookieSigner does not properly assign values %+v", signer)
+		}
+
+		p := &Policy{
+			Statements: []Statement{
+				{
+					Resource: "*",
+					Condition: Condition{
+						DateLessThan: &AWSEpochTime{time.Now().Add(1 * time.Hour)},
+					},
+				},
+			},
+		}
+
+		cookies, err := signer.SignWithPolicy(p)
+		if err != nil {
+			t.Fatalf("Error signing cookies %#v", err)
+		}
+		validateCookies(t, cookies, signer)
+
+	})
+}
+
+func TestCannedCookie(t *testing.T) {
+	runCookieSetup(t, func(privKey *rsa.PrivateKey) {
+		signer := NewCookieSigner("keyID", privKey)
+		cookies, err := signer.Sign("http://sub.cloudfront.com/path", time.Now().Add(1*time.Hour))
+		if err != nil {
+			t.Fatalf("Error signing cookies %#v", err)
+		}
+		validateCookies(t, cookies, signer)
+	})
+}
+
+func validateCookies(t *testing.T, c []*http.Cookie, s *CookieSigner) {
+	if c[0].Name != policyName {
+		t.Fatalf("policy name is incorrect, expected: %s\n got: %s", policyName, c[0].Name)
 	}
-	//test cookie signer without any additional options
-	policy, signature, key, err := signer.SignCookies(p, nil)
-	if err != nil {
-		t.Fatalf("Error signing cookies %#v", err)
+	if c[1].Name != signatureName {
+		t.Fatalf("signature name is incorrect, expected: %s\n got: %s", signatureName, c[1].Name)
+	}
+	if c[2].Name != keyName {
+		t.Fatalf("key name is incorrect, expected: %s\n got: %s", keyName, c[2].Name)
 	}
 
-	if policy.Name != policyName {
-		t.Fatalf("policy name is incorrect, expected: %s\n got: %s", policyName, policy.Name)
+	if c[0].Domain != s.Domain || c[0].Path != s.Path || c[0].Secure != s.Secure {
+		t.Fatalf("extra options were not applied correctly, expected: %+v\n got: %+v", s, c[0])
 	}
-	if signature.Name != signatureName {
-		t.Fatalf("signature name is incorrect, expected: %s\n got: %s", signatureName, signature.Name)
+	if c[1].Domain != s.Domain || c[1].Path != s.Path || c[1].Secure != s.Secure {
+		t.Fatalf("extra options were not applied correctly, expected: %+v\n got: %+v", s, c[1])
 	}
-	if key.Name != keyName {
-		t.Fatalf("key name is incorrect, expected: %s\n got: %s", keyName, key.Name)
+	if c[2].Domain != s.Domain || c[2].Path != s.Path || c[2].Secure != s.Secure {
+		t.Fatalf("extra options were not applied correctly, expected: %+v\n got: %+v", s, c[2])
 	}
-
-	//test cookie signer with additional options
-	o := &CookieOptions{
-		Path:   "/",
-		Domain: ".myexample.com",
-		Secure: true,
-	}
-
-	policy, signature, key, err = signer.SignCookies(p, o)
-	if err != nil {
-		t.Fatalf("Error signing cookies %#v", err)
-	}
-
-	if policy.Name != policyName {
-		t.Fatalf("policy name is incorrect, expected: %s\n got: %s", policyName, policy.Name)
-	}
-	if signature.Name != signatureName {
-		t.Fatalf("signature name is incorrect, expected: %s\n got: %s", signatureName, signature.Name)
-	}
-	if key.Name != keyName {
-		t.Fatalf("key name is incorrect, expected: %s\n got: %s", keyName, key.Name)
-	}
-
-	if policy.Domain != o.Domain || policy.Path != o.Path || policy.Secure != o.Secure {
-		t.Fatalf("extra options were not applied correctly, expected: %+v\n got: %+v", o, policy)
-	}
-	if signature.Domain != o.Domain || signature.Path != o.Path || signature.Secure != o.Secure {
-		t.Fatalf("extra options were not applied correctly, expected: %+v\n got: %+v", o, signature)
-	}
-	if key.Domain != o.Domain || key.Path != o.Path || key.Secure != o.Secure {
-		t.Fatalf("extra options were not applied correctly, expected: %+v\n got: %+v", o, key)
-	}
-
 }


### PR DESCRIPTION
I feel like signed cookies are a really important, and arguably preferable, alternative to signed URLs. Using the functions already provided by the sign package, I put together a very small addition to the package which just provides a wrapper to encodes the 3 cookies required for a properly signed cookie

I followed this [documentation](http://docs.aws.amazon.com/AmazonCloudFront/latoest/DeveloperGuide/private-content-setting-signed-cookie-custom-policy.html#private-content-custom-policy-statement-signed-cookies-examples) and I am now using this implementation in my app

Let me know if this doesn't quite work with you guys, and I'll be happy to refactor


