### PR TITLE
response.Body can be nil when requests time out

### DIFF
--- a/aws/request/request.go
+++ b/aws/request/request.go
@@ -253,9 +253,11 @@ func (r *Request) Send() error {
 				Proto:         r.HTTPRequest.Proto,
 				ContentLength: r.HTTPRequest.ContentLength,
 			}
-			// Closing response body. Since we are setting a new request to send off, this
-			// response will get squashed and leaked.
-			r.HTTPResponse.Body.Close()
+			if r.HTTPResponse.Body != nil {
+				// Closing response body. Since we are setting a new request to send off, this
+				// response will get squashed and leaked.
+				r.HTTPResponse.Body.Close()
+			}
 		}
 
 		r.Sign()

--- a/aws/request/request_test.go
+++ b/aws/request/request_test.go
@@ -3,6 +3,7 @@ package request_test
 import (
 	"bytes"
 	"encoding/json"
+	"errors"
 	"fmt"
 	"io"
 	"io/ioutil"
@@ -302,4 +303,41 @@ func TestRequestThrottleRetries(t *testing.T) {
 		assert.True(t, min <= v && v <= max,
 			"Expect delay to be within range, i:%d, v:%s, min:%s, max:%s", i, v, min, max)
 	}
+}
+
+// test that retries occur for request timeouts when response.Body can be nil
+func TestRequestRecoverTimeoutWithNilBody(t *testing.T) {
+	reqNum := 0
+	reqs := []*http.Response{
+		{StatusCode: 0, Body: nil}, // body can be nil when requests time out
+		{StatusCode: 200, Body: body(`{"data":"valid"}`)},
+	}
+	errors := []error{
+		errors.New("timeout"), nil,
+	}
+
+	s := awstesting.NewClient(aws.NewConfig().WithMaxRetries(10))
+	s.Handlers.Validate.Clear()
+	s.Handlers.Unmarshal.PushBack(unmarshal)
+	s.Handlers.UnmarshalError.PushBack(unmarshalError)
+	s.Handlers.AfterRetry.Clear() // force retry on all errors
+	s.Handlers.AfterRetry.PushBack(func(r *request.Request) {
+		if r.Error != nil {
+			r.Error = nil
+			r.Retryable = aws.Bool(true)
+			r.RetryCount++
+		}
+	})
+	s.Handlers.Send.Clear() // mock sending
+	s.Handlers.Send.PushBack(func(r *request.Request) {
+		r.HTTPResponse = reqs[reqNum]
+		r.Error = errors[reqNum]
+		reqNum++
+	})
+	out := &testData{}
+	r := s.NewRequest(&request.Operation{Name: "Operation"}, nil, out)
+	err := r.Send()
+	assert.Nil(t, err)
+	assert.Equal(t, 1, int(r.RetryCount))
+	assert.Equal(t, "valid", out.Data)
 }


### PR DESCRIPTION
This was generating panics (`nil pointer dereference`) on retries, since Body will can be empty in some cases (e.g.: when connections/requests time out there isn't a response).