### PR TITLE
Fix to not hash again if Checksum is set

### DIFF
--- a/service/glacier/customizations.go
+++ b/service/glacier/customizations.go
@@ -37,20 +37,16 @@ func addAccountID(r *request.Request) {
 }
 
 func addChecksum(r *request.Request) {
-	if r.Body == nil {
+	if r.Body == nil || r.HTTPRequest.Header.Get("X-Amz-Sha256-Tree-Hash") != "" {
 		return
 	}
 
 	h := ComputeHashes(r.Body)
+	hstr := hex.EncodeToString(h.TreeHash)
+	r.HTTPRequest.Header.Set("X-Amz-Sha256-Tree-Hash", hstr)
 
-	if r.HTTPRequest.Header.Get("X-Amz-Content-Sha256") == "" {
-		hstr := hex.EncodeToString(h.LinearHash)
-		r.HTTPRequest.Header.Set("X-Amz-Content-Sha256", hstr)
-	}
-	if r.HTTPRequest.Header.Get("X-Amz-Sha256-Tree-Hash") == "" {
-		hstr := hex.EncodeToString(h.TreeHash)
-		r.HTTPRequest.Header.Set("X-Amz-Sha256-Tree-Hash", hstr)
-	}
+	hLstr := hex.EncodeToString(h.LinearHash)
+	r.HTTPRequest.Header.Set("X-Amz-Content-Sha256", hLstr)
 }
 
 func addAPIVersion(r *request.Request) {

--- a/service/glacier/customizations_test.go
+++ b/service/glacier/customizations_test.go
@@ -75,3 +75,16 @@ func TestFillAccountIDWithNilStruct(t *testing.T) {
 	assert.Equal(t, empty, req.HTTPRequest.Header.Get("x-amz-content-sha256"))
 	assert.Equal(t, "", req.HTTPRequest.Header.Get("x-amz-sha256-tree-hash"))
 }
+
+func TestHashOnce(t *testing.T) {
+	req, _ := svc.UploadArchiveRequest(&glacier.UploadArchiveInput{
+		VaultName: aws.String("vault"),
+		Body:      payloadBuf,
+	})
+	req.HTTPRequest.Header.Set("X-Amz-Sha256-Tree-Hash", "0")
+
+	err := req.Build()
+	assert.NoError(t, err)
+
+	assert.Equal(t, "0", req.HTTPRequest.Header.Get("x-amz-sha256-tree-hash"))
+}


### PR DESCRIPTION
Hashing was occurring more times than needed when fields/headers were already set.