### PR TITLE
Support for AWS_SESSION_TOKEN

### DIFF
--- a/aws/credentials/env_provider.go
+++ b/aws/credentials/env_provider.go
@@ -48,26 +48,30 @@ func (e *EnvProvider) Retrieve() (Value, error) {
 	if id == "" {
 		id = os.Getenv("AWS_ACCESS_KEY")
 	}
+	if id == "" {
+		return Value{ProviderName: EnvProviderName}, ErrAccessKeyIDNotFound
+	}
 
 	secret := os.Getenv("AWS_SECRET_ACCESS_KEY")
 	if secret == "" {
 		secret = os.Getenv("AWS_SECRET_KEY")
 	}
-
-	if id == "" {
-		return Value{ProviderName: EnvProviderName}, ErrAccessKeyIDNotFound
-	}
-
 	if secret == "" {
 		return Value{ProviderName: EnvProviderName}, ErrSecretAccessKeyNotFound
+	}
+
+	sessionToken := os.Getenv("AWS_SESSION_TOKEN")
+	if sessionToken == "" {
+		// AWS_SECURITY_TOKEN is deprecated. Keeping it here for backwards compatibility
+		sessionToken = os.Getenv("AWS_SECURITY_TOKEN")
 	}
 
 	e.retrieved = true
 	return Value{
 		AccessKeyID:     id,
 		SecretAccessKey: secret,
-		SessionToken:    os.Getenv("AWS_SESSION_TOKEN"),
 		ProviderName:    EnvProviderName,
+		SessionToken:    sessionToken,
 	}, nil
 }
 


### PR DESCRIPTION
In this blog post [1] it is commented that all the SDKs support
`AWS_SESSION_TOKEN`, but it was not the case for the Go one that was using
the old version of the key: `AWS_SECURITY_TOKEN`

For backwards compatibility reasons this SDK will search for both keys
but prioritising the value (if any) found in `AWS_SESSION_TOKEN`.

[1] http://blogs.aws.amazon.com/security/post/Tx3D6U6WSFGOK2H/A-New-and-Standardized-Way-to-Manage-Credentials-in-the-AWS-SDKs