### PR TITLE
Moved example code into tree structure for better discoverability

### DIFF
--- a/example/service/cloudfront/signCookies/README.md
+++ b/example/service/cloudfront/signCookies/README.md
@@ -1,0 +1,12 @@
+# Example
+
+This example shows how the CloudFront CookieSigner can be used to generate signed cookies to provided short term access to restricted resourced fronted by CloudFront.
+
+# Usage
+Makes a request for object using CloudFront cookie signing, and outputs the contents of the object to stdout.
+
+```sh
+go run signCookies.go -file <privkey file>  -id <keyId> -r <resource pattern> -g <object to get>
+```
+
+

--- a/example/service/cloudfront/signCookies/signCookies.go
+++ b/example/service/cloudfront/signCookies/signCookies.go
@@ -10,8 +10,11 @@ import (
 	"github.com/aws/aws-sdk-go/service/cloudfront/sign"
 )
 
+// Makes a request for object using CloudFront cookie signing, and outputs
+// the contents of the object to stdout.
+//
 // Usage example:
-// go run main.go -file <privkey file>  -id <keyId> -r <resource pattern> -g <object to get>
+// go run signCookies.go -file <privkey file>  -id <keyId> -r <resource pattern> -g <object to get>
 func main() {
 	var keyFile string  // Private key PEM file
 	var keyID string    // Key pair ID of CloudFront key pair

--- a/example/service/s3/listObjects/README.md
+++ b/example/service/s3/listObjects/README.md
@@ -1,0 +1,27 @@
+# Example
+
+listObjects is an example using the AWS SDK for Go to list objects' key in a S3 bucket.
+
+
+# Usage
+
+The example uses the the bucket name provided, and lists all object keys in a bucket.
+
+```sh
+go run listObjects.go <bucket>
+```
+
+Output:
+```
+Page, 0
+Object: myKey
+Object: mykey.txt
+Object: resources/0001/item-01
+Object: resources/0001/item-02
+Object: resources/0001/item-03
+Object: resources/0002/item-01
+Object: resources/0002/item-02
+Object: resources/0002/item-03
+Object: resources/0002/item-04
+Object: resources/0002/item-05
+```

--- a/example/service/s3/listObjects/listObjects.go
+++ b/example/service/s3/listObjects/listObjects.go
@@ -1,0 +1,35 @@
+package main
+
+import (
+	"fmt"
+	"os"
+
+	"github.com/aws/aws-sdk-go/aws/session"
+	"github.com/aws/aws-sdk-go/service/s3"
+)
+
+// Lists all objects in a bucket using pagination
+//
+// Usage:
+// go run listObjects.go <bucket>
+func main() {
+	sess := session.New()
+
+	svc := s3.New(sess)
+
+	i := 0
+	err := svc.ListObjectsPages(&s3.ListObjectsInput{
+		Bucket: &os.Args[1],
+	}, func(p *s3.ListObjectsOutput, last bool) (shouldContinue bool) {
+		fmt.Println("Page,", i)
+
+		for _, obj := range p.Contents {
+			fmt.Println("Object:", *obj.Key)
+		}
+		return true
+	})
+	if err != nil {
+		fmt.Println("failed to list objects", err)
+		return
+	}
+}

--- a/example/service/s3/listObjectsConcurrently/README.md
+++ b/example/service/s3/listObjectsConcurrently/README.md
@@ -1,6 +1,6 @@
 ## Example
 
-listS3EncryptedObjects is an example using the AWS SDK for Go concurrently to list the the encrypted objects in the S3 buckets owned by an account.
+listS3EncryptedObjects is an example using the AWS SDK for Go concurrently to list the encrypted objects in the S3 buckets owned by an account.
 
 ## Usage
 
@@ -9,3 +9,5 @@ The example's `accounts` string slice contains a list of the SharedCredentials p
 ```
 AWS_REGION=us-east-1 go run example/listS3EncryptedObjects/main.go
 ```
+
+

--- a/example/service/s3/listObjectsConcurrently/listObjectsConcurrently.go
+++ b/example/service/s3/listObjectsConcurrently/listObjectsConcurrently.go
@@ -18,6 +18,11 @@ func exit(msg ...interface{}) {
 	os.Exit(1)
 }
 
+// Lists all encrypted objects owned by an account. The `accounts` string
+// contains a list of profiles to use.
+//
+// Usage:
+// go run listObjectsConcurrently.go
 func main() {
 	accounts := []string{"default", "default2", "otherprofile"}
 


### PR DESCRIPTION
Moves the example code files into a tree separated by service and purpose. This should make it easier for find contextualized examples as more are added.

```
/example
   ...
   /service/
       /s3/
            listObjectsConcurrently/
            listObjects/
       /cloudfront/
            signCookies/
       ...