### PR TITLE
private/signer/v4: Resign requests which are too old

### DIFF
--- a/private/signer/v4/v4.go
+++ b/private/signer/v4/v4.go
@@ -153,6 +153,7 @@ func Sign(req *request.Request) {
 	}
 
 	req.Error = s.sign()
+	req.Time = s.Time
 	req.SignedHeaderVals = s.signedHeaderVals
 }
 
@@ -162,11 +163,12 @@ func (v4 *signer) sign() error {
 	}
 
 	if v4.isRequestSigned() {
-		if !v4.Credentials.IsExpired() {
+		if !v4.Credentials.IsExpired() && time.Now().Before(v4.Time.Add(10*time.Minute)) {
 			// If the request is already signed, and the credentials have not
-			// expired yet ignore the signing request.
+			// expired, and the request is not too old ignore the signing request.
 			return nil
 		}
+		v4.Time = time.Now()
 
 		// The credentials have expired for this request. The current signing
 		// is invalid, and needs to be request because the request will fail.


### PR DESCRIPTION
Requests that are delayed to be sent, or are retried so many times that
the original date the request was signed with is past the age a
signature can be, the request needs to be resigned.  This prevents
issues for request being retried many times, and finally succeding but
encounter an expired signature.

Fix #486