### PR TITLE
Fix retries when response is nil

### DIFF
--- a/aws/request/request.go
+++ b/aws/request/request.go
@@ -253,7 +253,7 @@ func (r *Request) Send() error {
 				Proto:         r.HTTPRequest.Proto,
 				ContentLength: r.HTTPRequest.ContentLength,
 			}
-			if r.HTTPResponse.Body != nil {
+			if r.HTTPResponse != nil && r.HTTPResponse.Body != nil {
 				// Closing response body. Since we are setting a new request to send off, this
 				// response will get squashed and leaked.
 				r.HTTPResponse.Body.Close()

--- a/aws/request/request_test.go
+++ b/aws/request/request_test.go
@@ -341,3 +341,40 @@ func TestRequestRecoverTimeoutWithNilBody(t *testing.T) {
 	assert.Equal(t, 1, int(r.RetryCount))
 	assert.Equal(t, "valid", out.Data)
 }
+
+func TestRequestRecoverTimeoutWithNilResponse(t *testing.T) {
+	reqNum := 0
+	reqs := []*http.Response{
+		nil,
+		{StatusCode: 200, Body: body(`{"data":"valid"}`)},
+	}
+	errors := []error{
+		errors.New("timeout"),
+		nil,
+	}
+
+	s := awstesting.NewClient(aws.NewConfig().WithMaxRetries(10))
+	s.Handlers.Validate.Clear()
+	s.Handlers.Unmarshal.PushBack(unmarshal)
+	s.Handlers.UnmarshalError.PushBack(unmarshalError)
+	s.Handlers.AfterRetry.Clear() // force retry on all errors
+	s.Handlers.AfterRetry.PushBack(func(r *request.Request) {
+		if r.Error != nil {
+			r.Error = nil
+			r.Retryable = aws.Bool(true)
+			r.RetryCount++
+		}
+	})
+	s.Handlers.Send.Clear() // mock sending
+	s.Handlers.Send.PushBack(func(r *request.Request) {
+		r.HTTPResponse = reqs[reqNum]
+		r.Error = errors[reqNum]
+		reqNum++
+	})
+	out := &testData{}
+	r := s.NewRequest(&request.Operation{Name: "Operation"}, nil, out)
+	err := r.Send()
+	assert.Nil(t, err)
+	assert.Equal(t, 1, int(r.RetryCount))
+	assert.Equal(t, "valid", out.Data)
+}


### PR DESCRIPTION
If a failure occurs before `Request.HTTPResponse` is set, the retry handler will panic when trying to read `Request.HTTPResponse.Body`. This adds guards to the retry handler.

Note, this was partially fixed in https://github.com/aws/aws-sdk-go/pull/622, but this handles the case where the `Request.HTTPResponse` is completely `nil` (not just a `nil` `Body`).

cc: @ricardochimal @fabiokung 