### PR TITLE
private/signer/v4: Do not sign Authorization header on retries

### DIFF
--- a/private/signer/v4/v4.go
+++ b/private/signer/v4/v4.go
@@ -29,7 +29,8 @@ const (
 var ignoredHeaders = rules{
 	blacklist{
 		mapRule{
-			"User-Agent": struct{}{},
+			"Authorization": struct{}{},
+			"User-Agent":    struct{}{},
 		},
 	},
 }


### PR DESCRIPTION
Issue was discovered where the Authorization header would be incorrectly
added to the V4 signature. The header would be signed with the old
value, then updated once the signature was calculated for the new
request. This issue would occur when credentials were expired and the
request was retried.

Added Authorization to ignored headers list, and updated tests to
correctly verify that the Authorization headers are not signed when
requests are resigned.

Fix #627