### PR TITLE
service/s3: Add support for Expect: 100-Continue

### DIFF
--- a/aws/config.go
+++ b/aws/config.go
@@ -100,6 +100,22 @@ type Config struct {
 	//   Amazon S3: Virtual Hosting of Buckets
 	S3ForcePathStyle *bool
 
+	// Set this to `true` to disable the SDK adding the `Expect: 100-Continue`
+	// header to PUT requests over 2MB of content. 100-Continue instructs the
+	// HTTP client not to send the body until the service responds with a
+	// `continue` status. This is useful to prevent sending the request body
+	// until after the request is authenticated, and validated.
+	//
+	// http://docs.aws.amazon.com/AmazonS3/latest/API/RESTObjectPUT.html
+	//
+	// 100-Continue is only enabled for Go 1.6 and above. See `http.Transport`'s
+	// `ExpectContinueTimeout` for information on adjusting the continue wait timeout.
+	// https://golang.org/pkg/net/http/#Transport
+	//
+	// You should use this flag to disble 100-Continue if you experiance issues
+	// with proxies or thrid party S3 compatible services.
+	S3Disable100Continue *bool
+
 	// Set this to `true` to disable the EC2Metadata client from overriding the
 	// default http.Client's Timeout. This is helpful if you do not want the EC2Metadata
 	// client to create a new http.Client. This options is only meaningful if you're not
@@ -210,6 +226,13 @@ func (c *Config) WithS3ForcePathStyle(force bool) *Config {
 	return c
 }
 
+// WithS3Disable100Continue sets a config S3Disable100Continue value returning
+// a Config pointer for chaining.
+func (c *Config) WithS3Disable100Continue(disable bool) *Config {
+	c.S3Disable100Continue = &disable
+	return c
+}
+
 // WithEC2MetadataDisableTimeoutOverride sets a config EC2MetadataDisableTimeoutOverride value
 // returning a Config pointer for chaining.
 func (c *Config) WithEC2MetadataDisableTimeoutOverride(enable bool) *Config {
@@ -286,6 +309,10 @@ func mergeInConfig(dst *Config, other *Config) {
 
 	if other.S3ForcePathStyle != nil {
 		dst.S3ForcePathStyle = other.S3ForcePathStyle
+	}
+
+	if other.S3Disable100Continue != nil {
+		dst.S3Disable100Continue = other.S3Disable100Continue
 	}
 
 	if other.EC2MetadataDisableTimeoutOverride != nil {

--- a/service/s3/customizations.go
+++ b/service/s3/customizations.go
@@ -20,6 +20,10 @@ func init() {
 	}
 
 	initRequest = func(r *request.Request) {
+		// Add reuest handlers for specific platforms.
+		// e.g. 100-continue support for PUT requests using Go 1.6
+		platformRequestHandlers(r)
+
 		switch r.Operation.Name {
 		case opPutBucketCors, opPutBucketLifecycle, opPutBucketPolicy, opPutBucketTagging, opDeleteObjects, opPutBucketLifecycleConfiguration, opPutBucketReplication:
 			// These S3 operations require Content-MD5 to be set

--- a/service/s3/platform_handlers.go
+++ b/service/s3/platform_handlers.go
@@ -1,0 +1,8 @@
+// +build !go1.6
+
+package s3
+
+import "github.com/aws/aws-sdk-go/aws/request"
+
+func platformRequestHandlers(r *request.Request) {
+}

--- a/service/s3/platform_handlers_go1.6.go
+++ b/service/s3/platform_handlers_go1.6.go
@@ -1,0 +1,28 @@
+// +build go1.6
+
+package s3
+
+import (
+	"github.com/aws/aws-sdk-go/aws"
+	"github.com/aws/aws-sdk-go/aws/request"
+)
+
+func platformRequestHandlers(r *request.Request) {
+	if r.Operation.HTTPMethod == "PUT" {
+		// 100-Continue should only be used on put requests.
+		r.Handlers.Sign.PushBack(add100Continue)
+	}
+}
+
+func add100Continue(r *request.Request) {
+	if aws.BoolValue(r.Config.S3Disable100Continue) {
+		return
+	}
+	if r.HTTPRequest.ContentLength < 1024*1024*2 {
+		// Ignore requests smaller than 2MB. This helps prevent delaying
+		// requests unnecessarily.
+		return
+	}
+
+	r.HTTPRequest.Header.Set("Expect", "100-Continue")
+}

--- a/service/s3/platform_handlers_go1.6_test.go
+++ b/service/s3/platform_handlers_go1.6_test.go
@@ -1,0 +1,68 @@
+// +build go1.6
+
+package s3_test
+
+import (
+	"bytes"
+	"testing"
+
+	"github.com/aws/aws-sdk-go/aws"
+	"github.com/aws/aws-sdk-go/awstesting/unit"
+	"github.com/aws/aws-sdk-go/service/s3"
+	"github.com/stretchr/testify/assert"
+)
+
+func TestAdd100Continue_Added(t *testing.T) {
+	svc := s3.New(unit.Session)
+	r, _ := svc.PutObjectRequest(&s3.PutObjectInput{
+		Bucket: aws.String("bucket"),
+		Key:    aws.String("dest"),
+		Body:   bytes.NewReader(make([]byte, 1024*1024*5)),
+	})
+
+	err := r.Sign()
+
+	assert.NoError(t, err)
+	assert.Equal(t, "100-Continue", r.HTTPRequest.Header.Get("Expect"))
+}
+
+func TestAdd100Continue_SkipDisabled(t *testing.T) {
+	svc := s3.New(unit.Session, aws.NewConfig().WithS3Disable100Continue(true))
+	r, _ := svc.PutObjectRequest(&s3.PutObjectInput{
+		Bucket: aws.String("bucket"),
+		Key:    aws.String("dest"),
+		Body:   bytes.NewReader(make([]byte, 1024*1024*5)),
+	})
+
+	err := r.Sign()
+
+	assert.NoError(t, err)
+	assert.Empty(t, r.HTTPRequest.Header.Get("Expect"))
+}
+
+func TestAdd100Continue_SkipNonPUT(t *testing.T) {
+	svc := s3.New(unit.Session)
+	r, _ := svc.GetObjectRequest(&s3.GetObjectInput{
+		Bucket: aws.String("bucket"),
+		Key:    aws.String("dest"),
+	})
+
+	err := r.Sign()
+
+	assert.NoError(t, err)
+	assert.Empty(t, r.HTTPRequest.Header.Get("Expect"))
+}
+
+func TestAdd100Continue_SkipTooSmall(t *testing.T) {
+	svc := s3.New(unit.Session)
+	r, _ := svc.PutObjectRequest(&s3.PutObjectInput{
+		Bucket: aws.String("bucket"),
+		Key:    aws.String("dest"),
+		Body:   bytes.NewReader(make([]byte, 1024*1024*1)),
+	})
+
+	err := r.Sign()
+
+	assert.NoError(t, err)
+	assert.Empty(t, r.HTTPRequest.Header.Get("Expect"))
+}


### PR DESCRIPTION
Adds support for the HTTP header `Expect: 100-Continue` being set for S3
PUT requests over 2MB. This status allows the s3 service client to wait
for the S3 service to authenticate and validate the request prior to sending
the body. Reducing the transfer cost for invalid or unauthenticated request.