### PR TITLE
private/signer/v4: Remove Content-Length from blacklist of signed headers

### DIFF
--- a/private/signer/v4/functional_test.go
+++ b/private/signer/v4/functional_test.go
@@ -27,8 +27,8 @@ func TestPresignHandler(t *testing.T) {
 	assert.NoError(t, err)
 
 	expectedDate := "19700101T000000Z"
-	expectedHeaders := "content-disposition;host;x-amz-acl"
-	expectedSig := "b2754ba8ffeb74a40b94767017e24c4672107d6d5a894648d5d332ca61f5ffe4"
+	expectedHeaders := "content-disposition;content-length;host;x-amz-acl"
+	expectedSig := "f7c5effec05ec33b79ecdae84cbc7e394831fe091879abdf85c5e65f14adc35f"
 	expectedCred := "AKID/19700101/mock-region/s3/aws4_request"
 
 	u, _ := url.Parse(urlstr)
@@ -56,10 +56,11 @@ func TestPresignRequest(t *testing.T) {
 	assert.NoError(t, err)
 
 	expectedDate := "19700101T000000Z"
-	expectedHeaders := "content-disposition;host;x-amz-acl"
-	expectedSig := "b2754ba8ffeb74a40b94767017e24c4672107d6d5a894648d5d332ca61f5ffe4"
+	expectedHeaders := "content-disposition;content-length;host;x-amz-acl"
+	expectedSig := "f7c5effec05ec33b79ecdae84cbc7e394831fe091879abdf85c5e65f14adc35f"
 	expectedCred := "AKID/19700101/mock-region/s3/aws4_request"
 	expectedHeaderMap := http.Header{
+		"content-length":      []string{"0"},
 		"x-amz-acl":           []string{"public-read"},
 		"content-disposition": []string{"a+b c$d"},
 	}

--- a/private/signer/v4/v4.go
+++ b/private/signer/v4/v4.go
@@ -29,8 +29,7 @@ const (
 var ignoredHeaders = rules{
 	blacklist{
 		mapRule{
-			"Content-Length": struct{}{},
-			"User-Agent":     struct{}{},
+			"User-Agent": struct{}{},
 		},
 	},
 }

--- a/private/signer/v4/v4_test.go
+++ b/private/signer/v4/v4_test.go
@@ -56,8 +56,8 @@ func TestPresignRequest(t *testing.T) {
 	signer.sign()
 
 	expectedDate := "19700101T000000Z"
-	expectedHeaders := "content-type;host;x-amz-meta-other-header;x-amz-meta-other-header_with_underscore"
-	expectedSig := "59c79b83112a55d188a0708cdfd776f19e4265e700990c60798a05d8923a1300"
+	expectedHeaders := "content-length;content-type;host;x-amz-meta-other-header;x-amz-meta-other-header_with_underscore"
+	expectedSig := "ea7856749041f727690c580569738282e99c79355fe0d8f125d3b5535d2ece83"
 	expectedCred := "AKID/19700101/us-east-1/dynamodb/aws4_request"
 	expectedTarget := "prefix.Operation"
 
@@ -75,7 +75,7 @@ func TestSignRequest(t *testing.T) {
 	signer.sign()
 
 	expectedDate := "19700101T000000Z"
-	expectedSig := "AWS4-HMAC-SHA256 Credential=AKID/19700101/us-east-1/dynamodb/aws4_request, SignedHeaders=content-type;host;x-amz-date;x-amz-meta-other-header;x-amz-meta-other-header_with_underscore;x-amz-security-token;x-amz-target, Signature=47f95059b6f4c3fb5043545281560b3366961d3014757f8aac7480953c344509"
+	expectedSig := "AWS4-HMAC-SHA256 Credential=AKID/19700101/us-east-1/dynamodb/aws4_request, SignedHeaders=content-length;content-type;host;x-amz-date;x-amz-meta-other-header;x-amz-meta-other-header_with_underscore;x-amz-security-token;x-amz-target, Signature=ea766cabd2ec977d955a3c2bae1ae54f4515d70752f2207618396f20aa85bd21"
 
 	q := signer.Request.Header
 	assert.Equal(t, expectedSig, q.Get("Authorization"))


### PR DESCRIPTION
This fixes the bug where Content-Length was incorrectly being
blacklisted from a signed signature. The header was being incorrectly
excluded from the V4 signature.

Fix #625