### PR TITLE
service/s3: Add support for S3 accelerate

### DIFF
--- a/aws/config.go
+++ b/aws/config.go
@@ -116,6 +116,15 @@ type Config struct {
 	// with proxies or thrid party S3 compatible services.
 	S3Disable100Continue *bool
 
+	// Set this to `true` to enable S3 Accelerate feature. For all operations compatible
+	// with S3 Accelerate will use the accelerate endpoint for requests. Requests not compatible
+	// will fall back to normal S3 requests.
+	//
+	// The bucket must be enable for accelerate to be used with S3 client with accelerate
+	// enabled. If the bucket is not enabled for accelerate an error will be returned.
+	// The bucket name must be DNS compatible to also work with accelerate.
+	S3UseAccelerate *bool
+
 	// Set this to `true` to disable the EC2Metadata client from overriding the
 	// default http.Client's Timeout. This is helpful if you do not want the EC2Metadata
 	// client to create a new http.Client. This options is only meaningful if you're not
@@ -233,6 +242,13 @@ func (c *Config) WithS3Disable100Continue(disable bool) *Config {
 	return c
 }
 
+// WithS3UseAccelerate sets a config S3UseAccelerate value returning a Config
+// pointer for chaining.
+func (c *Config) WithS3UseAccelerate(enable bool) *Config {
+	c.S3UseAccelerate = &enable
+	return c
+}
+
 // WithEC2MetadataDisableTimeoutOverride sets a config EC2MetadataDisableTimeoutOverride value
 // returning a Config pointer for chaining.
 func (c *Config) WithEC2MetadataDisableTimeoutOverride(enable bool) *Config {
@@ -313,6 +329,10 @@ func mergeInConfig(dst *Config, other *Config) {
 
 	if other.S3Disable100Continue != nil {
 		dst.S3Disable100Continue = other.S3Disable100Continue
+	}
+
+	if other.S3UseAccelerate != nil {
+		dst.S3UseAccelerate = other.S3UseAccelerate
 	}
 
 	if other.EC2MetadataDisableTimeoutOverride != nil {

--- a/service/s3/customizations.go
+++ b/service/s3/customizations.go
@@ -6,36 +6,41 @@ import (
 )
 
 func init() {
-	initClient = func(c *client.Client) {
-		// Support building custom host-style bucket endpoints
-		c.Handlers.Build.PushFront(updateHostWithBucket)
+	initClient = defaultInitClientFn
+	initRequest = defaultInitRequestFn
+}
 
-		// Require SSL when using SSE keys
-		c.Handlers.Validate.PushBack(validateSSERequiresSSL)
-		c.Handlers.Build.PushBack(computeSSEKeys)
+func defaultInitClientFn(c *client.Client) {
+	// Support building custom endpoints based on config
+	c.Handlers.Build.PushFront(updateEndpointForS3Config)
 
-		// S3 uses custom error unmarshaling logic
-		c.Handlers.UnmarshalError.Clear()
-		c.Handlers.UnmarshalError.PushBack(unmarshalError)
-	}
+	// Require SSL when using SSE keys
+	c.Handlers.Validate.PushBack(validateSSERequiresSSL)
+	c.Handlers.Build.PushBack(computeSSEKeys)
 
-	initRequest = func(r *request.Request) {
-		// Add reuest handlers for specific platforms.
-		// e.g. 100-continue support for PUT requests using Go 1.6
-		platformRequestHandlers(r)
+	// S3 uses custom error unmarshaling logic
+	c.Handlers.UnmarshalError.Clear()
+	c.Handlers.UnmarshalError.PushBack(unmarshalError)
+}
 
-		switch r.Operation.Name {
-		case opPutBucketCors, opPutBucketLifecycle, opPutBucketPolicy, opPutBucketTagging, opDeleteObjects, opPutBucketLifecycleConfiguration, opPutBucketReplication:
-			// These S3 operations require Content-MD5 to be set
-			r.Handlers.Build.PushBack(contentMD5)
-		case opGetBucketLocation:
-			// GetBucketLocation has custom parsing logic
-			r.Handlers.Unmarshal.PushFront(buildGetBucketLocation)
-		case opCreateBucket:
-			// Auto-populate LocationConstraint with current region
-			r.Handlers.Validate.PushFront(populateLocationConstraint)
-		case opCopyObject, opUploadPartCopy, opCompleteMultipartUpload:
-			r.Handlers.Unmarshal.PushFront(copyMultipartStatusOKUnmarhsalError)
-		}
+func defaultInitRequestFn(r *request.Request) {
+	// Add reuest handlers for specific platforms.
+	// e.g. 100-continue support for PUT requests using Go 1.6
+	platformRequestHandlers(r)
+
+	switch r.Operation.Name {
+	case opPutBucketCors, opPutBucketLifecycle, opPutBucketPolicy,
+		opPutBucketTagging, opDeleteObjects, opPutBucketLifecycleConfiguration,
+		opPutBucketReplication:
+		// These S3 operations require Content-MD5 to be set
+		r.Handlers.Build.PushBack(contentMD5)
+	case opGetBucketLocation:
+		// GetBucketLocation has custom parsing logic
+		r.Handlers.Unmarshal.PushFront(buildGetBucketLocation)
+	case opCreateBucket:
+		// Auto-populate LocationConstraint with current region
+		r.Handlers.Validate.PushFront(populateLocationConstraint)
+	case opCopyObject, opUploadPartCopy, opCompleteMultipartUpload:
+		r.Handlers.Unmarshal.PushFront(copyMultipartStatusOKUnmarhsalError)
 	}
 }

--- a/service/s3/host_style_bucket.go
+++ b/service/s3/host_style_bucket.go
@@ -1,13 +1,123 @@
 package s3
 
 import (
+	"fmt"
+	"net/url"
 	"regexp"
 	"strings"
 
 	"github.com/aws/aws-sdk-go/aws"
+	"github.com/aws/aws-sdk-go/aws/awserr"
 	"github.com/aws/aws-sdk-go/aws/awsutil"
 	"github.com/aws/aws-sdk-go/aws/request"
 )
+
+// an operationBlacklist is a list of operation names that should a
+// request handler should not be executed with.
+type operationBlacklist []string
+
+// Continue will return true of the Request's operation name is not
+// in the blacklist. False otherwise.
+func (b operationBlacklist) Continue(r *request.Request) bool {
+	for i := 0; i < len(b); i++ {
+		if b[i] == r.Operation.Name {
+			return false
+		}
+	}
+	return true
+}
+
+var accelerateOpBlacklist = operationBlacklist{
+	opListBuckets, opCreateBucket, opDeleteBucket,
+}
+
+// Request handler to automatically add the bucket name to the endpoint domain
+// if possible. This style of bucket is valid for all bucket names which are
+// DNS compatible and do not contain "."
+func updateEndpointForS3Config(r *request.Request) {
+	forceHostStyle := aws.BoolValue(r.Config.S3ForcePathStyle)
+	accelerate := aws.BoolValue(r.Config.S3UseAccelerate)
+
+	if accelerate && accelerateOpBlacklist.Continue(r) {
+		if forceHostStyle {
+			if r.Config.Logger != nil {
+				r.Config.Logger.Log("ERROR: aws.Config.S3UseAccelerate is not compatible with aws.Config.S3ForcePathStyle, ignoring S3ForcePathStyle.")
+			}
+		}
+		updateEndpointForAccelerate(r)
+	} else if !forceHostStyle && r.Operation.Name != opGetBucketLocation {
+		updateEndpointForHostStyle(r)
+	}
+}
+
+func updateEndpointForHostStyle(r *request.Request) {
+	bucket, ok := bucketNameFromReqParams(r.Params)
+	if !ok {
+		// Ignore operation requests if the bucketname was not provided
+		// if this is an input validation error the validation handler
+		// will report it.
+		return
+	}
+
+	if !hostCompatibleBucketName(r.HTTPRequest.URL, bucket) {
+		// bucket name must be valid to put into the host
+		return
+	}
+
+	moveBucketToHost(r.HTTPRequest.URL, bucket)
+}
+
+func updateEndpointForAccelerate(r *request.Request) {
+	bucket, ok := bucketNameFromReqParams(r.Params)
+	if !ok {
+		// Ignore operation requests if the bucketname was not provided
+		// if this is an input validation error the validation handler
+		// will report it.
+		return
+	}
+
+	if !hostCompatibleBucketName(r.HTTPRequest.URL, bucket) {
+		r.Error = awserr.New("InvalidParameterException",
+			fmt.Sprintf("bucket name %s is not compatibile with S3 Accelerate", bucket),
+			nil)
+		return
+	}
+
+	// Change endpoint from s3(-[a-z0-1-])?.amazonaws.com to s3-accelerate.amazonaws.com
+	r.HTTPRequest.URL.Host = replaceHostRegion(r.HTTPRequest.URL.Host, "accelerate")
+	moveBucketToHost(r.HTTPRequest.URL, bucket)
+}
+
+// Attempts to retrieve the bucket name from the request input parameters.
+// If no bucket is found, or the field is empty "", false will be returned.
+func bucketNameFromReqParams(params interface{}) (string, bool) {
+	b, _ := awsutil.ValuesAtPath(params, "Bucket")
+	if len(b) == 0 {
+		return "", false
+	}
+
+	if bucket, ok := b[0].(*string); ok {
+		if bucketStr := aws.StringValue(bucket); bucketStr != "" {
+			return bucketStr, true
+		}
+	}
+
+	return "", false
+}
+
+// hostCompatibleBucketName returns true if the request should
+// put the bucket in the host. This is false if S3ForcePathStyle is
+// explicitly set or if the bucket is not DNS compatible.
+func hostCompatibleBucketName(u *url.URL, bucket string) bool {
+	// Bucket might be DNS compatible but dots in the hostname will fail
+	// certificate validation, so do not use host-style.
+	if u.Scheme == "https" && strings.Contains(bucket, ".") {
+		return false
+	}
+
+	// if the bucket is DNS compatible
+	return dnsCompatibleBucketName(bucket)
+}
 
 var reDomain = regexp.MustCompile(`^[a-z0-9][a-z0-9\.\-]{1,61}[a-z0-9]$`)
 var reIPAddress = regexp.MustCompile(`^(\d+\.){3}\d+$`)
@@ -20,41 +130,36 @@ func dnsCompatibleBucketName(bucket string) bool {
 		!strings.Contains(bucket, "..")
 }
 
-// hostStyleBucketName returns true if the request should put the bucket in
-// the host. This is false if S3ForcePathStyle is explicitly set or if the
-// bucket is not DNS compatible.
-func hostStyleBucketName(r *request.Request, bucket string) bool {
-	if aws.BoolValue(r.Config.S3ForcePathStyle) {
-		return false
+// moveBucketToHost moves the bucket name from the URI path to URL host.
+func moveBucketToHost(u *url.URL, bucket string) {
+	u.Host = bucket + "." + u.Host
+	u.Path = strings.Replace(u.Path, "/{Bucket}", "", -1)
+	if u.Path == "" {
+		u.Path = "/"
 	}
-
-	// Bucket might be DNS compatible but dots in the hostname will fail
-	// certificate validation, so do not use host-style.
-	if r.HTTPRequest.URL.Scheme == "https" && strings.Contains(bucket, ".") {
-		return false
-	}
-
-	// GetBucketLocation should be able to be called from any region within
-	// a partition, and return the associated region of the bucket.
-	if r.Operation.Name == opGetBucketLocation {
-		return false
-	}
-
-	// Use host-style if the bucket is DNS compatible
-	return dnsCompatibleBucketName(bucket)
 }
 
-func updateHostWithBucket(r *request.Request) {
-	b, _ := awsutil.ValuesAtPath(r.Params, "Bucket")
-	if len(b) == 0 {
-		return
+const s3HostPrefix = "s3"
+
+// replaceHostRegion replaces the S3 region string in the host with the
+// value provided. If v is empty the host prefix returned will be s3.
+func replaceHostRegion(host, v string) string {
+	if !strings.HasPrefix(host, s3HostPrefix) {
+		return host
 	}
 
-	if bucket := b[0].(*string); aws.StringValue(bucket) != "" && hostStyleBucketName(r, *bucket) {
-		r.HTTPRequest.URL.Host = *bucket + "." + r.HTTPRequest.URL.Host
-		r.HTTPRequest.URL.Path = strings.Replace(r.HTTPRequest.URL.Path, "/{Bucket}", "", -1)
-		if r.HTTPRequest.URL.Path == "" {
-			r.HTTPRequest.URL.Path = "/"
+	suffix := host[len(s3HostPrefix):]
+	for i := len(s3HostPrefix); i < len(host); i++ {
+		if host[i] == '.' {
+			// Trim until '.' leave the it in place.
+			suffix = host[i:]
+			break
 		}
 	}
+
+	if len(v) == 0 {
+		return fmt.Sprintf("s3%s", suffix)
+	}
+
+	return fmt.Sprintf("s3-%s%s", v, suffix)
 }

--- a/service/s3/host_style_bucket_test.go
+++ b/service/s3/host_style_bucket_test.go
@@ -8,42 +8,70 @@ import (
 	"github.com/stretchr/testify/require"
 
 	"github.com/aws/aws-sdk-go/aws"
+	"github.com/aws/aws-sdk-go/aws/awserr"
 	"github.com/aws/aws-sdk-go/awstesting/unit"
 	"github.com/aws/aws-sdk-go/service/s3"
 )
 
 type s3BucketTest struct {
-	bucket string
-	url    string
+	bucket  string
+	url     string
+	errCode string
 }
 
 var (
 	sslTests = []s3BucketTest{
-		{"abc", "https://abc.s3-mock-region.amazonaws.com/"},
-		{"a$b$c", "https://s3-mock-region.amazonaws.com/a%24b%24c"},
-		{"a.b.c", "https://s3-mock-region.amazonaws.com/a.b.c"},
-		{"a..bc", "https://s3-mock-region.amazonaws.com/a..bc"},
+		{"abc", "https://abc.s3-mock-region.amazonaws.com/", ""},
+		{"a$b$c", "https://s3-mock-region.amazonaws.com/a%24b%24c", ""},
+		{"a.b.c", "https://s3-mock-region.amazonaws.com/a.b.c", ""},
+		{"a..bc", "https://s3-mock-region.amazonaws.com/a..bc", ""},
 	}
 
 	nosslTests = []s3BucketTest{
-		{"a.b.c", "http://a.b.c.s3-mock-region.amazonaws.com/"},
-		{"a..bc", "http://s3-mock-region.amazonaws.com/a..bc"},
+		{"a.b.c", "http://a.b.c.s3-mock-region.amazonaws.com/", ""},
+		{"a..bc", "http://s3-mock-region.amazonaws.com/a..bc", ""},
 	}
 
 	forcepathTests = []s3BucketTest{
-		{"abc", "https://s3-mock-region.amazonaws.com/abc"},
-		{"a$b$c", "https://s3-mock-region.amazonaws.com/a%24b%24c"},
-		{"a.b.c", "https://s3-mock-region.amazonaws.com/a.b.c"},
-		{"a..bc", "https://s3-mock-region.amazonaws.com/a..bc"},
+		{"abc", "https://s3-mock-region.amazonaws.com/abc", ""},
+		{"a$b$c", "https://s3-mock-region.amazonaws.com/a%24b%24c", ""},
+		{"a.b.c", "https://s3-mock-region.amazonaws.com/a.b.c", ""},
+		{"a..bc", "https://s3-mock-region.amazonaws.com/a..bc", ""},
+	}
+
+	accelerateTests = []s3BucketTest{
+		{"abc", "https://abc.s3-accelerate.amazonaws.com/", ""},
+		{"a.b.c", "https://s3-mock-region.amazonaws.com/%7BBucket%7D", "InvalidParameterException"},
+		{"a$b$c", "https://s3-mock-region.amazonaws.com/%7BBucket%7D", "InvalidParameterException"},
+	}
+
+	accelerateNoSSLTests = []s3BucketTest{
+		{"abc", "http://abc.s3-accelerate.amazonaws.com/", ""},
+		{"a.b.c", "http://a.b.c.s3-accelerate.amazonaws.com/", ""},
+		{"a$b$c", "http://s3-mock-region.amazonaws.com/%7BBucket%7D", "InvalidParameterException"},
 	}
 )
 
 func runTests(t *testing.T, svc *s3.S3, tests []s3BucketTest) {
-	for _, test := range tests {
+	for i, test := range tests {
 		req, _ := svc.ListObjectsRequest(&s3.ListObjectsInput{Bucket: &test.bucket})
 		req.Build()
-		assert.Equal(t, test.url, req.HTTPRequest.URL.String())
+		assert.Equal(t, test.url, req.HTTPRequest.URL.String(), "test case %d", i)
+		if test.errCode != "" {
+			require.Error(t, req.Error, "test case %d", i)
+			assert.Contains(t, req.Error.(awserr.Error).Code(), test.errCode, "test case %d", i)
+		}
 	}
+}
+
+func TestAccelerateBucketBuild(t *testing.T) {
+	s := s3.New(unit.Session, &aws.Config{S3UseAccelerate: aws.Bool(true)})
+	runTests(t, s, accelerateTests)
+}
+
+func TestAccelerateNoSSLBucketBuild(t *testing.T) {
+	s := s3.New(unit.Session, &aws.Config{S3UseAccelerate: aws.Bool(true), DisableSSL: aws.Bool(true)})
+	runTests(t, s, accelerateNoSSLTests)
 }
 
 func TestHostStyleBucketBuild(t *testing.T) {


### PR DESCRIPTION
Updates S3 to support S3 accelerate functionality. To enable this set
the `aws.Config.S3Accelerate` flag to true. The bucket must have
accelerate enabled before you can use the SDK with the accelerate flag
enabled.