### PR TITLE
Generate API validation instead of using reflection

### DIFF
--- a/aws/corehandlers/param_validator.go
+++ b/aws/corehandlers/param_validator.go
@@ -1,153 +1,17 @@
 package corehandlers
 
-import (
-	"fmt"
-	"reflect"
-	"strconv"
-	"strings"
-
-	"github.com/aws/aws-sdk-go/aws/awserr"
-	"github.com/aws/aws-sdk-go/aws/request"
-)
+import "github.com/aws/aws-sdk-go/aws/request"
 
 // ValidateParametersHandler is a request handler to validate the input parameters.
 // Validating parameters only has meaning if done prior to the request being sent.
 var ValidateParametersHandler = request.NamedHandler{Name: "core.ValidateParametersHandler", Fn: func(r *request.Request) {
-	if r.ParamsFilled() {
-		v := validator{errors: []string{}}
-		v.validateAny(reflect.ValueOf(r.Params), "")
-
-		if count := len(v.errors); count > 0 {
-			format := "%d validation errors:\n- %s"
-			msg := fmt.Sprintf(format, count, strings.Join(v.errors, "\n- "))
-			r.Error = awserr.New("InvalidParameter", msg, nil)
-		}
-	}
-}}
-
-// A validator validates values. Collects validations errors which occurs.
-type validator struct {
-	errors []string
-}
-
-// There's no validation to be done on the contents of []byte values. Prepare
-// to check validateAny arguments against that type so we can quickly skip
-// them.
-var byteSliceType = reflect.TypeOf([]byte(nil))
-
-// validateAny will validate any struct, slice or map type. All validations
-// are also performed recursively for nested types.
-func (v *validator) validateAny(value reflect.Value, path string) {
-	value = reflect.Indirect(value)
-	if !value.IsValid() {
+	if !r.ParamsFilled() {
 		return
 	}
 
-	switch value.Kind() {
-	case reflect.Struct:
-		v.validateStruct(value, path)
-	case reflect.Slice:
-		if value.Type() == byteSliceType {
-			// We don't need to validate the contents of []byte.
-			return
-		}
-		for i := 0; i < value.Len(); i++ {
-			v.validateAny(value.Index(i), path+fmt.Sprintf("[%d]", i))
-		}
-	case reflect.Map:
-		for _, n := range value.MapKeys() {
-			v.validateAny(value.MapIndex(n), path+fmt.Sprintf("[%q]", n.String()))
+	if v, ok := r.Params.(request.Validator); ok {
+		if err := v.Validate(); err != nil {
+			r.Error = err
 		}
 	}
-}
-
-// validateStruct will validate the struct value's fields. If the structure has
-// nested types those types will be validated also.
-func (v *validator) validateStruct(value reflect.Value, path string) {
-	prefix := "."
-	if path == "" {
-		prefix = ""
-	}
-
-	for i := 0; i < value.Type().NumField(); i++ {
-		f := value.Type().Field(i)
-		if strings.ToLower(f.Name[0:1]) == f.Name[0:1] {
-			continue
-		}
-		fvalue := value.FieldByName(f.Name)
-
-		err := validateField(f, fvalue, validateFieldRequired, validateFieldMin)
-		if err != nil {
-			v.errors = append(v.errors, fmt.Sprintf("%s: %s", err.Error(), path+prefix+f.Name))
-			continue
-		}
-
-		v.validateAny(fvalue, path+prefix+f.Name)
-	}
-}
-
-type validatorFunc func(f reflect.StructField, fvalue reflect.Value) error
-
-func validateField(f reflect.StructField, fvalue reflect.Value, funcs ...validatorFunc) error {
-	for _, fn := range funcs {
-		if err := fn(f, fvalue); err != nil {
-			return err
-		}
-	}
-	return nil
-}
-
-// Validates that a field has a valid value provided for required fields.
-func validateFieldRequired(f reflect.StructField, fvalue reflect.Value) error {
-	if f.Tag.Get("required") == "" {
-		return nil
-	}
-
-	switch fvalue.Kind() {
-	case reflect.Ptr, reflect.Slice, reflect.Map:
-		if fvalue.IsNil() {
-			return fmt.Errorf("missing required parameter")
-		}
-	default:
-		if !fvalue.IsValid() {
-			return fmt.Errorf("missing required parameter")
-		}
-	}
-	return nil
-}
-
-// Validates that if a value is provided for a field, that value must be at
-// least a minimum length.
-func validateFieldMin(f reflect.StructField, fvalue reflect.Value) error {
-	minStr := f.Tag.Get("min")
-	if minStr == "" {
-		return nil
-	}
-	min, _ := strconv.ParseInt(minStr, 10, 64)
-
-	kind := fvalue.Kind()
-	if kind == reflect.Ptr {
-		if fvalue.IsNil() {
-			return nil
-		}
-		fvalue = fvalue.Elem()
-	}
-
-	switch fvalue.Kind() {
-	case reflect.String:
-		if int64(fvalue.Len()) < min {
-			return fmt.Errorf("field too short, minimum length %d", min)
-		}
-	case reflect.Slice, reflect.Map:
-		if fvalue.IsNil() {
-			return nil
-		}
-		if int64(fvalue.Len()) < min {
-			return fmt.Errorf("field too short, minimum length %d", min)
-		}
-
-		// TODO min can also apply to number minimum value.
-
-	}
-	return nil
-}
+}}

--- a/aws/corehandlers/param_validator_test.go
+++ b/aws/corehandlers/param_validator_test.go
@@ -1,6 +1,7 @@
 package corehandlers_test
 
 import (
+	"fmt"
 	"testing"
 
 	"github.com/stretchr/testify/assert"
@@ -28,18 +29,75 @@ var testSvc = func() *client.Client {
 }()
 
 type StructShape struct {
+	_ struct{} `type:"structure"`
+
 	RequiredList   []*ConditionalStructShape          `required:"true"`
 	RequiredMap    map[string]*ConditionalStructShape `required:"true"`
 	RequiredBool   *bool                              `required:"true"`
 	OptionalStruct *ConditionalStructShape
 
 	hiddenParameter *string
-	_               struct{}
+}
+
+func (s *StructShape) Validate() error {
+	invalidParams := request.ErrInvalidParams{Context: "StructShape"}
+	if s.RequiredList == nil {
+		invalidParams.Add(request.NewErrParamRequired("RequiredList"))
+	}
+	if s.RequiredMap == nil {
+		invalidParams.Add(request.NewErrParamRequired("RequiredMap"))
+	}
+	if s.RequiredBool == nil {
+		invalidParams.Add(request.NewErrParamRequired("RequiredBool"))
+	}
+	if s.RequiredList != nil {
+		for i, v := range s.RequiredList {
+			if v == nil {
+				continue
+			}
+			if err := v.Validate(); err != nil {
+				invalidParams.AddNested(fmt.Sprintf("%s[%v]", "RequiredList", i), err.(request.ErrInvalidParams))
+			}
+		}
+	}
+	if s.RequiredMap != nil {
+		for i, v := range s.RequiredMap {
+			if v == nil {
+				continue
+			}
+			if err := v.Validate(); err != nil {
+				invalidParams.AddNested(fmt.Sprintf("%s[%v]", "RequiredMap", i), err.(request.ErrInvalidParams))
+			}
+		}
+	}
+	if s.OptionalStruct != nil {
+		if err := s.OptionalStruct.Validate(); err != nil {
+			invalidParams.AddNested("OptionalStruct", err.(request.ErrInvalidParams))
+		}
+	}
+
+	if invalidParams.Len() > 0 {
+		return invalidParams
+	}
+	return nil
 }
 
 type ConditionalStructShape struct {
+	_ struct{} `type:"structure"`
+
 	Name *string `required:"true"`
-	_    struct{}
+}
+
+func (s *ConditionalStructShape) Validate() error {
+	invalidParams := request.ErrInvalidParams{Context: "ConditionalStructShape"}
+	if s.Name == nil {
+		invalidParams.Add(request.NewErrParamRequired("Name"))
+	}
+
+	if invalidParams.Len() > 0 {
+		return invalidParams
+	}
+	return nil
 }
 
 func TestNoErrors(t *testing.T) {
@@ -65,7 +123,15 @@ func TestMissingRequiredParameters(t *testing.T) {
 
 	require.Error(t, req.Error)
 	assert.Equal(t, "InvalidParameter", req.Error.(awserr.Error).Code())
-	assert.Equal(t, "3 validation errors:\n- missing required parameter: RequiredList\n- missing required parameter: RequiredMap\n- missing required parameter: RequiredBool", req.Error.(awserr.Error).Message())
+	assert.Equal(t, "3 validation error(s) found.", req.Error.(awserr.Error).Message())
+
+	errs := req.Error.(awserr.BatchedErrors).OrigErrs()
+	assert.Len(t, errs, 3)
+	assert.Equal(t, "ParamRequiredError: missing required field, StructShape.RequiredList.", errs[0].Error())
+	assert.Equal(t, "ParamRequiredError: missing required field, StructShape.RequiredMap.", errs[1].Error())
+	assert.Equal(t, "ParamRequiredError: missing required field, StructShape.RequiredBool.", errs[2].Error())
+
+	assert.Equal(t, "InvalidParameter: 3 validation error(s) found.\n- missing required field, StructShape.RequiredList.\n- missing required field, StructShape.RequiredMap.\n- missing required field, StructShape.RequiredBool.\n", req.Error.Error())
 }
 
 func TestNestedMissingRequiredParameters(t *testing.T) {
@@ -84,14 +150,37 @@ func TestNestedMissingRequiredParameters(t *testing.T) {
 
 	require.Error(t, req.Error)
 	assert.Equal(t, "InvalidParameter", req.Error.(awserr.Error).Code())
-	assert.Equal(t, "3 validation errors:\n- missing required parameter: RequiredList[0].Name\n- missing required parameter: RequiredMap[\"key2\"].Name\n- missing required parameter: OptionalStruct.Name", req.Error.(awserr.Error).Message())
+	assert.Equal(t, "3 validation error(s) found.", req.Error.(awserr.Error).Message())
+
+	errs := req.Error.(awserr.BatchedErrors).OrigErrs()
+	assert.Len(t, errs, 3)
+	assert.Equal(t, "ParamRequiredError: missing required field, StructShape.RequiredList[0].Name.", errs[0].Error())
+	assert.Equal(t, "ParamRequiredError: missing required field, StructShape.RequiredMap[key2].Name.", errs[1].Error())
+	assert.Equal(t, "ParamRequiredError: missing required field, StructShape.OptionalStruct.Name.", errs[2].Error())
 }
 
 type testInput struct {
-	StringField string            `min:"5"`
-	PtrStrField *string           `min:"2"`
+	StringField *string           `min:"5"`
 	ListField   []string          `min:"3"`
 	MapField    map[string]string `min:"4"`
+}
+
+func (s testInput) Validate() error {
+	invalidParams := request.ErrInvalidParams{Context: "testInput"}
+	if s.StringField != nil && len(*s.StringField) < 5 {
+		invalidParams.Add(request.NewErrParamMinLen("StringField", 5))
+	}
+	if s.ListField != nil && len(s.ListField) < 3 {
+		invalidParams.Add(request.NewErrParamMinLen("ListField", 3))
+	}
+	if s.MapField != nil && len(s.MapField) < 4 {
+		invalidParams.Add(request.NewErrParamMinLen("MapField", 4))
+	}
+
+	if invalidParams.Len() > 0 {
+		return invalidParams
+	}
+	return nil
 }
 
 var testsFieldMin = []struct {
@@ -99,24 +188,35 @@ var testsFieldMin = []struct {
 	in  testInput
 }{
 	{
-		err: awserr.New("InvalidParameter", "1 validation errors:\n- field too short, minimum length 5: StringField", nil),
-		in:  testInput{StringField: "abcd"},
+		err: func() awserr.Error {
+			invalidParams := request.ErrInvalidParams{Context: "testInput"}
+			invalidParams.Add(request.NewErrParamMinLen("StringField", 5))
+			return invalidParams
+		}(),
+		in: testInput{StringField: aws.String("abcd")},
 	},
 	{
-		err: awserr.New("InvalidParameter", "2 validation errors:\n- field too short, minimum length 5: StringField\n- field too short, minimum length 3: ListField", nil),
-		in:  testInput{StringField: "abcd", ListField: []string{"a", "b"}},
+		err: func() awserr.Error {
+			invalidParams := request.ErrInvalidParams{Context: "testInput"}
+			invalidParams.Add(request.NewErrParamMinLen("StringField", 5))
+			invalidParams.Add(request.NewErrParamMinLen("ListField", 3))
+			return invalidParams
+		}(),
+		in: testInput{StringField: aws.String("abcd"), ListField: []string{"a", "b"}},
 	},
 	{
-		err: awserr.New("InvalidParameter", "3 validation errors:\n- field too short, minimum length 5: StringField\n- field too short, minimum length 3: ListField\n- field too short, minimum length 4: MapField", nil),
-		in:  testInput{StringField: "abcd", ListField: []string{"a", "b"}, MapField: map[string]string{"a": "a", "b": "b"}},
-	},
-	{
-		err: awserr.New("InvalidParameter", "1 validation errors:\n- field too short, minimum length 2: PtrStrField", nil),
-		in:  testInput{StringField: "abcde", PtrStrField: aws.String("v")},
+		err: func() awserr.Error {
+			invalidParams := request.ErrInvalidParams{Context: "testInput"}
+			invalidParams.Add(request.NewErrParamMinLen("StringField", 5))
+			invalidParams.Add(request.NewErrParamMinLen("ListField", 3))
+			invalidParams.Add(request.NewErrParamMinLen("MapField", 4))
+			return invalidParams
+		}(),
+		in: testInput{StringField: aws.String("abcd"), ListField: []string{"a", "b"}, MapField: map[string]string{"a": "a", "b": "b"}},
 	},
 	{
 		err: nil,
-		in: testInput{StringField: "abcde", PtrStrField: aws.String("value"),
+		in: testInput{StringField: aws.String("abcde"),
 			ListField: []string{"a", "b", "c"}, MapField: map[string]string{"a": "a", "b": "b", "c": "c", "d": "d"}},
 	},
 }
@@ -126,7 +226,7 @@ func TestValidateFieldMinParameter(t *testing.T) {
 		req := testSvc.NewRequest(&request.Operation{}, &c.in, nil)
 		corehandlers.ValidateParametersHandler.Fn(req)
 
-		require.Equal(t, c.err, req.Error, "%d case failed", i)
+		assert.Equal(t, c.err, req.Error, "%d case failed", i)
 	}
 }
 
@@ -144,7 +244,7 @@ func BenchmarkValidateAny(b *testing.B) {
 
 	req, _ := kinesis.New(session.New()).PutRecordsRequest(input)
 
-	b.ReportAllocs()
+	b.ResetTimer()
 	for i := 0; i < b.N; i++ {
 		corehandlers.ValidateParametersHandler.Fn(req)
 		if err := req.Error; err != nil {

--- a/aws/request/validation.go
+++ b/aws/request/validation.go
@@ -1,0 +1,234 @@
+package request
+
+import (
+	"bytes"
+	"fmt"
+
+	"github.com/aws/aws-sdk-go/aws/awserr"
+)
+
+const (
+	// InvalidParameterErrCode is the error code for invalid parameters errors
+	InvalidParameterErrCode = "InvalidParameter"
+	// ParamRequiredErrCode is the error code for required parameter errors
+	ParamRequiredErrCode = "ParamRequiredError"
+	// ParamMinValueErrCode is the error code for fields with too low of a
+	// number value.
+	ParamMinValueErrCode = "ParamMinValueError"
+	// ParamMinLenErrCode is the error code for fields without enough elements.
+	ParamMinLenErrCode = "ParamMinLenError"
+)
+
+// Validator provides a way for types to perform validation logic on their
+// input values that external code can use to determine if a type's values
+// are valid.
+type Validator interface {
+	Validate() error
+}
+
+// An ErrInvalidParams provides wrapping of invalid parameter errors found when
+// validating API operation input parameters.
+type ErrInvalidParams struct {
+	// Context is the base context of the invalid parameter group.
+	Context string
+	errs    []ErrInvalidParam
+}
+
+// Add adds a new invalid parameter error to the collection of invalid
+// parameters. The context of the invalid parameter will be updated to reflect
+// this collection.
+func (e *ErrInvalidParams) Add(err ErrInvalidParam) {
+	err.SetContext(e.Context)
+	e.errs = append(e.errs, err)
+}
+
+// AddNested adds the invalid parameter errors from another ErrInvalidParams
+// value into this collection. The nested errors will have their nested context
+// updated and base context to reflect the merging.
+//
+// Use for nested validations errors.
+func (e *ErrInvalidParams) AddNested(nestedCtx string, nested ErrInvalidParams) {
+	for _, err := range nested.errs {
+		err.SetContext(e.Context)
+		err.AddNestedContext(nestedCtx)
+		e.errs = append(e.errs, err)
+	}
+}
+
+// Len returns the number of invalid parameter errors
+func (e ErrInvalidParams) Len() int {
+	return len(e.errs)
+}
+
+// Code returns the code of the error
+func (e ErrInvalidParams) Code() string {
+	return InvalidParameterErrCode
+}
+
+// Message returns the message of the error
+func (e ErrInvalidParams) Message() string {
+	return fmt.Sprintf("%d validation error(s) found.", len(e.errs))
+}
+
+// Error returns the string formatted form of the invalid parameters.
+func (e ErrInvalidParams) Error() string {
+	w := &bytes.Buffer{}
+	fmt.Fprintf(w, "%s: %s\n", e.Code(), e.Message())
+
+	for _, err := range e.errs {
+		fmt.Fprintf(w, "- %s\n", err.Message())
+	}
+
+	return w.String()
+}
+
+// OrigErr returns the invalid parameters as a awserr.BatchedErrors value
+func (e ErrInvalidParams) OrigErr() error {
+	return awserr.NewBatchError(
+		InvalidParameterErrCode, e.Message(), e.OrigErrs())
+}
+
+// OrigErrs returns a slice of the invalid parameters
+func (e ErrInvalidParams) OrigErrs() []error {
+	errs := make([]error, len(e.errs))
+	for i := 0; i < len(errs); i++ {
+		errs[i] = e.errs[i]
+	}
+
+	return errs
+}
+
+// An ErrInvalidParam represents an invalid parameter error type.
+type ErrInvalidParam interface {
+	awserr.Error
+
+	// Field name the error occurred on.
+	Field() string
+
+	// SetContext updates the context of the error.
+	SetContext(string)
+
+	// AddNestedContext updates the error's context to include a nested level.
+	AddNestedContext(string)
+}
+
+type errInvalidParam struct {
+	context       string
+	nestedContext string
+	field         string
+	code          string
+	msg           string
+}
+
+// Code returns the error code for the type of invalid parameter.
+func (e *errInvalidParam) Code() string {
+	return e.code
+}
+
+// Message returns the reason the parameter was invalid, and its context.
+func (e *errInvalidParam) Message() string {
+	return fmt.Sprintf("%s, %s.", e.msg, e.Field())
+}
+
+// Error returns the string version of the invalid parameter error.
+func (e *errInvalidParam) Error() string {
+	return fmt.Sprintf("%s: %s", e.code, e.Message())
+}
+
+// OrigErr returns nil, Implemented for awserr.Error interface.
+func (e *errInvalidParam) OrigErr() error {
+	return nil
+}
+
+// Field Returns the field and context the error occurred.
+func (e *errInvalidParam) Field() string {
+	field := e.context
+	if len(field) > 0 {
+		field += "."
+	}
+	if len(e.nestedContext) > 0 {
+		field += fmt.Sprintf("%s.", e.nestedContext)
+	}
+	field += e.field
+
+	return field
+}
+
+// SetContext updates the base context of the error.
+func (e *errInvalidParam) SetContext(ctx string) {
+	e.context = ctx
+}
+
+// AddNestedContext prepends a context to the field's path.
+func (e *errInvalidParam) AddNestedContext(ctx string) {
+	if len(e.nestedContext) == 0 {
+		e.nestedContext = ctx
+	} else {
+		e.nestedContext = fmt.Sprintf("%s.%s", ctx, e.nestedContext)
+	}
+
+}
+
+// An ErrParamRequired represents an required parameter error.
+type ErrParamRequired struct {
+	errInvalidParam
+}
+
+// NewErrParamRequired creates a new required parameter error.
+func NewErrParamRequired(field string) *ErrParamRequired {
+	return &ErrParamRequired{
+		errInvalidParam{
+			code:  ParamRequiredErrCode,
+			field: field,
+			msg:   fmt.Sprintf("missing required field"),
+		},
+	}
+}
+
+// An ErrParamMinValue represents a minimum value parameter error.
+type ErrParamMinValue struct {
+	errInvalidParam
+	min float64
+}
+
+// NewErrParamMinValue creates a new minimum value parameter error.
+func NewErrParamMinValue(field string, min float64) *ErrParamMinValue {
+	return &ErrParamMinValue{
+		errInvalidParam: errInvalidParam{
+			code:  ParamMinValueErrCode,
+			field: field,
+			msg:   fmt.Sprintf("minimum field value of %v", min),
+		},
+		min: min,
+	}
+}
+
+// MinValue returns the field's require minimum value.
+//
+// float64 is returned for both int and float min values.
+func (e *ErrParamMinValue) MinValue() float64 {
+	return e.min
+}
+
+// An ErrParamMinLen represents a minimum length parameter error.
+type ErrParamMinLen struct {
+	errInvalidParam
+	min int
+}
+
+// NewErrParamMinLen creates a new minimum length parameter error.
+func NewErrParamMinLen(field string, min int) *ErrParamMinLen {
+	return &ErrParamMinLen{
+		errInvalidParam: errInvalidParam{
+			code:  ParamMinValueErrCode,
+			field: field,
+			msg:   fmt.Sprintf("minimum field size of %v", min),
+		},
+		min: min,
+	}
+}
+
+// MinLen returns the field's required minimum length.
+func (e *ErrParamMinLen) MinLen() int {
+	return e.min
+}

--- a/awstesting/assert.go
+++ b/awstesting/assert.go
@@ -5,74 +5,12 @@ import (
 	"encoding/xml"
 	"fmt"
 	"net/url"
-	"reflect"
 	"regexp"
 	"sort"
-	"strconv"
-	"strings"
 	"testing"
 
-	"github.com/aws/aws-sdk-go/private/model/api"
 	"github.com/stretchr/testify/assert"
 )
-
-// findMember searches the shape for the member with the matching key name.
-func findMember(shape *api.Shape, key string) string {
-	for actualKey := range shape.MemberRefs {
-		if strings.ToLower(key) == strings.ToLower(actualKey) {
-			return actualKey
-		}
-	}
-	return ""
-}
-
-// GenerateAssertions builds assertions for a shape based on its type.
-//
-// The shape's recursive values also will have assertions generated for them.
-func GenerateAssertions(out interface{}, shape *api.Shape, prefix string) string {
-	switch t := out.(type) {
-	case map[string]interface{}:
-		keys := SortedKeys(t)
-
-		code := ""
-		if shape.Type == "map" {
-			for _, k := range keys {
-				v := t[k]
-				s := shape.ValueRef.Shape
-				code += GenerateAssertions(v, s, prefix+"[\""+k+"\"]")
-			}
-		} else {
-			for _, k := range keys {
-				v := t[k]
-				m := findMember(shape, k)
-				s := shape.MemberRefs[m].Shape
-				code += GenerateAssertions(v, s, prefix+"."+m+"")
-			}
-		}
-		return code
-	case []interface{}:
-		code := ""
-		for i, v := range t {
-			s := shape.MemberRef.Shape
-			code += GenerateAssertions(v, s, prefix+"["+strconv.Itoa(i)+"]")
-		}
-		return code
-	default:
-		switch shape.Type {
-		case "timestamp":
-			return fmt.Sprintf("assert.Equal(t, time.Unix(%#v, 0).UTC().String(), %s.String())\n", out, prefix)
-		case "blob":
-			return fmt.Sprintf("assert.Equal(t, %#v, string(%s))\n", out, prefix)
-		case "integer", "long":
-			return fmt.Sprintf("assert.Equal(t, int64(%#v), *%s)\n", out, prefix)
-		default:
-			if !reflect.ValueOf(out).IsValid() {
-				return fmt.Sprintf("assert.Nil(t, %s)\n", prefix)
-			}
-			return fmt.Sprintf("assert.Equal(t, %#v, *%s)\n", out, prefix)
-		}
-	}
-}
 
 // Match is a testing helper to test for testing error by comparing expected
 // with a regular expression.

--- a/awstesting/integration/smoke/shared.go
+++ b/awstesting/integration/smoke/shared.go
@@ -69,7 +69,7 @@ func init() {
 		err, ok := World["error"].(awserr.Error)
 		assert.True(T, ok, "no error returned")
 		if ok {
-			assert.Contains(T, err.Message(), data)
+			assert.Contains(T, err.Error(), data)
 		}
 	})
 
@@ -79,13 +79,13 @@ func init() {
 		if ok {
 			found := false
 			for _, row := range table {
-				if strings.Contains(err.Message(), row[0]) {
+				if strings.Contains(err.Error(), row[0]) {
 					found = true
 					break
 				}
 			}
 
-			assert.True(T, found, fmt.Sprintf("no error messages matched: \"%s\"", err.Message()))
+			assert.True(T, found, fmt.Sprintf("no error messages matched: \"%s\"", err.Error()))
 		}
 	})
 

--- a/models/protocol_tests/generate.go
+++ b/models/protocol_tests/generate.go
@@ -54,6 +54,7 @@ var _ = util.Trim("")
 var _ = url.Values{}
 var _ = io.EOF
 var _ = aws.String
+var _ = fmt.Println
 
 func init() {
 	protocol.RandReader = &awstesting.ZeroReader{}
@@ -72,6 +73,7 @@ var extraImports = []string{
 	"bytes",
 	"encoding/json",
 	"encoding/xml",
+	"fmt",
 	"io",
 	"io/ioutil",
 	"net/http",

--- a/models/protocol_tests/generate.go
+++ b/models/protocol_tests/generate.go
@@ -7,6 +7,7 @@ import (
 	"net/url"
 	"os"
 	"os/exec"
+	"reflect"
 	"regexp"
 	"sort"
 	"strconv"
@@ -234,7 +235,7 @@ func (i *testCase) TestCase(idx int) string {
 		input := tplInputTestCaseData{
 			TestCase:     i,
 			OpName:       strings.ToUpper(opName[0:1]) + opName[1:],
-			ParamsString: awstesting.ParamsStructFromJSON(i.Params, i.Given.InputRef.Shape, false),
+			ParamsString: api.ParamsStructFromJSON(i.Params, i.Given.InputRef.Shape, false),
 		}
 
 		if err := tplInputTestCase.Execute(&buf, input); err != nil {
@@ -245,7 +246,7 @@ func (i *testCase) TestCase(idx int) string {
 			TestCase:   i,
 			Body:       fmt.Sprintf("%q", i.OutputTest.Body),
 			OpName:     strings.ToUpper(opName[0:1]) + opName[1:],
-			Assertions: awstesting.GenerateAssertions(i.Data, i.Given.OutputRef.Shape, "out"),
+			Assertions: GenerateAssertions(i.Data, i.Given.OutputRef.Shape, "out"),
 		}
 
 		if err := tplOutputTestCase.Execute(&buf, output); err != nil {
@@ -329,6 +330,64 @@ func generateTestSuite(filename string) string {
 	}
 
 	return buf.String() + innerBuf.String()
+}
+
+// findMember searches the shape for the member with the matching key name.
+func findMember(shape *api.Shape, key string) string {
+	for actualKey := range shape.MemberRefs {
+		if strings.ToLower(key) == strings.ToLower(actualKey) {
+			return actualKey
+		}
+	}
+	return ""
+}
+
+// GenerateAssertions builds assertions for a shape based on its type.
+//
+// The shape's recursive values also will have assertions generated for them.
+func GenerateAssertions(out interface{}, shape *api.Shape, prefix string) string {
+	switch t := out.(type) {
+	case map[string]interface{}:
+		keys := awstesting.SortedKeys(t)
+
+		code := ""
+		if shape.Type == "map" {
+			for _, k := range keys {
+				v := t[k]
+				s := shape.ValueRef.Shape
+				code += GenerateAssertions(v, s, prefix+"[\""+k+"\"]")
+			}
+		} else {
+			for _, k := range keys {
+				v := t[k]
+				m := findMember(shape, k)
+				s := shape.MemberRefs[m].Shape
+				code += GenerateAssertions(v, s, prefix+"."+m+"")
+			}
+		}
+		return code
+	case []interface{}:
+		code := ""
+		for i, v := range t {
+			s := shape.MemberRef.Shape
+			code += GenerateAssertions(v, s, prefix+"["+strconv.Itoa(i)+"]")
+		}
+		return code
+	default:
+		switch shape.Type {
+		case "timestamp":
+			return fmt.Sprintf("assert.Equal(t, time.Unix(%#v, 0).UTC().String(), %s.String())\n", out, prefix)
+		case "blob":
+			return fmt.Sprintf("assert.Equal(t, %#v, string(%s))\n", out, prefix)
+		case "integer", "long":
+			return fmt.Sprintf("assert.Equal(t, int64(%#v), *%s)\n", out, prefix)
+		default:
+			if !reflect.ValueOf(out).IsValid() {
+				return fmt.Sprintf("assert.Nil(t, %s)\n", prefix)
+			}
+			return fmt.Sprintf("assert.Equal(t, %#v, *%s)\n", out, prefix)
+		}
+	}
 }
 
 func main() {

--- a/private/model/api/api.go
+++ b/private/model/api/api.go
@@ -34,6 +34,9 @@ type API struct {
 	// Set to true to not generate API service name constants
 	NoConstServiceNames bool
 
+	// Set to true to not generate validation shapes
+	NoValidataShapeMethods bool
+
 	SvcClientImportPath string
 
 	initialized bool
@@ -415,4 +418,68 @@ func (a *API) InterfaceGoCode() string {
 // with its package name. Takes a string depicting the Config.
 func (a *API) NewAPIGoCodeWithPkgName(cfg string) string {
 	return fmt.Sprintf("%s.New(%s)", a.PackageName(), cfg)
+}
+
+// computes the validation chain for all input shapes
+func (a *API) addShapeValidations() {
+	for _, o := range a.Operations {
+		resolveShapeValidations(o.InputRef.Shape)
+	}
+}
+
+// Updates the source shape and all nested shapes with the validations that
+// could possibly be needed.
+func resolveShapeValidations(s *Shape, ancestry ...*Shape) {
+	for _, a := range ancestry {
+		if a == s {
+			return
+		}
+	}
+
+	children := []string{}
+	for _, name := range s.MemberNames() {
+		ref := s.MemberRefs[name]
+
+		if s.IsRequired(name) && !s.Validations.Has(ref, ShapeValidationRequired) {
+			s.Validations = append(s.Validations, ShapeValidation{
+				Name: name, Ref: ref, Type: ShapeValidationRequired,
+			})
+		}
+
+		if ref.Shape.Min != 0 && !s.Validations.Has(ref, ShapeValidationMinVal) {
+			s.Validations = append(s.Validations, ShapeValidation{
+				Name: name, Ref: ref, Type: ShapeValidationMinVal,
+			})
+		}
+
+		switch ref.Shape.Type {
+		case "map", "list", "structure":
+			children = append(children, name)
+		}
+	}
+
+	ancestry = append(ancestry, s)
+	for _, name := range children {
+		ref := s.MemberRefs[name]
+		nestedShape := ref.Shape.NestedShape()
+
+		var v *ShapeValidation
+		if len(nestedShape.Validations) > 0 {
+			v = &ShapeValidation{
+				Name: name, Ref: ref, Type: ShapeValidationNested,
+			}
+		} else {
+			resolveShapeValidations(nestedShape, ancestry...)
+			if len(nestedShape.Validations) > 0 {
+				v = &ShapeValidation{
+					Name: name, Ref: ref, Type: ShapeValidationNested,
+				}
+			}
+		}
+
+		if v != nil && !s.Validations.Has(v.Ref, v.Type) {
+			s.Validations = append(s.Validations, *v)
+		}
+	}
+	ancestry = ancestry[:len(ancestry)-1]
 }

--- a/private/model/api/api_test.go
+++ b/private/model/api/api_test.go
@@ -1,3 +1,5 @@
+// +build 1.6
+
 package api
 
 import (

--- a/private/model/api/load.go
+++ b/private/model/api/load.go
@@ -60,5 +60,9 @@ func (a *API) Setup() {
 		a.removeUnusedShapes()
 	}
 
+	if !a.NoValidataShapeMethods {
+		a.addShapeValidations()
+	}
+
 	a.initialized = true
 }

--- a/private/model/api/load_test.go
+++ b/private/model/api/load_test.go
@@ -1,3 +1,5 @@
+// +build 1.6
+
 package api
 
 import (

--- a/private/model/api/param_filler.go
+++ b/private/model/api/param_filler.go
@@ -1,11 +1,11 @@
-package awstesting
+package api
 
 import (
 	"fmt"
 	"reflect"
 	"strings"
 
-	"github.com/aws/aws-sdk-go/private/model/api"
+	"github.com/aws/aws-sdk-go/awstesting"
 	"github.com/aws/aws-sdk-go/private/util"
 )
 
@@ -15,7 +15,7 @@ type paramFiller struct {
 }
 
 // typeName returns the type name of a shape.
-func (f paramFiller) typeName(shape *api.Shape) string {
+func (f paramFiller) typeName(shape *Shape) string {
 	if f.prefixPackageName && shape.Type == "structure" {
 		return "*" + shape.API.PackageName() + "." + shape.GoTypeElem()
 	}
@@ -23,13 +23,13 @@ func (f paramFiller) typeName(shape *api.Shape) string {
 }
 
 // ParamsStructFromJSON returns a JSON string representation of a structure.
-func ParamsStructFromJSON(value interface{}, shape *api.Shape, prefixPackageName bool) string {
+func ParamsStructFromJSON(value interface{}, shape *Shape, prefixPackageName bool) string {
 	f := paramFiller{prefixPackageName: prefixPackageName}
 	return util.GoFmt(f.paramsStructAny(value, shape))
 }
 
 // paramsStructAny returns the string representation of any value.
-func (f paramFiller) paramsStructAny(value interface{}, shape *api.Shape) string {
+func (f paramFiller) paramsStructAny(value interface{}, shape *Shape) string {
 	if value == nil {
 		return ""
 	}
@@ -85,7 +85,7 @@ func (f paramFiller) paramsStructAny(value interface{}, shape *api.Shape) string
 }
 
 // paramsStructStruct returns the string representation of a structure
-func (f paramFiller) paramsStructStruct(value map[string]interface{}, shape *api.Shape) string {
+func (f paramFiller) paramsStructStruct(value map[string]interface{}, shape *Shape) string {
 	out := "&" + f.typeName(shape)[1:] + "{\n"
 	for _, n := range shape.MemberNames() {
 		ref := shape.MemberRefs[n]
@@ -100,9 +100,9 @@ func (f paramFiller) paramsStructStruct(value map[string]interface{}, shape *api
 }
 
 // paramsStructMap returns the string representation of a map of values
-func (f paramFiller) paramsStructMap(value map[string]interface{}, shape *api.Shape) string {
+func (f paramFiller) paramsStructMap(value map[string]interface{}, shape *Shape) string {
 	out := f.typeName(shape) + "{\n"
-	keys := SortedKeys(value)
+	keys := awstesting.SortedKeys(value)
 	for _, k := range keys {
 		v := value[k]
 		out += fmt.Sprintf("%q: %s,\n", k, f.paramsStructAny(v, shape.ValueRef.Shape))
@@ -112,7 +112,7 @@ func (f paramFiller) paramsStructMap(value map[string]interface{}, shape *api.Sh
 }
 
 // paramsStructList returns the string representation of slice of values
-func (f paramFiller) paramsStructList(value []interface{}, shape *api.Shape) string {
+func (f paramFiller) paramsStructList(value []interface{}, shape *Shape) string {
 	out := f.typeName(shape) + "{\n"
 	for _, v := range value {
 		out += fmt.Sprintf("%s,\n", f.paramsStructAny(v, shape.MemberRef.Shape))

--- a/private/model/api/shape.go
+++ b/private/model/api/shape.go
@@ -8,8 +8,6 @@ import (
 	"sort"
 	"strings"
 	"text/template"
-
-	"github.com/aws/aws-sdk-go/private/util"
 )
 
 // A ShapeRef defines the usage of a shape within the API.
@@ -58,7 +56,7 @@ type Shape struct {
 	IdempotencyToken bool `json:"idempotencyToken"`
 	XMLNamespace     XMLInfo
 	Min              int // optional Minimum length (string, list) or value (number)
-	Max              int // optional Minimum length (string, list) or value (number)
+	Max              int // optional Maximum length (string, list) or value (number)
 
 	refs       []*ShapeRef // References to this shape
 	resolvePkg string      // use this package in the goType() if present
@@ -67,6 +65,14 @@ type Shape struct {
 	Placeholder bool
 
 	Deprecated bool `json:"deprecated"`
+
+	Validations ShapeValidations
+}
+
+// GoTags returns the struct tags for a shape.
+func (s *Shape) GoTags(root, required bool) string {
+	ref := &ShapeRef{ShapeName: s.ShapeName, API: s.API, Shape: s}
+	return ref.GoTags(root, required)
 }
 
 // Rename changes the name of the Shape to newName. Also updates
@@ -96,6 +102,31 @@ func (s *Shape) MemberNames() []string {
 // <packageName>.<type> format. Package naming only applies to structures.
 func (s *Shape) GoTypeWithPkgName() string {
 	return goType(s, true)
+}
+
+// GoStructType returns the type of a struct field based on the API
+// model definition.
+func (s *Shape) GoStructType(name string, ref *ShapeRef) string {
+	if (ref.Streaming || ref.Shape.Streaming) && s.Payload == name {
+		rtype := "io.ReadSeeker"
+		if len(s.refs) > 1 {
+			rtype = "aws.ReaderSeekCloser"
+		} else if strings.HasSuffix(s.ShapeName, "Output") {
+			rtype = "io.ReadCloser"
+		}
+
+		s.API.imports["io"] = true
+		return rtype
+	}
+
+	for _, v := range s.Validations {
+		// TODO move this to shape validation resolution
+		if (v.Ref.Shape.Type == "map" || v.Ref.Shape.Type == "list") && v.Type == ShapeValidationNested {
+			s.API.imports["fmt"] = true
+		}
+	}
+
+	return ref.GoType()
 }
 
 // GoType returns a shape's Go type
@@ -306,14 +337,14 @@ func (ref *ShapeRef) GoTags(toplevel bool, isRequired bool) string {
 // Docstring returns the godocs formated documentation
 func (ref *ShapeRef) Docstring() string {
 	if ref.Documentation != "" {
-		return ref.Documentation
+		return strings.Trim(ref.Documentation, "\n ")
 	}
 	return ref.Shape.Docstring()
 }
 
 // Docstring returns the godocs formated documentation
 func (s *Shape) Docstring() string {
-	return s.Documentation
+	return strings.Trim(s.Documentation, "\n ")
 }
 
 var goCodeStringerTmpl = template.Must(template.New("goCodeStringerTmpl").Parse(`
@@ -327,10 +358,11 @@ func (s {{ .ShapeName }}) GoString() string {
 }
 `))
 
-func (s *Shape) goCodeStringers() string {
+// GoCodeStringers renders the Stringers for API input/output shapes
+func (s *Shape) GoCodeStringers() string {
 	w := bytes.Buffer{}
 	if err := goCodeStringerTmpl.Execute(&w, s); err != nil {
-		panic(fmt.Sprintln("Unexpected error executing goCodeStringers template", err))
+		panic(fmt.Sprintln("Unexpected error executing GoCodeStringers template", err))
 	}
 
 	return w.String()
@@ -361,53 +393,78 @@ func (s *Shape) EnumName(n int) string {
 	return enum
 }
 
+// NestedShape returns the shape pointer value for the shape which is nested
+// under the current shape. If the shape is not nested nil will be returned.
+//
+// strucutures, the current shape is returned
+// map: the value shape of the map is returned
+// list: the element shape of the list is returned
+func (s *Shape) NestedShape() *Shape {
+	var nestedShape *Shape
+	switch s.Type {
+	case "structure":
+		nestedShape = s
+	case "map":
+		nestedShape = s.ValueRef.Shape
+	case "list":
+		nestedShape = s.MemberRef.Shape
+	}
+
+	return nestedShape
+}
+
+var structShapeTmpl = template.Must(template.New("StructShape").Parse(`
+{{ .Docstring }}
+type {{ .ShapeName }} struct {
+	_ struct{} {{ .GoTags true false }}
+
+	{{ $context := . -}}
+	{{ range $_, $name := $context.MemberNames -}}
+		{{ $elem := index $context.MemberRefs $name }}
+		{{ $isRequired := $context.IsRequired $name }}
+		{{ $elem.Docstring }}
+		{{ $name }} {{ $context.GoStructType $name $elem }} {{ $elem.GoTags false $isRequired }}
+	{{ end }}
+}
+{{ if not .API.NoStringerMethods }}
+	{{ .GoCodeStringers }}
+{{ end }}
+{{ if not .API.NoValidataShapeMethods }}
+	{{ if .Validations -}}
+		{{ .Validations.GoCode . }}
+	{{ end }}
+{{ end }}
+`))
+
+var enumShapeTmpl = template.Must(template.New("EnumShape").Parse(`
+{{ .Docstring }}
+const (
+	{{ $context := . -}}
+	{{ range $index, $elem := .Enum -}}
+		// @enum {{ $context.ShapeName }}
+		{{ index $context.EnumConsts $index }} = "{{ $elem }}"
+	{{ end }}
+)
+`))
+
 // GoCode returns the rendered Go code for the Shape.
 func (s *Shape) GoCode() string {
-	code := s.Docstring()
-	if !s.IsEnum() {
-		code += "type " + s.ShapeName + " "
-	}
+	b := &bytes.Buffer{}
 
 	switch {
 	case s.Type == "structure":
-		ref := &ShapeRef{ShapeName: s.ShapeName, API: s.API, Shape: s}
-
-		code += "struct {\n"
-		code += "_ struct{} " + ref.GoTags(true, false) + "\n\n"
-		for _, n := range s.MemberNames() {
-			m := s.MemberRefs[n]
-			code += m.Docstring()
-			if (m.Streaming || m.Shape.Streaming) && s.Payload == n {
-				rtype := "io.ReadSeeker"
-				if len(s.refs) > 1 {
-					rtype = "aws.ReaderSeekCloser"
-				} else if strings.HasSuffix(s.ShapeName, "Output") {
-					rtype = "io.ReadCloser"
-				}
-
-				s.API.imports["io"] = true
-				code += n + " " + rtype + " " + m.GoTags(false, s.IsRequired(n)) + "\n\n"
-			} else {
-				code += n + " " + m.GoType() + " " + m.GoTags(false, s.IsRequired(n)) + "\n\n"
-			}
-		}
-		code += "}"
-
-		if !s.API.NoStringerMethods {
-			code += s.goCodeStringers()
+		if err := structShapeTmpl.Execute(b, s); err != nil {
+			panic(fmt.Sprintf("Failed to generate struct shape %s, %v\n", s.ShapeName, err))
 		}
 	case s.IsEnum():
-		code += "const (\n"
-		for n, e := range s.Enum {
-			code += fmt.Sprintf("\t// @enum %s\n\t%s = %q\n",
-				s.ShapeName, s.EnumConsts[n], e)
+		if err := enumShapeTmpl.Execute(b, s); err != nil {
+			panic(fmt.Sprintf("Failed to generate enum shape %s, %v\n", s.ShapeName, err))
 		}
-		code += ")"
 	default:
-		panic("Cannot generate toplevel shape for " + s.Type)
+		panic(fmt.Sprintln("Cannot generate toplevel shape for", s.Type))
 	}
 
-	return util.GoFmt(code)
+	return b.String()
 }
 
 // IsEnum returns whether this shape is an enum list

--- a/private/model/api/shape_validation.go
+++ b/private/model/api/shape_validation.go
@@ -1,0 +1,153 @@
+package api
+
+import (
+	"bytes"
+	"fmt"
+	"text/template"
+)
+
+// A ShapeValidationType is the type of validation that a shape needs
+type ShapeValidationType int
+
+const (
+	// ShapeValidationRequired states the shape must be set
+	ShapeValidationRequired = iota
+
+	// ShapeValidationMinVal states the shape must have at least a number of
+	// elements, or for numbers a minimum value
+	ShapeValidationMinVal
+
+	// ShapeValidationNested states the shape has nested values that need
+	// to be validated
+	ShapeValidationNested
+)
+
+// A ShapeValidation contains information about a shape and the type of validation
+// that is needed
+type ShapeValidation struct {
+	// Name of the shape to be validated
+	Name string
+	// Reference to the shape within the context the shape is referenced
+	Ref *ShapeRef
+	// Type of validation needed
+	Type ShapeValidationType
+}
+
+var validationGoCodeTmpls = template.Must(template.New("validationGoCodeTmpls").Parse(`
+{{ define "requiredValue" -}}
+    if s.{{ .Name }} == nil { 
+		invalidParams.Add(request.NewErrParamRequired("{{ .Name }}"))
+    }
+{{- end }}
+{{ define "minLen" -}}
+	if s.{{ .Name }} != nil && len(s.{{ .Name }}) < {{ .Ref.Shape.Min }} {
+		invalidParams.Add(request.NewErrParamMinLen("{{ .Name }}", {{ .Ref.Shape.Min }}))
+	}
+{{- end }}
+{{ define "minLenString" -}}
+	if s.{{ .Name }} != nil && len(*s.{{ .Name }}) < {{ .Ref.Shape.Min }} {
+		invalidParams.Add(request.NewErrParamMinLen("{{ .Name }}", {{ .Ref.Shape.Min }}))
+	}
+{{- end }}
+{{ define "minVal" -}}
+	if s.{{ .Name }} != nil && *s.{{ .Name }} < {{ .Ref.Shape.Min }} {
+		invalidParams.Add(request.NewErrParamMinValue("{{ .Name }}", {{ .Ref.Shape.Min }}))
+	}
+{{- end }}
+{{ define "nestedMapList" -}}
+    if s.{{ .Name }} != nil { 
+		for i, v := range s.{{ .Name }} {
+			if v == nil { continue }
+			if err := v.Validate(); err != nil {
+				invalidParams.AddNested(fmt.Sprintf("%s[%v]", "{{ .Name }}", i), err.(request.ErrInvalidParams))
+			}
+		}
+	}
+{{- end }}
+{{ define "nestedStruct" -}}
+    if s.{{ .Name }} != nil { 
+		if err := s.{{ .Name }}.Validate(); err != nil {
+			invalidParams.AddNested("{{ .Name }}", err.(request.ErrInvalidParams))
+		}
+	}
+{{- end }}
+`))
+
+// GoCode returns the generated Go code for the Shape with its validation type.
+func (sv ShapeValidation) GoCode() string {
+	var err error
+
+	w := &bytes.Buffer{}
+	switch sv.Type {
+	case ShapeValidationRequired:
+		err = validationGoCodeTmpls.ExecuteTemplate(w, "requiredValue", sv)
+	case ShapeValidationMinVal:
+		switch sv.Ref.Shape.Type {
+		case "list", "map", "blob":
+			err = validationGoCodeTmpls.ExecuteTemplate(w, "minLen", sv)
+		case "string":
+			err = validationGoCodeTmpls.ExecuteTemplate(w, "minLenString", sv)
+		case "integer", "long", "float", "double":
+			err = validationGoCodeTmpls.ExecuteTemplate(w, "minVal", sv)
+		default:
+			panic(fmt.Sprintf("ShapeValidation.GoCode, %s's type %s, no min value handling",
+				sv.Name, sv.Ref.Shape.Type))
+		}
+	case ShapeValidationNested:
+		switch sv.Ref.Shape.Type {
+		case "map", "list":
+			err = validationGoCodeTmpls.ExecuteTemplate(w, "nestedMapList", sv)
+		default:
+			err = validationGoCodeTmpls.ExecuteTemplate(w, "nestedStruct", sv)
+		}
+	default:
+		panic(fmt.Sprintf("ShapeValidation.GoCode, %s's type %d, unknown validation type",
+			sv.Name, sv.Type))
+	}
+
+	if err != nil {
+		panic(fmt.Sprintf("ShapeValidation.GoCode failed, err: %v", err))
+	}
+
+	return w.String()
+}
+
+// A ShapeValidations is a collection of shape validations needed nested within
+// a parent shape
+type ShapeValidations []ShapeValidation
+
+var validateShapeTmpl = template.Must(template.New("ValidateShape").Parse(`
+// Validate inspects the fields of the type to determine if they are valid.
+func (s *{{ .Shape.ShapeName }}) Validate() error {
+	invalidParams := request.ErrInvalidParams{Context: "{{ .Shape.ShapeName }}"}
+	{{ range $_, $v := .Validations -}}
+		{{ $v.GoCode }}
+	{{ end }}
+	if invalidParams.Len() > 0 {
+		return invalidParams
+	}
+	return nil
+}
+`))
+
+// GoCode generates the Go code needed to perform validations for the
+// shape and its nested fields.
+func (vs ShapeValidations) GoCode(shape *Shape) string {
+	buf := &bytes.Buffer{}
+	validateShapeTmpl.Execute(buf, map[string]interface{}{
+		"Shape":       shape,
+		"Validations": vs,
+	})
+	return buf.String()
+}
+
+// Has returns true or false if the ShapeValidations already contains the
+// the reference and validation type.
+func (vs ShapeValidations) Has(ref *ShapeRef, typ ShapeValidationType) bool {
+	for _, v := range vs {
+		if v.Ref == ref && v.Type == typ {
+			return true
+		}
+	}
+	return false
+}

--- a/private/model/api/shapetag_test.go
+++ b/private/model/api/shapetag_test.go
@@ -1,3 +1,5 @@
+// +build 1.6
+
 package api_test
 
 import (

--- a/private/protocol/ec2query/build_test.go
+++ b/private/protocol/ec2query/build_test.go
@@ -4,6 +4,7 @@ import (
 	"bytes"
 	"encoding/json"
 	"encoding/xml"
+	"fmt"
 	"io"
 	"io/ioutil"
 	"net/http"
@@ -36,6 +37,7 @@ var _ = util.Trim("")
 var _ = url.Values{}
 var _ = io.EOF
 var _ = aws.String
+var _ = fmt.Println
 
 func init() {
 	protocol.RandReader = &awstesting.ZeroReader{}

--- a/private/protocol/ec2query/unmarshal_test.go
+++ b/private/protocol/ec2query/unmarshal_test.go
@@ -4,6 +4,7 @@ import (
 	"bytes"
 	"encoding/json"
 	"encoding/xml"
+	"fmt"
 	"io"
 	"io/ioutil"
 	"net/http"
@@ -36,6 +37,7 @@ var _ = util.Trim("")
 var _ = url.Values{}
 var _ = io.EOF
 var _ = aws.String
+var _ = fmt.Println
 
 func init() {
 	protocol.RandReader = &awstesting.ZeroReader{}

--- a/private/protocol/jsonrpc/build_test.go
+++ b/private/protocol/jsonrpc/build_test.go
@@ -4,6 +4,7 @@ import (
 	"bytes"
 	"encoding/json"
 	"encoding/xml"
+	"fmt"
 	"io"
 	"io/ioutil"
 	"net/http"
@@ -36,6 +37,7 @@ var _ = util.Trim("")
 var _ = url.Values{}
 var _ = io.EOF
 var _ = aws.String
+var _ = fmt.Println
 
 func init() {
 	protocol.RandReader = &awstesting.ZeroReader{}

--- a/private/protocol/jsonrpc/unmarshal_test.go
+++ b/private/protocol/jsonrpc/unmarshal_test.go
@@ -4,6 +4,7 @@ import (
 	"bytes"
 	"encoding/json"
 	"encoding/xml"
+	"fmt"
 	"io"
 	"io/ioutil"
 	"net/http"
@@ -36,6 +37,7 @@ var _ = util.Trim("")
 var _ = url.Values{}
 var _ = io.EOF
 var _ = aws.String
+var _ = fmt.Println
 
 func init() {
 	protocol.RandReader = &awstesting.ZeroReader{}

--- a/private/protocol/query/build_test.go
+++ b/private/protocol/query/build_test.go
@@ -4,6 +4,7 @@ import (
 	"bytes"
 	"encoding/json"
 	"encoding/xml"
+	"fmt"
 	"io"
 	"io/ioutil"
 	"net/http"
@@ -36,6 +37,7 @@ var _ = util.Trim("")
 var _ = url.Values{}
 var _ = io.EOF
 var _ = aws.String
+var _ = fmt.Println
 
 func init() {
 	protocol.RandReader = &awstesting.ZeroReader{}

--- a/private/protocol/query/unmarshal_test.go
+++ b/private/protocol/query/unmarshal_test.go
@@ -4,6 +4,7 @@ import (
 	"bytes"
 	"encoding/json"
 	"encoding/xml"
+	"fmt"
 	"io"
 	"io/ioutil"
 	"net/http"
@@ -36,6 +37,7 @@ var _ = util.Trim("")
 var _ = url.Values{}
 var _ = io.EOF
 var _ = aws.String
+var _ = fmt.Println
 
 func init() {
 	protocol.RandReader = &awstesting.ZeroReader{}

--- a/private/protocol/restjson/build_test.go
+++ b/private/protocol/restjson/build_test.go
@@ -4,6 +4,7 @@ import (
 	"bytes"
 	"encoding/json"
 	"encoding/xml"
+	"fmt"
 	"io"
 	"io/ioutil"
 	"net/http"
@@ -36,6 +37,7 @@ var _ = util.Trim("")
 var _ = url.Values{}
 var _ = io.EOF
 var _ = aws.String
+var _ = fmt.Println
 
 func init() {
 	protocol.RandReader = &awstesting.ZeroReader{}
@@ -813,6 +815,19 @@ type InputService8TestShapeInputService8TestCaseOperation1Input struct {
 	Checksum *string `location:"header" locationName:"x-amz-sha256-tree-hash" type:"string"`
 
 	VaultName *string `location:"uri" locationName:"vaultName" type:"string" required:"true"`
+}
+
+// Validate inspects the fields of the type to determine if they are valid.
+func (s *InputService8TestShapeInputService8TestCaseOperation1Input) Validate() error {
+	invalidParams := request.ErrInvalidParams{Context: "InputService8TestShapeInputService8TestCaseOperation1Input"}
+	if s.VaultName == nil {
+		invalidParams.Add(request.NewErrParamRequired("VaultName"))
+	}
+
+	if invalidParams.Len() > 0 {
+		return invalidParams
+	}
+	return nil
 }
 
 type InputService8TestShapeInputService8TestCaseOperation1Output struct {

--- a/private/protocol/restjson/unmarshal_test.go
+++ b/private/protocol/restjson/unmarshal_test.go
@@ -4,6 +4,7 @@ import (
 	"bytes"
 	"encoding/json"
 	"encoding/xml"
+	"fmt"
 	"io"
 	"io/ioutil"
 	"net/http"
@@ -36,6 +37,7 @@ var _ = util.Trim("")
 var _ = url.Values{}
 var _ = io.EOF
 var _ = aws.String
+var _ = fmt.Println
 
 func init() {
 	protocol.RandReader = &awstesting.ZeroReader{}

--- a/private/protocol/restxml/build_test.go
+++ b/private/protocol/restxml/build_test.go
@@ -4,6 +4,7 @@ import (
 	"bytes"
 	"encoding/json"
 	"encoding/xml"
+	"fmt"
 	"io"
 	"io/ioutil"
 	"net/http"
@@ -36,6 +37,7 @@ var _ = util.Trim("")
 var _ = url.Values{}
 var _ = io.EOF
 var _ = aws.String
+var _ = fmt.Println
 
 func init() {
 	protocol.RandReader = &awstesting.ZeroReader{}

--- a/private/protocol/restxml/unmarshal_test.go
+++ b/private/protocol/restxml/unmarshal_test.go
@@ -4,6 +4,7 @@ import (
 	"bytes"
 	"encoding/json"
 	"encoding/xml"
+	"fmt"
 	"io"
 	"io/ioutil"
 	"net/http"
@@ -36,6 +37,7 @@ var _ = util.Trim("")
 var _ = url.Values{}
 var _ = io.EOF
 var _ = aws.String
+var _ = fmt.Println
 
 func init() {
 	protocol.RandReader = &awstesting.ZeroReader{}

--- a/service/acm/api.go
+++ b/service/acm/api.go
@@ -4,6 +4,7 @@
 package acm
 
 import (
+	"fmt"
 	"time"
 
 	"github.com/aws/aws-sdk-go/aws/awsutil"
@@ -368,6 +369,38 @@ func (s AddTagsToCertificateInput) GoString() string {
 	return s.String()
 }
 
+// Validate inspects the fields of the type to determine if they are valid.
+func (s *AddTagsToCertificateInput) Validate() error {
+	invalidParams := request.ErrInvalidParams{Context: "AddTagsToCertificateInput"}
+	if s.CertificateArn == nil {
+		invalidParams.Add(request.NewErrParamRequired("CertificateArn"))
+	}
+	if s.CertificateArn != nil && len(*s.CertificateArn) < 20 {
+		invalidParams.Add(request.NewErrParamMinLen("CertificateArn", 20))
+	}
+	if s.Tags == nil {
+		invalidParams.Add(request.NewErrParamRequired("Tags"))
+	}
+	if s.Tags != nil && len(s.Tags) < 1 {
+		invalidParams.Add(request.NewErrParamMinLen("Tags", 1))
+	}
+	if s.Tags != nil {
+		for i, v := range s.Tags {
+			if v == nil {
+				continue
+			}
+			if err := v.Validate(); err != nil {
+				invalidParams.AddNested(fmt.Sprintf("%s[%v]", "Tags", i), err.(request.ErrInvalidParams))
+			}
+		}
+	}
+
+	if invalidParams.Len() > 0 {
+		return invalidParams
+	}
+	return nil
+}
+
 type AddTagsToCertificateOutput struct {
 	_ struct{} `type:"structure"`
 }
@@ -548,6 +581,22 @@ func (s DeleteCertificateInput) GoString() string {
 	return s.String()
 }
 
+// Validate inspects the fields of the type to determine if they are valid.
+func (s *DeleteCertificateInput) Validate() error {
+	invalidParams := request.ErrInvalidParams{Context: "DeleteCertificateInput"}
+	if s.CertificateArn == nil {
+		invalidParams.Add(request.NewErrParamRequired("CertificateArn"))
+	}
+	if s.CertificateArn != nil && len(*s.CertificateArn) < 20 {
+		invalidParams.Add(request.NewErrParamMinLen("CertificateArn", 20))
+	}
+
+	if invalidParams.Len() > 0 {
+		return invalidParams
+	}
+	return nil
+}
+
 type DeleteCertificateOutput struct {
 	_ struct{} `type:"structure"`
 }
@@ -582,6 +631,22 @@ func (s DescribeCertificateInput) String() string {
 // GoString returns the string representation
 func (s DescribeCertificateInput) GoString() string {
 	return s.String()
+}
+
+// Validate inspects the fields of the type to determine if they are valid.
+func (s *DescribeCertificateInput) Validate() error {
+	invalidParams := request.ErrInvalidParams{Context: "DescribeCertificateInput"}
+	if s.CertificateArn == nil {
+		invalidParams.Add(request.NewErrParamRequired("CertificateArn"))
+	}
+	if s.CertificateArn != nil && len(*s.CertificateArn) < 20 {
+		invalidParams.Add(request.NewErrParamMinLen("CertificateArn", 20))
+	}
+
+	if invalidParams.Len() > 0 {
+		return invalidParams
+	}
+	return nil
 }
 
 type DescribeCertificateOutput struct {
@@ -663,6 +728,28 @@ func (s DomainValidationOption) GoString() string {
 	return s.String()
 }
 
+// Validate inspects the fields of the type to determine if they are valid.
+func (s *DomainValidationOption) Validate() error {
+	invalidParams := request.ErrInvalidParams{Context: "DomainValidationOption"}
+	if s.DomainName == nil {
+		invalidParams.Add(request.NewErrParamRequired("DomainName"))
+	}
+	if s.DomainName != nil && len(*s.DomainName) < 1 {
+		invalidParams.Add(request.NewErrParamMinLen("DomainName", 1))
+	}
+	if s.ValidationDomain == nil {
+		invalidParams.Add(request.NewErrParamRequired("ValidationDomain"))
+	}
+	if s.ValidationDomain != nil && len(*s.ValidationDomain) < 1 {
+		invalidParams.Add(request.NewErrParamMinLen("ValidationDomain", 1))
+	}
+
+	if invalidParams.Len() > 0 {
+		return invalidParams
+	}
+	return nil
+}
+
 type GetCertificateInput struct {
 	_ struct{} `type:"structure"`
 
@@ -683,6 +770,22 @@ func (s GetCertificateInput) String() string {
 // GoString returns the string representation
 func (s GetCertificateInput) GoString() string {
 	return s.String()
+}
+
+// Validate inspects the fields of the type to determine if they are valid.
+func (s *GetCertificateInput) Validate() error {
+	invalidParams := request.ErrInvalidParams{Context: "GetCertificateInput"}
+	if s.CertificateArn == nil {
+		invalidParams.Add(request.NewErrParamRequired("CertificateArn"))
+	}
+	if s.CertificateArn != nil && len(*s.CertificateArn) < 20 {
+		invalidParams.Add(request.NewErrParamMinLen("CertificateArn", 20))
+	}
+
+	if invalidParams.Len() > 0 {
+		return invalidParams
+	}
+	return nil
 }
 
 type GetCertificateOutput struct {
@@ -751,6 +854,22 @@ func (s ListCertificatesInput) GoString() string {
 	return s.String()
 }
 
+// Validate inspects the fields of the type to determine if they are valid.
+func (s *ListCertificatesInput) Validate() error {
+	invalidParams := request.ErrInvalidParams{Context: "ListCertificatesInput"}
+	if s.MaxItems != nil && *s.MaxItems < 1 {
+		invalidParams.Add(request.NewErrParamMinValue("MaxItems", 1))
+	}
+	if s.NextToken != nil && len(*s.NextToken) < 1 {
+		invalidParams.Add(request.NewErrParamMinLen("NextToken", 1))
+	}
+
+	if invalidParams.Len() > 0 {
+		return invalidParams
+	}
+	return nil
+}
+
 type ListCertificatesOutput struct {
 	_ struct{} `type:"structure"`
 
@@ -795,6 +914,22 @@ func (s ListTagsForCertificateInput) GoString() string {
 	return s.String()
 }
 
+// Validate inspects the fields of the type to determine if they are valid.
+func (s *ListTagsForCertificateInput) Validate() error {
+	invalidParams := request.ErrInvalidParams{Context: "ListTagsForCertificateInput"}
+	if s.CertificateArn == nil {
+		invalidParams.Add(request.NewErrParamRequired("CertificateArn"))
+	}
+	if s.CertificateArn != nil && len(*s.CertificateArn) < 20 {
+		invalidParams.Add(request.NewErrParamMinLen("CertificateArn", 20))
+	}
+
+	if invalidParams.Len() > 0 {
+		return invalidParams
+	}
+	return nil
+}
+
 type ListTagsForCertificateOutput struct {
 	_ struct{} `type:"structure"`
 
@@ -836,6 +971,38 @@ func (s RemoveTagsFromCertificateInput) String() string {
 // GoString returns the string representation
 func (s RemoveTagsFromCertificateInput) GoString() string {
 	return s.String()
+}
+
+// Validate inspects the fields of the type to determine if they are valid.
+func (s *RemoveTagsFromCertificateInput) Validate() error {
+	invalidParams := request.ErrInvalidParams{Context: "RemoveTagsFromCertificateInput"}
+	if s.CertificateArn == nil {
+		invalidParams.Add(request.NewErrParamRequired("CertificateArn"))
+	}
+	if s.CertificateArn != nil && len(*s.CertificateArn) < 20 {
+		invalidParams.Add(request.NewErrParamMinLen("CertificateArn", 20))
+	}
+	if s.Tags == nil {
+		invalidParams.Add(request.NewErrParamRequired("Tags"))
+	}
+	if s.Tags != nil && len(s.Tags) < 1 {
+		invalidParams.Add(request.NewErrParamMinLen("Tags", 1))
+	}
+	if s.Tags != nil {
+		for i, v := range s.Tags {
+			if v == nil {
+				continue
+			}
+			if err := v.Validate(); err != nil {
+				invalidParams.AddNested(fmt.Sprintf("%s[%v]", "Tags", i), err.(request.ErrInvalidParams))
+			}
+		}
+	}
+
+	if invalidParams.Len() > 0 {
+		return invalidParams
+	}
+	return nil
 }
 
 type RemoveTagsFromCertificateOutput struct {
@@ -902,6 +1069,41 @@ func (s RequestCertificateInput) GoString() string {
 	return s.String()
 }
 
+// Validate inspects the fields of the type to determine if they are valid.
+func (s *RequestCertificateInput) Validate() error {
+	invalidParams := request.ErrInvalidParams{Context: "RequestCertificateInput"}
+	if s.DomainName == nil {
+		invalidParams.Add(request.NewErrParamRequired("DomainName"))
+	}
+	if s.DomainName != nil && len(*s.DomainName) < 1 {
+		invalidParams.Add(request.NewErrParamMinLen("DomainName", 1))
+	}
+	if s.DomainValidationOptions != nil && len(s.DomainValidationOptions) < 1 {
+		invalidParams.Add(request.NewErrParamMinLen("DomainValidationOptions", 1))
+	}
+	if s.IdempotencyToken != nil && len(*s.IdempotencyToken) < 1 {
+		invalidParams.Add(request.NewErrParamMinLen("IdempotencyToken", 1))
+	}
+	if s.SubjectAlternativeNames != nil && len(s.SubjectAlternativeNames) < 1 {
+		invalidParams.Add(request.NewErrParamMinLen("SubjectAlternativeNames", 1))
+	}
+	if s.DomainValidationOptions != nil {
+		for i, v := range s.DomainValidationOptions {
+			if v == nil {
+				continue
+			}
+			if err := v.Validate(); err != nil {
+				invalidParams.AddNested(fmt.Sprintf("%s[%v]", "DomainValidationOptions", i), err.(request.ErrInvalidParams))
+			}
+		}
+	}
+
+	if invalidParams.Len() > 0 {
+		return invalidParams
+	}
+	return nil
+}
+
 type RequestCertificateOutput struct {
 	_ struct{} `type:"structure"`
 
@@ -966,6 +1168,34 @@ func (s ResendValidationEmailInput) GoString() string {
 	return s.String()
 }
 
+// Validate inspects the fields of the type to determine if they are valid.
+func (s *ResendValidationEmailInput) Validate() error {
+	invalidParams := request.ErrInvalidParams{Context: "ResendValidationEmailInput"}
+	if s.CertificateArn == nil {
+		invalidParams.Add(request.NewErrParamRequired("CertificateArn"))
+	}
+	if s.CertificateArn != nil && len(*s.CertificateArn) < 20 {
+		invalidParams.Add(request.NewErrParamMinLen("CertificateArn", 20))
+	}
+	if s.Domain == nil {
+		invalidParams.Add(request.NewErrParamRequired("Domain"))
+	}
+	if s.Domain != nil && len(*s.Domain) < 1 {
+		invalidParams.Add(request.NewErrParamMinLen("Domain", 1))
+	}
+	if s.ValidationDomain == nil {
+		invalidParams.Add(request.NewErrParamRequired("ValidationDomain"))
+	}
+	if s.ValidationDomain != nil && len(*s.ValidationDomain) < 1 {
+		invalidParams.Add(request.NewErrParamMinLen("ValidationDomain", 1))
+	}
+
+	if invalidParams.Len() > 0 {
+		return invalidParams
+	}
+	return nil
+}
+
 type ResendValidationEmailOutput struct {
 	_ struct{} `type:"structure"`
 }
@@ -999,6 +1229,22 @@ func (s Tag) String() string {
 // GoString returns the string representation
 func (s Tag) GoString() string {
 	return s.String()
+}
+
+// Validate inspects the fields of the type to determine if they are valid.
+func (s *Tag) Validate() error {
+	invalidParams := request.ErrInvalidParams{Context: "Tag"}
+	if s.Key == nil {
+		invalidParams.Add(request.NewErrParamRequired("Key"))
+	}
+	if s.Key != nil && len(*s.Key) < 1 {
+		invalidParams.Add(request.NewErrParamMinLen("Key", 1))
+	}
+
+	if invalidParams.Len() > 0 {
+		return invalidParams
+	}
+	return nil
 }
 
 const (

--- a/service/apigateway/api.go
+++ b/service/apigateway/api.go
@@ -2502,6 +2502,31 @@ func (s CreateAuthorizerInput) GoString() string {
 	return s.String()
 }
 
+// Validate inspects the fields of the type to determine if they are valid.
+func (s *CreateAuthorizerInput) Validate() error {
+	invalidParams := request.ErrInvalidParams{Context: "CreateAuthorizerInput"}
+	if s.AuthorizerUri == nil {
+		invalidParams.Add(request.NewErrParamRequired("AuthorizerUri"))
+	}
+	if s.IdentitySource == nil {
+		invalidParams.Add(request.NewErrParamRequired("IdentitySource"))
+	}
+	if s.Name == nil {
+		invalidParams.Add(request.NewErrParamRequired("Name"))
+	}
+	if s.RestApiId == nil {
+		invalidParams.Add(request.NewErrParamRequired("RestApiId"))
+	}
+	if s.Type == nil {
+		invalidParams.Add(request.NewErrParamRequired("Type"))
+	}
+
+	if invalidParams.Len() > 0 {
+		return invalidParams
+	}
+	return nil
+}
+
 // Requests Amazon API Gateway to create a new BasePathMapping resource.
 type CreateBasePathMappingInput struct {
 	_ struct{} `type:"structure"`
@@ -2532,6 +2557,22 @@ func (s CreateBasePathMappingInput) String() string {
 // GoString returns the string representation
 func (s CreateBasePathMappingInput) GoString() string {
 	return s.String()
+}
+
+// Validate inspects the fields of the type to determine if they are valid.
+func (s *CreateBasePathMappingInput) Validate() error {
+	invalidParams := request.ErrInvalidParams{Context: "CreateBasePathMappingInput"}
+	if s.DomainName == nil {
+		invalidParams.Add(request.NewErrParamRequired("DomainName"))
+	}
+	if s.RestApiId == nil {
+		invalidParams.Add(request.NewErrParamRequired("RestApiId"))
+	}
+
+	if invalidParams.Len() > 0 {
+		return invalidParams
+	}
+	return nil
 }
 
 // Requests Amazon API Gateway to create a Deployment resource.
@@ -2573,6 +2614,22 @@ func (s CreateDeploymentInput) GoString() string {
 	return s.String()
 }
 
+// Validate inspects the fields of the type to determine if they are valid.
+func (s *CreateDeploymentInput) Validate() error {
+	invalidParams := request.ErrInvalidParams{Context: "CreateDeploymentInput"}
+	if s.RestApiId == nil {
+		invalidParams.Add(request.NewErrParamRequired("RestApiId"))
+	}
+	if s.StageName == nil {
+		invalidParams.Add(request.NewErrParamRequired("StageName"))
+	}
+
+	if invalidParams.Len() > 0 {
+		return invalidParams
+	}
+	return nil
+}
+
 // A request to create a new domain name.
 type CreateDomainNameInput struct {
 	_ struct{} `type:"structure"`
@@ -2608,6 +2665,31 @@ func (s CreateDomainNameInput) GoString() string {
 	return s.String()
 }
 
+// Validate inspects the fields of the type to determine if they are valid.
+func (s *CreateDomainNameInput) Validate() error {
+	invalidParams := request.ErrInvalidParams{Context: "CreateDomainNameInput"}
+	if s.CertificateBody == nil {
+		invalidParams.Add(request.NewErrParamRequired("CertificateBody"))
+	}
+	if s.CertificateChain == nil {
+		invalidParams.Add(request.NewErrParamRequired("CertificateChain"))
+	}
+	if s.CertificateName == nil {
+		invalidParams.Add(request.NewErrParamRequired("CertificateName"))
+	}
+	if s.CertificatePrivateKey == nil {
+		invalidParams.Add(request.NewErrParamRequired("CertificatePrivateKey"))
+	}
+	if s.DomainName == nil {
+		invalidParams.Add(request.NewErrParamRequired("DomainName"))
+	}
+
+	if invalidParams.Len() > 0 {
+		return invalidParams
+	}
+	return nil
+}
+
 // Request to add a new Model to an existing RestApi resource.
 type CreateModelInput struct {
 	_ struct{} `type:"structure"`
@@ -2639,6 +2721,25 @@ func (s CreateModelInput) GoString() string {
 	return s.String()
 }
 
+// Validate inspects the fields of the type to determine if they are valid.
+func (s *CreateModelInput) Validate() error {
+	invalidParams := request.ErrInvalidParams{Context: "CreateModelInput"}
+	if s.ContentType == nil {
+		invalidParams.Add(request.NewErrParamRequired("ContentType"))
+	}
+	if s.Name == nil {
+		invalidParams.Add(request.NewErrParamRequired("Name"))
+	}
+	if s.RestApiId == nil {
+		invalidParams.Add(request.NewErrParamRequired("RestApiId"))
+	}
+
+	if invalidParams.Len() > 0 {
+		return invalidParams
+	}
+	return nil
+}
+
 // Requests Amazon API Gateway to create a Resource resource.
 type CreateResourceInput struct {
 	_ struct{} `type:"structure"`
@@ -2663,6 +2764,25 @@ func (s CreateResourceInput) GoString() string {
 	return s.String()
 }
 
+// Validate inspects the fields of the type to determine if they are valid.
+func (s *CreateResourceInput) Validate() error {
+	invalidParams := request.ErrInvalidParams{Context: "CreateResourceInput"}
+	if s.ParentId == nil {
+		invalidParams.Add(request.NewErrParamRequired("ParentId"))
+	}
+	if s.PathPart == nil {
+		invalidParams.Add(request.NewErrParamRequired("PathPart"))
+	}
+	if s.RestApiId == nil {
+		invalidParams.Add(request.NewErrParamRequired("RestApiId"))
+	}
+
+	if invalidParams.Len() > 0 {
+		return invalidParams
+	}
+	return nil
+}
+
 // The POST Request to add a new RestApi resource to your collection.
 type CreateRestApiInput struct {
 	_ struct{} `type:"structure"`
@@ -2685,6 +2805,19 @@ func (s CreateRestApiInput) String() string {
 // GoString returns the string representation
 func (s CreateRestApiInput) GoString() string {
 	return s.String()
+}
+
+// Validate inspects the fields of the type to determine if they are valid.
+func (s *CreateRestApiInput) Validate() error {
+	invalidParams := request.ErrInvalidParams{Context: "CreateRestApiInput"}
+	if s.Name == nil {
+		invalidParams.Add(request.NewErrParamRequired("Name"))
+	}
+
+	if invalidParams.Len() > 0 {
+		return invalidParams
+	}
+	return nil
 }
 
 // Requests Amazon API Gateway to create a Stage resource.
@@ -2724,6 +2857,25 @@ func (s CreateStageInput) GoString() string {
 	return s.String()
 }
 
+// Validate inspects the fields of the type to determine if they are valid.
+func (s *CreateStageInput) Validate() error {
+	invalidParams := request.ErrInvalidParams{Context: "CreateStageInput"}
+	if s.DeploymentId == nil {
+		invalidParams.Add(request.NewErrParamRequired("DeploymentId"))
+	}
+	if s.RestApiId == nil {
+		invalidParams.Add(request.NewErrParamRequired("RestApiId"))
+	}
+	if s.StageName == nil {
+		invalidParams.Add(request.NewErrParamRequired("StageName"))
+	}
+
+	if invalidParams.Len() > 0 {
+		return invalidParams
+	}
+	return nil
+}
+
 // A request to delete the ApiKey resource.
 type DeleteApiKeyInput struct {
 	_ struct{} `type:"structure"`
@@ -2740,6 +2892,19 @@ func (s DeleteApiKeyInput) String() string {
 // GoString returns the string representation
 func (s DeleteApiKeyInput) GoString() string {
 	return s.String()
+}
+
+// Validate inspects the fields of the type to determine if they are valid.
+func (s *DeleteApiKeyInput) Validate() error {
+	invalidParams := request.ErrInvalidParams{Context: "DeleteApiKeyInput"}
+	if s.ApiKey == nil {
+		invalidParams.Add(request.NewErrParamRequired("ApiKey"))
+	}
+
+	if invalidParams.Len() > 0 {
+		return invalidParams
+	}
+	return nil
 }
 
 type DeleteApiKeyOutput struct {
@@ -2777,6 +2942,22 @@ func (s DeleteAuthorizerInput) GoString() string {
 	return s.String()
 }
 
+// Validate inspects the fields of the type to determine if they are valid.
+func (s *DeleteAuthorizerInput) Validate() error {
+	invalidParams := request.ErrInvalidParams{Context: "DeleteAuthorizerInput"}
+	if s.AuthorizerId == nil {
+		invalidParams.Add(request.NewErrParamRequired("AuthorizerId"))
+	}
+	if s.RestApiId == nil {
+		invalidParams.Add(request.NewErrParamRequired("RestApiId"))
+	}
+
+	if invalidParams.Len() > 0 {
+		return invalidParams
+	}
+	return nil
+}
+
 type DeleteAuthorizerOutput struct {
 	_ struct{} `type:"structure"`
 }
@@ -2812,6 +2993,22 @@ func (s DeleteBasePathMappingInput) GoString() string {
 	return s.String()
 }
 
+// Validate inspects the fields of the type to determine if they are valid.
+func (s *DeleteBasePathMappingInput) Validate() error {
+	invalidParams := request.ErrInvalidParams{Context: "DeleteBasePathMappingInput"}
+	if s.BasePath == nil {
+		invalidParams.Add(request.NewErrParamRequired("BasePath"))
+	}
+	if s.DomainName == nil {
+		invalidParams.Add(request.NewErrParamRequired("DomainName"))
+	}
+
+	if invalidParams.Len() > 0 {
+		return invalidParams
+	}
+	return nil
+}
+
 type DeleteBasePathMappingOutput struct {
 	_ struct{} `type:"structure"`
 }
@@ -2842,6 +3039,19 @@ func (s DeleteClientCertificateInput) String() string {
 // GoString returns the string representation
 func (s DeleteClientCertificateInput) GoString() string {
 	return s.String()
+}
+
+// Validate inspects the fields of the type to determine if they are valid.
+func (s *DeleteClientCertificateInput) Validate() error {
+	invalidParams := request.ErrInvalidParams{Context: "DeleteClientCertificateInput"}
+	if s.ClientCertificateId == nil {
+		invalidParams.Add(request.NewErrParamRequired("ClientCertificateId"))
+	}
+
+	if invalidParams.Len() > 0 {
+		return invalidParams
+	}
+	return nil
 }
 
 type DeleteClientCertificateOutput struct {
@@ -2879,6 +3089,22 @@ func (s DeleteDeploymentInput) GoString() string {
 	return s.String()
 }
 
+// Validate inspects the fields of the type to determine if they are valid.
+func (s *DeleteDeploymentInput) Validate() error {
+	invalidParams := request.ErrInvalidParams{Context: "DeleteDeploymentInput"}
+	if s.DeploymentId == nil {
+		invalidParams.Add(request.NewErrParamRequired("DeploymentId"))
+	}
+	if s.RestApiId == nil {
+		invalidParams.Add(request.NewErrParamRequired("RestApiId"))
+	}
+
+	if invalidParams.Len() > 0 {
+		return invalidParams
+	}
+	return nil
+}
+
 type DeleteDeploymentOutput struct {
 	_ struct{} `type:"structure"`
 }
@@ -2909,6 +3135,19 @@ func (s DeleteDomainNameInput) String() string {
 // GoString returns the string representation
 func (s DeleteDomainNameInput) GoString() string {
 	return s.String()
+}
+
+// Validate inspects the fields of the type to determine if they are valid.
+func (s *DeleteDomainNameInput) Validate() error {
+	invalidParams := request.ErrInvalidParams{Context: "DeleteDomainNameInput"}
+	if s.DomainName == nil {
+		invalidParams.Add(request.NewErrParamRequired("DomainName"))
+	}
+
+	if invalidParams.Len() > 0 {
+		return invalidParams
+	}
+	return nil
 }
 
 type DeleteDomainNameOutput struct {
@@ -2947,6 +3186,25 @@ func (s DeleteIntegrationInput) String() string {
 // GoString returns the string representation
 func (s DeleteIntegrationInput) GoString() string {
 	return s.String()
+}
+
+// Validate inspects the fields of the type to determine if they are valid.
+func (s *DeleteIntegrationInput) Validate() error {
+	invalidParams := request.ErrInvalidParams{Context: "DeleteIntegrationInput"}
+	if s.HttpMethod == nil {
+		invalidParams.Add(request.NewErrParamRequired("HttpMethod"))
+	}
+	if s.ResourceId == nil {
+		invalidParams.Add(request.NewErrParamRequired("ResourceId"))
+	}
+	if s.RestApiId == nil {
+		invalidParams.Add(request.NewErrParamRequired("RestApiId"))
+	}
+
+	if invalidParams.Len() > 0 {
+		return invalidParams
+	}
+	return nil
 }
 
 type DeleteIntegrationOutput struct {
@@ -2990,6 +3248,28 @@ func (s DeleteIntegrationResponseInput) GoString() string {
 	return s.String()
 }
 
+// Validate inspects the fields of the type to determine if they are valid.
+func (s *DeleteIntegrationResponseInput) Validate() error {
+	invalidParams := request.ErrInvalidParams{Context: "DeleteIntegrationResponseInput"}
+	if s.HttpMethod == nil {
+		invalidParams.Add(request.NewErrParamRequired("HttpMethod"))
+	}
+	if s.ResourceId == nil {
+		invalidParams.Add(request.NewErrParamRequired("ResourceId"))
+	}
+	if s.RestApiId == nil {
+		invalidParams.Add(request.NewErrParamRequired("RestApiId"))
+	}
+	if s.StatusCode == nil {
+		invalidParams.Add(request.NewErrParamRequired("StatusCode"))
+	}
+
+	if invalidParams.Len() > 0 {
+		return invalidParams
+	}
+	return nil
+}
+
 type DeleteIntegrationResponseOutput struct {
 	_ struct{} `type:"structure"`
 }
@@ -3026,6 +3306,25 @@ func (s DeleteMethodInput) String() string {
 // GoString returns the string representation
 func (s DeleteMethodInput) GoString() string {
 	return s.String()
+}
+
+// Validate inspects the fields of the type to determine if they are valid.
+func (s *DeleteMethodInput) Validate() error {
+	invalidParams := request.ErrInvalidParams{Context: "DeleteMethodInput"}
+	if s.HttpMethod == nil {
+		invalidParams.Add(request.NewErrParamRequired("HttpMethod"))
+	}
+	if s.ResourceId == nil {
+		invalidParams.Add(request.NewErrParamRequired("ResourceId"))
+	}
+	if s.RestApiId == nil {
+		invalidParams.Add(request.NewErrParamRequired("RestApiId"))
+	}
+
+	if invalidParams.Len() > 0 {
+		return invalidParams
+	}
+	return nil
 }
 
 type DeleteMethodOutput struct {
@@ -3069,6 +3368,28 @@ func (s DeleteMethodResponseInput) GoString() string {
 	return s.String()
 }
 
+// Validate inspects the fields of the type to determine if they are valid.
+func (s *DeleteMethodResponseInput) Validate() error {
+	invalidParams := request.ErrInvalidParams{Context: "DeleteMethodResponseInput"}
+	if s.HttpMethod == nil {
+		invalidParams.Add(request.NewErrParamRequired("HttpMethod"))
+	}
+	if s.ResourceId == nil {
+		invalidParams.Add(request.NewErrParamRequired("ResourceId"))
+	}
+	if s.RestApiId == nil {
+		invalidParams.Add(request.NewErrParamRequired("RestApiId"))
+	}
+	if s.StatusCode == nil {
+		invalidParams.Add(request.NewErrParamRequired("StatusCode"))
+	}
+
+	if invalidParams.Len() > 0 {
+		return invalidParams
+	}
+	return nil
+}
+
 type DeleteMethodResponseOutput struct {
 	_ struct{} `type:"structure"`
 }
@@ -3102,6 +3423,22 @@ func (s DeleteModelInput) String() string {
 // GoString returns the string representation
 func (s DeleteModelInput) GoString() string {
 	return s.String()
+}
+
+// Validate inspects the fields of the type to determine if they are valid.
+func (s *DeleteModelInput) Validate() error {
+	invalidParams := request.ErrInvalidParams{Context: "DeleteModelInput"}
+	if s.ModelName == nil {
+		invalidParams.Add(request.NewErrParamRequired("ModelName"))
+	}
+	if s.RestApiId == nil {
+		invalidParams.Add(request.NewErrParamRequired("RestApiId"))
+	}
+
+	if invalidParams.Len() > 0 {
+		return invalidParams
+	}
+	return nil
 }
 
 type DeleteModelOutput struct {
@@ -3139,6 +3476,22 @@ func (s DeleteResourceInput) GoString() string {
 	return s.String()
 }
 
+// Validate inspects the fields of the type to determine if they are valid.
+func (s *DeleteResourceInput) Validate() error {
+	invalidParams := request.ErrInvalidParams{Context: "DeleteResourceInput"}
+	if s.ResourceId == nil {
+		invalidParams.Add(request.NewErrParamRequired("ResourceId"))
+	}
+	if s.RestApiId == nil {
+		invalidParams.Add(request.NewErrParamRequired("RestApiId"))
+	}
+
+	if invalidParams.Len() > 0 {
+		return invalidParams
+	}
+	return nil
+}
+
 type DeleteResourceOutput struct {
 	_ struct{} `type:"structure"`
 }
@@ -3169,6 +3522,19 @@ func (s DeleteRestApiInput) String() string {
 // GoString returns the string representation
 func (s DeleteRestApiInput) GoString() string {
 	return s.String()
+}
+
+// Validate inspects the fields of the type to determine if they are valid.
+func (s *DeleteRestApiInput) Validate() error {
+	invalidParams := request.ErrInvalidParams{Context: "DeleteRestApiInput"}
+	if s.RestApiId == nil {
+		invalidParams.Add(request.NewErrParamRequired("RestApiId"))
+	}
+
+	if invalidParams.Len() > 0 {
+		return invalidParams
+	}
+	return nil
 }
 
 type DeleteRestApiOutput struct {
@@ -3204,6 +3570,22 @@ func (s DeleteStageInput) String() string {
 // GoString returns the string representation
 func (s DeleteStageInput) GoString() string {
 	return s.String()
+}
+
+// Validate inspects the fields of the type to determine if they are valid.
+func (s *DeleteStageInput) Validate() error {
+	invalidParams := request.ErrInvalidParams{Context: "DeleteStageInput"}
+	if s.RestApiId == nil {
+		invalidParams.Add(request.NewErrParamRequired("RestApiId"))
+	}
+	if s.StageName == nil {
+		invalidParams.Add(request.NewErrParamRequired("StageName"))
+	}
+
+	if invalidParams.Len() > 0 {
+		return invalidParams
+	}
+	return nil
 }
 
 type DeleteStageOutput struct {
@@ -3302,6 +3684,22 @@ func (s FlushStageAuthorizersCacheInput) GoString() string {
 	return s.String()
 }
 
+// Validate inspects the fields of the type to determine if they are valid.
+func (s *FlushStageAuthorizersCacheInput) Validate() error {
+	invalidParams := request.ErrInvalidParams{Context: "FlushStageAuthorizersCacheInput"}
+	if s.RestApiId == nil {
+		invalidParams.Add(request.NewErrParamRequired("RestApiId"))
+	}
+	if s.StageName == nil {
+		invalidParams.Add(request.NewErrParamRequired("StageName"))
+	}
+
+	if invalidParams.Len() > 0 {
+		return invalidParams
+	}
+	return nil
+}
+
 type FlushStageAuthorizersCacheOutput struct {
 	_ struct{} `type:"structure"`
 }
@@ -3335,6 +3733,22 @@ func (s FlushStageCacheInput) String() string {
 // GoString returns the string representation
 func (s FlushStageCacheInput) GoString() string {
 	return s.String()
+}
+
+// Validate inspects the fields of the type to determine if they are valid.
+func (s *FlushStageCacheInput) Validate() error {
+	invalidParams := request.ErrInvalidParams{Context: "FlushStageCacheInput"}
+	if s.RestApiId == nil {
+		invalidParams.Add(request.NewErrParamRequired("RestApiId"))
+	}
+	if s.StageName == nil {
+		invalidParams.Add(request.NewErrParamRequired("StageName"))
+	}
+
+	if invalidParams.Len() > 0 {
+		return invalidParams
+	}
+	return nil
 }
 
 type FlushStageCacheOutput struct {
@@ -3403,6 +3817,19 @@ func (s GetApiKeyInput) GoString() string {
 	return s.String()
 }
 
+// Validate inspects the fields of the type to determine if they are valid.
+func (s *GetApiKeyInput) Validate() error {
+	invalidParams := request.ErrInvalidParams{Context: "GetApiKeyInput"}
+	if s.ApiKey == nil {
+		invalidParams.Add(request.NewErrParamRequired("ApiKey"))
+	}
+
+	if invalidParams.Len() > 0 {
+		return invalidParams
+	}
+	return nil
+}
+
 // A request to get information about the current ApiKeys resource.
 type GetApiKeysInput struct {
 	_ struct{} `type:"structure"`
@@ -3465,6 +3892,22 @@ func (s GetAuthorizerInput) GoString() string {
 	return s.String()
 }
 
+// Validate inspects the fields of the type to determine if they are valid.
+func (s *GetAuthorizerInput) Validate() error {
+	invalidParams := request.ErrInvalidParams{Context: "GetAuthorizerInput"}
+	if s.AuthorizerId == nil {
+		invalidParams.Add(request.NewErrParamRequired("AuthorizerId"))
+	}
+	if s.RestApiId == nil {
+		invalidParams.Add(request.NewErrParamRequired("RestApiId"))
+	}
+
+	if invalidParams.Len() > 0 {
+		return invalidParams
+	}
+	return nil
+}
+
 // Request to describe an existing Authorizers resource.
 type GetAuthorizersInput struct {
 	_ struct{} `type:"structure"`
@@ -3488,6 +3931,19 @@ func (s GetAuthorizersInput) String() string {
 // GoString returns the string representation
 func (s GetAuthorizersInput) GoString() string {
 	return s.String()
+}
+
+// Validate inspects the fields of the type to determine if they are valid.
+func (s *GetAuthorizersInput) Validate() error {
+	invalidParams := request.ErrInvalidParams{Context: "GetAuthorizersInput"}
+	if s.RestApiId == nil {
+		invalidParams.Add(request.NewErrParamRequired("RestApiId"))
+	}
+
+	if invalidParams.Len() > 0 {
+		return invalidParams
+	}
+	return nil
 }
 
 // Represents a collection of Authorizer resources.
@@ -3534,6 +3990,22 @@ func (s GetBasePathMappingInput) GoString() string {
 	return s.String()
 }
 
+// Validate inspects the fields of the type to determine if they are valid.
+func (s *GetBasePathMappingInput) Validate() error {
+	invalidParams := request.ErrInvalidParams{Context: "GetBasePathMappingInput"}
+	if s.BasePath == nil {
+		invalidParams.Add(request.NewErrParamRequired("BasePath"))
+	}
+	if s.DomainName == nil {
+		invalidParams.Add(request.NewErrParamRequired("DomainName"))
+	}
+
+	if invalidParams.Len() > 0 {
+		return invalidParams
+	}
+	return nil
+}
+
 // A request to get information about a collection of BasePathMapping resources.
 type GetBasePathMappingsInput struct {
 	_ struct{} `type:"structure"`
@@ -3559,6 +4031,19 @@ func (s GetBasePathMappingsInput) String() string {
 // GoString returns the string representation
 func (s GetBasePathMappingsInput) GoString() string {
 	return s.String()
+}
+
+// Validate inspects the fields of the type to determine if they are valid.
+func (s *GetBasePathMappingsInput) Validate() error {
+	invalidParams := request.ErrInvalidParams{Context: "GetBasePathMappingsInput"}
+	if s.DomainName == nil {
+		invalidParams.Add(request.NewErrParamRequired("DomainName"))
+	}
+
+	if invalidParams.Len() > 0 {
+		return invalidParams
+	}
+	return nil
 }
 
 // Represents a collection of BasePathMapping resources.
@@ -3598,6 +4083,19 @@ func (s GetClientCertificateInput) String() string {
 // GoString returns the string representation
 func (s GetClientCertificateInput) GoString() string {
 	return s.String()
+}
+
+// Validate inspects the fields of the type to determine if they are valid.
+func (s *GetClientCertificateInput) Validate() error {
+	invalidParams := request.ErrInvalidParams{Context: "GetClientCertificateInput"}
+	if s.ClientCertificateId == nil {
+		invalidParams.Add(request.NewErrParamRequired("ClientCertificateId"))
+	}
+
+	if invalidParams.Len() > 0 {
+		return invalidParams
+	}
+	return nil
 }
 
 // A request to get information about a collection of ClientCertificate resources.
@@ -3667,6 +4165,22 @@ func (s GetDeploymentInput) GoString() string {
 	return s.String()
 }
 
+// Validate inspects the fields of the type to determine if they are valid.
+func (s *GetDeploymentInput) Validate() error {
+	invalidParams := request.ErrInvalidParams{Context: "GetDeploymentInput"}
+	if s.DeploymentId == nil {
+		invalidParams.Add(request.NewErrParamRequired("DeploymentId"))
+	}
+	if s.RestApiId == nil {
+		invalidParams.Add(request.NewErrParamRequired("RestApiId"))
+	}
+
+	if invalidParams.Len() > 0 {
+		return invalidParams
+	}
+	return nil
+}
+
 // Requests Amazon API Gateway to get information about a Deployments collection.
 type GetDeploymentsInput struct {
 	_ struct{} `type:"structure"`
@@ -3692,6 +4206,19 @@ func (s GetDeploymentsInput) String() string {
 // GoString returns the string representation
 func (s GetDeploymentsInput) GoString() string {
 	return s.String()
+}
+
+// Validate inspects the fields of the type to determine if they are valid.
+func (s *GetDeploymentsInput) Validate() error {
+	invalidParams := request.ErrInvalidParams{Context: "GetDeploymentsInput"}
+	if s.RestApiId == nil {
+		invalidParams.Add(request.NewErrParamRequired("RestApiId"))
+	}
+
+	if invalidParams.Len() > 0 {
+		return invalidParams
+	}
+	return nil
 }
 
 // Represents a collection resource that contains zero or more references to
@@ -3734,6 +4261,19 @@ func (s GetDomainNameInput) String() string {
 // GoString returns the string representation
 func (s GetDomainNameInput) GoString() string {
 	return s.String()
+}
+
+// Validate inspects the fields of the type to determine if they are valid.
+func (s *GetDomainNameInput) Validate() error {
+	invalidParams := request.ErrInvalidParams{Context: "GetDomainNameInput"}
+	if s.DomainName == nil {
+		invalidParams.Add(request.NewErrParamRequired("DomainName"))
+	}
+
+	if invalidParams.Len() > 0 {
+		return invalidParams
+	}
+	return nil
 }
 
 // Request to describe a collection of DomainName resources.
@@ -3816,6 +4356,25 @@ func (s GetExportInput) GoString() string {
 	return s.String()
 }
 
+// Validate inspects the fields of the type to determine if they are valid.
+func (s *GetExportInput) Validate() error {
+	invalidParams := request.ErrInvalidParams{Context: "GetExportInput"}
+	if s.ExportType == nil {
+		invalidParams.Add(request.NewErrParamRequired("ExportType"))
+	}
+	if s.RestApiId == nil {
+		invalidParams.Add(request.NewErrParamRequired("RestApiId"))
+	}
+	if s.StageName == nil {
+		invalidParams.Add(request.NewErrParamRequired("StageName"))
+	}
+
+	if invalidParams.Len() > 0 {
+		return invalidParams
+	}
+	return nil
+}
+
 // The binary blob response to GetExport, which contains the generated SDK.
 type GetExportOutput struct {
 	_ struct{} `type:"structure" payload:"Body"`
@@ -3865,6 +4424,25 @@ func (s GetIntegrationInput) GoString() string {
 	return s.String()
 }
 
+// Validate inspects the fields of the type to determine if they are valid.
+func (s *GetIntegrationInput) Validate() error {
+	invalidParams := request.ErrInvalidParams{Context: "GetIntegrationInput"}
+	if s.HttpMethod == nil {
+		invalidParams.Add(request.NewErrParamRequired("HttpMethod"))
+	}
+	if s.ResourceId == nil {
+		invalidParams.Add(request.NewErrParamRequired("ResourceId"))
+	}
+	if s.RestApiId == nil {
+		invalidParams.Add(request.NewErrParamRequired("RestApiId"))
+	}
+
+	if invalidParams.Len() > 0 {
+		return invalidParams
+	}
+	return nil
+}
+
 // Represents a get integration response request.
 type GetIntegrationResponseInput struct {
 	_ struct{} `type:"structure"`
@@ -3892,6 +4470,28 @@ func (s GetIntegrationResponseInput) GoString() string {
 	return s.String()
 }
 
+// Validate inspects the fields of the type to determine if they are valid.
+func (s *GetIntegrationResponseInput) Validate() error {
+	invalidParams := request.ErrInvalidParams{Context: "GetIntegrationResponseInput"}
+	if s.HttpMethod == nil {
+		invalidParams.Add(request.NewErrParamRequired("HttpMethod"))
+	}
+	if s.ResourceId == nil {
+		invalidParams.Add(request.NewErrParamRequired("ResourceId"))
+	}
+	if s.RestApiId == nil {
+		invalidParams.Add(request.NewErrParamRequired("RestApiId"))
+	}
+	if s.StatusCode == nil {
+		invalidParams.Add(request.NewErrParamRequired("StatusCode"))
+	}
+
+	if invalidParams.Len() > 0 {
+		return invalidParams
+	}
+	return nil
+}
+
 // Request to describe an existing Method resource.
 type GetMethodInput struct {
 	_ struct{} `type:"structure"`
@@ -3914,6 +4514,25 @@ func (s GetMethodInput) String() string {
 // GoString returns the string representation
 func (s GetMethodInput) GoString() string {
 	return s.String()
+}
+
+// Validate inspects the fields of the type to determine if they are valid.
+func (s *GetMethodInput) Validate() error {
+	invalidParams := request.ErrInvalidParams{Context: "GetMethodInput"}
+	if s.HttpMethod == nil {
+		invalidParams.Add(request.NewErrParamRequired("HttpMethod"))
+	}
+	if s.ResourceId == nil {
+		invalidParams.Add(request.NewErrParamRequired("ResourceId"))
+	}
+	if s.RestApiId == nil {
+		invalidParams.Add(request.NewErrParamRequired("RestApiId"))
+	}
+
+	if invalidParams.Len() > 0 {
+		return invalidParams
+	}
+	return nil
 }
 
 // Request to describe a MethodResponse resource.
@@ -3943,6 +4562,28 @@ func (s GetMethodResponseInput) GoString() string {
 	return s.String()
 }
 
+// Validate inspects the fields of the type to determine if they are valid.
+func (s *GetMethodResponseInput) Validate() error {
+	invalidParams := request.ErrInvalidParams{Context: "GetMethodResponseInput"}
+	if s.HttpMethod == nil {
+		invalidParams.Add(request.NewErrParamRequired("HttpMethod"))
+	}
+	if s.ResourceId == nil {
+		invalidParams.Add(request.NewErrParamRequired("ResourceId"))
+	}
+	if s.RestApiId == nil {
+		invalidParams.Add(request.NewErrParamRequired("RestApiId"))
+	}
+	if s.StatusCode == nil {
+		invalidParams.Add(request.NewErrParamRequired("StatusCode"))
+	}
+
+	if invalidParams.Len() > 0 {
+		return invalidParams
+	}
+	return nil
+}
+
 // Request to list information about a model in an existing RestApi resource.
 type GetModelInput struct {
 	_ struct{} `type:"structure"`
@@ -3967,6 +4608,22 @@ func (s GetModelInput) GoString() string {
 	return s.String()
 }
 
+// Validate inspects the fields of the type to determine if they are valid.
+func (s *GetModelInput) Validate() error {
+	invalidParams := request.ErrInvalidParams{Context: "GetModelInput"}
+	if s.ModelName == nil {
+		invalidParams.Add(request.NewErrParamRequired("ModelName"))
+	}
+	if s.RestApiId == nil {
+		invalidParams.Add(request.NewErrParamRequired("RestApiId"))
+	}
+
+	if invalidParams.Len() > 0 {
+		return invalidParams
+	}
+	return nil
+}
+
 // Request to generate a sample mapping template used to transform the payload.
 type GetModelTemplateInput struct {
 	_ struct{} `type:"structure"`
@@ -3986,6 +4643,22 @@ func (s GetModelTemplateInput) String() string {
 // GoString returns the string representation
 func (s GetModelTemplateInput) GoString() string {
 	return s.String()
+}
+
+// Validate inspects the fields of the type to determine if they are valid.
+func (s *GetModelTemplateInput) Validate() error {
+	invalidParams := request.ErrInvalidParams{Context: "GetModelTemplateInput"}
+	if s.ModelName == nil {
+		invalidParams.Add(request.NewErrParamRequired("ModelName"))
+	}
+	if s.RestApiId == nil {
+		invalidParams.Add(request.NewErrParamRequired("RestApiId"))
+	}
+
+	if invalidParams.Len() > 0 {
+		return invalidParams
+	}
+	return nil
 }
 
 // Represents a mapping template used to transform a payload.
@@ -4033,6 +4706,19 @@ func (s GetModelsInput) GoString() string {
 	return s.String()
 }
 
+// Validate inspects the fields of the type to determine if they are valid.
+func (s *GetModelsInput) Validate() error {
+	invalidParams := request.ErrInvalidParams{Context: "GetModelsInput"}
+	if s.RestApiId == nil {
+		invalidParams.Add(request.NewErrParamRequired("RestApiId"))
+	}
+
+	if invalidParams.Len() > 0 {
+		return invalidParams
+	}
+	return nil
+}
+
 // Represents a collection of Model resources.
 type GetModelsOutput struct {
 	_ struct{} `type:"structure"`
@@ -4074,6 +4760,22 @@ func (s GetResourceInput) GoString() string {
 	return s.String()
 }
 
+// Validate inspects the fields of the type to determine if they are valid.
+func (s *GetResourceInput) Validate() error {
+	invalidParams := request.ErrInvalidParams{Context: "GetResourceInput"}
+	if s.ResourceId == nil {
+		invalidParams.Add(request.NewErrParamRequired("ResourceId"))
+	}
+	if s.RestApiId == nil {
+		invalidParams.Add(request.NewErrParamRequired("RestApiId"))
+	}
+
+	if invalidParams.Len() > 0 {
+		return invalidParams
+	}
+	return nil
+}
+
 // Request to list information about a collection of resources.
 type GetResourcesInput struct {
 	_ struct{} `type:"structure"`
@@ -4098,6 +4800,19 @@ func (s GetResourcesInput) String() string {
 // GoString returns the string representation
 func (s GetResourcesInput) GoString() string {
 	return s.String()
+}
+
+// Validate inspects the fields of the type to determine if they are valid.
+func (s *GetResourcesInput) Validate() error {
+	invalidParams := request.ErrInvalidParams{Context: "GetResourcesInput"}
+	if s.RestApiId == nil {
+		invalidParams.Add(request.NewErrParamRequired("RestApiId"))
+	}
+
+	if invalidParams.Len() > 0 {
+		return invalidParams
+	}
+	return nil
 }
 
 // Represents a collection of Resource resources.
@@ -4136,6 +4851,19 @@ func (s GetRestApiInput) String() string {
 // GoString returns the string representation
 func (s GetRestApiInput) GoString() string {
 	return s.String()
+}
+
+// Validate inspects the fields of the type to determine if they are valid.
+func (s *GetRestApiInput) Validate() error {
+	invalidParams := request.ErrInvalidParams{Context: "GetRestApiInput"}
+	if s.RestApiId == nil {
+		invalidParams.Add(request.NewErrParamRequired("RestApiId"))
+	}
+
+	if invalidParams.Len() > 0 {
+		return invalidParams
+	}
+	return nil
 }
 
 // The GET request to list existing RestApis defined for your collection.
@@ -4213,6 +4941,25 @@ func (s GetSdkInput) GoString() string {
 	return s.String()
 }
 
+// Validate inspects the fields of the type to determine if they are valid.
+func (s *GetSdkInput) Validate() error {
+	invalidParams := request.ErrInvalidParams{Context: "GetSdkInput"}
+	if s.RestApiId == nil {
+		invalidParams.Add(request.NewErrParamRequired("RestApiId"))
+	}
+	if s.SdkType == nil {
+		invalidParams.Add(request.NewErrParamRequired("SdkType"))
+	}
+	if s.StageName == nil {
+		invalidParams.Add(request.NewErrParamRequired("StageName"))
+	}
+
+	if invalidParams.Len() > 0 {
+		return invalidParams
+	}
+	return nil
+}
+
 // The binary blob response to GetSdk, which contains the generated SDK.
 type GetSdkOutput struct {
 	_ struct{} `type:"structure" payload:"Body"`
@@ -4259,6 +5006,22 @@ func (s GetStageInput) GoString() string {
 	return s.String()
 }
 
+// Validate inspects the fields of the type to determine if they are valid.
+func (s *GetStageInput) Validate() error {
+	invalidParams := request.ErrInvalidParams{Context: "GetStageInput"}
+	if s.RestApiId == nil {
+		invalidParams.Add(request.NewErrParamRequired("RestApiId"))
+	}
+	if s.StageName == nil {
+		invalidParams.Add(request.NewErrParamRequired("StageName"))
+	}
+
+	if invalidParams.Len() > 0 {
+		return invalidParams
+	}
+	return nil
+}
+
 // Requests Amazon API Gateway to get information about one or more Stage resources.
 type GetStagesInput struct {
 	_ struct{} `type:"structure"`
@@ -4278,6 +5041,19 @@ func (s GetStagesInput) String() string {
 // GoString returns the string representation
 func (s GetStagesInput) GoString() string {
 	return s.String()
+}
+
+// Validate inspects the fields of the type to determine if they are valid.
+func (s *GetStagesInput) Validate() error {
+	invalidParams := request.ErrInvalidParams{Context: "GetStagesInput"}
+	if s.RestApiId == nil {
+		invalidParams.Add(request.NewErrParamRequired("RestApiId"))
+	}
+
+	if invalidParams.Len() > 0 {
+		return invalidParams
+	}
+	return nil
 }
 
 // A list of Stage resource that are associated with the ApiKey resource.
@@ -4323,6 +5099,19 @@ func (s ImportRestApiInput) String() string {
 // GoString returns the string representation
 func (s ImportRestApiInput) GoString() string {
 	return s.String()
+}
+
+// Validate inspects the fields of the type to determine if they are valid.
+func (s *ImportRestApiInput) Validate() error {
+	invalidParams := request.ErrInvalidParams{Context: "ImportRestApiInput"}
+	if s.Body == nil {
+		invalidParams.Add(request.NewErrParamRequired("Body"))
+	}
+
+	if invalidParams.Len() > 0 {
+		return invalidParams
+	}
+	return nil
 }
 
 // Represents a HTTP, AWS, or Mock integration.
@@ -4729,6 +5518,28 @@ func (s PutIntegrationInput) GoString() string {
 	return s.String()
 }
 
+// Validate inspects the fields of the type to determine if they are valid.
+func (s *PutIntegrationInput) Validate() error {
+	invalidParams := request.ErrInvalidParams{Context: "PutIntegrationInput"}
+	if s.HttpMethod == nil {
+		invalidParams.Add(request.NewErrParamRequired("HttpMethod"))
+	}
+	if s.ResourceId == nil {
+		invalidParams.Add(request.NewErrParamRequired("ResourceId"))
+	}
+	if s.RestApiId == nil {
+		invalidParams.Add(request.NewErrParamRequired("RestApiId"))
+	}
+	if s.Type == nil {
+		invalidParams.Add(request.NewErrParamRequired("Type"))
+	}
+
+	if invalidParams.Len() > 0 {
+		return invalidParams
+	}
+	return nil
+}
+
 // Represents a put integration response request.
 type PutIntegrationResponseInput struct {
 	_ struct{} `type:"structure"`
@@ -4770,6 +5581,28 @@ func (s PutIntegrationResponseInput) String() string {
 // GoString returns the string representation
 func (s PutIntegrationResponseInput) GoString() string {
 	return s.String()
+}
+
+// Validate inspects the fields of the type to determine if they are valid.
+func (s *PutIntegrationResponseInput) Validate() error {
+	invalidParams := request.ErrInvalidParams{Context: "PutIntegrationResponseInput"}
+	if s.HttpMethod == nil {
+		invalidParams.Add(request.NewErrParamRequired("HttpMethod"))
+	}
+	if s.ResourceId == nil {
+		invalidParams.Add(request.NewErrParamRequired("ResourceId"))
+	}
+	if s.RestApiId == nil {
+		invalidParams.Add(request.NewErrParamRequired("RestApiId"))
+	}
+	if s.StatusCode == nil {
+		invalidParams.Add(request.NewErrParamRequired("StatusCode"))
+	}
+
+	if invalidParams.Len() > 0 {
+		return invalidParams
+	}
+	return nil
 }
 
 // Request to add a method to an existing Resource resource.
@@ -4821,6 +5654,28 @@ func (s PutMethodInput) GoString() string {
 	return s.String()
 }
 
+// Validate inspects the fields of the type to determine if they are valid.
+func (s *PutMethodInput) Validate() error {
+	invalidParams := request.ErrInvalidParams{Context: "PutMethodInput"}
+	if s.AuthorizationType == nil {
+		invalidParams.Add(request.NewErrParamRequired("AuthorizationType"))
+	}
+	if s.HttpMethod == nil {
+		invalidParams.Add(request.NewErrParamRequired("HttpMethod"))
+	}
+	if s.ResourceId == nil {
+		invalidParams.Add(request.NewErrParamRequired("ResourceId"))
+	}
+	if s.RestApiId == nil {
+		invalidParams.Add(request.NewErrParamRequired("RestApiId"))
+	}
+
+	if invalidParams.Len() > 0 {
+		return invalidParams
+	}
+	return nil
+}
+
 // Request to add a MethodResponse to an existing Method resource.
 type PutMethodResponseInput struct {
 	_ struct{} `type:"structure"`
@@ -4862,6 +5717,28 @@ func (s PutMethodResponseInput) GoString() string {
 	return s.String()
 }
 
+// Validate inspects the fields of the type to determine if they are valid.
+func (s *PutMethodResponseInput) Validate() error {
+	invalidParams := request.ErrInvalidParams{Context: "PutMethodResponseInput"}
+	if s.HttpMethod == nil {
+		invalidParams.Add(request.NewErrParamRequired("HttpMethod"))
+	}
+	if s.ResourceId == nil {
+		invalidParams.Add(request.NewErrParamRequired("ResourceId"))
+	}
+	if s.RestApiId == nil {
+		invalidParams.Add(request.NewErrParamRequired("RestApiId"))
+	}
+	if s.StatusCode == nil {
+		invalidParams.Add(request.NewErrParamRequired("StatusCode"))
+	}
+
+	if invalidParams.Len() > 0 {
+		return invalidParams
+	}
+	return nil
+}
+
 // A PUT request to update an existing API, with external API definitions specified
 // as the request body.
 type PutRestApiInput struct {
@@ -4894,6 +5771,22 @@ func (s PutRestApiInput) String() string {
 // GoString returns the string representation
 func (s PutRestApiInput) GoString() string {
 	return s.String()
+}
+
+// Validate inspects the fields of the type to determine if they are valid.
+func (s *PutRestApiInput) Validate() error {
+	invalidParams := request.ErrInvalidParams{Context: "PutRestApiInput"}
+	if s.Body == nil {
+		invalidParams.Add(request.NewErrParamRequired("Body"))
+	}
+	if s.RestApiId == nil {
+		invalidParams.Add(request.NewErrParamRequired("RestApiId"))
+	}
+
+	if invalidParams.Len() > 0 {
+		return invalidParams
+	}
+	return nil
 }
 
 // Represents a resource.
@@ -5073,6 +5966,22 @@ func (s TestInvokeAuthorizerInput) GoString() string {
 	return s.String()
 }
 
+// Validate inspects the fields of the type to determine if they are valid.
+func (s *TestInvokeAuthorizerInput) Validate() error {
+	invalidParams := request.ErrInvalidParams{Context: "TestInvokeAuthorizerInput"}
+	if s.AuthorizerId == nil {
+		invalidParams.Add(request.NewErrParamRequired("AuthorizerId"))
+	}
+	if s.RestApiId == nil {
+		invalidParams.Add(request.NewErrParamRequired("RestApiId"))
+	}
+
+	if invalidParams.Len() > 0 {
+		return invalidParams
+	}
+	return nil
+}
+
 // Represents the response of the test invoke request in for a custom Authorizer
 type TestInvokeAuthorizerOutput struct {
 	_ struct{} `type:"structure"`
@@ -5147,6 +6056,25 @@ func (s TestInvokeMethodInput) String() string {
 // GoString returns the string representation
 func (s TestInvokeMethodInput) GoString() string {
 	return s.String()
+}
+
+// Validate inspects the fields of the type to determine if they are valid.
+func (s *TestInvokeMethodInput) Validate() error {
+	invalidParams := request.ErrInvalidParams{Context: "TestInvokeMethodInput"}
+	if s.HttpMethod == nil {
+		invalidParams.Add(request.NewErrParamRequired("HttpMethod"))
+	}
+	if s.ResourceId == nil {
+		invalidParams.Add(request.NewErrParamRequired("ResourceId"))
+	}
+	if s.RestApiId == nil {
+		invalidParams.Add(request.NewErrParamRequired("RestApiId"))
+	}
+
+	if invalidParams.Len() > 0 {
+		return invalidParams
+	}
+	return nil
 }
 
 // Represents the response of the test invoke request in HTTP method.
@@ -5242,6 +6170,19 @@ func (s UpdateApiKeyInput) GoString() string {
 	return s.String()
 }
 
+// Validate inspects the fields of the type to determine if they are valid.
+func (s *UpdateApiKeyInput) Validate() error {
+	invalidParams := request.ErrInvalidParams{Context: "UpdateApiKeyInput"}
+	if s.ApiKey == nil {
+		invalidParams.Add(request.NewErrParamRequired("ApiKey"))
+	}
+
+	if invalidParams.Len() > 0 {
+		return invalidParams
+	}
+	return nil
+}
+
 // Request to update an existing Authorizer resource.
 type UpdateAuthorizerInput struct {
 	_ struct{} `type:"structure"`
@@ -5265,6 +6206,22 @@ func (s UpdateAuthorizerInput) String() string {
 // GoString returns the string representation
 func (s UpdateAuthorizerInput) GoString() string {
 	return s.String()
+}
+
+// Validate inspects the fields of the type to determine if they are valid.
+func (s *UpdateAuthorizerInput) Validate() error {
+	invalidParams := request.ErrInvalidParams{Context: "UpdateAuthorizerInput"}
+	if s.AuthorizerId == nil {
+		invalidParams.Add(request.NewErrParamRequired("AuthorizerId"))
+	}
+	if s.RestApiId == nil {
+		invalidParams.Add(request.NewErrParamRequired("RestApiId"))
+	}
+
+	if invalidParams.Len() > 0 {
+		return invalidParams
+	}
+	return nil
 }
 
 // A request to change information about the BasePathMapping resource.
@@ -5292,6 +6249,22 @@ func (s UpdateBasePathMappingInput) GoString() string {
 	return s.String()
 }
 
+// Validate inspects the fields of the type to determine if they are valid.
+func (s *UpdateBasePathMappingInput) Validate() error {
+	invalidParams := request.ErrInvalidParams{Context: "UpdateBasePathMappingInput"}
+	if s.BasePath == nil {
+		invalidParams.Add(request.NewErrParamRequired("BasePath"))
+	}
+	if s.DomainName == nil {
+		invalidParams.Add(request.NewErrParamRequired("DomainName"))
+	}
+
+	if invalidParams.Len() > 0 {
+		return invalidParams
+	}
+	return nil
+}
+
 // A request to change information about an ClientCertificate resource.
 type UpdateClientCertificateInput struct {
 	_ struct{} `type:"structure"`
@@ -5312,6 +6285,19 @@ func (s UpdateClientCertificateInput) String() string {
 // GoString returns the string representation
 func (s UpdateClientCertificateInput) GoString() string {
 	return s.String()
+}
+
+// Validate inspects the fields of the type to determine if they are valid.
+func (s *UpdateClientCertificateInput) Validate() error {
+	invalidParams := request.ErrInvalidParams{Context: "UpdateClientCertificateInput"}
+	if s.ClientCertificateId == nil {
+		invalidParams.Add(request.NewErrParamRequired("ClientCertificateId"))
+	}
+
+	if invalidParams.Len() > 0 {
+		return invalidParams
+	}
+	return nil
 }
 
 // Requests Amazon API Gateway to change information about a Deployment resource.
@@ -5341,6 +6327,22 @@ func (s UpdateDeploymentInput) GoString() string {
 	return s.String()
 }
 
+// Validate inspects the fields of the type to determine if they are valid.
+func (s *UpdateDeploymentInput) Validate() error {
+	invalidParams := request.ErrInvalidParams{Context: "UpdateDeploymentInput"}
+	if s.DeploymentId == nil {
+		invalidParams.Add(request.NewErrParamRequired("DeploymentId"))
+	}
+	if s.RestApiId == nil {
+		invalidParams.Add(request.NewErrParamRequired("RestApiId"))
+	}
+
+	if invalidParams.Len() > 0 {
+		return invalidParams
+	}
+	return nil
+}
+
 // A request to change information about the DomainName resource.
 type UpdateDomainNameInput struct {
 	_ struct{} `type:"structure"`
@@ -5361,6 +6363,19 @@ func (s UpdateDomainNameInput) String() string {
 // GoString returns the string representation
 func (s UpdateDomainNameInput) GoString() string {
 	return s.String()
+}
+
+// Validate inspects the fields of the type to determine if they are valid.
+func (s *UpdateDomainNameInput) Validate() error {
+	invalidParams := request.ErrInvalidParams{Context: "UpdateDomainNameInput"}
+	if s.DomainName == nil {
+		invalidParams.Add(request.NewErrParamRequired("DomainName"))
+	}
+
+	if invalidParams.Len() > 0 {
+		return invalidParams
+	}
+	return nil
 }
 
 // Represents an update integration request.
@@ -5389,6 +6404,25 @@ func (s UpdateIntegrationInput) String() string {
 // GoString returns the string representation
 func (s UpdateIntegrationInput) GoString() string {
 	return s.String()
+}
+
+// Validate inspects the fields of the type to determine if they are valid.
+func (s *UpdateIntegrationInput) Validate() error {
+	invalidParams := request.ErrInvalidParams{Context: "UpdateIntegrationInput"}
+	if s.HttpMethod == nil {
+		invalidParams.Add(request.NewErrParamRequired("HttpMethod"))
+	}
+	if s.ResourceId == nil {
+		invalidParams.Add(request.NewErrParamRequired("ResourceId"))
+	}
+	if s.RestApiId == nil {
+		invalidParams.Add(request.NewErrParamRequired("RestApiId"))
+	}
+
+	if invalidParams.Len() > 0 {
+		return invalidParams
+	}
+	return nil
 }
 
 // Represents an update integration response request.
@@ -5422,6 +6456,28 @@ func (s UpdateIntegrationResponseInput) GoString() string {
 	return s.String()
 }
 
+// Validate inspects the fields of the type to determine if they are valid.
+func (s *UpdateIntegrationResponseInput) Validate() error {
+	invalidParams := request.ErrInvalidParams{Context: "UpdateIntegrationResponseInput"}
+	if s.HttpMethod == nil {
+		invalidParams.Add(request.NewErrParamRequired("HttpMethod"))
+	}
+	if s.ResourceId == nil {
+		invalidParams.Add(request.NewErrParamRequired("ResourceId"))
+	}
+	if s.RestApiId == nil {
+		invalidParams.Add(request.NewErrParamRequired("RestApiId"))
+	}
+	if s.StatusCode == nil {
+		invalidParams.Add(request.NewErrParamRequired("StatusCode"))
+	}
+
+	if invalidParams.Len() > 0 {
+		return invalidParams
+	}
+	return nil
+}
+
 // Request to update an existing Method resource.
 type UpdateMethodInput struct {
 	_ struct{} `type:"structure"`
@@ -5448,6 +6504,25 @@ func (s UpdateMethodInput) String() string {
 // GoString returns the string representation
 func (s UpdateMethodInput) GoString() string {
 	return s.String()
+}
+
+// Validate inspects the fields of the type to determine if they are valid.
+func (s *UpdateMethodInput) Validate() error {
+	invalidParams := request.ErrInvalidParams{Context: "UpdateMethodInput"}
+	if s.HttpMethod == nil {
+		invalidParams.Add(request.NewErrParamRequired("HttpMethod"))
+	}
+	if s.ResourceId == nil {
+		invalidParams.Add(request.NewErrParamRequired("ResourceId"))
+	}
+	if s.RestApiId == nil {
+		invalidParams.Add(request.NewErrParamRequired("RestApiId"))
+	}
+
+	if invalidParams.Len() > 0 {
+		return invalidParams
+	}
+	return nil
 }
 
 // A request to update an existing MethodResponse resource.
@@ -5481,6 +6556,28 @@ func (s UpdateMethodResponseInput) GoString() string {
 	return s.String()
 }
 
+// Validate inspects the fields of the type to determine if they are valid.
+func (s *UpdateMethodResponseInput) Validate() error {
+	invalidParams := request.ErrInvalidParams{Context: "UpdateMethodResponseInput"}
+	if s.HttpMethod == nil {
+		invalidParams.Add(request.NewErrParamRequired("HttpMethod"))
+	}
+	if s.ResourceId == nil {
+		invalidParams.Add(request.NewErrParamRequired("ResourceId"))
+	}
+	if s.RestApiId == nil {
+		invalidParams.Add(request.NewErrParamRequired("RestApiId"))
+	}
+	if s.StatusCode == nil {
+		invalidParams.Add(request.NewErrParamRequired("StatusCode"))
+	}
+
+	if invalidParams.Len() > 0 {
+		return invalidParams
+	}
+	return nil
+}
+
 // Request to update an existing model in an existing RestApi resource.
 type UpdateModelInput struct {
 	_ struct{} `type:"structure"`
@@ -5504,6 +6601,22 @@ func (s UpdateModelInput) String() string {
 // GoString returns the string representation
 func (s UpdateModelInput) GoString() string {
 	return s.String()
+}
+
+// Validate inspects the fields of the type to determine if they are valid.
+func (s *UpdateModelInput) Validate() error {
+	invalidParams := request.ErrInvalidParams{Context: "UpdateModelInput"}
+	if s.ModelName == nil {
+		invalidParams.Add(request.NewErrParamRequired("ModelName"))
+	}
+	if s.RestApiId == nil {
+		invalidParams.Add(request.NewErrParamRequired("RestApiId"))
+	}
+
+	if invalidParams.Len() > 0 {
+		return invalidParams
+	}
+	return nil
 }
 
 // Request to change information about a Resource resource.
@@ -5531,6 +6644,22 @@ func (s UpdateResourceInput) GoString() string {
 	return s.String()
 }
 
+// Validate inspects the fields of the type to determine if they are valid.
+func (s *UpdateResourceInput) Validate() error {
+	invalidParams := request.ErrInvalidParams{Context: "UpdateResourceInput"}
+	if s.ResourceId == nil {
+		invalidParams.Add(request.NewErrParamRequired("ResourceId"))
+	}
+	if s.RestApiId == nil {
+		invalidParams.Add(request.NewErrParamRequired("RestApiId"))
+	}
+
+	if invalidParams.Len() > 0 {
+		return invalidParams
+	}
+	return nil
+}
+
 // Request to update an existing RestApi resource in your collection.
 type UpdateRestApiInput struct {
 	_ struct{} `type:"structure"`
@@ -5551,6 +6680,19 @@ func (s UpdateRestApiInput) String() string {
 // GoString returns the string representation
 func (s UpdateRestApiInput) GoString() string {
 	return s.String()
+}
+
+// Validate inspects the fields of the type to determine if they are valid.
+func (s *UpdateRestApiInput) Validate() error {
+	invalidParams := request.ErrInvalidParams{Context: "UpdateRestApiInput"}
+	if s.RestApiId == nil {
+		invalidParams.Add(request.NewErrParamRequired("RestApiId"))
+	}
+
+	if invalidParams.Len() > 0 {
+		return invalidParams
+	}
+	return nil
 }
 
 // Requests Amazon API Gateway to change information about a Stage resource.
@@ -5577,6 +6719,22 @@ func (s UpdateStageInput) String() string {
 // GoString returns the string representation
 func (s UpdateStageInput) GoString() string {
 	return s.String()
+}
+
+// Validate inspects the fields of the type to determine if they are valid.
+func (s *UpdateStageInput) Validate() error {
+	invalidParams := request.ErrInvalidParams{Context: "UpdateStageInput"}
+	if s.RestApiId == nil {
+		invalidParams.Add(request.NewErrParamRequired("RestApiId"))
+	}
+	if s.StageName == nil {
+		invalidParams.Add(request.NewErrParamRequired("StageName"))
+	}
+
+	if invalidParams.Len() > 0 {
+		return invalidParams
+	}
+	return nil
 }
 
 // The authorizer type. Only current value is TOKEN.

--- a/service/autoscaling/api.go
+++ b/service/autoscaling/api.go
@@ -4,6 +4,7 @@
 package autoscaling
 
 import (
+	"fmt"
 	"time"
 
 	"github.com/aws/aws-sdk-go/aws/awsutil"
@@ -1837,6 +1838,22 @@ func (s AttachInstancesInput) GoString() string {
 	return s.String()
 }
 
+// Validate inspects the fields of the type to determine if they are valid.
+func (s *AttachInstancesInput) Validate() error {
+	invalidParams := request.ErrInvalidParams{Context: "AttachInstancesInput"}
+	if s.AutoScalingGroupName == nil {
+		invalidParams.Add(request.NewErrParamRequired("AutoScalingGroupName"))
+	}
+	if s.AutoScalingGroupName != nil && len(*s.AutoScalingGroupName) < 1 {
+		invalidParams.Add(request.NewErrParamMinLen("AutoScalingGroupName", 1))
+	}
+
+	if invalidParams.Len() > 0 {
+		return invalidParams
+	}
+	return nil
+}
+
 type AttachInstancesOutput struct {
 	_ struct{} `type:"structure"`
 }
@@ -1869,6 +1886,19 @@ func (s AttachLoadBalancersInput) String() string {
 // GoString returns the string representation
 func (s AttachLoadBalancersInput) GoString() string {
 	return s.String()
+}
+
+// Validate inspects the fields of the type to determine if they are valid.
+func (s *AttachLoadBalancersInput) Validate() error {
+	invalidParams := request.ErrInvalidParams{Context: "AttachLoadBalancersInput"}
+	if s.AutoScalingGroupName != nil && len(*s.AutoScalingGroupName) < 1 {
+		invalidParams.Add(request.NewErrParamMinLen("AutoScalingGroupName", 1))
+	}
+
+	if invalidParams.Len() > 0 {
+		return invalidParams
+	}
+	return nil
 }
 
 type AttachLoadBalancersOutput struct {
@@ -1916,6 +1946,30 @@ func (s BlockDeviceMapping) GoString() string {
 	return s.String()
 }
 
+// Validate inspects the fields of the type to determine if they are valid.
+func (s *BlockDeviceMapping) Validate() error {
+	invalidParams := request.ErrInvalidParams{Context: "BlockDeviceMapping"}
+	if s.DeviceName == nil {
+		invalidParams.Add(request.NewErrParamRequired("DeviceName"))
+	}
+	if s.DeviceName != nil && len(*s.DeviceName) < 1 {
+		invalidParams.Add(request.NewErrParamMinLen("DeviceName", 1))
+	}
+	if s.VirtualName != nil && len(*s.VirtualName) < 1 {
+		invalidParams.Add(request.NewErrParamMinLen("VirtualName", 1))
+	}
+	if s.Ebs != nil {
+		if err := s.Ebs.Validate(); err != nil {
+			invalidParams.AddNested("Ebs", err.(request.ErrInvalidParams))
+		}
+	}
+
+	if invalidParams.Len() > 0 {
+		return invalidParams
+	}
+	return nil
+}
+
 type CompleteLifecycleActionInput struct {
 	_ struct{} `type:"structure"`
 
@@ -1946,6 +2000,37 @@ func (s CompleteLifecycleActionInput) String() string {
 // GoString returns the string representation
 func (s CompleteLifecycleActionInput) GoString() string {
 	return s.String()
+}
+
+// Validate inspects the fields of the type to determine if they are valid.
+func (s *CompleteLifecycleActionInput) Validate() error {
+	invalidParams := request.ErrInvalidParams{Context: "CompleteLifecycleActionInput"}
+	if s.AutoScalingGroupName == nil {
+		invalidParams.Add(request.NewErrParamRequired("AutoScalingGroupName"))
+	}
+	if s.AutoScalingGroupName != nil && len(*s.AutoScalingGroupName) < 1 {
+		invalidParams.Add(request.NewErrParamMinLen("AutoScalingGroupName", 1))
+	}
+	if s.InstanceId != nil && len(*s.InstanceId) < 1 {
+		invalidParams.Add(request.NewErrParamMinLen("InstanceId", 1))
+	}
+	if s.LifecycleActionResult == nil {
+		invalidParams.Add(request.NewErrParamRequired("LifecycleActionResult"))
+	}
+	if s.LifecycleActionToken != nil && len(*s.LifecycleActionToken) < 36 {
+		invalidParams.Add(request.NewErrParamMinLen("LifecycleActionToken", 36))
+	}
+	if s.LifecycleHookName == nil {
+		invalidParams.Add(request.NewErrParamRequired("LifecycleHookName"))
+	}
+	if s.LifecycleHookName != nil && len(*s.LifecycleHookName) < 1 {
+		invalidParams.Add(request.NewErrParamMinLen("LifecycleHookName", 1))
+	}
+
+	if invalidParams.Len() > 0 {
+		return invalidParams
+	}
+	return nil
 }
 
 type CompleteLifecycleActionOutput struct {
@@ -2075,6 +2160,56 @@ func (s CreateAutoScalingGroupInput) String() string {
 // GoString returns the string representation
 func (s CreateAutoScalingGroupInput) GoString() string {
 	return s.String()
+}
+
+// Validate inspects the fields of the type to determine if they are valid.
+func (s *CreateAutoScalingGroupInput) Validate() error {
+	invalidParams := request.ErrInvalidParams{Context: "CreateAutoScalingGroupInput"}
+	if s.AutoScalingGroupName == nil {
+		invalidParams.Add(request.NewErrParamRequired("AutoScalingGroupName"))
+	}
+	if s.AutoScalingGroupName != nil && len(*s.AutoScalingGroupName) < 1 {
+		invalidParams.Add(request.NewErrParamMinLen("AutoScalingGroupName", 1))
+	}
+	if s.AvailabilityZones != nil && len(s.AvailabilityZones) < 1 {
+		invalidParams.Add(request.NewErrParamMinLen("AvailabilityZones", 1))
+	}
+	if s.HealthCheckType != nil && len(*s.HealthCheckType) < 1 {
+		invalidParams.Add(request.NewErrParamMinLen("HealthCheckType", 1))
+	}
+	if s.InstanceId != nil && len(*s.InstanceId) < 1 {
+		invalidParams.Add(request.NewErrParamMinLen("InstanceId", 1))
+	}
+	if s.LaunchConfigurationName != nil && len(*s.LaunchConfigurationName) < 1 {
+		invalidParams.Add(request.NewErrParamMinLen("LaunchConfigurationName", 1))
+	}
+	if s.MaxSize == nil {
+		invalidParams.Add(request.NewErrParamRequired("MaxSize"))
+	}
+	if s.MinSize == nil {
+		invalidParams.Add(request.NewErrParamRequired("MinSize"))
+	}
+	if s.PlacementGroup != nil && len(*s.PlacementGroup) < 1 {
+		invalidParams.Add(request.NewErrParamMinLen("PlacementGroup", 1))
+	}
+	if s.VPCZoneIdentifier != nil && len(*s.VPCZoneIdentifier) < 1 {
+		invalidParams.Add(request.NewErrParamMinLen("VPCZoneIdentifier", 1))
+	}
+	if s.Tags != nil {
+		for i, v := range s.Tags {
+			if v == nil {
+				continue
+			}
+			if err := v.Validate(); err != nil {
+				invalidParams.AddNested(fmt.Sprintf("%s[%v]", "Tags", i), err.(request.ErrInvalidParams))
+			}
+		}
+	}
+
+	if invalidParams.Len() > 0 {
+		return invalidParams
+	}
+	return nil
 }
 
 type CreateAutoScalingGroupOutput struct {
@@ -2245,6 +2380,62 @@ func (s CreateLaunchConfigurationInput) GoString() string {
 	return s.String()
 }
 
+// Validate inspects the fields of the type to determine if they are valid.
+func (s *CreateLaunchConfigurationInput) Validate() error {
+	invalidParams := request.ErrInvalidParams{Context: "CreateLaunchConfigurationInput"}
+	if s.ClassicLinkVPCId != nil && len(*s.ClassicLinkVPCId) < 1 {
+		invalidParams.Add(request.NewErrParamMinLen("ClassicLinkVPCId", 1))
+	}
+	if s.IamInstanceProfile != nil && len(*s.IamInstanceProfile) < 1 {
+		invalidParams.Add(request.NewErrParamMinLen("IamInstanceProfile", 1))
+	}
+	if s.ImageId != nil && len(*s.ImageId) < 1 {
+		invalidParams.Add(request.NewErrParamMinLen("ImageId", 1))
+	}
+	if s.InstanceId != nil && len(*s.InstanceId) < 1 {
+		invalidParams.Add(request.NewErrParamMinLen("InstanceId", 1))
+	}
+	if s.InstanceType != nil && len(*s.InstanceType) < 1 {
+		invalidParams.Add(request.NewErrParamMinLen("InstanceType", 1))
+	}
+	if s.KernelId != nil && len(*s.KernelId) < 1 {
+		invalidParams.Add(request.NewErrParamMinLen("KernelId", 1))
+	}
+	if s.KeyName != nil && len(*s.KeyName) < 1 {
+		invalidParams.Add(request.NewErrParamMinLen("KeyName", 1))
+	}
+	if s.LaunchConfigurationName == nil {
+		invalidParams.Add(request.NewErrParamRequired("LaunchConfigurationName"))
+	}
+	if s.LaunchConfigurationName != nil && len(*s.LaunchConfigurationName) < 1 {
+		invalidParams.Add(request.NewErrParamMinLen("LaunchConfigurationName", 1))
+	}
+	if s.PlacementTenancy != nil && len(*s.PlacementTenancy) < 1 {
+		invalidParams.Add(request.NewErrParamMinLen("PlacementTenancy", 1))
+	}
+	if s.RamdiskId != nil && len(*s.RamdiskId) < 1 {
+		invalidParams.Add(request.NewErrParamMinLen("RamdiskId", 1))
+	}
+	if s.SpotPrice != nil && len(*s.SpotPrice) < 1 {
+		invalidParams.Add(request.NewErrParamMinLen("SpotPrice", 1))
+	}
+	if s.BlockDeviceMappings != nil {
+		for i, v := range s.BlockDeviceMappings {
+			if v == nil {
+				continue
+			}
+			if err := v.Validate(); err != nil {
+				invalidParams.AddNested(fmt.Sprintf("%s[%v]", "BlockDeviceMappings", i), err.(request.ErrInvalidParams))
+			}
+		}
+	}
+
+	if invalidParams.Len() > 0 {
+		return invalidParams
+	}
+	return nil
+}
+
 type CreateLaunchConfigurationOutput struct {
 	_ struct{} `type:"structure"`
 }
@@ -2274,6 +2465,29 @@ func (s CreateOrUpdateTagsInput) String() string {
 // GoString returns the string representation
 func (s CreateOrUpdateTagsInput) GoString() string {
 	return s.String()
+}
+
+// Validate inspects the fields of the type to determine if they are valid.
+func (s *CreateOrUpdateTagsInput) Validate() error {
+	invalidParams := request.ErrInvalidParams{Context: "CreateOrUpdateTagsInput"}
+	if s.Tags == nil {
+		invalidParams.Add(request.NewErrParamRequired("Tags"))
+	}
+	if s.Tags != nil {
+		for i, v := range s.Tags {
+			if v == nil {
+				continue
+			}
+			if err := v.Validate(); err != nil {
+				invalidParams.AddNested(fmt.Sprintf("%s[%v]", "Tags", i), err.(request.ErrInvalidParams))
+			}
+		}
+	}
+
+	if invalidParams.Len() > 0 {
+		return invalidParams
+	}
+	return nil
 }
 
 type CreateOrUpdateTagsOutput struct {
@@ -2312,6 +2526,22 @@ func (s DeleteAutoScalingGroupInput) GoString() string {
 	return s.String()
 }
 
+// Validate inspects the fields of the type to determine if they are valid.
+func (s *DeleteAutoScalingGroupInput) Validate() error {
+	invalidParams := request.ErrInvalidParams{Context: "DeleteAutoScalingGroupInput"}
+	if s.AutoScalingGroupName == nil {
+		invalidParams.Add(request.NewErrParamRequired("AutoScalingGroupName"))
+	}
+	if s.AutoScalingGroupName != nil && len(*s.AutoScalingGroupName) < 1 {
+		invalidParams.Add(request.NewErrParamMinLen("AutoScalingGroupName", 1))
+	}
+
+	if invalidParams.Len() > 0 {
+		return invalidParams
+	}
+	return nil
+}
+
 type DeleteAutoScalingGroupOutput struct {
 	_ struct{} `type:"structure"`
 }
@@ -2341,6 +2571,22 @@ func (s DeleteLaunchConfigurationInput) String() string {
 // GoString returns the string representation
 func (s DeleteLaunchConfigurationInput) GoString() string {
 	return s.String()
+}
+
+// Validate inspects the fields of the type to determine if they are valid.
+func (s *DeleteLaunchConfigurationInput) Validate() error {
+	invalidParams := request.ErrInvalidParams{Context: "DeleteLaunchConfigurationInput"}
+	if s.LaunchConfigurationName == nil {
+		invalidParams.Add(request.NewErrParamRequired("LaunchConfigurationName"))
+	}
+	if s.LaunchConfigurationName != nil && len(*s.LaunchConfigurationName) < 1 {
+		invalidParams.Add(request.NewErrParamMinLen("LaunchConfigurationName", 1))
+	}
+
+	if invalidParams.Len() > 0 {
+		return invalidParams
+	}
+	return nil
 }
 
 type DeleteLaunchConfigurationOutput struct {
@@ -2375,6 +2621,28 @@ func (s DeleteLifecycleHookInput) String() string {
 // GoString returns the string representation
 func (s DeleteLifecycleHookInput) GoString() string {
 	return s.String()
+}
+
+// Validate inspects the fields of the type to determine if they are valid.
+func (s *DeleteLifecycleHookInput) Validate() error {
+	invalidParams := request.ErrInvalidParams{Context: "DeleteLifecycleHookInput"}
+	if s.AutoScalingGroupName == nil {
+		invalidParams.Add(request.NewErrParamRequired("AutoScalingGroupName"))
+	}
+	if s.AutoScalingGroupName != nil && len(*s.AutoScalingGroupName) < 1 {
+		invalidParams.Add(request.NewErrParamMinLen("AutoScalingGroupName", 1))
+	}
+	if s.LifecycleHookName == nil {
+		invalidParams.Add(request.NewErrParamRequired("LifecycleHookName"))
+	}
+	if s.LifecycleHookName != nil && len(*s.LifecycleHookName) < 1 {
+		invalidParams.Add(request.NewErrParamMinLen("LifecycleHookName", 1))
+	}
+
+	if invalidParams.Len() > 0 {
+		return invalidParams
+	}
+	return nil
 }
 
 type DeleteLifecycleHookOutput struct {
@@ -2412,6 +2680,28 @@ func (s DeleteNotificationConfigurationInput) GoString() string {
 	return s.String()
 }
 
+// Validate inspects the fields of the type to determine if they are valid.
+func (s *DeleteNotificationConfigurationInput) Validate() error {
+	invalidParams := request.ErrInvalidParams{Context: "DeleteNotificationConfigurationInput"}
+	if s.AutoScalingGroupName == nil {
+		invalidParams.Add(request.NewErrParamRequired("AutoScalingGroupName"))
+	}
+	if s.AutoScalingGroupName != nil && len(*s.AutoScalingGroupName) < 1 {
+		invalidParams.Add(request.NewErrParamMinLen("AutoScalingGroupName", 1))
+	}
+	if s.TopicARN == nil {
+		invalidParams.Add(request.NewErrParamRequired("TopicARN"))
+	}
+	if s.TopicARN != nil && len(*s.TopicARN) < 1 {
+		invalidParams.Add(request.NewErrParamMinLen("TopicARN", 1))
+	}
+
+	if invalidParams.Len() > 0 {
+		return invalidParams
+	}
+	return nil
+}
+
 type DeleteNotificationConfigurationOutput struct {
 	_ struct{} `type:"structure"`
 }
@@ -2444,6 +2734,25 @@ func (s DeletePolicyInput) String() string {
 // GoString returns the string representation
 func (s DeletePolicyInput) GoString() string {
 	return s.String()
+}
+
+// Validate inspects the fields of the type to determine if they are valid.
+func (s *DeletePolicyInput) Validate() error {
+	invalidParams := request.ErrInvalidParams{Context: "DeletePolicyInput"}
+	if s.AutoScalingGroupName != nil && len(*s.AutoScalingGroupName) < 1 {
+		invalidParams.Add(request.NewErrParamMinLen("AutoScalingGroupName", 1))
+	}
+	if s.PolicyName == nil {
+		invalidParams.Add(request.NewErrParamRequired("PolicyName"))
+	}
+	if s.PolicyName != nil && len(*s.PolicyName) < 1 {
+		invalidParams.Add(request.NewErrParamMinLen("PolicyName", 1))
+	}
+
+	if invalidParams.Len() > 0 {
+		return invalidParams
+	}
+	return nil
 }
 
 type DeletePolicyOutput struct {
@@ -2480,6 +2789,25 @@ func (s DeleteScheduledActionInput) GoString() string {
 	return s.String()
 }
 
+// Validate inspects the fields of the type to determine if they are valid.
+func (s *DeleteScheduledActionInput) Validate() error {
+	invalidParams := request.ErrInvalidParams{Context: "DeleteScheduledActionInput"}
+	if s.AutoScalingGroupName != nil && len(*s.AutoScalingGroupName) < 1 {
+		invalidParams.Add(request.NewErrParamMinLen("AutoScalingGroupName", 1))
+	}
+	if s.ScheduledActionName == nil {
+		invalidParams.Add(request.NewErrParamRequired("ScheduledActionName"))
+	}
+	if s.ScheduledActionName != nil && len(*s.ScheduledActionName) < 1 {
+		invalidParams.Add(request.NewErrParamMinLen("ScheduledActionName", 1))
+	}
+
+	if invalidParams.Len() > 0 {
+		return invalidParams
+	}
+	return nil
+}
+
 type DeleteScheduledActionOutput struct {
 	_ struct{} `type:"structure"`
 }
@@ -2509,6 +2837,29 @@ func (s DeleteTagsInput) String() string {
 // GoString returns the string representation
 func (s DeleteTagsInput) GoString() string {
 	return s.String()
+}
+
+// Validate inspects the fields of the type to determine if they are valid.
+func (s *DeleteTagsInput) Validate() error {
+	invalidParams := request.ErrInvalidParams{Context: "DeleteTagsInput"}
+	if s.Tags == nil {
+		invalidParams.Add(request.NewErrParamRequired("Tags"))
+	}
+	if s.Tags != nil {
+		for i, v := range s.Tags {
+			if v == nil {
+				continue
+			}
+			if err := v.Validate(); err != nil {
+				invalidParams.AddNested(fmt.Sprintf("%s[%v]", "Tags", i), err.(request.ErrInvalidParams))
+			}
+		}
+	}
+
+	if invalidParams.Len() > 0 {
+		return invalidParams
+	}
+	return nil
 }
 
 type DeleteTagsOutput struct {
@@ -2831,6 +3182,22 @@ func (s DescribeLifecycleHooksInput) GoString() string {
 	return s.String()
 }
 
+// Validate inspects the fields of the type to determine if they are valid.
+func (s *DescribeLifecycleHooksInput) Validate() error {
+	invalidParams := request.ErrInvalidParams{Context: "DescribeLifecycleHooksInput"}
+	if s.AutoScalingGroupName == nil {
+		invalidParams.Add(request.NewErrParamRequired("AutoScalingGroupName"))
+	}
+	if s.AutoScalingGroupName != nil && len(*s.AutoScalingGroupName) < 1 {
+		invalidParams.Add(request.NewErrParamMinLen("AutoScalingGroupName", 1))
+	}
+
+	if invalidParams.Len() > 0 {
+		return invalidParams
+	}
+	return nil
+}
+
 type DescribeLifecycleHooksOutput struct {
 	_ struct{} `type:"structure"`
 
@@ -2870,6 +3237,22 @@ func (s DescribeLoadBalancersInput) String() string {
 // GoString returns the string representation
 func (s DescribeLoadBalancersInput) GoString() string {
 	return s.String()
+}
+
+// Validate inspects the fields of the type to determine if they are valid.
+func (s *DescribeLoadBalancersInput) Validate() error {
+	invalidParams := request.ErrInvalidParams{Context: "DescribeLoadBalancersInput"}
+	if s.AutoScalingGroupName == nil {
+		invalidParams.Add(request.NewErrParamRequired("AutoScalingGroupName"))
+	}
+	if s.AutoScalingGroupName != nil && len(*s.AutoScalingGroupName) < 1 {
+		invalidParams.Add(request.NewErrParamMinLen("AutoScalingGroupName", 1))
+	}
+
+	if invalidParams.Len() > 0 {
+		return invalidParams
+	}
+	return nil
 }
 
 type DescribeLoadBalancersOutput struct {
@@ -3005,6 +3388,19 @@ func (s DescribePoliciesInput) GoString() string {
 	return s.String()
 }
 
+// Validate inspects the fields of the type to determine if they are valid.
+func (s *DescribePoliciesInput) Validate() error {
+	invalidParams := request.ErrInvalidParams{Context: "DescribePoliciesInput"}
+	if s.AutoScalingGroupName != nil && len(*s.AutoScalingGroupName) < 1 {
+		invalidParams.Add(request.NewErrParamMinLen("AutoScalingGroupName", 1))
+	}
+
+	if invalidParams.Len() > 0 {
+		return invalidParams
+	}
+	return nil
+}
+
 type DescribePoliciesOutput struct {
 	_ struct{} `type:"structure"`
 
@@ -3055,6 +3451,19 @@ func (s DescribeScalingActivitiesInput) String() string {
 // GoString returns the string representation
 func (s DescribeScalingActivitiesInput) GoString() string {
 	return s.String()
+}
+
+// Validate inspects the fields of the type to determine if they are valid.
+func (s *DescribeScalingActivitiesInput) Validate() error {
+	invalidParams := request.ErrInvalidParams{Context: "DescribeScalingActivitiesInput"}
+	if s.AutoScalingGroupName != nil && len(*s.AutoScalingGroupName) < 1 {
+		invalidParams.Add(request.NewErrParamMinLen("AutoScalingGroupName", 1))
+	}
+
+	if invalidParams.Len() > 0 {
+		return invalidParams
+	}
+	return nil
 }
 
 type DescribeScalingActivitiesOutput struct {
@@ -3148,6 +3557,19 @@ func (s DescribeScheduledActionsInput) String() string {
 // GoString returns the string representation
 func (s DescribeScheduledActionsInput) GoString() string {
 	return s.String()
+}
+
+// Validate inspects the fields of the type to determine if they are valid.
+func (s *DescribeScheduledActionsInput) Validate() error {
+	invalidParams := request.ErrInvalidParams{Context: "DescribeScheduledActionsInput"}
+	if s.AutoScalingGroupName != nil && len(*s.AutoScalingGroupName) < 1 {
+		invalidParams.Add(request.NewErrParamMinLen("AutoScalingGroupName", 1))
+	}
+
+	if invalidParams.Len() > 0 {
+		return invalidParams
+	}
+	return nil
 }
 
 type DescribeScheduledActionsOutput struct {
@@ -3272,6 +3694,25 @@ func (s DetachInstancesInput) GoString() string {
 	return s.String()
 }
 
+// Validate inspects the fields of the type to determine if they are valid.
+func (s *DetachInstancesInput) Validate() error {
+	invalidParams := request.ErrInvalidParams{Context: "DetachInstancesInput"}
+	if s.AutoScalingGroupName == nil {
+		invalidParams.Add(request.NewErrParamRequired("AutoScalingGroupName"))
+	}
+	if s.AutoScalingGroupName != nil && len(*s.AutoScalingGroupName) < 1 {
+		invalidParams.Add(request.NewErrParamMinLen("AutoScalingGroupName", 1))
+	}
+	if s.ShouldDecrementDesiredCapacity == nil {
+		invalidParams.Add(request.NewErrParamRequired("ShouldDecrementDesiredCapacity"))
+	}
+
+	if invalidParams.Len() > 0 {
+		return invalidParams
+	}
+	return nil
+}
+
 type DetachInstancesOutput struct {
 	_ struct{} `type:"structure"`
 
@@ -3307,6 +3748,19 @@ func (s DetachLoadBalancersInput) String() string {
 // GoString returns the string representation
 func (s DetachLoadBalancersInput) GoString() string {
 	return s.String()
+}
+
+// Validate inspects the fields of the type to determine if they are valid.
+func (s *DetachLoadBalancersInput) Validate() error {
+	invalidParams := request.ErrInvalidParams{Context: "DetachLoadBalancersInput"}
+	if s.AutoScalingGroupName != nil && len(*s.AutoScalingGroupName) < 1 {
+		invalidParams.Add(request.NewErrParamMinLen("AutoScalingGroupName", 1))
+	}
+
+	if invalidParams.Len() > 0 {
+		return invalidParams
+	}
+	return nil
 }
 
 type DetachLoadBalancersOutput struct {
@@ -3358,6 +3812,22 @@ func (s DisableMetricsCollectionInput) String() string {
 // GoString returns the string representation
 func (s DisableMetricsCollectionInput) GoString() string {
 	return s.String()
+}
+
+// Validate inspects the fields of the type to determine if they are valid.
+func (s *DisableMetricsCollectionInput) Validate() error {
+	invalidParams := request.ErrInvalidParams{Context: "DisableMetricsCollectionInput"}
+	if s.AutoScalingGroupName == nil {
+		invalidParams.Add(request.NewErrParamRequired("AutoScalingGroupName"))
+	}
+	if s.AutoScalingGroupName != nil && len(*s.AutoScalingGroupName) < 1 {
+		invalidParams.Add(request.NewErrParamMinLen("AutoScalingGroupName", 1))
+	}
+
+	if invalidParams.Len() > 0 {
+		return invalidParams
+	}
+	return nil
 }
 
 type DisableMetricsCollectionOutput struct {
@@ -3428,6 +3898,28 @@ func (s Ebs) GoString() string {
 	return s.String()
 }
 
+// Validate inspects the fields of the type to determine if they are valid.
+func (s *Ebs) Validate() error {
+	invalidParams := request.ErrInvalidParams{Context: "Ebs"}
+	if s.Iops != nil && *s.Iops < 100 {
+		invalidParams.Add(request.NewErrParamMinValue("Iops", 100))
+	}
+	if s.SnapshotId != nil && len(*s.SnapshotId) < 1 {
+		invalidParams.Add(request.NewErrParamMinLen("SnapshotId", 1))
+	}
+	if s.VolumeSize != nil && *s.VolumeSize < 1 {
+		invalidParams.Add(request.NewErrParamMinValue("VolumeSize", 1))
+	}
+	if s.VolumeType != nil && len(*s.VolumeType) < 1 {
+		invalidParams.Add(request.NewErrParamMinLen("VolumeType", 1))
+	}
+
+	if invalidParams.Len() > 0 {
+		return invalidParams
+	}
+	return nil
+}
+
 type EnableMetricsCollectionInput struct {
 	_ struct{} `type:"structure"`
 
@@ -3470,6 +3962,28 @@ func (s EnableMetricsCollectionInput) String() string {
 // GoString returns the string representation
 func (s EnableMetricsCollectionInput) GoString() string {
 	return s.String()
+}
+
+// Validate inspects the fields of the type to determine if they are valid.
+func (s *EnableMetricsCollectionInput) Validate() error {
+	invalidParams := request.ErrInvalidParams{Context: "EnableMetricsCollectionInput"}
+	if s.AutoScalingGroupName == nil {
+		invalidParams.Add(request.NewErrParamRequired("AutoScalingGroupName"))
+	}
+	if s.AutoScalingGroupName != nil && len(*s.AutoScalingGroupName) < 1 {
+		invalidParams.Add(request.NewErrParamMinLen("AutoScalingGroupName", 1))
+	}
+	if s.Granularity == nil {
+		invalidParams.Add(request.NewErrParamRequired("Granularity"))
+	}
+	if s.Granularity != nil && len(*s.Granularity) < 1 {
+		invalidParams.Add(request.NewErrParamMinLen("Granularity", 1))
+	}
+
+	if invalidParams.Len() > 0 {
+		return invalidParams
+	}
+	return nil
 }
 
 type EnableMetricsCollectionOutput struct {
@@ -3550,6 +4064,25 @@ func (s EnterStandbyInput) GoString() string {
 	return s.String()
 }
 
+// Validate inspects the fields of the type to determine if they are valid.
+func (s *EnterStandbyInput) Validate() error {
+	invalidParams := request.ErrInvalidParams{Context: "EnterStandbyInput"}
+	if s.AutoScalingGroupName == nil {
+		invalidParams.Add(request.NewErrParamRequired("AutoScalingGroupName"))
+	}
+	if s.AutoScalingGroupName != nil && len(*s.AutoScalingGroupName) < 1 {
+		invalidParams.Add(request.NewErrParamMinLen("AutoScalingGroupName", 1))
+	}
+	if s.ShouldDecrementDesiredCapacity == nil {
+		invalidParams.Add(request.NewErrParamRequired("ShouldDecrementDesiredCapacity"))
+	}
+
+	if invalidParams.Len() > 0 {
+		return invalidParams
+	}
+	return nil
+}
+
 type EnterStandbyOutput struct {
 	_ struct{} `type:"structure"`
 
@@ -3616,6 +4149,25 @@ func (s ExecutePolicyInput) GoString() string {
 	return s.String()
 }
 
+// Validate inspects the fields of the type to determine if they are valid.
+func (s *ExecutePolicyInput) Validate() error {
+	invalidParams := request.ErrInvalidParams{Context: "ExecutePolicyInput"}
+	if s.AutoScalingGroupName != nil && len(*s.AutoScalingGroupName) < 1 {
+		invalidParams.Add(request.NewErrParamMinLen("AutoScalingGroupName", 1))
+	}
+	if s.PolicyName == nil {
+		invalidParams.Add(request.NewErrParamRequired("PolicyName"))
+	}
+	if s.PolicyName != nil && len(*s.PolicyName) < 1 {
+		invalidParams.Add(request.NewErrParamMinLen("PolicyName", 1))
+	}
+
+	if invalidParams.Len() > 0 {
+		return invalidParams
+	}
+	return nil
+}
+
 type ExecutePolicyOutput struct {
 	_ struct{} `type:"structure"`
 }
@@ -3648,6 +4200,22 @@ func (s ExitStandbyInput) String() string {
 // GoString returns the string representation
 func (s ExitStandbyInput) GoString() string {
 	return s.String()
+}
+
+// Validate inspects the fields of the type to determine if they are valid.
+func (s *ExitStandbyInput) Validate() error {
+	invalidParams := request.ErrInvalidParams{Context: "ExitStandbyInput"}
+	if s.AutoScalingGroupName == nil {
+		invalidParams.Add(request.NewErrParamRequired("AutoScalingGroupName"))
+	}
+	if s.AutoScalingGroupName != nil && len(*s.AutoScalingGroupName) < 1 {
+		invalidParams.Add(request.NewErrParamMinLen("AutoScalingGroupName", 1))
+	}
+
+	if invalidParams.Len() > 0 {
+		return invalidParams
+	}
+	return nil
 }
 
 type ExitStandbyOutput struct {
@@ -4242,6 +4810,34 @@ func (s PutLifecycleHookInput) GoString() string {
 	return s.String()
 }
 
+// Validate inspects the fields of the type to determine if they are valid.
+func (s *PutLifecycleHookInput) Validate() error {
+	invalidParams := request.ErrInvalidParams{Context: "PutLifecycleHookInput"}
+	if s.AutoScalingGroupName == nil {
+		invalidParams.Add(request.NewErrParamRequired("AutoScalingGroupName"))
+	}
+	if s.AutoScalingGroupName != nil && len(*s.AutoScalingGroupName) < 1 {
+		invalidParams.Add(request.NewErrParamMinLen("AutoScalingGroupName", 1))
+	}
+	if s.LifecycleHookName == nil {
+		invalidParams.Add(request.NewErrParamRequired("LifecycleHookName"))
+	}
+	if s.LifecycleHookName != nil && len(*s.LifecycleHookName) < 1 {
+		invalidParams.Add(request.NewErrParamMinLen("LifecycleHookName", 1))
+	}
+	if s.NotificationMetadata != nil && len(*s.NotificationMetadata) < 1 {
+		invalidParams.Add(request.NewErrParamMinLen("NotificationMetadata", 1))
+	}
+	if s.RoleARN != nil && len(*s.RoleARN) < 1 {
+		invalidParams.Add(request.NewErrParamMinLen("RoleARN", 1))
+	}
+
+	if invalidParams.Len() > 0 {
+		return invalidParams
+	}
+	return nil
+}
+
 type PutLifecycleHookOutput struct {
 	_ struct{} `type:"structure"`
 }
@@ -4279,6 +4875,31 @@ func (s PutNotificationConfigurationInput) String() string {
 // GoString returns the string representation
 func (s PutNotificationConfigurationInput) GoString() string {
 	return s.String()
+}
+
+// Validate inspects the fields of the type to determine if they are valid.
+func (s *PutNotificationConfigurationInput) Validate() error {
+	invalidParams := request.ErrInvalidParams{Context: "PutNotificationConfigurationInput"}
+	if s.AutoScalingGroupName == nil {
+		invalidParams.Add(request.NewErrParamRequired("AutoScalingGroupName"))
+	}
+	if s.AutoScalingGroupName != nil && len(*s.AutoScalingGroupName) < 1 {
+		invalidParams.Add(request.NewErrParamMinLen("AutoScalingGroupName", 1))
+	}
+	if s.NotificationTypes == nil {
+		invalidParams.Add(request.NewErrParamRequired("NotificationTypes"))
+	}
+	if s.TopicARN == nil {
+		invalidParams.Add(request.NewErrParamRequired("TopicARN"))
+	}
+	if s.TopicARN != nil && len(*s.TopicARN) < 1 {
+		invalidParams.Add(request.NewErrParamMinLen("TopicARN", 1))
+	}
+
+	if invalidParams.Len() > 0 {
+		return invalidParams
+	}
+	return nil
 }
 
 type PutNotificationConfigurationOutput struct {
@@ -4374,6 +4995,50 @@ func (s PutScalingPolicyInput) GoString() string {
 	return s.String()
 }
 
+// Validate inspects the fields of the type to determine if they are valid.
+func (s *PutScalingPolicyInput) Validate() error {
+	invalidParams := request.ErrInvalidParams{Context: "PutScalingPolicyInput"}
+	if s.AdjustmentType == nil {
+		invalidParams.Add(request.NewErrParamRequired("AdjustmentType"))
+	}
+	if s.AdjustmentType != nil && len(*s.AdjustmentType) < 1 {
+		invalidParams.Add(request.NewErrParamMinLen("AdjustmentType", 1))
+	}
+	if s.AutoScalingGroupName == nil {
+		invalidParams.Add(request.NewErrParamRequired("AutoScalingGroupName"))
+	}
+	if s.AutoScalingGroupName != nil && len(*s.AutoScalingGroupName) < 1 {
+		invalidParams.Add(request.NewErrParamMinLen("AutoScalingGroupName", 1))
+	}
+	if s.MetricAggregationType != nil && len(*s.MetricAggregationType) < 1 {
+		invalidParams.Add(request.NewErrParamMinLen("MetricAggregationType", 1))
+	}
+	if s.PolicyName == nil {
+		invalidParams.Add(request.NewErrParamRequired("PolicyName"))
+	}
+	if s.PolicyName != nil && len(*s.PolicyName) < 1 {
+		invalidParams.Add(request.NewErrParamMinLen("PolicyName", 1))
+	}
+	if s.PolicyType != nil && len(*s.PolicyType) < 1 {
+		invalidParams.Add(request.NewErrParamMinLen("PolicyType", 1))
+	}
+	if s.StepAdjustments != nil {
+		for i, v := range s.StepAdjustments {
+			if v == nil {
+				continue
+			}
+			if err := v.Validate(); err != nil {
+				invalidParams.AddNested(fmt.Sprintf("%s[%v]", "StepAdjustments", i), err.(request.ErrInvalidParams))
+			}
+		}
+	}
+
+	if invalidParams.Len() > 0 {
+		return invalidParams
+	}
+	return nil
+}
+
 type PutScalingPolicyOutput struct {
 	_ struct{} `type:"structure"`
 
@@ -4444,6 +5109,31 @@ func (s PutScheduledUpdateGroupActionInput) GoString() string {
 	return s.String()
 }
 
+// Validate inspects the fields of the type to determine if they are valid.
+func (s *PutScheduledUpdateGroupActionInput) Validate() error {
+	invalidParams := request.ErrInvalidParams{Context: "PutScheduledUpdateGroupActionInput"}
+	if s.AutoScalingGroupName == nil {
+		invalidParams.Add(request.NewErrParamRequired("AutoScalingGroupName"))
+	}
+	if s.AutoScalingGroupName != nil && len(*s.AutoScalingGroupName) < 1 {
+		invalidParams.Add(request.NewErrParamMinLen("AutoScalingGroupName", 1))
+	}
+	if s.Recurrence != nil && len(*s.Recurrence) < 1 {
+		invalidParams.Add(request.NewErrParamMinLen("Recurrence", 1))
+	}
+	if s.ScheduledActionName == nil {
+		invalidParams.Add(request.NewErrParamRequired("ScheduledActionName"))
+	}
+	if s.ScheduledActionName != nil && len(*s.ScheduledActionName) < 1 {
+		invalidParams.Add(request.NewErrParamMinLen("ScheduledActionName", 1))
+	}
+
+	if invalidParams.Len() > 0 {
+		return invalidParams
+	}
+	return nil
+}
+
 type PutScheduledUpdateGroupActionOutput struct {
 	_ struct{} `type:"structure"`
 }
@@ -4484,6 +5174,34 @@ func (s RecordLifecycleActionHeartbeatInput) String() string {
 // GoString returns the string representation
 func (s RecordLifecycleActionHeartbeatInput) GoString() string {
 	return s.String()
+}
+
+// Validate inspects the fields of the type to determine if they are valid.
+func (s *RecordLifecycleActionHeartbeatInput) Validate() error {
+	invalidParams := request.ErrInvalidParams{Context: "RecordLifecycleActionHeartbeatInput"}
+	if s.AutoScalingGroupName == nil {
+		invalidParams.Add(request.NewErrParamRequired("AutoScalingGroupName"))
+	}
+	if s.AutoScalingGroupName != nil && len(*s.AutoScalingGroupName) < 1 {
+		invalidParams.Add(request.NewErrParamMinLen("AutoScalingGroupName", 1))
+	}
+	if s.InstanceId != nil && len(*s.InstanceId) < 1 {
+		invalidParams.Add(request.NewErrParamMinLen("InstanceId", 1))
+	}
+	if s.LifecycleActionToken != nil && len(*s.LifecycleActionToken) < 36 {
+		invalidParams.Add(request.NewErrParamMinLen("LifecycleActionToken", 36))
+	}
+	if s.LifecycleHookName == nil {
+		invalidParams.Add(request.NewErrParamRequired("LifecycleHookName"))
+	}
+	if s.LifecycleHookName != nil && len(*s.LifecycleHookName) < 1 {
+		invalidParams.Add(request.NewErrParamMinLen("LifecycleHookName", 1))
+	}
+
+	if invalidParams.Len() > 0 {
+		return invalidParams
+	}
+	return nil
 }
 
 type RecordLifecycleActionHeartbeatOutput struct {
@@ -4614,6 +5332,22 @@ func (s ScalingProcessQuery) GoString() string {
 	return s.String()
 }
 
+// Validate inspects the fields of the type to determine if they are valid.
+func (s *ScalingProcessQuery) Validate() error {
+	invalidParams := request.ErrInvalidParams{Context: "ScalingProcessQuery"}
+	if s.AutoScalingGroupName == nil {
+		invalidParams.Add(request.NewErrParamRequired("AutoScalingGroupName"))
+	}
+	if s.AutoScalingGroupName != nil && len(*s.AutoScalingGroupName) < 1 {
+		invalidParams.Add(request.NewErrParamMinLen("AutoScalingGroupName", 1))
+	}
+
+	if invalidParams.Len() > 0 {
+		return invalidParams
+	}
+	return nil
+}
+
 // Describes a scheduled update to an Auto Scaling group.
 type ScheduledUpdateGroupAction struct {
 	_ struct{} `type:"structure"`
@@ -4690,6 +5424,25 @@ func (s SetDesiredCapacityInput) GoString() string {
 	return s.String()
 }
 
+// Validate inspects the fields of the type to determine if they are valid.
+func (s *SetDesiredCapacityInput) Validate() error {
+	invalidParams := request.ErrInvalidParams{Context: "SetDesiredCapacityInput"}
+	if s.AutoScalingGroupName == nil {
+		invalidParams.Add(request.NewErrParamRequired("AutoScalingGroupName"))
+	}
+	if s.AutoScalingGroupName != nil && len(*s.AutoScalingGroupName) < 1 {
+		invalidParams.Add(request.NewErrParamMinLen("AutoScalingGroupName", 1))
+	}
+	if s.DesiredCapacity == nil {
+		invalidParams.Add(request.NewErrParamRequired("DesiredCapacity"))
+	}
+
+	if invalidParams.Len() > 0 {
+		return invalidParams
+	}
+	return nil
+}
+
 type SetDesiredCapacityOutput struct {
 	_ struct{} `type:"structure"`
 }
@@ -4735,6 +5488,28 @@ func (s SetInstanceHealthInput) GoString() string {
 	return s.String()
 }
 
+// Validate inspects the fields of the type to determine if they are valid.
+func (s *SetInstanceHealthInput) Validate() error {
+	invalidParams := request.ErrInvalidParams{Context: "SetInstanceHealthInput"}
+	if s.HealthStatus == nil {
+		invalidParams.Add(request.NewErrParamRequired("HealthStatus"))
+	}
+	if s.HealthStatus != nil && len(*s.HealthStatus) < 1 {
+		invalidParams.Add(request.NewErrParamMinLen("HealthStatus", 1))
+	}
+	if s.InstanceId == nil {
+		invalidParams.Add(request.NewErrParamRequired("InstanceId"))
+	}
+	if s.InstanceId != nil && len(*s.InstanceId) < 1 {
+		invalidParams.Add(request.NewErrParamMinLen("InstanceId", 1))
+	}
+
+	if invalidParams.Len() > 0 {
+		return invalidParams
+	}
+	return nil
+}
+
 type SetInstanceHealthOutput struct {
 	_ struct{} `type:"structure"`
 }
@@ -4771,6 +5546,28 @@ func (s SetInstanceProtectionInput) String() string {
 // GoString returns the string representation
 func (s SetInstanceProtectionInput) GoString() string {
 	return s.String()
+}
+
+// Validate inspects the fields of the type to determine if they are valid.
+func (s *SetInstanceProtectionInput) Validate() error {
+	invalidParams := request.ErrInvalidParams{Context: "SetInstanceProtectionInput"}
+	if s.AutoScalingGroupName == nil {
+		invalidParams.Add(request.NewErrParamRequired("AutoScalingGroupName"))
+	}
+	if s.AutoScalingGroupName != nil && len(*s.AutoScalingGroupName) < 1 {
+		invalidParams.Add(request.NewErrParamMinLen("AutoScalingGroupName", 1))
+	}
+	if s.InstanceIds == nil {
+		invalidParams.Add(request.NewErrParamRequired("InstanceIds"))
+	}
+	if s.ProtectedFromScaleIn == nil {
+		invalidParams.Add(request.NewErrParamRequired("ProtectedFromScaleIn"))
+	}
+
+	if invalidParams.Len() > 0 {
+		return invalidParams
+	}
+	return nil
 }
 
 type SetInstanceProtectionOutput struct {
@@ -4851,6 +5648,19 @@ func (s StepAdjustment) GoString() string {
 	return s.String()
 }
 
+// Validate inspects the fields of the type to determine if they are valid.
+func (s *StepAdjustment) Validate() error {
+	invalidParams := request.ErrInvalidParams{Context: "StepAdjustment"}
+	if s.ScalingAdjustment == nil {
+		invalidParams.Add(request.NewErrParamRequired("ScalingAdjustment"))
+	}
+
+	if invalidParams.Len() > 0 {
+		return invalidParams
+	}
+	return nil
+}
+
 type SuspendProcessesOutput struct {
 	_ struct{} `type:"structure"`
 }
@@ -4918,6 +5728,22 @@ func (s Tag) GoString() string {
 	return s.String()
 }
 
+// Validate inspects the fields of the type to determine if they are valid.
+func (s *Tag) Validate() error {
+	invalidParams := request.ErrInvalidParams{Context: "Tag"}
+	if s.Key == nil {
+		invalidParams.Add(request.NewErrParamRequired("Key"))
+	}
+	if s.Key != nil && len(*s.Key) < 1 {
+		invalidParams.Add(request.NewErrParamMinLen("Key", 1))
+	}
+
+	if invalidParams.Len() > 0 {
+		return invalidParams
+	}
+	return nil
+}
+
 // Describes a tag for an Auto Scaling group.
 type TagDescription struct {
 	_ struct{} `type:"structure"`
@@ -4968,6 +5794,25 @@ func (s TerminateInstanceInAutoScalingGroupInput) String() string {
 // GoString returns the string representation
 func (s TerminateInstanceInAutoScalingGroupInput) GoString() string {
 	return s.String()
+}
+
+// Validate inspects the fields of the type to determine if they are valid.
+func (s *TerminateInstanceInAutoScalingGroupInput) Validate() error {
+	invalidParams := request.ErrInvalidParams{Context: "TerminateInstanceInAutoScalingGroupInput"}
+	if s.InstanceId == nil {
+		invalidParams.Add(request.NewErrParamRequired("InstanceId"))
+	}
+	if s.InstanceId != nil && len(*s.InstanceId) < 1 {
+		invalidParams.Add(request.NewErrParamMinLen("InstanceId", 1))
+	}
+	if s.ShouldDecrementDesiredCapacity == nil {
+		invalidParams.Add(request.NewErrParamRequired("ShouldDecrementDesiredCapacity"))
+	}
+
+	if invalidParams.Len() > 0 {
+		return invalidParams
+	}
+	return nil
 }
 
 type TerminateInstanceInAutoScalingGroupOutput struct {
@@ -5065,6 +5910,37 @@ func (s UpdateAutoScalingGroupInput) String() string {
 // GoString returns the string representation
 func (s UpdateAutoScalingGroupInput) GoString() string {
 	return s.String()
+}
+
+// Validate inspects the fields of the type to determine if they are valid.
+func (s *UpdateAutoScalingGroupInput) Validate() error {
+	invalidParams := request.ErrInvalidParams{Context: "UpdateAutoScalingGroupInput"}
+	if s.AutoScalingGroupName == nil {
+		invalidParams.Add(request.NewErrParamRequired("AutoScalingGroupName"))
+	}
+	if s.AutoScalingGroupName != nil && len(*s.AutoScalingGroupName) < 1 {
+		invalidParams.Add(request.NewErrParamMinLen("AutoScalingGroupName", 1))
+	}
+	if s.AvailabilityZones != nil && len(s.AvailabilityZones) < 1 {
+		invalidParams.Add(request.NewErrParamMinLen("AvailabilityZones", 1))
+	}
+	if s.HealthCheckType != nil && len(*s.HealthCheckType) < 1 {
+		invalidParams.Add(request.NewErrParamMinLen("HealthCheckType", 1))
+	}
+	if s.LaunchConfigurationName != nil && len(*s.LaunchConfigurationName) < 1 {
+		invalidParams.Add(request.NewErrParamMinLen("LaunchConfigurationName", 1))
+	}
+	if s.PlacementGroup != nil && len(*s.PlacementGroup) < 1 {
+		invalidParams.Add(request.NewErrParamMinLen("PlacementGroup", 1))
+	}
+	if s.VPCZoneIdentifier != nil && len(*s.VPCZoneIdentifier) < 1 {
+		invalidParams.Add(request.NewErrParamMinLen("VPCZoneIdentifier", 1))
+	}
+
+	if invalidParams.Len() > 0 {
+		return invalidParams
+	}
+	return nil
 }
 
 type UpdateAutoScalingGroupOutput struct {

--- a/service/cloudformation/api.go
+++ b/service/cloudformation/api.go
@@ -879,6 +879,19 @@ func (s CancelUpdateStackInput) GoString() string {
 	return s.String()
 }
 
+// Validate inspects the fields of the type to determine if they are valid.
+func (s *CancelUpdateStackInput) Validate() error {
+	invalidParams := request.ErrInvalidParams{Context: "CancelUpdateStackInput"}
+	if s.StackName == nil {
+		invalidParams.Add(request.NewErrParamRequired("StackName"))
+	}
+
+	if invalidParams.Len() > 0 {
+		return invalidParams
+	}
+	return nil
+}
+
 type CancelUpdateStackOutput struct {
 	_ struct{} `type:"structure"`
 }
@@ -976,6 +989,22 @@ func (s ContinueUpdateRollbackInput) String() string {
 // GoString returns the string representation
 func (s ContinueUpdateRollbackInput) GoString() string {
 	return s.String()
+}
+
+// Validate inspects the fields of the type to determine if they are valid.
+func (s *ContinueUpdateRollbackInput) Validate() error {
+	invalidParams := request.ErrInvalidParams{Context: "ContinueUpdateRollbackInput"}
+	if s.StackName == nil {
+		invalidParams.Add(request.NewErrParamRequired("StackName"))
+	}
+	if s.StackName != nil && len(*s.StackName) < 1 {
+		invalidParams.Add(request.NewErrParamMinLen("StackName", 1))
+	}
+
+	if invalidParams.Len() > 0 {
+		return invalidParams
+	}
+	return nil
 }
 
 // The output for a ContinueUpdateRollback action.
@@ -1096,6 +1125,40 @@ func (s CreateChangeSetInput) String() string {
 // GoString returns the string representation
 func (s CreateChangeSetInput) GoString() string {
 	return s.String()
+}
+
+// Validate inspects the fields of the type to determine if they are valid.
+func (s *CreateChangeSetInput) Validate() error {
+	invalidParams := request.ErrInvalidParams{Context: "CreateChangeSetInput"}
+	if s.ChangeSetName == nil {
+		invalidParams.Add(request.NewErrParamRequired("ChangeSetName"))
+	}
+	if s.ChangeSetName != nil && len(*s.ChangeSetName) < 1 {
+		invalidParams.Add(request.NewErrParamMinLen("ChangeSetName", 1))
+	}
+	if s.ClientToken != nil && len(*s.ClientToken) < 1 {
+		invalidParams.Add(request.NewErrParamMinLen("ClientToken", 1))
+	}
+	if s.Description != nil && len(*s.Description) < 1 {
+		invalidParams.Add(request.NewErrParamMinLen("Description", 1))
+	}
+	if s.StackName == nil {
+		invalidParams.Add(request.NewErrParamRequired("StackName"))
+	}
+	if s.StackName != nil && len(*s.StackName) < 1 {
+		invalidParams.Add(request.NewErrParamMinLen("StackName", 1))
+	}
+	if s.TemplateBody != nil && len(*s.TemplateBody) < 1 {
+		invalidParams.Add(request.NewErrParamMinLen("TemplateBody", 1))
+	}
+	if s.TemplateURL != nil && len(*s.TemplateURL) < 1 {
+		invalidParams.Add(request.NewErrParamMinLen("TemplateURL", 1))
+	}
+
+	if invalidParams.Len() > 0 {
+		return invalidParams
+	}
+	return nil
 }
 
 // The output for the CreateChangeSet action.
@@ -1238,6 +1301,34 @@ func (s CreateStackInput) GoString() string {
 	return s.String()
 }
 
+// Validate inspects the fields of the type to determine if they are valid.
+func (s *CreateStackInput) Validate() error {
+	invalidParams := request.ErrInvalidParams{Context: "CreateStackInput"}
+	if s.StackName == nil {
+		invalidParams.Add(request.NewErrParamRequired("StackName"))
+	}
+	if s.StackPolicyBody != nil && len(*s.StackPolicyBody) < 1 {
+		invalidParams.Add(request.NewErrParamMinLen("StackPolicyBody", 1))
+	}
+	if s.StackPolicyURL != nil && len(*s.StackPolicyURL) < 1 {
+		invalidParams.Add(request.NewErrParamMinLen("StackPolicyURL", 1))
+	}
+	if s.TemplateBody != nil && len(*s.TemplateBody) < 1 {
+		invalidParams.Add(request.NewErrParamMinLen("TemplateBody", 1))
+	}
+	if s.TemplateURL != nil && len(*s.TemplateURL) < 1 {
+		invalidParams.Add(request.NewErrParamMinLen("TemplateURL", 1))
+	}
+	if s.TimeoutInMinutes != nil && *s.TimeoutInMinutes < 1 {
+		invalidParams.Add(request.NewErrParamMinValue("TimeoutInMinutes", 1))
+	}
+
+	if invalidParams.Len() > 0 {
+		return invalidParams
+	}
+	return nil
+}
+
 // The output for a CreateStack action.
 type CreateStackOutput struct {
 	_ struct{} `type:"structure"`
@@ -1277,6 +1368,25 @@ func (s DeleteChangeSetInput) String() string {
 // GoString returns the string representation
 func (s DeleteChangeSetInput) GoString() string {
 	return s.String()
+}
+
+// Validate inspects the fields of the type to determine if they are valid.
+func (s *DeleteChangeSetInput) Validate() error {
+	invalidParams := request.ErrInvalidParams{Context: "DeleteChangeSetInput"}
+	if s.ChangeSetName == nil {
+		invalidParams.Add(request.NewErrParamRequired("ChangeSetName"))
+	}
+	if s.ChangeSetName != nil && len(*s.ChangeSetName) < 1 {
+		invalidParams.Add(request.NewErrParamMinLen("ChangeSetName", 1))
+	}
+	if s.StackName != nil && len(*s.StackName) < 1 {
+		invalidParams.Add(request.NewErrParamMinLen("StackName", 1))
+	}
+
+	if invalidParams.Len() > 0 {
+		return invalidParams
+	}
+	return nil
 }
 
 // The output for the DeleteChangeSet action.
@@ -1320,6 +1430,19 @@ func (s DeleteStackInput) GoString() string {
 	return s.String()
 }
 
+// Validate inspects the fields of the type to determine if they are valid.
+func (s *DeleteStackInput) Validate() error {
+	invalidParams := request.ErrInvalidParams{Context: "DeleteStackInput"}
+	if s.StackName == nil {
+		invalidParams.Add(request.NewErrParamRequired("StackName"))
+	}
+
+	if invalidParams.Len() > 0 {
+		return invalidParams
+	}
+	return nil
+}
+
 type DeleteStackOutput struct {
 	_ struct{} `type:"structure"`
 }
@@ -1350,6 +1473,19 @@ func (s DescribeAccountLimitsInput) String() string {
 // GoString returns the string representation
 func (s DescribeAccountLimitsInput) GoString() string {
 	return s.String()
+}
+
+// Validate inspects the fields of the type to determine if they are valid.
+func (s *DescribeAccountLimitsInput) Validate() error {
+	invalidParams := request.ErrInvalidParams{Context: "DescribeAccountLimitsInput"}
+	if s.NextToken != nil && len(*s.NextToken) < 1 {
+		invalidParams.Add(request.NewErrParamMinLen("NextToken", 1))
+	}
+
+	if invalidParams.Len() > 0 {
+		return invalidParams
+	}
+	return nil
 }
 
 // The output for the DescribeAccountLimits action.
@@ -1400,6 +1536,28 @@ func (s DescribeChangeSetInput) String() string {
 // GoString returns the string representation
 func (s DescribeChangeSetInput) GoString() string {
 	return s.String()
+}
+
+// Validate inspects the fields of the type to determine if they are valid.
+func (s *DescribeChangeSetInput) Validate() error {
+	invalidParams := request.ErrInvalidParams{Context: "DescribeChangeSetInput"}
+	if s.ChangeSetName == nil {
+		invalidParams.Add(request.NewErrParamRequired("ChangeSetName"))
+	}
+	if s.ChangeSetName != nil && len(*s.ChangeSetName) < 1 {
+		invalidParams.Add(request.NewErrParamMinLen("ChangeSetName", 1))
+	}
+	if s.NextToken != nil && len(*s.NextToken) < 1 {
+		invalidParams.Add(request.NewErrParamMinLen("NextToken", 1))
+	}
+	if s.StackName != nil && len(*s.StackName) < 1 {
+		invalidParams.Add(request.NewErrParamMinLen("StackName", 1))
+	}
+
+	if invalidParams.Len() > 0 {
+		return invalidParams
+	}
+	return nil
 }
 
 // The output for the DescribeChangeSet action.
@@ -1495,6 +1653,19 @@ func (s DescribeStackEventsInput) GoString() string {
 	return s.String()
 }
 
+// Validate inspects the fields of the type to determine if they are valid.
+func (s *DescribeStackEventsInput) Validate() error {
+	invalidParams := request.ErrInvalidParams{Context: "DescribeStackEventsInput"}
+	if s.NextToken != nil && len(*s.NextToken) < 1 {
+		invalidParams.Add(request.NewErrParamMinLen("NextToken", 1))
+	}
+
+	if invalidParams.Len() > 0 {
+		return invalidParams
+	}
+	return nil
+}
+
 // The output for a DescribeStackEvents action.
 type DescribeStackEventsOutput struct {
 	_ struct{} `type:"structure"`
@@ -1543,6 +1714,22 @@ func (s DescribeStackResourceInput) String() string {
 // GoString returns the string representation
 func (s DescribeStackResourceInput) GoString() string {
 	return s.String()
+}
+
+// Validate inspects the fields of the type to determine if they are valid.
+func (s *DescribeStackResourceInput) Validate() error {
+	invalidParams := request.ErrInvalidParams{Context: "DescribeStackResourceInput"}
+	if s.LogicalResourceId == nil {
+		invalidParams.Add(request.NewErrParamRequired("LogicalResourceId"))
+	}
+	if s.StackName == nil {
+		invalidParams.Add(request.NewErrParamRequired("StackName"))
+	}
+
+	if invalidParams.Len() > 0 {
+		return invalidParams
+	}
+	return nil
 }
 
 // The output for a DescribeStackResource action.
@@ -1653,6 +1840,19 @@ func (s DescribeStacksInput) GoString() string {
 	return s.String()
 }
 
+// Validate inspects the fields of the type to determine if they are valid.
+func (s *DescribeStacksInput) Validate() error {
+	invalidParams := request.ErrInvalidParams{Context: "DescribeStacksInput"}
+	if s.NextToken != nil && len(*s.NextToken) < 1 {
+		invalidParams.Add(request.NewErrParamMinLen("NextToken", 1))
+	}
+
+	if invalidParams.Len() > 0 {
+		return invalidParams
+	}
+	return nil
+}
+
 // The output for a DescribeStacks action.
 type DescribeStacksOutput struct {
 	_ struct{} `type:"structure"`
@@ -1710,6 +1910,22 @@ func (s EstimateTemplateCostInput) GoString() string {
 	return s.String()
 }
 
+// Validate inspects the fields of the type to determine if they are valid.
+func (s *EstimateTemplateCostInput) Validate() error {
+	invalidParams := request.ErrInvalidParams{Context: "EstimateTemplateCostInput"}
+	if s.TemplateBody != nil && len(*s.TemplateBody) < 1 {
+		invalidParams.Add(request.NewErrParamMinLen("TemplateBody", 1))
+	}
+	if s.TemplateURL != nil && len(*s.TemplateURL) < 1 {
+		invalidParams.Add(request.NewErrParamMinLen("TemplateURL", 1))
+	}
+
+	if invalidParams.Len() > 0 {
+		return invalidParams
+	}
+	return nil
+}
+
 // The output for a EstimateTemplateCost action.
 type EstimateTemplateCostOutput struct {
 	_ struct{} `type:"structure"`
@@ -1752,6 +1968,25 @@ func (s ExecuteChangeSetInput) GoString() string {
 	return s.String()
 }
 
+// Validate inspects the fields of the type to determine if they are valid.
+func (s *ExecuteChangeSetInput) Validate() error {
+	invalidParams := request.ErrInvalidParams{Context: "ExecuteChangeSetInput"}
+	if s.ChangeSetName == nil {
+		invalidParams.Add(request.NewErrParamRequired("ChangeSetName"))
+	}
+	if s.ChangeSetName != nil && len(*s.ChangeSetName) < 1 {
+		invalidParams.Add(request.NewErrParamMinLen("ChangeSetName", 1))
+	}
+	if s.StackName != nil && len(*s.StackName) < 1 {
+		invalidParams.Add(request.NewErrParamMinLen("StackName", 1))
+	}
+
+	if invalidParams.Len() > 0 {
+		return invalidParams
+	}
+	return nil
+}
+
 // The output for the ExecuteChangeSet action.
 type ExecuteChangeSetOutput struct {
 	_ struct{} `type:"structure"`
@@ -1784,6 +2019,19 @@ func (s GetStackPolicyInput) String() string {
 // GoString returns the string representation
 func (s GetStackPolicyInput) GoString() string {
 	return s.String()
+}
+
+// Validate inspects the fields of the type to determine if they are valid.
+func (s *GetStackPolicyInput) Validate() error {
+	invalidParams := request.ErrInvalidParams{Context: "GetStackPolicyInput"}
+	if s.StackName == nil {
+		invalidParams.Add(request.NewErrParamRequired("StackName"))
+	}
+
+	if invalidParams.Len() > 0 {
+		return invalidParams
+	}
+	return nil
 }
 
 // The output for the GetStackPolicy action.
@@ -1827,6 +2075,19 @@ func (s GetTemplateInput) String() string {
 // GoString returns the string representation
 func (s GetTemplateInput) GoString() string {
 	return s.String()
+}
+
+// Validate inspects the fields of the type to determine if they are valid.
+func (s *GetTemplateInput) Validate() error {
+	invalidParams := request.ErrInvalidParams{Context: "GetTemplateInput"}
+	if s.StackName == nil {
+		invalidParams.Add(request.NewErrParamRequired("StackName"))
+	}
+
+	if invalidParams.Len() > 0 {
+		return invalidParams
+	}
+	return nil
 }
 
 // The output for GetTemplate action.
@@ -1889,6 +2150,25 @@ func (s GetTemplateSummaryInput) String() string {
 // GoString returns the string representation
 func (s GetTemplateSummaryInput) GoString() string {
 	return s.String()
+}
+
+// Validate inspects the fields of the type to determine if they are valid.
+func (s *GetTemplateSummaryInput) Validate() error {
+	invalidParams := request.ErrInvalidParams{Context: "GetTemplateSummaryInput"}
+	if s.StackName != nil && len(*s.StackName) < 1 {
+		invalidParams.Add(request.NewErrParamMinLen("StackName", 1))
+	}
+	if s.TemplateBody != nil && len(*s.TemplateBody) < 1 {
+		invalidParams.Add(request.NewErrParamMinLen("TemplateBody", 1))
+	}
+	if s.TemplateURL != nil && len(*s.TemplateURL) < 1 {
+		invalidParams.Add(request.NewErrParamMinLen("TemplateURL", 1))
+	}
+
+	if invalidParams.Len() > 0 {
+		return invalidParams
+	}
+	return nil
 }
 
 // The output for the GetTemplateSummary action.
@@ -1958,6 +2238,25 @@ func (s ListChangeSetsInput) GoString() string {
 	return s.String()
 }
 
+// Validate inspects the fields of the type to determine if they are valid.
+func (s *ListChangeSetsInput) Validate() error {
+	invalidParams := request.ErrInvalidParams{Context: "ListChangeSetsInput"}
+	if s.NextToken != nil && len(*s.NextToken) < 1 {
+		invalidParams.Add(request.NewErrParamMinLen("NextToken", 1))
+	}
+	if s.StackName == nil {
+		invalidParams.Add(request.NewErrParamRequired("StackName"))
+	}
+	if s.StackName != nil && len(*s.StackName) < 1 {
+		invalidParams.Add(request.NewErrParamMinLen("StackName", 1))
+	}
+
+	if invalidParams.Len() > 0 {
+		return invalidParams
+	}
+	return nil
+}
+
 // The output for the ListChangeSets action.
 type ListChangeSetsOutput struct {
 	_ struct{} `type:"structure"`
@@ -2008,6 +2307,22 @@ func (s ListStackResourcesInput) GoString() string {
 	return s.String()
 }
 
+// Validate inspects the fields of the type to determine if they are valid.
+func (s *ListStackResourcesInput) Validate() error {
+	invalidParams := request.ErrInvalidParams{Context: "ListStackResourcesInput"}
+	if s.NextToken != nil && len(*s.NextToken) < 1 {
+		invalidParams.Add(request.NewErrParamMinLen("NextToken", 1))
+	}
+	if s.StackName == nil {
+		invalidParams.Add(request.NewErrParamRequired("StackName"))
+	}
+
+	if invalidParams.Len() > 0 {
+		return invalidParams
+	}
+	return nil
+}
+
 // The output for a ListStackResources action.
 type ListStackResourcesOutput struct {
 	_ struct{} `type:"structure"`
@@ -2051,6 +2366,19 @@ func (s ListStacksInput) String() string {
 // GoString returns the string representation
 func (s ListStacksInput) GoString() string {
 	return s.String()
+}
+
+// Validate inspects the fields of the type to determine if they are valid.
+func (s *ListStacksInput) Validate() error {
+	invalidParams := request.ErrInvalidParams{Context: "ListStacksInput"}
+	if s.NextToken != nil && len(*s.NextToken) < 1 {
+		invalidParams.Add(request.NewErrParamMinLen("NextToken", 1))
+	}
+
+	if invalidParams.Len() > 0 {
+		return invalidParams
+	}
+	return nil
 }
 
 // The output for ListStacks action.
@@ -2358,6 +2686,25 @@ func (s SetStackPolicyInput) GoString() string {
 	return s.String()
 }
 
+// Validate inspects the fields of the type to determine if they are valid.
+func (s *SetStackPolicyInput) Validate() error {
+	invalidParams := request.ErrInvalidParams{Context: "SetStackPolicyInput"}
+	if s.StackName == nil {
+		invalidParams.Add(request.NewErrParamRequired("StackName"))
+	}
+	if s.StackPolicyBody != nil && len(*s.StackPolicyBody) < 1 {
+		invalidParams.Add(request.NewErrParamMinLen("StackPolicyBody", 1))
+	}
+	if s.StackPolicyURL != nil && len(*s.StackPolicyURL) < 1 {
+		invalidParams.Add(request.NewErrParamMinLen("StackPolicyURL", 1))
+	}
+
+	if invalidParams.Len() > 0 {
+		return invalidParams
+	}
+	return nil
+}
+
 type SetStackPolicyOutput struct {
 	_ struct{} `type:"structure"`
 }
@@ -2403,6 +2750,34 @@ func (s SignalResourceInput) String() string {
 // GoString returns the string representation
 func (s SignalResourceInput) GoString() string {
 	return s.String()
+}
+
+// Validate inspects the fields of the type to determine if they are valid.
+func (s *SignalResourceInput) Validate() error {
+	invalidParams := request.ErrInvalidParams{Context: "SignalResourceInput"}
+	if s.LogicalResourceId == nil {
+		invalidParams.Add(request.NewErrParamRequired("LogicalResourceId"))
+	}
+	if s.StackName == nil {
+		invalidParams.Add(request.NewErrParamRequired("StackName"))
+	}
+	if s.StackName != nil && len(*s.StackName) < 1 {
+		invalidParams.Add(request.NewErrParamMinLen("StackName", 1))
+	}
+	if s.Status == nil {
+		invalidParams.Add(request.NewErrParamRequired("Status"))
+	}
+	if s.UniqueId == nil {
+		invalidParams.Add(request.NewErrParamRequired("UniqueId"))
+	}
+	if s.UniqueId != nil && len(*s.UniqueId) < 1 {
+		invalidParams.Add(request.NewErrParamMinLen("UniqueId", 1))
+	}
+
+	if invalidParams.Len() > 0 {
+		return invalidParams
+	}
+	return nil
 }
 
 type SignalResourceOutput struct {
@@ -2878,6 +3253,37 @@ func (s UpdateStackInput) GoString() string {
 	return s.String()
 }
 
+// Validate inspects the fields of the type to determine if they are valid.
+func (s *UpdateStackInput) Validate() error {
+	invalidParams := request.ErrInvalidParams{Context: "UpdateStackInput"}
+	if s.StackName == nil {
+		invalidParams.Add(request.NewErrParamRequired("StackName"))
+	}
+	if s.StackPolicyBody != nil && len(*s.StackPolicyBody) < 1 {
+		invalidParams.Add(request.NewErrParamMinLen("StackPolicyBody", 1))
+	}
+	if s.StackPolicyDuringUpdateBody != nil && len(*s.StackPolicyDuringUpdateBody) < 1 {
+		invalidParams.Add(request.NewErrParamMinLen("StackPolicyDuringUpdateBody", 1))
+	}
+	if s.StackPolicyDuringUpdateURL != nil && len(*s.StackPolicyDuringUpdateURL) < 1 {
+		invalidParams.Add(request.NewErrParamMinLen("StackPolicyDuringUpdateURL", 1))
+	}
+	if s.StackPolicyURL != nil && len(*s.StackPolicyURL) < 1 {
+		invalidParams.Add(request.NewErrParamMinLen("StackPolicyURL", 1))
+	}
+	if s.TemplateBody != nil && len(*s.TemplateBody) < 1 {
+		invalidParams.Add(request.NewErrParamMinLen("TemplateBody", 1))
+	}
+	if s.TemplateURL != nil && len(*s.TemplateURL) < 1 {
+		invalidParams.Add(request.NewErrParamMinLen("TemplateURL", 1))
+	}
+
+	if invalidParams.Len() > 0 {
+		return invalidParams
+	}
+	return nil
+}
+
 // The output for a UpdateStack action.
 type UpdateStackOutput struct {
 	_ struct{} `type:"structure"`
@@ -2927,6 +3333,22 @@ func (s ValidateTemplateInput) String() string {
 // GoString returns the string representation
 func (s ValidateTemplateInput) GoString() string {
 	return s.String()
+}
+
+// Validate inspects the fields of the type to determine if they are valid.
+func (s *ValidateTemplateInput) Validate() error {
+	invalidParams := request.ErrInvalidParams{Context: "ValidateTemplateInput"}
+	if s.TemplateBody != nil && len(*s.TemplateBody) < 1 {
+		invalidParams.Add(request.NewErrParamMinLen("TemplateBody", 1))
+	}
+	if s.TemplateURL != nil && len(*s.TemplateURL) < 1 {
+		invalidParams.Add(request.NewErrParamMinLen("TemplateURL", 1))
+	}
+
+	if invalidParams.Len() > 0 {
+		return invalidParams
+	}
+	return nil
 }
 
 // The output for ValidateTemplate action.

--- a/service/cloudfront/api.go
+++ b/service/cloudfront/api.go
@@ -4,6 +4,7 @@
 package cloudfront
 
 import (
+	"fmt"
 	"time"
 
 	"github.com/aws/aws-sdk-go/aws/awsutil"
@@ -722,6 +723,19 @@ func (s Aliases) GoString() string {
 	return s.String()
 }
 
+// Validate inspects the fields of the type to determine if they are valid.
+func (s *Aliases) Validate() error {
+	invalidParams := request.ErrInvalidParams{Context: "Aliases"}
+	if s.Quantity == nil {
+		invalidParams.Add(request.NewErrParamRequired("Quantity"))
+	}
+
+	if invalidParams.Len() > 0 {
+		return invalidParams
+	}
+	return nil
+}
+
 // A complex type that controls which HTTP methods CloudFront processes and
 // forwards to your Amazon S3 bucket or your custom origin. There are three
 // choices: - CloudFront forwards only GET and HEAD requests. - CloudFront forwards
@@ -759,6 +773,27 @@ func (s AllowedMethods) String() string {
 // GoString returns the string representation
 func (s AllowedMethods) GoString() string {
 	return s.String()
+}
+
+// Validate inspects the fields of the type to determine if they are valid.
+func (s *AllowedMethods) Validate() error {
+	invalidParams := request.ErrInvalidParams{Context: "AllowedMethods"}
+	if s.Items == nil {
+		invalidParams.Add(request.NewErrParamRequired("Items"))
+	}
+	if s.Quantity == nil {
+		invalidParams.Add(request.NewErrParamRequired("Quantity"))
+	}
+	if s.CachedMethods != nil {
+		if err := s.CachedMethods.Validate(); err != nil {
+			invalidParams.AddNested("CachedMethods", err.(request.ErrInvalidParams))
+		}
+	}
+
+	if invalidParams.Len() > 0 {
+		return invalidParams
+	}
+	return nil
 }
 
 // A complex type that describes how CloudFront processes requests. You can
@@ -885,6 +920,49 @@ func (s CacheBehavior) GoString() string {
 	return s.String()
 }
 
+// Validate inspects the fields of the type to determine if they are valid.
+func (s *CacheBehavior) Validate() error {
+	invalidParams := request.ErrInvalidParams{Context: "CacheBehavior"}
+	if s.ForwardedValues == nil {
+		invalidParams.Add(request.NewErrParamRequired("ForwardedValues"))
+	}
+	if s.MinTTL == nil {
+		invalidParams.Add(request.NewErrParamRequired("MinTTL"))
+	}
+	if s.PathPattern == nil {
+		invalidParams.Add(request.NewErrParamRequired("PathPattern"))
+	}
+	if s.TargetOriginId == nil {
+		invalidParams.Add(request.NewErrParamRequired("TargetOriginId"))
+	}
+	if s.TrustedSigners == nil {
+		invalidParams.Add(request.NewErrParamRequired("TrustedSigners"))
+	}
+	if s.ViewerProtocolPolicy == nil {
+		invalidParams.Add(request.NewErrParamRequired("ViewerProtocolPolicy"))
+	}
+	if s.AllowedMethods != nil {
+		if err := s.AllowedMethods.Validate(); err != nil {
+			invalidParams.AddNested("AllowedMethods", err.(request.ErrInvalidParams))
+		}
+	}
+	if s.ForwardedValues != nil {
+		if err := s.ForwardedValues.Validate(); err != nil {
+			invalidParams.AddNested("ForwardedValues", err.(request.ErrInvalidParams))
+		}
+	}
+	if s.TrustedSigners != nil {
+		if err := s.TrustedSigners.Validate(); err != nil {
+			invalidParams.AddNested("TrustedSigners", err.(request.ErrInvalidParams))
+		}
+	}
+
+	if invalidParams.Len() > 0 {
+		return invalidParams
+	}
+	return nil
+}
+
 // A complex type that contains zero or more CacheBehavior elements.
 type CacheBehaviors struct {
 	_ struct{} `type:"structure"`
@@ -905,6 +983,29 @@ func (s CacheBehaviors) String() string {
 // GoString returns the string representation
 func (s CacheBehaviors) GoString() string {
 	return s.String()
+}
+
+// Validate inspects the fields of the type to determine if they are valid.
+func (s *CacheBehaviors) Validate() error {
+	invalidParams := request.ErrInvalidParams{Context: "CacheBehaviors"}
+	if s.Quantity == nil {
+		invalidParams.Add(request.NewErrParamRequired("Quantity"))
+	}
+	if s.Items != nil {
+		for i, v := range s.Items {
+			if v == nil {
+				continue
+			}
+			if err := v.Validate(); err != nil {
+				invalidParams.AddNested(fmt.Sprintf("%s[%v]", "Items", i), err.(request.ErrInvalidParams))
+			}
+		}
+	}
+
+	if invalidParams.Len() > 0 {
+		return invalidParams
+	}
+	return nil
 }
 
 // A complex type that controls whether CloudFront caches the response to requests
@@ -936,6 +1037,22 @@ func (s CachedMethods) GoString() string {
 	return s.String()
 }
 
+// Validate inspects the fields of the type to determine if they are valid.
+func (s *CachedMethods) Validate() error {
+	invalidParams := request.ErrInvalidParams{Context: "CachedMethods"}
+	if s.Items == nil {
+		invalidParams.Add(request.NewErrParamRequired("Items"))
+	}
+	if s.Quantity == nil {
+		invalidParams.Add(request.NewErrParamRequired("Quantity"))
+	}
+
+	if invalidParams.Len() > 0 {
+		return invalidParams
+	}
+	return nil
+}
+
 // A complex type that specifies the whitelisted cookies, if any, that you want
 // CloudFront to forward to your origin that is associated with this cache behavior.
 type CookieNames struct {
@@ -957,6 +1074,19 @@ func (s CookieNames) String() string {
 // GoString returns the string representation
 func (s CookieNames) GoString() string {
 	return s.String()
+}
+
+// Validate inspects the fields of the type to determine if they are valid.
+func (s *CookieNames) Validate() error {
+	invalidParams := request.ErrInvalidParams{Context: "CookieNames"}
+	if s.Quantity == nil {
+		invalidParams.Add(request.NewErrParamRequired("Quantity"))
+	}
+
+	if invalidParams.Len() > 0 {
+		return invalidParams
+	}
+	return nil
 }
 
 // A complex type that specifies the cookie preferences associated with this
@@ -985,6 +1115,24 @@ func (s CookiePreference) GoString() string {
 	return s.String()
 }
 
+// Validate inspects the fields of the type to determine if they are valid.
+func (s *CookiePreference) Validate() error {
+	invalidParams := request.ErrInvalidParams{Context: "CookiePreference"}
+	if s.Forward == nil {
+		invalidParams.Add(request.NewErrParamRequired("Forward"))
+	}
+	if s.WhitelistedNames != nil {
+		if err := s.WhitelistedNames.Validate(); err != nil {
+			invalidParams.AddNested("WhitelistedNames", err.(request.ErrInvalidParams))
+		}
+	}
+
+	if invalidParams.Len() > 0 {
+		return invalidParams
+	}
+	return nil
+}
+
 // The request to create a new origin access identity.
 type CreateCloudFrontOriginAccessIdentityInput struct {
 	_ struct{} `type:"structure" payload:"CloudFrontOriginAccessIdentityConfig"`
@@ -1001,6 +1149,24 @@ func (s CreateCloudFrontOriginAccessIdentityInput) String() string {
 // GoString returns the string representation
 func (s CreateCloudFrontOriginAccessIdentityInput) GoString() string {
 	return s.String()
+}
+
+// Validate inspects the fields of the type to determine if they are valid.
+func (s *CreateCloudFrontOriginAccessIdentityInput) Validate() error {
+	invalidParams := request.ErrInvalidParams{Context: "CreateCloudFrontOriginAccessIdentityInput"}
+	if s.CloudFrontOriginAccessIdentityConfig == nil {
+		invalidParams.Add(request.NewErrParamRequired("CloudFrontOriginAccessIdentityConfig"))
+	}
+	if s.CloudFrontOriginAccessIdentityConfig != nil {
+		if err := s.CloudFrontOriginAccessIdentityConfig.Validate(); err != nil {
+			invalidParams.AddNested("CloudFrontOriginAccessIdentityConfig", err.(request.ErrInvalidParams))
+		}
+	}
+
+	if invalidParams.Len() > 0 {
+		return invalidParams
+	}
+	return nil
 }
 
 // The returned result of the corresponding request.
@@ -1044,6 +1210,24 @@ func (s CreateDistributionInput) String() string {
 // GoString returns the string representation
 func (s CreateDistributionInput) GoString() string {
 	return s.String()
+}
+
+// Validate inspects the fields of the type to determine if they are valid.
+func (s *CreateDistributionInput) Validate() error {
+	invalidParams := request.ErrInvalidParams{Context: "CreateDistributionInput"}
+	if s.DistributionConfig == nil {
+		invalidParams.Add(request.NewErrParamRequired("DistributionConfig"))
+	}
+	if s.DistributionConfig != nil {
+		if err := s.DistributionConfig.Validate(); err != nil {
+			invalidParams.AddNested("DistributionConfig", err.(request.ErrInvalidParams))
+		}
+	}
+
+	if invalidParams.Len() > 0 {
+		return invalidParams
+	}
+	return nil
 }
 
 // The returned result of the corresponding request.
@@ -1092,6 +1276,27 @@ func (s CreateInvalidationInput) GoString() string {
 	return s.String()
 }
 
+// Validate inspects the fields of the type to determine if they are valid.
+func (s *CreateInvalidationInput) Validate() error {
+	invalidParams := request.ErrInvalidParams{Context: "CreateInvalidationInput"}
+	if s.DistributionId == nil {
+		invalidParams.Add(request.NewErrParamRequired("DistributionId"))
+	}
+	if s.InvalidationBatch == nil {
+		invalidParams.Add(request.NewErrParamRequired("InvalidationBatch"))
+	}
+	if s.InvalidationBatch != nil {
+		if err := s.InvalidationBatch.Validate(); err != nil {
+			invalidParams.AddNested("InvalidationBatch", err.(request.ErrInvalidParams))
+		}
+	}
+
+	if invalidParams.Len() > 0 {
+		return invalidParams
+	}
+	return nil
+}
+
 // The returned result of the corresponding request.
 type CreateInvalidationOutput struct {
 	_ struct{} `type:"structure" payload:"Invalidation"`
@@ -1130,6 +1335,24 @@ func (s CreateStreamingDistributionInput) String() string {
 // GoString returns the string representation
 func (s CreateStreamingDistributionInput) GoString() string {
 	return s.String()
+}
+
+// Validate inspects the fields of the type to determine if they are valid.
+func (s *CreateStreamingDistributionInput) Validate() error {
+	invalidParams := request.ErrInvalidParams{Context: "CreateStreamingDistributionInput"}
+	if s.StreamingDistributionConfig == nil {
+		invalidParams.Add(request.NewErrParamRequired("StreamingDistributionConfig"))
+	}
+	if s.StreamingDistributionConfig != nil {
+		if err := s.StreamingDistributionConfig.Validate(); err != nil {
+			invalidParams.AddNested("StreamingDistributionConfig", err.(request.ErrInvalidParams))
+		}
+	}
+
+	if invalidParams.Len() > 0 {
+		return invalidParams
+	}
+	return nil
 }
 
 // The returned result of the corresponding request.
@@ -1204,6 +1427,19 @@ func (s CustomErrorResponse) GoString() string {
 	return s.String()
 }
 
+// Validate inspects the fields of the type to determine if they are valid.
+func (s *CustomErrorResponse) Validate() error {
+	invalidParams := request.ErrInvalidParams{Context: "CustomErrorResponse"}
+	if s.ErrorCode == nil {
+		invalidParams.Add(request.NewErrParamRequired("ErrorCode"))
+	}
+
+	if invalidParams.Len() > 0 {
+		return invalidParams
+	}
+	return nil
+}
+
 // A complex type that contains zero or more CustomErrorResponse elements.
 type CustomErrorResponses struct {
 	_ struct{} `type:"structure"`
@@ -1226,6 +1462,29 @@ func (s CustomErrorResponses) GoString() string {
 	return s.String()
 }
 
+// Validate inspects the fields of the type to determine if they are valid.
+func (s *CustomErrorResponses) Validate() error {
+	invalidParams := request.ErrInvalidParams{Context: "CustomErrorResponses"}
+	if s.Quantity == nil {
+		invalidParams.Add(request.NewErrParamRequired("Quantity"))
+	}
+	if s.Items != nil {
+		for i, v := range s.Items {
+			if v == nil {
+				continue
+			}
+			if err := v.Validate(); err != nil {
+				invalidParams.AddNested(fmt.Sprintf("%s[%v]", "Items", i), err.(request.ErrInvalidParams))
+			}
+		}
+	}
+
+	if invalidParams.Len() > 0 {
+		return invalidParams
+	}
+	return nil
+}
+
 // A complex type that contains the list of Custom Headers for each origin.
 type CustomHeaders struct {
 	_ struct{} `type:"structure"`
@@ -1245,6 +1504,29 @@ func (s CustomHeaders) String() string {
 // GoString returns the string representation
 func (s CustomHeaders) GoString() string {
 	return s.String()
+}
+
+// Validate inspects the fields of the type to determine if they are valid.
+func (s *CustomHeaders) Validate() error {
+	invalidParams := request.ErrInvalidParams{Context: "CustomHeaders"}
+	if s.Quantity == nil {
+		invalidParams.Add(request.NewErrParamRequired("Quantity"))
+	}
+	if s.Items != nil {
+		for i, v := range s.Items {
+			if v == nil {
+				continue
+			}
+			if err := v.Validate(); err != nil {
+				invalidParams.AddNested(fmt.Sprintf("%s[%v]", "Items", i), err.(request.ErrInvalidParams))
+			}
+		}
+	}
+
+	if invalidParams.Len() > 0 {
+		return invalidParams
+	}
+	return nil
 }
 
 // A customer origin.
@@ -1273,6 +1555,30 @@ func (s CustomOriginConfig) String() string {
 // GoString returns the string representation
 func (s CustomOriginConfig) GoString() string {
 	return s.String()
+}
+
+// Validate inspects the fields of the type to determine if they are valid.
+func (s *CustomOriginConfig) Validate() error {
+	invalidParams := request.ErrInvalidParams{Context: "CustomOriginConfig"}
+	if s.HTTPPort == nil {
+		invalidParams.Add(request.NewErrParamRequired("HTTPPort"))
+	}
+	if s.HTTPSPort == nil {
+		invalidParams.Add(request.NewErrParamRequired("HTTPSPort"))
+	}
+	if s.OriginProtocolPolicy == nil {
+		invalidParams.Add(request.NewErrParamRequired("OriginProtocolPolicy"))
+	}
+	if s.OriginSslProtocols != nil {
+		if err := s.OriginSslProtocols.Validate(); err != nil {
+			invalidParams.AddNested("OriginSslProtocols", err.(request.ErrInvalidParams))
+		}
+	}
+
+	if invalidParams.Len() > 0 {
+		return invalidParams
+	}
+	return nil
 }
 
 // A complex type that describes the default cache behavior if you do not specify
@@ -1379,6 +1685,46 @@ func (s DefaultCacheBehavior) GoString() string {
 	return s.String()
 }
 
+// Validate inspects the fields of the type to determine if they are valid.
+func (s *DefaultCacheBehavior) Validate() error {
+	invalidParams := request.ErrInvalidParams{Context: "DefaultCacheBehavior"}
+	if s.ForwardedValues == nil {
+		invalidParams.Add(request.NewErrParamRequired("ForwardedValues"))
+	}
+	if s.MinTTL == nil {
+		invalidParams.Add(request.NewErrParamRequired("MinTTL"))
+	}
+	if s.TargetOriginId == nil {
+		invalidParams.Add(request.NewErrParamRequired("TargetOriginId"))
+	}
+	if s.TrustedSigners == nil {
+		invalidParams.Add(request.NewErrParamRequired("TrustedSigners"))
+	}
+	if s.ViewerProtocolPolicy == nil {
+		invalidParams.Add(request.NewErrParamRequired("ViewerProtocolPolicy"))
+	}
+	if s.AllowedMethods != nil {
+		if err := s.AllowedMethods.Validate(); err != nil {
+			invalidParams.AddNested("AllowedMethods", err.(request.ErrInvalidParams))
+		}
+	}
+	if s.ForwardedValues != nil {
+		if err := s.ForwardedValues.Validate(); err != nil {
+			invalidParams.AddNested("ForwardedValues", err.(request.ErrInvalidParams))
+		}
+	}
+	if s.TrustedSigners != nil {
+		if err := s.TrustedSigners.Validate(); err != nil {
+			invalidParams.AddNested("TrustedSigners", err.(request.ErrInvalidParams))
+		}
+	}
+
+	if invalidParams.Len() > 0 {
+		return invalidParams
+	}
+	return nil
+}
+
 // The request to delete a origin access identity.
 type DeleteCloudFrontOriginAccessIdentityInput struct {
 	_ struct{} `type:"structure"`
@@ -1399,6 +1745,19 @@ func (s DeleteCloudFrontOriginAccessIdentityInput) String() string {
 // GoString returns the string representation
 func (s DeleteCloudFrontOriginAccessIdentityInput) GoString() string {
 	return s.String()
+}
+
+// Validate inspects the fields of the type to determine if they are valid.
+func (s *DeleteCloudFrontOriginAccessIdentityInput) Validate() error {
+	invalidParams := request.ErrInvalidParams{Context: "DeleteCloudFrontOriginAccessIdentityInput"}
+	if s.Id == nil {
+		invalidParams.Add(request.NewErrParamRequired("Id"))
+	}
+
+	if invalidParams.Len() > 0 {
+		return invalidParams
+	}
+	return nil
 }
 
 type DeleteCloudFrontOriginAccessIdentityOutput struct {
@@ -1437,6 +1796,19 @@ func (s DeleteDistributionInput) GoString() string {
 	return s.String()
 }
 
+// Validate inspects the fields of the type to determine if they are valid.
+func (s *DeleteDistributionInput) Validate() error {
+	invalidParams := request.ErrInvalidParams{Context: "DeleteDistributionInput"}
+	if s.Id == nil {
+		invalidParams.Add(request.NewErrParamRequired("Id"))
+	}
+
+	if invalidParams.Len() > 0 {
+		return invalidParams
+	}
+	return nil
+}
+
 type DeleteDistributionOutput struct {
 	_ struct{} `type:"structure"`
 }
@@ -1471,6 +1843,19 @@ func (s DeleteStreamingDistributionInput) String() string {
 // GoString returns the string representation
 func (s DeleteStreamingDistributionInput) GoString() string {
 	return s.String()
+}
+
+// Validate inspects the fields of the type to determine if they are valid.
+func (s *DeleteStreamingDistributionInput) Validate() error {
+	invalidParams := request.ErrInvalidParams{Context: "DeleteStreamingDistributionInput"}
+	if s.Id == nil {
+		invalidParams.Add(request.NewErrParamRequired("Id"))
+	}
+
+	if invalidParams.Len() > 0 {
+		return invalidParams
+	}
+	return nil
 }
 
 type DeleteStreamingDistributionOutput struct {
@@ -1611,6 +1996,66 @@ func (s DistributionConfig) GoString() string {
 	return s.String()
 }
 
+// Validate inspects the fields of the type to determine if they are valid.
+func (s *DistributionConfig) Validate() error {
+	invalidParams := request.ErrInvalidParams{Context: "DistributionConfig"}
+	if s.CallerReference == nil {
+		invalidParams.Add(request.NewErrParamRequired("CallerReference"))
+	}
+	if s.Comment == nil {
+		invalidParams.Add(request.NewErrParamRequired("Comment"))
+	}
+	if s.DefaultCacheBehavior == nil {
+		invalidParams.Add(request.NewErrParamRequired("DefaultCacheBehavior"))
+	}
+	if s.Enabled == nil {
+		invalidParams.Add(request.NewErrParamRequired("Enabled"))
+	}
+	if s.Origins == nil {
+		invalidParams.Add(request.NewErrParamRequired("Origins"))
+	}
+	if s.Aliases != nil {
+		if err := s.Aliases.Validate(); err != nil {
+			invalidParams.AddNested("Aliases", err.(request.ErrInvalidParams))
+		}
+	}
+	if s.CacheBehaviors != nil {
+		if err := s.CacheBehaviors.Validate(); err != nil {
+			invalidParams.AddNested("CacheBehaviors", err.(request.ErrInvalidParams))
+		}
+	}
+	if s.CustomErrorResponses != nil {
+		if err := s.CustomErrorResponses.Validate(); err != nil {
+			invalidParams.AddNested("CustomErrorResponses", err.(request.ErrInvalidParams))
+		}
+	}
+	if s.DefaultCacheBehavior != nil {
+		if err := s.DefaultCacheBehavior.Validate(); err != nil {
+			invalidParams.AddNested("DefaultCacheBehavior", err.(request.ErrInvalidParams))
+		}
+	}
+	if s.Logging != nil {
+		if err := s.Logging.Validate(); err != nil {
+			invalidParams.AddNested("Logging", err.(request.ErrInvalidParams))
+		}
+	}
+	if s.Origins != nil {
+		if err := s.Origins.Validate(); err != nil {
+			invalidParams.AddNested("Origins", err.(request.ErrInvalidParams))
+		}
+	}
+	if s.Restrictions != nil {
+		if err := s.Restrictions.Validate(); err != nil {
+			invalidParams.AddNested("Restrictions", err.(request.ErrInvalidParams))
+		}
+	}
+
+	if invalidParams.Len() > 0 {
+		return invalidParams
+	}
+	return nil
+}
+
 // A distribution list.
 type DistributionList struct {
 	_ struct{} `type:"structure"`
@@ -1744,6 +2189,32 @@ func (s ForwardedValues) GoString() string {
 	return s.String()
 }
 
+// Validate inspects the fields of the type to determine if they are valid.
+func (s *ForwardedValues) Validate() error {
+	invalidParams := request.ErrInvalidParams{Context: "ForwardedValues"}
+	if s.Cookies == nil {
+		invalidParams.Add(request.NewErrParamRequired("Cookies"))
+	}
+	if s.QueryString == nil {
+		invalidParams.Add(request.NewErrParamRequired("QueryString"))
+	}
+	if s.Cookies != nil {
+		if err := s.Cookies.Validate(); err != nil {
+			invalidParams.AddNested("Cookies", err.(request.ErrInvalidParams))
+		}
+	}
+	if s.Headers != nil {
+		if err := s.Headers.Validate(); err != nil {
+			invalidParams.AddNested("Headers", err.(request.ErrInvalidParams))
+		}
+	}
+
+	if invalidParams.Len() > 0 {
+		return invalidParams
+	}
+	return nil
+}
+
 // A complex type that controls the countries in which your content is distributed.
 // For more information about geo restriction, go to Customizing Error Responses
 // in the Amazon CloudFront Developer Guide. CloudFront determines the location
@@ -1788,6 +2259,22 @@ func (s GeoRestriction) GoString() string {
 	return s.String()
 }
 
+// Validate inspects the fields of the type to determine if they are valid.
+func (s *GeoRestriction) Validate() error {
+	invalidParams := request.ErrInvalidParams{Context: "GeoRestriction"}
+	if s.Quantity == nil {
+		invalidParams.Add(request.NewErrParamRequired("Quantity"))
+	}
+	if s.RestrictionType == nil {
+		invalidParams.Add(request.NewErrParamRequired("RestrictionType"))
+	}
+
+	if invalidParams.Len() > 0 {
+		return invalidParams
+	}
+	return nil
+}
+
 // The request to get an origin access identity's configuration.
 type GetCloudFrontOriginAccessIdentityConfigInput struct {
 	_ struct{} `type:"structure"`
@@ -1804,6 +2291,19 @@ func (s GetCloudFrontOriginAccessIdentityConfigInput) String() string {
 // GoString returns the string representation
 func (s GetCloudFrontOriginAccessIdentityConfigInput) GoString() string {
 	return s.String()
+}
+
+// Validate inspects the fields of the type to determine if they are valid.
+func (s *GetCloudFrontOriginAccessIdentityConfigInput) Validate() error {
+	invalidParams := request.ErrInvalidParams{Context: "GetCloudFrontOriginAccessIdentityConfigInput"}
+	if s.Id == nil {
+		invalidParams.Add(request.NewErrParamRequired("Id"))
+	}
+
+	if invalidParams.Len() > 0 {
+		return invalidParams
+	}
+	return nil
 }
 
 // The returned result of the corresponding request.
@@ -1843,6 +2343,19 @@ func (s GetCloudFrontOriginAccessIdentityInput) String() string {
 // GoString returns the string representation
 func (s GetCloudFrontOriginAccessIdentityInput) GoString() string {
 	return s.String()
+}
+
+// Validate inspects the fields of the type to determine if they are valid.
+func (s *GetCloudFrontOriginAccessIdentityInput) Validate() error {
+	invalidParams := request.ErrInvalidParams{Context: "GetCloudFrontOriginAccessIdentityInput"}
+	if s.Id == nil {
+		invalidParams.Add(request.NewErrParamRequired("Id"))
+	}
+
+	if invalidParams.Len() > 0 {
+		return invalidParams
+	}
+	return nil
 }
 
 // The returned result of the corresponding request.
@@ -1885,6 +2398,19 @@ func (s GetDistributionConfigInput) GoString() string {
 	return s.String()
 }
 
+// Validate inspects the fields of the type to determine if they are valid.
+func (s *GetDistributionConfigInput) Validate() error {
+	invalidParams := request.ErrInvalidParams{Context: "GetDistributionConfigInput"}
+	if s.Id == nil {
+		invalidParams.Add(request.NewErrParamRequired("Id"))
+	}
+
+	if invalidParams.Len() > 0 {
+		return invalidParams
+	}
+	return nil
+}
+
 // The returned result of the corresponding request.
 type GetDistributionConfigOutput struct {
 	_ struct{} `type:"structure" payload:"DistributionConfig"`
@@ -1922,6 +2448,19 @@ func (s GetDistributionInput) String() string {
 // GoString returns the string representation
 func (s GetDistributionInput) GoString() string {
 	return s.String()
+}
+
+// Validate inspects the fields of the type to determine if they are valid.
+func (s *GetDistributionInput) Validate() error {
+	invalidParams := request.ErrInvalidParams{Context: "GetDistributionInput"}
+	if s.Id == nil {
+		invalidParams.Add(request.NewErrParamRequired("Id"))
+	}
+
+	if invalidParams.Len() > 0 {
+		return invalidParams
+	}
+	return nil
 }
 
 // The returned result of the corresponding request.
@@ -1966,6 +2505,22 @@ func (s GetInvalidationInput) GoString() string {
 	return s.String()
 }
 
+// Validate inspects the fields of the type to determine if they are valid.
+func (s *GetInvalidationInput) Validate() error {
+	invalidParams := request.ErrInvalidParams{Context: "GetInvalidationInput"}
+	if s.DistributionId == nil {
+		invalidParams.Add(request.NewErrParamRequired("DistributionId"))
+	}
+	if s.Id == nil {
+		invalidParams.Add(request.NewErrParamRequired("Id"))
+	}
+
+	if invalidParams.Len() > 0 {
+		return invalidParams
+	}
+	return nil
+}
+
 // The returned result of the corresponding request.
 type GetInvalidationOutput struct {
 	_ struct{} `type:"structure" payload:"Invalidation"`
@@ -2000,6 +2555,19 @@ func (s GetStreamingDistributionConfigInput) String() string {
 // GoString returns the string representation
 func (s GetStreamingDistributionConfigInput) GoString() string {
 	return s.String()
+}
+
+// Validate inspects the fields of the type to determine if they are valid.
+func (s *GetStreamingDistributionConfigInput) Validate() error {
+	invalidParams := request.ErrInvalidParams{Context: "GetStreamingDistributionConfigInput"}
+	if s.Id == nil {
+		invalidParams.Add(request.NewErrParamRequired("Id"))
+	}
+
+	if invalidParams.Len() > 0 {
+		return invalidParams
+	}
+	return nil
 }
 
 // The returned result of the corresponding request.
@@ -2039,6 +2607,19 @@ func (s GetStreamingDistributionInput) String() string {
 // GoString returns the string representation
 func (s GetStreamingDistributionInput) GoString() string {
 	return s.String()
+}
+
+// Validate inspects the fields of the type to determine if they are valid.
+func (s *GetStreamingDistributionInput) Validate() error {
+	invalidParams := request.ErrInvalidParams{Context: "GetStreamingDistributionInput"}
+	if s.Id == nil {
+		invalidParams.Add(request.NewErrParamRequired("Id"))
+	}
+
+	if invalidParams.Len() > 0 {
+		return invalidParams
+	}
+	return nil
 }
 
 // The returned result of the corresponding request.
@@ -2097,6 +2678,19 @@ func (s Headers) String() string {
 // GoString returns the string representation
 func (s Headers) GoString() string {
 	return s.String()
+}
+
+// Validate inspects the fields of the type to determine if they are valid.
+func (s *Headers) Validate() error {
+	invalidParams := request.ErrInvalidParams{Context: "Headers"}
+	if s.Quantity == nil {
+		invalidParams.Add(request.NewErrParamRequired("Quantity"))
+	}
+
+	if invalidParams.Len() > 0 {
+		return invalidParams
+	}
+	return nil
 }
 
 // An invalidation.
@@ -2159,6 +2753,27 @@ func (s InvalidationBatch) String() string {
 // GoString returns the string representation
 func (s InvalidationBatch) GoString() string {
 	return s.String()
+}
+
+// Validate inspects the fields of the type to determine if they are valid.
+func (s *InvalidationBatch) Validate() error {
+	invalidParams := request.ErrInvalidParams{Context: "InvalidationBatch"}
+	if s.CallerReference == nil {
+		invalidParams.Add(request.NewErrParamRequired("CallerReference"))
+	}
+	if s.Paths == nil {
+		invalidParams.Add(request.NewErrParamRequired("Paths"))
+	}
+	if s.Paths != nil {
+		if err := s.Paths.Validate(); err != nil {
+			invalidParams.AddNested("Paths", err.(request.ErrInvalidParams))
+		}
+	}
+
+	if invalidParams.Len() > 0 {
+		return invalidParams
+	}
+	return nil
 }
 
 // An invalidation list.
@@ -2321,6 +2936,19 @@ func (s ListDistributionsByWebACLIdInput) GoString() string {
 	return s.String()
 }
 
+// Validate inspects the fields of the type to determine if they are valid.
+func (s *ListDistributionsByWebACLIdInput) Validate() error {
+	invalidParams := request.ErrInvalidParams{Context: "ListDistributionsByWebACLIdInput"}
+	if s.WebACLId == nil {
+		invalidParams.Add(request.NewErrParamRequired("WebACLId"))
+	}
+
+	if invalidParams.Len() > 0 {
+		return invalidParams
+	}
+	return nil
+}
+
 // The response to a request to list the distributions that are associated with
 // a specified AWS WAF web ACL.
 type ListDistributionsByWebACLIdOutput struct {
@@ -2412,6 +3040,19 @@ func (s ListInvalidationsInput) String() string {
 // GoString returns the string representation
 func (s ListInvalidationsInput) GoString() string {
 	return s.String()
+}
+
+// Validate inspects the fields of the type to determine if they are valid.
+func (s *ListInvalidationsInput) Validate() error {
+	invalidParams := request.ErrInvalidParams{Context: "ListInvalidationsInput"}
+	if s.DistributionId == nil {
+		invalidParams.Add(request.NewErrParamRequired("DistributionId"))
+	}
+
+	if invalidParams.Len() > 0 {
+		return invalidParams
+	}
+	return nil
 }
 
 // The returned result of the corresponding request.
@@ -2515,6 +3156,28 @@ func (s LoggingConfig) GoString() string {
 	return s.String()
 }
 
+// Validate inspects the fields of the type to determine if they are valid.
+func (s *LoggingConfig) Validate() error {
+	invalidParams := request.ErrInvalidParams{Context: "LoggingConfig"}
+	if s.Bucket == nil {
+		invalidParams.Add(request.NewErrParamRequired("Bucket"))
+	}
+	if s.Enabled == nil {
+		invalidParams.Add(request.NewErrParamRequired("Enabled"))
+	}
+	if s.IncludeCookies == nil {
+		invalidParams.Add(request.NewErrParamRequired("IncludeCookies"))
+	}
+	if s.Prefix == nil {
+		invalidParams.Add(request.NewErrParamRequired("Prefix"))
+	}
+
+	if invalidParams.Len() > 0 {
+		return invalidParams
+	}
+	return nil
+}
+
 // A complex type that describes the Amazon S3 bucket or the HTTP server (for
 // example, a web server) from which CloudFront gets your files.You must create
 // at least one origin.
@@ -2560,6 +3223,37 @@ func (s Origin) String() string {
 // GoString returns the string representation
 func (s Origin) GoString() string {
 	return s.String()
+}
+
+// Validate inspects the fields of the type to determine if they are valid.
+func (s *Origin) Validate() error {
+	invalidParams := request.ErrInvalidParams{Context: "Origin"}
+	if s.DomainName == nil {
+		invalidParams.Add(request.NewErrParamRequired("DomainName"))
+	}
+	if s.Id == nil {
+		invalidParams.Add(request.NewErrParamRequired("Id"))
+	}
+	if s.CustomHeaders != nil {
+		if err := s.CustomHeaders.Validate(); err != nil {
+			invalidParams.AddNested("CustomHeaders", err.(request.ErrInvalidParams))
+		}
+	}
+	if s.CustomOriginConfig != nil {
+		if err := s.CustomOriginConfig.Validate(); err != nil {
+			invalidParams.AddNested("CustomOriginConfig", err.(request.ErrInvalidParams))
+		}
+	}
+	if s.S3OriginConfig != nil {
+		if err := s.S3OriginConfig.Validate(); err != nil {
+			invalidParams.AddNested("S3OriginConfig", err.(request.ErrInvalidParams))
+		}
+	}
+
+	if invalidParams.Len() > 0 {
+		return invalidParams
+	}
+	return nil
 }
 
 // CloudFront origin access identity.
@@ -2617,6 +3311,22 @@ func (s OriginAccessIdentityConfig) String() string {
 // GoString returns the string representation
 func (s OriginAccessIdentityConfig) GoString() string {
 	return s.String()
+}
+
+// Validate inspects the fields of the type to determine if they are valid.
+func (s *OriginAccessIdentityConfig) Validate() error {
+	invalidParams := request.ErrInvalidParams{Context: "OriginAccessIdentityConfig"}
+	if s.CallerReference == nil {
+		invalidParams.Add(request.NewErrParamRequired("CallerReference"))
+	}
+	if s.Comment == nil {
+		invalidParams.Add(request.NewErrParamRequired("Comment"))
+	}
+
+	if invalidParams.Len() > 0 {
+		return invalidParams
+	}
+	return nil
 }
 
 // The CloudFrontOriginAccessIdentityList type.
@@ -2707,6 +3417,22 @@ func (s OriginCustomHeader) GoString() string {
 	return s.String()
 }
 
+// Validate inspects the fields of the type to determine if they are valid.
+func (s *OriginCustomHeader) Validate() error {
+	invalidParams := request.ErrInvalidParams{Context: "OriginCustomHeader"}
+	if s.HeaderName == nil {
+		invalidParams.Add(request.NewErrParamRequired("HeaderName"))
+	}
+	if s.HeaderValue == nil {
+		invalidParams.Add(request.NewErrParamRequired("HeaderValue"))
+	}
+
+	if invalidParams.Len() > 0 {
+		return invalidParams
+	}
+	return nil
+}
+
 // A complex type that contains the list of SSL/TLS protocols that you want
 // CloudFront to use when communicating with your origin over HTTPS.
 type OriginSslProtocols struct {
@@ -2732,6 +3458,22 @@ func (s OriginSslProtocols) GoString() string {
 	return s.String()
 }
 
+// Validate inspects the fields of the type to determine if they are valid.
+func (s *OriginSslProtocols) Validate() error {
+	invalidParams := request.ErrInvalidParams{Context: "OriginSslProtocols"}
+	if s.Items == nil {
+		invalidParams.Add(request.NewErrParamRequired("Items"))
+	}
+	if s.Quantity == nil {
+		invalidParams.Add(request.NewErrParamRequired("Quantity"))
+	}
+
+	if invalidParams.Len() > 0 {
+		return invalidParams
+	}
+	return nil
+}
+
 // A complex type that contains information about origins for this distribution.
 type Origins struct {
 	_ struct{} `type:"structure"`
@@ -2751,6 +3493,32 @@ func (s Origins) String() string {
 // GoString returns the string representation
 func (s Origins) GoString() string {
 	return s.String()
+}
+
+// Validate inspects the fields of the type to determine if they are valid.
+func (s *Origins) Validate() error {
+	invalidParams := request.ErrInvalidParams{Context: "Origins"}
+	if s.Items != nil && len(s.Items) < 1 {
+		invalidParams.Add(request.NewErrParamMinLen("Items", 1))
+	}
+	if s.Quantity == nil {
+		invalidParams.Add(request.NewErrParamRequired("Quantity"))
+	}
+	if s.Items != nil {
+		for i, v := range s.Items {
+			if v == nil {
+				continue
+			}
+			if err := v.Validate(); err != nil {
+				invalidParams.AddNested(fmt.Sprintf("%s[%v]", "Items", i), err.(request.ErrInvalidParams))
+			}
+		}
+	}
+
+	if invalidParams.Len() > 0 {
+		return invalidParams
+	}
+	return nil
 }
 
 // A complex type that contains information about the objects that you want
@@ -2773,6 +3541,19 @@ func (s Paths) String() string {
 // GoString returns the string representation
 func (s Paths) GoString() string {
 	return s.String()
+}
+
+// Validate inspects the fields of the type to determine if they are valid.
+func (s *Paths) Validate() error {
+	invalidParams := request.ErrInvalidParams{Context: "Paths"}
+	if s.Quantity == nil {
+		invalidParams.Add(request.NewErrParamRequired("Quantity"))
+	}
+
+	if invalidParams.Len() > 0 {
+		return invalidParams
+	}
+	return nil
 }
 
 // A complex type that identifies ways in which you want to restrict distribution
@@ -2799,6 +3580,24 @@ func (s Restrictions) GoString() string {
 	return s.String()
 }
 
+// Validate inspects the fields of the type to determine if they are valid.
+func (s *Restrictions) Validate() error {
+	invalidParams := request.ErrInvalidParams{Context: "Restrictions"}
+	if s.GeoRestriction == nil {
+		invalidParams.Add(request.NewErrParamRequired("GeoRestriction"))
+	}
+	if s.GeoRestriction != nil {
+		if err := s.GeoRestriction.Validate(); err != nil {
+			invalidParams.AddNested("GeoRestriction", err.(request.ErrInvalidParams))
+		}
+	}
+
+	if invalidParams.Len() > 0 {
+		return invalidParams
+	}
+	return nil
+}
+
 // A complex type that contains information about the Amazon S3 bucket from
 // which you want CloudFront to get your media files for distribution.
 type S3Origin struct {
@@ -2819,6 +3618,22 @@ func (s S3Origin) String() string {
 // GoString returns the string representation
 func (s S3Origin) GoString() string {
 	return s.String()
+}
+
+// Validate inspects the fields of the type to determine if they are valid.
+func (s *S3Origin) Validate() error {
+	invalidParams := request.ErrInvalidParams{Context: "S3Origin"}
+	if s.DomainName == nil {
+		invalidParams.Add(request.NewErrParamRequired("DomainName"))
+	}
+	if s.OriginAccessIdentity == nil {
+		invalidParams.Add(request.NewErrParamRequired("OriginAccessIdentity"))
+	}
+
+	if invalidParams.Len() > 0 {
+		return invalidParams
+	}
+	return nil
 }
 
 // A complex type that contains information about the Amazon S3 origin. If the
@@ -2848,6 +3663,19 @@ func (s S3OriginConfig) String() string {
 // GoString returns the string representation
 func (s S3OriginConfig) GoString() string {
 	return s.String()
+}
+
+// Validate inspects the fields of the type to determine if they are valid.
+func (s *S3OriginConfig) Validate() error {
+	invalidParams := request.ErrInvalidParams{Context: "S3OriginConfig"}
+	if s.OriginAccessIdentity == nil {
+		invalidParams.Add(request.NewErrParamRequired("OriginAccessIdentity"))
+	}
+
+	if invalidParams.Len() > 0 {
+		return invalidParams
+	}
+	return nil
 }
 
 // A complex type that lists the AWS accounts that were included in the TrustedSigners
@@ -2982,6 +3810,51 @@ func (s StreamingDistributionConfig) GoString() string {
 	return s.String()
 }
 
+// Validate inspects the fields of the type to determine if they are valid.
+func (s *StreamingDistributionConfig) Validate() error {
+	invalidParams := request.ErrInvalidParams{Context: "StreamingDistributionConfig"}
+	if s.CallerReference == nil {
+		invalidParams.Add(request.NewErrParamRequired("CallerReference"))
+	}
+	if s.Comment == nil {
+		invalidParams.Add(request.NewErrParamRequired("Comment"))
+	}
+	if s.Enabled == nil {
+		invalidParams.Add(request.NewErrParamRequired("Enabled"))
+	}
+	if s.S3Origin == nil {
+		invalidParams.Add(request.NewErrParamRequired("S3Origin"))
+	}
+	if s.TrustedSigners == nil {
+		invalidParams.Add(request.NewErrParamRequired("TrustedSigners"))
+	}
+	if s.Aliases != nil {
+		if err := s.Aliases.Validate(); err != nil {
+			invalidParams.AddNested("Aliases", err.(request.ErrInvalidParams))
+		}
+	}
+	if s.Logging != nil {
+		if err := s.Logging.Validate(); err != nil {
+			invalidParams.AddNested("Logging", err.(request.ErrInvalidParams))
+		}
+	}
+	if s.S3Origin != nil {
+		if err := s.S3Origin.Validate(); err != nil {
+			invalidParams.AddNested("S3Origin", err.(request.ErrInvalidParams))
+		}
+	}
+	if s.TrustedSigners != nil {
+		if err := s.TrustedSigners.Validate(); err != nil {
+			invalidParams.AddNested("TrustedSigners", err.(request.ErrInvalidParams))
+		}
+	}
+
+	if invalidParams.Len() > 0 {
+		return invalidParams
+	}
+	return nil
+}
+
 // A streaming distribution list.
 type StreamingDistributionList struct {
 	_ struct{} `type:"structure"`
@@ -3113,6 +3986,25 @@ func (s StreamingLoggingConfig) GoString() string {
 	return s.String()
 }
 
+// Validate inspects the fields of the type to determine if they are valid.
+func (s *StreamingLoggingConfig) Validate() error {
+	invalidParams := request.ErrInvalidParams{Context: "StreamingLoggingConfig"}
+	if s.Bucket == nil {
+		invalidParams.Add(request.NewErrParamRequired("Bucket"))
+	}
+	if s.Enabled == nil {
+		invalidParams.Add(request.NewErrParamRequired("Enabled"))
+	}
+	if s.Prefix == nil {
+		invalidParams.Add(request.NewErrParamRequired("Prefix"))
+	}
+
+	if invalidParams.Len() > 0 {
+		return invalidParams
+	}
+	return nil
+}
+
 // A complex type that specifies the AWS accounts, if any, that you want to
 // allow to create signed URLs for private content. If you want to require signed
 // URLs in requests for objects in the target origin that match the PathPattern
@@ -3149,6 +4041,22 @@ func (s TrustedSigners) GoString() string {
 	return s.String()
 }
 
+// Validate inspects the fields of the type to determine if they are valid.
+func (s *TrustedSigners) Validate() error {
+	invalidParams := request.ErrInvalidParams{Context: "TrustedSigners"}
+	if s.Enabled == nil {
+		invalidParams.Add(request.NewErrParamRequired("Enabled"))
+	}
+	if s.Quantity == nil {
+		invalidParams.Add(request.NewErrParamRequired("Quantity"))
+	}
+
+	if invalidParams.Len() > 0 {
+		return invalidParams
+	}
+	return nil
+}
+
 // The request to update an origin access identity.
 type UpdateCloudFrontOriginAccessIdentityInput struct {
 	_ struct{} `type:"structure" payload:"CloudFrontOriginAccessIdentityConfig"`
@@ -3172,6 +4080,27 @@ func (s UpdateCloudFrontOriginAccessIdentityInput) String() string {
 // GoString returns the string representation
 func (s UpdateCloudFrontOriginAccessIdentityInput) GoString() string {
 	return s.String()
+}
+
+// Validate inspects the fields of the type to determine if they are valid.
+func (s *UpdateCloudFrontOriginAccessIdentityInput) Validate() error {
+	invalidParams := request.ErrInvalidParams{Context: "UpdateCloudFrontOriginAccessIdentityInput"}
+	if s.CloudFrontOriginAccessIdentityConfig == nil {
+		invalidParams.Add(request.NewErrParamRequired("CloudFrontOriginAccessIdentityConfig"))
+	}
+	if s.Id == nil {
+		invalidParams.Add(request.NewErrParamRequired("Id"))
+	}
+	if s.CloudFrontOriginAccessIdentityConfig != nil {
+		if err := s.CloudFrontOriginAccessIdentityConfig.Validate(); err != nil {
+			invalidParams.AddNested("CloudFrontOriginAccessIdentityConfig", err.(request.ErrInvalidParams))
+		}
+	}
+
+	if invalidParams.Len() > 0 {
+		return invalidParams
+	}
+	return nil
 }
 
 // The returned result of the corresponding request.
@@ -3220,6 +4149,27 @@ func (s UpdateDistributionInput) GoString() string {
 	return s.String()
 }
 
+// Validate inspects the fields of the type to determine if they are valid.
+func (s *UpdateDistributionInput) Validate() error {
+	invalidParams := request.ErrInvalidParams{Context: "UpdateDistributionInput"}
+	if s.DistributionConfig == nil {
+		invalidParams.Add(request.NewErrParamRequired("DistributionConfig"))
+	}
+	if s.Id == nil {
+		invalidParams.Add(request.NewErrParamRequired("Id"))
+	}
+	if s.DistributionConfig != nil {
+		if err := s.DistributionConfig.Validate(); err != nil {
+			invalidParams.AddNested("DistributionConfig", err.(request.ErrInvalidParams))
+		}
+	}
+
+	if invalidParams.Len() > 0 {
+		return invalidParams
+	}
+	return nil
+}
+
 // The returned result of the corresponding request.
 type UpdateDistributionOutput struct {
 	_ struct{} `type:"structure" payload:"Distribution"`
@@ -3264,6 +4214,27 @@ func (s UpdateStreamingDistributionInput) String() string {
 // GoString returns the string representation
 func (s UpdateStreamingDistributionInput) GoString() string {
 	return s.String()
+}
+
+// Validate inspects the fields of the type to determine if they are valid.
+func (s *UpdateStreamingDistributionInput) Validate() error {
+	invalidParams := request.ErrInvalidParams{Context: "UpdateStreamingDistributionInput"}
+	if s.Id == nil {
+		invalidParams.Add(request.NewErrParamRequired("Id"))
+	}
+	if s.StreamingDistributionConfig == nil {
+		invalidParams.Add(request.NewErrParamRequired("StreamingDistributionConfig"))
+	}
+	if s.StreamingDistributionConfig != nil {
+		if err := s.StreamingDistributionConfig.Validate(); err != nil {
+			invalidParams.AddNested("StreamingDistributionConfig", err.(request.ErrInvalidParams))
+		}
+	}
+
+	if invalidParams.Len() > 0 {
+		return invalidParams
+	}
+	return nil
 }
 
 // The returned result of the corresponding request.

--- a/service/cloudhsm/api.go
+++ b/service/cloudhsm/api.go
@@ -4,6 +4,8 @@
 package cloudhsm
 
 import (
+	"fmt"
+
 	"github.com/aws/aws-sdk-go/aws/awsutil"
 	"github.com/aws/aws-sdk-go/aws/request"
 )
@@ -613,6 +615,32 @@ func (s AddTagsToResourceInput) GoString() string {
 	return s.String()
 }
 
+// Validate inspects the fields of the type to determine if they are valid.
+func (s *AddTagsToResourceInput) Validate() error {
+	invalidParams := request.ErrInvalidParams{Context: "AddTagsToResourceInput"}
+	if s.ResourceArn == nil {
+		invalidParams.Add(request.NewErrParamRequired("ResourceArn"))
+	}
+	if s.TagList == nil {
+		invalidParams.Add(request.NewErrParamRequired("TagList"))
+	}
+	if s.TagList != nil {
+		for i, v := range s.TagList {
+			if v == nil {
+				continue
+			}
+			if err := v.Validate(); err != nil {
+				invalidParams.AddNested(fmt.Sprintf("%s[%v]", "TagList", i), err.(request.ErrInvalidParams))
+			}
+		}
+	}
+
+	if invalidParams.Len() > 0 {
+		return invalidParams
+	}
+	return nil
+}
+
 type AddTagsToResourceOutput struct {
 	_ struct{} `type:"structure"`
 
@@ -646,6 +674,19 @@ func (s CreateHapgInput) String() string {
 // GoString returns the string representation
 func (s CreateHapgInput) GoString() string {
 	return s.String()
+}
+
+// Validate inspects the fields of the type to determine if they are valid.
+func (s *CreateHapgInput) Validate() error {
+	invalidParams := request.ErrInvalidParams{Context: "CreateHapgInput"}
+	if s.Label == nil {
+		invalidParams.Add(request.NewErrParamRequired("Label"))
+	}
+
+	if invalidParams.Len() > 0 {
+		return invalidParams
+	}
+	return nil
 }
 
 // Contains the output of the CreateHAPartitionGroup action.
@@ -714,6 +755,28 @@ func (s CreateHsmInput) GoString() string {
 	return s.String()
 }
 
+// Validate inspects the fields of the type to determine if they are valid.
+func (s *CreateHsmInput) Validate() error {
+	invalidParams := request.ErrInvalidParams{Context: "CreateHsmInput"}
+	if s.IamRoleArn == nil {
+		invalidParams.Add(request.NewErrParamRequired("IamRoleArn"))
+	}
+	if s.SshKey == nil {
+		invalidParams.Add(request.NewErrParamRequired("SshKey"))
+	}
+	if s.SubnetId == nil {
+		invalidParams.Add(request.NewErrParamRequired("SubnetId"))
+	}
+	if s.SubscriptionType == nil {
+		invalidParams.Add(request.NewErrParamRequired("SubscriptionType"))
+	}
+
+	if invalidParams.Len() > 0 {
+		return invalidParams
+	}
+	return nil
+}
+
 // Contains the output of the CreateHsm operation.
 type CreateHsmOutput struct {
 	_ struct{} `type:"structure"`
@@ -754,6 +817,22 @@ func (s CreateLunaClientInput) GoString() string {
 	return s.String()
 }
 
+// Validate inspects the fields of the type to determine if they are valid.
+func (s *CreateLunaClientInput) Validate() error {
+	invalidParams := request.ErrInvalidParams{Context: "CreateLunaClientInput"}
+	if s.Certificate == nil {
+		invalidParams.Add(request.NewErrParamRequired("Certificate"))
+	}
+	if s.Certificate != nil && len(*s.Certificate) < 600 {
+		invalidParams.Add(request.NewErrParamMinLen("Certificate", 600))
+	}
+
+	if invalidParams.Len() > 0 {
+		return invalidParams
+	}
+	return nil
+}
+
 // Contains the output of the CreateLunaClient action.
 type CreateLunaClientOutput struct {
 	_ struct{} `type:"structure"`
@@ -788,6 +867,19 @@ func (s DeleteHapgInput) String() string {
 // GoString returns the string representation
 func (s DeleteHapgInput) GoString() string {
 	return s.String()
+}
+
+// Validate inspects the fields of the type to determine if they are valid.
+func (s *DeleteHapgInput) Validate() error {
+	invalidParams := request.ErrInvalidParams{Context: "DeleteHapgInput"}
+	if s.HapgArn == nil {
+		invalidParams.Add(request.NewErrParamRequired("HapgArn"))
+	}
+
+	if invalidParams.Len() > 0 {
+		return invalidParams
+	}
+	return nil
 }
 
 // Contains the output of the DeleteHapg action.
@@ -826,6 +918,19 @@ func (s DeleteHsmInput) GoString() string {
 	return s.String()
 }
 
+// Validate inspects the fields of the type to determine if they are valid.
+func (s *DeleteHsmInput) Validate() error {
+	invalidParams := request.ErrInvalidParams{Context: "DeleteHsmInput"}
+	if s.HsmArn == nil {
+		invalidParams.Add(request.NewErrParamRequired("HsmArn"))
+	}
+
+	if invalidParams.Len() > 0 {
+		return invalidParams
+	}
+	return nil
+}
+
 // Contains the output of the DeleteHsm operation.
 type DeleteHsmOutput struct {
 	_ struct{} `type:"structure"`
@@ -861,6 +966,19 @@ func (s DeleteLunaClientInput) GoString() string {
 	return s.String()
 }
 
+// Validate inspects the fields of the type to determine if they are valid.
+func (s *DeleteLunaClientInput) Validate() error {
+	invalidParams := request.ErrInvalidParams{Context: "DeleteLunaClientInput"}
+	if s.ClientArn == nil {
+		invalidParams.Add(request.NewErrParamRequired("ClientArn"))
+	}
+
+	if invalidParams.Len() > 0 {
+		return invalidParams
+	}
+	return nil
+}
+
 type DeleteLunaClientOutput struct {
 	_ struct{} `type:"structure"`
 
@@ -894,6 +1012,19 @@ func (s DescribeHapgInput) String() string {
 // GoString returns the string representation
 func (s DescribeHapgInput) GoString() string {
 	return s.String()
+}
+
+// Validate inspects the fields of the type to determine if they are valid.
+func (s *DescribeHapgInput) Validate() error {
+	invalidParams := request.ErrInvalidParams{Context: "DescribeHapgInput"}
+	if s.HapgArn == nil {
+		invalidParams.Add(request.NewErrParamRequired("HapgArn"))
+	}
+
+	if invalidParams.Len() > 0 {
+		return invalidParams
+	}
+	return nil
 }
 
 // Contains the output of the DescribeHapg action.
@@ -1116,6 +1247,25 @@ func (s GetConfigInput) GoString() string {
 	return s.String()
 }
 
+// Validate inspects the fields of the type to determine if they are valid.
+func (s *GetConfigInput) Validate() error {
+	invalidParams := request.ErrInvalidParams{Context: "GetConfigInput"}
+	if s.ClientArn == nil {
+		invalidParams.Add(request.NewErrParamRequired("ClientArn"))
+	}
+	if s.ClientVersion == nil {
+		invalidParams.Add(request.NewErrParamRequired("ClientVersion"))
+	}
+	if s.HapgList == nil {
+		invalidParams.Add(request.NewErrParamRequired("HapgList"))
+	}
+
+	if invalidParams.Len() > 0 {
+		return invalidParams
+	}
+	return nil
+}
+
 type GetConfigOutput struct {
 	_ struct{} `type:"structure"`
 
@@ -1306,6 +1456,19 @@ func (s ListTagsForResourceInput) GoString() string {
 	return s.String()
 }
 
+// Validate inspects the fields of the type to determine if they are valid.
+func (s *ListTagsForResourceInput) Validate() error {
+	invalidParams := request.ErrInvalidParams{Context: "ListTagsForResourceInput"}
+	if s.ResourceArn == nil {
+		invalidParams.Add(request.NewErrParamRequired("ResourceArn"))
+	}
+
+	if invalidParams.Len() > 0 {
+		return invalidParams
+	}
+	return nil
+}
+
 type ListTagsForResourceOutput struct {
 	_ struct{} `type:"structure"`
 
@@ -1345,6 +1508,19 @@ func (s ModifyHapgInput) String() string {
 // GoString returns the string representation
 func (s ModifyHapgInput) GoString() string {
 	return s.String()
+}
+
+// Validate inspects the fields of the type to determine if they are valid.
+func (s *ModifyHapgInput) Validate() error {
+	invalidParams := request.ErrInvalidParams{Context: "ModifyHapgInput"}
+	if s.HapgArn == nil {
+		invalidParams.Add(request.NewErrParamRequired("HapgArn"))
+	}
+
+	if invalidParams.Len() > 0 {
+		return invalidParams
+	}
+	return nil
 }
 
 type ModifyHapgOutput struct {
@@ -1403,6 +1579,19 @@ func (s ModifyHsmInput) GoString() string {
 	return s.String()
 }
 
+// Validate inspects the fields of the type to determine if they are valid.
+func (s *ModifyHsmInput) Validate() error {
+	invalidParams := request.ErrInvalidParams{Context: "ModifyHsmInput"}
+	if s.HsmArn == nil {
+		invalidParams.Add(request.NewErrParamRequired("HsmArn"))
+	}
+
+	if invalidParams.Len() > 0 {
+		return invalidParams
+	}
+	return nil
+}
+
 // Contains the output of the ModifyHsm operation.
 type ModifyHsmOutput struct {
 	_ struct{} `type:"structure"`
@@ -1439,6 +1628,25 @@ func (s ModifyLunaClientInput) String() string {
 // GoString returns the string representation
 func (s ModifyLunaClientInput) GoString() string {
 	return s.String()
+}
+
+// Validate inspects the fields of the type to determine if they are valid.
+func (s *ModifyLunaClientInput) Validate() error {
+	invalidParams := request.ErrInvalidParams{Context: "ModifyLunaClientInput"}
+	if s.Certificate == nil {
+		invalidParams.Add(request.NewErrParamRequired("Certificate"))
+	}
+	if s.Certificate != nil && len(*s.Certificate) < 600 {
+		invalidParams.Add(request.NewErrParamMinLen("Certificate", 600))
+	}
+	if s.ClientArn == nil {
+		invalidParams.Add(request.NewErrParamRequired("ClientArn"))
+	}
+
+	if invalidParams.Len() > 0 {
+		return invalidParams
+	}
+	return nil
 }
 
 type ModifyLunaClientOutput struct {
@@ -1481,6 +1689,22 @@ func (s RemoveTagsFromResourceInput) GoString() string {
 	return s.String()
 }
 
+// Validate inspects the fields of the type to determine if they are valid.
+func (s *RemoveTagsFromResourceInput) Validate() error {
+	invalidParams := request.ErrInvalidParams{Context: "RemoveTagsFromResourceInput"}
+	if s.ResourceArn == nil {
+		invalidParams.Add(request.NewErrParamRequired("ResourceArn"))
+	}
+	if s.TagKeyList == nil {
+		invalidParams.Add(request.NewErrParamRequired("TagKeyList"))
+	}
+
+	if invalidParams.Len() > 0 {
+		return invalidParams
+	}
+	return nil
+}
+
 type RemoveTagsFromResourceOutput struct {
 	_ struct{} `type:"structure"`
 
@@ -1518,6 +1742,25 @@ func (s Tag) String() string {
 // GoString returns the string representation
 func (s Tag) GoString() string {
 	return s.String()
+}
+
+// Validate inspects the fields of the type to determine if they are valid.
+func (s *Tag) Validate() error {
+	invalidParams := request.ErrInvalidParams{Context: "Tag"}
+	if s.Key == nil {
+		invalidParams.Add(request.NewErrParamRequired("Key"))
+	}
+	if s.Key != nil && len(*s.Key) < 1 {
+		invalidParams.Add(request.NewErrParamMinLen("Key", 1))
+	}
+	if s.Value == nil {
+		invalidParams.Add(request.NewErrParamRequired("Value"))
+	}
+
+	if invalidParams.Len() > 0 {
+		return invalidParams
+	}
+	return nil
 }
 
 const (

--- a/service/cloudsearch/api.go
+++ b/service/cloudsearch/api.go
@@ -854,6 +854,25 @@ func (s AnalysisScheme) GoString() string {
 	return s.String()
 }
 
+// Validate inspects the fields of the type to determine if they are valid.
+func (s *AnalysisScheme) Validate() error {
+	invalidParams := request.ErrInvalidParams{Context: "AnalysisScheme"}
+	if s.AnalysisSchemeLanguage == nil {
+		invalidParams.Add(request.NewErrParamRequired("AnalysisSchemeLanguage"))
+	}
+	if s.AnalysisSchemeName == nil {
+		invalidParams.Add(request.NewErrParamRequired("AnalysisSchemeName"))
+	}
+	if s.AnalysisSchemeName != nil && len(*s.AnalysisSchemeName) < 1 {
+		invalidParams.Add(request.NewErrParamMinLen("AnalysisSchemeName", 1))
+	}
+
+	if invalidParams.Len() > 0 {
+		return invalidParams
+	}
+	return nil
+}
+
 // The status and configuration of an AnalysisScheme.
 type AnalysisSchemeStatus struct {
 	_ struct{} `type:"structure"`
@@ -921,6 +940,22 @@ func (s BuildSuggestersInput) GoString() string {
 	return s.String()
 }
 
+// Validate inspects the fields of the type to determine if they are valid.
+func (s *BuildSuggestersInput) Validate() error {
+	invalidParams := request.ErrInvalidParams{Context: "BuildSuggestersInput"}
+	if s.DomainName == nil {
+		invalidParams.Add(request.NewErrParamRequired("DomainName"))
+	}
+	if s.DomainName != nil && len(*s.DomainName) < 3 {
+		invalidParams.Add(request.NewErrParamMinLen("DomainName", 3))
+	}
+
+	if invalidParams.Len() > 0 {
+		return invalidParams
+	}
+	return nil
+}
+
 // The result of a BuildSuggester request. Contains a list of the fields used
 // for suggestions.
 type BuildSuggestersOutput struct {
@@ -959,6 +994,22 @@ func (s CreateDomainInput) String() string {
 // GoString returns the string representation
 func (s CreateDomainInput) GoString() string {
 	return s.String()
+}
+
+// Validate inspects the fields of the type to determine if they are valid.
+func (s *CreateDomainInput) Validate() error {
+	invalidParams := request.ErrInvalidParams{Context: "CreateDomainInput"}
+	if s.DomainName == nil {
+		invalidParams.Add(request.NewErrParamRequired("DomainName"))
+	}
+	if s.DomainName != nil && len(*s.DomainName) < 3 {
+		invalidParams.Add(request.NewErrParamMinLen("DomainName", 3))
+	}
+
+	if invalidParams.Len() > 0 {
+		return invalidParams
+	}
+	return nil
 }
 
 // The result of a CreateDomainRequest. Contains the status of a newly created
@@ -1060,6 +1111,19 @@ func (s DateOptions) GoString() string {
 	return s.String()
 }
 
+// Validate inspects the fields of the type to determine if they are valid.
+func (s *DateOptions) Validate() error {
+	invalidParams := request.ErrInvalidParams{Context: "DateOptions"}
+	if s.SourceField != nil && len(*s.SourceField) < 1 {
+		invalidParams.Add(request.NewErrParamMinLen("SourceField", 1))
+	}
+
+	if invalidParams.Len() > 0 {
+		return invalidParams
+	}
+	return nil
+}
+
 // Container for the parameters to the DefineAnalysisScheme operation. Specifies
 // the name of the domain you want to update and the analysis scheme configuration.
 type DefineAnalysisSchemeInput struct {
@@ -1086,6 +1150,30 @@ func (s DefineAnalysisSchemeInput) String() string {
 // GoString returns the string representation
 func (s DefineAnalysisSchemeInput) GoString() string {
 	return s.String()
+}
+
+// Validate inspects the fields of the type to determine if they are valid.
+func (s *DefineAnalysisSchemeInput) Validate() error {
+	invalidParams := request.ErrInvalidParams{Context: "DefineAnalysisSchemeInput"}
+	if s.AnalysisScheme == nil {
+		invalidParams.Add(request.NewErrParamRequired("AnalysisScheme"))
+	}
+	if s.DomainName == nil {
+		invalidParams.Add(request.NewErrParamRequired("DomainName"))
+	}
+	if s.DomainName != nil && len(*s.DomainName) < 3 {
+		invalidParams.Add(request.NewErrParamMinLen("DomainName", 3))
+	}
+	if s.AnalysisScheme != nil {
+		if err := s.AnalysisScheme.Validate(); err != nil {
+			invalidParams.AddNested("AnalysisScheme", err.(request.ErrInvalidParams))
+		}
+	}
+
+	if invalidParams.Len() > 0 {
+		return invalidParams
+	}
+	return nil
 }
 
 // The result of a DefineAnalysisScheme request. Contains the status of the
@@ -1135,6 +1223,30 @@ func (s DefineExpressionInput) GoString() string {
 	return s.String()
 }
 
+// Validate inspects the fields of the type to determine if they are valid.
+func (s *DefineExpressionInput) Validate() error {
+	invalidParams := request.ErrInvalidParams{Context: "DefineExpressionInput"}
+	if s.DomainName == nil {
+		invalidParams.Add(request.NewErrParamRequired("DomainName"))
+	}
+	if s.DomainName != nil && len(*s.DomainName) < 3 {
+		invalidParams.Add(request.NewErrParamMinLen("DomainName", 3))
+	}
+	if s.Expression == nil {
+		invalidParams.Add(request.NewErrParamRequired("Expression"))
+	}
+	if s.Expression != nil {
+		if err := s.Expression.Validate(); err != nil {
+			invalidParams.AddNested("Expression", err.(request.ErrInvalidParams))
+		}
+	}
+
+	if invalidParams.Len() > 0 {
+		return invalidParams
+	}
+	return nil
+}
+
 // The result of a DefineExpression request. Contains the status of the newly-configured
 // expression.
 type DefineExpressionOutput struct {
@@ -1177,6 +1289,30 @@ func (s DefineIndexFieldInput) String() string {
 // GoString returns the string representation
 func (s DefineIndexFieldInput) GoString() string {
 	return s.String()
+}
+
+// Validate inspects the fields of the type to determine if they are valid.
+func (s *DefineIndexFieldInput) Validate() error {
+	invalidParams := request.ErrInvalidParams{Context: "DefineIndexFieldInput"}
+	if s.DomainName == nil {
+		invalidParams.Add(request.NewErrParamRequired("DomainName"))
+	}
+	if s.DomainName != nil && len(*s.DomainName) < 3 {
+		invalidParams.Add(request.NewErrParamMinLen("DomainName", 3))
+	}
+	if s.IndexField == nil {
+		invalidParams.Add(request.NewErrParamRequired("IndexField"))
+	}
+	if s.IndexField != nil {
+		if err := s.IndexField.Validate(); err != nil {
+			invalidParams.AddNested("IndexField", err.(request.ErrInvalidParams))
+		}
+	}
+
+	if invalidParams.Len() > 0 {
+		return invalidParams
+	}
+	return nil
 }
 
 // The result of a DefineIndexField request. Contains the status of the newly-configured
@@ -1225,6 +1361,30 @@ func (s DefineSuggesterInput) GoString() string {
 	return s.String()
 }
 
+// Validate inspects the fields of the type to determine if they are valid.
+func (s *DefineSuggesterInput) Validate() error {
+	invalidParams := request.ErrInvalidParams{Context: "DefineSuggesterInput"}
+	if s.DomainName == nil {
+		invalidParams.Add(request.NewErrParamRequired("DomainName"))
+	}
+	if s.DomainName != nil && len(*s.DomainName) < 3 {
+		invalidParams.Add(request.NewErrParamMinLen("DomainName", 3))
+	}
+	if s.Suggester == nil {
+		invalidParams.Add(request.NewErrParamRequired("Suggester"))
+	}
+	if s.Suggester != nil {
+		if err := s.Suggester.Validate(); err != nil {
+			invalidParams.AddNested("Suggester", err.(request.ErrInvalidParams))
+		}
+	}
+
+	if invalidParams.Len() > 0 {
+		return invalidParams
+	}
+	return nil
+}
+
 // The result of a DefineSuggester request. Contains the status of the newly-configured
 // suggester.
 type DefineSuggesterOutput struct {
@@ -1270,6 +1430,28 @@ func (s DeleteAnalysisSchemeInput) GoString() string {
 	return s.String()
 }
 
+// Validate inspects the fields of the type to determine if they are valid.
+func (s *DeleteAnalysisSchemeInput) Validate() error {
+	invalidParams := request.ErrInvalidParams{Context: "DeleteAnalysisSchemeInput"}
+	if s.AnalysisSchemeName == nil {
+		invalidParams.Add(request.NewErrParamRequired("AnalysisSchemeName"))
+	}
+	if s.AnalysisSchemeName != nil && len(*s.AnalysisSchemeName) < 1 {
+		invalidParams.Add(request.NewErrParamMinLen("AnalysisSchemeName", 1))
+	}
+	if s.DomainName == nil {
+		invalidParams.Add(request.NewErrParamRequired("DomainName"))
+	}
+	if s.DomainName != nil && len(*s.DomainName) < 3 {
+		invalidParams.Add(request.NewErrParamMinLen("DomainName", 3))
+	}
+
+	if invalidParams.Len() > 0 {
+		return invalidParams
+	}
+	return nil
+}
+
 // The result of a DeleteAnalysisScheme request. Contains the status of the
 // deleted analysis scheme.
 type DeleteAnalysisSchemeOutput struct {
@@ -1306,6 +1488,22 @@ func (s DeleteDomainInput) String() string {
 // GoString returns the string representation
 func (s DeleteDomainInput) GoString() string {
 	return s.String()
+}
+
+// Validate inspects the fields of the type to determine if they are valid.
+func (s *DeleteDomainInput) Validate() error {
+	invalidParams := request.ErrInvalidParams{Context: "DeleteDomainInput"}
+	if s.DomainName == nil {
+		invalidParams.Add(request.NewErrParamRequired("DomainName"))
+	}
+	if s.DomainName != nil && len(*s.DomainName) < 3 {
+		invalidParams.Add(request.NewErrParamMinLen("DomainName", 3))
+	}
+
+	if invalidParams.Len() > 0 {
+		return invalidParams
+	}
+	return nil
 }
 
 // The result of a DeleteDomain request. Contains the status of a newly deleted
@@ -1351,6 +1549,28 @@ func (s DeleteExpressionInput) String() string {
 // GoString returns the string representation
 func (s DeleteExpressionInput) GoString() string {
 	return s.String()
+}
+
+// Validate inspects the fields of the type to determine if they are valid.
+func (s *DeleteExpressionInput) Validate() error {
+	invalidParams := request.ErrInvalidParams{Context: "DeleteExpressionInput"}
+	if s.DomainName == nil {
+		invalidParams.Add(request.NewErrParamRequired("DomainName"))
+	}
+	if s.DomainName != nil && len(*s.DomainName) < 3 {
+		invalidParams.Add(request.NewErrParamMinLen("DomainName", 3))
+	}
+	if s.ExpressionName == nil {
+		invalidParams.Add(request.NewErrParamRequired("ExpressionName"))
+	}
+	if s.ExpressionName != nil && len(*s.ExpressionName) < 1 {
+		invalidParams.Add(request.NewErrParamMinLen("ExpressionName", 1))
+	}
+
+	if invalidParams.Len() > 0 {
+		return invalidParams
+	}
+	return nil
 }
 
 // The result of a DeleteExpression request. Specifies the expression being
@@ -1399,6 +1619,28 @@ func (s DeleteIndexFieldInput) GoString() string {
 	return s.String()
 }
 
+// Validate inspects the fields of the type to determine if they are valid.
+func (s *DeleteIndexFieldInput) Validate() error {
+	invalidParams := request.ErrInvalidParams{Context: "DeleteIndexFieldInput"}
+	if s.DomainName == nil {
+		invalidParams.Add(request.NewErrParamRequired("DomainName"))
+	}
+	if s.DomainName != nil && len(*s.DomainName) < 3 {
+		invalidParams.Add(request.NewErrParamMinLen("DomainName", 3))
+	}
+	if s.IndexFieldName == nil {
+		invalidParams.Add(request.NewErrParamRequired("IndexFieldName"))
+	}
+	if s.IndexFieldName != nil && len(*s.IndexFieldName) < 1 {
+		invalidParams.Add(request.NewErrParamMinLen("IndexFieldName", 1))
+	}
+
+	if invalidParams.Len() > 0 {
+		return invalidParams
+	}
+	return nil
+}
+
 // The result of a DeleteIndexField request.
 type DeleteIndexFieldOutput struct {
 	_ struct{} `type:"structure"`
@@ -1441,6 +1683,28 @@ func (s DeleteSuggesterInput) String() string {
 // GoString returns the string representation
 func (s DeleteSuggesterInput) GoString() string {
 	return s.String()
+}
+
+// Validate inspects the fields of the type to determine if they are valid.
+func (s *DeleteSuggesterInput) Validate() error {
+	invalidParams := request.ErrInvalidParams{Context: "DeleteSuggesterInput"}
+	if s.DomainName == nil {
+		invalidParams.Add(request.NewErrParamRequired("DomainName"))
+	}
+	if s.DomainName != nil && len(*s.DomainName) < 3 {
+		invalidParams.Add(request.NewErrParamMinLen("DomainName", 3))
+	}
+	if s.SuggesterName == nil {
+		invalidParams.Add(request.NewErrParamRequired("SuggesterName"))
+	}
+	if s.SuggesterName != nil && len(*s.SuggesterName) < 1 {
+		invalidParams.Add(request.NewErrParamMinLen("SuggesterName", 1))
+	}
+
+	if invalidParams.Len() > 0 {
+		return invalidParams
+	}
+	return nil
 }
 
 // The result of a DeleteSuggester request. Contains the status of the deleted
@@ -1491,6 +1755,22 @@ func (s DescribeAnalysisSchemesInput) GoString() string {
 	return s.String()
 }
 
+// Validate inspects the fields of the type to determine if they are valid.
+func (s *DescribeAnalysisSchemesInput) Validate() error {
+	invalidParams := request.ErrInvalidParams{Context: "DescribeAnalysisSchemesInput"}
+	if s.DomainName == nil {
+		invalidParams.Add(request.NewErrParamRequired("DomainName"))
+	}
+	if s.DomainName != nil && len(*s.DomainName) < 3 {
+		invalidParams.Add(request.NewErrParamMinLen("DomainName", 3))
+	}
+
+	if invalidParams.Len() > 0 {
+		return invalidParams
+	}
+	return nil
+}
+
 // The result of a DescribeAnalysisSchemes request. Contains the analysis schemes
 // configured for the domain specified in the request.
 type DescribeAnalysisSchemesOutput struct {
@@ -1533,6 +1813,22 @@ func (s DescribeAvailabilityOptionsInput) String() string {
 // GoString returns the string representation
 func (s DescribeAvailabilityOptionsInput) GoString() string {
 	return s.String()
+}
+
+// Validate inspects the fields of the type to determine if they are valid.
+func (s *DescribeAvailabilityOptionsInput) Validate() error {
+	invalidParams := request.ErrInvalidParams{Context: "DescribeAvailabilityOptionsInput"}
+	if s.DomainName == nil {
+		invalidParams.Add(request.NewErrParamRequired("DomainName"))
+	}
+	if s.DomainName != nil && len(*s.DomainName) < 3 {
+		invalidParams.Add(request.NewErrParamMinLen("DomainName", 3))
+	}
+
+	if invalidParams.Len() > 0 {
+		return invalidParams
+	}
+	return nil
 }
 
 // The result of a DescribeAvailabilityOptions request. Indicates whether or
@@ -1624,6 +1920,22 @@ func (s DescribeExpressionsInput) GoString() string {
 	return s.String()
 }
 
+// Validate inspects the fields of the type to determine if they are valid.
+func (s *DescribeExpressionsInput) Validate() error {
+	invalidParams := request.ErrInvalidParams{Context: "DescribeExpressionsInput"}
+	if s.DomainName == nil {
+		invalidParams.Add(request.NewErrParamRequired("DomainName"))
+	}
+	if s.DomainName != nil && len(*s.DomainName) < 3 {
+		invalidParams.Add(request.NewErrParamMinLen("DomainName", 3))
+	}
+
+	if invalidParams.Len() > 0 {
+		return invalidParams
+	}
+	return nil
+}
+
 // The result of a DescribeExpressions request. Contains the expressions configured
 // for the domain specified in the request.
 type DescribeExpressionsOutput struct {
@@ -1673,6 +1985,22 @@ func (s DescribeIndexFieldsInput) GoString() string {
 	return s.String()
 }
 
+// Validate inspects the fields of the type to determine if they are valid.
+func (s *DescribeIndexFieldsInput) Validate() error {
+	invalidParams := request.ErrInvalidParams{Context: "DescribeIndexFieldsInput"}
+	if s.DomainName == nil {
+		invalidParams.Add(request.NewErrParamRequired("DomainName"))
+	}
+	if s.DomainName != nil && len(*s.DomainName) < 3 {
+		invalidParams.Add(request.NewErrParamMinLen("DomainName", 3))
+	}
+
+	if invalidParams.Len() > 0 {
+		return invalidParams
+	}
+	return nil
+}
+
 // The result of a DescribeIndexFields request. Contains the index fields configured
 // for the domain specified in the request.
 type DescribeIndexFieldsOutput struct {
@@ -1712,6 +2040,22 @@ func (s DescribeScalingParametersInput) String() string {
 // GoString returns the string representation
 func (s DescribeScalingParametersInput) GoString() string {
 	return s.String()
+}
+
+// Validate inspects the fields of the type to determine if they are valid.
+func (s *DescribeScalingParametersInput) Validate() error {
+	invalidParams := request.ErrInvalidParams{Context: "DescribeScalingParametersInput"}
+	if s.DomainName == nil {
+		invalidParams.Add(request.NewErrParamRequired("DomainName"))
+	}
+	if s.DomainName != nil && len(*s.DomainName) < 3 {
+		invalidParams.Add(request.NewErrParamMinLen("DomainName", 3))
+	}
+
+	if invalidParams.Len() > 0 {
+		return invalidParams
+	}
+	return nil
 }
 
 // The result of a DescribeScalingParameters request. Contains the scaling parameters
@@ -1756,6 +2100,22 @@ func (s DescribeServiceAccessPoliciesInput) String() string {
 // GoString returns the string representation
 func (s DescribeServiceAccessPoliciesInput) GoString() string {
 	return s.String()
+}
+
+// Validate inspects the fields of the type to determine if they are valid.
+func (s *DescribeServiceAccessPoliciesInput) Validate() error {
+	invalidParams := request.ErrInvalidParams{Context: "DescribeServiceAccessPoliciesInput"}
+	if s.DomainName == nil {
+		invalidParams.Add(request.NewErrParamRequired("DomainName"))
+	}
+	if s.DomainName != nil && len(*s.DomainName) < 3 {
+		invalidParams.Add(request.NewErrParamMinLen("DomainName", 3))
+	}
+
+	if invalidParams.Len() > 0 {
+		return invalidParams
+	}
+	return nil
 }
 
 // The result of a DescribeServiceAccessPolicies request.
@@ -1803,6 +2163,22 @@ func (s DescribeSuggestersInput) String() string {
 // GoString returns the string representation
 func (s DescribeSuggestersInput) GoString() string {
 	return s.String()
+}
+
+// Validate inspects the fields of the type to determine if they are valid.
+func (s *DescribeSuggestersInput) Validate() error {
+	invalidParams := request.ErrInvalidParams{Context: "DescribeSuggestersInput"}
+	if s.DomainName == nil {
+		invalidParams.Add(request.NewErrParamRequired("DomainName"))
+	}
+	if s.DomainName != nil && len(*s.DomainName) < 3 {
+		invalidParams.Add(request.NewErrParamMinLen("DomainName", 3))
+	}
+
+	if invalidParams.Len() > 0 {
+		return invalidParams
+	}
+	return nil
 }
 
 // The result of a DescribeSuggesters request.
@@ -1855,6 +2231,22 @@ func (s DocumentSuggesterOptions) String() string {
 // GoString returns the string representation
 func (s DocumentSuggesterOptions) GoString() string {
 	return s.String()
+}
+
+// Validate inspects the fields of the type to determine if they are valid.
+func (s *DocumentSuggesterOptions) Validate() error {
+	invalidParams := request.ErrInvalidParams{Context: "DocumentSuggesterOptions"}
+	if s.SourceField == nil {
+		invalidParams.Add(request.NewErrParamRequired("SourceField"))
+	}
+	if s.SourceField != nil && len(*s.SourceField) < 1 {
+		invalidParams.Add(request.NewErrParamMinLen("SourceField", 1))
+	}
+
+	if invalidParams.Len() > 0 {
+		return invalidParams
+	}
+	return nil
 }
 
 // The current status of the search domain.
@@ -1990,6 +2382,19 @@ func (s DoubleOptions) GoString() string {
 	return s.String()
 }
 
+// Validate inspects the fields of the type to determine if they are valid.
+func (s *DoubleOptions) Validate() error {
+	invalidParams := request.ErrInvalidParams{Context: "DoubleOptions"}
+	if s.SourceField != nil && len(*s.SourceField) < 1 {
+		invalidParams.Add(request.NewErrParamMinLen("SourceField", 1))
+	}
+
+	if invalidParams.Len() > 0 {
+		return invalidParams
+	}
+	return nil
+}
+
 // A named expression that can be evaluated at search time. Can be used to sort
 // the search results, define other expressions, or return computed information
 // in the search results.
@@ -2015,6 +2420,28 @@ func (s Expression) String() string {
 // GoString returns the string representation
 func (s Expression) GoString() string {
 	return s.String()
+}
+
+// Validate inspects the fields of the type to determine if they are valid.
+func (s *Expression) Validate() error {
+	invalidParams := request.ErrInvalidParams{Context: "Expression"}
+	if s.ExpressionName == nil {
+		invalidParams.Add(request.NewErrParamRequired("ExpressionName"))
+	}
+	if s.ExpressionName != nil && len(*s.ExpressionName) < 1 {
+		invalidParams.Add(request.NewErrParamMinLen("ExpressionName", 1))
+	}
+	if s.ExpressionValue == nil {
+		invalidParams.Add(request.NewErrParamRequired("ExpressionValue"))
+	}
+	if s.ExpressionValue != nil && len(*s.ExpressionValue) < 1 {
+		invalidParams.Add(request.NewErrParamMinLen("ExpressionValue", 1))
+	}
+
+	if invalidParams.Len() > 0 {
+		return invalidParams
+	}
+	return nil
 }
 
 // The value of an Expression and its current status.
@@ -2058,6 +2485,22 @@ func (s IndexDocumentsInput) String() string {
 // GoString returns the string representation
 func (s IndexDocumentsInput) GoString() string {
 	return s.String()
+}
+
+// Validate inspects the fields of the type to determine if they are valid.
+func (s *IndexDocumentsInput) Validate() error {
+	invalidParams := request.ErrInvalidParams{Context: "IndexDocumentsInput"}
+	if s.DomainName == nil {
+		invalidParams.Add(request.NewErrParamRequired("DomainName"))
+	}
+	if s.DomainName != nil && len(*s.DomainName) < 3 {
+		invalidParams.Add(request.NewErrParamMinLen("DomainName", 3))
+	}
+
+	if invalidParams.Len() > 0 {
+		return invalidParams
+	}
+	return nil
 }
 
 // The result of an IndexDocuments request. Contains the status of the indexing
@@ -2169,6 +2612,55 @@ func (s IndexField) GoString() string {
 	return s.String()
 }
 
+// Validate inspects the fields of the type to determine if they are valid.
+func (s *IndexField) Validate() error {
+	invalidParams := request.ErrInvalidParams{Context: "IndexField"}
+	if s.IndexFieldName == nil {
+		invalidParams.Add(request.NewErrParamRequired("IndexFieldName"))
+	}
+	if s.IndexFieldName != nil && len(*s.IndexFieldName) < 1 {
+		invalidParams.Add(request.NewErrParamMinLen("IndexFieldName", 1))
+	}
+	if s.IndexFieldType == nil {
+		invalidParams.Add(request.NewErrParamRequired("IndexFieldType"))
+	}
+	if s.DateOptions != nil {
+		if err := s.DateOptions.Validate(); err != nil {
+			invalidParams.AddNested("DateOptions", err.(request.ErrInvalidParams))
+		}
+	}
+	if s.DoubleOptions != nil {
+		if err := s.DoubleOptions.Validate(); err != nil {
+			invalidParams.AddNested("DoubleOptions", err.(request.ErrInvalidParams))
+		}
+	}
+	if s.IntOptions != nil {
+		if err := s.IntOptions.Validate(); err != nil {
+			invalidParams.AddNested("IntOptions", err.(request.ErrInvalidParams))
+		}
+	}
+	if s.LatLonOptions != nil {
+		if err := s.LatLonOptions.Validate(); err != nil {
+			invalidParams.AddNested("LatLonOptions", err.(request.ErrInvalidParams))
+		}
+	}
+	if s.LiteralOptions != nil {
+		if err := s.LiteralOptions.Validate(); err != nil {
+			invalidParams.AddNested("LiteralOptions", err.(request.ErrInvalidParams))
+		}
+	}
+	if s.TextOptions != nil {
+		if err := s.TextOptions.Validate(); err != nil {
+			invalidParams.AddNested("TextOptions", err.(request.ErrInvalidParams))
+		}
+	}
+
+	if invalidParams.Len() > 0 {
+		return invalidParams
+	}
+	return nil
+}
+
 // The value of an IndexField and its current status.
 type IndexFieldStatus struct {
 	_ struct{} `type:"structure"`
@@ -2259,6 +2751,19 @@ func (s IntOptions) GoString() string {
 	return s.String()
 }
 
+// Validate inspects the fields of the type to determine if they are valid.
+func (s *IntOptions) Validate() error {
+	invalidParams := request.ErrInvalidParams{Context: "IntOptions"}
+	if s.SourceField != nil && len(*s.SourceField) < 1 {
+		invalidParams.Add(request.NewErrParamMinLen("SourceField", 1))
+	}
+
+	if invalidParams.Len() > 0 {
+		return invalidParams
+	}
+	return nil
+}
+
 // Options for a latlon field. A latlon field contains a location stored as
 // a latitude and longitude value pair. Present if IndexFieldType specifies
 // the field is of type latlon. All options are enabled by default.
@@ -2305,6 +2810,19 @@ func (s LatLonOptions) String() string {
 // GoString returns the string representation
 func (s LatLonOptions) GoString() string {
 	return s.String()
+}
+
+// Validate inspects the fields of the type to determine if they are valid.
+func (s *LatLonOptions) Validate() error {
+	invalidParams := request.ErrInvalidParams{Context: "LatLonOptions"}
+	if s.SourceField != nil && len(*s.SourceField) < 1 {
+		invalidParams.Add(request.NewErrParamMinLen("SourceField", 1))
+	}
+
+	if invalidParams.Len() > 0 {
+		return invalidParams
+	}
+	return nil
 }
 
 type Limits struct {
@@ -2437,6 +2955,19 @@ func (s LiteralOptions) GoString() string {
 	return s.String()
 }
 
+// Validate inspects the fields of the type to determine if they are valid.
+func (s *LiteralOptions) Validate() error {
+	invalidParams := request.ErrInvalidParams{Context: "LiteralOptions"}
+	if s.SourceField != nil && len(*s.SourceField) < 1 {
+		invalidParams.Add(request.NewErrParamMinLen("SourceField", 1))
+	}
+
+	if invalidParams.Len() > 0 {
+		return invalidParams
+	}
+	return nil
+}
+
 // The status of domain configuration option.
 type OptionStatus struct {
 	_ struct{} `type:"structure"`
@@ -2565,6 +3096,30 @@ func (s Suggester) GoString() string {
 	return s.String()
 }
 
+// Validate inspects the fields of the type to determine if they are valid.
+func (s *Suggester) Validate() error {
+	invalidParams := request.ErrInvalidParams{Context: "Suggester"}
+	if s.DocumentSuggesterOptions == nil {
+		invalidParams.Add(request.NewErrParamRequired("DocumentSuggesterOptions"))
+	}
+	if s.SuggesterName == nil {
+		invalidParams.Add(request.NewErrParamRequired("SuggesterName"))
+	}
+	if s.SuggesterName != nil && len(*s.SuggesterName) < 1 {
+		invalidParams.Add(request.NewErrParamMinLen("SuggesterName", 1))
+	}
+	if s.DocumentSuggesterOptions != nil {
+		if err := s.DocumentSuggesterOptions.Validate(); err != nil {
+			invalidParams.AddNested("DocumentSuggesterOptions", err.(request.ErrInvalidParams))
+		}
+	}
+
+	if invalidParams.Len() > 0 {
+		return invalidParams
+	}
+	return nil
+}
+
 // The value of a Suggester and its current status.
 type SuggesterStatus struct {
 	_ struct{} `type:"structure"`
@@ -2668,6 +3223,19 @@ func (s TextOptions) GoString() string {
 	return s.String()
 }
 
+// Validate inspects the fields of the type to determine if they are valid.
+func (s *TextOptions) Validate() error {
+	invalidParams := request.ErrInvalidParams{Context: "TextOptions"}
+	if s.SourceField != nil && len(*s.SourceField) < 1 {
+		invalidParams.Add(request.NewErrParamMinLen("SourceField", 1))
+	}
+
+	if invalidParams.Len() > 0 {
+		return invalidParams
+	}
+	return nil
+}
+
 // Container for the parameters to the UpdateAvailabilityOptions operation.
 // Specifies the name of the domain you want to update and the Multi-AZ availability
 // option.
@@ -2695,6 +3263,25 @@ func (s UpdateAvailabilityOptionsInput) String() string {
 // GoString returns the string representation
 func (s UpdateAvailabilityOptionsInput) GoString() string {
 	return s.String()
+}
+
+// Validate inspects the fields of the type to determine if they are valid.
+func (s *UpdateAvailabilityOptionsInput) Validate() error {
+	invalidParams := request.ErrInvalidParams{Context: "UpdateAvailabilityOptionsInput"}
+	if s.DomainName == nil {
+		invalidParams.Add(request.NewErrParamRequired("DomainName"))
+	}
+	if s.DomainName != nil && len(*s.DomainName) < 3 {
+		invalidParams.Add(request.NewErrParamMinLen("DomainName", 3))
+	}
+	if s.MultiAZ == nil {
+		invalidParams.Add(request.NewErrParamRequired("MultiAZ"))
+	}
+
+	if invalidParams.Len() > 0 {
+		return invalidParams
+	}
+	return nil
 }
 
 // The result of a UpdateAvailabilityOptions request. Contains the status of
@@ -2743,6 +3330,25 @@ func (s UpdateScalingParametersInput) GoString() string {
 	return s.String()
 }
 
+// Validate inspects the fields of the type to determine if they are valid.
+func (s *UpdateScalingParametersInput) Validate() error {
+	invalidParams := request.ErrInvalidParams{Context: "UpdateScalingParametersInput"}
+	if s.DomainName == nil {
+		invalidParams.Add(request.NewErrParamRequired("DomainName"))
+	}
+	if s.DomainName != nil && len(*s.DomainName) < 3 {
+		invalidParams.Add(request.NewErrParamMinLen("DomainName", 3))
+	}
+	if s.ScalingParameters == nil {
+		invalidParams.Add(request.NewErrParamRequired("ScalingParameters"))
+	}
+
+	if invalidParams.Len() > 0 {
+		return invalidParams
+	}
+	return nil
+}
+
 // The result of a UpdateScalingParameters request. Contains the status of the
 // newly-configured scaling parameters.
 type UpdateScalingParametersOutput struct {
@@ -2787,6 +3393,25 @@ func (s UpdateServiceAccessPoliciesInput) String() string {
 // GoString returns the string representation
 func (s UpdateServiceAccessPoliciesInput) GoString() string {
 	return s.String()
+}
+
+// Validate inspects the fields of the type to determine if they are valid.
+func (s *UpdateServiceAccessPoliciesInput) Validate() error {
+	invalidParams := request.ErrInvalidParams{Context: "UpdateServiceAccessPoliciesInput"}
+	if s.AccessPolicies == nil {
+		invalidParams.Add(request.NewErrParamRequired("AccessPolicies"))
+	}
+	if s.DomainName == nil {
+		invalidParams.Add(request.NewErrParamRequired("DomainName"))
+	}
+	if s.DomainName != nil && len(*s.DomainName) < 3 {
+		invalidParams.Add(request.NewErrParamMinLen("DomainName", 3))
+	}
+
+	if invalidParams.Len() > 0 {
+		return invalidParams
+	}
+	return nil
 }
 
 // The result of an UpdateServiceAccessPolicies request. Contains the new access

--- a/service/cloudsearchdomain/api.go
+++ b/service/cloudsearchdomain/api.go
@@ -620,6 +620,19 @@ func (s SearchInput) GoString() string {
 	return s.String()
 }
 
+// Validate inspects the fields of the type to determine if they are valid.
+func (s *SearchInput) Validate() error {
+	invalidParams := request.ErrInvalidParams{Context: "SearchInput"}
+	if s.Query == nil {
+		invalidParams.Add(request.NewErrParamRequired("Query"))
+	}
+
+	if invalidParams.Len() > 0 {
+		return invalidParams
+	}
+	return nil
+}
+
 // The result of a Search request. Contains the documents that match the specified
 // search criteria and any requested fields, highlights, and facet information.
 type SearchOutput struct {
@@ -692,6 +705,22 @@ func (s SuggestInput) String() string {
 // GoString returns the string representation
 func (s SuggestInput) GoString() string {
 	return s.String()
+}
+
+// Validate inspects the fields of the type to determine if they are valid.
+func (s *SuggestInput) Validate() error {
+	invalidParams := request.ErrInvalidParams{Context: "SuggestInput"}
+	if s.Query == nil {
+		invalidParams.Add(request.NewErrParamRequired("Query"))
+	}
+	if s.Suggester == nil {
+		invalidParams.Add(request.NewErrParamRequired("Suggester"))
+	}
+
+	if invalidParams.Len() > 0 {
+		return invalidParams
+	}
+	return nil
 }
 
 // Container for the suggestion information returned in a SuggestResponse.
@@ -808,6 +837,22 @@ func (s UploadDocumentsInput) String() string {
 // GoString returns the string representation
 func (s UploadDocumentsInput) GoString() string {
 	return s.String()
+}
+
+// Validate inspects the fields of the type to determine if they are valid.
+func (s *UploadDocumentsInput) Validate() error {
+	invalidParams := request.ErrInvalidParams{Context: "UploadDocumentsInput"}
+	if s.ContentType == nil {
+		invalidParams.Add(request.NewErrParamRequired("ContentType"))
+	}
+	if s.Documents == nil {
+		invalidParams.Add(request.NewErrParamRequired("Documents"))
+	}
+
+	if invalidParams.Len() > 0 {
+		return invalidParams
+	}
+	return nil
 }
 
 // Contains the response to an UploadDocuments request.

--- a/service/cloudtrail/api.go
+++ b/service/cloudtrail/api.go
@@ -4,6 +4,7 @@
 package cloudtrail
 
 import (
+	"fmt"
 	"time"
 
 	"github.com/aws/aws-sdk-go/aws/awsutil"
@@ -408,6 +409,29 @@ func (s AddTagsInput) GoString() string {
 	return s.String()
 }
 
+// Validate inspects the fields of the type to determine if they are valid.
+func (s *AddTagsInput) Validate() error {
+	invalidParams := request.ErrInvalidParams{Context: "AddTagsInput"}
+	if s.ResourceId == nil {
+		invalidParams.Add(request.NewErrParamRequired("ResourceId"))
+	}
+	if s.TagsList != nil {
+		for i, v := range s.TagsList {
+			if v == nil {
+				continue
+			}
+			if err := v.Validate(); err != nil {
+				invalidParams.AddNested(fmt.Sprintf("%s[%v]", "TagsList", i), err.(request.ErrInvalidParams))
+			}
+		}
+	}
+
+	if invalidParams.Len() > 0 {
+		return invalidParams
+	}
+	return nil
+}
+
 // Returns the objects or data listed below if successful. Otherwise, returns
 // an error.
 type AddTagsOutput struct {
@@ -503,6 +527,22 @@ func (s CreateTrailInput) GoString() string {
 	return s.String()
 }
 
+// Validate inspects the fields of the type to determine if they are valid.
+func (s *CreateTrailInput) Validate() error {
+	invalidParams := request.ErrInvalidParams{Context: "CreateTrailInput"}
+	if s.Name == nil {
+		invalidParams.Add(request.NewErrParamRequired("Name"))
+	}
+	if s.S3BucketName == nil {
+		invalidParams.Add(request.NewErrParamRequired("S3BucketName"))
+	}
+
+	if invalidParams.Len() > 0 {
+		return invalidParams
+	}
+	return nil
+}
+
 // Returns the objects or data listed below if successful. Otherwise, returns
 // an error.
 type CreateTrailOutput struct {
@@ -579,6 +619,19 @@ func (s DeleteTrailInput) String() string {
 // GoString returns the string representation
 func (s DeleteTrailInput) GoString() string {
 	return s.String()
+}
+
+// Validate inspects the fields of the type to determine if they are valid.
+func (s *DeleteTrailInput) Validate() error {
+	invalidParams := request.ErrInvalidParams{Context: "DeleteTrailInput"}
+	if s.Name == nil {
+		invalidParams.Add(request.NewErrParamRequired("Name"))
+	}
+
+	if invalidParams.Len() > 0 {
+		return invalidParams
+	}
+	return nil
 }
 
 // Returns the objects or data listed below if successful. Otherwise, returns
@@ -704,6 +757,19 @@ func (s GetTrailStatusInput) String() string {
 // GoString returns the string representation
 func (s GetTrailStatusInput) GoString() string {
 	return s.String()
+}
+
+// Validate inspects the fields of the type to determine if they are valid.
+func (s *GetTrailStatusInput) Validate() error {
+	invalidParams := request.ErrInvalidParams{Context: "GetTrailStatusInput"}
+	if s.Name == nil {
+		invalidParams.Add(request.NewErrParamRequired("Name"))
+	}
+
+	if invalidParams.Len() > 0 {
+		return invalidParams
+	}
+	return nil
 }
 
 // Returns the objects or data listed below if successful. Otherwise, returns
@@ -871,6 +937,19 @@ func (s ListTagsInput) GoString() string {
 	return s.String()
 }
 
+// Validate inspects the fields of the type to determine if they are valid.
+func (s *ListTagsInput) Validate() error {
+	invalidParams := request.ErrInvalidParams{Context: "ListTagsInput"}
+	if s.ResourceIdList == nil {
+		invalidParams.Add(request.NewErrParamRequired("ResourceIdList"))
+	}
+
+	if invalidParams.Len() > 0 {
+		return invalidParams
+	}
+	return nil
+}
+
 // Returns the objects or data listed below if successful. Otherwise, returns
 // an error.
 type ListTagsOutput struct {
@@ -914,6 +993,22 @@ func (s LookupAttribute) GoString() string {
 	return s.String()
 }
 
+// Validate inspects the fields of the type to determine if they are valid.
+func (s *LookupAttribute) Validate() error {
+	invalidParams := request.ErrInvalidParams{Context: "LookupAttribute"}
+	if s.AttributeKey == nil {
+		invalidParams.Add(request.NewErrParamRequired("AttributeKey"))
+	}
+	if s.AttributeValue == nil {
+		invalidParams.Add(request.NewErrParamRequired("AttributeValue"))
+	}
+
+	if invalidParams.Len() > 0 {
+		return invalidParams
+	}
+	return nil
+}
+
 // Contains a request for LookupEvents.
 type LookupEventsInput struct {
 	_ struct{} `type:"structure"`
@@ -952,6 +1047,29 @@ func (s LookupEventsInput) String() string {
 // GoString returns the string representation
 func (s LookupEventsInput) GoString() string {
 	return s.String()
+}
+
+// Validate inspects the fields of the type to determine if they are valid.
+func (s *LookupEventsInput) Validate() error {
+	invalidParams := request.ErrInvalidParams{Context: "LookupEventsInput"}
+	if s.MaxResults != nil && *s.MaxResults < 1 {
+		invalidParams.Add(request.NewErrParamMinValue("MaxResults", 1))
+	}
+	if s.LookupAttributes != nil {
+		for i, v := range s.LookupAttributes {
+			if v == nil {
+				continue
+			}
+			if err := v.Validate(); err != nil {
+				invalidParams.AddNested(fmt.Sprintf("%s[%v]", "LookupAttributes", i), err.(request.ErrInvalidParams))
+			}
+		}
+	}
+
+	if invalidParams.Len() > 0 {
+		return invalidParams
+	}
+	return nil
 }
 
 // Contains a response to a LookupEvents action.
@@ -1030,6 +1148,29 @@ func (s RemoveTagsInput) String() string {
 // GoString returns the string representation
 func (s RemoveTagsInput) GoString() string {
 	return s.String()
+}
+
+// Validate inspects the fields of the type to determine if they are valid.
+func (s *RemoveTagsInput) Validate() error {
+	invalidParams := request.ErrInvalidParams{Context: "RemoveTagsInput"}
+	if s.ResourceId == nil {
+		invalidParams.Add(request.NewErrParamRequired("ResourceId"))
+	}
+	if s.TagsList != nil {
+		for i, v := range s.TagsList {
+			if v == nil {
+				continue
+			}
+			if err := v.Validate(); err != nil {
+				invalidParams.AddNested(fmt.Sprintf("%s[%v]", "TagsList", i), err.(request.ErrInvalidParams))
+			}
+		}
+	}
+
+	if invalidParams.Len() > 0 {
+		return invalidParams
+	}
+	return nil
 }
 
 // Returns the objects or data listed below if successful. Otherwise, returns
@@ -1116,6 +1257,19 @@ func (s StartLoggingInput) GoString() string {
 	return s.String()
 }
 
+// Validate inspects the fields of the type to determine if they are valid.
+func (s *StartLoggingInput) Validate() error {
+	invalidParams := request.ErrInvalidParams{Context: "StartLoggingInput"}
+	if s.Name == nil {
+		invalidParams.Add(request.NewErrParamRequired("Name"))
+	}
+
+	if invalidParams.Len() > 0 {
+		return invalidParams
+	}
+	return nil
+}
+
 // Returns the objects or data listed below if successful. Otherwise, returns
 // an error.
 type StartLoggingOutput struct {
@@ -1150,6 +1304,19 @@ func (s StopLoggingInput) String() string {
 // GoString returns the string representation
 func (s StopLoggingInput) GoString() string {
 	return s.String()
+}
+
+// Validate inspects the fields of the type to determine if they are valid.
+func (s *StopLoggingInput) Validate() error {
+	invalidParams := request.ErrInvalidParams{Context: "StopLoggingInput"}
+	if s.Name == nil {
+		invalidParams.Add(request.NewErrParamRequired("Name"))
+	}
+
+	if invalidParams.Len() > 0 {
+		return invalidParams
+	}
+	return nil
 }
 
 // Returns the objects or data listed below if successful. Otherwise, returns
@@ -1189,6 +1356,19 @@ func (s Tag) String() string {
 // GoString returns the string representation
 func (s Tag) GoString() string {
 	return s.String()
+}
+
+// Validate inspects the fields of the type to determine if they are valid.
+func (s *Tag) Validate() error {
+	invalidParams := request.ErrInvalidParams{Context: "Tag"}
+	if s.Key == nil {
+		invalidParams.Add(request.NewErrParamRequired("Key"))
+	}
+
+	if invalidParams.Len() > 0 {
+		return invalidParams
+	}
+	return nil
 }
 
 // The settings for a trail.
@@ -1336,6 +1516,19 @@ func (s UpdateTrailInput) String() string {
 // GoString returns the string representation
 func (s UpdateTrailInput) GoString() string {
 	return s.String()
+}
+
+// Validate inspects the fields of the type to determine if they are valid.
+func (s *UpdateTrailInput) Validate() error {
+	invalidParams := request.ErrInvalidParams{Context: "UpdateTrailInput"}
+	if s.Name == nil {
+		invalidParams.Add(request.NewErrParamRequired("Name"))
+	}
+
+	if invalidParams.Len() > 0 {
+		return invalidParams
+	}
+	return nil
 }
 
 // Returns the objects or data listed below if successful. Otherwise, returns

--- a/service/cloudwatch/api.go
+++ b/service/cloudwatch/api.go
@@ -4,6 +4,7 @@
 package cloudwatch
 
 import (
+	"fmt"
 	"time"
 
 	"github.com/aws/aws-sdk-go/aws/awsutil"
@@ -546,6 +547,19 @@ func (s DeleteAlarmsInput) GoString() string {
 	return s.String()
 }
 
+// Validate inspects the fields of the type to determine if they are valid.
+func (s *DeleteAlarmsInput) Validate() error {
+	invalidParams := request.ErrInvalidParams{Context: "DeleteAlarmsInput"}
+	if s.AlarmNames == nil {
+		invalidParams.Add(request.NewErrParamRequired("AlarmNames"))
+	}
+
+	if invalidParams.Len() > 0 {
+		return invalidParams
+	}
+	return nil
+}
+
 type DeleteAlarmsOutput struct {
 	_ struct{} `type:"structure"`
 }
@@ -591,6 +605,22 @@ func (s DescribeAlarmHistoryInput) String() string {
 // GoString returns the string representation
 func (s DescribeAlarmHistoryInput) GoString() string {
 	return s.String()
+}
+
+// Validate inspects the fields of the type to determine if they are valid.
+func (s *DescribeAlarmHistoryInput) Validate() error {
+	invalidParams := request.ErrInvalidParams{Context: "DescribeAlarmHistoryInput"}
+	if s.AlarmName != nil && len(*s.AlarmName) < 1 {
+		invalidParams.Add(request.NewErrParamMinLen("AlarmName", 1))
+	}
+	if s.MaxRecords != nil && *s.MaxRecords < 1 {
+		invalidParams.Add(request.NewErrParamMinValue("MaxRecords", 1))
+	}
+
+	if invalidParams.Len() > 0 {
+		return invalidParams
+	}
+	return nil
 }
 
 // The output for the DescribeAlarmHistory action.
@@ -648,6 +678,41 @@ func (s DescribeAlarmsForMetricInput) GoString() string {
 	return s.String()
 }
 
+// Validate inspects the fields of the type to determine if they are valid.
+func (s *DescribeAlarmsForMetricInput) Validate() error {
+	invalidParams := request.ErrInvalidParams{Context: "DescribeAlarmsForMetricInput"}
+	if s.MetricName == nil {
+		invalidParams.Add(request.NewErrParamRequired("MetricName"))
+	}
+	if s.MetricName != nil && len(*s.MetricName) < 1 {
+		invalidParams.Add(request.NewErrParamMinLen("MetricName", 1))
+	}
+	if s.Namespace == nil {
+		invalidParams.Add(request.NewErrParamRequired("Namespace"))
+	}
+	if s.Namespace != nil && len(*s.Namespace) < 1 {
+		invalidParams.Add(request.NewErrParamMinLen("Namespace", 1))
+	}
+	if s.Period != nil && *s.Period < 60 {
+		invalidParams.Add(request.NewErrParamMinValue("Period", 60))
+	}
+	if s.Dimensions != nil {
+		for i, v := range s.Dimensions {
+			if v == nil {
+				continue
+			}
+			if err := v.Validate(); err != nil {
+				invalidParams.AddNested(fmt.Sprintf("%s[%v]", "Dimensions", i), err.(request.ErrInvalidParams))
+			}
+		}
+	}
+
+	if invalidParams.Len() > 0 {
+		return invalidParams
+	}
+	return nil
+}
+
 // The output for the DescribeAlarmsForMetric action.
 type DescribeAlarmsForMetricOutput struct {
 	_ struct{} `type:"structure"`
@@ -700,6 +765,25 @@ func (s DescribeAlarmsInput) GoString() string {
 	return s.String()
 }
 
+// Validate inspects the fields of the type to determine if they are valid.
+func (s *DescribeAlarmsInput) Validate() error {
+	invalidParams := request.ErrInvalidParams{Context: "DescribeAlarmsInput"}
+	if s.ActionPrefix != nil && len(*s.ActionPrefix) < 1 {
+		invalidParams.Add(request.NewErrParamMinLen("ActionPrefix", 1))
+	}
+	if s.AlarmNamePrefix != nil && len(*s.AlarmNamePrefix) < 1 {
+		invalidParams.Add(request.NewErrParamMinLen("AlarmNamePrefix", 1))
+	}
+	if s.MaxRecords != nil && *s.MaxRecords < 1 {
+		invalidParams.Add(request.NewErrParamMinValue("MaxRecords", 1))
+	}
+
+	if invalidParams.Len() > 0 {
+		return invalidParams
+	}
+	return nil
+}
+
 // The output for the DescribeAlarms action.
 type DescribeAlarmsOutput struct {
 	_ struct{} `type:"structure"`
@@ -745,6 +829,28 @@ func (s Dimension) GoString() string {
 	return s.String()
 }
 
+// Validate inspects the fields of the type to determine if they are valid.
+func (s *Dimension) Validate() error {
+	invalidParams := request.ErrInvalidParams{Context: "Dimension"}
+	if s.Name == nil {
+		invalidParams.Add(request.NewErrParamRequired("Name"))
+	}
+	if s.Name != nil && len(*s.Name) < 1 {
+		invalidParams.Add(request.NewErrParamMinLen("Name", 1))
+	}
+	if s.Value == nil {
+		invalidParams.Add(request.NewErrParamRequired("Value"))
+	}
+	if s.Value != nil && len(*s.Value) < 1 {
+		invalidParams.Add(request.NewErrParamMinLen("Value", 1))
+	}
+
+	if invalidParams.Len() > 0 {
+		return invalidParams
+	}
+	return nil
+}
+
 // The DimensionFilter data type is used to filter ListMetrics results.
 type DimensionFilter struct {
 	_ struct{} `type:"structure"`
@@ -769,6 +875,25 @@ func (s DimensionFilter) GoString() string {
 	return s.String()
 }
 
+// Validate inspects the fields of the type to determine if they are valid.
+func (s *DimensionFilter) Validate() error {
+	invalidParams := request.ErrInvalidParams{Context: "DimensionFilter"}
+	if s.Name == nil {
+		invalidParams.Add(request.NewErrParamRequired("Name"))
+	}
+	if s.Name != nil && len(*s.Name) < 1 {
+		invalidParams.Add(request.NewErrParamMinLen("Name", 1))
+	}
+	if s.Value != nil && len(*s.Value) < 1 {
+		invalidParams.Add(request.NewErrParamMinLen("Value", 1))
+	}
+
+	if invalidParams.Len() > 0 {
+		return invalidParams
+	}
+	return nil
+}
+
 type DisableAlarmActionsInput struct {
 	_ struct{} `type:"structure"`
 
@@ -784,6 +909,19 @@ func (s DisableAlarmActionsInput) String() string {
 // GoString returns the string representation
 func (s DisableAlarmActionsInput) GoString() string {
 	return s.String()
+}
+
+// Validate inspects the fields of the type to determine if they are valid.
+func (s *DisableAlarmActionsInput) Validate() error {
+	invalidParams := request.ErrInvalidParams{Context: "DisableAlarmActionsInput"}
+	if s.AlarmNames == nil {
+		invalidParams.Add(request.NewErrParamRequired("AlarmNames"))
+	}
+
+	if invalidParams.Len() > 0 {
+		return invalidParams
+	}
+	return nil
 }
 
 type DisableAlarmActionsOutput struct {
@@ -815,6 +953,19 @@ func (s EnableAlarmActionsInput) String() string {
 // GoString returns the string representation
 func (s EnableAlarmActionsInput) GoString() string {
 	return s.String()
+}
+
+// Validate inspects the fields of the type to determine if they are valid.
+func (s *EnableAlarmActionsInput) Validate() error {
+	invalidParams := request.ErrInvalidParams{Context: "EnableAlarmActionsInput"}
+	if s.AlarmNames == nil {
+		invalidParams.Add(request.NewErrParamRequired("AlarmNames"))
+	}
+
+	if invalidParams.Len() > 0 {
+		return invalidParams
+	}
+	return nil
 }
 
 type EnableAlarmActionsOutput struct {
@@ -883,6 +1034,56 @@ func (s GetMetricStatisticsInput) GoString() string {
 	return s.String()
 }
 
+// Validate inspects the fields of the type to determine if they are valid.
+func (s *GetMetricStatisticsInput) Validate() error {
+	invalidParams := request.ErrInvalidParams{Context: "GetMetricStatisticsInput"}
+	if s.EndTime == nil {
+		invalidParams.Add(request.NewErrParamRequired("EndTime"))
+	}
+	if s.MetricName == nil {
+		invalidParams.Add(request.NewErrParamRequired("MetricName"))
+	}
+	if s.MetricName != nil && len(*s.MetricName) < 1 {
+		invalidParams.Add(request.NewErrParamMinLen("MetricName", 1))
+	}
+	if s.Namespace == nil {
+		invalidParams.Add(request.NewErrParamRequired("Namespace"))
+	}
+	if s.Namespace != nil && len(*s.Namespace) < 1 {
+		invalidParams.Add(request.NewErrParamMinLen("Namespace", 1))
+	}
+	if s.Period == nil {
+		invalidParams.Add(request.NewErrParamRequired("Period"))
+	}
+	if s.Period != nil && *s.Period < 60 {
+		invalidParams.Add(request.NewErrParamMinValue("Period", 60))
+	}
+	if s.StartTime == nil {
+		invalidParams.Add(request.NewErrParamRequired("StartTime"))
+	}
+	if s.Statistics == nil {
+		invalidParams.Add(request.NewErrParamRequired("Statistics"))
+	}
+	if s.Statistics != nil && len(s.Statistics) < 1 {
+		invalidParams.Add(request.NewErrParamMinLen("Statistics", 1))
+	}
+	if s.Dimensions != nil {
+		for i, v := range s.Dimensions {
+			if v == nil {
+				continue
+			}
+			if err := v.Validate(); err != nil {
+				invalidParams.AddNested(fmt.Sprintf("%s[%v]", "Dimensions", i), err.(request.ErrInvalidParams))
+			}
+		}
+	}
+
+	if invalidParams.Len() > 0 {
+		return invalidParams
+	}
+	return nil
+}
+
 // The output for the GetMetricStatistics action.
 type GetMetricStatisticsOutput struct {
 	_ struct{} `type:"structure"`
@@ -929,6 +1130,32 @@ func (s ListMetricsInput) String() string {
 // GoString returns the string representation
 func (s ListMetricsInput) GoString() string {
 	return s.String()
+}
+
+// Validate inspects the fields of the type to determine if they are valid.
+func (s *ListMetricsInput) Validate() error {
+	invalidParams := request.ErrInvalidParams{Context: "ListMetricsInput"}
+	if s.MetricName != nil && len(*s.MetricName) < 1 {
+		invalidParams.Add(request.NewErrParamMinLen("MetricName", 1))
+	}
+	if s.Namespace != nil && len(*s.Namespace) < 1 {
+		invalidParams.Add(request.NewErrParamMinLen("Namespace", 1))
+	}
+	if s.Dimensions != nil {
+		for i, v := range s.Dimensions {
+			if v == nil {
+				continue
+			}
+			if err := v.Validate(); err != nil {
+				invalidParams.AddNested(fmt.Sprintf("%s[%v]", "Dimensions", i), err.(request.ErrInvalidParams))
+			}
+		}
+	}
+
+	if invalidParams.Len() > 0 {
+		return invalidParams
+	}
+	return nil
 }
 
 // The output for the ListMetrics action.
@@ -1115,6 +1342,37 @@ func (s MetricDatum) GoString() string {
 	return s.String()
 }
 
+// Validate inspects the fields of the type to determine if they are valid.
+func (s *MetricDatum) Validate() error {
+	invalidParams := request.ErrInvalidParams{Context: "MetricDatum"}
+	if s.MetricName == nil {
+		invalidParams.Add(request.NewErrParamRequired("MetricName"))
+	}
+	if s.MetricName != nil && len(*s.MetricName) < 1 {
+		invalidParams.Add(request.NewErrParamMinLen("MetricName", 1))
+	}
+	if s.Dimensions != nil {
+		for i, v := range s.Dimensions {
+			if v == nil {
+				continue
+			}
+			if err := v.Validate(); err != nil {
+				invalidParams.AddNested(fmt.Sprintf("%s[%v]", "Dimensions", i), err.(request.ErrInvalidParams))
+			}
+		}
+	}
+	if s.StatisticValues != nil {
+		if err := s.StatisticValues.Validate(); err != nil {
+			invalidParams.AddNested("StatisticValues", err.(request.ErrInvalidParams))
+		}
+	}
+
+	if invalidParams.Len() > 0 {
+		return invalidParams
+	}
+	return nil
+}
+
 type PutMetricAlarmInput struct {
 	_ struct{} `type:"structure"`
 
@@ -1228,6 +1486,65 @@ func (s PutMetricAlarmInput) GoString() string {
 	return s.String()
 }
 
+// Validate inspects the fields of the type to determine if they are valid.
+func (s *PutMetricAlarmInput) Validate() error {
+	invalidParams := request.ErrInvalidParams{Context: "PutMetricAlarmInput"}
+	if s.AlarmName == nil {
+		invalidParams.Add(request.NewErrParamRequired("AlarmName"))
+	}
+	if s.AlarmName != nil && len(*s.AlarmName) < 1 {
+		invalidParams.Add(request.NewErrParamMinLen("AlarmName", 1))
+	}
+	if s.ComparisonOperator == nil {
+		invalidParams.Add(request.NewErrParamRequired("ComparisonOperator"))
+	}
+	if s.EvaluationPeriods == nil {
+		invalidParams.Add(request.NewErrParamRequired("EvaluationPeriods"))
+	}
+	if s.EvaluationPeriods != nil && *s.EvaluationPeriods < 1 {
+		invalidParams.Add(request.NewErrParamMinValue("EvaluationPeriods", 1))
+	}
+	if s.MetricName == nil {
+		invalidParams.Add(request.NewErrParamRequired("MetricName"))
+	}
+	if s.MetricName != nil && len(*s.MetricName) < 1 {
+		invalidParams.Add(request.NewErrParamMinLen("MetricName", 1))
+	}
+	if s.Namespace == nil {
+		invalidParams.Add(request.NewErrParamRequired("Namespace"))
+	}
+	if s.Namespace != nil && len(*s.Namespace) < 1 {
+		invalidParams.Add(request.NewErrParamMinLen("Namespace", 1))
+	}
+	if s.Period == nil {
+		invalidParams.Add(request.NewErrParamRequired("Period"))
+	}
+	if s.Period != nil && *s.Period < 60 {
+		invalidParams.Add(request.NewErrParamMinValue("Period", 60))
+	}
+	if s.Statistic == nil {
+		invalidParams.Add(request.NewErrParamRequired("Statistic"))
+	}
+	if s.Threshold == nil {
+		invalidParams.Add(request.NewErrParamRequired("Threshold"))
+	}
+	if s.Dimensions != nil {
+		for i, v := range s.Dimensions {
+			if v == nil {
+				continue
+			}
+			if err := v.Validate(); err != nil {
+				invalidParams.AddNested(fmt.Sprintf("%s[%v]", "Dimensions", i), err.(request.ErrInvalidParams))
+			}
+		}
+	}
+
+	if invalidParams.Len() > 0 {
+		return invalidParams
+	}
+	return nil
+}
+
 type PutMetricAlarmOutput struct {
 	_ struct{} `type:"structure"`
 }
@@ -1264,6 +1581,35 @@ func (s PutMetricDataInput) String() string {
 // GoString returns the string representation
 func (s PutMetricDataInput) GoString() string {
 	return s.String()
+}
+
+// Validate inspects the fields of the type to determine if they are valid.
+func (s *PutMetricDataInput) Validate() error {
+	invalidParams := request.ErrInvalidParams{Context: "PutMetricDataInput"}
+	if s.MetricData == nil {
+		invalidParams.Add(request.NewErrParamRequired("MetricData"))
+	}
+	if s.Namespace == nil {
+		invalidParams.Add(request.NewErrParamRequired("Namespace"))
+	}
+	if s.Namespace != nil && len(*s.Namespace) < 1 {
+		invalidParams.Add(request.NewErrParamMinLen("Namespace", 1))
+	}
+	if s.MetricData != nil {
+		for i, v := range s.MetricData {
+			if v == nil {
+				continue
+			}
+			if err := v.Validate(); err != nil {
+				invalidParams.AddNested(fmt.Sprintf("%s[%v]", "MetricData", i), err.(request.ErrInvalidParams))
+			}
+		}
+	}
+
+	if invalidParams.Len() > 0 {
+		return invalidParams
+	}
+	return nil
 }
 
 type PutMetricDataOutput struct {
@@ -1309,6 +1655,28 @@ func (s SetAlarmStateInput) GoString() string {
 	return s.String()
 }
 
+// Validate inspects the fields of the type to determine if they are valid.
+func (s *SetAlarmStateInput) Validate() error {
+	invalidParams := request.ErrInvalidParams{Context: "SetAlarmStateInput"}
+	if s.AlarmName == nil {
+		invalidParams.Add(request.NewErrParamRequired("AlarmName"))
+	}
+	if s.AlarmName != nil && len(*s.AlarmName) < 1 {
+		invalidParams.Add(request.NewErrParamMinLen("AlarmName", 1))
+	}
+	if s.StateReason == nil {
+		invalidParams.Add(request.NewErrParamRequired("StateReason"))
+	}
+	if s.StateValue == nil {
+		invalidParams.Add(request.NewErrParamRequired("StateValue"))
+	}
+
+	if invalidParams.Len() > 0 {
+		return invalidParams
+	}
+	return nil
+}
+
 type SetAlarmStateOutput struct {
 	_ struct{} `type:"structure"`
 }
@@ -1349,6 +1717,28 @@ func (s StatisticSet) String() string {
 // GoString returns the string representation
 func (s StatisticSet) GoString() string {
 	return s.String()
+}
+
+// Validate inspects the fields of the type to determine if they are valid.
+func (s *StatisticSet) Validate() error {
+	invalidParams := request.ErrInvalidParams{Context: "StatisticSet"}
+	if s.Maximum == nil {
+		invalidParams.Add(request.NewErrParamRequired("Maximum"))
+	}
+	if s.Minimum == nil {
+		invalidParams.Add(request.NewErrParamRequired("Minimum"))
+	}
+	if s.SampleCount == nil {
+		invalidParams.Add(request.NewErrParamRequired("SampleCount"))
+	}
+	if s.Sum == nil {
+		invalidParams.Add(request.NewErrParamRequired("Sum"))
+	}
+
+	if invalidParams.Len() > 0 {
+		return invalidParams
+	}
+	return nil
 }
 
 const (

--- a/service/cloudwatchevents/api.go
+++ b/service/cloudwatchevents/api.go
@@ -4,6 +4,7 @@
 package cloudwatchevents
 
 import (
+	"fmt"
 	"time"
 
 	"github.com/aws/aws-sdk-go/aws/awsutil"
@@ -435,6 +436,22 @@ func (s DeleteRuleInput) GoString() string {
 	return s.String()
 }
 
+// Validate inspects the fields of the type to determine if they are valid.
+func (s *DeleteRuleInput) Validate() error {
+	invalidParams := request.ErrInvalidParams{Context: "DeleteRuleInput"}
+	if s.Name == nil {
+		invalidParams.Add(request.NewErrParamRequired("Name"))
+	}
+	if s.Name != nil && len(*s.Name) < 1 {
+		invalidParams.Add(request.NewErrParamMinLen("Name", 1))
+	}
+
+	if invalidParams.Len() > 0 {
+		return invalidParams
+	}
+	return nil
+}
+
 type DeleteRuleOutput struct {
 	_ struct{} `type:"structure"`
 }
@@ -465,6 +482,22 @@ func (s DescribeRuleInput) String() string {
 // GoString returns the string representation
 func (s DescribeRuleInput) GoString() string {
 	return s.String()
+}
+
+// Validate inspects the fields of the type to determine if they are valid.
+func (s *DescribeRuleInput) Validate() error {
+	invalidParams := request.ErrInvalidParams{Context: "DescribeRuleInput"}
+	if s.Name == nil {
+		invalidParams.Add(request.NewErrParamRequired("Name"))
+	}
+	if s.Name != nil && len(*s.Name) < 1 {
+		invalidParams.Add(request.NewErrParamMinLen("Name", 1))
+	}
+
+	if invalidParams.Len() > 0 {
+		return invalidParams
+	}
+	return nil
 }
 
 // The result of the DescribeRule operation.
@@ -521,6 +554,22 @@ func (s DisableRuleInput) GoString() string {
 	return s.String()
 }
 
+// Validate inspects the fields of the type to determine if they are valid.
+func (s *DisableRuleInput) Validate() error {
+	invalidParams := request.ErrInvalidParams{Context: "DisableRuleInput"}
+	if s.Name == nil {
+		invalidParams.Add(request.NewErrParamRequired("Name"))
+	}
+	if s.Name != nil && len(*s.Name) < 1 {
+		invalidParams.Add(request.NewErrParamMinLen("Name", 1))
+	}
+
+	if invalidParams.Len() > 0 {
+		return invalidParams
+	}
+	return nil
+}
+
 type DisableRuleOutput struct {
 	_ struct{} `type:"structure"`
 }
@@ -551,6 +600,22 @@ func (s EnableRuleInput) String() string {
 // GoString returns the string representation
 func (s EnableRuleInput) GoString() string {
 	return s.String()
+}
+
+// Validate inspects the fields of the type to determine if they are valid.
+func (s *EnableRuleInput) Validate() error {
+	invalidParams := request.ErrInvalidParams{Context: "EnableRuleInput"}
+	if s.Name == nil {
+		invalidParams.Add(request.NewErrParamRequired("Name"))
+	}
+	if s.Name != nil && len(*s.Name) < 1 {
+		invalidParams.Add(request.NewErrParamMinLen("Name", 1))
+	}
+
+	if invalidParams.Len() > 0 {
+		return invalidParams
+	}
+	return nil
 }
 
 type EnableRuleOutput struct {
@@ -591,6 +656,28 @@ func (s ListRuleNamesByTargetInput) String() string {
 // GoString returns the string representation
 func (s ListRuleNamesByTargetInput) GoString() string {
 	return s.String()
+}
+
+// Validate inspects the fields of the type to determine if they are valid.
+func (s *ListRuleNamesByTargetInput) Validate() error {
+	invalidParams := request.ErrInvalidParams{Context: "ListRuleNamesByTargetInput"}
+	if s.Limit != nil && *s.Limit < 1 {
+		invalidParams.Add(request.NewErrParamMinValue("Limit", 1))
+	}
+	if s.NextToken != nil && len(*s.NextToken) < 1 {
+		invalidParams.Add(request.NewErrParamMinLen("NextToken", 1))
+	}
+	if s.TargetArn == nil {
+		invalidParams.Add(request.NewErrParamRequired("TargetArn"))
+	}
+	if s.TargetArn != nil && len(*s.TargetArn) < 1 {
+		invalidParams.Add(request.NewErrParamMinLen("TargetArn", 1))
+	}
+
+	if invalidParams.Len() > 0 {
+		return invalidParams
+	}
+	return nil
 }
 
 // The result of the ListRuleNamesByTarget operation.
@@ -639,6 +726,25 @@ func (s ListRulesInput) GoString() string {
 	return s.String()
 }
 
+// Validate inspects the fields of the type to determine if they are valid.
+func (s *ListRulesInput) Validate() error {
+	invalidParams := request.ErrInvalidParams{Context: "ListRulesInput"}
+	if s.Limit != nil && *s.Limit < 1 {
+		invalidParams.Add(request.NewErrParamMinValue("Limit", 1))
+	}
+	if s.NamePrefix != nil && len(*s.NamePrefix) < 1 {
+		invalidParams.Add(request.NewErrParamMinLen("NamePrefix", 1))
+	}
+	if s.NextToken != nil && len(*s.NextToken) < 1 {
+		invalidParams.Add(request.NewErrParamMinLen("NextToken", 1))
+	}
+
+	if invalidParams.Len() > 0 {
+		return invalidParams
+	}
+	return nil
+}
+
 // The result of the ListRules operation.
 type ListRulesOutput struct {
 	_ struct{} `type:"structure"`
@@ -685,6 +791,28 @@ func (s ListTargetsByRuleInput) GoString() string {
 	return s.String()
 }
 
+// Validate inspects the fields of the type to determine if they are valid.
+func (s *ListTargetsByRuleInput) Validate() error {
+	invalidParams := request.ErrInvalidParams{Context: "ListTargetsByRuleInput"}
+	if s.Limit != nil && *s.Limit < 1 {
+		invalidParams.Add(request.NewErrParamMinValue("Limit", 1))
+	}
+	if s.NextToken != nil && len(*s.NextToken) < 1 {
+		invalidParams.Add(request.NewErrParamMinLen("NextToken", 1))
+	}
+	if s.Rule == nil {
+		invalidParams.Add(request.NewErrParamRequired("Rule"))
+	}
+	if s.Rule != nil && len(*s.Rule) < 1 {
+		invalidParams.Add(request.NewErrParamMinLen("Rule", 1))
+	}
+
+	if invalidParams.Len() > 0 {
+		return invalidParams
+	}
+	return nil
+}
+
 // The result of the ListTargetsByRule operation.
 type ListTargetsByRuleOutput struct {
 	_ struct{} `type:"structure"`
@@ -724,6 +852,22 @@ func (s PutEventsInput) String() string {
 // GoString returns the string representation
 func (s PutEventsInput) GoString() string {
 	return s.String()
+}
+
+// Validate inspects the fields of the type to determine if they are valid.
+func (s *PutEventsInput) Validate() error {
+	invalidParams := request.ErrInvalidParams{Context: "PutEventsInput"}
+	if s.Entries == nil {
+		invalidParams.Add(request.NewErrParamRequired("Entries"))
+	}
+	if s.Entries != nil && len(s.Entries) < 1 {
+		invalidParams.Add(request.NewErrParamMinLen("Entries", 1))
+	}
+
+	if invalidParams.Len() > 0 {
+		return invalidParams
+	}
+	return nil
 }
 
 // The result of the PutEvents operation.
@@ -841,6 +985,25 @@ func (s PutRuleInput) GoString() string {
 	return s.String()
 }
 
+// Validate inspects the fields of the type to determine if they are valid.
+func (s *PutRuleInput) Validate() error {
+	invalidParams := request.ErrInvalidParams{Context: "PutRuleInput"}
+	if s.Name == nil {
+		invalidParams.Add(request.NewErrParamRequired("Name"))
+	}
+	if s.Name != nil && len(*s.Name) < 1 {
+		invalidParams.Add(request.NewErrParamMinLen("Name", 1))
+	}
+	if s.RoleArn != nil && len(*s.RoleArn) < 1 {
+		invalidParams.Add(request.NewErrParamMinLen("RoleArn", 1))
+	}
+
+	if invalidParams.Len() > 0 {
+		return invalidParams
+	}
+	return nil
+}
+
 // The result of the PutRule operation.
 type PutRuleOutput struct {
 	_ struct{} `type:"structure"`
@@ -878,6 +1041,35 @@ func (s PutTargetsInput) String() string {
 // GoString returns the string representation
 func (s PutTargetsInput) GoString() string {
 	return s.String()
+}
+
+// Validate inspects the fields of the type to determine if they are valid.
+func (s *PutTargetsInput) Validate() error {
+	invalidParams := request.ErrInvalidParams{Context: "PutTargetsInput"}
+	if s.Rule == nil {
+		invalidParams.Add(request.NewErrParamRequired("Rule"))
+	}
+	if s.Rule != nil && len(*s.Rule) < 1 {
+		invalidParams.Add(request.NewErrParamMinLen("Rule", 1))
+	}
+	if s.Targets == nil {
+		invalidParams.Add(request.NewErrParamRequired("Targets"))
+	}
+	if s.Targets != nil {
+		for i, v := range s.Targets {
+			if v == nil {
+				continue
+			}
+			if err := v.Validate(); err != nil {
+				invalidParams.AddNested(fmt.Sprintf("%s[%v]", "Targets", i), err.(request.ErrInvalidParams))
+			}
+		}
+	}
+
+	if invalidParams.Len() > 0 {
+		return invalidParams
+	}
+	return nil
 }
 
 // The result of the PutTargets operation.
@@ -944,6 +1136,28 @@ func (s RemoveTargetsInput) String() string {
 // GoString returns the string representation
 func (s RemoveTargetsInput) GoString() string {
 	return s.String()
+}
+
+// Validate inspects the fields of the type to determine if they are valid.
+func (s *RemoveTargetsInput) Validate() error {
+	invalidParams := request.ErrInvalidParams{Context: "RemoveTargetsInput"}
+	if s.Ids == nil {
+		invalidParams.Add(request.NewErrParamRequired("Ids"))
+	}
+	if s.Ids != nil && len(s.Ids) < 1 {
+		invalidParams.Add(request.NewErrParamMinLen("Ids", 1))
+	}
+	if s.Rule == nil {
+		invalidParams.Add(request.NewErrParamRequired("Rule"))
+	}
+	if s.Rule != nil && len(*s.Rule) < 1 {
+		invalidParams.Add(request.NewErrParamMinLen("Rule", 1))
+	}
+
+	if invalidParams.Len() > 0 {
+		return invalidParams
+	}
+	return nil
 }
 
 // The result of the RemoveTargets operation.
@@ -1071,6 +1285,28 @@ func (s Target) GoString() string {
 	return s.String()
 }
 
+// Validate inspects the fields of the type to determine if they are valid.
+func (s *Target) Validate() error {
+	invalidParams := request.ErrInvalidParams{Context: "Target"}
+	if s.Arn == nil {
+		invalidParams.Add(request.NewErrParamRequired("Arn"))
+	}
+	if s.Arn != nil && len(*s.Arn) < 1 {
+		invalidParams.Add(request.NewErrParamMinLen("Arn", 1))
+	}
+	if s.Id == nil {
+		invalidParams.Add(request.NewErrParamRequired("Id"))
+	}
+	if s.Id != nil && len(*s.Id) < 1 {
+		invalidParams.Add(request.NewErrParamMinLen("Id", 1))
+	}
+
+	if invalidParams.Len() > 0 {
+		return invalidParams
+	}
+	return nil
+}
+
 // Container for the parameters to the TestEventPattern operation.
 type TestEventPatternInput struct {
 	_ struct{} `type:"structure"`
@@ -1090,6 +1326,22 @@ func (s TestEventPatternInput) String() string {
 // GoString returns the string representation
 func (s TestEventPatternInput) GoString() string {
 	return s.String()
+}
+
+// Validate inspects the fields of the type to determine if they are valid.
+func (s *TestEventPatternInput) Validate() error {
+	invalidParams := request.ErrInvalidParams{Context: "TestEventPatternInput"}
+	if s.Event == nil {
+		invalidParams.Add(request.NewErrParamRequired("Event"))
+	}
+	if s.EventPattern == nil {
+		invalidParams.Add(request.NewErrParamRequired("EventPattern"))
+	}
+
+	if invalidParams.Len() > 0 {
+		return invalidParams
+	}
+	return nil
 }
 
 // The result of the TestEventPattern operation.

--- a/service/cloudwatchlogs/api.go
+++ b/service/cloudwatchlogs/api.go
@@ -4,6 +4,8 @@
 package cloudwatchlogs
 
 import (
+	"fmt"
+
 	"github.com/aws/aws-sdk-go/aws/awsutil"
 	"github.com/aws/aws-sdk-go/aws/request"
 	"github.com/aws/aws-sdk-go/private/protocol"
@@ -968,6 +970,22 @@ func (s CancelExportTaskInput) GoString() string {
 	return s.String()
 }
 
+// Validate inspects the fields of the type to determine if they are valid.
+func (s *CancelExportTaskInput) Validate() error {
+	invalidParams := request.ErrInvalidParams{Context: "CancelExportTaskInput"}
+	if s.TaskId == nil {
+		invalidParams.Add(request.NewErrParamRequired("TaskId"))
+	}
+	if s.TaskId != nil && len(*s.TaskId) < 1 {
+		invalidParams.Add(request.NewErrParamMinLen("TaskId", 1))
+	}
+
+	if invalidParams.Len() > 0 {
+		return invalidParams
+	}
+	return nil
+}
+
 type CancelExportTaskOutput struct {
 	_ struct{} `type:"structure"`
 }
@@ -1025,6 +1043,40 @@ func (s CreateExportTaskInput) GoString() string {
 	return s.String()
 }
 
+// Validate inspects the fields of the type to determine if they are valid.
+func (s *CreateExportTaskInput) Validate() error {
+	invalidParams := request.ErrInvalidParams{Context: "CreateExportTaskInput"}
+	if s.Destination == nil {
+		invalidParams.Add(request.NewErrParamRequired("Destination"))
+	}
+	if s.Destination != nil && len(*s.Destination) < 1 {
+		invalidParams.Add(request.NewErrParamMinLen("Destination", 1))
+	}
+	if s.From == nil {
+		invalidParams.Add(request.NewErrParamRequired("From"))
+	}
+	if s.LogGroupName == nil {
+		invalidParams.Add(request.NewErrParamRequired("LogGroupName"))
+	}
+	if s.LogGroupName != nil && len(*s.LogGroupName) < 1 {
+		invalidParams.Add(request.NewErrParamMinLen("LogGroupName", 1))
+	}
+	if s.LogStreamNamePrefix != nil && len(*s.LogStreamNamePrefix) < 1 {
+		invalidParams.Add(request.NewErrParamMinLen("LogStreamNamePrefix", 1))
+	}
+	if s.TaskName != nil && len(*s.TaskName) < 1 {
+		invalidParams.Add(request.NewErrParamMinLen("TaskName", 1))
+	}
+	if s.To == nil {
+		invalidParams.Add(request.NewErrParamRequired("To"))
+	}
+
+	if invalidParams.Len() > 0 {
+		return invalidParams
+	}
+	return nil
+}
+
 type CreateExportTaskOutput struct {
 	_ struct{} `type:"structure"`
 
@@ -1057,6 +1109,22 @@ func (s CreateLogGroupInput) String() string {
 // GoString returns the string representation
 func (s CreateLogGroupInput) GoString() string {
 	return s.String()
+}
+
+// Validate inspects the fields of the type to determine if they are valid.
+func (s *CreateLogGroupInput) Validate() error {
+	invalidParams := request.ErrInvalidParams{Context: "CreateLogGroupInput"}
+	if s.LogGroupName == nil {
+		invalidParams.Add(request.NewErrParamRequired("LogGroupName"))
+	}
+	if s.LogGroupName != nil && len(*s.LogGroupName) < 1 {
+		invalidParams.Add(request.NewErrParamMinLen("LogGroupName", 1))
+	}
+
+	if invalidParams.Len() > 0 {
+		return invalidParams
+	}
+	return nil
 }
 
 type CreateLogGroupOutput struct {
@@ -1093,6 +1161,28 @@ func (s CreateLogStreamInput) GoString() string {
 	return s.String()
 }
 
+// Validate inspects the fields of the type to determine if they are valid.
+func (s *CreateLogStreamInput) Validate() error {
+	invalidParams := request.ErrInvalidParams{Context: "CreateLogStreamInput"}
+	if s.LogGroupName == nil {
+		invalidParams.Add(request.NewErrParamRequired("LogGroupName"))
+	}
+	if s.LogGroupName != nil && len(*s.LogGroupName) < 1 {
+		invalidParams.Add(request.NewErrParamMinLen("LogGroupName", 1))
+	}
+	if s.LogStreamName == nil {
+		invalidParams.Add(request.NewErrParamRequired("LogStreamName"))
+	}
+	if s.LogStreamName != nil && len(*s.LogStreamName) < 1 {
+		invalidParams.Add(request.NewErrParamMinLen("LogStreamName", 1))
+	}
+
+	if invalidParams.Len() > 0 {
+		return invalidParams
+	}
+	return nil
+}
+
 type CreateLogStreamOutput struct {
 	_ struct{} `type:"structure"`
 }
@@ -1124,6 +1214,22 @@ func (s DeleteDestinationInput) GoString() string {
 	return s.String()
 }
 
+// Validate inspects the fields of the type to determine if they are valid.
+func (s *DeleteDestinationInput) Validate() error {
+	invalidParams := request.ErrInvalidParams{Context: "DeleteDestinationInput"}
+	if s.DestinationName == nil {
+		invalidParams.Add(request.NewErrParamRequired("DestinationName"))
+	}
+	if s.DestinationName != nil && len(*s.DestinationName) < 1 {
+		invalidParams.Add(request.NewErrParamMinLen("DestinationName", 1))
+	}
+
+	if invalidParams.Len() > 0 {
+		return invalidParams
+	}
+	return nil
+}
+
 type DeleteDestinationOutput struct {
 	_ struct{} `type:"structure"`
 }
@@ -1153,6 +1259,22 @@ func (s DeleteLogGroupInput) String() string {
 // GoString returns the string representation
 func (s DeleteLogGroupInput) GoString() string {
 	return s.String()
+}
+
+// Validate inspects the fields of the type to determine if they are valid.
+func (s *DeleteLogGroupInput) Validate() error {
+	invalidParams := request.ErrInvalidParams{Context: "DeleteLogGroupInput"}
+	if s.LogGroupName == nil {
+		invalidParams.Add(request.NewErrParamRequired("LogGroupName"))
+	}
+	if s.LogGroupName != nil && len(*s.LogGroupName) < 1 {
+		invalidParams.Add(request.NewErrParamMinLen("LogGroupName", 1))
+	}
+
+	if invalidParams.Len() > 0 {
+		return invalidParams
+	}
+	return nil
 }
 
 type DeleteLogGroupOutput struct {
@@ -1189,6 +1311,28 @@ func (s DeleteLogStreamInput) GoString() string {
 	return s.String()
 }
 
+// Validate inspects the fields of the type to determine if they are valid.
+func (s *DeleteLogStreamInput) Validate() error {
+	invalidParams := request.ErrInvalidParams{Context: "DeleteLogStreamInput"}
+	if s.LogGroupName == nil {
+		invalidParams.Add(request.NewErrParamRequired("LogGroupName"))
+	}
+	if s.LogGroupName != nil && len(*s.LogGroupName) < 1 {
+		invalidParams.Add(request.NewErrParamMinLen("LogGroupName", 1))
+	}
+	if s.LogStreamName == nil {
+		invalidParams.Add(request.NewErrParamRequired("LogStreamName"))
+	}
+	if s.LogStreamName != nil && len(*s.LogStreamName) < 1 {
+		invalidParams.Add(request.NewErrParamMinLen("LogStreamName", 1))
+	}
+
+	if invalidParams.Len() > 0 {
+		return invalidParams
+	}
+	return nil
+}
+
 type DeleteLogStreamOutput struct {
 	_ struct{} `type:"structure"`
 }
@@ -1223,6 +1367,28 @@ func (s DeleteMetricFilterInput) GoString() string {
 	return s.String()
 }
 
+// Validate inspects the fields of the type to determine if they are valid.
+func (s *DeleteMetricFilterInput) Validate() error {
+	invalidParams := request.ErrInvalidParams{Context: "DeleteMetricFilterInput"}
+	if s.FilterName == nil {
+		invalidParams.Add(request.NewErrParamRequired("FilterName"))
+	}
+	if s.FilterName != nil && len(*s.FilterName) < 1 {
+		invalidParams.Add(request.NewErrParamMinLen("FilterName", 1))
+	}
+	if s.LogGroupName == nil {
+		invalidParams.Add(request.NewErrParamRequired("LogGroupName"))
+	}
+	if s.LogGroupName != nil && len(*s.LogGroupName) < 1 {
+		invalidParams.Add(request.NewErrParamMinLen("LogGroupName", 1))
+	}
+
+	if invalidParams.Len() > 0 {
+		return invalidParams
+	}
+	return nil
+}
+
 type DeleteMetricFilterOutput struct {
 	_ struct{} `type:"structure"`
 }
@@ -1253,6 +1419,22 @@ func (s DeleteRetentionPolicyInput) String() string {
 // GoString returns the string representation
 func (s DeleteRetentionPolicyInput) GoString() string {
 	return s.String()
+}
+
+// Validate inspects the fields of the type to determine if they are valid.
+func (s *DeleteRetentionPolicyInput) Validate() error {
+	invalidParams := request.ErrInvalidParams{Context: "DeleteRetentionPolicyInput"}
+	if s.LogGroupName == nil {
+		invalidParams.Add(request.NewErrParamRequired("LogGroupName"))
+	}
+	if s.LogGroupName != nil && len(*s.LogGroupName) < 1 {
+		invalidParams.Add(request.NewErrParamMinLen("LogGroupName", 1))
+	}
+
+	if invalidParams.Len() > 0 {
+		return invalidParams
+	}
+	return nil
 }
 
 type DeleteRetentionPolicyOutput struct {
@@ -1288,6 +1470,28 @@ func (s DeleteSubscriptionFilterInput) String() string {
 // GoString returns the string representation
 func (s DeleteSubscriptionFilterInput) GoString() string {
 	return s.String()
+}
+
+// Validate inspects the fields of the type to determine if they are valid.
+func (s *DeleteSubscriptionFilterInput) Validate() error {
+	invalidParams := request.ErrInvalidParams{Context: "DeleteSubscriptionFilterInput"}
+	if s.FilterName == nil {
+		invalidParams.Add(request.NewErrParamRequired("FilterName"))
+	}
+	if s.FilterName != nil && len(*s.FilterName) < 1 {
+		invalidParams.Add(request.NewErrParamMinLen("FilterName", 1))
+	}
+	if s.LogGroupName == nil {
+		invalidParams.Add(request.NewErrParamRequired("LogGroupName"))
+	}
+	if s.LogGroupName != nil && len(*s.LogGroupName) < 1 {
+		invalidParams.Add(request.NewErrParamMinLen("LogGroupName", 1))
+	}
+
+	if invalidParams.Len() > 0 {
+		return invalidParams
+	}
+	return nil
 }
 
 type DeleteSubscriptionFilterOutput struct {
@@ -1328,6 +1532,25 @@ func (s DescribeDestinationsInput) String() string {
 // GoString returns the string representation
 func (s DescribeDestinationsInput) GoString() string {
 	return s.String()
+}
+
+// Validate inspects the fields of the type to determine if they are valid.
+func (s *DescribeDestinationsInput) Validate() error {
+	invalidParams := request.ErrInvalidParams{Context: "DescribeDestinationsInput"}
+	if s.DestinationNamePrefix != nil && len(*s.DestinationNamePrefix) < 1 {
+		invalidParams.Add(request.NewErrParamMinLen("DestinationNamePrefix", 1))
+	}
+	if s.Limit != nil && *s.Limit < 1 {
+		invalidParams.Add(request.NewErrParamMinValue("Limit", 1))
+	}
+	if s.NextToken != nil && len(*s.NextToken) < 1 {
+		invalidParams.Add(request.NewErrParamMinLen("NextToken", 1))
+	}
+
+	if invalidParams.Len() > 0 {
+		return invalidParams
+	}
+	return nil
 }
 
 type DescribeDestinationsOutput struct {
@@ -1382,6 +1605,25 @@ func (s DescribeExportTasksInput) GoString() string {
 	return s.String()
 }
 
+// Validate inspects the fields of the type to determine if they are valid.
+func (s *DescribeExportTasksInput) Validate() error {
+	invalidParams := request.ErrInvalidParams{Context: "DescribeExportTasksInput"}
+	if s.Limit != nil && *s.Limit < 1 {
+		invalidParams.Add(request.NewErrParamMinValue("Limit", 1))
+	}
+	if s.NextToken != nil && len(*s.NextToken) < 1 {
+		invalidParams.Add(request.NewErrParamMinLen("NextToken", 1))
+	}
+	if s.TaskId != nil && len(*s.TaskId) < 1 {
+		invalidParams.Add(request.NewErrParamMinLen("TaskId", 1))
+	}
+
+	if invalidParams.Len() > 0 {
+		return invalidParams
+	}
+	return nil
+}
+
 type DescribeExportTasksOutput struct {
 	_ struct{} `type:"structure"`
 
@@ -1429,6 +1671,25 @@ func (s DescribeLogGroupsInput) String() string {
 // GoString returns the string representation
 func (s DescribeLogGroupsInput) GoString() string {
 	return s.String()
+}
+
+// Validate inspects the fields of the type to determine if they are valid.
+func (s *DescribeLogGroupsInput) Validate() error {
+	invalidParams := request.ErrInvalidParams{Context: "DescribeLogGroupsInput"}
+	if s.Limit != nil && *s.Limit < 1 {
+		invalidParams.Add(request.NewErrParamMinValue("Limit", 1))
+	}
+	if s.LogGroupNamePrefix != nil && len(*s.LogGroupNamePrefix) < 1 {
+		invalidParams.Add(request.NewErrParamMinLen("LogGroupNamePrefix", 1))
+	}
+	if s.NextToken != nil && len(*s.NextToken) < 1 {
+		invalidParams.Add(request.NewErrParamMinLen("NextToken", 1))
+	}
+
+	if invalidParams.Len() > 0 {
+		return invalidParams
+	}
+	return nil
 }
 
 type DescribeLogGroupsOutput struct {
@@ -1493,6 +1754,31 @@ func (s DescribeLogStreamsInput) GoString() string {
 	return s.String()
 }
 
+// Validate inspects the fields of the type to determine if they are valid.
+func (s *DescribeLogStreamsInput) Validate() error {
+	invalidParams := request.ErrInvalidParams{Context: "DescribeLogStreamsInput"}
+	if s.Limit != nil && *s.Limit < 1 {
+		invalidParams.Add(request.NewErrParamMinValue("Limit", 1))
+	}
+	if s.LogGroupName == nil {
+		invalidParams.Add(request.NewErrParamRequired("LogGroupName"))
+	}
+	if s.LogGroupName != nil && len(*s.LogGroupName) < 1 {
+		invalidParams.Add(request.NewErrParamMinLen("LogGroupName", 1))
+	}
+	if s.LogStreamNamePrefix != nil && len(*s.LogStreamNamePrefix) < 1 {
+		invalidParams.Add(request.NewErrParamMinLen("LogStreamNamePrefix", 1))
+	}
+	if s.NextToken != nil && len(*s.NextToken) < 1 {
+		invalidParams.Add(request.NewErrParamMinLen("NextToken", 1))
+	}
+
+	if invalidParams.Len() > 0 {
+		return invalidParams
+	}
+	return nil
+}
+
 type DescribeLogStreamsOutput struct {
 	_ struct{} `type:"structure"`
 
@@ -1545,6 +1831,31 @@ func (s DescribeMetricFiltersInput) GoString() string {
 	return s.String()
 }
 
+// Validate inspects the fields of the type to determine if they are valid.
+func (s *DescribeMetricFiltersInput) Validate() error {
+	invalidParams := request.ErrInvalidParams{Context: "DescribeMetricFiltersInput"}
+	if s.FilterNamePrefix != nil && len(*s.FilterNamePrefix) < 1 {
+		invalidParams.Add(request.NewErrParamMinLen("FilterNamePrefix", 1))
+	}
+	if s.Limit != nil && *s.Limit < 1 {
+		invalidParams.Add(request.NewErrParamMinValue("Limit", 1))
+	}
+	if s.LogGroupName == nil {
+		invalidParams.Add(request.NewErrParamRequired("LogGroupName"))
+	}
+	if s.LogGroupName != nil && len(*s.LogGroupName) < 1 {
+		invalidParams.Add(request.NewErrParamMinLen("LogGroupName", 1))
+	}
+	if s.NextToken != nil && len(*s.NextToken) < 1 {
+		invalidParams.Add(request.NewErrParamMinLen("NextToken", 1))
+	}
+
+	if invalidParams.Len() > 0 {
+		return invalidParams
+	}
+	return nil
+}
+
 type DescribeMetricFiltersOutput struct {
 	_ struct{} `type:"structure"`
 
@@ -1593,6 +1904,31 @@ func (s DescribeSubscriptionFiltersInput) String() string {
 // GoString returns the string representation
 func (s DescribeSubscriptionFiltersInput) GoString() string {
 	return s.String()
+}
+
+// Validate inspects the fields of the type to determine if they are valid.
+func (s *DescribeSubscriptionFiltersInput) Validate() error {
+	invalidParams := request.ErrInvalidParams{Context: "DescribeSubscriptionFiltersInput"}
+	if s.FilterNamePrefix != nil && len(*s.FilterNamePrefix) < 1 {
+		invalidParams.Add(request.NewErrParamMinLen("FilterNamePrefix", 1))
+	}
+	if s.Limit != nil && *s.Limit < 1 {
+		invalidParams.Add(request.NewErrParamMinValue("Limit", 1))
+	}
+	if s.LogGroupName == nil {
+		invalidParams.Add(request.NewErrParamRequired("LogGroupName"))
+	}
+	if s.LogGroupName != nil && len(*s.LogGroupName) < 1 {
+		invalidParams.Add(request.NewErrParamMinLen("LogGroupName", 1))
+	}
+	if s.NextToken != nil && len(*s.NextToken) < 1 {
+		invalidParams.Add(request.NewErrParamMinLen("NextToken", 1))
+	}
+
+	if invalidParams.Len() > 0 {
+		return invalidParams
+	}
+	return nil
 }
 
 type DescribeSubscriptionFiltersOutput struct {
@@ -1788,6 +2124,31 @@ func (s FilterLogEventsInput) GoString() string {
 	return s.String()
 }
 
+// Validate inspects the fields of the type to determine if they are valid.
+func (s *FilterLogEventsInput) Validate() error {
+	invalidParams := request.ErrInvalidParams{Context: "FilterLogEventsInput"}
+	if s.Limit != nil && *s.Limit < 1 {
+		invalidParams.Add(request.NewErrParamMinValue("Limit", 1))
+	}
+	if s.LogGroupName == nil {
+		invalidParams.Add(request.NewErrParamRequired("LogGroupName"))
+	}
+	if s.LogGroupName != nil && len(*s.LogGroupName) < 1 {
+		invalidParams.Add(request.NewErrParamMinLen("LogGroupName", 1))
+	}
+	if s.LogStreamNames != nil && len(s.LogStreamNames) < 1 {
+		invalidParams.Add(request.NewErrParamMinLen("LogStreamNames", 1))
+	}
+	if s.NextToken != nil && len(*s.NextToken) < 1 {
+		invalidParams.Add(request.NewErrParamMinLen("NextToken", 1))
+	}
+
+	if invalidParams.Len() > 0 {
+		return invalidParams
+	}
+	return nil
+}
+
 type FilterLogEventsOutput struct {
 	_ struct{} `type:"structure"`
 
@@ -1890,6 +2251,34 @@ func (s GetLogEventsInput) GoString() string {
 	return s.String()
 }
 
+// Validate inspects the fields of the type to determine if they are valid.
+func (s *GetLogEventsInput) Validate() error {
+	invalidParams := request.ErrInvalidParams{Context: "GetLogEventsInput"}
+	if s.Limit != nil && *s.Limit < 1 {
+		invalidParams.Add(request.NewErrParamMinValue("Limit", 1))
+	}
+	if s.LogGroupName == nil {
+		invalidParams.Add(request.NewErrParamRequired("LogGroupName"))
+	}
+	if s.LogGroupName != nil && len(*s.LogGroupName) < 1 {
+		invalidParams.Add(request.NewErrParamMinLen("LogGroupName", 1))
+	}
+	if s.LogStreamName == nil {
+		invalidParams.Add(request.NewErrParamRequired("LogStreamName"))
+	}
+	if s.LogStreamName != nil && len(*s.LogStreamName) < 1 {
+		invalidParams.Add(request.NewErrParamMinLen("LogStreamName", 1))
+	}
+	if s.NextToken != nil && len(*s.NextToken) < 1 {
+		invalidParams.Add(request.NewErrParamMinLen("NextToken", 1))
+	}
+
+	if invalidParams.Len() > 0 {
+		return invalidParams
+	}
+	return nil
+}
+
 type GetLogEventsOutput struct {
 	_ struct{} `type:"structure"`
 
@@ -1938,6 +2327,25 @@ func (s InputLogEvent) String() string {
 // GoString returns the string representation
 func (s InputLogEvent) GoString() string {
 	return s.String()
+}
+
+// Validate inspects the fields of the type to determine if they are valid.
+func (s *InputLogEvent) Validate() error {
+	invalidParams := request.ErrInvalidParams{Context: "InputLogEvent"}
+	if s.Message == nil {
+		invalidParams.Add(request.NewErrParamRequired("Message"))
+	}
+	if s.Message != nil && len(*s.Message) < 1 {
+		invalidParams.Add(request.NewErrParamMinLen("Message", 1))
+	}
+	if s.Timestamp == nil {
+		invalidParams.Add(request.NewErrParamRequired("Timestamp"))
+	}
+
+	if invalidParams.Len() > 0 {
+		return invalidParams
+	}
+	return nil
 }
 
 type LogGroup struct {
@@ -2093,6 +2501,25 @@ func (s MetricTransformation) GoString() string {
 	return s.String()
 }
 
+// Validate inspects the fields of the type to determine if they are valid.
+func (s *MetricTransformation) Validate() error {
+	invalidParams := request.ErrInvalidParams{Context: "MetricTransformation"}
+	if s.MetricName == nil {
+		invalidParams.Add(request.NewErrParamRequired("MetricName"))
+	}
+	if s.MetricNamespace == nil {
+		invalidParams.Add(request.NewErrParamRequired("MetricNamespace"))
+	}
+	if s.MetricValue == nil {
+		invalidParams.Add(request.NewErrParamRequired("MetricValue"))
+	}
+
+	if invalidParams.Len() > 0 {
+		return invalidParams
+	}
+	return nil
+}
+
 type OutputLogEvent struct {
 	_ struct{} `type:"structure"`
 
@@ -2141,6 +2568,34 @@ func (s PutDestinationInput) GoString() string {
 	return s.String()
 }
 
+// Validate inspects the fields of the type to determine if they are valid.
+func (s *PutDestinationInput) Validate() error {
+	invalidParams := request.ErrInvalidParams{Context: "PutDestinationInput"}
+	if s.DestinationName == nil {
+		invalidParams.Add(request.NewErrParamRequired("DestinationName"))
+	}
+	if s.DestinationName != nil && len(*s.DestinationName) < 1 {
+		invalidParams.Add(request.NewErrParamMinLen("DestinationName", 1))
+	}
+	if s.RoleArn == nil {
+		invalidParams.Add(request.NewErrParamRequired("RoleArn"))
+	}
+	if s.RoleArn != nil && len(*s.RoleArn) < 1 {
+		invalidParams.Add(request.NewErrParamMinLen("RoleArn", 1))
+	}
+	if s.TargetArn == nil {
+		invalidParams.Add(request.NewErrParamRequired("TargetArn"))
+	}
+	if s.TargetArn != nil && len(*s.TargetArn) < 1 {
+		invalidParams.Add(request.NewErrParamMinLen("TargetArn", 1))
+	}
+
+	if invalidParams.Len() > 0 {
+		return invalidParams
+	}
+	return nil
+}
+
 type PutDestinationOutput struct {
 	_ struct{} `type:"structure"`
 
@@ -2177,6 +2632,28 @@ func (s PutDestinationPolicyInput) String() string {
 // GoString returns the string representation
 func (s PutDestinationPolicyInput) GoString() string {
 	return s.String()
+}
+
+// Validate inspects the fields of the type to determine if they are valid.
+func (s *PutDestinationPolicyInput) Validate() error {
+	invalidParams := request.ErrInvalidParams{Context: "PutDestinationPolicyInput"}
+	if s.AccessPolicy == nil {
+		invalidParams.Add(request.NewErrParamRequired("AccessPolicy"))
+	}
+	if s.AccessPolicy != nil && len(*s.AccessPolicy) < 1 {
+		invalidParams.Add(request.NewErrParamMinLen("AccessPolicy", 1))
+	}
+	if s.DestinationName == nil {
+		invalidParams.Add(request.NewErrParamRequired("DestinationName"))
+	}
+	if s.DestinationName != nil && len(*s.DestinationName) < 1 {
+		invalidParams.Add(request.NewErrParamMinLen("DestinationName", 1))
+	}
+
+	if invalidParams.Len() > 0 {
+		return invalidParams
+	}
+	return nil
 }
 
 type PutDestinationPolicyOutput struct {
@@ -2218,6 +2695,47 @@ func (s PutLogEventsInput) String() string {
 // GoString returns the string representation
 func (s PutLogEventsInput) GoString() string {
 	return s.String()
+}
+
+// Validate inspects the fields of the type to determine if they are valid.
+func (s *PutLogEventsInput) Validate() error {
+	invalidParams := request.ErrInvalidParams{Context: "PutLogEventsInput"}
+	if s.LogEvents == nil {
+		invalidParams.Add(request.NewErrParamRequired("LogEvents"))
+	}
+	if s.LogEvents != nil && len(s.LogEvents) < 1 {
+		invalidParams.Add(request.NewErrParamMinLen("LogEvents", 1))
+	}
+	if s.LogGroupName == nil {
+		invalidParams.Add(request.NewErrParamRequired("LogGroupName"))
+	}
+	if s.LogGroupName != nil && len(*s.LogGroupName) < 1 {
+		invalidParams.Add(request.NewErrParamMinLen("LogGroupName", 1))
+	}
+	if s.LogStreamName == nil {
+		invalidParams.Add(request.NewErrParamRequired("LogStreamName"))
+	}
+	if s.LogStreamName != nil && len(*s.LogStreamName) < 1 {
+		invalidParams.Add(request.NewErrParamMinLen("LogStreamName", 1))
+	}
+	if s.SequenceToken != nil && len(*s.SequenceToken) < 1 {
+		invalidParams.Add(request.NewErrParamMinLen("SequenceToken", 1))
+	}
+	if s.LogEvents != nil {
+		for i, v := range s.LogEvents {
+			if v == nil {
+				continue
+			}
+			if err := v.Validate(); err != nil {
+				invalidParams.AddNested(fmt.Sprintf("%s[%v]", "LogEvents", i), err.(request.ErrInvalidParams))
+			}
+		}
+	}
+
+	if invalidParams.Len() > 0 {
+		return invalidParams
+	}
+	return nil
 }
 
 type PutLogEventsOutput struct {
@@ -2268,6 +2786,47 @@ func (s PutMetricFilterInput) GoString() string {
 	return s.String()
 }
 
+// Validate inspects the fields of the type to determine if they are valid.
+func (s *PutMetricFilterInput) Validate() error {
+	invalidParams := request.ErrInvalidParams{Context: "PutMetricFilterInput"}
+	if s.FilterName == nil {
+		invalidParams.Add(request.NewErrParamRequired("FilterName"))
+	}
+	if s.FilterName != nil && len(*s.FilterName) < 1 {
+		invalidParams.Add(request.NewErrParamMinLen("FilterName", 1))
+	}
+	if s.FilterPattern == nil {
+		invalidParams.Add(request.NewErrParamRequired("FilterPattern"))
+	}
+	if s.LogGroupName == nil {
+		invalidParams.Add(request.NewErrParamRequired("LogGroupName"))
+	}
+	if s.LogGroupName != nil && len(*s.LogGroupName) < 1 {
+		invalidParams.Add(request.NewErrParamMinLen("LogGroupName", 1))
+	}
+	if s.MetricTransformations == nil {
+		invalidParams.Add(request.NewErrParamRequired("MetricTransformations"))
+	}
+	if s.MetricTransformations != nil && len(s.MetricTransformations) < 1 {
+		invalidParams.Add(request.NewErrParamMinLen("MetricTransformations", 1))
+	}
+	if s.MetricTransformations != nil {
+		for i, v := range s.MetricTransformations {
+			if v == nil {
+				continue
+			}
+			if err := v.Validate(); err != nil {
+				invalidParams.AddNested(fmt.Sprintf("%s[%v]", "MetricTransformations", i), err.(request.ErrInvalidParams))
+			}
+		}
+	}
+
+	if invalidParams.Len() > 0 {
+		return invalidParams
+	}
+	return nil
+}
+
 type PutMetricFilterOutput struct {
 	_ struct{} `type:"structure"`
 }
@@ -2302,6 +2861,25 @@ func (s PutRetentionPolicyInput) String() string {
 // GoString returns the string representation
 func (s PutRetentionPolicyInput) GoString() string {
 	return s.String()
+}
+
+// Validate inspects the fields of the type to determine if they are valid.
+func (s *PutRetentionPolicyInput) Validate() error {
+	invalidParams := request.ErrInvalidParams{Context: "PutRetentionPolicyInput"}
+	if s.LogGroupName == nil {
+		invalidParams.Add(request.NewErrParamRequired("LogGroupName"))
+	}
+	if s.LogGroupName != nil && len(*s.LogGroupName) < 1 {
+		invalidParams.Add(request.NewErrParamMinLen("LogGroupName", 1))
+	}
+	if s.RetentionInDays == nil {
+		invalidParams.Add(request.NewErrParamRequired("RetentionInDays"))
+	}
+
+	if invalidParams.Len() > 0 {
+		return invalidParams
+	}
+	return nil
 }
 
 type PutRetentionPolicyOutput struct {
@@ -2356,6 +2934,40 @@ func (s PutSubscriptionFilterInput) String() string {
 // GoString returns the string representation
 func (s PutSubscriptionFilterInput) GoString() string {
 	return s.String()
+}
+
+// Validate inspects the fields of the type to determine if they are valid.
+func (s *PutSubscriptionFilterInput) Validate() error {
+	invalidParams := request.ErrInvalidParams{Context: "PutSubscriptionFilterInput"}
+	if s.DestinationArn == nil {
+		invalidParams.Add(request.NewErrParamRequired("DestinationArn"))
+	}
+	if s.DestinationArn != nil && len(*s.DestinationArn) < 1 {
+		invalidParams.Add(request.NewErrParamMinLen("DestinationArn", 1))
+	}
+	if s.FilterName == nil {
+		invalidParams.Add(request.NewErrParamRequired("FilterName"))
+	}
+	if s.FilterName != nil && len(*s.FilterName) < 1 {
+		invalidParams.Add(request.NewErrParamMinLen("FilterName", 1))
+	}
+	if s.FilterPattern == nil {
+		invalidParams.Add(request.NewErrParamRequired("FilterPattern"))
+	}
+	if s.LogGroupName == nil {
+		invalidParams.Add(request.NewErrParamRequired("LogGroupName"))
+	}
+	if s.LogGroupName != nil && len(*s.LogGroupName) < 1 {
+		invalidParams.Add(request.NewErrParamMinLen("LogGroupName", 1))
+	}
+	if s.RoleArn != nil && len(*s.RoleArn) < 1 {
+		invalidParams.Add(request.NewErrParamMinLen("RoleArn", 1))
+	}
+
+	if invalidParams.Len() > 0 {
+		return invalidParams
+	}
+	return nil
 }
 
 type PutSubscriptionFilterOutput struct {
@@ -2469,6 +3081,25 @@ func (s TestMetricFilterInput) String() string {
 // GoString returns the string representation
 func (s TestMetricFilterInput) GoString() string {
 	return s.String()
+}
+
+// Validate inspects the fields of the type to determine if they are valid.
+func (s *TestMetricFilterInput) Validate() error {
+	invalidParams := request.ErrInvalidParams{Context: "TestMetricFilterInput"}
+	if s.FilterPattern == nil {
+		invalidParams.Add(request.NewErrParamRequired("FilterPattern"))
+	}
+	if s.LogEventMessages == nil {
+		invalidParams.Add(request.NewErrParamRequired("LogEventMessages"))
+	}
+	if s.LogEventMessages != nil && len(s.LogEventMessages) < 1 {
+		invalidParams.Add(request.NewErrParamMinLen("LogEventMessages", 1))
+	}
+
+	if invalidParams.Len() > 0 {
+		return invalidParams
+	}
+	return nil
 }
 
 type TestMetricFilterOutput struct {

--- a/service/codecommit/api.go
+++ b/service/codecommit/api.go
@@ -512,6 +512,19 @@ func (s BatchGetRepositoriesInput) GoString() string {
 	return s.String()
 }
 
+// Validate inspects the fields of the type to determine if they are valid.
+func (s *BatchGetRepositoriesInput) Validate() error {
+	invalidParams := request.ErrInvalidParams{Context: "BatchGetRepositoriesInput"}
+	if s.RepositoryNames == nil {
+		invalidParams.Add(request.NewErrParamRequired("RepositoryNames"))
+	}
+
+	if invalidParams.Len() > 0 {
+		return invalidParams
+	}
+	return nil
+}
+
 // Represents the output of a batch get repositories operation.
 type BatchGetRepositoriesOutput struct {
 	_ struct{} `type:"structure"`
@@ -614,6 +627,31 @@ func (s CreateBranchInput) GoString() string {
 	return s.String()
 }
 
+// Validate inspects the fields of the type to determine if they are valid.
+func (s *CreateBranchInput) Validate() error {
+	invalidParams := request.ErrInvalidParams{Context: "CreateBranchInput"}
+	if s.BranchName == nil {
+		invalidParams.Add(request.NewErrParamRequired("BranchName"))
+	}
+	if s.BranchName != nil && len(*s.BranchName) < 1 {
+		invalidParams.Add(request.NewErrParamMinLen("BranchName", 1))
+	}
+	if s.CommitId == nil {
+		invalidParams.Add(request.NewErrParamRequired("CommitId"))
+	}
+	if s.RepositoryName == nil {
+		invalidParams.Add(request.NewErrParamRequired("RepositoryName"))
+	}
+	if s.RepositoryName != nil && len(*s.RepositoryName) < 1 {
+		invalidParams.Add(request.NewErrParamMinLen("RepositoryName", 1))
+	}
+
+	if invalidParams.Len() > 0 {
+		return invalidParams
+	}
+	return nil
+}
+
 type CreateBranchOutput struct {
 	_ struct{} `type:"structure"`
 }
@@ -661,6 +699,22 @@ func (s CreateRepositoryInput) GoString() string {
 	return s.String()
 }
 
+// Validate inspects the fields of the type to determine if they are valid.
+func (s *CreateRepositoryInput) Validate() error {
+	invalidParams := request.ErrInvalidParams{Context: "CreateRepositoryInput"}
+	if s.RepositoryName == nil {
+		invalidParams.Add(request.NewErrParamRequired("RepositoryName"))
+	}
+	if s.RepositoryName != nil && len(*s.RepositoryName) < 1 {
+		invalidParams.Add(request.NewErrParamMinLen("RepositoryName", 1))
+	}
+
+	if invalidParams.Len() > 0 {
+		return invalidParams
+	}
+	return nil
+}
+
 // Represents the output of a create repository operation.
 type CreateRepositoryOutput struct {
 	_ struct{} `type:"structure"`
@@ -695,6 +749,22 @@ func (s DeleteRepositoryInput) String() string {
 // GoString returns the string representation
 func (s DeleteRepositoryInput) GoString() string {
 	return s.String()
+}
+
+// Validate inspects the fields of the type to determine if they are valid.
+func (s *DeleteRepositoryInput) Validate() error {
+	invalidParams := request.ErrInvalidParams{Context: "DeleteRepositoryInput"}
+	if s.RepositoryName == nil {
+		invalidParams.Add(request.NewErrParamRequired("RepositoryName"))
+	}
+	if s.RepositoryName != nil && len(*s.RepositoryName) < 1 {
+		invalidParams.Add(request.NewErrParamMinLen("RepositoryName", 1))
+	}
+
+	if invalidParams.Len() > 0 {
+		return invalidParams
+	}
+	return nil
 }
 
 // Represents the output of a delete repository operation.
@@ -737,6 +807,22 @@ func (s GetBranchInput) GoString() string {
 	return s.String()
 }
 
+// Validate inspects the fields of the type to determine if they are valid.
+func (s *GetBranchInput) Validate() error {
+	invalidParams := request.ErrInvalidParams{Context: "GetBranchInput"}
+	if s.BranchName != nil && len(*s.BranchName) < 1 {
+		invalidParams.Add(request.NewErrParamMinLen("BranchName", 1))
+	}
+	if s.RepositoryName != nil && len(*s.RepositoryName) < 1 {
+		invalidParams.Add(request.NewErrParamMinLen("RepositoryName", 1))
+	}
+
+	if invalidParams.Len() > 0 {
+		return invalidParams
+	}
+	return nil
+}
+
 // Represents the output of a get branch operation.
 type GetBranchOutput struct {
 	_ struct{} `type:"structure"`
@@ -776,6 +862,25 @@ func (s GetCommitInput) GoString() string {
 	return s.String()
 }
 
+// Validate inspects the fields of the type to determine if they are valid.
+func (s *GetCommitInput) Validate() error {
+	invalidParams := request.ErrInvalidParams{Context: "GetCommitInput"}
+	if s.CommitId == nil {
+		invalidParams.Add(request.NewErrParamRequired("CommitId"))
+	}
+	if s.RepositoryName == nil {
+		invalidParams.Add(request.NewErrParamRequired("RepositoryName"))
+	}
+	if s.RepositoryName != nil && len(*s.RepositoryName) < 1 {
+		invalidParams.Add(request.NewErrParamMinLen("RepositoryName", 1))
+	}
+
+	if invalidParams.Len() > 0 {
+		return invalidParams
+	}
+	return nil
+}
+
 // Represents the output of a get commit operation.
 type GetCommitOutput struct {
 	_ struct{} `type:"structure"`
@@ -812,6 +917,22 @@ func (s GetRepositoryInput) GoString() string {
 	return s.String()
 }
 
+// Validate inspects the fields of the type to determine if they are valid.
+func (s *GetRepositoryInput) Validate() error {
+	invalidParams := request.ErrInvalidParams{Context: "GetRepositoryInput"}
+	if s.RepositoryName == nil {
+		invalidParams.Add(request.NewErrParamRequired("RepositoryName"))
+	}
+	if s.RepositoryName != nil && len(*s.RepositoryName) < 1 {
+		invalidParams.Add(request.NewErrParamMinLen("RepositoryName", 1))
+	}
+
+	if invalidParams.Len() > 0 {
+		return invalidParams
+	}
+	return nil
+}
+
 // Represents the output of a get repository operation.
 type GetRepositoryOutput struct {
 	_ struct{} `type:"structure"`
@@ -846,6 +967,19 @@ func (s GetRepositoryTriggersInput) String() string {
 // GoString returns the string representation
 func (s GetRepositoryTriggersInput) GoString() string {
 	return s.String()
+}
+
+// Validate inspects the fields of the type to determine if they are valid.
+func (s *GetRepositoryTriggersInput) Validate() error {
+	invalidParams := request.ErrInvalidParams{Context: "GetRepositoryTriggersInput"}
+	if s.RepositoryName != nil && len(*s.RepositoryName) < 1 {
+		invalidParams.Add(request.NewErrParamMinLen("RepositoryName", 1))
+	}
+
+	if invalidParams.Len() > 0 {
+		return invalidParams
+	}
+	return nil
 }
 
 // Represents the output of a get repository triggers operation.
@@ -888,6 +1022,22 @@ func (s ListBranchesInput) String() string {
 // GoString returns the string representation
 func (s ListBranchesInput) GoString() string {
 	return s.String()
+}
+
+// Validate inspects the fields of the type to determine if they are valid.
+func (s *ListBranchesInput) Validate() error {
+	invalidParams := request.ErrInvalidParams{Context: "ListBranchesInput"}
+	if s.RepositoryName == nil {
+		invalidParams.Add(request.NewErrParamRequired("RepositoryName"))
+	}
+	if s.RepositoryName != nil && len(*s.RepositoryName) < 1 {
+		invalidParams.Add(request.NewErrParamMinLen("RepositoryName", 1))
+	}
+
+	if invalidParams.Len() > 0 {
+		return invalidParams
+	}
+	return nil
 }
 
 // Represents the output of a list branches operation.
@@ -981,6 +1131,19 @@ func (s PutRepositoryTriggersInput) String() string {
 // GoString returns the string representation
 func (s PutRepositoryTriggersInput) GoString() string {
 	return s.String()
+}
+
+// Validate inspects the fields of the type to determine if they are valid.
+func (s *PutRepositoryTriggersInput) Validate() error {
+	invalidParams := request.ErrInvalidParams{Context: "PutRepositoryTriggersInput"}
+	if s.RepositoryName != nil && len(*s.RepositoryName) < 1 {
+		invalidParams.Add(request.NewErrParamMinLen("RepositoryName", 1))
+	}
+
+	if invalidParams.Len() > 0 {
+		return invalidParams
+	}
+	return nil
 }
 
 // Represents the output of a put repository triggers operation.
@@ -1145,6 +1308,19 @@ func (s TestRepositoryTriggersInput) GoString() string {
 	return s.String()
 }
 
+// Validate inspects the fields of the type to determine if they are valid.
+func (s *TestRepositoryTriggersInput) Validate() error {
+	invalidParams := request.ErrInvalidParams{Context: "TestRepositoryTriggersInput"}
+	if s.RepositoryName != nil && len(*s.RepositoryName) < 1 {
+		invalidParams.Add(request.NewErrParamMinLen("RepositoryName", 1))
+	}
+
+	if invalidParams.Len() > 0 {
+		return invalidParams
+	}
+	return nil
+}
+
 // Represents the output of a test repository triggers operation.
 type TestRepositoryTriggersOutput struct {
 	_ struct{} `type:"structure"`
@@ -1189,6 +1365,28 @@ func (s UpdateDefaultBranchInput) GoString() string {
 	return s.String()
 }
 
+// Validate inspects the fields of the type to determine if they are valid.
+func (s *UpdateDefaultBranchInput) Validate() error {
+	invalidParams := request.ErrInvalidParams{Context: "UpdateDefaultBranchInput"}
+	if s.DefaultBranchName == nil {
+		invalidParams.Add(request.NewErrParamRequired("DefaultBranchName"))
+	}
+	if s.DefaultBranchName != nil && len(*s.DefaultBranchName) < 1 {
+		invalidParams.Add(request.NewErrParamMinLen("DefaultBranchName", 1))
+	}
+	if s.RepositoryName == nil {
+		invalidParams.Add(request.NewErrParamRequired("RepositoryName"))
+	}
+	if s.RepositoryName != nil && len(*s.RepositoryName) < 1 {
+		invalidParams.Add(request.NewErrParamMinLen("RepositoryName", 1))
+	}
+
+	if invalidParams.Len() > 0 {
+		return invalidParams
+	}
+	return nil
+}
+
 type UpdateDefaultBranchOutput struct {
 	_ struct{} `type:"structure"`
 }
@@ -1225,6 +1423,22 @@ func (s UpdateRepositoryDescriptionInput) GoString() string {
 	return s.String()
 }
 
+// Validate inspects the fields of the type to determine if they are valid.
+func (s *UpdateRepositoryDescriptionInput) Validate() error {
+	invalidParams := request.ErrInvalidParams{Context: "UpdateRepositoryDescriptionInput"}
+	if s.RepositoryName == nil {
+		invalidParams.Add(request.NewErrParamRequired("RepositoryName"))
+	}
+	if s.RepositoryName != nil && len(*s.RepositoryName) < 1 {
+		invalidParams.Add(request.NewErrParamMinLen("RepositoryName", 1))
+	}
+
+	if invalidParams.Len() > 0 {
+		return invalidParams
+	}
+	return nil
+}
+
 type UpdateRepositoryDescriptionOutput struct {
 	_ struct{} `type:"structure"`
 }
@@ -1258,6 +1472,28 @@ func (s UpdateRepositoryNameInput) String() string {
 // GoString returns the string representation
 func (s UpdateRepositoryNameInput) GoString() string {
 	return s.String()
+}
+
+// Validate inspects the fields of the type to determine if they are valid.
+func (s *UpdateRepositoryNameInput) Validate() error {
+	invalidParams := request.ErrInvalidParams{Context: "UpdateRepositoryNameInput"}
+	if s.NewName == nil {
+		invalidParams.Add(request.NewErrParamRequired("NewName"))
+	}
+	if s.NewName != nil && len(*s.NewName) < 1 {
+		invalidParams.Add(request.NewErrParamMinLen("NewName", 1))
+	}
+	if s.OldName == nil {
+		invalidParams.Add(request.NewErrParamRequired("OldName"))
+	}
+	if s.OldName != nil && len(*s.OldName) < 1 {
+		invalidParams.Add(request.NewErrParamMinLen("OldName", 1))
+	}
+
+	if invalidParams.Len() > 0 {
+		return invalidParams
+	}
+	return nil
 }
 
 type UpdateRepositoryNameOutput struct {

--- a/service/codedeploy/api.go
+++ b/service/codedeploy/api.go
@@ -1092,6 +1092,22 @@ func (s AddTagsToOnPremisesInstancesInput) GoString() string {
 	return s.String()
 }
 
+// Validate inspects the fields of the type to determine if they are valid.
+func (s *AddTagsToOnPremisesInstancesInput) Validate() error {
+	invalidParams := request.ErrInvalidParams{Context: "AddTagsToOnPremisesInstancesInput"}
+	if s.InstanceNames == nil {
+		invalidParams.Add(request.NewErrParamRequired("InstanceNames"))
+	}
+	if s.Tags == nil {
+		invalidParams.Add(request.NewErrParamRequired("Tags"))
+	}
+
+	if invalidParams.Len() > 0 {
+		return invalidParams
+	}
+	return nil
+}
+
 type AddTagsToOnPremisesInstancesOutput struct {
 	_ struct{} `type:"structure"`
 }
@@ -1176,6 +1192,25 @@ func (s BatchGetApplicationRevisionsInput) GoString() string {
 	return s.String()
 }
 
+// Validate inspects the fields of the type to determine if they are valid.
+func (s *BatchGetApplicationRevisionsInput) Validate() error {
+	invalidParams := request.ErrInvalidParams{Context: "BatchGetApplicationRevisionsInput"}
+	if s.ApplicationName == nil {
+		invalidParams.Add(request.NewErrParamRequired("ApplicationName"))
+	}
+	if s.ApplicationName != nil && len(*s.ApplicationName) < 1 {
+		invalidParams.Add(request.NewErrParamMinLen("ApplicationName", 1))
+	}
+	if s.Revisions == nil {
+		invalidParams.Add(request.NewErrParamRequired("Revisions"))
+	}
+
+	if invalidParams.Len() > 0 {
+		return invalidParams
+	}
+	return nil
+}
+
 // Represents the output of a batch get application revisions operation.
 type BatchGetApplicationRevisionsOutput struct {
 	_ struct{} `type:"structure"`
@@ -1258,6 +1293,25 @@ func (s BatchGetDeploymentGroupsInput) GoString() string {
 	return s.String()
 }
 
+// Validate inspects the fields of the type to determine if they are valid.
+func (s *BatchGetDeploymentGroupsInput) Validate() error {
+	invalidParams := request.ErrInvalidParams{Context: "BatchGetDeploymentGroupsInput"}
+	if s.ApplicationName == nil {
+		invalidParams.Add(request.NewErrParamRequired("ApplicationName"))
+	}
+	if s.ApplicationName != nil && len(*s.ApplicationName) < 1 {
+		invalidParams.Add(request.NewErrParamMinLen("ApplicationName", 1))
+	}
+	if s.DeploymentGroupNames == nil {
+		invalidParams.Add(request.NewErrParamRequired("DeploymentGroupNames"))
+	}
+
+	if invalidParams.Len() > 0 {
+		return invalidParams
+	}
+	return nil
+}
+
 // Represents the output of a batch get deployment groups operation.
 type BatchGetDeploymentGroupsOutput struct {
 	_ struct{} `type:"structure"`
@@ -1298,6 +1352,22 @@ func (s BatchGetDeploymentInstancesInput) String() string {
 // GoString returns the string representation
 func (s BatchGetDeploymentInstancesInput) GoString() string {
 	return s.String()
+}
+
+// Validate inspects the fields of the type to determine if they are valid.
+func (s *BatchGetDeploymentInstancesInput) Validate() error {
+	invalidParams := request.ErrInvalidParams{Context: "BatchGetDeploymentInstancesInput"}
+	if s.DeploymentId == nil {
+		invalidParams.Add(request.NewErrParamRequired("DeploymentId"))
+	}
+	if s.InstanceIds == nil {
+		invalidParams.Add(request.NewErrParamRequired("InstanceIds"))
+	}
+
+	if invalidParams.Len() > 0 {
+		return invalidParams
+	}
+	return nil
 }
 
 // Represents the output of a batch get deployment instance operation.
@@ -1412,6 +1482,22 @@ func (s CreateApplicationInput) GoString() string {
 	return s.String()
 }
 
+// Validate inspects the fields of the type to determine if they are valid.
+func (s *CreateApplicationInput) Validate() error {
+	invalidParams := request.ErrInvalidParams{Context: "CreateApplicationInput"}
+	if s.ApplicationName == nil {
+		invalidParams.Add(request.NewErrParamRequired("ApplicationName"))
+	}
+	if s.ApplicationName != nil && len(*s.ApplicationName) < 1 {
+		invalidParams.Add(request.NewErrParamMinLen("ApplicationName", 1))
+	}
+
+	if invalidParams.Len() > 0 {
+		return invalidParams
+	}
+	return nil
+}
+
 // Represents the output of a create application operation.
 type CreateApplicationOutput struct {
 	_ struct{} `type:"structure"`
@@ -1464,6 +1550,22 @@ func (s CreateDeploymentConfigInput) String() string {
 // GoString returns the string representation
 func (s CreateDeploymentConfigInput) GoString() string {
 	return s.String()
+}
+
+// Validate inspects the fields of the type to determine if they are valid.
+func (s *CreateDeploymentConfigInput) Validate() error {
+	invalidParams := request.ErrInvalidParams{Context: "CreateDeploymentConfigInput"}
+	if s.DeploymentConfigName == nil {
+		invalidParams.Add(request.NewErrParamRequired("DeploymentConfigName"))
+	}
+	if s.DeploymentConfigName != nil && len(*s.DeploymentConfigName) < 1 {
+		invalidParams.Add(request.NewErrParamMinLen("DeploymentConfigName", 1))
+	}
+
+	if invalidParams.Len() > 0 {
+		return invalidParams
+	}
+	return nil
 }
 
 // Represents the output of a create deployment configuration operation.
@@ -1576,6 +1678,34 @@ func (s CreateDeploymentGroupInput) GoString() string {
 	return s.String()
 }
 
+// Validate inspects the fields of the type to determine if they are valid.
+func (s *CreateDeploymentGroupInput) Validate() error {
+	invalidParams := request.ErrInvalidParams{Context: "CreateDeploymentGroupInput"}
+	if s.ApplicationName == nil {
+		invalidParams.Add(request.NewErrParamRequired("ApplicationName"))
+	}
+	if s.ApplicationName != nil && len(*s.ApplicationName) < 1 {
+		invalidParams.Add(request.NewErrParamMinLen("ApplicationName", 1))
+	}
+	if s.DeploymentConfigName != nil && len(*s.DeploymentConfigName) < 1 {
+		invalidParams.Add(request.NewErrParamMinLen("DeploymentConfigName", 1))
+	}
+	if s.DeploymentGroupName == nil {
+		invalidParams.Add(request.NewErrParamRequired("DeploymentGroupName"))
+	}
+	if s.DeploymentGroupName != nil && len(*s.DeploymentGroupName) < 1 {
+		invalidParams.Add(request.NewErrParamMinLen("DeploymentGroupName", 1))
+	}
+	if s.ServiceRoleArn == nil {
+		invalidParams.Add(request.NewErrParamRequired("ServiceRoleArn"))
+	}
+
+	if invalidParams.Len() > 0 {
+		return invalidParams
+	}
+	return nil
+}
+
 // Represents the output of a create deployment group operation.
 type CreateDeploymentGroupOutput struct {
 	_ struct{} `type:"structure"`
@@ -1641,6 +1771,28 @@ func (s CreateDeploymentInput) GoString() string {
 	return s.String()
 }
 
+// Validate inspects the fields of the type to determine if they are valid.
+func (s *CreateDeploymentInput) Validate() error {
+	invalidParams := request.ErrInvalidParams{Context: "CreateDeploymentInput"}
+	if s.ApplicationName == nil {
+		invalidParams.Add(request.NewErrParamRequired("ApplicationName"))
+	}
+	if s.ApplicationName != nil && len(*s.ApplicationName) < 1 {
+		invalidParams.Add(request.NewErrParamMinLen("ApplicationName", 1))
+	}
+	if s.DeploymentConfigName != nil && len(*s.DeploymentConfigName) < 1 {
+		invalidParams.Add(request.NewErrParamMinLen("DeploymentConfigName", 1))
+	}
+	if s.DeploymentGroupName != nil && len(*s.DeploymentGroupName) < 1 {
+		invalidParams.Add(request.NewErrParamMinLen("DeploymentGroupName", 1))
+	}
+
+	if invalidParams.Len() > 0 {
+		return invalidParams
+	}
+	return nil
+}
+
 // Represents the output of a create deployment operation.
 type CreateDeploymentOutput struct {
 	_ struct{} `type:"structure"`
@@ -1678,6 +1830,22 @@ func (s DeleteApplicationInput) GoString() string {
 	return s.String()
 }
 
+// Validate inspects the fields of the type to determine if they are valid.
+func (s *DeleteApplicationInput) Validate() error {
+	invalidParams := request.ErrInvalidParams{Context: "DeleteApplicationInput"}
+	if s.ApplicationName == nil {
+		invalidParams.Add(request.NewErrParamRequired("ApplicationName"))
+	}
+	if s.ApplicationName != nil && len(*s.ApplicationName) < 1 {
+		invalidParams.Add(request.NewErrParamMinLen("ApplicationName", 1))
+	}
+
+	if invalidParams.Len() > 0 {
+		return invalidParams
+	}
+	return nil
+}
+
 type DeleteApplicationOutput struct {
 	_ struct{} `type:"structure"`
 }
@@ -1709,6 +1877,22 @@ func (s DeleteDeploymentConfigInput) String() string {
 // GoString returns the string representation
 func (s DeleteDeploymentConfigInput) GoString() string {
 	return s.String()
+}
+
+// Validate inspects the fields of the type to determine if they are valid.
+func (s *DeleteDeploymentConfigInput) Validate() error {
+	invalidParams := request.ErrInvalidParams{Context: "DeleteDeploymentConfigInput"}
+	if s.DeploymentConfigName == nil {
+		invalidParams.Add(request.NewErrParamRequired("DeploymentConfigName"))
+	}
+	if s.DeploymentConfigName != nil && len(*s.DeploymentConfigName) < 1 {
+		invalidParams.Add(request.NewErrParamMinLen("DeploymentConfigName", 1))
+	}
+
+	if invalidParams.Len() > 0 {
+		return invalidParams
+	}
+	return nil
 }
 
 type DeleteDeploymentConfigOutput struct {
@@ -1745,6 +1929,28 @@ func (s DeleteDeploymentGroupInput) String() string {
 // GoString returns the string representation
 func (s DeleteDeploymentGroupInput) GoString() string {
 	return s.String()
+}
+
+// Validate inspects the fields of the type to determine if they are valid.
+func (s *DeleteDeploymentGroupInput) Validate() error {
+	invalidParams := request.ErrInvalidParams{Context: "DeleteDeploymentGroupInput"}
+	if s.ApplicationName == nil {
+		invalidParams.Add(request.NewErrParamRequired("ApplicationName"))
+	}
+	if s.ApplicationName != nil && len(*s.ApplicationName) < 1 {
+		invalidParams.Add(request.NewErrParamMinLen("ApplicationName", 1))
+	}
+	if s.DeploymentGroupName == nil {
+		invalidParams.Add(request.NewErrParamRequired("DeploymentGroupName"))
+	}
+	if s.DeploymentGroupName != nil && len(*s.DeploymentGroupName) < 1 {
+		invalidParams.Add(request.NewErrParamMinLen("DeploymentGroupName", 1))
+	}
+
+	if invalidParams.Len() > 0 {
+		return invalidParams
+	}
+	return nil
 }
 
 // Represents the output of a delete deployment group operation.
@@ -1966,6 +2172,19 @@ func (s DeregisterOnPremisesInstanceInput) GoString() string {
 	return s.String()
 }
 
+// Validate inspects the fields of the type to determine if they are valid.
+func (s *DeregisterOnPremisesInstanceInput) Validate() error {
+	invalidParams := request.ErrInvalidParams{Context: "DeregisterOnPremisesInstanceInput"}
+	if s.InstanceName == nil {
+		invalidParams.Add(request.NewErrParamRequired("InstanceName"))
+	}
+
+	if invalidParams.Len() > 0 {
+		return invalidParams
+	}
+	return nil
+}
+
 type DeregisterOnPremisesInstanceOutput struct {
 	_ struct{} `type:"structure"`
 }
@@ -2132,6 +2351,22 @@ func (s GetApplicationInput) GoString() string {
 	return s.String()
 }
 
+// Validate inspects the fields of the type to determine if they are valid.
+func (s *GetApplicationInput) Validate() error {
+	invalidParams := request.ErrInvalidParams{Context: "GetApplicationInput"}
+	if s.ApplicationName == nil {
+		invalidParams.Add(request.NewErrParamRequired("ApplicationName"))
+	}
+	if s.ApplicationName != nil && len(*s.ApplicationName) < 1 {
+		invalidParams.Add(request.NewErrParamMinLen("ApplicationName", 1))
+	}
+
+	if invalidParams.Len() > 0 {
+		return invalidParams
+	}
+	return nil
+}
+
 // Represents the output of a get application operation.
 type GetApplicationOutput struct {
 	_ struct{} `type:"structure"`
@@ -2169,6 +2404,25 @@ func (s GetApplicationRevisionInput) String() string {
 // GoString returns the string representation
 func (s GetApplicationRevisionInput) GoString() string {
 	return s.String()
+}
+
+// Validate inspects the fields of the type to determine if they are valid.
+func (s *GetApplicationRevisionInput) Validate() error {
+	invalidParams := request.ErrInvalidParams{Context: "GetApplicationRevisionInput"}
+	if s.ApplicationName == nil {
+		invalidParams.Add(request.NewErrParamRequired("ApplicationName"))
+	}
+	if s.ApplicationName != nil && len(*s.ApplicationName) < 1 {
+		invalidParams.Add(request.NewErrParamMinLen("ApplicationName", 1))
+	}
+	if s.Revision == nil {
+		invalidParams.Add(request.NewErrParamRequired("Revision"))
+	}
+
+	if invalidParams.Len() > 0 {
+		return invalidParams
+	}
+	return nil
 }
 
 // Represents the output of a get application revision operation.
@@ -2214,6 +2468,22 @@ func (s GetDeploymentConfigInput) GoString() string {
 	return s.String()
 }
 
+// Validate inspects the fields of the type to determine if they are valid.
+func (s *GetDeploymentConfigInput) Validate() error {
+	invalidParams := request.ErrInvalidParams{Context: "GetDeploymentConfigInput"}
+	if s.DeploymentConfigName == nil {
+		invalidParams.Add(request.NewErrParamRequired("DeploymentConfigName"))
+	}
+	if s.DeploymentConfigName != nil && len(*s.DeploymentConfigName) < 1 {
+		invalidParams.Add(request.NewErrParamMinLen("DeploymentConfigName", 1))
+	}
+
+	if invalidParams.Len() > 0 {
+		return invalidParams
+	}
+	return nil
+}
+
 // Represents the output of a get deployment configuration operation.
 type GetDeploymentConfigOutput struct {
 	_ struct{} `type:"structure"`
@@ -2254,6 +2524,28 @@ func (s GetDeploymentGroupInput) GoString() string {
 	return s.String()
 }
 
+// Validate inspects the fields of the type to determine if they are valid.
+func (s *GetDeploymentGroupInput) Validate() error {
+	invalidParams := request.ErrInvalidParams{Context: "GetDeploymentGroupInput"}
+	if s.ApplicationName == nil {
+		invalidParams.Add(request.NewErrParamRequired("ApplicationName"))
+	}
+	if s.ApplicationName != nil && len(*s.ApplicationName) < 1 {
+		invalidParams.Add(request.NewErrParamMinLen("ApplicationName", 1))
+	}
+	if s.DeploymentGroupName == nil {
+		invalidParams.Add(request.NewErrParamRequired("DeploymentGroupName"))
+	}
+	if s.DeploymentGroupName != nil && len(*s.DeploymentGroupName) < 1 {
+		invalidParams.Add(request.NewErrParamMinLen("DeploymentGroupName", 1))
+	}
+
+	if invalidParams.Len() > 0 {
+		return invalidParams
+	}
+	return nil
+}
+
 // Represents the output of a get deployment group operation.
 type GetDeploymentGroupOutput struct {
 	_ struct{} `type:"structure"`
@@ -2290,6 +2582,19 @@ func (s GetDeploymentInput) GoString() string {
 	return s.String()
 }
 
+// Validate inspects the fields of the type to determine if they are valid.
+func (s *GetDeploymentInput) Validate() error {
+	invalidParams := request.ErrInvalidParams{Context: "GetDeploymentInput"}
+	if s.DeploymentId == nil {
+		invalidParams.Add(request.NewErrParamRequired("DeploymentId"))
+	}
+
+	if invalidParams.Len() > 0 {
+		return invalidParams
+	}
+	return nil
+}
+
 // Represents the input of a get deployment instance operation.
 type GetDeploymentInstanceInput struct {
 	_ struct{} `type:"structure"`
@@ -2309,6 +2614,22 @@ func (s GetDeploymentInstanceInput) String() string {
 // GoString returns the string representation
 func (s GetDeploymentInstanceInput) GoString() string {
 	return s.String()
+}
+
+// Validate inspects the fields of the type to determine if they are valid.
+func (s *GetDeploymentInstanceInput) Validate() error {
+	invalidParams := request.ErrInvalidParams{Context: "GetDeploymentInstanceInput"}
+	if s.DeploymentId == nil {
+		invalidParams.Add(request.NewErrParamRequired("DeploymentId"))
+	}
+	if s.InstanceId == nil {
+		invalidParams.Add(request.NewErrParamRequired("InstanceId"))
+	}
+
+	if invalidParams.Len() > 0 {
+		return invalidParams
+	}
+	return nil
 }
 
 // Represents the output of a get deployment instance operation.
@@ -2363,6 +2684,19 @@ func (s GetOnPremisesInstanceInput) String() string {
 // GoString returns the string representation
 func (s GetOnPremisesInstanceInput) GoString() string {
 	return s.String()
+}
+
+// Validate inspects the fields of the type to determine if they are valid.
+func (s *GetOnPremisesInstanceInput) Validate() error {
+	invalidParams := request.ErrInvalidParams{Context: "GetOnPremisesInstanceInput"}
+	if s.InstanceName == nil {
+		invalidParams.Add(request.NewErrParamRequired("InstanceName"))
+	}
+
+	if invalidParams.Len() > 0 {
+		return invalidParams
+	}
+	return nil
 }
 
 // Represents the output of a get on-premises instance operation.
@@ -2571,6 +2905,22 @@ func (s ListApplicationRevisionsInput) GoString() string {
 	return s.String()
 }
 
+// Validate inspects the fields of the type to determine if they are valid.
+func (s *ListApplicationRevisionsInput) Validate() error {
+	invalidParams := request.ErrInvalidParams{Context: "ListApplicationRevisionsInput"}
+	if s.ApplicationName == nil {
+		invalidParams.Add(request.NewErrParamRequired("ApplicationName"))
+	}
+	if s.ApplicationName != nil && len(*s.ApplicationName) < 1 {
+		invalidParams.Add(request.NewErrParamMinLen("ApplicationName", 1))
+	}
+
+	if invalidParams.Len() > 0 {
+		return invalidParams
+	}
+	return nil
+}
+
 // Represents the output of a list application revisions operation.
 type ListApplicationRevisionsOutput struct {
 	_ struct{} `type:"structure"`
@@ -2703,6 +3053,22 @@ func (s ListDeploymentGroupsInput) GoString() string {
 	return s.String()
 }
 
+// Validate inspects the fields of the type to determine if they are valid.
+func (s *ListDeploymentGroupsInput) Validate() error {
+	invalidParams := request.ErrInvalidParams{Context: "ListDeploymentGroupsInput"}
+	if s.ApplicationName == nil {
+		invalidParams.Add(request.NewErrParamRequired("ApplicationName"))
+	}
+	if s.ApplicationName != nil && len(*s.ApplicationName) < 1 {
+		invalidParams.Add(request.NewErrParamMinLen("ApplicationName", 1))
+	}
+
+	if invalidParams.Len() > 0 {
+		return invalidParams
+	}
+	return nil
+}
+
 // Represents the output of a list deployment groups operation.
 type ListDeploymentGroupsOutput struct {
 	_ struct{} `type:"structure"`
@@ -2758,6 +3124,19 @@ func (s ListDeploymentInstancesInput) String() string {
 // GoString returns the string representation
 func (s ListDeploymentInstancesInput) GoString() string {
 	return s.String()
+}
+
+// Validate inspects the fields of the type to determine if they are valid.
+func (s *ListDeploymentInstancesInput) Validate() error {
+	invalidParams := request.ErrInvalidParams{Context: "ListDeploymentInstancesInput"}
+	if s.DeploymentId == nil {
+		invalidParams.Add(request.NewErrParamRequired("DeploymentId"))
+	}
+
+	if invalidParams.Len() > 0 {
+		return invalidParams
+	}
+	return nil
 }
 
 // Represents the output of a list deployment instances operation.
@@ -2819,6 +3198,22 @@ func (s ListDeploymentsInput) String() string {
 // GoString returns the string representation
 func (s ListDeploymentsInput) GoString() string {
 	return s.String()
+}
+
+// Validate inspects the fields of the type to determine if they are valid.
+func (s *ListDeploymentsInput) Validate() error {
+	invalidParams := request.ErrInvalidParams{Context: "ListDeploymentsInput"}
+	if s.ApplicationName != nil && len(*s.ApplicationName) < 1 {
+		invalidParams.Add(request.NewErrParamMinLen("ApplicationName", 1))
+	}
+	if s.DeploymentGroupName != nil && len(*s.DeploymentGroupName) < 1 {
+		invalidParams.Add(request.NewErrParamMinLen("DeploymentGroupName", 1))
+	}
+
+	if invalidParams.Len() > 0 {
+		return invalidParams
+	}
+	return nil
 }
 
 // Represents the output of a list deployments operation.
@@ -2966,6 +3361,25 @@ func (s RegisterApplicationRevisionInput) GoString() string {
 	return s.String()
 }
 
+// Validate inspects the fields of the type to determine if they are valid.
+func (s *RegisterApplicationRevisionInput) Validate() error {
+	invalidParams := request.ErrInvalidParams{Context: "RegisterApplicationRevisionInput"}
+	if s.ApplicationName == nil {
+		invalidParams.Add(request.NewErrParamRequired("ApplicationName"))
+	}
+	if s.ApplicationName != nil && len(*s.ApplicationName) < 1 {
+		invalidParams.Add(request.NewErrParamMinLen("ApplicationName", 1))
+	}
+	if s.Revision == nil {
+		invalidParams.Add(request.NewErrParamRequired("Revision"))
+	}
+
+	if invalidParams.Len() > 0 {
+		return invalidParams
+	}
+	return nil
+}
+
 type RegisterApplicationRevisionOutput struct {
 	_ struct{} `type:"structure"`
 }
@@ -3001,6 +3415,22 @@ func (s RegisterOnPremisesInstanceInput) GoString() string {
 	return s.String()
 }
 
+// Validate inspects the fields of the type to determine if they are valid.
+func (s *RegisterOnPremisesInstanceInput) Validate() error {
+	invalidParams := request.ErrInvalidParams{Context: "RegisterOnPremisesInstanceInput"}
+	if s.IamUserArn == nil {
+		invalidParams.Add(request.NewErrParamRequired("IamUserArn"))
+	}
+	if s.InstanceName == nil {
+		invalidParams.Add(request.NewErrParamRequired("InstanceName"))
+	}
+
+	if invalidParams.Len() > 0 {
+		return invalidParams
+	}
+	return nil
+}
+
 type RegisterOnPremisesInstanceOutput struct {
 	_ struct{} `type:"structure"`
 }
@@ -3034,6 +3464,22 @@ func (s RemoveTagsFromOnPremisesInstancesInput) String() string {
 // GoString returns the string representation
 func (s RemoveTagsFromOnPremisesInstancesInput) GoString() string {
 	return s.String()
+}
+
+// Validate inspects the fields of the type to determine if they are valid.
+func (s *RemoveTagsFromOnPremisesInstancesInput) Validate() error {
+	invalidParams := request.ErrInvalidParams{Context: "RemoveTagsFromOnPremisesInstancesInput"}
+	if s.InstanceNames == nil {
+		invalidParams.Add(request.NewErrParamRequired("InstanceNames"))
+	}
+	if s.Tags == nil {
+		invalidParams.Add(request.NewErrParamRequired("Tags"))
+	}
+
+	if invalidParams.Len() > 0 {
+		return invalidParams
+	}
+	return nil
 }
 
 type RemoveTagsFromOnPremisesInstancesOutput struct {
@@ -3158,6 +3604,19 @@ func (s StopDeploymentInput) String() string {
 // GoString returns the string representation
 func (s StopDeploymentInput) GoString() string {
 	return s.String()
+}
+
+// Validate inspects the fields of the type to determine if they are valid.
+func (s *StopDeploymentInput) Validate() error {
+	invalidParams := request.ErrInvalidParams{Context: "StopDeploymentInput"}
+	if s.DeploymentId == nil {
+		invalidParams.Add(request.NewErrParamRequired("DeploymentId"))
+	}
+
+	if invalidParams.Len() > 0 {
+		return invalidParams
+	}
+	return nil
 }
 
 // Represents the output of a stop deployment operation.
@@ -3307,6 +3766,22 @@ func (s UpdateApplicationInput) GoString() string {
 	return s.String()
 }
 
+// Validate inspects the fields of the type to determine if they are valid.
+func (s *UpdateApplicationInput) Validate() error {
+	invalidParams := request.ErrInvalidParams{Context: "UpdateApplicationInput"}
+	if s.ApplicationName != nil && len(*s.ApplicationName) < 1 {
+		invalidParams.Add(request.NewErrParamMinLen("ApplicationName", 1))
+	}
+	if s.NewApplicationName != nil && len(*s.NewApplicationName) < 1 {
+		invalidParams.Add(request.NewErrParamMinLen("NewApplicationName", 1))
+	}
+
+	if invalidParams.Len() > 0 {
+		return invalidParams
+	}
+	return nil
+}
+
 type UpdateApplicationOutput struct {
 	_ struct{} `type:"structure"`
 }
@@ -3369,6 +3844,34 @@ func (s UpdateDeploymentGroupInput) String() string {
 // GoString returns the string representation
 func (s UpdateDeploymentGroupInput) GoString() string {
 	return s.String()
+}
+
+// Validate inspects the fields of the type to determine if they are valid.
+func (s *UpdateDeploymentGroupInput) Validate() error {
+	invalidParams := request.ErrInvalidParams{Context: "UpdateDeploymentGroupInput"}
+	if s.ApplicationName == nil {
+		invalidParams.Add(request.NewErrParamRequired("ApplicationName"))
+	}
+	if s.ApplicationName != nil && len(*s.ApplicationName) < 1 {
+		invalidParams.Add(request.NewErrParamMinLen("ApplicationName", 1))
+	}
+	if s.CurrentDeploymentGroupName == nil {
+		invalidParams.Add(request.NewErrParamRequired("CurrentDeploymentGroupName"))
+	}
+	if s.CurrentDeploymentGroupName != nil && len(*s.CurrentDeploymentGroupName) < 1 {
+		invalidParams.Add(request.NewErrParamMinLen("CurrentDeploymentGroupName", 1))
+	}
+	if s.DeploymentConfigName != nil && len(*s.DeploymentConfigName) < 1 {
+		invalidParams.Add(request.NewErrParamMinLen("DeploymentConfigName", 1))
+	}
+	if s.NewDeploymentGroupName != nil && len(*s.NewDeploymentGroupName) < 1 {
+		invalidParams.Add(request.NewErrParamMinLen("NewDeploymentGroupName", 1))
+	}
+
+	if invalidParams.Len() > 0 {
+		return invalidParams
+	}
+	return nil
 }
 
 // Represents the output of an update deployment group operation.

--- a/service/codepipeline/api.go
+++ b/service/codepipeline/api.go
@@ -4,6 +4,7 @@
 package codepipeline
 
 import (
+	"fmt"
 	"time"
 
 	"github.com/aws/aws-sdk-go/aws/awsutil"
@@ -740,6 +741,22 @@ func (s AcknowledgeJobInput) GoString() string {
 	return s.String()
 }
 
+// Validate inspects the fields of the type to determine if they are valid.
+func (s *AcknowledgeJobInput) Validate() error {
+	invalidParams := request.ErrInvalidParams{Context: "AcknowledgeJobInput"}
+	if s.JobId == nil {
+		invalidParams.Add(request.NewErrParamRequired("JobId"))
+	}
+	if s.Nonce == nil {
+		invalidParams.Add(request.NewErrParamRequired("Nonce"))
+	}
+
+	if invalidParams.Len() > 0 {
+		return invalidParams
+	}
+	return nil
+}
+
 // Represents the output of an acknowledge job action.
 type AcknowledgeJobOutput struct {
 	_ struct{} `type:"structure"`
@@ -783,6 +800,28 @@ func (s AcknowledgeThirdPartyJobInput) String() string {
 // GoString returns the string representation
 func (s AcknowledgeThirdPartyJobInput) GoString() string {
 	return s.String()
+}
+
+// Validate inspects the fields of the type to determine if they are valid.
+func (s *AcknowledgeThirdPartyJobInput) Validate() error {
+	invalidParams := request.ErrInvalidParams{Context: "AcknowledgeThirdPartyJobInput"}
+	if s.ClientToken == nil {
+		invalidParams.Add(request.NewErrParamRequired("ClientToken"))
+	}
+	if s.JobId == nil {
+		invalidParams.Add(request.NewErrParamRequired("JobId"))
+	}
+	if s.JobId != nil && len(*s.JobId) < 1 {
+		invalidParams.Add(request.NewErrParamMinLen("JobId", 1))
+	}
+	if s.Nonce == nil {
+		invalidParams.Add(request.NewErrParamRequired("Nonce"))
+	}
+
+	if invalidParams.Len() > 0 {
+		return invalidParams
+	}
+	return nil
 }
 
 // Represents the output of an acknowledge third party job action.
@@ -871,6 +910,34 @@ func (s ActionConfigurationProperty) GoString() string {
 	return s.String()
 }
 
+// Validate inspects the fields of the type to determine if they are valid.
+func (s *ActionConfigurationProperty) Validate() error {
+	invalidParams := request.ErrInvalidParams{Context: "ActionConfigurationProperty"}
+	if s.Description != nil && len(*s.Description) < 1 {
+		invalidParams.Add(request.NewErrParamMinLen("Description", 1))
+	}
+	if s.Key == nil {
+		invalidParams.Add(request.NewErrParamRequired("Key"))
+	}
+	if s.Name == nil {
+		invalidParams.Add(request.NewErrParamRequired("Name"))
+	}
+	if s.Name != nil && len(*s.Name) < 1 {
+		invalidParams.Add(request.NewErrParamMinLen("Name", 1))
+	}
+	if s.Required == nil {
+		invalidParams.Add(request.NewErrParamRequired("Required"))
+	}
+	if s.Secret == nil {
+		invalidParams.Add(request.NewErrParamRequired("Secret"))
+	}
+
+	if invalidParams.Len() > 0 {
+		return invalidParams
+	}
+	return nil
+}
+
 // Represents the context of an action within the stage of a pipeline to a job
 // worker.
 type ActionContext struct {
@@ -927,6 +994,53 @@ func (s ActionDeclaration) String() string {
 // GoString returns the string representation
 func (s ActionDeclaration) GoString() string {
 	return s.String()
+}
+
+// Validate inspects the fields of the type to determine if they are valid.
+func (s *ActionDeclaration) Validate() error {
+	invalidParams := request.ErrInvalidParams{Context: "ActionDeclaration"}
+	if s.ActionTypeId == nil {
+		invalidParams.Add(request.NewErrParamRequired("ActionTypeId"))
+	}
+	if s.Name == nil {
+		invalidParams.Add(request.NewErrParamRequired("Name"))
+	}
+	if s.Name != nil && len(*s.Name) < 1 {
+		invalidParams.Add(request.NewErrParamMinLen("Name", 1))
+	}
+	if s.RunOrder != nil && *s.RunOrder < 1 {
+		invalidParams.Add(request.NewErrParamMinValue("RunOrder", 1))
+	}
+	if s.ActionTypeId != nil {
+		if err := s.ActionTypeId.Validate(); err != nil {
+			invalidParams.AddNested("ActionTypeId", err.(request.ErrInvalidParams))
+		}
+	}
+	if s.InputArtifacts != nil {
+		for i, v := range s.InputArtifacts {
+			if v == nil {
+				continue
+			}
+			if err := v.Validate(); err != nil {
+				invalidParams.AddNested(fmt.Sprintf("%s[%v]", "InputArtifacts", i), err.(request.ErrInvalidParams))
+			}
+		}
+	}
+	if s.OutputArtifacts != nil {
+		for i, v := range s.OutputArtifacts {
+			if v == nil {
+				continue
+			}
+			if err := v.Validate(); err != nil {
+				invalidParams.AddNested(fmt.Sprintf("%s[%v]", "OutputArtifacts", i), err.(request.ErrInvalidParams))
+			}
+		}
+	}
+
+	if invalidParams.Len() > 0 {
+		return invalidParams
+	}
+	return nil
 }
 
 // Represents information about how an action runs.
@@ -992,6 +1106,22 @@ func (s ActionRevision) String() string {
 // GoString returns the string representation
 func (s ActionRevision) GoString() string {
 	return s.String()
+}
+
+// Validate inspects the fields of the type to determine if they are valid.
+func (s *ActionRevision) Validate() error {
+	invalidParams := request.ErrInvalidParams{Context: "ActionRevision"}
+	if s.Created == nil {
+		invalidParams.Add(request.NewErrParamRequired("Created"))
+	}
+	if s.RevisionId == nil {
+		invalidParams.Add(request.NewErrParamRequired("RevisionId"))
+	}
+
+	if invalidParams.Len() > 0 {
+		return invalidParams
+	}
+	return nil
 }
 
 // Represents information about the state of an action.
@@ -1088,6 +1218,34 @@ func (s ActionTypeId) GoString() string {
 	return s.String()
 }
 
+// Validate inspects the fields of the type to determine if they are valid.
+func (s *ActionTypeId) Validate() error {
+	invalidParams := request.ErrInvalidParams{Context: "ActionTypeId"}
+	if s.Category == nil {
+		invalidParams.Add(request.NewErrParamRequired("Category"))
+	}
+	if s.Owner == nil {
+		invalidParams.Add(request.NewErrParamRequired("Owner"))
+	}
+	if s.Provider == nil {
+		invalidParams.Add(request.NewErrParamRequired("Provider"))
+	}
+	if s.Provider != nil && len(*s.Provider) < 1 {
+		invalidParams.Add(request.NewErrParamMinLen("Provider", 1))
+	}
+	if s.Version == nil {
+		invalidParams.Add(request.NewErrParamRequired("Version"))
+	}
+	if s.Version != nil && len(*s.Version) < 1 {
+		invalidParams.Add(request.NewErrParamMinLen("Version", 1))
+	}
+
+	if invalidParams.Len() > 0 {
+		return invalidParams
+	}
+	return nil
+}
+
 // Returns information about the settings for an action type.
 type ActionTypeSettings struct {
 	_ struct{} `type:"structure"`
@@ -1123,6 +1281,28 @@ func (s ActionTypeSettings) String() string {
 // GoString returns the string representation
 func (s ActionTypeSettings) GoString() string {
 	return s.String()
+}
+
+// Validate inspects the fields of the type to determine if they are valid.
+func (s *ActionTypeSettings) Validate() error {
+	invalidParams := request.ErrInvalidParams{Context: "ActionTypeSettings"}
+	if s.EntityUrlTemplate != nil && len(*s.EntityUrlTemplate) < 1 {
+		invalidParams.Add(request.NewErrParamMinLen("EntityUrlTemplate", 1))
+	}
+	if s.ExecutionUrlTemplate != nil && len(*s.ExecutionUrlTemplate) < 1 {
+		invalidParams.Add(request.NewErrParamMinLen("ExecutionUrlTemplate", 1))
+	}
+	if s.RevisionUrlTemplate != nil && len(*s.RevisionUrlTemplate) < 1 {
+		invalidParams.Add(request.NewErrParamMinLen("RevisionUrlTemplate", 1))
+	}
+	if s.ThirdPartyConfigurationUrl != nil && len(*s.ThirdPartyConfigurationUrl) < 1 {
+		invalidParams.Add(request.NewErrParamMinLen("ThirdPartyConfigurationUrl", 1))
+	}
+
+	if invalidParams.Len() > 0 {
+		return invalidParams
+	}
+	return nil
 }
 
 // Represents information about an artifact that will be worked upon by actions
@@ -1170,6 +1350,22 @@ func (s ArtifactDetails) String() string {
 // GoString returns the string representation
 func (s ArtifactDetails) GoString() string {
 	return s.String()
+}
+
+// Validate inspects the fields of the type to determine if they are valid.
+func (s *ArtifactDetails) Validate() error {
+	invalidParams := request.ErrInvalidParams{Context: "ArtifactDetails"}
+	if s.MaximumCount == nil {
+		invalidParams.Add(request.NewErrParamRequired("MaximumCount"))
+	}
+	if s.MinimumCount == nil {
+		invalidParams.Add(request.NewErrParamRequired("MinimumCount"))
+	}
+
+	if invalidParams.Len() > 0 {
+		return invalidParams
+	}
+	return nil
 }
 
 // Represents information about the location of an artifact.
@@ -1222,6 +1418,30 @@ func (s ArtifactStore) GoString() string {
 	return s.String()
 }
 
+// Validate inspects the fields of the type to determine if they are valid.
+func (s *ArtifactStore) Validate() error {
+	invalidParams := request.ErrInvalidParams{Context: "ArtifactStore"}
+	if s.Location == nil {
+		invalidParams.Add(request.NewErrParamRequired("Location"))
+	}
+	if s.Location != nil && len(*s.Location) < 3 {
+		invalidParams.Add(request.NewErrParamMinLen("Location", 3))
+	}
+	if s.Type == nil {
+		invalidParams.Add(request.NewErrParamRequired("Type"))
+	}
+	if s.EncryptionKey != nil {
+		if err := s.EncryptionKey.Validate(); err != nil {
+			invalidParams.AddNested("EncryptionKey", err.(request.ErrInvalidParams))
+		}
+	}
+
+	if invalidParams.Len() > 0 {
+		return invalidParams
+	}
+	return nil
+}
+
 // Represents information about a gate declaration.
 type BlockerDeclaration struct {
 	_ struct{} `type:"structure"`
@@ -1241,6 +1461,25 @@ func (s BlockerDeclaration) String() string {
 // GoString returns the string representation
 func (s BlockerDeclaration) GoString() string {
 	return s.String()
+}
+
+// Validate inspects the fields of the type to determine if they are valid.
+func (s *BlockerDeclaration) Validate() error {
+	invalidParams := request.ErrInvalidParams{Context: "BlockerDeclaration"}
+	if s.Name == nil {
+		invalidParams.Add(request.NewErrParamRequired("Name"))
+	}
+	if s.Name != nil && len(*s.Name) < 1 {
+		invalidParams.Add(request.NewErrParamMinLen("Name", 1))
+	}
+	if s.Type == nil {
+		invalidParams.Add(request.NewErrParamRequired("Type"))
+	}
+
+	if invalidParams.Len() > 0 {
+		return invalidParams
+	}
+	return nil
 }
 
 // Represents the input of a create custom action operation.
@@ -1282,6 +1521,62 @@ func (s CreateCustomActionTypeInput) GoString() string {
 	return s.String()
 }
 
+// Validate inspects the fields of the type to determine if they are valid.
+func (s *CreateCustomActionTypeInput) Validate() error {
+	invalidParams := request.ErrInvalidParams{Context: "CreateCustomActionTypeInput"}
+	if s.Category == nil {
+		invalidParams.Add(request.NewErrParamRequired("Category"))
+	}
+	if s.InputArtifactDetails == nil {
+		invalidParams.Add(request.NewErrParamRequired("InputArtifactDetails"))
+	}
+	if s.OutputArtifactDetails == nil {
+		invalidParams.Add(request.NewErrParamRequired("OutputArtifactDetails"))
+	}
+	if s.Provider == nil {
+		invalidParams.Add(request.NewErrParamRequired("Provider"))
+	}
+	if s.Provider != nil && len(*s.Provider) < 1 {
+		invalidParams.Add(request.NewErrParamMinLen("Provider", 1))
+	}
+	if s.Version == nil {
+		invalidParams.Add(request.NewErrParamRequired("Version"))
+	}
+	if s.Version != nil && len(*s.Version) < 1 {
+		invalidParams.Add(request.NewErrParamMinLen("Version", 1))
+	}
+	if s.ConfigurationProperties != nil {
+		for i, v := range s.ConfigurationProperties {
+			if v == nil {
+				continue
+			}
+			if err := v.Validate(); err != nil {
+				invalidParams.AddNested(fmt.Sprintf("%s[%v]", "ConfigurationProperties", i), err.(request.ErrInvalidParams))
+			}
+		}
+	}
+	if s.InputArtifactDetails != nil {
+		if err := s.InputArtifactDetails.Validate(); err != nil {
+			invalidParams.AddNested("InputArtifactDetails", err.(request.ErrInvalidParams))
+		}
+	}
+	if s.OutputArtifactDetails != nil {
+		if err := s.OutputArtifactDetails.Validate(); err != nil {
+			invalidParams.AddNested("OutputArtifactDetails", err.(request.ErrInvalidParams))
+		}
+	}
+	if s.Settings != nil {
+		if err := s.Settings.Validate(); err != nil {
+			invalidParams.AddNested("Settings", err.(request.ErrInvalidParams))
+		}
+	}
+
+	if invalidParams.Len() > 0 {
+		return invalidParams
+	}
+	return nil
+}
+
 // Represents the output of a create custom action operation.
 type CreateCustomActionTypeOutput struct {
 	_ struct{} `type:"structure"`
@@ -1316,6 +1611,24 @@ func (s CreatePipelineInput) String() string {
 // GoString returns the string representation
 func (s CreatePipelineInput) GoString() string {
 	return s.String()
+}
+
+// Validate inspects the fields of the type to determine if they are valid.
+func (s *CreatePipelineInput) Validate() error {
+	invalidParams := request.ErrInvalidParams{Context: "CreatePipelineInput"}
+	if s.Pipeline == nil {
+		invalidParams.Add(request.NewErrParamRequired("Pipeline"))
+	}
+	if s.Pipeline != nil {
+		if err := s.Pipeline.Validate(); err != nil {
+			invalidParams.AddNested("Pipeline", err.(request.ErrInvalidParams))
+		}
+	}
+
+	if invalidParams.Len() > 0 {
+		return invalidParams
+	}
+	return nil
 }
 
 // Represents the output of a create pipeline action.
@@ -1357,6 +1670,22 @@ func (s CurrentRevision) GoString() string {
 	return s.String()
 }
 
+// Validate inspects the fields of the type to determine if they are valid.
+func (s *CurrentRevision) Validate() error {
+	invalidParams := request.ErrInvalidParams{Context: "CurrentRevision"}
+	if s.ChangeIdentifier == nil {
+		invalidParams.Add(request.NewErrParamRequired("ChangeIdentifier"))
+	}
+	if s.Revision == nil {
+		invalidParams.Add(request.NewErrParamRequired("Revision"))
+	}
+
+	if invalidParams.Len() > 0 {
+		return invalidParams
+	}
+	return nil
+}
+
 // Represents the input of a delete custom action operation. The custom action
 // will be marked as deleted.
 type DeleteCustomActionTypeInput struct {
@@ -1381,6 +1710,31 @@ func (s DeleteCustomActionTypeInput) String() string {
 // GoString returns the string representation
 func (s DeleteCustomActionTypeInput) GoString() string {
 	return s.String()
+}
+
+// Validate inspects the fields of the type to determine if they are valid.
+func (s *DeleteCustomActionTypeInput) Validate() error {
+	invalidParams := request.ErrInvalidParams{Context: "DeleteCustomActionTypeInput"}
+	if s.Category == nil {
+		invalidParams.Add(request.NewErrParamRequired("Category"))
+	}
+	if s.Provider == nil {
+		invalidParams.Add(request.NewErrParamRequired("Provider"))
+	}
+	if s.Provider != nil && len(*s.Provider) < 1 {
+		invalidParams.Add(request.NewErrParamMinLen("Provider", 1))
+	}
+	if s.Version == nil {
+		invalidParams.Add(request.NewErrParamRequired("Version"))
+	}
+	if s.Version != nil && len(*s.Version) < 1 {
+		invalidParams.Add(request.NewErrParamMinLen("Version", 1))
+	}
+
+	if invalidParams.Len() > 0 {
+		return invalidParams
+	}
+	return nil
 }
 
 type DeleteCustomActionTypeOutput struct {
@@ -1413,6 +1767,22 @@ func (s DeletePipelineInput) String() string {
 // GoString returns the string representation
 func (s DeletePipelineInput) GoString() string {
 	return s.String()
+}
+
+// Validate inspects the fields of the type to determine if they are valid.
+func (s *DeletePipelineInput) Validate() error {
+	invalidParams := request.ErrInvalidParams{Context: "DeletePipelineInput"}
+	if s.Name == nil {
+		invalidParams.Add(request.NewErrParamRequired("Name"))
+	}
+	if s.Name != nil && len(*s.Name) < 1 {
+		invalidParams.Add(request.NewErrParamMinLen("Name", 1))
+	}
+
+	if invalidParams.Len() > 0 {
+		return invalidParams
+	}
+	return nil
 }
 
 type DeletePipelineOutput struct {
@@ -1463,6 +1833,37 @@ func (s DisableStageTransitionInput) GoString() string {
 	return s.String()
 }
 
+// Validate inspects the fields of the type to determine if they are valid.
+func (s *DisableStageTransitionInput) Validate() error {
+	invalidParams := request.ErrInvalidParams{Context: "DisableStageTransitionInput"}
+	if s.PipelineName == nil {
+		invalidParams.Add(request.NewErrParamRequired("PipelineName"))
+	}
+	if s.PipelineName != nil && len(*s.PipelineName) < 1 {
+		invalidParams.Add(request.NewErrParamMinLen("PipelineName", 1))
+	}
+	if s.Reason == nil {
+		invalidParams.Add(request.NewErrParamRequired("Reason"))
+	}
+	if s.Reason != nil && len(*s.Reason) < 1 {
+		invalidParams.Add(request.NewErrParamMinLen("Reason", 1))
+	}
+	if s.StageName == nil {
+		invalidParams.Add(request.NewErrParamRequired("StageName"))
+	}
+	if s.StageName != nil && len(*s.StageName) < 1 {
+		invalidParams.Add(request.NewErrParamMinLen("StageName", 1))
+	}
+	if s.TransitionType == nil {
+		invalidParams.Add(request.NewErrParamRequired("TransitionType"))
+	}
+
+	if invalidParams.Len() > 0 {
+		return invalidParams
+	}
+	return nil
+}
+
 type DisableStageTransitionOutput struct {
 	_ struct{} `type:"structure"`
 }
@@ -1505,6 +1906,31 @@ func (s EnableStageTransitionInput) GoString() string {
 	return s.String()
 }
 
+// Validate inspects the fields of the type to determine if they are valid.
+func (s *EnableStageTransitionInput) Validate() error {
+	invalidParams := request.ErrInvalidParams{Context: "EnableStageTransitionInput"}
+	if s.PipelineName == nil {
+		invalidParams.Add(request.NewErrParamRequired("PipelineName"))
+	}
+	if s.PipelineName != nil && len(*s.PipelineName) < 1 {
+		invalidParams.Add(request.NewErrParamMinLen("PipelineName", 1))
+	}
+	if s.StageName == nil {
+		invalidParams.Add(request.NewErrParamRequired("StageName"))
+	}
+	if s.StageName != nil && len(*s.StageName) < 1 {
+		invalidParams.Add(request.NewErrParamMinLen("StageName", 1))
+	}
+	if s.TransitionType == nil {
+		invalidParams.Add(request.NewErrParamRequired("TransitionType"))
+	}
+
+	if invalidParams.Len() > 0 {
+		return invalidParams
+	}
+	return nil
+}
+
 type EnableStageTransitionOutput struct {
 	_ struct{} `type:"structure"`
 }
@@ -1539,6 +1965,25 @@ func (s EncryptionKey) String() string {
 // GoString returns the string representation
 func (s EncryptionKey) GoString() string {
 	return s.String()
+}
+
+// Validate inspects the fields of the type to determine if they are valid.
+func (s *EncryptionKey) Validate() error {
+	invalidParams := request.ErrInvalidParams{Context: "EncryptionKey"}
+	if s.Id == nil {
+		invalidParams.Add(request.NewErrParamRequired("Id"))
+	}
+	if s.Id != nil && len(*s.Id) < 1 {
+		invalidParams.Add(request.NewErrParamMinLen("Id", 1))
+	}
+	if s.Type == nil {
+		invalidParams.Add(request.NewErrParamRequired("Type"))
+	}
+
+	if invalidParams.Len() > 0 {
+		return invalidParams
+	}
+	return nil
 }
 
 // Represents information about an error in AWS CodePipeline.
@@ -1613,6 +2058,22 @@ func (s FailureDetails) GoString() string {
 	return s.String()
 }
 
+// Validate inspects the fields of the type to determine if they are valid.
+func (s *FailureDetails) Validate() error {
+	invalidParams := request.ErrInvalidParams{Context: "FailureDetails"}
+	if s.Message == nil {
+		invalidParams.Add(request.NewErrParamRequired("Message"))
+	}
+	if s.Type == nil {
+		invalidParams.Add(request.NewErrParamRequired("Type"))
+	}
+
+	if invalidParams.Len() > 0 {
+		return invalidParams
+	}
+	return nil
+}
+
 // Represents the input of a get job details action.
 type GetJobDetailsInput struct {
 	_ struct{} `type:"structure"`
@@ -1629,6 +2090,19 @@ func (s GetJobDetailsInput) String() string {
 // GoString returns the string representation
 func (s GetJobDetailsInput) GoString() string {
 	return s.String()
+}
+
+// Validate inspects the fields of the type to determine if they are valid.
+func (s *GetJobDetailsInput) Validate() error {
+	invalidParams := request.ErrInvalidParams{Context: "GetJobDetailsInput"}
+	if s.JobId == nil {
+		invalidParams.Add(request.NewErrParamRequired("JobId"))
+	}
+
+	if invalidParams.Len() > 0 {
+		return invalidParams
+	}
+	return nil
 }
 
 // Represents the output of a get job details action.
@@ -1675,6 +2149,25 @@ func (s GetPipelineInput) GoString() string {
 	return s.String()
 }
 
+// Validate inspects the fields of the type to determine if they are valid.
+func (s *GetPipelineInput) Validate() error {
+	invalidParams := request.ErrInvalidParams{Context: "GetPipelineInput"}
+	if s.Name == nil {
+		invalidParams.Add(request.NewErrParamRequired("Name"))
+	}
+	if s.Name != nil && len(*s.Name) < 1 {
+		invalidParams.Add(request.NewErrParamMinLen("Name", 1))
+	}
+	if s.Version != nil && *s.Version < 1 {
+		invalidParams.Add(request.NewErrParamMinValue("Version", 1))
+	}
+
+	if invalidParams.Len() > 0 {
+		return invalidParams
+	}
+	return nil
+}
+
 // Represents the output of a get pipeline action.
 type GetPipelineOutput struct {
 	_ struct{} `type:"structure"`
@@ -1709,6 +2202,22 @@ func (s GetPipelineStateInput) String() string {
 // GoString returns the string representation
 func (s GetPipelineStateInput) GoString() string {
 	return s.String()
+}
+
+// Validate inspects the fields of the type to determine if they are valid.
+func (s *GetPipelineStateInput) Validate() error {
+	invalidParams := request.ErrInvalidParams{Context: "GetPipelineStateInput"}
+	if s.Name == nil {
+		invalidParams.Add(request.NewErrParamRequired("Name"))
+	}
+	if s.Name != nil && len(*s.Name) < 1 {
+		invalidParams.Add(request.NewErrParamMinLen("Name", 1))
+	}
+
+	if invalidParams.Len() > 0 {
+		return invalidParams
+	}
+	return nil
 }
 
 // Represents the output of a get pipeline state action.
@@ -1766,6 +2275,25 @@ func (s GetThirdPartyJobDetailsInput) GoString() string {
 	return s.String()
 }
 
+// Validate inspects the fields of the type to determine if they are valid.
+func (s *GetThirdPartyJobDetailsInput) Validate() error {
+	invalidParams := request.ErrInvalidParams{Context: "GetThirdPartyJobDetailsInput"}
+	if s.ClientToken == nil {
+		invalidParams.Add(request.NewErrParamRequired("ClientToken"))
+	}
+	if s.JobId == nil {
+		invalidParams.Add(request.NewErrParamRequired("JobId"))
+	}
+	if s.JobId != nil && len(*s.JobId) < 1 {
+		invalidParams.Add(request.NewErrParamMinLen("JobId", 1))
+	}
+
+	if invalidParams.Len() > 0 {
+		return invalidParams
+	}
+	return nil
+}
+
 // Represents the output of a get third party job details action.
 type GetThirdPartyJobDetailsOutput struct {
 	_ struct{} `type:"structure"`
@@ -1807,6 +2335,22 @@ func (s InputArtifact) String() string {
 // GoString returns the string representation
 func (s InputArtifact) GoString() string {
 	return s.String()
+}
+
+// Validate inspects the fields of the type to determine if they are valid.
+func (s *InputArtifact) Validate() error {
+	invalidParams := request.ErrInvalidParams{Context: "InputArtifact"}
+	if s.Name == nil {
+		invalidParams.Add(request.NewErrParamRequired("Name"))
+	}
+	if s.Name != nil && len(*s.Name) < 1 {
+		invalidParams.Add(request.NewErrParamMinLen("Name", 1))
+	}
+
+	if invalidParams.Len() > 0 {
+		return invalidParams
+	}
+	return nil
 }
 
 // Represents information about a job.
@@ -2021,6 +2565,22 @@ func (s OutputArtifact) GoString() string {
 	return s.String()
 }
 
+// Validate inspects the fields of the type to determine if they are valid.
+func (s *OutputArtifact) Validate() error {
+	invalidParams := request.ErrInvalidParams{Context: "OutputArtifact"}
+	if s.Name == nil {
+		invalidParams.Add(request.NewErrParamRequired("Name"))
+	}
+	if s.Name != nil && len(*s.Name) < 1 {
+		invalidParams.Add(request.NewErrParamMinLen("Name", 1))
+	}
+
+	if invalidParams.Len() > 0 {
+		return invalidParams
+	}
+	return nil
+}
+
 // Represents information about a pipeline to a job worker.
 type PipelineContext struct {
 	_ struct{} `type:"structure"`
@@ -2082,6 +2642,49 @@ func (s PipelineDeclaration) GoString() string {
 	return s.String()
 }
 
+// Validate inspects the fields of the type to determine if they are valid.
+func (s *PipelineDeclaration) Validate() error {
+	invalidParams := request.ErrInvalidParams{Context: "PipelineDeclaration"}
+	if s.ArtifactStore == nil {
+		invalidParams.Add(request.NewErrParamRequired("ArtifactStore"))
+	}
+	if s.Name == nil {
+		invalidParams.Add(request.NewErrParamRequired("Name"))
+	}
+	if s.Name != nil && len(*s.Name) < 1 {
+		invalidParams.Add(request.NewErrParamMinLen("Name", 1))
+	}
+	if s.RoleArn == nil {
+		invalidParams.Add(request.NewErrParamRequired("RoleArn"))
+	}
+	if s.Stages == nil {
+		invalidParams.Add(request.NewErrParamRequired("Stages"))
+	}
+	if s.Version != nil && *s.Version < 1 {
+		invalidParams.Add(request.NewErrParamMinValue("Version", 1))
+	}
+	if s.ArtifactStore != nil {
+		if err := s.ArtifactStore.Validate(); err != nil {
+			invalidParams.AddNested("ArtifactStore", err.(request.ErrInvalidParams))
+		}
+	}
+	if s.Stages != nil {
+		for i, v := range s.Stages {
+			if v == nil {
+				continue
+			}
+			if err := v.Validate(); err != nil {
+				invalidParams.AddNested(fmt.Sprintf("%s[%v]", "Stages", i), err.(request.ErrInvalidParams))
+			}
+		}
+	}
+
+	if invalidParams.Len() > 0 {
+		return invalidParams
+	}
+	return nil
+}
+
 // Returns a summary of a pipeline.
 type PipelineSummary struct {
 	_ struct{} `type:"structure"`
@@ -2136,6 +2739,27 @@ func (s PollForJobsInput) GoString() string {
 	return s.String()
 }
 
+// Validate inspects the fields of the type to determine if they are valid.
+func (s *PollForJobsInput) Validate() error {
+	invalidParams := request.ErrInvalidParams{Context: "PollForJobsInput"}
+	if s.ActionTypeId == nil {
+		invalidParams.Add(request.NewErrParamRequired("ActionTypeId"))
+	}
+	if s.MaxBatchSize != nil && *s.MaxBatchSize < 1 {
+		invalidParams.Add(request.NewErrParamMinValue("MaxBatchSize", 1))
+	}
+	if s.ActionTypeId != nil {
+		if err := s.ActionTypeId.Validate(); err != nil {
+			invalidParams.AddNested("ActionTypeId", err.(request.ErrInvalidParams))
+		}
+	}
+
+	if invalidParams.Len() > 0 {
+		return invalidParams
+	}
+	return nil
+}
+
 // Represents the output of a poll for jobs action.
 type PollForJobsOutput struct {
 	_ struct{} `type:"structure"`
@@ -2173,6 +2797,27 @@ func (s PollForThirdPartyJobsInput) String() string {
 // GoString returns the string representation
 func (s PollForThirdPartyJobsInput) GoString() string {
 	return s.String()
+}
+
+// Validate inspects the fields of the type to determine if they are valid.
+func (s *PollForThirdPartyJobsInput) Validate() error {
+	invalidParams := request.ErrInvalidParams{Context: "PollForThirdPartyJobsInput"}
+	if s.ActionTypeId == nil {
+		invalidParams.Add(request.NewErrParamRequired("ActionTypeId"))
+	}
+	if s.MaxBatchSize != nil && *s.MaxBatchSize < 1 {
+		invalidParams.Add(request.NewErrParamMinValue("MaxBatchSize", 1))
+	}
+	if s.ActionTypeId != nil {
+		if err := s.ActionTypeId.Validate(); err != nil {
+			invalidParams.AddNested("ActionTypeId", err.(request.ErrInvalidParams))
+		}
+	}
+
+	if invalidParams.Len() > 0 {
+		return invalidParams
+	}
+	return nil
 }
 
 // Represents the output of a poll for third party jobs action.
@@ -2220,6 +2865,42 @@ func (s PutActionRevisionInput) GoString() string {
 	return s.String()
 }
 
+// Validate inspects the fields of the type to determine if they are valid.
+func (s *PutActionRevisionInput) Validate() error {
+	invalidParams := request.ErrInvalidParams{Context: "PutActionRevisionInput"}
+	if s.ActionName == nil {
+		invalidParams.Add(request.NewErrParamRequired("ActionName"))
+	}
+	if s.ActionName != nil && len(*s.ActionName) < 1 {
+		invalidParams.Add(request.NewErrParamMinLen("ActionName", 1))
+	}
+	if s.ActionRevision == nil {
+		invalidParams.Add(request.NewErrParamRequired("ActionRevision"))
+	}
+	if s.PipelineName == nil {
+		invalidParams.Add(request.NewErrParamRequired("PipelineName"))
+	}
+	if s.PipelineName != nil && len(*s.PipelineName) < 1 {
+		invalidParams.Add(request.NewErrParamMinLen("PipelineName", 1))
+	}
+	if s.StageName == nil {
+		invalidParams.Add(request.NewErrParamRequired("StageName"))
+	}
+	if s.StageName != nil && len(*s.StageName) < 1 {
+		invalidParams.Add(request.NewErrParamMinLen("StageName", 1))
+	}
+	if s.ActionRevision != nil {
+		if err := s.ActionRevision.Validate(); err != nil {
+			invalidParams.AddNested("ActionRevision", err.(request.ErrInvalidParams))
+		}
+	}
+
+	if invalidParams.Len() > 0 {
+		return invalidParams
+	}
+	return nil
+}
+
 // Represents the output of a put action revision action.
 type PutActionRevisionOutput struct {
 	_ struct{} `type:"structure"`
@@ -2261,6 +2942,27 @@ func (s PutJobFailureResultInput) String() string {
 // GoString returns the string representation
 func (s PutJobFailureResultInput) GoString() string {
 	return s.String()
+}
+
+// Validate inspects the fields of the type to determine if they are valid.
+func (s *PutJobFailureResultInput) Validate() error {
+	invalidParams := request.ErrInvalidParams{Context: "PutJobFailureResultInput"}
+	if s.FailureDetails == nil {
+		invalidParams.Add(request.NewErrParamRequired("FailureDetails"))
+	}
+	if s.JobId == nil {
+		invalidParams.Add(request.NewErrParamRequired("JobId"))
+	}
+	if s.FailureDetails != nil {
+		if err := s.FailureDetails.Validate(); err != nil {
+			invalidParams.AddNested("FailureDetails", err.(request.ErrInvalidParams))
+		}
+	}
+
+	if invalidParams.Len() > 0 {
+		return invalidParams
+	}
+	return nil
 }
 
 type PutJobFailureResultOutput struct {
@@ -2308,6 +3010,24 @@ func (s PutJobSuccessResultInput) GoString() string {
 	return s.String()
 }
 
+// Validate inspects the fields of the type to determine if they are valid.
+func (s *PutJobSuccessResultInput) Validate() error {
+	invalidParams := request.ErrInvalidParams{Context: "PutJobSuccessResultInput"}
+	if s.JobId == nil {
+		invalidParams.Add(request.NewErrParamRequired("JobId"))
+	}
+	if s.CurrentRevision != nil {
+		if err := s.CurrentRevision.Validate(); err != nil {
+			invalidParams.AddNested("CurrentRevision", err.(request.ErrInvalidParams))
+		}
+	}
+
+	if invalidParams.Len() > 0 {
+		return invalidParams
+	}
+	return nil
+}
+
 type PutJobSuccessResultOutput struct {
 	_ struct{} `type:"structure"`
 }
@@ -2345,6 +3065,33 @@ func (s PutThirdPartyJobFailureResultInput) String() string {
 // GoString returns the string representation
 func (s PutThirdPartyJobFailureResultInput) GoString() string {
 	return s.String()
+}
+
+// Validate inspects the fields of the type to determine if they are valid.
+func (s *PutThirdPartyJobFailureResultInput) Validate() error {
+	invalidParams := request.ErrInvalidParams{Context: "PutThirdPartyJobFailureResultInput"}
+	if s.ClientToken == nil {
+		invalidParams.Add(request.NewErrParamRequired("ClientToken"))
+	}
+	if s.FailureDetails == nil {
+		invalidParams.Add(request.NewErrParamRequired("FailureDetails"))
+	}
+	if s.JobId == nil {
+		invalidParams.Add(request.NewErrParamRequired("JobId"))
+	}
+	if s.JobId != nil && len(*s.JobId) < 1 {
+		invalidParams.Add(request.NewErrParamMinLen("JobId", 1))
+	}
+	if s.FailureDetails != nil {
+		if err := s.FailureDetails.Validate(); err != nil {
+			invalidParams.AddNested("FailureDetails", err.(request.ErrInvalidParams))
+		}
+	}
+
+	if invalidParams.Len() > 0 {
+		return invalidParams
+	}
+	return nil
 }
 
 type PutThirdPartyJobFailureResultOutput struct {
@@ -2393,6 +3140,30 @@ func (s PutThirdPartyJobSuccessResultInput) String() string {
 // GoString returns the string representation
 func (s PutThirdPartyJobSuccessResultInput) GoString() string {
 	return s.String()
+}
+
+// Validate inspects the fields of the type to determine if they are valid.
+func (s *PutThirdPartyJobSuccessResultInput) Validate() error {
+	invalidParams := request.ErrInvalidParams{Context: "PutThirdPartyJobSuccessResultInput"}
+	if s.ClientToken == nil {
+		invalidParams.Add(request.NewErrParamRequired("ClientToken"))
+	}
+	if s.JobId == nil {
+		invalidParams.Add(request.NewErrParamRequired("JobId"))
+	}
+	if s.JobId != nil && len(*s.JobId) < 1 {
+		invalidParams.Add(request.NewErrParamMinLen("JobId", 1))
+	}
+	if s.CurrentRevision != nil {
+		if err := s.CurrentRevision.Validate(); err != nil {
+			invalidParams.AddNested("CurrentRevision", err.(request.ErrInvalidParams))
+		}
+	}
+
+	if invalidParams.Len() > 0 {
+		return invalidParams
+	}
+	return nil
 }
 
 type PutThirdPartyJobSuccessResultOutput struct {
@@ -2473,6 +3244,45 @@ func (s StageDeclaration) GoString() string {
 	return s.String()
 }
 
+// Validate inspects the fields of the type to determine if they are valid.
+func (s *StageDeclaration) Validate() error {
+	invalidParams := request.ErrInvalidParams{Context: "StageDeclaration"}
+	if s.Actions == nil {
+		invalidParams.Add(request.NewErrParamRequired("Actions"))
+	}
+	if s.Name == nil {
+		invalidParams.Add(request.NewErrParamRequired("Name"))
+	}
+	if s.Name != nil && len(*s.Name) < 1 {
+		invalidParams.Add(request.NewErrParamMinLen("Name", 1))
+	}
+	if s.Actions != nil {
+		for i, v := range s.Actions {
+			if v == nil {
+				continue
+			}
+			if err := v.Validate(); err != nil {
+				invalidParams.AddNested(fmt.Sprintf("%s[%v]", "Actions", i), err.(request.ErrInvalidParams))
+			}
+		}
+	}
+	if s.Blockers != nil {
+		for i, v := range s.Blockers {
+			if v == nil {
+				continue
+			}
+			if err := v.Validate(); err != nil {
+				invalidParams.AddNested(fmt.Sprintf("%s[%v]", "Blockers", i), err.(request.ErrInvalidParams))
+			}
+		}
+	}
+
+	if invalidParams.Len() > 0 {
+		return invalidParams
+	}
+	return nil
+}
+
 // Represents information about the state of the stage.
 type StageState struct {
 	_ struct{} `type:"structure"`
@@ -2513,6 +3323,22 @@ func (s StartPipelineExecutionInput) String() string {
 // GoString returns the string representation
 func (s StartPipelineExecutionInput) GoString() string {
 	return s.String()
+}
+
+// Validate inspects the fields of the type to determine if they are valid.
+func (s *StartPipelineExecutionInput) Validate() error {
+	invalidParams := request.ErrInvalidParams{Context: "StartPipelineExecutionInput"}
+	if s.Name == nil {
+		invalidParams.Add(request.NewErrParamRequired("Name"))
+	}
+	if s.Name != nil && len(*s.Name) < 1 {
+		invalidParams.Add(request.NewErrParamMinLen("Name", 1))
+	}
+
+	if invalidParams.Len() > 0 {
+		return invalidParams
+	}
+	return nil
 }
 
 // Represents the output of a start pipeline execution action.
@@ -2677,6 +3503,24 @@ func (s UpdatePipelineInput) String() string {
 // GoString returns the string representation
 func (s UpdatePipelineInput) GoString() string {
 	return s.String()
+}
+
+// Validate inspects the fields of the type to determine if they are valid.
+func (s *UpdatePipelineInput) Validate() error {
+	invalidParams := request.ErrInvalidParams{Context: "UpdatePipelineInput"}
+	if s.Pipeline == nil {
+		invalidParams.Add(request.NewErrParamRequired("Pipeline"))
+	}
+	if s.Pipeline != nil {
+		if err := s.Pipeline.Validate(); err != nil {
+			invalidParams.AddNested("Pipeline", err.(request.ErrInvalidParams))
+		}
+	}
+
+	if invalidParams.Len() > 0 {
+		return invalidParams
+	}
+	return nil
 }
 
 // Represents the output of an update pipeline action.

--- a/service/cognitoidentity/api.go
+++ b/service/cognitoidentity/api.go
@@ -4,6 +4,7 @@
 package cognitoidentity
 
 import (
+	"fmt"
 	"time"
 
 	"github.com/aws/aws-sdk-go/aws/awsutil"
@@ -628,6 +629,38 @@ func (s CreateIdentityPoolInput) GoString() string {
 	return s.String()
 }
 
+// Validate inspects the fields of the type to determine if they are valid.
+func (s *CreateIdentityPoolInput) Validate() error {
+	invalidParams := request.ErrInvalidParams{Context: "CreateIdentityPoolInput"}
+	if s.AllowUnauthenticatedIdentities == nil {
+		invalidParams.Add(request.NewErrParamRequired("AllowUnauthenticatedIdentities"))
+	}
+	if s.DeveloperProviderName != nil && len(*s.DeveloperProviderName) < 1 {
+		invalidParams.Add(request.NewErrParamMinLen("DeveloperProviderName", 1))
+	}
+	if s.IdentityPoolName == nil {
+		invalidParams.Add(request.NewErrParamRequired("IdentityPoolName"))
+	}
+	if s.IdentityPoolName != nil && len(*s.IdentityPoolName) < 1 {
+		invalidParams.Add(request.NewErrParamMinLen("IdentityPoolName", 1))
+	}
+	if s.CognitoIdentityProviders != nil {
+		for i, v := range s.CognitoIdentityProviders {
+			if v == nil {
+				continue
+			}
+			if err := v.Validate(); err != nil {
+				invalidParams.AddNested(fmt.Sprintf("%s[%v]", "CognitoIdentityProviders", i), err.(request.ErrInvalidParams))
+			}
+		}
+	}
+
+	if invalidParams.Len() > 0 {
+		return invalidParams
+	}
+	return nil
+}
+
 // Credentials for the provided identity ID.
 type Credentials struct {
 	_ struct{} `type:"structure"`
@@ -673,6 +706,22 @@ func (s DeleteIdentitiesInput) GoString() string {
 	return s.String()
 }
 
+// Validate inspects the fields of the type to determine if they are valid.
+func (s *DeleteIdentitiesInput) Validate() error {
+	invalidParams := request.ErrInvalidParams{Context: "DeleteIdentitiesInput"}
+	if s.IdentityIdsToDelete == nil {
+		invalidParams.Add(request.NewErrParamRequired("IdentityIdsToDelete"))
+	}
+	if s.IdentityIdsToDelete != nil && len(s.IdentityIdsToDelete) < 1 {
+		invalidParams.Add(request.NewErrParamMinLen("IdentityIdsToDelete", 1))
+	}
+
+	if invalidParams.Len() > 0 {
+		return invalidParams
+	}
+	return nil
+}
+
 // Returned in response to a successful DeleteIdentities operation.
 type DeleteIdentitiesOutput struct {
 	_ struct{} `type:"structure"`
@@ -710,6 +759,22 @@ func (s DeleteIdentityPoolInput) GoString() string {
 	return s.String()
 }
 
+// Validate inspects the fields of the type to determine if they are valid.
+func (s *DeleteIdentityPoolInput) Validate() error {
+	invalidParams := request.ErrInvalidParams{Context: "DeleteIdentityPoolInput"}
+	if s.IdentityPoolId == nil {
+		invalidParams.Add(request.NewErrParamRequired("IdentityPoolId"))
+	}
+	if s.IdentityPoolId != nil && len(*s.IdentityPoolId) < 1 {
+		invalidParams.Add(request.NewErrParamMinLen("IdentityPoolId", 1))
+	}
+
+	if invalidParams.Len() > 0 {
+		return invalidParams
+	}
+	return nil
+}
+
 type DeleteIdentityPoolOutput struct {
 	_ struct{} `type:"structure"`
 }
@@ -742,6 +807,22 @@ func (s DescribeIdentityInput) GoString() string {
 	return s.String()
 }
 
+// Validate inspects the fields of the type to determine if they are valid.
+func (s *DescribeIdentityInput) Validate() error {
+	invalidParams := request.ErrInvalidParams{Context: "DescribeIdentityInput"}
+	if s.IdentityId == nil {
+		invalidParams.Add(request.NewErrParamRequired("IdentityId"))
+	}
+	if s.IdentityId != nil && len(*s.IdentityId) < 1 {
+		invalidParams.Add(request.NewErrParamMinLen("IdentityId", 1))
+	}
+
+	if invalidParams.Len() > 0 {
+		return invalidParams
+	}
+	return nil
+}
+
 // Input to the DescribeIdentityPool action.
 type DescribeIdentityPoolInput struct {
 	_ struct{} `type:"structure"`
@@ -758,6 +839,22 @@ func (s DescribeIdentityPoolInput) String() string {
 // GoString returns the string representation
 func (s DescribeIdentityPoolInput) GoString() string {
 	return s.String()
+}
+
+// Validate inspects the fields of the type to determine if they are valid.
+func (s *DescribeIdentityPoolInput) Validate() error {
+	invalidParams := request.ErrInvalidParams{Context: "DescribeIdentityPoolInput"}
+	if s.IdentityPoolId == nil {
+		invalidParams.Add(request.NewErrParamRequired("IdentityPoolId"))
+	}
+	if s.IdentityPoolId != nil && len(*s.IdentityPoolId) < 1 {
+		invalidParams.Add(request.NewErrParamMinLen("IdentityPoolId", 1))
+	}
+
+	if invalidParams.Len() > 0 {
+		return invalidParams
+	}
+	return nil
 }
 
 // Input to the GetCredentialsForIdentity action.
@@ -779,6 +876,22 @@ func (s GetCredentialsForIdentityInput) String() string {
 // GoString returns the string representation
 func (s GetCredentialsForIdentityInput) GoString() string {
 	return s.String()
+}
+
+// Validate inspects the fields of the type to determine if they are valid.
+func (s *GetCredentialsForIdentityInput) Validate() error {
+	invalidParams := request.ErrInvalidParams{Context: "GetCredentialsForIdentityInput"}
+	if s.IdentityId == nil {
+		invalidParams.Add(request.NewErrParamRequired("IdentityId"))
+	}
+	if s.IdentityId != nil && len(*s.IdentityId) < 1 {
+		invalidParams.Add(request.NewErrParamMinLen("IdentityId", 1))
+	}
+
+	if invalidParams.Len() > 0 {
+		return invalidParams
+	}
+	return nil
 }
 
 // Returned in response to a successful GetCredentialsForIdentity operation.
@@ -831,6 +944,25 @@ func (s GetIdInput) GoString() string {
 	return s.String()
 }
 
+// Validate inspects the fields of the type to determine if they are valid.
+func (s *GetIdInput) Validate() error {
+	invalidParams := request.ErrInvalidParams{Context: "GetIdInput"}
+	if s.AccountId != nil && len(*s.AccountId) < 1 {
+		invalidParams.Add(request.NewErrParamMinLen("AccountId", 1))
+	}
+	if s.IdentityPoolId == nil {
+		invalidParams.Add(request.NewErrParamRequired("IdentityPoolId"))
+	}
+	if s.IdentityPoolId != nil && len(*s.IdentityPoolId) < 1 {
+		invalidParams.Add(request.NewErrParamMinLen("IdentityPoolId", 1))
+	}
+
+	if invalidParams.Len() > 0 {
+		return invalidParams
+	}
+	return nil
+}
+
 // Returned in response to a GetId request.
 type GetIdOutput struct {
 	_ struct{} `type:"structure"`
@@ -865,6 +997,22 @@ func (s GetIdentityPoolRolesInput) String() string {
 // GoString returns the string representation
 func (s GetIdentityPoolRolesInput) GoString() string {
 	return s.String()
+}
+
+// Validate inspects the fields of the type to determine if they are valid.
+func (s *GetIdentityPoolRolesInput) Validate() error {
+	invalidParams := request.ErrInvalidParams{Context: "GetIdentityPoolRolesInput"}
+	if s.IdentityPoolId == nil {
+		invalidParams.Add(request.NewErrParamRequired("IdentityPoolId"))
+	}
+	if s.IdentityPoolId != nil && len(*s.IdentityPoolId) < 1 {
+		invalidParams.Add(request.NewErrParamMinLen("IdentityPoolId", 1))
+	}
+
+	if invalidParams.Len() > 0 {
+		return invalidParams
+	}
+	return nil
 }
 
 // Returned in response to a successful GetIdentityPoolRoles operation.
@@ -931,6 +1079,31 @@ func (s GetOpenIdTokenForDeveloperIdentityInput) GoString() string {
 	return s.String()
 }
 
+// Validate inspects the fields of the type to determine if they are valid.
+func (s *GetOpenIdTokenForDeveloperIdentityInput) Validate() error {
+	invalidParams := request.ErrInvalidParams{Context: "GetOpenIdTokenForDeveloperIdentityInput"}
+	if s.IdentityId != nil && len(*s.IdentityId) < 1 {
+		invalidParams.Add(request.NewErrParamMinLen("IdentityId", 1))
+	}
+	if s.IdentityPoolId == nil {
+		invalidParams.Add(request.NewErrParamRequired("IdentityPoolId"))
+	}
+	if s.IdentityPoolId != nil && len(*s.IdentityPoolId) < 1 {
+		invalidParams.Add(request.NewErrParamMinLen("IdentityPoolId", 1))
+	}
+	if s.Logins == nil {
+		invalidParams.Add(request.NewErrParamRequired("Logins"))
+	}
+	if s.TokenDuration != nil && *s.TokenDuration < 1 {
+		invalidParams.Add(request.NewErrParamMinValue("TokenDuration", 1))
+	}
+
+	if invalidParams.Len() > 0 {
+		return invalidParams
+	}
+	return nil
+}
+
 // Returned in response to a successful GetOpenIdTokenForDeveloperIdentity request.
 type GetOpenIdTokenForDeveloperIdentityOutput struct {
 	_ struct{} `type:"structure"`
@@ -975,6 +1148,22 @@ func (s GetOpenIdTokenInput) String() string {
 // GoString returns the string representation
 func (s GetOpenIdTokenInput) GoString() string {
 	return s.String()
+}
+
+// Validate inspects the fields of the type to determine if they are valid.
+func (s *GetOpenIdTokenInput) Validate() error {
+	invalidParams := request.ErrInvalidParams{Context: "GetOpenIdTokenInput"}
+	if s.IdentityId == nil {
+		invalidParams.Add(request.NewErrParamRequired("IdentityId"))
+	}
+	if s.IdentityId != nil && len(*s.IdentityId) < 1 {
+		invalidParams.Add(request.NewErrParamMinLen("IdentityId", 1))
+	}
+
+	if invalidParams.Len() > 0 {
+		return invalidParams
+	}
+	return nil
 }
 
 // Returned in response to a successful GetOpenIdToken request.
@@ -1062,6 +1251,44 @@ func (s IdentityPool) GoString() string {
 	return s.String()
 }
 
+// Validate inspects the fields of the type to determine if they are valid.
+func (s *IdentityPool) Validate() error {
+	invalidParams := request.ErrInvalidParams{Context: "IdentityPool"}
+	if s.AllowUnauthenticatedIdentities == nil {
+		invalidParams.Add(request.NewErrParamRequired("AllowUnauthenticatedIdentities"))
+	}
+	if s.DeveloperProviderName != nil && len(*s.DeveloperProviderName) < 1 {
+		invalidParams.Add(request.NewErrParamMinLen("DeveloperProviderName", 1))
+	}
+	if s.IdentityPoolId == nil {
+		invalidParams.Add(request.NewErrParamRequired("IdentityPoolId"))
+	}
+	if s.IdentityPoolId != nil && len(*s.IdentityPoolId) < 1 {
+		invalidParams.Add(request.NewErrParamMinLen("IdentityPoolId", 1))
+	}
+	if s.IdentityPoolName == nil {
+		invalidParams.Add(request.NewErrParamRequired("IdentityPoolName"))
+	}
+	if s.IdentityPoolName != nil && len(*s.IdentityPoolName) < 1 {
+		invalidParams.Add(request.NewErrParamMinLen("IdentityPoolName", 1))
+	}
+	if s.CognitoIdentityProviders != nil {
+		for i, v := range s.CognitoIdentityProviders {
+			if v == nil {
+				continue
+			}
+			if err := v.Validate(); err != nil {
+				invalidParams.AddNested(fmt.Sprintf("%s[%v]", "CognitoIdentityProviders", i), err.(request.ErrInvalidParams))
+			}
+		}
+	}
+
+	if invalidParams.Len() > 0 {
+		return invalidParams
+	}
+	return nil
+}
+
 // A description of the identity pool.
 type IdentityPoolShortDescription struct {
 	_ struct{} `type:"structure"`
@@ -1112,6 +1339,31 @@ func (s ListIdentitiesInput) GoString() string {
 	return s.String()
 }
 
+// Validate inspects the fields of the type to determine if they are valid.
+func (s *ListIdentitiesInput) Validate() error {
+	invalidParams := request.ErrInvalidParams{Context: "ListIdentitiesInput"}
+	if s.IdentityPoolId == nil {
+		invalidParams.Add(request.NewErrParamRequired("IdentityPoolId"))
+	}
+	if s.IdentityPoolId != nil && len(*s.IdentityPoolId) < 1 {
+		invalidParams.Add(request.NewErrParamMinLen("IdentityPoolId", 1))
+	}
+	if s.MaxResults == nil {
+		invalidParams.Add(request.NewErrParamRequired("MaxResults"))
+	}
+	if s.MaxResults != nil && *s.MaxResults < 1 {
+		invalidParams.Add(request.NewErrParamMinValue("MaxResults", 1))
+	}
+	if s.NextToken != nil && len(*s.NextToken) < 1 {
+		invalidParams.Add(request.NewErrParamMinLen("NextToken", 1))
+	}
+
+	if invalidParams.Len() > 0 {
+		return invalidParams
+	}
+	return nil
+}
+
 // The response to a ListIdentities request.
 type ListIdentitiesOutput struct {
 	_ struct{} `type:"structure"`
@@ -1155,6 +1407,25 @@ func (s ListIdentityPoolsInput) String() string {
 // GoString returns the string representation
 func (s ListIdentityPoolsInput) GoString() string {
 	return s.String()
+}
+
+// Validate inspects the fields of the type to determine if they are valid.
+func (s *ListIdentityPoolsInput) Validate() error {
+	invalidParams := request.ErrInvalidParams{Context: "ListIdentityPoolsInput"}
+	if s.MaxResults == nil {
+		invalidParams.Add(request.NewErrParamRequired("MaxResults"))
+	}
+	if s.MaxResults != nil && *s.MaxResults < 1 {
+		invalidParams.Add(request.NewErrParamMinValue("MaxResults", 1))
+	}
+	if s.NextToken != nil && len(*s.NextToken) < 1 {
+		invalidParams.Add(request.NewErrParamMinLen("NextToken", 1))
+	}
+
+	if invalidParams.Len() > 0 {
+		return invalidParams
+	}
+	return nil
 }
 
 // The result of a successful ListIdentityPools action.
@@ -1213,6 +1484,34 @@ func (s LookupDeveloperIdentityInput) String() string {
 // GoString returns the string representation
 func (s LookupDeveloperIdentityInput) GoString() string {
 	return s.String()
+}
+
+// Validate inspects the fields of the type to determine if they are valid.
+func (s *LookupDeveloperIdentityInput) Validate() error {
+	invalidParams := request.ErrInvalidParams{Context: "LookupDeveloperIdentityInput"}
+	if s.DeveloperUserIdentifier != nil && len(*s.DeveloperUserIdentifier) < 1 {
+		invalidParams.Add(request.NewErrParamMinLen("DeveloperUserIdentifier", 1))
+	}
+	if s.IdentityId != nil && len(*s.IdentityId) < 1 {
+		invalidParams.Add(request.NewErrParamMinLen("IdentityId", 1))
+	}
+	if s.IdentityPoolId == nil {
+		invalidParams.Add(request.NewErrParamRequired("IdentityPoolId"))
+	}
+	if s.IdentityPoolId != nil && len(*s.IdentityPoolId) < 1 {
+		invalidParams.Add(request.NewErrParamMinLen("IdentityPoolId", 1))
+	}
+	if s.MaxResults != nil && *s.MaxResults < 1 {
+		invalidParams.Add(request.NewErrParamMinValue("MaxResults", 1))
+	}
+	if s.NextToken != nil && len(*s.NextToken) < 1 {
+		invalidParams.Add(request.NewErrParamMinLen("NextToken", 1))
+	}
+
+	if invalidParams.Len() > 0 {
+		return invalidParams
+	}
+	return nil
 }
 
 // Returned in response to a successful LookupDeveloperIdentity action.
@@ -1277,6 +1576,40 @@ func (s MergeDeveloperIdentitiesInput) GoString() string {
 	return s.String()
 }
 
+// Validate inspects the fields of the type to determine if they are valid.
+func (s *MergeDeveloperIdentitiesInput) Validate() error {
+	invalidParams := request.ErrInvalidParams{Context: "MergeDeveloperIdentitiesInput"}
+	if s.DestinationUserIdentifier == nil {
+		invalidParams.Add(request.NewErrParamRequired("DestinationUserIdentifier"))
+	}
+	if s.DestinationUserIdentifier != nil && len(*s.DestinationUserIdentifier) < 1 {
+		invalidParams.Add(request.NewErrParamMinLen("DestinationUserIdentifier", 1))
+	}
+	if s.DeveloperProviderName == nil {
+		invalidParams.Add(request.NewErrParamRequired("DeveloperProviderName"))
+	}
+	if s.DeveloperProviderName != nil && len(*s.DeveloperProviderName) < 1 {
+		invalidParams.Add(request.NewErrParamMinLen("DeveloperProviderName", 1))
+	}
+	if s.IdentityPoolId == nil {
+		invalidParams.Add(request.NewErrParamRequired("IdentityPoolId"))
+	}
+	if s.IdentityPoolId != nil && len(*s.IdentityPoolId) < 1 {
+		invalidParams.Add(request.NewErrParamMinLen("IdentityPoolId", 1))
+	}
+	if s.SourceUserIdentifier == nil {
+		invalidParams.Add(request.NewErrParamRequired("SourceUserIdentifier"))
+	}
+	if s.SourceUserIdentifier != nil && len(*s.SourceUserIdentifier) < 1 {
+		invalidParams.Add(request.NewErrParamMinLen("SourceUserIdentifier", 1))
+	}
+
+	if invalidParams.Len() > 0 {
+		return invalidParams
+	}
+	return nil
+}
+
 // Returned in response to a successful MergeDeveloperIdentities action.
 type MergeDeveloperIdentitiesOutput struct {
 	_ struct{} `type:"structure"`
@@ -1316,6 +1649,22 @@ func (s Provider) GoString() string {
 	return s.String()
 }
 
+// Validate inspects the fields of the type to determine if they are valid.
+func (s *Provider) Validate() error {
+	invalidParams := request.ErrInvalidParams{Context: "Provider"}
+	if s.ClientId != nil && len(*s.ClientId) < 1 {
+		invalidParams.Add(request.NewErrParamMinLen("ClientId", 1))
+	}
+	if s.ProviderName != nil && len(*s.ProviderName) < 1 {
+		invalidParams.Add(request.NewErrParamMinLen("ProviderName", 1))
+	}
+
+	if invalidParams.Len() > 0 {
+		return invalidParams
+	}
+	return nil
+}
+
 // Input to the SetIdentityPoolRoles action.
 type SetIdentityPoolRolesInput struct {
 	_ struct{} `type:"structure"`
@@ -1337,6 +1686,25 @@ func (s SetIdentityPoolRolesInput) String() string {
 // GoString returns the string representation
 func (s SetIdentityPoolRolesInput) GoString() string {
 	return s.String()
+}
+
+// Validate inspects the fields of the type to determine if they are valid.
+func (s *SetIdentityPoolRolesInput) Validate() error {
+	invalidParams := request.ErrInvalidParams{Context: "SetIdentityPoolRolesInput"}
+	if s.IdentityPoolId == nil {
+		invalidParams.Add(request.NewErrParamRequired("IdentityPoolId"))
+	}
+	if s.IdentityPoolId != nil && len(*s.IdentityPoolId) < 1 {
+		invalidParams.Add(request.NewErrParamMinLen("IdentityPoolId", 1))
+	}
+	if s.Roles == nil {
+		invalidParams.Add(request.NewErrParamRequired("Roles"))
+	}
+
+	if invalidParams.Len() > 0 {
+		return invalidParams
+	}
+	return nil
 }
 
 type SetIdentityPoolRolesOutput struct {
@@ -1380,6 +1748,40 @@ func (s UnlinkDeveloperIdentityInput) GoString() string {
 	return s.String()
 }
 
+// Validate inspects the fields of the type to determine if they are valid.
+func (s *UnlinkDeveloperIdentityInput) Validate() error {
+	invalidParams := request.ErrInvalidParams{Context: "UnlinkDeveloperIdentityInput"}
+	if s.DeveloperProviderName == nil {
+		invalidParams.Add(request.NewErrParamRequired("DeveloperProviderName"))
+	}
+	if s.DeveloperProviderName != nil && len(*s.DeveloperProviderName) < 1 {
+		invalidParams.Add(request.NewErrParamMinLen("DeveloperProviderName", 1))
+	}
+	if s.DeveloperUserIdentifier == nil {
+		invalidParams.Add(request.NewErrParamRequired("DeveloperUserIdentifier"))
+	}
+	if s.DeveloperUserIdentifier != nil && len(*s.DeveloperUserIdentifier) < 1 {
+		invalidParams.Add(request.NewErrParamMinLen("DeveloperUserIdentifier", 1))
+	}
+	if s.IdentityId == nil {
+		invalidParams.Add(request.NewErrParamRequired("IdentityId"))
+	}
+	if s.IdentityId != nil && len(*s.IdentityId) < 1 {
+		invalidParams.Add(request.NewErrParamMinLen("IdentityId", 1))
+	}
+	if s.IdentityPoolId == nil {
+		invalidParams.Add(request.NewErrParamRequired("IdentityPoolId"))
+	}
+	if s.IdentityPoolId != nil && len(*s.IdentityPoolId) < 1 {
+		invalidParams.Add(request.NewErrParamMinLen("IdentityPoolId", 1))
+	}
+
+	if invalidParams.Len() > 0 {
+		return invalidParams
+	}
+	return nil
+}
+
 type UnlinkDeveloperIdentityOutput struct {
 	_ struct{} `type:"structure"`
 }
@@ -1416,6 +1818,28 @@ func (s UnlinkIdentityInput) String() string {
 // GoString returns the string representation
 func (s UnlinkIdentityInput) GoString() string {
 	return s.String()
+}
+
+// Validate inspects the fields of the type to determine if they are valid.
+func (s *UnlinkIdentityInput) Validate() error {
+	invalidParams := request.ErrInvalidParams{Context: "UnlinkIdentityInput"}
+	if s.IdentityId == nil {
+		invalidParams.Add(request.NewErrParamRequired("IdentityId"))
+	}
+	if s.IdentityId != nil && len(*s.IdentityId) < 1 {
+		invalidParams.Add(request.NewErrParamMinLen("IdentityId", 1))
+	}
+	if s.Logins == nil {
+		invalidParams.Add(request.NewErrParamRequired("Logins"))
+	}
+	if s.LoginsToRemove == nil {
+		invalidParams.Add(request.NewErrParamRequired("LoginsToRemove"))
+	}
+
+	if invalidParams.Len() > 0 {
+		return invalidParams
+	}
+	return nil
 }
 
 type UnlinkIdentityOutput struct {

--- a/service/cognitoidentityprovider/api.go
+++ b/service/cognitoidentityprovider/api.go
@@ -4,6 +4,7 @@
 package cognitoidentityprovider
 
 import (
+	"fmt"
 	"time"
 
 	"github.com/aws/aws-sdk-go/aws/awsutil"
@@ -1044,6 +1045,38 @@ func (s AddCustomAttributesInput) GoString() string {
 	return s.String()
 }
 
+// Validate inspects the fields of the type to determine if they are valid.
+func (s *AddCustomAttributesInput) Validate() error {
+	invalidParams := request.ErrInvalidParams{Context: "AddCustomAttributesInput"}
+	if s.CustomAttributes == nil {
+		invalidParams.Add(request.NewErrParamRequired("CustomAttributes"))
+	}
+	if s.CustomAttributes != nil && len(s.CustomAttributes) < 1 {
+		invalidParams.Add(request.NewErrParamMinLen("CustomAttributes", 1))
+	}
+	if s.UserPoolId == nil {
+		invalidParams.Add(request.NewErrParamRequired("UserPoolId"))
+	}
+	if s.UserPoolId != nil && len(*s.UserPoolId) < 1 {
+		invalidParams.Add(request.NewErrParamMinLen("UserPoolId", 1))
+	}
+	if s.CustomAttributes != nil {
+		for i, v := range s.CustomAttributes {
+			if v == nil {
+				continue
+			}
+			if err := v.Validate(); err != nil {
+				invalidParams.AddNested(fmt.Sprintf("%s[%v]", "CustomAttributes", i), err.(request.ErrInvalidParams))
+			}
+		}
+	}
+
+	if invalidParams.Len() > 0 {
+		return invalidParams
+	}
+	return nil
+}
+
 // Represents the response from the server for the request to add custom attributes.
 type AddCustomAttributesOutput struct {
 	_ struct{} `type:"structure"`
@@ -1078,6 +1111,28 @@ func (s AdminConfirmSignUpInput) String() string {
 // GoString returns the string representation
 func (s AdminConfirmSignUpInput) GoString() string {
 	return s.String()
+}
+
+// Validate inspects the fields of the type to determine if they are valid.
+func (s *AdminConfirmSignUpInput) Validate() error {
+	invalidParams := request.ErrInvalidParams{Context: "AdminConfirmSignUpInput"}
+	if s.UserPoolId == nil {
+		invalidParams.Add(request.NewErrParamRequired("UserPoolId"))
+	}
+	if s.UserPoolId != nil && len(*s.UserPoolId) < 1 {
+		invalidParams.Add(request.NewErrParamMinLen("UserPoolId", 1))
+	}
+	if s.Username == nil {
+		invalidParams.Add(request.NewErrParamRequired("Username"))
+	}
+	if s.Username != nil && len(*s.Username) < 1 {
+		invalidParams.Add(request.NewErrParamMinLen("Username", 1))
+	}
+
+	if invalidParams.Len() > 0 {
+		return invalidParams
+	}
+	return nil
 }
 
 // Represents the response from the server for the request to confirm registration.
@@ -1119,6 +1174,31 @@ func (s AdminDeleteUserAttributesInput) GoString() string {
 	return s.String()
 }
 
+// Validate inspects the fields of the type to determine if they are valid.
+func (s *AdminDeleteUserAttributesInput) Validate() error {
+	invalidParams := request.ErrInvalidParams{Context: "AdminDeleteUserAttributesInput"}
+	if s.UserAttributeNames == nil {
+		invalidParams.Add(request.NewErrParamRequired("UserAttributeNames"))
+	}
+	if s.UserPoolId == nil {
+		invalidParams.Add(request.NewErrParamRequired("UserPoolId"))
+	}
+	if s.UserPoolId != nil && len(*s.UserPoolId) < 1 {
+		invalidParams.Add(request.NewErrParamMinLen("UserPoolId", 1))
+	}
+	if s.Username == nil {
+		invalidParams.Add(request.NewErrParamRequired("Username"))
+	}
+	if s.Username != nil && len(*s.Username) < 1 {
+		invalidParams.Add(request.NewErrParamMinLen("Username", 1))
+	}
+
+	if invalidParams.Len() > 0 {
+		return invalidParams
+	}
+	return nil
+}
+
 // Represents the response received from the server for a request to delete
 // user attributes.
 type AdminDeleteUserAttributesOutput struct {
@@ -1156,6 +1236,28 @@ func (s AdminDeleteUserInput) GoString() string {
 	return s.String()
 }
 
+// Validate inspects the fields of the type to determine if they are valid.
+func (s *AdminDeleteUserInput) Validate() error {
+	invalidParams := request.ErrInvalidParams{Context: "AdminDeleteUserInput"}
+	if s.UserPoolId == nil {
+		invalidParams.Add(request.NewErrParamRequired("UserPoolId"))
+	}
+	if s.UserPoolId != nil && len(*s.UserPoolId) < 1 {
+		invalidParams.Add(request.NewErrParamMinLen("UserPoolId", 1))
+	}
+	if s.Username == nil {
+		invalidParams.Add(request.NewErrParamRequired("Username"))
+	}
+	if s.Username != nil && len(*s.Username) < 1 {
+		invalidParams.Add(request.NewErrParamMinLen("Username", 1))
+	}
+
+	if invalidParams.Len() > 0 {
+		return invalidParams
+	}
+	return nil
+}
+
 type AdminDeleteUserOutput struct {
 	_ struct{} `type:"structure"`
 }
@@ -1189,6 +1291,28 @@ func (s AdminDisableUserInput) String() string {
 // GoString returns the string representation
 func (s AdminDisableUserInput) GoString() string {
 	return s.String()
+}
+
+// Validate inspects the fields of the type to determine if they are valid.
+func (s *AdminDisableUserInput) Validate() error {
+	invalidParams := request.ErrInvalidParams{Context: "AdminDisableUserInput"}
+	if s.UserPoolId == nil {
+		invalidParams.Add(request.NewErrParamRequired("UserPoolId"))
+	}
+	if s.UserPoolId != nil && len(*s.UserPoolId) < 1 {
+		invalidParams.Add(request.NewErrParamMinLen("UserPoolId", 1))
+	}
+	if s.Username == nil {
+		invalidParams.Add(request.NewErrParamRequired("Username"))
+	}
+	if s.Username != nil && len(*s.Username) < 1 {
+		invalidParams.Add(request.NewErrParamMinLen("Username", 1))
+	}
+
+	if invalidParams.Len() > 0 {
+		return invalidParams
+	}
+	return nil
 }
 
 // Represents the response received from the server to disable the user as an
@@ -1228,6 +1352,28 @@ func (s AdminEnableUserInput) GoString() string {
 	return s.String()
 }
 
+// Validate inspects the fields of the type to determine if they are valid.
+func (s *AdminEnableUserInput) Validate() error {
+	invalidParams := request.ErrInvalidParams{Context: "AdminEnableUserInput"}
+	if s.UserPoolId == nil {
+		invalidParams.Add(request.NewErrParamRequired("UserPoolId"))
+	}
+	if s.UserPoolId != nil && len(*s.UserPoolId) < 1 {
+		invalidParams.Add(request.NewErrParamMinLen("UserPoolId", 1))
+	}
+	if s.Username == nil {
+		invalidParams.Add(request.NewErrParamRequired("Username"))
+	}
+	if s.Username != nil && len(*s.Username) < 1 {
+		invalidParams.Add(request.NewErrParamMinLen("Username", 1))
+	}
+
+	if invalidParams.Len() > 0 {
+		return invalidParams
+	}
+	return nil
+}
+
 // Represents the response from the server for the request to enable a user
 // as an administrator.
 type AdminEnableUserOutput struct {
@@ -1264,6 +1410,28 @@ func (s AdminGetUserInput) String() string {
 // GoString returns the string representation
 func (s AdminGetUserInput) GoString() string {
 	return s.String()
+}
+
+// Validate inspects the fields of the type to determine if they are valid.
+func (s *AdminGetUserInput) Validate() error {
+	invalidParams := request.ErrInvalidParams{Context: "AdminGetUserInput"}
+	if s.UserPoolId == nil {
+		invalidParams.Add(request.NewErrParamRequired("UserPoolId"))
+	}
+	if s.UserPoolId != nil && len(*s.UserPoolId) < 1 {
+		invalidParams.Add(request.NewErrParamMinLen("UserPoolId", 1))
+	}
+	if s.Username == nil {
+		invalidParams.Add(request.NewErrParamRequired("Username"))
+	}
+	if s.Username != nil && len(*s.Username) < 1 {
+		invalidParams.Add(request.NewErrParamMinLen("Username", 1))
+	}
+
+	if invalidParams.Len() > 0 {
+		return invalidParams
+	}
+	return nil
 }
 
 // Represents the response from the server from the request to get the specified
@@ -1329,6 +1497,28 @@ func (s AdminResetUserPasswordInput) GoString() string {
 	return s.String()
 }
 
+// Validate inspects the fields of the type to determine if they are valid.
+func (s *AdminResetUserPasswordInput) Validate() error {
+	invalidParams := request.ErrInvalidParams{Context: "AdminResetUserPasswordInput"}
+	if s.UserPoolId == nil {
+		invalidParams.Add(request.NewErrParamRequired("UserPoolId"))
+	}
+	if s.UserPoolId != nil && len(*s.UserPoolId) < 1 {
+		invalidParams.Add(request.NewErrParamMinLen("UserPoolId", 1))
+	}
+	if s.Username == nil {
+		invalidParams.Add(request.NewErrParamRequired("Username"))
+	}
+	if s.Username != nil && len(*s.Username) < 1 {
+		invalidParams.Add(request.NewErrParamMinLen("Username", 1))
+	}
+
+	if invalidParams.Len() > 0 {
+		return invalidParams
+	}
+	return nil
+}
+
 // Represents the response from the server to reset a user password as an administrator.
 type AdminResetUserPasswordOutput struct {
 	_ struct{} `type:"structure"`
@@ -1367,6 +1557,41 @@ func (s AdminSetUserSettingsInput) String() string {
 // GoString returns the string representation
 func (s AdminSetUserSettingsInput) GoString() string {
 	return s.String()
+}
+
+// Validate inspects the fields of the type to determine if they are valid.
+func (s *AdminSetUserSettingsInput) Validate() error {
+	invalidParams := request.ErrInvalidParams{Context: "AdminSetUserSettingsInput"}
+	if s.MFAOptions == nil {
+		invalidParams.Add(request.NewErrParamRequired("MFAOptions"))
+	}
+	if s.UserPoolId == nil {
+		invalidParams.Add(request.NewErrParamRequired("UserPoolId"))
+	}
+	if s.UserPoolId != nil && len(*s.UserPoolId) < 1 {
+		invalidParams.Add(request.NewErrParamMinLen("UserPoolId", 1))
+	}
+	if s.Username == nil {
+		invalidParams.Add(request.NewErrParamRequired("Username"))
+	}
+	if s.Username != nil && len(*s.Username) < 1 {
+		invalidParams.Add(request.NewErrParamMinLen("Username", 1))
+	}
+	if s.MFAOptions != nil {
+		for i, v := range s.MFAOptions {
+			if v == nil {
+				continue
+			}
+			if err := v.Validate(); err != nil {
+				invalidParams.AddNested(fmt.Sprintf("%s[%v]", "MFAOptions", i), err.(request.ErrInvalidParams))
+			}
+		}
+	}
+
+	if invalidParams.Len() > 0 {
+		return invalidParams
+	}
+	return nil
 }
 
 // Represents the response from the server to set user settings as an administrator.
@@ -1408,6 +1633,41 @@ func (s AdminUpdateUserAttributesInput) GoString() string {
 	return s.String()
 }
 
+// Validate inspects the fields of the type to determine if they are valid.
+func (s *AdminUpdateUserAttributesInput) Validate() error {
+	invalidParams := request.ErrInvalidParams{Context: "AdminUpdateUserAttributesInput"}
+	if s.UserAttributes == nil {
+		invalidParams.Add(request.NewErrParamRequired("UserAttributes"))
+	}
+	if s.UserPoolId == nil {
+		invalidParams.Add(request.NewErrParamRequired("UserPoolId"))
+	}
+	if s.UserPoolId != nil && len(*s.UserPoolId) < 1 {
+		invalidParams.Add(request.NewErrParamMinLen("UserPoolId", 1))
+	}
+	if s.Username == nil {
+		invalidParams.Add(request.NewErrParamRequired("Username"))
+	}
+	if s.Username != nil && len(*s.Username) < 1 {
+		invalidParams.Add(request.NewErrParamMinLen("Username", 1))
+	}
+	if s.UserAttributes != nil {
+		for i, v := range s.UserAttributes {
+			if v == nil {
+				continue
+			}
+			if err := v.Validate(); err != nil {
+				invalidParams.AddNested(fmt.Sprintf("%s[%v]", "UserAttributes", i), err.(request.ErrInvalidParams))
+			}
+		}
+	}
+
+	if invalidParams.Len() > 0 {
+		return invalidParams
+	}
+	return nil
+}
+
 // Represents the response from the server for the request to update user attributes
 // as an administrator.
 type AdminUpdateUserAttributesOutput struct {
@@ -1445,6 +1705,22 @@ func (s AttributeType) GoString() string {
 	return s.String()
 }
 
+// Validate inspects the fields of the type to determine if they are valid.
+func (s *AttributeType) Validate() error {
+	invalidParams := request.ErrInvalidParams{Context: "AttributeType"}
+	if s.Name == nil {
+		invalidParams.Add(request.NewErrParamRequired("Name"))
+	}
+	if s.Name != nil && len(*s.Name) < 1 {
+		invalidParams.Add(request.NewErrParamMinLen("Name", 1))
+	}
+
+	if invalidParams.Len() > 0 {
+		return invalidParams
+	}
+	return nil
+}
+
 // Represents the request to change a user password.
 type ChangePasswordInput struct {
 	_ struct{} `type:"structure"`
@@ -1467,6 +1743,28 @@ func (s ChangePasswordInput) String() string {
 // GoString returns the string representation
 func (s ChangePasswordInput) GoString() string {
 	return s.String()
+}
+
+// Validate inspects the fields of the type to determine if they are valid.
+func (s *ChangePasswordInput) Validate() error {
+	invalidParams := request.ErrInvalidParams{Context: "ChangePasswordInput"}
+	if s.PreviousPassword == nil {
+		invalidParams.Add(request.NewErrParamRequired("PreviousPassword"))
+	}
+	if s.PreviousPassword != nil && len(*s.PreviousPassword) < 6 {
+		invalidParams.Add(request.NewErrParamMinLen("PreviousPassword", 6))
+	}
+	if s.ProposedPassword == nil {
+		invalidParams.Add(request.NewErrParamRequired("ProposedPassword"))
+	}
+	if s.ProposedPassword != nil && len(*s.ProposedPassword) < 6 {
+		invalidParams.Add(request.NewErrParamMinLen("ProposedPassword", 6))
+	}
+
+	if invalidParams.Len() > 0 {
+		return invalidParams
+	}
+	return nil
 }
 
 // The response from the server to the change password request.
@@ -1540,6 +1838,43 @@ func (s ConfirmForgotPasswordInput) GoString() string {
 	return s.String()
 }
 
+// Validate inspects the fields of the type to determine if they are valid.
+func (s *ConfirmForgotPasswordInput) Validate() error {
+	invalidParams := request.ErrInvalidParams{Context: "ConfirmForgotPasswordInput"}
+	if s.ClientId == nil {
+		invalidParams.Add(request.NewErrParamRequired("ClientId"))
+	}
+	if s.ClientId != nil && len(*s.ClientId) < 1 {
+		invalidParams.Add(request.NewErrParamMinLen("ClientId", 1))
+	}
+	if s.ConfirmationCode == nil {
+		invalidParams.Add(request.NewErrParamRequired("ConfirmationCode"))
+	}
+	if s.ConfirmationCode != nil && len(*s.ConfirmationCode) < 1 {
+		invalidParams.Add(request.NewErrParamMinLen("ConfirmationCode", 1))
+	}
+	if s.Password == nil {
+		invalidParams.Add(request.NewErrParamRequired("Password"))
+	}
+	if s.Password != nil && len(*s.Password) < 6 {
+		invalidParams.Add(request.NewErrParamMinLen("Password", 6))
+	}
+	if s.SecretHash != nil && len(*s.SecretHash) < 1 {
+		invalidParams.Add(request.NewErrParamMinLen("SecretHash", 1))
+	}
+	if s.Username == nil {
+		invalidParams.Add(request.NewErrParamRequired("Username"))
+	}
+	if s.Username != nil && len(*s.Username) < 1 {
+		invalidParams.Add(request.NewErrParamMinLen("Username", 1))
+	}
+
+	if invalidParams.Len() > 0 {
+		return invalidParams
+	}
+	return nil
+}
+
 // The response from the server that results from a user's request to retrieve
 // a forgotten password.
 type ConfirmForgotPasswordOutput struct {
@@ -1592,6 +1927,37 @@ func (s ConfirmSignUpInput) GoString() string {
 	return s.String()
 }
 
+// Validate inspects the fields of the type to determine if they are valid.
+func (s *ConfirmSignUpInput) Validate() error {
+	invalidParams := request.ErrInvalidParams{Context: "ConfirmSignUpInput"}
+	if s.ClientId == nil {
+		invalidParams.Add(request.NewErrParamRequired("ClientId"))
+	}
+	if s.ClientId != nil && len(*s.ClientId) < 1 {
+		invalidParams.Add(request.NewErrParamMinLen("ClientId", 1))
+	}
+	if s.ConfirmationCode == nil {
+		invalidParams.Add(request.NewErrParamRequired("ConfirmationCode"))
+	}
+	if s.ConfirmationCode != nil && len(*s.ConfirmationCode) < 1 {
+		invalidParams.Add(request.NewErrParamMinLen("ConfirmationCode", 1))
+	}
+	if s.SecretHash != nil && len(*s.SecretHash) < 1 {
+		invalidParams.Add(request.NewErrParamMinLen("SecretHash", 1))
+	}
+	if s.Username == nil {
+		invalidParams.Add(request.NewErrParamRequired("Username"))
+	}
+	if s.Username != nil && len(*s.Username) < 1 {
+		invalidParams.Add(request.NewErrParamMinLen("Username", 1))
+	}
+
+	if invalidParams.Len() > 0 {
+		return invalidParams
+	}
+	return nil
+}
+
 // Represents the response from the server for the registration confirmation.
 type ConfirmSignUpOutput struct {
 	_ struct{} `type:"structure"`
@@ -1630,6 +1996,28 @@ func (s CreateUserPoolClientInput) String() string {
 // GoString returns the string representation
 func (s CreateUserPoolClientInput) GoString() string {
 	return s.String()
+}
+
+// Validate inspects the fields of the type to determine if they are valid.
+func (s *CreateUserPoolClientInput) Validate() error {
+	invalidParams := request.ErrInvalidParams{Context: "CreateUserPoolClientInput"}
+	if s.ClientName == nil {
+		invalidParams.Add(request.NewErrParamRequired("ClientName"))
+	}
+	if s.ClientName != nil && len(*s.ClientName) < 1 {
+		invalidParams.Add(request.NewErrParamMinLen("ClientName", 1))
+	}
+	if s.UserPoolId == nil {
+		invalidParams.Add(request.NewErrParamRequired("UserPoolId"))
+	}
+	if s.UserPoolId != nil && len(*s.UserPoolId) < 1 {
+		invalidParams.Add(request.NewErrParamMinLen("UserPoolId", 1))
+	}
+
+	if invalidParams.Len() > 0 {
+		return invalidParams
+	}
+	return nil
 }
 
 // Represents the response from the server to create a user pool client.
@@ -1696,6 +2084,44 @@ func (s CreateUserPoolInput) GoString() string {
 	return s.String()
 }
 
+// Validate inspects the fields of the type to determine if they are valid.
+func (s *CreateUserPoolInput) Validate() error {
+	invalidParams := request.ErrInvalidParams{Context: "CreateUserPoolInput"}
+	if s.EmailVerificationMessage != nil && len(*s.EmailVerificationMessage) < 6 {
+		invalidParams.Add(request.NewErrParamMinLen("EmailVerificationMessage", 6))
+	}
+	if s.EmailVerificationSubject != nil && len(*s.EmailVerificationSubject) < 1 {
+		invalidParams.Add(request.NewErrParamMinLen("EmailVerificationSubject", 1))
+	}
+	if s.PoolName == nil {
+		invalidParams.Add(request.NewErrParamRequired("PoolName"))
+	}
+	if s.PoolName != nil && len(*s.PoolName) < 1 {
+		invalidParams.Add(request.NewErrParamMinLen("PoolName", 1))
+	}
+	if s.SmsAuthenticationMessage != nil && len(*s.SmsAuthenticationMessage) < 6 {
+		invalidParams.Add(request.NewErrParamMinLen("SmsAuthenticationMessage", 6))
+	}
+	if s.SmsVerificationMessage != nil && len(*s.SmsVerificationMessage) < 6 {
+		invalidParams.Add(request.NewErrParamMinLen("SmsVerificationMessage", 6))
+	}
+	if s.LambdaConfig != nil {
+		if err := s.LambdaConfig.Validate(); err != nil {
+			invalidParams.AddNested("LambdaConfig", err.(request.ErrInvalidParams))
+		}
+	}
+	if s.Policies != nil {
+		if err := s.Policies.Validate(); err != nil {
+			invalidParams.AddNested("Policies", err.(request.ErrInvalidParams))
+		}
+	}
+
+	if invalidParams.Len() > 0 {
+		return invalidParams
+	}
+	return nil
+}
+
 // Represents the response from the server for the request to create a user
 // pool.
 type CreateUserPoolOutput struct {
@@ -1734,6 +2160,19 @@ func (s DeleteUserAttributesInput) String() string {
 // GoString returns the string representation
 func (s DeleteUserAttributesInput) GoString() string {
 	return s.String()
+}
+
+// Validate inspects the fields of the type to determine if they are valid.
+func (s *DeleteUserAttributesInput) Validate() error {
+	invalidParams := request.ErrInvalidParams{Context: "DeleteUserAttributesInput"}
+	if s.UserAttributeNames == nil {
+		invalidParams.Add(request.NewErrParamRequired("UserAttributeNames"))
+	}
+
+	if invalidParams.Len() > 0 {
+		return invalidParams
+	}
+	return nil
 }
 
 // Represents the response from the server to delete user attributes.
@@ -1804,6 +2243,28 @@ func (s DeleteUserPoolClientInput) GoString() string {
 	return s.String()
 }
 
+// Validate inspects the fields of the type to determine if they are valid.
+func (s *DeleteUserPoolClientInput) Validate() error {
+	invalidParams := request.ErrInvalidParams{Context: "DeleteUserPoolClientInput"}
+	if s.ClientId == nil {
+		invalidParams.Add(request.NewErrParamRequired("ClientId"))
+	}
+	if s.ClientId != nil && len(*s.ClientId) < 1 {
+		invalidParams.Add(request.NewErrParamMinLen("ClientId", 1))
+	}
+	if s.UserPoolId == nil {
+		invalidParams.Add(request.NewErrParamRequired("UserPoolId"))
+	}
+	if s.UserPoolId != nil && len(*s.UserPoolId) < 1 {
+		invalidParams.Add(request.NewErrParamMinLen("UserPoolId", 1))
+	}
+
+	if invalidParams.Len() > 0 {
+		return invalidParams
+	}
+	return nil
+}
+
 type DeleteUserPoolClientOutput struct {
 	_ struct{} `type:"structure"`
 }
@@ -1834,6 +2295,22 @@ func (s DeleteUserPoolInput) String() string {
 // GoString returns the string representation
 func (s DeleteUserPoolInput) GoString() string {
 	return s.String()
+}
+
+// Validate inspects the fields of the type to determine if they are valid.
+func (s *DeleteUserPoolInput) Validate() error {
+	invalidParams := request.ErrInvalidParams{Context: "DeleteUserPoolInput"}
+	if s.UserPoolId == nil {
+		invalidParams.Add(request.NewErrParamRequired("UserPoolId"))
+	}
+	if s.UserPoolId != nil && len(*s.UserPoolId) < 1 {
+		invalidParams.Add(request.NewErrParamMinLen("UserPoolId", 1))
+	}
+
+	if invalidParams.Len() > 0 {
+		return invalidParams
+	}
+	return nil
 }
 
 type DeleteUserPoolOutput struct {
@@ -1871,6 +2348,28 @@ func (s DescribeUserPoolClientInput) GoString() string {
 	return s.String()
 }
 
+// Validate inspects the fields of the type to determine if they are valid.
+func (s *DescribeUserPoolClientInput) Validate() error {
+	invalidParams := request.ErrInvalidParams{Context: "DescribeUserPoolClientInput"}
+	if s.ClientId == nil {
+		invalidParams.Add(request.NewErrParamRequired("ClientId"))
+	}
+	if s.ClientId != nil && len(*s.ClientId) < 1 {
+		invalidParams.Add(request.NewErrParamMinLen("ClientId", 1))
+	}
+	if s.UserPoolId == nil {
+		invalidParams.Add(request.NewErrParamRequired("UserPoolId"))
+	}
+	if s.UserPoolId != nil && len(*s.UserPoolId) < 1 {
+		invalidParams.Add(request.NewErrParamMinLen("UserPoolId", 1))
+	}
+
+	if invalidParams.Len() > 0 {
+		return invalidParams
+	}
+	return nil
+}
+
 // Represents the response from the server from a request to describe the user
 // pool client.
 type DescribeUserPoolClientOutput struct {
@@ -1906,6 +2405,22 @@ func (s DescribeUserPoolInput) String() string {
 // GoString returns the string representation
 func (s DescribeUserPoolInput) GoString() string {
 	return s.String()
+}
+
+// Validate inspects the fields of the type to determine if they are valid.
+func (s *DescribeUserPoolInput) Validate() error {
+	invalidParams := request.ErrInvalidParams{Context: "DescribeUserPoolInput"}
+	if s.UserPoolId == nil {
+		invalidParams.Add(request.NewErrParamRequired("UserPoolId"))
+	}
+	if s.UserPoolId != nil && len(*s.UserPoolId) < 1 {
+		invalidParams.Add(request.NewErrParamMinLen("UserPoolId", 1))
+	}
+
+	if invalidParams.Len() > 0 {
+		return invalidParams
+	}
+	return nil
 }
 
 // Represents the response to describe the user pool.
@@ -1952,6 +2467,31 @@ func (s ForgotPasswordInput) GoString() string {
 	return s.String()
 }
 
+// Validate inspects the fields of the type to determine if they are valid.
+func (s *ForgotPasswordInput) Validate() error {
+	invalidParams := request.ErrInvalidParams{Context: "ForgotPasswordInput"}
+	if s.ClientId == nil {
+		invalidParams.Add(request.NewErrParamRequired("ClientId"))
+	}
+	if s.ClientId != nil && len(*s.ClientId) < 1 {
+		invalidParams.Add(request.NewErrParamMinLen("ClientId", 1))
+	}
+	if s.SecretHash != nil && len(*s.SecretHash) < 1 {
+		invalidParams.Add(request.NewErrParamMinLen("SecretHash", 1))
+	}
+	if s.Username == nil {
+		invalidParams.Add(request.NewErrParamRequired("Username"))
+	}
+	if s.Username != nil && len(*s.Username) < 1 {
+		invalidParams.Add(request.NewErrParamMinLen("Username", 1))
+	}
+
+	if invalidParams.Len() > 0 {
+		return invalidParams
+	}
+	return nil
+}
+
 // Respresents the response from the server regarding the request to reset a
 // password.
 type ForgotPasswordOutput struct {
@@ -1989,6 +2529,22 @@ func (s GetJWKSInput) GoString() string {
 	return s.String()
 }
 
+// Validate inspects the fields of the type to determine if they are valid.
+func (s *GetJWKSInput) Validate() error {
+	invalidParams := request.ErrInvalidParams{Context: "GetJWKSInput"}
+	if s.UserPoolId == nil {
+		invalidParams.Add(request.NewErrParamRequired("UserPoolId"))
+	}
+	if s.UserPoolId != nil && len(*s.UserPoolId) < 1 {
+		invalidParams.Add(request.NewErrParamMinLen("UserPoolId", 1))
+	}
+
+	if invalidParams.Len() > 0 {
+		return invalidParams
+	}
+	return nil
+}
+
 // Represents the response from the server to get JSON Web keys.
 type GetJWKSOutput struct {
 	_ struct{} `type:"structure"`
@@ -2024,6 +2580,22 @@ func (s GetOpenIdConfigurationInput) String() string {
 // GoString returns the string representation
 func (s GetOpenIdConfigurationInput) GoString() string {
 	return s.String()
+}
+
+// Validate inspects the fields of the type to determine if they are valid.
+func (s *GetOpenIdConfigurationInput) Validate() error {
+	invalidParams := request.ErrInvalidParams{Context: "GetOpenIdConfigurationInput"}
+	if s.UserPoolId == nil {
+		invalidParams.Add(request.NewErrParamRequired("UserPoolId"))
+	}
+	if s.UserPoolId != nil && len(*s.UserPoolId) < 1 {
+		invalidParams.Add(request.NewErrParamMinLen("UserPoolId", 1))
+	}
+
+	if invalidParams.Len() > 0 {
+		return invalidParams
+	}
+	return nil
 }
 
 // Represents the response from the server to get the Open ID configuration
@@ -2086,6 +2658,22 @@ func (s GetUserAttributeVerificationCodeInput) String() string {
 // GoString returns the string representation
 func (s GetUserAttributeVerificationCodeInput) GoString() string {
 	return s.String()
+}
+
+// Validate inspects the fields of the type to determine if they are valid.
+func (s *GetUserAttributeVerificationCodeInput) Validate() error {
+	invalidParams := request.ErrInvalidParams{Context: "GetUserAttributeVerificationCodeInput"}
+	if s.AttributeName == nil {
+		invalidParams.Add(request.NewErrParamRequired("AttributeName"))
+	}
+	if s.AttributeName != nil && len(*s.AttributeName) < 1 {
+		invalidParams.Add(request.NewErrParamMinLen("AttributeName", 1))
+	}
+
+	if invalidParams.Len() > 0 {
+		return invalidParams
+	}
+	return nil
 }
 
 // The verification code response returned by the server response to get the
@@ -2219,6 +2807,31 @@ func (s LambdaConfigType) GoString() string {
 	return s.String()
 }
 
+// Validate inspects the fields of the type to determine if they are valid.
+func (s *LambdaConfigType) Validate() error {
+	invalidParams := request.ErrInvalidParams{Context: "LambdaConfigType"}
+	if s.CustomMessage != nil && len(*s.CustomMessage) < 20 {
+		invalidParams.Add(request.NewErrParamMinLen("CustomMessage", 20))
+	}
+	if s.PostAuthentication != nil && len(*s.PostAuthentication) < 20 {
+		invalidParams.Add(request.NewErrParamMinLen("PostAuthentication", 20))
+	}
+	if s.PostConfirmation != nil && len(*s.PostConfirmation) < 20 {
+		invalidParams.Add(request.NewErrParamMinLen("PostConfirmation", 20))
+	}
+	if s.PreAuthentication != nil && len(*s.PreAuthentication) < 20 {
+		invalidParams.Add(request.NewErrParamMinLen("PreAuthentication", 20))
+	}
+	if s.PreSignUp != nil && len(*s.PreSignUp) < 20 {
+		invalidParams.Add(request.NewErrParamMinLen("PreSignUp", 20))
+	}
+
+	if invalidParams.Len() > 0 {
+		return invalidParams
+	}
+	return nil
+}
+
 // Represents the request to list the user pool clients.
 type ListUserPoolClientsInput struct {
 	_ struct{} `type:"structure"`
@@ -2243,6 +2856,28 @@ func (s ListUserPoolClientsInput) String() string {
 // GoString returns the string representation
 func (s ListUserPoolClientsInput) GoString() string {
 	return s.String()
+}
+
+// Validate inspects the fields of the type to determine if they are valid.
+func (s *ListUserPoolClientsInput) Validate() error {
+	invalidParams := request.ErrInvalidParams{Context: "ListUserPoolClientsInput"}
+	if s.MaxResults != nil && *s.MaxResults < 1 {
+		invalidParams.Add(request.NewErrParamMinValue("MaxResults", 1))
+	}
+	if s.NextToken != nil && len(*s.NextToken) < 1 {
+		invalidParams.Add(request.NewErrParamMinLen("NextToken", 1))
+	}
+	if s.UserPoolId == nil {
+		invalidParams.Add(request.NewErrParamRequired("UserPoolId"))
+	}
+	if s.UserPoolId != nil && len(*s.UserPoolId) < 1 {
+		invalidParams.Add(request.NewErrParamMinLen("UserPoolId", 1))
+	}
+
+	if invalidParams.Len() > 0 {
+		return invalidParams
+	}
+	return nil
 }
 
 // Represents the response from the server that lists user pool clients.
@@ -2288,6 +2923,25 @@ func (s ListUserPoolsInput) String() string {
 // GoString returns the string representation
 func (s ListUserPoolsInput) GoString() string {
 	return s.String()
+}
+
+// Validate inspects the fields of the type to determine if they are valid.
+func (s *ListUserPoolsInput) Validate() error {
+	invalidParams := request.ErrInvalidParams{Context: "ListUserPoolsInput"}
+	if s.MaxResults == nil {
+		invalidParams.Add(request.NewErrParamRequired("MaxResults"))
+	}
+	if s.MaxResults != nil && *s.MaxResults < 1 {
+		invalidParams.Add(request.NewErrParamMinValue("MaxResults", 1))
+	}
+	if s.NextToken != nil && len(*s.NextToken) < 1 {
+		invalidParams.Add(request.NewErrParamMinLen("NextToken", 1))
+	}
+
+	if invalidParams.Len() > 0 {
+		return invalidParams
+	}
+	return nil
 }
 
 // Represents the response to list user pools.
@@ -2348,6 +3002,28 @@ func (s ListUsersInput) GoString() string {
 	return s.String()
 }
 
+// Validate inspects the fields of the type to determine if they are valid.
+func (s *ListUsersInput) Validate() error {
+	invalidParams := request.ErrInvalidParams{Context: "ListUsersInput"}
+	if s.Limit != nil && *s.Limit < 1 {
+		invalidParams.Add(request.NewErrParamMinValue("Limit", 1))
+	}
+	if s.PaginationToken != nil && len(*s.PaginationToken) < 1 {
+		invalidParams.Add(request.NewErrParamMinLen("PaginationToken", 1))
+	}
+	if s.UserPoolId == nil {
+		invalidParams.Add(request.NewErrParamRequired("UserPoolId"))
+	}
+	if s.UserPoolId != nil && len(*s.UserPoolId) < 1 {
+		invalidParams.Add(request.NewErrParamMinLen("UserPoolId", 1))
+	}
+
+	if invalidParams.Len() > 0 {
+		return invalidParams
+	}
+	return nil
+}
+
 // The response from the request to list users.
 type ListUsersOutput struct {
 	_ struct{} `type:"structure"`
@@ -2389,6 +3065,19 @@ func (s MFAOptionType) String() string {
 // GoString returns the string representation
 func (s MFAOptionType) GoString() string {
 	return s.String()
+}
+
+// Validate inspects the fields of the type to determine if they are valid.
+func (s *MFAOptionType) Validate() error {
+	invalidParams := request.ErrInvalidParams{Context: "MFAOptionType"}
+	if s.AttributeName != nil && len(*s.AttributeName) < 1 {
+		invalidParams.Add(request.NewErrParamMinLen("AttributeName", 1))
+	}
+
+	if invalidParams.Len() > 0 {
+		return invalidParams
+	}
+	return nil
 }
 
 // The minimum and maximum value of an attribute that is of the number data
@@ -2448,6 +3137,19 @@ func (s PasswordPolicyType) GoString() string {
 	return s.String()
 }
 
+// Validate inspects the fields of the type to determine if they are valid.
+func (s *PasswordPolicyType) Validate() error {
+	invalidParams := request.ErrInvalidParams{Context: "PasswordPolicyType"}
+	if s.MinimumLength != nil && *s.MinimumLength < 6 {
+		invalidParams.Add(request.NewErrParamMinValue("MinimumLength", 6))
+	}
+
+	if invalidParams.Len() > 0 {
+		return invalidParams
+	}
+	return nil
+}
+
 // Represents the request to resend the confirmation code.
 type ResendConfirmationCodeInput struct {
 	_ struct{} `type:"structure"`
@@ -2471,6 +3173,31 @@ func (s ResendConfirmationCodeInput) String() string {
 // GoString returns the string representation
 func (s ResendConfirmationCodeInput) GoString() string {
 	return s.String()
+}
+
+// Validate inspects the fields of the type to determine if they are valid.
+func (s *ResendConfirmationCodeInput) Validate() error {
+	invalidParams := request.ErrInvalidParams{Context: "ResendConfirmationCodeInput"}
+	if s.ClientId == nil {
+		invalidParams.Add(request.NewErrParamRequired("ClientId"))
+	}
+	if s.ClientId != nil && len(*s.ClientId) < 1 {
+		invalidParams.Add(request.NewErrParamMinLen("ClientId", 1))
+	}
+	if s.SecretHash != nil && len(*s.SecretHash) < 1 {
+		invalidParams.Add(request.NewErrParamMinLen("SecretHash", 1))
+	}
+	if s.Username == nil {
+		invalidParams.Add(request.NewErrParamRequired("Username"))
+	}
+	if s.Username != nil && len(*s.Username) < 1 {
+		invalidParams.Add(request.NewErrParamMinLen("Username", 1))
+	}
+
+	if invalidParams.Len() > 0 {
+		return invalidParams
+	}
+	return nil
 }
 
 // The response from the server when the Amazon Cognito service makes the request
@@ -2530,6 +3257,19 @@ func (s SchemaAttributeType) GoString() string {
 	return s.String()
 }
 
+// Validate inspects the fields of the type to determine if they are valid.
+func (s *SchemaAttributeType) Validate() error {
+	invalidParams := request.ErrInvalidParams{Context: "SchemaAttributeType"}
+	if s.Name != nil && len(*s.Name) < 1 {
+		invalidParams.Add(request.NewErrParamMinLen("Name", 1))
+	}
+
+	if invalidParams.Len() > 0 {
+		return invalidParams
+	}
+	return nil
+}
+
 // Represents the request to set user settings.
 type SetUserSettingsInput struct {
 	_ struct{} `type:"structure"`
@@ -2549,6 +3289,32 @@ func (s SetUserSettingsInput) String() string {
 // GoString returns the string representation
 func (s SetUserSettingsInput) GoString() string {
 	return s.String()
+}
+
+// Validate inspects the fields of the type to determine if they are valid.
+func (s *SetUserSettingsInput) Validate() error {
+	invalidParams := request.ErrInvalidParams{Context: "SetUserSettingsInput"}
+	if s.AccessToken == nil {
+		invalidParams.Add(request.NewErrParamRequired("AccessToken"))
+	}
+	if s.MFAOptions == nil {
+		invalidParams.Add(request.NewErrParamRequired("MFAOptions"))
+	}
+	if s.MFAOptions != nil {
+		for i, v := range s.MFAOptions {
+			if v == nil {
+				continue
+			}
+			if err := v.Validate(); err != nil {
+				invalidParams.AddNested(fmt.Sprintf("%s[%v]", "MFAOptions", i), err.(request.ErrInvalidParams))
+			}
+		}
+	}
+
+	if invalidParams.Len() > 0 {
+		return invalidParams
+	}
+	return nil
 }
 
 // The response from the server for a set user settings request.
@@ -2598,6 +3364,57 @@ func (s SignUpInput) String() string {
 // GoString returns the string representation
 func (s SignUpInput) GoString() string {
 	return s.String()
+}
+
+// Validate inspects the fields of the type to determine if they are valid.
+func (s *SignUpInput) Validate() error {
+	invalidParams := request.ErrInvalidParams{Context: "SignUpInput"}
+	if s.ClientId == nil {
+		invalidParams.Add(request.NewErrParamRequired("ClientId"))
+	}
+	if s.ClientId != nil && len(*s.ClientId) < 1 {
+		invalidParams.Add(request.NewErrParamMinLen("ClientId", 1))
+	}
+	if s.Password == nil {
+		invalidParams.Add(request.NewErrParamRequired("Password"))
+	}
+	if s.Password != nil && len(*s.Password) < 6 {
+		invalidParams.Add(request.NewErrParamMinLen("Password", 6))
+	}
+	if s.SecretHash != nil && len(*s.SecretHash) < 1 {
+		invalidParams.Add(request.NewErrParamMinLen("SecretHash", 1))
+	}
+	if s.Username == nil {
+		invalidParams.Add(request.NewErrParamRequired("Username"))
+	}
+	if s.Username != nil && len(*s.Username) < 1 {
+		invalidParams.Add(request.NewErrParamMinLen("Username", 1))
+	}
+	if s.UserAttributes != nil {
+		for i, v := range s.UserAttributes {
+			if v == nil {
+				continue
+			}
+			if err := v.Validate(); err != nil {
+				invalidParams.AddNested(fmt.Sprintf("%s[%v]", "UserAttributes", i), err.(request.ErrInvalidParams))
+			}
+		}
+	}
+	if s.ValidationData != nil {
+		for i, v := range s.ValidationData {
+			if v == nil {
+				continue
+			}
+			if err := v.Validate(); err != nil {
+				invalidParams.AddNested(fmt.Sprintf("%s[%v]", "ValidationData", i), err.(request.ErrInvalidParams))
+			}
+		}
+	}
+
+	if invalidParams.Len() > 0 {
+		return invalidParams
+	}
+	return nil
 }
 
 // The response from the server for a registration request.
@@ -2663,6 +3480,29 @@ func (s UpdateUserAttributesInput) GoString() string {
 	return s.String()
 }
 
+// Validate inspects the fields of the type to determine if they are valid.
+func (s *UpdateUserAttributesInput) Validate() error {
+	invalidParams := request.ErrInvalidParams{Context: "UpdateUserAttributesInput"}
+	if s.UserAttributes == nil {
+		invalidParams.Add(request.NewErrParamRequired("UserAttributes"))
+	}
+	if s.UserAttributes != nil {
+		for i, v := range s.UserAttributes {
+			if v == nil {
+				continue
+			}
+			if err := v.Validate(); err != nil {
+				invalidParams.AddNested(fmt.Sprintf("%s[%v]", "UserAttributes", i), err.(request.ErrInvalidParams))
+			}
+		}
+	}
+
+	if invalidParams.Len() > 0 {
+		return invalidParams
+	}
+	return nil
+}
+
 // Represents the response from the server for the request to update user attributes.
 type UpdateUserAttributesOutput struct {
 	_ struct{} `type:"structure"`
@@ -2705,6 +3545,31 @@ func (s UpdateUserPoolClientInput) String() string {
 // GoString returns the string representation
 func (s UpdateUserPoolClientInput) GoString() string {
 	return s.String()
+}
+
+// Validate inspects the fields of the type to determine if they are valid.
+func (s *UpdateUserPoolClientInput) Validate() error {
+	invalidParams := request.ErrInvalidParams{Context: "UpdateUserPoolClientInput"}
+	if s.ClientId == nil {
+		invalidParams.Add(request.NewErrParamRequired("ClientId"))
+	}
+	if s.ClientId != nil && len(*s.ClientId) < 1 {
+		invalidParams.Add(request.NewErrParamMinLen("ClientId", 1))
+	}
+	if s.ClientName != nil && len(*s.ClientName) < 1 {
+		invalidParams.Add(request.NewErrParamMinLen("ClientName", 1))
+	}
+	if s.UserPoolId == nil {
+		invalidParams.Add(request.NewErrParamRequired("UserPoolId"))
+	}
+	if s.UserPoolId != nil && len(*s.UserPoolId) < 1 {
+		invalidParams.Add(request.NewErrParamMinLen("UserPoolId", 1))
+	}
+
+	if invalidParams.Len() > 0 {
+		return invalidParams
+	}
+	return nil
 }
 
 // Represents the response from the server to the request to update the user
@@ -2774,6 +3639,44 @@ func (s UpdateUserPoolInput) String() string {
 // GoString returns the string representation
 func (s UpdateUserPoolInput) GoString() string {
 	return s.String()
+}
+
+// Validate inspects the fields of the type to determine if they are valid.
+func (s *UpdateUserPoolInput) Validate() error {
+	invalidParams := request.ErrInvalidParams{Context: "UpdateUserPoolInput"}
+	if s.EmailVerificationMessage != nil && len(*s.EmailVerificationMessage) < 6 {
+		invalidParams.Add(request.NewErrParamMinLen("EmailVerificationMessage", 6))
+	}
+	if s.EmailVerificationSubject != nil && len(*s.EmailVerificationSubject) < 1 {
+		invalidParams.Add(request.NewErrParamMinLen("EmailVerificationSubject", 1))
+	}
+	if s.SmsAuthenticationMessage != nil && len(*s.SmsAuthenticationMessage) < 6 {
+		invalidParams.Add(request.NewErrParamMinLen("SmsAuthenticationMessage", 6))
+	}
+	if s.SmsVerificationMessage != nil && len(*s.SmsVerificationMessage) < 6 {
+		invalidParams.Add(request.NewErrParamMinLen("SmsVerificationMessage", 6))
+	}
+	if s.UserPoolId == nil {
+		invalidParams.Add(request.NewErrParamRequired("UserPoolId"))
+	}
+	if s.UserPoolId != nil && len(*s.UserPoolId) < 1 {
+		invalidParams.Add(request.NewErrParamMinLen("UserPoolId", 1))
+	}
+	if s.LambdaConfig != nil {
+		if err := s.LambdaConfig.Validate(); err != nil {
+			invalidParams.AddNested("LambdaConfig", err.(request.ErrInvalidParams))
+		}
+	}
+	if s.Policies != nil {
+		if err := s.Policies.Validate(); err != nil {
+			invalidParams.AddNested("Policies", err.(request.ErrInvalidParams))
+		}
+	}
+
+	if invalidParams.Len() > 0 {
+		return invalidParams
+	}
+	return nil
 }
 
 // Represents the response from the server when you make a request to update
@@ -2899,6 +3802,21 @@ func (s UserPoolPolicyType) String() string {
 // GoString returns the string representation
 func (s UserPoolPolicyType) GoString() string {
 	return s.String()
+}
+
+// Validate inspects the fields of the type to determine if they are valid.
+func (s *UserPoolPolicyType) Validate() error {
+	invalidParams := request.ErrInvalidParams{Context: "UserPoolPolicyType"}
+	if s.PasswordPolicy != nil {
+		if err := s.PasswordPolicy.Validate(); err != nil {
+			invalidParams.AddNested("PasswordPolicy", err.(request.ErrInvalidParams))
+		}
+	}
+
+	if invalidParams.Len() > 0 {
+		return invalidParams
+	}
+	return nil
 }
 
 // A container with information about the user pool type.
@@ -3029,6 +3947,28 @@ func (s VerifyUserAttributeInput) String() string {
 // GoString returns the string representation
 func (s VerifyUserAttributeInput) GoString() string {
 	return s.String()
+}
+
+// Validate inspects the fields of the type to determine if they are valid.
+func (s *VerifyUserAttributeInput) Validate() error {
+	invalidParams := request.ErrInvalidParams{Context: "VerifyUserAttributeInput"}
+	if s.AttributeName == nil {
+		invalidParams.Add(request.NewErrParamRequired("AttributeName"))
+	}
+	if s.AttributeName != nil && len(*s.AttributeName) < 1 {
+		invalidParams.Add(request.NewErrParamMinLen("AttributeName", 1))
+	}
+	if s.Code == nil {
+		invalidParams.Add(request.NewErrParamRequired("Code"))
+	}
+	if s.Code != nil && len(*s.Code) < 1 {
+		invalidParams.Add(request.NewErrParamMinLen("Code", 1))
+	}
+
+	if invalidParams.Len() > 0 {
+		return invalidParams
+	}
+	return nil
 }
 
 // A container representing the response from the server from the request to

--- a/service/cognitosync/api.go
+++ b/service/cognitosync/api.go
@@ -4,6 +4,7 @@
 package cognitosync
 
 import (
+	"fmt"
 	"time"
 
 	"github.com/aws/aws-sdk-go/aws/awsutil"
@@ -580,6 +581,22 @@ func (s BulkPublishInput) GoString() string {
 	return s.String()
 }
 
+// Validate inspects the fields of the type to determine if they are valid.
+func (s *BulkPublishInput) Validate() error {
+	invalidParams := request.ErrInvalidParams{Context: "BulkPublishInput"}
+	if s.IdentityPoolId == nil {
+		invalidParams.Add(request.NewErrParamRequired("IdentityPoolId"))
+	}
+	if s.IdentityPoolId != nil && len(*s.IdentityPoolId) < 1 {
+		invalidParams.Add(request.NewErrParamMinLen("IdentityPoolId", 1))
+	}
+
+	if invalidParams.Len() > 0 {
+		return invalidParams
+	}
+	return nil
+}
+
 // The output for the BulkPublish operation.
 type BulkPublishOutput struct {
 	_ struct{} `type:"structure"`
@@ -628,6 +645,22 @@ func (s CognitoStreams) String() string {
 // GoString returns the string representation
 func (s CognitoStreams) GoString() string {
 	return s.String()
+}
+
+// Validate inspects the fields of the type to determine if they are valid.
+func (s *CognitoStreams) Validate() error {
+	invalidParams := request.ErrInvalidParams{Context: "CognitoStreams"}
+	if s.RoleArn != nil && len(*s.RoleArn) < 20 {
+		invalidParams.Add(request.NewErrParamMinLen("RoleArn", 20))
+	}
+	if s.StreamName != nil && len(*s.StreamName) < 1 {
+		invalidParams.Add(request.NewErrParamMinLen("StreamName", 1))
+	}
+
+	if invalidParams.Len() > 0 {
+		return invalidParams
+	}
+	return nil
 }
 
 // A collection of data for an identity pool. An identity pool can have multiple
@@ -699,6 +732,34 @@ func (s DeleteDatasetInput) GoString() string {
 	return s.String()
 }
 
+// Validate inspects the fields of the type to determine if they are valid.
+func (s *DeleteDatasetInput) Validate() error {
+	invalidParams := request.ErrInvalidParams{Context: "DeleteDatasetInput"}
+	if s.DatasetName == nil {
+		invalidParams.Add(request.NewErrParamRequired("DatasetName"))
+	}
+	if s.DatasetName != nil && len(*s.DatasetName) < 1 {
+		invalidParams.Add(request.NewErrParamMinLen("DatasetName", 1))
+	}
+	if s.IdentityId == nil {
+		invalidParams.Add(request.NewErrParamRequired("IdentityId"))
+	}
+	if s.IdentityId != nil && len(*s.IdentityId) < 1 {
+		invalidParams.Add(request.NewErrParamMinLen("IdentityId", 1))
+	}
+	if s.IdentityPoolId == nil {
+		invalidParams.Add(request.NewErrParamRequired("IdentityPoolId"))
+	}
+	if s.IdentityPoolId != nil && len(*s.IdentityPoolId) < 1 {
+		invalidParams.Add(request.NewErrParamMinLen("IdentityPoolId", 1))
+	}
+
+	if invalidParams.Len() > 0 {
+		return invalidParams
+	}
+	return nil
+}
+
 // Response to a successful DeleteDataset request.
 type DeleteDatasetOutput struct {
 	_ struct{} `type:"structure"`
@@ -749,6 +810,34 @@ func (s DescribeDatasetInput) GoString() string {
 	return s.String()
 }
 
+// Validate inspects the fields of the type to determine if they are valid.
+func (s *DescribeDatasetInput) Validate() error {
+	invalidParams := request.ErrInvalidParams{Context: "DescribeDatasetInput"}
+	if s.DatasetName == nil {
+		invalidParams.Add(request.NewErrParamRequired("DatasetName"))
+	}
+	if s.DatasetName != nil && len(*s.DatasetName) < 1 {
+		invalidParams.Add(request.NewErrParamMinLen("DatasetName", 1))
+	}
+	if s.IdentityId == nil {
+		invalidParams.Add(request.NewErrParamRequired("IdentityId"))
+	}
+	if s.IdentityId != nil && len(*s.IdentityId) < 1 {
+		invalidParams.Add(request.NewErrParamMinLen("IdentityId", 1))
+	}
+	if s.IdentityPoolId == nil {
+		invalidParams.Add(request.NewErrParamRequired("IdentityPoolId"))
+	}
+	if s.IdentityPoolId != nil && len(*s.IdentityPoolId) < 1 {
+		invalidParams.Add(request.NewErrParamMinLen("IdentityPoolId", 1))
+	}
+
+	if invalidParams.Len() > 0 {
+		return invalidParams
+	}
+	return nil
+}
+
 // Response to a successful DescribeDataset request.
 type DescribeDatasetOutput struct {
 	_ struct{} `type:"structure"`
@@ -788,6 +877,22 @@ func (s DescribeIdentityPoolUsageInput) String() string {
 // GoString returns the string representation
 func (s DescribeIdentityPoolUsageInput) GoString() string {
 	return s.String()
+}
+
+// Validate inspects the fields of the type to determine if they are valid.
+func (s *DescribeIdentityPoolUsageInput) Validate() error {
+	invalidParams := request.ErrInvalidParams{Context: "DescribeIdentityPoolUsageInput"}
+	if s.IdentityPoolId == nil {
+		invalidParams.Add(request.NewErrParamRequired("IdentityPoolId"))
+	}
+	if s.IdentityPoolId != nil && len(*s.IdentityPoolId) < 1 {
+		invalidParams.Add(request.NewErrParamMinLen("IdentityPoolId", 1))
+	}
+
+	if invalidParams.Len() > 0 {
+		return invalidParams
+	}
+	return nil
 }
 
 // Response to a successful DescribeIdentityPoolUsage request.
@@ -831,6 +936,28 @@ func (s DescribeIdentityUsageInput) GoString() string {
 	return s.String()
 }
 
+// Validate inspects the fields of the type to determine if they are valid.
+func (s *DescribeIdentityUsageInput) Validate() error {
+	invalidParams := request.ErrInvalidParams{Context: "DescribeIdentityUsageInput"}
+	if s.IdentityId == nil {
+		invalidParams.Add(request.NewErrParamRequired("IdentityId"))
+	}
+	if s.IdentityId != nil && len(*s.IdentityId) < 1 {
+		invalidParams.Add(request.NewErrParamMinLen("IdentityId", 1))
+	}
+	if s.IdentityPoolId == nil {
+		invalidParams.Add(request.NewErrParamRequired("IdentityPoolId"))
+	}
+	if s.IdentityPoolId != nil && len(*s.IdentityPoolId) < 1 {
+		invalidParams.Add(request.NewErrParamMinLen("IdentityPoolId", 1))
+	}
+
+	if invalidParams.Len() > 0 {
+		return invalidParams
+	}
+	return nil
+}
+
 // The response to a successful DescribeIdentityUsage request.
 type DescribeIdentityUsageOutput struct {
 	_ struct{} `type:"structure"`
@@ -866,6 +993,22 @@ func (s GetBulkPublishDetailsInput) String() string {
 // GoString returns the string representation
 func (s GetBulkPublishDetailsInput) GoString() string {
 	return s.String()
+}
+
+// Validate inspects the fields of the type to determine if they are valid.
+func (s *GetBulkPublishDetailsInput) Validate() error {
+	invalidParams := request.ErrInvalidParams{Context: "GetBulkPublishDetailsInput"}
+	if s.IdentityPoolId == nil {
+		invalidParams.Add(request.NewErrParamRequired("IdentityPoolId"))
+	}
+	if s.IdentityPoolId != nil && len(*s.IdentityPoolId) < 1 {
+		invalidParams.Add(request.NewErrParamMinLen("IdentityPoolId", 1))
+	}
+
+	if invalidParams.Len() > 0 {
+		return invalidParams
+	}
+	return nil
 }
 
 // The output for the GetBulkPublishDetails operation.
@@ -928,6 +1071,22 @@ func (s GetCognitoEventsInput) GoString() string {
 	return s.String()
 }
 
+// Validate inspects the fields of the type to determine if they are valid.
+func (s *GetCognitoEventsInput) Validate() error {
+	invalidParams := request.ErrInvalidParams{Context: "GetCognitoEventsInput"}
+	if s.IdentityPoolId == nil {
+		invalidParams.Add(request.NewErrParamRequired("IdentityPoolId"))
+	}
+	if s.IdentityPoolId != nil && len(*s.IdentityPoolId) < 1 {
+		invalidParams.Add(request.NewErrParamMinLen("IdentityPoolId", 1))
+	}
+
+	if invalidParams.Len() > 0 {
+		return invalidParams
+	}
+	return nil
+}
+
 // The response from the GetCognitoEvents request
 type GetCognitoEventsOutput struct {
 	_ struct{} `type:"structure"`
@@ -964,6 +1123,22 @@ func (s GetIdentityPoolConfigurationInput) String() string {
 // GoString returns the string representation
 func (s GetIdentityPoolConfigurationInput) GoString() string {
 	return s.String()
+}
+
+// Validate inspects the fields of the type to determine if they are valid.
+func (s *GetIdentityPoolConfigurationInput) Validate() error {
+	invalidParams := request.ErrInvalidParams{Context: "GetIdentityPoolConfigurationInput"}
+	if s.IdentityPoolId == nil {
+		invalidParams.Add(request.NewErrParamRequired("IdentityPoolId"))
+	}
+	if s.IdentityPoolId != nil && len(*s.IdentityPoolId) < 1 {
+		invalidParams.Add(request.NewErrParamMinLen("IdentityPoolId", 1))
+	}
+
+	if invalidParams.Len() > 0 {
+		return invalidParams
+	}
+	return nil
 }
 
 // The output for the GetIdentityPoolConfiguration operation.
@@ -1080,6 +1255,28 @@ func (s ListDatasetsInput) GoString() string {
 	return s.String()
 }
 
+// Validate inspects the fields of the type to determine if they are valid.
+func (s *ListDatasetsInput) Validate() error {
+	invalidParams := request.ErrInvalidParams{Context: "ListDatasetsInput"}
+	if s.IdentityId == nil {
+		invalidParams.Add(request.NewErrParamRequired("IdentityId"))
+	}
+	if s.IdentityId != nil && len(*s.IdentityId) < 1 {
+		invalidParams.Add(request.NewErrParamMinLen("IdentityId", 1))
+	}
+	if s.IdentityPoolId == nil {
+		invalidParams.Add(request.NewErrParamRequired("IdentityPoolId"))
+	}
+	if s.IdentityPoolId != nil && len(*s.IdentityPoolId) < 1 {
+		invalidParams.Add(request.NewErrParamMinLen("IdentityPoolId", 1))
+	}
+
+	if invalidParams.Len() > 0 {
+		return invalidParams
+	}
+	return nil
+}
+
 // Returned for a successful ListDatasets request.
 type ListDatasetsOutput struct {
 	_ struct{} `type:"structure"`
@@ -1191,6 +1388,34 @@ func (s ListRecordsInput) GoString() string {
 	return s.String()
 }
 
+// Validate inspects the fields of the type to determine if they are valid.
+func (s *ListRecordsInput) Validate() error {
+	invalidParams := request.ErrInvalidParams{Context: "ListRecordsInput"}
+	if s.DatasetName == nil {
+		invalidParams.Add(request.NewErrParamRequired("DatasetName"))
+	}
+	if s.DatasetName != nil && len(*s.DatasetName) < 1 {
+		invalidParams.Add(request.NewErrParamMinLen("DatasetName", 1))
+	}
+	if s.IdentityId == nil {
+		invalidParams.Add(request.NewErrParamRequired("IdentityId"))
+	}
+	if s.IdentityId != nil && len(*s.IdentityId) < 1 {
+		invalidParams.Add(request.NewErrParamMinLen("IdentityId", 1))
+	}
+	if s.IdentityPoolId == nil {
+		invalidParams.Add(request.NewErrParamRequired("IdentityPoolId"))
+	}
+	if s.IdentityPoolId != nil && len(*s.IdentityPoolId) < 1 {
+		invalidParams.Add(request.NewErrParamMinLen("IdentityPoolId", 1))
+	}
+
+	if invalidParams.Len() > 0 {
+		return invalidParams
+	}
+	return nil
+}
+
 // Returned for a successful ListRecordsRequest.
 type ListRecordsOutput struct {
 	_ struct{} `type:"structure"`
@@ -1252,6 +1477,19 @@ func (s PushSync) String() string {
 // GoString returns the string representation
 func (s PushSync) GoString() string {
 	return s.String()
+}
+
+// Validate inspects the fields of the type to determine if they are valid.
+func (s *PushSync) Validate() error {
+	invalidParams := request.ErrInvalidParams{Context: "PushSync"}
+	if s.RoleArn != nil && len(*s.RoleArn) < 20 {
+		invalidParams.Add(request.NewErrParamMinLen("RoleArn", 20))
+	}
+
+	if invalidParams.Len() > 0 {
+		return invalidParams
+	}
+	return nil
 }
 
 // The basic data structure of a dataset.
@@ -1317,6 +1555,28 @@ func (s RecordPatch) GoString() string {
 	return s.String()
 }
 
+// Validate inspects the fields of the type to determine if they are valid.
+func (s *RecordPatch) Validate() error {
+	invalidParams := request.ErrInvalidParams{Context: "RecordPatch"}
+	if s.Key == nil {
+		invalidParams.Add(request.NewErrParamRequired("Key"))
+	}
+	if s.Key != nil && len(*s.Key) < 1 {
+		invalidParams.Add(request.NewErrParamMinLen("Key", 1))
+	}
+	if s.Op == nil {
+		invalidParams.Add(request.NewErrParamRequired("Op"))
+	}
+	if s.SyncCount == nil {
+		invalidParams.Add(request.NewErrParamRequired("SyncCount"))
+	}
+
+	if invalidParams.Len() > 0 {
+		return invalidParams
+	}
+	return nil
+}
+
 // A request to RegisterDevice.
 type RegisterDeviceInput struct {
 	_ struct{} `type:"structure"`
@@ -1344,6 +1604,34 @@ func (s RegisterDeviceInput) String() string {
 // GoString returns the string representation
 func (s RegisterDeviceInput) GoString() string {
 	return s.String()
+}
+
+// Validate inspects the fields of the type to determine if they are valid.
+func (s *RegisterDeviceInput) Validate() error {
+	invalidParams := request.ErrInvalidParams{Context: "RegisterDeviceInput"}
+	if s.IdentityId == nil {
+		invalidParams.Add(request.NewErrParamRequired("IdentityId"))
+	}
+	if s.IdentityId != nil && len(*s.IdentityId) < 1 {
+		invalidParams.Add(request.NewErrParamMinLen("IdentityId", 1))
+	}
+	if s.IdentityPoolId == nil {
+		invalidParams.Add(request.NewErrParamRequired("IdentityPoolId"))
+	}
+	if s.IdentityPoolId != nil && len(*s.IdentityPoolId) < 1 {
+		invalidParams.Add(request.NewErrParamMinLen("IdentityPoolId", 1))
+	}
+	if s.Platform == nil {
+		invalidParams.Add(request.NewErrParamRequired("Platform"))
+	}
+	if s.Token == nil {
+		invalidParams.Add(request.NewErrParamRequired("Token"))
+	}
+
+	if invalidParams.Len() > 0 {
+		return invalidParams
+	}
+	return nil
 }
 
 // Response to a RegisterDevice request.
@@ -1387,6 +1675,25 @@ func (s SetCognitoEventsInput) GoString() string {
 	return s.String()
 }
 
+// Validate inspects the fields of the type to determine if they are valid.
+func (s *SetCognitoEventsInput) Validate() error {
+	invalidParams := request.ErrInvalidParams{Context: "SetCognitoEventsInput"}
+	if s.Events == nil {
+		invalidParams.Add(request.NewErrParamRequired("Events"))
+	}
+	if s.IdentityPoolId == nil {
+		invalidParams.Add(request.NewErrParamRequired("IdentityPoolId"))
+	}
+	if s.IdentityPoolId != nil && len(*s.IdentityPoolId) < 1 {
+		invalidParams.Add(request.NewErrParamMinLen("IdentityPoolId", 1))
+	}
+
+	if invalidParams.Len() > 0 {
+		return invalidParams
+	}
+	return nil
+}
+
 type SetCognitoEventsOutput struct {
 	_ struct{} `type:"structure"`
 }
@@ -1424,6 +1731,32 @@ func (s SetIdentityPoolConfigurationInput) String() string {
 // GoString returns the string representation
 func (s SetIdentityPoolConfigurationInput) GoString() string {
 	return s.String()
+}
+
+// Validate inspects the fields of the type to determine if they are valid.
+func (s *SetIdentityPoolConfigurationInput) Validate() error {
+	invalidParams := request.ErrInvalidParams{Context: "SetIdentityPoolConfigurationInput"}
+	if s.IdentityPoolId == nil {
+		invalidParams.Add(request.NewErrParamRequired("IdentityPoolId"))
+	}
+	if s.IdentityPoolId != nil && len(*s.IdentityPoolId) < 1 {
+		invalidParams.Add(request.NewErrParamMinLen("IdentityPoolId", 1))
+	}
+	if s.CognitoStreams != nil {
+		if err := s.CognitoStreams.Validate(); err != nil {
+			invalidParams.AddNested("CognitoStreams", err.(request.ErrInvalidParams))
+		}
+	}
+	if s.PushSync != nil {
+		if err := s.PushSync.Validate(); err != nil {
+			invalidParams.AddNested("PushSync", err.(request.ErrInvalidParams))
+		}
+	}
+
+	if invalidParams.Len() > 0 {
+		return invalidParams
+	}
+	return nil
 }
 
 // The output for the SetIdentityPoolConfiguration operation
@@ -1479,6 +1812,40 @@ func (s SubscribeToDatasetInput) GoString() string {
 	return s.String()
 }
 
+// Validate inspects the fields of the type to determine if they are valid.
+func (s *SubscribeToDatasetInput) Validate() error {
+	invalidParams := request.ErrInvalidParams{Context: "SubscribeToDatasetInput"}
+	if s.DatasetName == nil {
+		invalidParams.Add(request.NewErrParamRequired("DatasetName"))
+	}
+	if s.DatasetName != nil && len(*s.DatasetName) < 1 {
+		invalidParams.Add(request.NewErrParamMinLen("DatasetName", 1))
+	}
+	if s.DeviceId == nil {
+		invalidParams.Add(request.NewErrParamRequired("DeviceId"))
+	}
+	if s.DeviceId != nil && len(*s.DeviceId) < 1 {
+		invalidParams.Add(request.NewErrParamMinLen("DeviceId", 1))
+	}
+	if s.IdentityId == nil {
+		invalidParams.Add(request.NewErrParamRequired("IdentityId"))
+	}
+	if s.IdentityId != nil && len(*s.IdentityId) < 1 {
+		invalidParams.Add(request.NewErrParamMinLen("IdentityId", 1))
+	}
+	if s.IdentityPoolId == nil {
+		invalidParams.Add(request.NewErrParamRequired("IdentityPoolId"))
+	}
+	if s.IdentityPoolId != nil && len(*s.IdentityPoolId) < 1 {
+		invalidParams.Add(request.NewErrParamMinLen("IdentityPoolId", 1))
+	}
+
+	if invalidParams.Len() > 0 {
+		return invalidParams
+	}
+	return nil
+}
+
 // Response to a SubscribeToDataset request.
 type SubscribeToDatasetOutput struct {
 	_ struct{} `type:"structure"`
@@ -1520,6 +1887,40 @@ func (s UnsubscribeFromDatasetInput) String() string {
 // GoString returns the string representation
 func (s UnsubscribeFromDatasetInput) GoString() string {
 	return s.String()
+}
+
+// Validate inspects the fields of the type to determine if they are valid.
+func (s *UnsubscribeFromDatasetInput) Validate() error {
+	invalidParams := request.ErrInvalidParams{Context: "UnsubscribeFromDatasetInput"}
+	if s.DatasetName == nil {
+		invalidParams.Add(request.NewErrParamRequired("DatasetName"))
+	}
+	if s.DatasetName != nil && len(*s.DatasetName) < 1 {
+		invalidParams.Add(request.NewErrParamMinLen("DatasetName", 1))
+	}
+	if s.DeviceId == nil {
+		invalidParams.Add(request.NewErrParamRequired("DeviceId"))
+	}
+	if s.DeviceId != nil && len(*s.DeviceId) < 1 {
+		invalidParams.Add(request.NewErrParamMinLen("DeviceId", 1))
+	}
+	if s.IdentityId == nil {
+		invalidParams.Add(request.NewErrParamRequired("IdentityId"))
+	}
+	if s.IdentityId != nil && len(*s.IdentityId) < 1 {
+		invalidParams.Add(request.NewErrParamMinLen("IdentityId", 1))
+	}
+	if s.IdentityPoolId == nil {
+		invalidParams.Add(request.NewErrParamRequired("IdentityPoolId"))
+	}
+	if s.IdentityPoolId != nil && len(*s.IdentityPoolId) < 1 {
+		invalidParams.Add(request.NewErrParamMinLen("IdentityPoolId", 1))
+	}
+
+	if invalidParams.Len() > 0 {
+		return invalidParams
+	}
+	return nil
 }
 
 // Response to an UnsubscribeFromDataset request.
@@ -1577,6 +1978,50 @@ func (s UpdateRecordsInput) String() string {
 // GoString returns the string representation
 func (s UpdateRecordsInput) GoString() string {
 	return s.String()
+}
+
+// Validate inspects the fields of the type to determine if they are valid.
+func (s *UpdateRecordsInput) Validate() error {
+	invalidParams := request.ErrInvalidParams{Context: "UpdateRecordsInput"}
+	if s.DatasetName == nil {
+		invalidParams.Add(request.NewErrParamRequired("DatasetName"))
+	}
+	if s.DatasetName != nil && len(*s.DatasetName) < 1 {
+		invalidParams.Add(request.NewErrParamMinLen("DatasetName", 1))
+	}
+	if s.DeviceId != nil && len(*s.DeviceId) < 1 {
+		invalidParams.Add(request.NewErrParamMinLen("DeviceId", 1))
+	}
+	if s.IdentityId == nil {
+		invalidParams.Add(request.NewErrParamRequired("IdentityId"))
+	}
+	if s.IdentityId != nil && len(*s.IdentityId) < 1 {
+		invalidParams.Add(request.NewErrParamMinLen("IdentityId", 1))
+	}
+	if s.IdentityPoolId == nil {
+		invalidParams.Add(request.NewErrParamRequired("IdentityPoolId"))
+	}
+	if s.IdentityPoolId != nil && len(*s.IdentityPoolId) < 1 {
+		invalidParams.Add(request.NewErrParamMinLen("IdentityPoolId", 1))
+	}
+	if s.SyncSessionToken == nil {
+		invalidParams.Add(request.NewErrParamRequired("SyncSessionToken"))
+	}
+	if s.RecordPatches != nil {
+		for i, v := range s.RecordPatches {
+			if v == nil {
+				continue
+			}
+			if err := v.Validate(); err != nil {
+				invalidParams.AddNested(fmt.Sprintf("%s[%v]", "RecordPatches", i), err.(request.ErrInvalidParams))
+			}
+		}
+	}
+
+	if invalidParams.Len() > 0 {
+		return invalidParams
+	}
+	return nil
 }
 
 // Returned for a successful UpdateRecordsRequest.

--- a/service/configservice/api.go
+++ b/service/configservice/api.go
@@ -4,6 +4,7 @@
 package configservice
 
 import (
+	"fmt"
 	"time"
 
 	"github.com/aws/aws-sdk-go/aws/awsutil"
@@ -1089,6 +1090,35 @@ func (s ConfigRule) GoString() string {
 	return s.String()
 }
 
+// Validate inspects the fields of the type to determine if they are valid.
+func (s *ConfigRule) Validate() error {
+	invalidParams := request.ErrInvalidParams{Context: "ConfigRule"}
+	if s.ConfigRuleName != nil && len(*s.ConfigRuleName) < 1 {
+		invalidParams.Add(request.NewErrParamMinLen("ConfigRuleName", 1))
+	}
+	if s.InputParameters != nil && len(*s.InputParameters) < 1 {
+		invalidParams.Add(request.NewErrParamMinLen("InputParameters", 1))
+	}
+	if s.Source == nil {
+		invalidParams.Add(request.NewErrParamRequired("Source"))
+	}
+	if s.Scope != nil {
+		if err := s.Scope.Validate(); err != nil {
+			invalidParams.AddNested("Scope", err.(request.ErrInvalidParams))
+		}
+	}
+	if s.Source != nil {
+		if err := s.Source.Validate(); err != nil {
+			invalidParams.AddNested("Source", err.(request.ErrInvalidParams))
+		}
+	}
+
+	if invalidParams.Len() > 0 {
+		return invalidParams
+	}
+	return nil
+}
+
 // Status information for your AWS managed Config rules. The status includes
 // information such as the last time the rule ran, the last time it failed,
 // and the related error for the last failure.
@@ -1312,6 +1342,19 @@ func (s ConfigurationRecorder) GoString() string {
 	return s.String()
 }
 
+// Validate inspects the fields of the type to determine if they are valid.
+func (s *ConfigurationRecorder) Validate() error {
+	invalidParams := request.ErrInvalidParams{Context: "ConfigurationRecorder"}
+	if s.Name != nil && len(*s.Name) < 1 {
+		invalidParams.Add(request.NewErrParamMinLen("Name", 1))
+	}
+
+	if invalidParams.Len() > 0 {
+		return invalidParams
+	}
+	return nil
+}
+
 // The current status of the configuration recorder.
 type ConfigurationRecorderStatus struct {
 	_ struct{} `type:"structure"`
@@ -1368,6 +1411,22 @@ func (s DeleteConfigRuleInput) GoString() string {
 	return s.String()
 }
 
+// Validate inspects the fields of the type to determine if they are valid.
+func (s *DeleteConfigRuleInput) Validate() error {
+	invalidParams := request.ErrInvalidParams{Context: "DeleteConfigRuleInput"}
+	if s.ConfigRuleName == nil {
+		invalidParams.Add(request.NewErrParamRequired("ConfigRuleName"))
+	}
+	if s.ConfigRuleName != nil && len(*s.ConfigRuleName) < 1 {
+		invalidParams.Add(request.NewErrParamMinLen("ConfigRuleName", 1))
+	}
+
+	if invalidParams.Len() > 0 {
+		return invalidParams
+	}
+	return nil
+}
+
 type DeleteConfigRuleOutput struct {
 	_ struct{} `type:"structure"`
 }
@@ -1401,6 +1460,22 @@ func (s DeleteDeliveryChannelInput) GoString() string {
 	return s.String()
 }
 
+// Validate inspects the fields of the type to determine if they are valid.
+func (s *DeleteDeliveryChannelInput) Validate() error {
+	invalidParams := request.ErrInvalidParams{Context: "DeleteDeliveryChannelInput"}
+	if s.DeliveryChannelName == nil {
+		invalidParams.Add(request.NewErrParamRequired("DeliveryChannelName"))
+	}
+	if s.DeliveryChannelName != nil && len(*s.DeliveryChannelName) < 1 {
+		invalidParams.Add(request.NewErrParamMinLen("DeliveryChannelName", 1))
+	}
+
+	if invalidParams.Len() > 0 {
+		return invalidParams
+	}
+	return nil
+}
+
 type DeleteDeliveryChannelOutput struct {
 	_ struct{} `type:"structure"`
 }
@@ -1431,6 +1506,22 @@ func (s DeliverConfigSnapshotInput) String() string {
 // GoString returns the string representation
 func (s DeliverConfigSnapshotInput) GoString() string {
 	return s.String()
+}
+
+// Validate inspects the fields of the type to determine if they are valid.
+func (s *DeliverConfigSnapshotInput) Validate() error {
+	invalidParams := request.ErrInvalidParams{Context: "DeliverConfigSnapshotInput"}
+	if s.DeliveryChannelName == nil {
+		invalidParams.Add(request.NewErrParamRequired("DeliveryChannelName"))
+	}
+	if s.DeliveryChannelName != nil && len(*s.DeliveryChannelName) < 1 {
+		invalidParams.Add(request.NewErrParamMinLen("DeliveryChannelName", 1))
+	}
+
+	if invalidParams.Len() > 0 {
+		return invalidParams
+	}
+	return nil
 }
 
 // The output for the DeliverConfigSnapshot action in JSON format.
@@ -1485,6 +1576,19 @@ func (s DeliveryChannel) String() string {
 // GoString returns the string representation
 func (s DeliveryChannel) GoString() string {
 	return s.String()
+}
+
+// Validate inspects the fields of the type to determine if they are valid.
+func (s *DeliveryChannel) Validate() error {
+	invalidParams := request.ErrInvalidParams{Context: "DeliveryChannel"}
+	if s.Name != nil && len(*s.Name) < 1 {
+		invalidParams.Add(request.NewErrParamMinLen("Name", 1))
+	}
+
+	if invalidParams.Len() > 0 {
+		return invalidParams
+	}
+	return nil
 }
 
 // The status of a specified delivery channel.
@@ -1602,6 +1706,22 @@ func (s DescribeComplianceByResourceInput) String() string {
 // GoString returns the string representation
 func (s DescribeComplianceByResourceInput) GoString() string {
 	return s.String()
+}
+
+// Validate inspects the fields of the type to determine if they are valid.
+func (s *DescribeComplianceByResourceInput) Validate() error {
+	invalidParams := request.ErrInvalidParams{Context: "DescribeComplianceByResourceInput"}
+	if s.ResourceId != nil && len(*s.ResourceId) < 1 {
+		invalidParams.Add(request.NewErrParamMinLen("ResourceId", 1))
+	}
+	if s.ResourceType != nil && len(*s.ResourceType) < 1 {
+		invalidParams.Add(request.NewErrParamMinLen("ResourceType", 1))
+	}
+
+	if invalidParams.Len() > 0 {
+		return invalidParams
+	}
+	return nil
 }
 
 type DescribeComplianceByResourceOutput struct {
@@ -1895,6 +2015,37 @@ func (s Evaluation) GoString() string {
 	return s.String()
 }
 
+// Validate inspects the fields of the type to determine if they are valid.
+func (s *Evaluation) Validate() error {
+	invalidParams := request.ErrInvalidParams{Context: "Evaluation"}
+	if s.Annotation != nil && len(*s.Annotation) < 1 {
+		invalidParams.Add(request.NewErrParamMinLen("Annotation", 1))
+	}
+	if s.ComplianceResourceId == nil {
+		invalidParams.Add(request.NewErrParamRequired("ComplianceResourceId"))
+	}
+	if s.ComplianceResourceId != nil && len(*s.ComplianceResourceId) < 1 {
+		invalidParams.Add(request.NewErrParamMinLen("ComplianceResourceId", 1))
+	}
+	if s.ComplianceResourceType == nil {
+		invalidParams.Add(request.NewErrParamRequired("ComplianceResourceType"))
+	}
+	if s.ComplianceResourceType != nil && len(*s.ComplianceResourceType) < 1 {
+		invalidParams.Add(request.NewErrParamMinLen("ComplianceResourceType", 1))
+	}
+	if s.ComplianceType == nil {
+		invalidParams.Add(request.NewErrParamRequired("ComplianceType"))
+	}
+	if s.OrderingTimestamp == nil {
+		invalidParams.Add(request.NewErrParamRequired("OrderingTimestamp"))
+	}
+
+	if invalidParams.Len() > 0 {
+		return invalidParams
+	}
+	return nil
+}
+
 // The details of an AWS Config evaluation. Provides the AWS resource that was
 // evaluated, the compliance of the resource, related timestamps, and supplementary
 // information.
@@ -2018,6 +2169,22 @@ func (s GetComplianceDetailsByConfigRuleInput) GoString() string {
 	return s.String()
 }
 
+// Validate inspects the fields of the type to determine if they are valid.
+func (s *GetComplianceDetailsByConfigRuleInput) Validate() error {
+	invalidParams := request.ErrInvalidParams{Context: "GetComplianceDetailsByConfigRuleInput"}
+	if s.ConfigRuleName == nil {
+		invalidParams.Add(request.NewErrParamRequired("ConfigRuleName"))
+	}
+	if s.ConfigRuleName != nil && len(*s.ConfigRuleName) < 1 {
+		invalidParams.Add(request.NewErrParamMinLen("ConfigRuleName", 1))
+	}
+
+	if invalidParams.Len() > 0 {
+		return invalidParams
+	}
+	return nil
+}
+
 type GetComplianceDetailsByConfigRuleOutput struct {
 	_ struct{} `type:"structure"`
 
@@ -2067,6 +2234,28 @@ func (s GetComplianceDetailsByResourceInput) String() string {
 // GoString returns the string representation
 func (s GetComplianceDetailsByResourceInput) GoString() string {
 	return s.String()
+}
+
+// Validate inspects the fields of the type to determine if they are valid.
+func (s *GetComplianceDetailsByResourceInput) Validate() error {
+	invalidParams := request.ErrInvalidParams{Context: "GetComplianceDetailsByResourceInput"}
+	if s.ResourceId == nil {
+		invalidParams.Add(request.NewErrParamRequired("ResourceId"))
+	}
+	if s.ResourceId != nil && len(*s.ResourceId) < 1 {
+		invalidParams.Add(request.NewErrParamMinLen("ResourceId", 1))
+	}
+	if s.ResourceType == nil {
+		invalidParams.Add(request.NewErrParamRequired("ResourceType"))
+	}
+	if s.ResourceType != nil && len(*s.ResourceType) < 1 {
+		invalidParams.Add(request.NewErrParamMinLen("ResourceType", 1))
+	}
+
+	if invalidParams.Len() > 0 {
+		return invalidParams
+	}
+	return nil
 }
 
 type GetComplianceDetailsByResourceOutput struct {
@@ -2206,6 +2395,22 @@ func (s GetResourceConfigHistoryInput) GoString() string {
 	return s.String()
 }
 
+// Validate inspects the fields of the type to determine if they are valid.
+func (s *GetResourceConfigHistoryInput) Validate() error {
+	invalidParams := request.ErrInvalidParams{Context: "GetResourceConfigHistoryInput"}
+	if s.ResourceId == nil {
+		invalidParams.Add(request.NewErrParamRequired("ResourceId"))
+	}
+	if s.ResourceType == nil {
+		invalidParams.Add(request.NewErrParamRequired("ResourceType"))
+	}
+
+	if invalidParams.Len() > 0 {
+		return invalidParams
+	}
+	return nil
+}
+
 // The output for the GetResourceConfigHistory action.
 type GetResourceConfigHistoryOutput struct {
 	_ struct{} `type:"structure"`
@@ -2268,6 +2473,19 @@ func (s ListDiscoveredResourcesInput) GoString() string {
 	return s.String()
 }
 
+// Validate inspects the fields of the type to determine if they are valid.
+func (s *ListDiscoveredResourcesInput) Validate() error {
+	invalidParams := request.ErrInvalidParams{Context: "ListDiscoveredResourcesInput"}
+	if s.ResourceType == nil {
+		invalidParams.Add(request.NewErrParamRequired("ResourceType"))
+	}
+
+	if invalidParams.Len() > 0 {
+		return invalidParams
+	}
+	return nil
+}
+
 type ListDiscoveredResourcesOutput struct {
 	_ struct{} `type:"structure"`
 
@@ -2314,6 +2532,24 @@ func (s PutConfigRuleInput) GoString() string {
 	return s.String()
 }
 
+// Validate inspects the fields of the type to determine if they are valid.
+func (s *PutConfigRuleInput) Validate() error {
+	invalidParams := request.ErrInvalidParams{Context: "PutConfigRuleInput"}
+	if s.ConfigRule == nil {
+		invalidParams.Add(request.NewErrParamRequired("ConfigRule"))
+	}
+	if s.ConfigRule != nil {
+		if err := s.ConfigRule.Validate(); err != nil {
+			invalidParams.AddNested("ConfigRule", err.(request.ErrInvalidParams))
+		}
+	}
+
+	if invalidParams.Len() > 0 {
+		return invalidParams
+	}
+	return nil
+}
+
 type PutConfigRuleOutput struct {
 	_ struct{} `type:"structure"`
 }
@@ -2347,6 +2583,24 @@ func (s PutConfigurationRecorderInput) GoString() string {
 	return s.String()
 }
 
+// Validate inspects the fields of the type to determine if they are valid.
+func (s *PutConfigurationRecorderInput) Validate() error {
+	invalidParams := request.ErrInvalidParams{Context: "PutConfigurationRecorderInput"}
+	if s.ConfigurationRecorder == nil {
+		invalidParams.Add(request.NewErrParamRequired("ConfigurationRecorder"))
+	}
+	if s.ConfigurationRecorder != nil {
+		if err := s.ConfigurationRecorder.Validate(); err != nil {
+			invalidParams.AddNested("ConfigurationRecorder", err.(request.ErrInvalidParams))
+		}
+	}
+
+	if invalidParams.Len() > 0 {
+		return invalidParams
+	}
+	return nil
+}
+
 type PutConfigurationRecorderOutput struct {
 	_ struct{} `type:"structure"`
 }
@@ -2378,6 +2632,24 @@ func (s PutDeliveryChannelInput) String() string {
 // GoString returns the string representation
 func (s PutDeliveryChannelInput) GoString() string {
 	return s.String()
+}
+
+// Validate inspects the fields of the type to determine if they are valid.
+func (s *PutDeliveryChannelInput) Validate() error {
+	invalidParams := request.ErrInvalidParams{Context: "PutDeliveryChannelInput"}
+	if s.DeliveryChannel == nil {
+		invalidParams.Add(request.NewErrParamRequired("DeliveryChannel"))
+	}
+	if s.DeliveryChannel != nil {
+		if err := s.DeliveryChannel.Validate(); err != nil {
+			invalidParams.AddNested("DeliveryChannel", err.(request.ErrInvalidParams))
+		}
+	}
+
+	if invalidParams.Len() > 0 {
+		return invalidParams
+	}
+	return nil
 }
 
 type PutDeliveryChannelOutput struct {
@@ -2415,6 +2687,29 @@ func (s PutEvaluationsInput) String() string {
 // GoString returns the string representation
 func (s PutEvaluationsInput) GoString() string {
 	return s.String()
+}
+
+// Validate inspects the fields of the type to determine if they are valid.
+func (s *PutEvaluationsInput) Validate() error {
+	invalidParams := request.ErrInvalidParams{Context: "PutEvaluationsInput"}
+	if s.ResultToken == nil {
+		invalidParams.Add(request.NewErrParamRequired("ResultToken"))
+	}
+	if s.Evaluations != nil {
+		for i, v := range s.Evaluations {
+			if v == nil {
+				continue
+			}
+			if err := v.Validate(); err != nil {
+				invalidParams.AddNested(fmt.Sprintf("%s[%v]", "Evaluations", i), err.(request.ErrInvalidParams))
+			}
+		}
+	}
+
+	if invalidParams.Len() > 0 {
+		return invalidParams
+	}
+	return nil
 }
 
 type PutEvaluationsOutput struct {
@@ -2610,6 +2905,25 @@ func (s Scope) GoString() string {
 	return s.String()
 }
 
+// Validate inspects the fields of the type to determine if they are valid.
+func (s *Scope) Validate() error {
+	invalidParams := request.ErrInvalidParams{Context: "Scope"}
+	if s.ComplianceResourceId != nil && len(*s.ComplianceResourceId) < 1 {
+		invalidParams.Add(request.NewErrParamMinLen("ComplianceResourceId", 1))
+	}
+	if s.TagKey != nil && len(*s.TagKey) < 1 {
+		invalidParams.Add(request.NewErrParamMinLen("TagKey", 1))
+	}
+	if s.TagValue != nil && len(*s.TagValue) < 1 {
+		invalidParams.Add(request.NewErrParamMinLen("TagValue", 1))
+	}
+
+	if invalidParams.Len() > 0 {
+		return invalidParams
+	}
+	return nil
+}
+
 // Provides the AWS Config rule owner (AWS or customer), the rule identifier,
 // and the events that trigger the evaluation of your AWS resources.
 type Source struct {
@@ -2638,6 +2952,19 @@ func (s Source) String() string {
 // GoString returns the string representation
 func (s Source) GoString() string {
 	return s.String()
+}
+
+// Validate inspects the fields of the type to determine if they are valid.
+func (s *Source) Validate() error {
+	invalidParams := request.ErrInvalidParams{Context: "Source"}
+	if s.SourceIdentifier != nil && len(*s.SourceIdentifier) < 1 {
+		invalidParams.Add(request.NewErrParamMinLen("SourceIdentifier", 1))
+	}
+
+	if invalidParams.Len() > 0 {
+		return invalidParams
+	}
+	return nil
 }
 
 // Provides the source and type of the event that triggers AWS Config to evaluate
@@ -2686,6 +3013,22 @@ func (s StartConfigurationRecorderInput) GoString() string {
 	return s.String()
 }
 
+// Validate inspects the fields of the type to determine if they are valid.
+func (s *StartConfigurationRecorderInput) Validate() error {
+	invalidParams := request.ErrInvalidParams{Context: "StartConfigurationRecorderInput"}
+	if s.ConfigurationRecorderName == nil {
+		invalidParams.Add(request.NewErrParamRequired("ConfigurationRecorderName"))
+	}
+	if s.ConfigurationRecorderName != nil && len(*s.ConfigurationRecorderName) < 1 {
+		invalidParams.Add(request.NewErrParamMinLen("ConfigurationRecorderName", 1))
+	}
+
+	if invalidParams.Len() > 0 {
+		return invalidParams
+	}
+	return nil
+}
+
 type StartConfigurationRecorderOutput struct {
 	_ struct{} `type:"structure"`
 }
@@ -2717,6 +3060,22 @@ func (s StopConfigurationRecorderInput) String() string {
 // GoString returns the string representation
 func (s StopConfigurationRecorderInput) GoString() string {
 	return s.String()
+}
+
+// Validate inspects the fields of the type to determine if they are valid.
+func (s *StopConfigurationRecorderInput) Validate() error {
+	invalidParams := request.ErrInvalidParams{Context: "StopConfigurationRecorderInput"}
+	if s.ConfigurationRecorderName == nil {
+		invalidParams.Add(request.NewErrParamRequired("ConfigurationRecorderName"))
+	}
+	if s.ConfigurationRecorderName != nil && len(*s.ConfigurationRecorderName) < 1 {
+		invalidParams.Add(request.NewErrParamMinLen("ConfigurationRecorderName", 1))
+	}
+
+	if invalidParams.Len() > 0 {
+		return invalidParams
+	}
+	return nil
 }
 
 type StopConfigurationRecorderOutput struct {

--- a/service/databasemigrationservice/api.go
+++ b/service/databasemigrationservice/api.go
@@ -4,6 +4,7 @@
 package databasemigrationservice
 
 import (
+	"fmt"
 	"time"
 
 	"github.com/aws/aws-sdk-go/aws/awsutil"
@@ -865,6 +866,22 @@ func (s AddTagsToResourceInput) GoString() string {
 	return s.String()
 }
 
+// Validate inspects the fields of the type to determine if they are valid.
+func (s *AddTagsToResourceInput) Validate() error {
+	invalidParams := request.ErrInvalidParams{Context: "AddTagsToResourceInput"}
+	if s.ResourceArn == nil {
+		invalidParams.Add(request.NewErrParamRequired("ResourceArn"))
+	}
+	if s.Tags == nil {
+		invalidParams.Add(request.NewErrParamRequired("Tags"))
+	}
+
+	if invalidParams.Len() > 0 {
+		return invalidParams
+	}
+	return nil
+}
+
 type AddTagsToResourceOutput struct {
 	_ struct{} `type:"structure"`
 }
@@ -985,6 +1002,37 @@ func (s CreateEndpointInput) GoString() string {
 	return s.String()
 }
 
+// Validate inspects the fields of the type to determine if they are valid.
+func (s *CreateEndpointInput) Validate() error {
+	invalidParams := request.ErrInvalidParams{Context: "CreateEndpointInput"}
+	if s.EndpointIdentifier == nil {
+		invalidParams.Add(request.NewErrParamRequired("EndpointIdentifier"))
+	}
+	if s.EndpointType == nil {
+		invalidParams.Add(request.NewErrParamRequired("EndpointType"))
+	}
+	if s.EngineName == nil {
+		invalidParams.Add(request.NewErrParamRequired("EngineName"))
+	}
+	if s.Password == nil {
+		invalidParams.Add(request.NewErrParamRequired("Password"))
+	}
+	if s.Port == nil {
+		invalidParams.Add(request.NewErrParamRequired("Port"))
+	}
+	if s.ServerName == nil {
+		invalidParams.Add(request.NewErrParamRequired("ServerName"))
+	}
+	if s.Username == nil {
+		invalidParams.Add(request.NewErrParamRequired("Username"))
+	}
+
+	if invalidParams.Len() > 0 {
+		return invalidParams
+	}
+	return nil
+}
+
 type CreateEndpointOutput struct {
 	_ struct{} `type:"structure"`
 
@@ -1084,6 +1132,22 @@ func (s CreateReplicationInstanceInput) GoString() string {
 	return s.String()
 }
 
+// Validate inspects the fields of the type to determine if they are valid.
+func (s *CreateReplicationInstanceInput) Validate() error {
+	invalidParams := request.ErrInvalidParams{Context: "CreateReplicationInstanceInput"}
+	if s.ReplicationInstanceClass == nil {
+		invalidParams.Add(request.NewErrParamRequired("ReplicationInstanceClass"))
+	}
+	if s.ReplicationInstanceIdentifier == nil {
+		invalidParams.Add(request.NewErrParamRequired("ReplicationInstanceIdentifier"))
+	}
+
+	if invalidParams.Len() > 0 {
+		return invalidParams
+	}
+	return nil
+}
+
 type CreateReplicationInstanceOutput struct {
 	_ struct{} `type:"structure"`
 
@@ -1131,6 +1195,25 @@ func (s CreateReplicationSubnetGroupInput) String() string {
 // GoString returns the string representation
 func (s CreateReplicationSubnetGroupInput) GoString() string {
 	return s.String()
+}
+
+// Validate inspects the fields of the type to determine if they are valid.
+func (s *CreateReplicationSubnetGroupInput) Validate() error {
+	invalidParams := request.ErrInvalidParams{Context: "CreateReplicationSubnetGroupInput"}
+	if s.ReplicationSubnetGroupDescription == nil {
+		invalidParams.Add(request.NewErrParamRequired("ReplicationSubnetGroupDescription"))
+	}
+	if s.ReplicationSubnetGroupIdentifier == nil {
+		invalidParams.Add(request.NewErrParamRequired("ReplicationSubnetGroupIdentifier"))
+	}
+	if s.SubnetIds == nil {
+		invalidParams.Add(request.NewErrParamRequired("SubnetIds"))
+	}
+
+	if invalidParams.Len() > 0 {
+		return invalidParams
+	}
+	return nil
 }
 
 type CreateReplicationSubnetGroupOutput struct {
@@ -1196,6 +1279,34 @@ func (s CreateReplicationTaskInput) GoString() string {
 	return s.String()
 }
 
+// Validate inspects the fields of the type to determine if they are valid.
+func (s *CreateReplicationTaskInput) Validate() error {
+	invalidParams := request.ErrInvalidParams{Context: "CreateReplicationTaskInput"}
+	if s.MigrationType == nil {
+		invalidParams.Add(request.NewErrParamRequired("MigrationType"))
+	}
+	if s.ReplicationInstanceArn == nil {
+		invalidParams.Add(request.NewErrParamRequired("ReplicationInstanceArn"))
+	}
+	if s.ReplicationTaskIdentifier == nil {
+		invalidParams.Add(request.NewErrParamRequired("ReplicationTaskIdentifier"))
+	}
+	if s.SourceEndpointArn == nil {
+		invalidParams.Add(request.NewErrParamRequired("SourceEndpointArn"))
+	}
+	if s.TableMappings == nil {
+		invalidParams.Add(request.NewErrParamRequired("TableMappings"))
+	}
+	if s.TargetEndpointArn == nil {
+		invalidParams.Add(request.NewErrParamRequired("TargetEndpointArn"))
+	}
+
+	if invalidParams.Len() > 0 {
+		return invalidParams
+	}
+	return nil
+}
+
 type CreateReplicationTaskOutput struct {
 	_ struct{} `type:"structure"`
 
@@ -1228,6 +1339,19 @@ func (s DeleteEndpointInput) String() string {
 // GoString returns the string representation
 func (s DeleteEndpointInput) GoString() string {
 	return s.String()
+}
+
+// Validate inspects the fields of the type to determine if they are valid.
+func (s *DeleteEndpointInput) Validate() error {
+	invalidParams := request.ErrInvalidParams{Context: "DeleteEndpointInput"}
+	if s.EndpointArn == nil {
+		invalidParams.Add(request.NewErrParamRequired("EndpointArn"))
+	}
+
+	if invalidParams.Len() > 0 {
+		return invalidParams
+	}
+	return nil
 }
 
 type DeleteEndpointOutput struct {
@@ -1264,6 +1388,19 @@ func (s DeleteReplicationInstanceInput) GoString() string {
 	return s.String()
 }
 
+// Validate inspects the fields of the type to determine if they are valid.
+func (s *DeleteReplicationInstanceInput) Validate() error {
+	invalidParams := request.ErrInvalidParams{Context: "DeleteReplicationInstanceInput"}
+	if s.ReplicationInstanceArn == nil {
+		invalidParams.Add(request.NewErrParamRequired("ReplicationInstanceArn"))
+	}
+
+	if invalidParams.Len() > 0 {
+		return invalidParams
+	}
+	return nil
+}
+
 type DeleteReplicationInstanceOutput struct {
 	_ struct{} `type:"structure"`
 
@@ -1298,6 +1435,19 @@ func (s DeleteReplicationSubnetGroupInput) GoString() string {
 	return s.String()
 }
 
+// Validate inspects the fields of the type to determine if they are valid.
+func (s *DeleteReplicationSubnetGroupInput) Validate() error {
+	invalidParams := request.ErrInvalidParams{Context: "DeleteReplicationSubnetGroupInput"}
+	if s.ReplicationSubnetGroupIdentifier == nil {
+		invalidParams.Add(request.NewErrParamRequired("ReplicationSubnetGroupIdentifier"))
+	}
+
+	if invalidParams.Len() > 0 {
+		return invalidParams
+	}
+	return nil
+}
+
 type DeleteReplicationSubnetGroupOutput struct {
 	_ struct{} `type:"structure"`
 }
@@ -1327,6 +1477,19 @@ func (s DeleteReplicationTaskInput) String() string {
 // GoString returns the string representation
 func (s DeleteReplicationTaskInput) GoString() string {
 	return s.String()
+}
+
+// Validate inspects the fields of the type to determine if they are valid.
+func (s *DeleteReplicationTaskInput) Validate() error {
+	invalidParams := request.ErrInvalidParams{Context: "DeleteReplicationTaskInput"}
+	if s.ReplicationTaskArn == nil {
+		invalidParams.Add(request.NewErrParamRequired("ReplicationTaskArn"))
+	}
+
+	if invalidParams.Len() > 0 {
+		return invalidParams
+	}
+	return nil
 }
 
 type DeleteReplicationTaskOutput struct {
@@ -1410,6 +1573,26 @@ func (s DescribeConnectionsInput) GoString() string {
 	return s.String()
 }
 
+// Validate inspects the fields of the type to determine if they are valid.
+func (s *DescribeConnectionsInput) Validate() error {
+	invalidParams := request.ErrInvalidParams{Context: "DescribeConnectionsInput"}
+	if s.Filters != nil {
+		for i, v := range s.Filters {
+			if v == nil {
+				continue
+			}
+			if err := v.Validate(); err != nil {
+				invalidParams.AddNested(fmt.Sprintf("%s[%v]", "Filters", i), err.(request.ErrInvalidParams))
+			}
+		}
+	}
+
+	if invalidParams.Len() > 0 {
+		return invalidParams
+	}
+	return nil
+}
+
 type DescribeConnectionsOutput struct {
 	_ struct{} `type:"structure"`
 
@@ -1465,6 +1648,26 @@ func (s DescribeEndpointTypesInput) GoString() string {
 	return s.String()
 }
 
+// Validate inspects the fields of the type to determine if they are valid.
+func (s *DescribeEndpointTypesInput) Validate() error {
+	invalidParams := request.ErrInvalidParams{Context: "DescribeEndpointTypesInput"}
+	if s.Filters != nil {
+		for i, v := range s.Filters {
+			if v == nil {
+				continue
+			}
+			if err := v.Validate(); err != nil {
+				invalidParams.AddNested(fmt.Sprintf("%s[%v]", "Filters", i), err.(request.ErrInvalidParams))
+			}
+		}
+	}
+
+	if invalidParams.Len() > 0 {
+		return invalidParams
+	}
+	return nil
+}
+
 type DescribeEndpointTypesOutput struct {
 	_ struct{} `type:"structure"`
 
@@ -1518,6 +1721,26 @@ func (s DescribeEndpointsInput) String() string {
 // GoString returns the string representation
 func (s DescribeEndpointsInput) GoString() string {
 	return s.String()
+}
+
+// Validate inspects the fields of the type to determine if they are valid.
+func (s *DescribeEndpointsInput) Validate() error {
+	invalidParams := request.ErrInvalidParams{Context: "DescribeEndpointsInput"}
+	if s.Filters != nil {
+		for i, v := range s.Filters {
+			if v == nil {
+				continue
+			}
+			if err := v.Validate(); err != nil {
+				invalidParams.AddNested(fmt.Sprintf("%s[%v]", "Filters", i), err.(request.ErrInvalidParams))
+			}
+		}
+	}
+
+	if invalidParams.Len() > 0 {
+		return invalidParams
+	}
+	return nil
 }
 
 type DescribeEndpointsOutput struct {
@@ -1609,6 +1832,19 @@ func (s DescribeRefreshSchemasStatusInput) GoString() string {
 	return s.String()
 }
 
+// Validate inspects the fields of the type to determine if they are valid.
+func (s *DescribeRefreshSchemasStatusInput) Validate() error {
+	invalidParams := request.ErrInvalidParams{Context: "DescribeRefreshSchemasStatusInput"}
+	if s.EndpointArn == nil {
+		invalidParams.Add(request.NewErrParamRequired("EndpointArn"))
+	}
+
+	if invalidParams.Len() > 0 {
+		return invalidParams
+	}
+	return nil
+}
+
 type DescribeRefreshSchemasStatusOutput struct {
 	_ struct{} `type:"structure"`
 
@@ -1658,6 +1894,26 @@ func (s DescribeReplicationInstancesInput) String() string {
 // GoString returns the string representation
 func (s DescribeReplicationInstancesInput) GoString() string {
 	return s.String()
+}
+
+// Validate inspects the fields of the type to determine if they are valid.
+func (s *DescribeReplicationInstancesInput) Validate() error {
+	invalidParams := request.ErrInvalidParams{Context: "DescribeReplicationInstancesInput"}
+	if s.Filters != nil {
+		for i, v := range s.Filters {
+			if v == nil {
+				continue
+			}
+			if err := v.Validate(); err != nil {
+				invalidParams.AddNested(fmt.Sprintf("%s[%v]", "Filters", i), err.(request.ErrInvalidParams))
+			}
+		}
+	}
+
+	if invalidParams.Len() > 0 {
+		return invalidParams
+	}
+	return nil
 }
 
 type DescribeReplicationInstancesOutput struct {
@@ -1711,6 +1967,26 @@ func (s DescribeReplicationSubnetGroupsInput) String() string {
 // GoString returns the string representation
 func (s DescribeReplicationSubnetGroupsInput) GoString() string {
 	return s.String()
+}
+
+// Validate inspects the fields of the type to determine if they are valid.
+func (s *DescribeReplicationSubnetGroupsInput) Validate() error {
+	invalidParams := request.ErrInvalidParams{Context: "DescribeReplicationSubnetGroupsInput"}
+	if s.Filters != nil {
+		for i, v := range s.Filters {
+			if v == nil {
+				continue
+			}
+			if err := v.Validate(); err != nil {
+				invalidParams.AddNested(fmt.Sprintf("%s[%v]", "Filters", i), err.(request.ErrInvalidParams))
+			}
+		}
+	}
+
+	if invalidParams.Len() > 0 {
+		return invalidParams
+	}
+	return nil
 }
 
 type DescribeReplicationSubnetGroupsOutput struct {
@@ -1769,6 +2045,26 @@ func (s DescribeReplicationTasksInput) GoString() string {
 	return s.String()
 }
 
+// Validate inspects the fields of the type to determine if they are valid.
+func (s *DescribeReplicationTasksInput) Validate() error {
+	invalidParams := request.ErrInvalidParams{Context: "DescribeReplicationTasksInput"}
+	if s.Filters != nil {
+		for i, v := range s.Filters {
+			if v == nil {
+				continue
+			}
+			if err := v.Validate(); err != nil {
+				invalidParams.AddNested(fmt.Sprintf("%s[%v]", "Filters", i), err.(request.ErrInvalidParams))
+			}
+		}
+	}
+
+	if invalidParams.Len() > 0 {
+		return invalidParams
+	}
+	return nil
+}
+
 type DescribeReplicationTasksOutput struct {
 	_ struct{} `type:"structure"`
 
@@ -1822,6 +2118,19 @@ func (s DescribeSchemasInput) GoString() string {
 	return s.String()
 }
 
+// Validate inspects the fields of the type to determine if they are valid.
+func (s *DescribeSchemasInput) Validate() error {
+	invalidParams := request.ErrInvalidParams{Context: "DescribeSchemasInput"}
+	if s.EndpointArn == nil {
+		invalidParams.Add(request.NewErrParamRequired("EndpointArn"))
+	}
+
+	if invalidParams.Len() > 0 {
+		return invalidParams
+	}
+	return nil
+}
+
 type DescribeSchemasOutput struct {
 	_ struct{} `type:"structure"`
 
@@ -1873,6 +2182,19 @@ func (s DescribeTableStatisticsInput) String() string {
 // GoString returns the string representation
 func (s DescribeTableStatisticsInput) GoString() string {
 	return s.String()
+}
+
+// Validate inspects the fields of the type to determine if they are valid.
+func (s *DescribeTableStatisticsInput) Validate() error {
+	invalidParams := request.ErrInvalidParams{Context: "DescribeTableStatisticsInput"}
+	if s.ReplicationTaskArn == nil {
+		invalidParams.Add(request.NewErrParamRequired("ReplicationTaskArn"))
+	}
+
+	if invalidParams.Len() > 0 {
+		return invalidParams
+	}
+	return nil
 }
 
 type DescribeTableStatisticsOutput struct {
@@ -1973,6 +2295,22 @@ func (s Filter) GoString() string {
 	return s.String()
 }
 
+// Validate inspects the fields of the type to determine if they are valid.
+func (s *Filter) Validate() error {
+	invalidParams := request.ErrInvalidParams{Context: "Filter"}
+	if s.Name == nil {
+		invalidParams.Add(request.NewErrParamRequired("Name"))
+	}
+	if s.Values == nil {
+		invalidParams.Add(request.NewErrParamRequired("Values"))
+	}
+
+	if invalidParams.Len() > 0 {
+		return invalidParams
+	}
+	return nil
+}
+
 type ListTagsForResourceInput struct {
 	_ struct{} `type:"structure"`
 
@@ -1989,6 +2327,19 @@ func (s ListTagsForResourceInput) String() string {
 // GoString returns the string representation
 func (s ListTagsForResourceInput) GoString() string {
 	return s.String()
+}
+
+// Validate inspects the fields of the type to determine if they are valid.
+func (s *ListTagsForResourceInput) Validate() error {
+	invalidParams := request.ErrInvalidParams{Context: "ListTagsForResourceInput"}
+	if s.ResourceArn == nil {
+		invalidParams.Add(request.NewErrParamRequired("ResourceArn"))
+	}
+
+	if invalidParams.Len() > 0 {
+		return invalidParams
+	}
+	return nil
 }
 
 type ListTagsForResourceOutput struct {
@@ -2053,6 +2404,19 @@ func (s ModifyEndpointInput) String() string {
 // GoString returns the string representation
 func (s ModifyEndpointInput) GoString() string {
 	return s.String()
+}
+
+// Validate inspects the fields of the type to determine if they are valid.
+func (s *ModifyEndpointInput) Validate() error {
+	invalidParams := request.ErrInvalidParams{Context: "ModifyEndpointInput"}
+	if s.EndpointArn == nil {
+		invalidParams.Add(request.NewErrParamRequired("EndpointArn"))
+	}
+
+	if invalidParams.Len() > 0 {
+		return invalidParams
+	}
+	return nil
 }
 
 type ModifyEndpointOutput struct {
@@ -2144,6 +2508,19 @@ func (s ModifyReplicationInstanceInput) GoString() string {
 	return s.String()
 }
 
+// Validate inspects the fields of the type to determine if they are valid.
+func (s *ModifyReplicationInstanceInput) Validate() error {
+	invalidParams := request.ErrInvalidParams{Context: "ModifyReplicationInstanceInput"}
+	if s.ReplicationInstanceArn == nil {
+		invalidParams.Add(request.NewErrParamRequired("ReplicationInstanceArn"))
+	}
+
+	if invalidParams.Len() > 0 {
+		return invalidParams
+	}
+	return nil
+}
+
 type ModifyReplicationInstanceOutput struct {
 	_ struct{} `type:"structure"`
 
@@ -2182,6 +2559,22 @@ func (s ModifyReplicationSubnetGroupInput) String() string {
 // GoString returns the string representation
 func (s ModifyReplicationSubnetGroupInput) GoString() string {
 	return s.String()
+}
+
+// Validate inspects the fields of the type to determine if they are valid.
+func (s *ModifyReplicationSubnetGroupInput) Validate() error {
+	invalidParams := request.ErrInvalidParams{Context: "ModifyReplicationSubnetGroupInput"}
+	if s.ReplicationSubnetGroupIdentifier == nil {
+		invalidParams.Add(request.NewErrParamRequired("ReplicationSubnetGroupIdentifier"))
+	}
+	if s.SubnetIds == nil {
+		invalidParams.Add(request.NewErrParamRequired("SubnetIds"))
+	}
+
+	if invalidParams.Len() > 0 {
+		return invalidParams
+	}
+	return nil
 }
 
 type ModifyReplicationSubnetGroupOutput struct {
@@ -2263,6 +2656,22 @@ func (s RefreshSchemasInput) GoString() string {
 	return s.String()
 }
 
+// Validate inspects the fields of the type to determine if they are valid.
+func (s *RefreshSchemasInput) Validate() error {
+	invalidParams := request.ErrInvalidParams{Context: "RefreshSchemasInput"}
+	if s.EndpointArn == nil {
+		invalidParams.Add(request.NewErrParamRequired("EndpointArn"))
+	}
+	if s.ReplicationInstanceArn == nil {
+		invalidParams.Add(request.NewErrParamRequired("ReplicationInstanceArn"))
+	}
+
+	if invalidParams.Len() > 0 {
+		return invalidParams
+	}
+	return nil
+}
+
 type RefreshSchemasOutput struct {
 	_ struct{} `type:"structure"`
 
@@ -2328,6 +2737,22 @@ func (s RemoveTagsFromResourceInput) String() string {
 // GoString returns the string representation
 func (s RemoveTagsFromResourceInput) GoString() string {
 	return s.String()
+}
+
+// Validate inspects the fields of the type to determine if they are valid.
+func (s *RemoveTagsFromResourceInput) Validate() error {
+	invalidParams := request.ErrInvalidParams{Context: "RemoveTagsFromResourceInput"}
+	if s.ResourceArn == nil {
+		invalidParams.Add(request.NewErrParamRequired("ResourceArn"))
+	}
+	if s.TagKeys == nil {
+		invalidParams.Add(request.NewErrParamRequired("TagKeys"))
+	}
+
+	if invalidParams.Len() > 0 {
+		return invalidParams
+	}
+	return nil
 }
 
 type RemoveTagsFromResourceOutput struct {
@@ -2594,6 +3019,22 @@ func (s StartReplicationTaskInput) GoString() string {
 	return s.String()
 }
 
+// Validate inspects the fields of the type to determine if they are valid.
+func (s *StartReplicationTaskInput) Validate() error {
+	invalidParams := request.ErrInvalidParams{Context: "StartReplicationTaskInput"}
+	if s.ReplicationTaskArn == nil {
+		invalidParams.Add(request.NewErrParamRequired("ReplicationTaskArn"))
+	}
+	if s.StartReplicationTaskType == nil {
+		invalidParams.Add(request.NewErrParamRequired("StartReplicationTaskType"))
+	}
+
+	if invalidParams.Len() > 0 {
+		return invalidParams
+	}
+	return nil
+}
+
 type StartReplicationTaskOutput struct {
 	_ struct{} `type:"structure"`
 
@@ -2626,6 +3067,19 @@ func (s StopReplicationTaskInput) String() string {
 // GoString returns the string representation
 func (s StopReplicationTaskInput) GoString() string {
 	return s.String()
+}
+
+// Validate inspects the fields of the type to determine if they are valid.
+func (s *StopReplicationTaskInput) Validate() error {
+	invalidParams := request.ErrInvalidParams{Context: "StopReplicationTaskInput"}
+	if s.ReplicationTaskArn == nil {
+		invalidParams.Add(request.NewErrParamRequired("ReplicationTaskArn"))
+	}
+
+	if invalidParams.Len() > 0 {
+		return invalidParams
+	}
+	return nil
 }
 
 type StopReplicationTaskOutput struct {
@@ -2777,6 +3231,22 @@ func (s TestConnectionInput) String() string {
 // GoString returns the string representation
 func (s TestConnectionInput) GoString() string {
 	return s.String()
+}
+
+// Validate inspects the fields of the type to determine if they are valid.
+func (s *TestConnectionInput) Validate() error {
+	invalidParams := request.ErrInvalidParams{Context: "TestConnectionInput"}
+	if s.EndpointArn == nil {
+		invalidParams.Add(request.NewErrParamRequired("EndpointArn"))
+	}
+	if s.ReplicationInstanceArn == nil {
+		invalidParams.Add(request.NewErrParamRequired("ReplicationInstanceArn"))
+	}
+
+	if invalidParams.Len() > 0 {
+		return invalidParams
+	}
+	return nil
 }
 
 type TestConnectionOutput struct {

--- a/service/datapipeline/api.go
+++ b/service/datapipeline/api.go
@@ -4,6 +4,7 @@
 package datapipeline
 
 import (
+	"fmt"
 	"time"
 
 	"github.com/aws/aws-sdk-go/aws/awsutil"
@@ -679,6 +680,32 @@ func (s ActivatePipelineInput) GoString() string {
 	return s.String()
 }
 
+// Validate inspects the fields of the type to determine if they are valid.
+func (s *ActivatePipelineInput) Validate() error {
+	invalidParams := request.ErrInvalidParams{Context: "ActivatePipelineInput"}
+	if s.PipelineId == nil {
+		invalidParams.Add(request.NewErrParamRequired("PipelineId"))
+	}
+	if s.PipelineId != nil && len(*s.PipelineId) < 1 {
+		invalidParams.Add(request.NewErrParamMinLen("PipelineId", 1))
+	}
+	if s.ParameterValues != nil {
+		for i, v := range s.ParameterValues {
+			if v == nil {
+				continue
+			}
+			if err := v.Validate(); err != nil {
+				invalidParams.AddNested(fmt.Sprintf("%s[%v]", "ParameterValues", i), err.(request.ErrInvalidParams))
+			}
+		}
+	}
+
+	if invalidParams.Len() > 0 {
+		return invalidParams
+	}
+	return nil
+}
+
 // Contains the output of ActivatePipeline.
 type ActivatePipelineOutput struct {
 	_ struct{} `type:"structure"`
@@ -713,6 +740,35 @@ func (s AddTagsInput) String() string {
 // GoString returns the string representation
 func (s AddTagsInput) GoString() string {
 	return s.String()
+}
+
+// Validate inspects the fields of the type to determine if they are valid.
+func (s *AddTagsInput) Validate() error {
+	invalidParams := request.ErrInvalidParams{Context: "AddTagsInput"}
+	if s.PipelineId == nil {
+		invalidParams.Add(request.NewErrParamRequired("PipelineId"))
+	}
+	if s.PipelineId != nil && len(*s.PipelineId) < 1 {
+		invalidParams.Add(request.NewErrParamMinLen("PipelineId", 1))
+	}
+	if s.Tags == nil {
+		invalidParams.Add(request.NewErrParamRequired("Tags"))
+	}
+	if s.Tags != nil {
+		for i, v := range s.Tags {
+			if v == nil {
+				continue
+			}
+			if err := v.Validate(); err != nil {
+				invalidParams.AddNested(fmt.Sprintf("%s[%v]", "Tags", i), err.(request.ErrInvalidParams))
+			}
+		}
+	}
+
+	if invalidParams.Len() > 0 {
+		return invalidParams
+	}
+	return nil
 }
 
 // Contains the output of AddTags.
@@ -772,6 +828,38 @@ func (s CreatePipelineInput) GoString() string {
 	return s.String()
 }
 
+// Validate inspects the fields of the type to determine if they are valid.
+func (s *CreatePipelineInput) Validate() error {
+	invalidParams := request.ErrInvalidParams{Context: "CreatePipelineInput"}
+	if s.Name == nil {
+		invalidParams.Add(request.NewErrParamRequired("Name"))
+	}
+	if s.Name != nil && len(*s.Name) < 1 {
+		invalidParams.Add(request.NewErrParamMinLen("Name", 1))
+	}
+	if s.UniqueId == nil {
+		invalidParams.Add(request.NewErrParamRequired("UniqueId"))
+	}
+	if s.UniqueId != nil && len(*s.UniqueId) < 1 {
+		invalidParams.Add(request.NewErrParamMinLen("UniqueId", 1))
+	}
+	if s.Tags != nil {
+		for i, v := range s.Tags {
+			if v == nil {
+				continue
+			}
+			if err := v.Validate(); err != nil {
+				invalidParams.AddNested(fmt.Sprintf("%s[%v]", "Tags", i), err.(request.ErrInvalidParams))
+			}
+		}
+	}
+
+	if invalidParams.Len() > 0 {
+		return invalidParams
+	}
+	return nil
+}
+
 // Contains the output of CreatePipeline.
 type CreatePipelineOutput struct {
 	_ struct{} `type:"structure"`
@@ -814,6 +902,22 @@ func (s DeactivatePipelineInput) GoString() string {
 	return s.String()
 }
 
+// Validate inspects the fields of the type to determine if they are valid.
+func (s *DeactivatePipelineInput) Validate() error {
+	invalidParams := request.ErrInvalidParams{Context: "DeactivatePipelineInput"}
+	if s.PipelineId == nil {
+		invalidParams.Add(request.NewErrParamRequired("PipelineId"))
+	}
+	if s.PipelineId != nil && len(*s.PipelineId) < 1 {
+		invalidParams.Add(request.NewErrParamMinLen("PipelineId", 1))
+	}
+
+	if invalidParams.Len() > 0 {
+		return invalidParams
+	}
+	return nil
+}
+
 // Contains the output of DeactivatePipeline.
 type DeactivatePipelineOutput struct {
 	_ struct{} `type:"structure"`
@@ -845,6 +949,22 @@ func (s DeletePipelineInput) String() string {
 // GoString returns the string representation
 func (s DeletePipelineInput) GoString() string {
 	return s.String()
+}
+
+// Validate inspects the fields of the type to determine if they are valid.
+func (s *DeletePipelineInput) Validate() error {
+	invalidParams := request.ErrInvalidParams{Context: "DeletePipelineInput"}
+	if s.PipelineId == nil {
+		invalidParams.Add(request.NewErrParamRequired("PipelineId"))
+	}
+	if s.PipelineId != nil && len(*s.PipelineId) < 1 {
+		invalidParams.Add(request.NewErrParamMinLen("PipelineId", 1))
+	}
+
+	if invalidParams.Len() > 0 {
+		return invalidParams
+	}
+	return nil
 }
 
 type DeletePipelineOutput struct {
@@ -893,6 +1013,25 @@ func (s DescribeObjectsInput) GoString() string {
 	return s.String()
 }
 
+// Validate inspects the fields of the type to determine if they are valid.
+func (s *DescribeObjectsInput) Validate() error {
+	invalidParams := request.ErrInvalidParams{Context: "DescribeObjectsInput"}
+	if s.ObjectIds == nil {
+		invalidParams.Add(request.NewErrParamRequired("ObjectIds"))
+	}
+	if s.PipelineId == nil {
+		invalidParams.Add(request.NewErrParamRequired("PipelineId"))
+	}
+	if s.PipelineId != nil && len(*s.PipelineId) < 1 {
+		invalidParams.Add(request.NewErrParamMinLen("PipelineId", 1))
+	}
+
+	if invalidParams.Len() > 0 {
+		return invalidParams
+	}
+	return nil
+}
+
 // Contains the output of DescribeObjects.
 type DescribeObjectsOutput struct {
 	_ struct{} `type:"structure"`
@@ -938,6 +1077,19 @@ func (s DescribePipelinesInput) GoString() string {
 	return s.String()
 }
 
+// Validate inspects the fields of the type to determine if they are valid.
+func (s *DescribePipelinesInput) Validate() error {
+	invalidParams := request.ErrInvalidParams{Context: "DescribePipelinesInput"}
+	if s.PipelineIds == nil {
+		invalidParams.Add(request.NewErrParamRequired("PipelineIds"))
+	}
+
+	if invalidParams.Len() > 0 {
+		return invalidParams
+	}
+	return nil
+}
+
 // Contains the output of DescribePipelines.
 type DescribePipelinesOutput struct {
 	_ struct{} `type:"structure"`
@@ -978,6 +1130,31 @@ func (s EvaluateExpressionInput) String() string {
 // GoString returns the string representation
 func (s EvaluateExpressionInput) GoString() string {
 	return s.String()
+}
+
+// Validate inspects the fields of the type to determine if they are valid.
+func (s *EvaluateExpressionInput) Validate() error {
+	invalidParams := request.ErrInvalidParams{Context: "EvaluateExpressionInput"}
+	if s.Expression == nil {
+		invalidParams.Add(request.NewErrParamRequired("Expression"))
+	}
+	if s.ObjectId == nil {
+		invalidParams.Add(request.NewErrParamRequired("ObjectId"))
+	}
+	if s.ObjectId != nil && len(*s.ObjectId) < 1 {
+		invalidParams.Add(request.NewErrParamMinLen("ObjectId", 1))
+	}
+	if s.PipelineId == nil {
+		invalidParams.Add(request.NewErrParamRequired("PipelineId"))
+	}
+	if s.PipelineId != nil && len(*s.PipelineId) < 1 {
+		invalidParams.Add(request.NewErrParamMinLen("PipelineId", 1))
+	}
+
+	if invalidParams.Len() > 0 {
+		return invalidParams
+	}
+	return nil
 }
 
 // Contains the output of EvaluateExpression.
@@ -1024,6 +1201,25 @@ func (s Field) GoString() string {
 	return s.String()
 }
 
+// Validate inspects the fields of the type to determine if they are valid.
+func (s *Field) Validate() error {
+	invalidParams := request.ErrInvalidParams{Context: "Field"}
+	if s.Key == nil {
+		invalidParams.Add(request.NewErrParamRequired("Key"))
+	}
+	if s.Key != nil && len(*s.Key) < 1 {
+		invalidParams.Add(request.NewErrParamMinLen("Key", 1))
+	}
+	if s.RefValue != nil && len(*s.RefValue) < 1 {
+		invalidParams.Add(request.NewErrParamMinLen("RefValue", 1))
+	}
+
+	if invalidParams.Len() > 0 {
+		return invalidParams
+	}
+	return nil
+}
+
 // Contains the parameters for GetPipelineDefinition.
 type GetPipelineDefinitionInput struct {
 	_ struct{} `type:"structure"`
@@ -1045,6 +1241,22 @@ func (s GetPipelineDefinitionInput) String() string {
 // GoString returns the string representation
 func (s GetPipelineDefinitionInput) GoString() string {
 	return s.String()
+}
+
+// Validate inspects the fields of the type to determine if they are valid.
+func (s *GetPipelineDefinitionInput) Validate() error {
+	invalidParams := request.ErrInvalidParams{Context: "GetPipelineDefinitionInput"}
+	if s.PipelineId == nil {
+		invalidParams.Add(request.NewErrParamRequired("PipelineId"))
+	}
+	if s.PipelineId != nil && len(*s.PipelineId) < 1 {
+		invalidParams.Add(request.NewErrParamMinLen("PipelineId", 1))
+	}
+
+	if invalidParams.Len() > 0 {
+		return invalidParams
+	}
+	return nil
 }
 
 // Contains the output of GetPipelineDefinition.
@@ -1209,6 +1421,25 @@ func (s ParameterAttribute) GoString() string {
 	return s.String()
 }
 
+// Validate inspects the fields of the type to determine if they are valid.
+func (s *ParameterAttribute) Validate() error {
+	invalidParams := request.ErrInvalidParams{Context: "ParameterAttribute"}
+	if s.Key == nil {
+		invalidParams.Add(request.NewErrParamRequired("Key"))
+	}
+	if s.Key != nil && len(*s.Key) < 1 {
+		invalidParams.Add(request.NewErrParamMinLen("Key", 1))
+	}
+	if s.StringValue == nil {
+		invalidParams.Add(request.NewErrParamRequired("StringValue"))
+	}
+
+	if invalidParams.Len() > 0 {
+		return invalidParams
+	}
+	return nil
+}
+
 // Contains information about a parameter object.
 type ParameterObject struct {
 	_ struct{} `type:"structure"`
@@ -1230,6 +1461,35 @@ func (s ParameterObject) GoString() string {
 	return s.String()
 }
 
+// Validate inspects the fields of the type to determine if they are valid.
+func (s *ParameterObject) Validate() error {
+	invalidParams := request.ErrInvalidParams{Context: "ParameterObject"}
+	if s.Attributes == nil {
+		invalidParams.Add(request.NewErrParamRequired("Attributes"))
+	}
+	if s.Id == nil {
+		invalidParams.Add(request.NewErrParamRequired("Id"))
+	}
+	if s.Id != nil && len(*s.Id) < 1 {
+		invalidParams.Add(request.NewErrParamMinLen("Id", 1))
+	}
+	if s.Attributes != nil {
+		for i, v := range s.Attributes {
+			if v == nil {
+				continue
+			}
+			if err := v.Validate(); err != nil {
+				invalidParams.AddNested(fmt.Sprintf("%s[%v]", "Attributes", i), err.(request.ErrInvalidParams))
+			}
+		}
+	}
+
+	if invalidParams.Len() > 0 {
+		return invalidParams
+	}
+	return nil
+}
+
 // A value or list of parameter values.
 type ParameterValue struct {
 	_ struct{} `type:"structure"`
@@ -1249,6 +1509,25 @@ func (s ParameterValue) String() string {
 // GoString returns the string representation
 func (s ParameterValue) GoString() string {
 	return s.String()
+}
+
+// Validate inspects the fields of the type to determine if they are valid.
+func (s *ParameterValue) Validate() error {
+	invalidParams := request.ErrInvalidParams{Context: "ParameterValue"}
+	if s.Id == nil {
+		invalidParams.Add(request.NewErrParamRequired("Id"))
+	}
+	if s.Id != nil && len(*s.Id) < 1 {
+		invalidParams.Add(request.NewErrParamMinLen("Id", 1))
+	}
+	if s.StringValue == nil {
+		invalidParams.Add(request.NewErrParamRequired("StringValue"))
+	}
+
+	if invalidParams.Len() > 0 {
+		return invalidParams
+	}
+	return nil
 }
 
 // Contains pipeline metadata.
@@ -1334,6 +1613,41 @@ func (s PipelineObject) GoString() string {
 	return s.String()
 }
 
+// Validate inspects the fields of the type to determine if they are valid.
+func (s *PipelineObject) Validate() error {
+	invalidParams := request.ErrInvalidParams{Context: "PipelineObject"}
+	if s.Fields == nil {
+		invalidParams.Add(request.NewErrParamRequired("Fields"))
+	}
+	if s.Id == nil {
+		invalidParams.Add(request.NewErrParamRequired("Id"))
+	}
+	if s.Id != nil && len(*s.Id) < 1 {
+		invalidParams.Add(request.NewErrParamMinLen("Id", 1))
+	}
+	if s.Name == nil {
+		invalidParams.Add(request.NewErrParamRequired("Name"))
+	}
+	if s.Name != nil && len(*s.Name) < 1 {
+		invalidParams.Add(request.NewErrParamMinLen("Name", 1))
+	}
+	if s.Fields != nil {
+		for i, v := range s.Fields {
+			if v == nil {
+				continue
+			}
+			if err := v.Validate(); err != nil {
+				invalidParams.AddNested(fmt.Sprintf("%s[%v]", "Fields", i), err.(request.ErrInvalidParams))
+			}
+		}
+	}
+
+	if invalidParams.Len() > 0 {
+		return invalidParams
+	}
+	return nil
+}
+
 // Contains the parameters for PollForTask.
 type PollForTaskInput struct {
 	_ struct{} `type:"structure"`
@@ -1365,6 +1679,22 @@ func (s PollForTaskInput) String() string {
 // GoString returns the string representation
 func (s PollForTaskInput) GoString() string {
 	return s.String()
+}
+
+// Validate inspects the fields of the type to determine if they are valid.
+func (s *PollForTaskInput) Validate() error {
+	invalidParams := request.ErrInvalidParams{Context: "PollForTaskInput"}
+	if s.Hostname != nil && len(*s.Hostname) < 1 {
+		invalidParams.Add(request.NewErrParamMinLen("Hostname", 1))
+	}
+	if s.WorkerGroup == nil {
+		invalidParams.Add(request.NewErrParamRequired("WorkerGroup"))
+	}
+
+	if invalidParams.Len() > 0 {
+		return invalidParams
+	}
+	return nil
 }
 
 // Contains the output of PollForTask.
@@ -1414,6 +1744,55 @@ func (s PutPipelineDefinitionInput) String() string {
 // GoString returns the string representation
 func (s PutPipelineDefinitionInput) GoString() string {
 	return s.String()
+}
+
+// Validate inspects the fields of the type to determine if they are valid.
+func (s *PutPipelineDefinitionInput) Validate() error {
+	invalidParams := request.ErrInvalidParams{Context: "PutPipelineDefinitionInput"}
+	if s.PipelineId == nil {
+		invalidParams.Add(request.NewErrParamRequired("PipelineId"))
+	}
+	if s.PipelineId != nil && len(*s.PipelineId) < 1 {
+		invalidParams.Add(request.NewErrParamMinLen("PipelineId", 1))
+	}
+	if s.PipelineObjects == nil {
+		invalidParams.Add(request.NewErrParamRequired("PipelineObjects"))
+	}
+	if s.ParameterObjects != nil {
+		for i, v := range s.ParameterObjects {
+			if v == nil {
+				continue
+			}
+			if err := v.Validate(); err != nil {
+				invalidParams.AddNested(fmt.Sprintf("%s[%v]", "ParameterObjects", i), err.(request.ErrInvalidParams))
+			}
+		}
+	}
+	if s.ParameterValues != nil {
+		for i, v := range s.ParameterValues {
+			if v == nil {
+				continue
+			}
+			if err := v.Validate(); err != nil {
+				invalidParams.AddNested(fmt.Sprintf("%s[%v]", "ParameterValues", i), err.(request.ErrInvalidParams))
+			}
+		}
+	}
+	if s.PipelineObjects != nil {
+		for i, v := range s.PipelineObjects {
+			if v == nil {
+				continue
+			}
+			if err := v.Validate(); err != nil {
+				invalidParams.AddNested(fmt.Sprintf("%s[%v]", "PipelineObjects", i), err.(request.ErrInvalidParams))
+			}
+		}
+	}
+
+	if invalidParams.Len() > 0 {
+		return invalidParams
+	}
+	return nil
 }
 
 // Contains the output of PutPipelineDefinition.
@@ -1499,6 +1878,25 @@ func (s QueryObjectsInput) GoString() string {
 	return s.String()
 }
 
+// Validate inspects the fields of the type to determine if they are valid.
+func (s *QueryObjectsInput) Validate() error {
+	invalidParams := request.ErrInvalidParams{Context: "QueryObjectsInput"}
+	if s.PipelineId == nil {
+		invalidParams.Add(request.NewErrParamRequired("PipelineId"))
+	}
+	if s.PipelineId != nil && len(*s.PipelineId) < 1 {
+		invalidParams.Add(request.NewErrParamMinLen("PipelineId", 1))
+	}
+	if s.Sphere == nil {
+		invalidParams.Add(request.NewErrParamRequired("Sphere"))
+	}
+
+	if invalidParams.Len() > 0 {
+		return invalidParams
+	}
+	return nil
+}
+
 // Contains the output of QueryObjects.
 type QueryObjectsOutput struct {
 	_ struct{} `type:"structure"`
@@ -1547,6 +1945,25 @@ func (s RemoveTagsInput) GoString() string {
 	return s.String()
 }
 
+// Validate inspects the fields of the type to determine if they are valid.
+func (s *RemoveTagsInput) Validate() error {
+	invalidParams := request.ErrInvalidParams{Context: "RemoveTagsInput"}
+	if s.PipelineId == nil {
+		invalidParams.Add(request.NewErrParamRequired("PipelineId"))
+	}
+	if s.PipelineId != nil && len(*s.PipelineId) < 1 {
+		invalidParams.Add(request.NewErrParamMinLen("PipelineId", 1))
+	}
+	if s.TagKeys == nil {
+		invalidParams.Add(request.NewErrParamRequired("TagKeys"))
+	}
+
+	if invalidParams.Len() > 0 {
+		return invalidParams
+	}
+	return nil
+}
+
 // Contains the output of RemoveTags.
 type RemoveTagsOutput struct {
 	_ struct{} `type:"structure"`
@@ -1583,6 +2000,32 @@ func (s ReportTaskProgressInput) String() string {
 // GoString returns the string representation
 func (s ReportTaskProgressInput) GoString() string {
 	return s.String()
+}
+
+// Validate inspects the fields of the type to determine if they are valid.
+func (s *ReportTaskProgressInput) Validate() error {
+	invalidParams := request.ErrInvalidParams{Context: "ReportTaskProgressInput"}
+	if s.TaskId == nil {
+		invalidParams.Add(request.NewErrParamRequired("TaskId"))
+	}
+	if s.TaskId != nil && len(*s.TaskId) < 1 {
+		invalidParams.Add(request.NewErrParamMinLen("TaskId", 1))
+	}
+	if s.Fields != nil {
+		for i, v := range s.Fields {
+			if v == nil {
+				continue
+			}
+			if err := v.Validate(); err != nil {
+				invalidParams.AddNested(fmt.Sprintf("%s[%v]", "Fields", i), err.(request.ErrInvalidParams))
+			}
+		}
+	}
+
+	if invalidParams.Len() > 0 {
+		return invalidParams
+	}
+	return nil
 }
 
 // Contains the output of ReportTaskProgress.
@@ -1634,6 +2077,25 @@ func (s ReportTaskRunnerHeartbeatInput) String() string {
 // GoString returns the string representation
 func (s ReportTaskRunnerHeartbeatInput) GoString() string {
 	return s.String()
+}
+
+// Validate inspects the fields of the type to determine if they are valid.
+func (s *ReportTaskRunnerHeartbeatInput) Validate() error {
+	invalidParams := request.ErrInvalidParams{Context: "ReportTaskRunnerHeartbeatInput"}
+	if s.Hostname != nil && len(*s.Hostname) < 1 {
+		invalidParams.Add(request.NewErrParamMinLen("Hostname", 1))
+	}
+	if s.TaskrunnerId == nil {
+		invalidParams.Add(request.NewErrParamRequired("TaskrunnerId"))
+	}
+	if s.TaskrunnerId != nil && len(*s.TaskrunnerId) < 1 {
+		invalidParams.Add(request.NewErrParamMinLen("TaskrunnerId", 1))
+	}
+
+	if invalidParams.Len() > 0 {
+		return invalidParams
+	}
+	return nil
 }
 
 // Contains the output of ReportTaskRunnerHeartbeat.
@@ -1706,6 +2168,28 @@ func (s SetStatusInput) GoString() string {
 	return s.String()
 }
 
+// Validate inspects the fields of the type to determine if they are valid.
+func (s *SetStatusInput) Validate() error {
+	invalidParams := request.ErrInvalidParams{Context: "SetStatusInput"}
+	if s.ObjectIds == nil {
+		invalidParams.Add(request.NewErrParamRequired("ObjectIds"))
+	}
+	if s.PipelineId == nil {
+		invalidParams.Add(request.NewErrParamRequired("PipelineId"))
+	}
+	if s.PipelineId != nil && len(*s.PipelineId) < 1 {
+		invalidParams.Add(request.NewErrParamMinLen("PipelineId", 1))
+	}
+	if s.Status == nil {
+		invalidParams.Add(request.NewErrParamRequired("Status"))
+	}
+
+	if invalidParams.Len() > 0 {
+		return invalidParams
+	}
+	return nil
+}
+
 type SetStatusOutput struct {
 	_ struct{} `type:"structure"`
 }
@@ -1761,6 +2245,25 @@ func (s SetTaskStatusInput) GoString() string {
 	return s.String()
 }
 
+// Validate inspects the fields of the type to determine if they are valid.
+func (s *SetTaskStatusInput) Validate() error {
+	invalidParams := request.ErrInvalidParams{Context: "SetTaskStatusInput"}
+	if s.TaskId == nil {
+		invalidParams.Add(request.NewErrParamRequired("TaskId"))
+	}
+	if s.TaskId != nil && len(*s.TaskId) < 1 {
+		invalidParams.Add(request.NewErrParamMinLen("TaskId", 1))
+	}
+	if s.TaskStatus == nil {
+		invalidParams.Add(request.NewErrParamRequired("TaskStatus"))
+	}
+
+	if invalidParams.Len() > 0 {
+		return invalidParams
+	}
+	return nil
+}
+
 // Contains the output of SetTaskStatus.
 type SetTaskStatusOutput struct {
 	_ struct{} `type:"structure"`
@@ -1803,6 +2306,25 @@ func (s Tag) String() string {
 // GoString returns the string representation
 func (s Tag) GoString() string {
 	return s.String()
+}
+
+// Validate inspects the fields of the type to determine if they are valid.
+func (s *Tag) Validate() error {
+	invalidParams := request.ErrInvalidParams{Context: "Tag"}
+	if s.Key == nil {
+		invalidParams.Add(request.NewErrParamRequired("Key"))
+	}
+	if s.Key != nil && len(*s.Key) < 1 {
+		invalidParams.Add(request.NewErrParamMinLen("Key", 1))
+	}
+	if s.Value == nil {
+		invalidParams.Add(request.NewErrParamRequired("Value"))
+	}
+
+	if invalidParams.Len() > 0 {
+		return invalidParams
+	}
+	return nil
 }
 
 // Contains information about a pipeline task that is assigned to a task runner.
@@ -1860,6 +2382,55 @@ func (s ValidatePipelineDefinitionInput) String() string {
 // GoString returns the string representation
 func (s ValidatePipelineDefinitionInput) GoString() string {
 	return s.String()
+}
+
+// Validate inspects the fields of the type to determine if they are valid.
+func (s *ValidatePipelineDefinitionInput) Validate() error {
+	invalidParams := request.ErrInvalidParams{Context: "ValidatePipelineDefinitionInput"}
+	if s.PipelineId == nil {
+		invalidParams.Add(request.NewErrParamRequired("PipelineId"))
+	}
+	if s.PipelineId != nil && len(*s.PipelineId) < 1 {
+		invalidParams.Add(request.NewErrParamMinLen("PipelineId", 1))
+	}
+	if s.PipelineObjects == nil {
+		invalidParams.Add(request.NewErrParamRequired("PipelineObjects"))
+	}
+	if s.ParameterObjects != nil {
+		for i, v := range s.ParameterObjects {
+			if v == nil {
+				continue
+			}
+			if err := v.Validate(); err != nil {
+				invalidParams.AddNested(fmt.Sprintf("%s[%v]", "ParameterObjects", i), err.(request.ErrInvalidParams))
+			}
+		}
+	}
+	if s.ParameterValues != nil {
+		for i, v := range s.ParameterValues {
+			if v == nil {
+				continue
+			}
+			if err := v.Validate(); err != nil {
+				invalidParams.AddNested(fmt.Sprintf("%s[%v]", "ParameterValues", i), err.(request.ErrInvalidParams))
+			}
+		}
+	}
+	if s.PipelineObjects != nil {
+		for i, v := range s.PipelineObjects {
+			if v == nil {
+				continue
+			}
+			if err := v.Validate(); err != nil {
+				invalidParams.AddNested(fmt.Sprintf("%s[%v]", "PipelineObjects", i), err.(request.ErrInvalidParams))
+			}
+		}
+	}
+
+	if invalidParams.Len() > 0 {
+		return invalidParams
+	}
+	return nil
 }
 
 // Contains the output of ValidatePipelineDefinition.

--- a/service/devicefarm/api.go
+++ b/service/devicefarm/api.go
@@ -1437,6 +1437,28 @@ func (s CreateDevicePoolInput) GoString() string {
 	return s.String()
 }
 
+// Validate inspects the fields of the type to determine if they are valid.
+func (s *CreateDevicePoolInput) Validate() error {
+	invalidParams := request.ErrInvalidParams{Context: "CreateDevicePoolInput"}
+	if s.Name == nil {
+		invalidParams.Add(request.NewErrParamRequired("Name"))
+	}
+	if s.ProjectArn == nil {
+		invalidParams.Add(request.NewErrParamRequired("ProjectArn"))
+	}
+	if s.ProjectArn != nil && len(*s.ProjectArn) < 32 {
+		invalidParams.Add(request.NewErrParamMinLen("ProjectArn", 32))
+	}
+	if s.Rules == nil {
+		invalidParams.Add(request.NewErrParamRequired("Rules"))
+	}
+
+	if invalidParams.Len() > 0 {
+		return invalidParams
+	}
+	return nil
+}
+
 // Represents the result of a create device pool request.
 type CreateDevicePoolOutput struct {
 	_ struct{} `type:"structure"`
@@ -1471,6 +1493,19 @@ func (s CreateProjectInput) String() string {
 // GoString returns the string representation
 func (s CreateProjectInput) GoString() string {
 	return s.String()
+}
+
+// Validate inspects the fields of the type to determine if they are valid.
+func (s *CreateProjectInput) Validate() error {
+	invalidParams := request.ErrInvalidParams{Context: "CreateProjectInput"}
+	if s.Name == nil {
+		invalidParams.Add(request.NewErrParamRequired("Name"))
+	}
+
+	if invalidParams.Len() > 0 {
+		return invalidParams
+	}
+	return nil
 }
 
 // Represents the result of a create project request.
@@ -1556,6 +1591,28 @@ func (s CreateUploadInput) GoString() string {
 	return s.String()
 }
 
+// Validate inspects the fields of the type to determine if they are valid.
+func (s *CreateUploadInput) Validate() error {
+	invalidParams := request.ErrInvalidParams{Context: "CreateUploadInput"}
+	if s.Name == nil {
+		invalidParams.Add(request.NewErrParamRequired("Name"))
+	}
+	if s.ProjectArn == nil {
+		invalidParams.Add(request.NewErrParamRequired("ProjectArn"))
+	}
+	if s.ProjectArn != nil && len(*s.ProjectArn) < 32 {
+		invalidParams.Add(request.NewErrParamMinLen("ProjectArn", 32))
+	}
+	if s.Type == nil {
+		invalidParams.Add(request.NewErrParamRequired("Type"))
+	}
+
+	if invalidParams.Len() > 0 {
+		return invalidParams
+	}
+	return nil
+}
+
 // Represents the result of a create upload request.
 type CreateUploadOutput struct {
 	_ struct{} `type:"structure"`
@@ -1593,6 +1650,22 @@ func (s DeleteDevicePoolInput) GoString() string {
 	return s.String()
 }
 
+// Validate inspects the fields of the type to determine if they are valid.
+func (s *DeleteDevicePoolInput) Validate() error {
+	invalidParams := request.ErrInvalidParams{Context: "DeleteDevicePoolInput"}
+	if s.Arn == nil {
+		invalidParams.Add(request.NewErrParamRequired("Arn"))
+	}
+	if s.Arn != nil && len(*s.Arn) < 32 {
+		invalidParams.Add(request.NewErrParamMinLen("Arn", 32))
+	}
+
+	if invalidParams.Len() > 0 {
+		return invalidParams
+	}
+	return nil
+}
+
 // Represents the result of a delete device pool request.
 type DeleteDevicePoolOutput struct {
 	_ struct{} `type:"structure"`
@@ -1625,6 +1698,22 @@ func (s DeleteProjectInput) String() string {
 // GoString returns the string representation
 func (s DeleteProjectInput) GoString() string {
 	return s.String()
+}
+
+// Validate inspects the fields of the type to determine if they are valid.
+func (s *DeleteProjectInput) Validate() error {
+	invalidParams := request.ErrInvalidParams{Context: "DeleteProjectInput"}
+	if s.Arn == nil {
+		invalidParams.Add(request.NewErrParamRequired("Arn"))
+	}
+	if s.Arn != nil && len(*s.Arn) < 32 {
+		invalidParams.Add(request.NewErrParamMinLen("Arn", 32))
+	}
+
+	if invalidParams.Len() > 0 {
+		return invalidParams
+	}
+	return nil
 }
 
 // Represents the result of a delete project request.
@@ -1660,6 +1749,22 @@ func (s DeleteRunInput) GoString() string {
 	return s.String()
 }
 
+// Validate inspects the fields of the type to determine if they are valid.
+func (s *DeleteRunInput) Validate() error {
+	invalidParams := request.ErrInvalidParams{Context: "DeleteRunInput"}
+	if s.Arn == nil {
+		invalidParams.Add(request.NewErrParamRequired("Arn"))
+	}
+	if s.Arn != nil && len(*s.Arn) < 32 {
+		invalidParams.Add(request.NewErrParamMinLen("Arn", 32))
+	}
+
+	if invalidParams.Len() > 0 {
+		return invalidParams
+	}
+	return nil
+}
+
 // Represents the result of a delete run request.
 type DeleteRunOutput struct {
 	_ struct{} `type:"structure"`
@@ -1692,6 +1797,22 @@ func (s DeleteUploadInput) String() string {
 // GoString returns the string representation
 func (s DeleteUploadInput) GoString() string {
 	return s.String()
+}
+
+// Validate inspects the fields of the type to determine if they are valid.
+func (s *DeleteUploadInput) Validate() error {
+	invalidParams := request.ErrInvalidParams{Context: "DeleteUploadInput"}
+	if s.Arn == nil {
+		invalidParams.Add(request.NewErrParamRequired("Arn"))
+	}
+	if s.Arn != nil && len(*s.Arn) < 32 {
+		invalidParams.Add(request.NewErrParamMinLen("Arn", 32))
+	}
+
+	if invalidParams.Len() > 0 {
+		return invalidParams
+	}
+	return nil
 }
 
 // Represents the result of a delete upload request.
@@ -1919,6 +2040,22 @@ func (s GetDeviceInput) GoString() string {
 	return s.String()
 }
 
+// Validate inspects the fields of the type to determine if they are valid.
+func (s *GetDeviceInput) Validate() error {
+	invalidParams := request.ErrInvalidParams{Context: "GetDeviceInput"}
+	if s.Arn == nil {
+		invalidParams.Add(request.NewErrParamRequired("Arn"))
+	}
+	if s.Arn != nil && len(*s.Arn) < 32 {
+		invalidParams.Add(request.NewErrParamMinLen("Arn", 32))
+	}
+
+	if invalidParams.Len() > 0 {
+		return invalidParams
+	}
+	return nil
+}
+
 // Represents the result of a get device request.
 type GetDeviceOutput struct {
 	_ struct{} `type:"structure"`
@@ -1992,6 +2129,25 @@ func (s GetDevicePoolCompatibilityInput) GoString() string {
 	return s.String()
 }
 
+// Validate inspects the fields of the type to determine if they are valid.
+func (s *GetDevicePoolCompatibilityInput) Validate() error {
+	invalidParams := request.ErrInvalidParams{Context: "GetDevicePoolCompatibilityInput"}
+	if s.AppArn != nil && len(*s.AppArn) < 32 {
+		invalidParams.Add(request.NewErrParamMinLen("AppArn", 32))
+	}
+	if s.DevicePoolArn == nil {
+		invalidParams.Add(request.NewErrParamRequired("DevicePoolArn"))
+	}
+	if s.DevicePoolArn != nil && len(*s.DevicePoolArn) < 32 {
+		invalidParams.Add(request.NewErrParamMinLen("DevicePoolArn", 32))
+	}
+
+	if invalidParams.Len() > 0 {
+		return invalidParams
+	}
+	return nil
+}
+
 // Represents the result of describe device pool compatibility request.
 type GetDevicePoolCompatibilityOutput struct {
 	_ struct{} `type:"structure"`
@@ -2031,6 +2187,22 @@ func (s GetDevicePoolInput) GoString() string {
 	return s.String()
 }
 
+// Validate inspects the fields of the type to determine if they are valid.
+func (s *GetDevicePoolInput) Validate() error {
+	invalidParams := request.ErrInvalidParams{Context: "GetDevicePoolInput"}
+	if s.Arn == nil {
+		invalidParams.Add(request.NewErrParamRequired("Arn"))
+	}
+	if s.Arn != nil && len(*s.Arn) < 32 {
+		invalidParams.Add(request.NewErrParamMinLen("Arn", 32))
+	}
+
+	if invalidParams.Len() > 0 {
+		return invalidParams
+	}
+	return nil
+}
+
 // Represents the result of a get device pool request.
 type GetDevicePoolOutput struct {
 	_ struct{} `type:"structure"`
@@ -2065,6 +2237,22 @@ func (s GetJobInput) String() string {
 // GoString returns the string representation
 func (s GetJobInput) GoString() string {
 	return s.String()
+}
+
+// Validate inspects the fields of the type to determine if they are valid.
+func (s *GetJobInput) Validate() error {
+	invalidParams := request.ErrInvalidParams{Context: "GetJobInput"}
+	if s.Arn == nil {
+		invalidParams.Add(request.NewErrParamRequired("Arn"))
+	}
+	if s.Arn != nil && len(*s.Arn) < 32 {
+		invalidParams.Add(request.NewErrParamMinLen("Arn", 32))
+	}
+
+	if invalidParams.Len() > 0 {
+		return invalidParams
+	}
+	return nil
 }
 
 // Represents the result of a get job request.
@@ -2103,6 +2291,19 @@ func (s GetOfferingStatusInput) String() string {
 // GoString returns the string representation
 func (s GetOfferingStatusInput) GoString() string {
 	return s.String()
+}
+
+// Validate inspects the fields of the type to determine if they are valid.
+func (s *GetOfferingStatusInput) Validate() error {
+	invalidParams := request.ErrInvalidParams{Context: "GetOfferingStatusInput"}
+	if s.NextToken != nil && len(*s.NextToken) < 4 {
+		invalidParams.Add(request.NewErrParamMinLen("NextToken", 4))
+	}
+
+	if invalidParams.Len() > 0 {
+		return invalidParams
+	}
+	return nil
 }
 
 // Returns the status result for a device offering.
@@ -2148,6 +2349,22 @@ func (s GetProjectInput) GoString() string {
 	return s.String()
 }
 
+// Validate inspects the fields of the type to determine if they are valid.
+func (s *GetProjectInput) Validate() error {
+	invalidParams := request.ErrInvalidParams{Context: "GetProjectInput"}
+	if s.Arn == nil {
+		invalidParams.Add(request.NewErrParamRequired("Arn"))
+	}
+	if s.Arn != nil && len(*s.Arn) < 32 {
+		invalidParams.Add(request.NewErrParamMinLen("Arn", 32))
+	}
+
+	if invalidParams.Len() > 0 {
+		return invalidParams
+	}
+	return nil
+}
+
 // Represents the result of a get project request.
 type GetProjectOutput struct {
 	_ struct{} `type:"structure"`
@@ -2183,6 +2400,22 @@ func (s GetRunInput) String() string {
 // GoString returns the string representation
 func (s GetRunInput) GoString() string {
 	return s.String()
+}
+
+// Validate inspects the fields of the type to determine if they are valid.
+func (s *GetRunInput) Validate() error {
+	invalidParams := request.ErrInvalidParams{Context: "GetRunInput"}
+	if s.Arn == nil {
+		invalidParams.Add(request.NewErrParamRequired("Arn"))
+	}
+	if s.Arn != nil && len(*s.Arn) < 32 {
+		invalidParams.Add(request.NewErrParamMinLen("Arn", 32))
+	}
+
+	if invalidParams.Len() > 0 {
+		return invalidParams
+	}
+	return nil
 }
 
 // Represents the result of a get run request.
@@ -2221,6 +2454,22 @@ func (s GetSuiteInput) GoString() string {
 	return s.String()
 }
 
+// Validate inspects the fields of the type to determine if they are valid.
+func (s *GetSuiteInput) Validate() error {
+	invalidParams := request.ErrInvalidParams{Context: "GetSuiteInput"}
+	if s.Arn == nil {
+		invalidParams.Add(request.NewErrParamRequired("Arn"))
+	}
+	if s.Arn != nil && len(*s.Arn) < 32 {
+		invalidParams.Add(request.NewErrParamMinLen("Arn", 32))
+	}
+
+	if invalidParams.Len() > 0 {
+		return invalidParams
+	}
+	return nil
+}
+
 // Represents the result of a get suite request.
 type GetSuiteOutput struct {
 	_ struct{} `type:"structure"`
@@ -2257,6 +2506,22 @@ func (s GetTestInput) GoString() string {
 	return s.String()
 }
 
+// Validate inspects the fields of the type to determine if they are valid.
+func (s *GetTestInput) Validate() error {
+	invalidParams := request.ErrInvalidParams{Context: "GetTestInput"}
+	if s.Arn == nil {
+		invalidParams.Add(request.NewErrParamRequired("Arn"))
+	}
+	if s.Arn != nil && len(*s.Arn) < 32 {
+		invalidParams.Add(request.NewErrParamMinLen("Arn", 32))
+	}
+
+	if invalidParams.Len() > 0 {
+		return invalidParams
+	}
+	return nil
+}
+
 // Represents the result of a get test request.
 type GetTestOutput struct {
 	_ struct{} `type:"structure"`
@@ -2291,6 +2556,22 @@ func (s GetUploadInput) String() string {
 // GoString returns the string representation
 func (s GetUploadInput) GoString() string {
 	return s.String()
+}
+
+// Validate inspects the fields of the type to determine if they are valid.
+func (s *GetUploadInput) Validate() error {
+	invalidParams := request.ErrInvalidParams{Context: "GetUploadInput"}
+	if s.Arn == nil {
+		invalidParams.Add(request.NewErrParamRequired("Arn"))
+	}
+	if s.Arn != nil && len(*s.Arn) < 32 {
+		invalidParams.Add(request.NewErrParamMinLen("Arn", 32))
+	}
+
+	if invalidParams.Len() > 0 {
+		return invalidParams
+	}
+	return nil
 }
 
 // Represents the result of a get upload request.
@@ -2490,6 +2771,28 @@ func (s ListArtifactsInput) GoString() string {
 	return s.String()
 }
 
+// Validate inspects the fields of the type to determine if they are valid.
+func (s *ListArtifactsInput) Validate() error {
+	invalidParams := request.ErrInvalidParams{Context: "ListArtifactsInput"}
+	if s.Arn == nil {
+		invalidParams.Add(request.NewErrParamRequired("Arn"))
+	}
+	if s.Arn != nil && len(*s.Arn) < 32 {
+		invalidParams.Add(request.NewErrParamMinLen("Arn", 32))
+	}
+	if s.NextToken != nil && len(*s.NextToken) < 4 {
+		invalidParams.Add(request.NewErrParamMinLen("NextToken", 4))
+	}
+	if s.Type == nil {
+		invalidParams.Add(request.NewErrParamRequired("Type"))
+	}
+
+	if invalidParams.Len() > 0 {
+		return invalidParams
+	}
+	return nil
+}
+
 // Represents the result of a list artifacts operation.
 type ListArtifactsOutput struct {
 	_ struct{} `type:"structure"`
@@ -2544,6 +2847,25 @@ func (s ListDevicePoolsInput) GoString() string {
 	return s.String()
 }
 
+// Validate inspects the fields of the type to determine if they are valid.
+func (s *ListDevicePoolsInput) Validate() error {
+	invalidParams := request.ErrInvalidParams{Context: "ListDevicePoolsInput"}
+	if s.Arn == nil {
+		invalidParams.Add(request.NewErrParamRequired("Arn"))
+	}
+	if s.Arn != nil && len(*s.Arn) < 32 {
+		invalidParams.Add(request.NewErrParamMinLen("Arn", 32))
+	}
+	if s.NextToken != nil && len(*s.NextToken) < 4 {
+		invalidParams.Add(request.NewErrParamMinLen("NextToken", 4))
+	}
+
+	if invalidParams.Len() > 0 {
+		return invalidParams
+	}
+	return nil
+}
+
 // Represents the result of a list device pools request.
 type ListDevicePoolsOutput struct {
 	_ struct{} `type:"structure"`
@@ -2587,6 +2909,22 @@ func (s ListDevicesInput) String() string {
 // GoString returns the string representation
 func (s ListDevicesInput) GoString() string {
 	return s.String()
+}
+
+// Validate inspects the fields of the type to determine if they are valid.
+func (s *ListDevicesInput) Validate() error {
+	invalidParams := request.ErrInvalidParams{Context: "ListDevicesInput"}
+	if s.Arn != nil && len(*s.Arn) < 32 {
+		invalidParams.Add(request.NewErrParamMinLen("Arn", 32))
+	}
+	if s.NextToken != nil && len(*s.NextToken) < 4 {
+		invalidParams.Add(request.NewErrParamMinLen("NextToken", 4))
+	}
+
+	if invalidParams.Len() > 0 {
+		return invalidParams
+	}
+	return nil
 }
 
 // Represents the result of a list devices operation.
@@ -2634,6 +2972,25 @@ func (s ListJobsInput) GoString() string {
 	return s.String()
 }
 
+// Validate inspects the fields of the type to determine if they are valid.
+func (s *ListJobsInput) Validate() error {
+	invalidParams := request.ErrInvalidParams{Context: "ListJobsInput"}
+	if s.Arn == nil {
+		invalidParams.Add(request.NewErrParamRequired("Arn"))
+	}
+	if s.Arn != nil && len(*s.Arn) < 32 {
+		invalidParams.Add(request.NewErrParamMinLen("Arn", 32))
+	}
+	if s.NextToken != nil && len(*s.NextToken) < 4 {
+		invalidParams.Add(request.NewErrParamMinLen("NextToken", 4))
+	}
+
+	if invalidParams.Len() > 0 {
+		return invalidParams
+	}
+	return nil
+}
+
 // Represents the result of a list jobs request.
 type ListJobsOutput struct {
 	_ struct{} `type:"structure"`
@@ -2674,6 +3031,19 @@ func (s ListOfferingTransactionsInput) String() string {
 // GoString returns the string representation
 func (s ListOfferingTransactionsInput) GoString() string {
 	return s.String()
+}
+
+// Validate inspects the fields of the type to determine if they are valid.
+func (s *ListOfferingTransactionsInput) Validate() error {
+	invalidParams := request.ErrInvalidParams{Context: "ListOfferingTransactionsInput"}
+	if s.NextToken != nil && len(*s.NextToken) < 4 {
+		invalidParams.Add(request.NewErrParamMinLen("NextToken", 4))
+	}
+
+	if invalidParams.Len() > 0 {
+		return invalidParams
+	}
+	return nil
 }
 
 // Returns the transaction log of the specified offerings.
@@ -2718,6 +3088,19 @@ func (s ListOfferingsInput) GoString() string {
 	return s.String()
 }
 
+// Validate inspects the fields of the type to determine if they are valid.
+func (s *ListOfferingsInput) Validate() error {
+	invalidParams := request.ErrInvalidParams{Context: "ListOfferingsInput"}
+	if s.NextToken != nil && len(*s.NextToken) < 4 {
+		invalidParams.Add(request.NewErrParamMinLen("NextToken", 4))
+	}
+
+	if invalidParams.Len() > 0 {
+		return invalidParams
+	}
+	return nil
+}
+
 // Represents the return values of the list of offerings.
 type ListOfferingsOutput struct {
 	_ struct{} `type:"structure"`
@@ -2760,6 +3143,22 @@ func (s ListProjectsInput) String() string {
 // GoString returns the string representation
 func (s ListProjectsInput) GoString() string {
 	return s.String()
+}
+
+// Validate inspects the fields of the type to determine if they are valid.
+func (s *ListProjectsInput) Validate() error {
+	invalidParams := request.ErrInvalidParams{Context: "ListProjectsInput"}
+	if s.Arn != nil && len(*s.Arn) < 32 {
+		invalidParams.Add(request.NewErrParamMinLen("Arn", 32))
+	}
+	if s.NextToken != nil && len(*s.NextToken) < 4 {
+		invalidParams.Add(request.NewErrParamMinLen("NextToken", 4))
+	}
+
+	if invalidParams.Len() > 0 {
+		return invalidParams
+	}
+	return nil
 }
 
 // Represents the result of a list projects request.
@@ -2807,6 +3206,25 @@ func (s ListRunsInput) GoString() string {
 	return s.String()
 }
 
+// Validate inspects the fields of the type to determine if they are valid.
+func (s *ListRunsInput) Validate() error {
+	invalidParams := request.ErrInvalidParams{Context: "ListRunsInput"}
+	if s.Arn == nil {
+		invalidParams.Add(request.NewErrParamRequired("Arn"))
+	}
+	if s.Arn != nil && len(*s.Arn) < 32 {
+		invalidParams.Add(request.NewErrParamMinLen("Arn", 32))
+	}
+	if s.NextToken != nil && len(*s.NextToken) < 4 {
+		invalidParams.Add(request.NewErrParamMinLen("NextToken", 4))
+	}
+
+	if invalidParams.Len() > 0 {
+		return invalidParams
+	}
+	return nil
+}
+
 // Represents the result of a list runs request.
 type ListRunsOutput struct {
 	_ struct{} `type:"structure"`
@@ -2850,6 +3268,25 @@ func (s ListSamplesInput) String() string {
 // GoString returns the string representation
 func (s ListSamplesInput) GoString() string {
 	return s.String()
+}
+
+// Validate inspects the fields of the type to determine if they are valid.
+func (s *ListSamplesInput) Validate() error {
+	invalidParams := request.ErrInvalidParams{Context: "ListSamplesInput"}
+	if s.Arn == nil {
+		invalidParams.Add(request.NewErrParamRequired("Arn"))
+	}
+	if s.Arn != nil && len(*s.Arn) < 32 {
+		invalidParams.Add(request.NewErrParamMinLen("Arn", 32))
+	}
+	if s.NextToken != nil && len(*s.NextToken) < 4 {
+		invalidParams.Add(request.NewErrParamMinLen("NextToken", 4))
+	}
+
+	if invalidParams.Len() > 0 {
+		return invalidParams
+	}
+	return nil
 }
 
 // Represents the result of a list samples request.
@@ -2897,6 +3334,25 @@ func (s ListSuitesInput) GoString() string {
 	return s.String()
 }
 
+// Validate inspects the fields of the type to determine if they are valid.
+func (s *ListSuitesInput) Validate() error {
+	invalidParams := request.ErrInvalidParams{Context: "ListSuitesInput"}
+	if s.Arn == nil {
+		invalidParams.Add(request.NewErrParamRequired("Arn"))
+	}
+	if s.Arn != nil && len(*s.Arn) < 32 {
+		invalidParams.Add(request.NewErrParamMinLen("Arn", 32))
+	}
+	if s.NextToken != nil && len(*s.NextToken) < 4 {
+		invalidParams.Add(request.NewErrParamMinLen("NextToken", 4))
+	}
+
+	if invalidParams.Len() > 0 {
+		return invalidParams
+	}
+	return nil
+}
+
 // Represents the result of a list suites request.
 type ListSuitesOutput struct {
 	_ struct{} `type:"structure"`
@@ -2942,6 +3398,25 @@ func (s ListTestsInput) GoString() string {
 	return s.String()
 }
 
+// Validate inspects the fields of the type to determine if they are valid.
+func (s *ListTestsInput) Validate() error {
+	invalidParams := request.ErrInvalidParams{Context: "ListTestsInput"}
+	if s.Arn == nil {
+		invalidParams.Add(request.NewErrParamRequired("Arn"))
+	}
+	if s.Arn != nil && len(*s.Arn) < 32 {
+		invalidParams.Add(request.NewErrParamMinLen("Arn", 32))
+	}
+	if s.NextToken != nil && len(*s.NextToken) < 4 {
+		invalidParams.Add(request.NewErrParamMinLen("NextToken", 4))
+	}
+
+	if invalidParams.Len() > 0 {
+		return invalidParams
+	}
+	return nil
+}
+
 // Represents the result of a list tests request.
 type ListTestsOutput struct {
 	_ struct{} `type:"structure"`
@@ -2985,6 +3460,25 @@ func (s ListUniqueProblemsInput) String() string {
 // GoString returns the string representation
 func (s ListUniqueProblemsInput) GoString() string {
 	return s.String()
+}
+
+// Validate inspects the fields of the type to determine if they are valid.
+func (s *ListUniqueProblemsInput) Validate() error {
+	invalidParams := request.ErrInvalidParams{Context: "ListUniqueProblemsInput"}
+	if s.Arn == nil {
+		invalidParams.Add(request.NewErrParamRequired("Arn"))
+	}
+	if s.Arn != nil && len(*s.Arn) < 32 {
+		invalidParams.Add(request.NewErrParamMinLen("Arn", 32))
+	}
+	if s.NextToken != nil && len(*s.NextToken) < 4 {
+		invalidParams.Add(request.NewErrParamMinLen("NextToken", 4))
+	}
+
+	if invalidParams.Len() > 0 {
+		return invalidParams
+	}
+	return nil
 }
 
 // Represents the result of a list unique problems request.
@@ -3048,6 +3542,25 @@ func (s ListUploadsInput) GoString() string {
 	return s.String()
 }
 
+// Validate inspects the fields of the type to determine if they are valid.
+func (s *ListUploadsInput) Validate() error {
+	invalidParams := request.ErrInvalidParams{Context: "ListUploadsInput"}
+	if s.Arn == nil {
+		invalidParams.Add(request.NewErrParamRequired("Arn"))
+	}
+	if s.Arn != nil && len(*s.Arn) < 32 {
+		invalidParams.Add(request.NewErrParamMinLen("Arn", 32))
+	}
+	if s.NextToken != nil && len(*s.NextToken) < 4 {
+		invalidParams.Add(request.NewErrParamMinLen("NextToken", 4))
+	}
+
+	if invalidParams.Len() > 0 {
+		return invalidParams
+	}
+	return nil
+}
+
 // Represents the result of a list uploads request.
 type ListUploadsOutput struct {
 	_ struct{} `type:"structure"`
@@ -3093,6 +3606,22 @@ func (s Location) String() string {
 // GoString returns the string representation
 func (s Location) GoString() string {
 	return s.String()
+}
+
+// Validate inspects the fields of the type to determine if they are valid.
+func (s *Location) Validate() error {
+	invalidParams := request.ErrInvalidParams{Context: "Location"}
+	if s.Latitude == nil {
+		invalidParams.Add(request.NewErrParamRequired("Latitude"))
+	}
+	if s.Longitude == nil {
+		invalidParams.Add(request.NewErrParamRequired("Longitude"))
+	}
+
+	if invalidParams.Len() > 0 {
+		return invalidParams
+	}
+	return nil
 }
 
 // A number representing the monetary amount for an offering or transaction.
@@ -3319,6 +3848,19 @@ func (s PurchaseOfferingInput) GoString() string {
 	return s.String()
 }
 
+// Validate inspects the fields of the type to determine if they are valid.
+func (s *PurchaseOfferingInput) Validate() error {
+	invalidParams := request.ErrInvalidParams{Context: "PurchaseOfferingInput"}
+	if s.OfferingId != nil && len(*s.OfferingId) < 32 {
+		invalidParams.Add(request.NewErrParamMinLen("OfferingId", 32))
+	}
+
+	if invalidParams.Len() > 0 {
+		return invalidParams
+	}
+	return nil
+}
+
 // The result of the purchase offering (e.g., success or failure).
 type PurchaseOfferingOutput struct {
 	_ struct{} `type:"structure"`
@@ -3405,6 +3947,19 @@ func (s RenewOfferingInput) String() string {
 // GoString returns the string representation
 func (s RenewOfferingInput) GoString() string {
 	return s.String()
+}
+
+// Validate inspects the fields of the type to determine if they are valid.
+func (s *RenewOfferingInput) Validate() error {
+	invalidParams := request.ErrInvalidParams{Context: "RenewOfferingInput"}
+	if s.OfferingId != nil && len(*s.OfferingId) < 32 {
+		invalidParams.Add(request.NewErrParamMinLen("OfferingId", 32))
+	}
+
+	if invalidParams.Len() > 0 {
+		return invalidParams
+	}
+	return nil
 }
 
 // The result of a renewal offering.
@@ -3731,6 +4286,27 @@ func (s ScheduleRunConfiguration) GoString() string {
 	return s.String()
 }
 
+// Validate inspects the fields of the type to determine if they are valid.
+func (s *ScheduleRunConfiguration) Validate() error {
+	invalidParams := request.ErrInvalidParams{Context: "ScheduleRunConfiguration"}
+	if s.ExtraDataPackageArn != nil && len(*s.ExtraDataPackageArn) < 32 {
+		invalidParams.Add(request.NewErrParamMinLen("ExtraDataPackageArn", 32))
+	}
+	if s.NetworkProfileArn != nil && len(*s.NetworkProfileArn) < 32 {
+		invalidParams.Add(request.NewErrParamMinLen("NetworkProfileArn", 32))
+	}
+	if s.Location != nil {
+		if err := s.Location.Validate(); err != nil {
+			invalidParams.AddNested("Location", err.(request.ErrInvalidParams))
+		}
+	}
+
+	if invalidParams.Len() > 0 {
+		return invalidParams
+	}
+	return nil
+}
+
 // Represents a request to the schedule run operation.
 type ScheduleRunInput struct {
 	_ struct{} `type:"structure"`
@@ -3762,6 +4338,44 @@ func (s ScheduleRunInput) String() string {
 // GoString returns the string representation
 func (s ScheduleRunInput) GoString() string {
 	return s.String()
+}
+
+// Validate inspects the fields of the type to determine if they are valid.
+func (s *ScheduleRunInput) Validate() error {
+	invalidParams := request.ErrInvalidParams{Context: "ScheduleRunInput"}
+	if s.AppArn != nil && len(*s.AppArn) < 32 {
+		invalidParams.Add(request.NewErrParamMinLen("AppArn", 32))
+	}
+	if s.DevicePoolArn == nil {
+		invalidParams.Add(request.NewErrParamRequired("DevicePoolArn"))
+	}
+	if s.DevicePoolArn != nil && len(*s.DevicePoolArn) < 32 {
+		invalidParams.Add(request.NewErrParamMinLen("DevicePoolArn", 32))
+	}
+	if s.ProjectArn == nil {
+		invalidParams.Add(request.NewErrParamRequired("ProjectArn"))
+	}
+	if s.ProjectArn != nil && len(*s.ProjectArn) < 32 {
+		invalidParams.Add(request.NewErrParamMinLen("ProjectArn", 32))
+	}
+	if s.Test == nil {
+		invalidParams.Add(request.NewErrParamRequired("Test"))
+	}
+	if s.Configuration != nil {
+		if err := s.Configuration.Validate(); err != nil {
+			invalidParams.AddNested("Configuration", err.(request.ErrInvalidParams))
+		}
+	}
+	if s.Test != nil {
+		if err := s.Test.Validate(); err != nil {
+			invalidParams.AddNested("Test", err.(request.ErrInvalidParams))
+		}
+	}
+
+	if invalidParams.Len() > 0 {
+		return invalidParams
+	}
+	return nil
 }
 
 // Represents the result of a schedule run request.
@@ -3840,6 +4454,22 @@ func (s ScheduleRunTest) GoString() string {
 	return s.String()
 }
 
+// Validate inspects the fields of the type to determine if they are valid.
+func (s *ScheduleRunTest) Validate() error {
+	invalidParams := request.ErrInvalidParams{Context: "ScheduleRunTest"}
+	if s.TestPackageArn != nil && len(*s.TestPackageArn) < 32 {
+		invalidParams.Add(request.NewErrParamMinLen("TestPackageArn", 32))
+	}
+	if s.Type == nil {
+		invalidParams.Add(request.NewErrParamRequired("Type"))
+	}
+
+	if invalidParams.Len() > 0 {
+		return invalidParams
+	}
+	return nil
+}
+
 // Represents the request to stop a specific run.
 type StopRunInput struct {
 	_ struct{} `type:"structure"`
@@ -3857,6 +4487,22 @@ func (s StopRunInput) String() string {
 // GoString returns the string representation
 func (s StopRunInput) GoString() string {
 	return s.String()
+}
+
+// Validate inspects the fields of the type to determine if they are valid.
+func (s *StopRunInput) Validate() error {
+	invalidParams := request.ErrInvalidParams{Context: "StopRunInput"}
+	if s.Arn == nil {
+		invalidParams.Add(request.NewErrParamRequired("Arn"))
+	}
+	if s.Arn != nil && len(*s.Arn) < 32 {
+		invalidParams.Add(request.NewErrParamMinLen("Arn", 32))
+	}
+
+	if invalidParams.Len() > 0 {
+		return invalidParams
+	}
+	return nil
 }
 
 // Represents the results of your stop run attempt.
@@ -4158,6 +4804,22 @@ func (s UpdateDevicePoolInput) GoString() string {
 	return s.String()
 }
 
+// Validate inspects the fields of the type to determine if they are valid.
+func (s *UpdateDevicePoolInput) Validate() error {
+	invalidParams := request.ErrInvalidParams{Context: "UpdateDevicePoolInput"}
+	if s.Arn == nil {
+		invalidParams.Add(request.NewErrParamRequired("Arn"))
+	}
+	if s.Arn != nil && len(*s.Arn) < 32 {
+		invalidParams.Add(request.NewErrParamMinLen("Arn", 32))
+	}
+
+	if invalidParams.Len() > 0 {
+		return invalidParams
+	}
+	return nil
+}
+
 // Represents the result of an update device pool request.
 type UpdateDevicePoolOutput struct {
 	_ struct{} `type:"structure"`
@@ -4195,6 +4857,22 @@ func (s UpdateProjectInput) String() string {
 // GoString returns the string representation
 func (s UpdateProjectInput) GoString() string {
 	return s.String()
+}
+
+// Validate inspects the fields of the type to determine if they are valid.
+func (s *UpdateProjectInput) Validate() error {
+	invalidParams := request.ErrInvalidParams{Context: "UpdateProjectInput"}
+	if s.Arn == nil {
+		invalidParams.Add(request.NewErrParamRequired("Arn"))
+	}
+	if s.Arn != nil && len(*s.Arn) < 32 {
+		invalidParams.Add(request.NewErrParamMinLen("Arn", 32))
+	}
+
+	if invalidParams.Len() > 0 {
+		return invalidParams
+	}
+	return nil
 }
 
 // Represents the result of an update project request.

--- a/service/directconnect/api.go
+++ b/service/directconnect/api.go
@@ -658,6 +658,31 @@ func (s AllocateConnectionOnInterconnectInput) GoString() string {
 	return s.String()
 }
 
+// Validate inspects the fields of the type to determine if they are valid.
+func (s *AllocateConnectionOnInterconnectInput) Validate() error {
+	invalidParams := request.ErrInvalidParams{Context: "AllocateConnectionOnInterconnectInput"}
+	if s.Bandwidth == nil {
+		invalidParams.Add(request.NewErrParamRequired("Bandwidth"))
+	}
+	if s.ConnectionName == nil {
+		invalidParams.Add(request.NewErrParamRequired("ConnectionName"))
+	}
+	if s.InterconnectId == nil {
+		invalidParams.Add(request.NewErrParamRequired("InterconnectId"))
+	}
+	if s.OwnerAccount == nil {
+		invalidParams.Add(request.NewErrParamRequired("OwnerAccount"))
+	}
+	if s.Vlan == nil {
+		invalidParams.Add(request.NewErrParamRequired("Vlan"))
+	}
+
+	if invalidParams.Len() > 0 {
+		return invalidParams
+	}
+	return nil
+}
+
 // Container for the parameters to the AllocatePrivateVirtualInterface operation.
 type AllocatePrivateVirtualInterfaceInput struct {
 	_ struct{} `type:"structure"`
@@ -686,6 +711,30 @@ func (s AllocatePrivateVirtualInterfaceInput) String() string {
 // GoString returns the string representation
 func (s AllocatePrivateVirtualInterfaceInput) GoString() string {
 	return s.String()
+}
+
+// Validate inspects the fields of the type to determine if they are valid.
+func (s *AllocatePrivateVirtualInterfaceInput) Validate() error {
+	invalidParams := request.ErrInvalidParams{Context: "AllocatePrivateVirtualInterfaceInput"}
+	if s.ConnectionId == nil {
+		invalidParams.Add(request.NewErrParamRequired("ConnectionId"))
+	}
+	if s.NewPrivateVirtualInterfaceAllocation == nil {
+		invalidParams.Add(request.NewErrParamRequired("NewPrivateVirtualInterfaceAllocation"))
+	}
+	if s.OwnerAccount == nil {
+		invalidParams.Add(request.NewErrParamRequired("OwnerAccount"))
+	}
+	if s.NewPrivateVirtualInterfaceAllocation != nil {
+		if err := s.NewPrivateVirtualInterfaceAllocation.Validate(); err != nil {
+			invalidParams.AddNested("NewPrivateVirtualInterfaceAllocation", err.(request.ErrInvalidParams))
+		}
+	}
+
+	if invalidParams.Len() > 0 {
+		return invalidParams
+	}
+	return nil
 }
 
 // Container for the parameters to the AllocatePublicVirtualInterface operation.
@@ -718,6 +767,30 @@ func (s AllocatePublicVirtualInterfaceInput) GoString() string {
 	return s.String()
 }
 
+// Validate inspects the fields of the type to determine if they are valid.
+func (s *AllocatePublicVirtualInterfaceInput) Validate() error {
+	invalidParams := request.ErrInvalidParams{Context: "AllocatePublicVirtualInterfaceInput"}
+	if s.ConnectionId == nil {
+		invalidParams.Add(request.NewErrParamRequired("ConnectionId"))
+	}
+	if s.NewPublicVirtualInterfaceAllocation == nil {
+		invalidParams.Add(request.NewErrParamRequired("NewPublicVirtualInterfaceAllocation"))
+	}
+	if s.OwnerAccount == nil {
+		invalidParams.Add(request.NewErrParamRequired("OwnerAccount"))
+	}
+	if s.NewPublicVirtualInterfaceAllocation != nil {
+		if err := s.NewPublicVirtualInterfaceAllocation.Validate(); err != nil {
+			invalidParams.AddNested("NewPublicVirtualInterfaceAllocation", err.(request.ErrInvalidParams))
+		}
+	}
+
+	if invalidParams.Len() > 0 {
+		return invalidParams
+	}
+	return nil
+}
+
 // Container for the parameters to the ConfirmConnection operation.
 type ConfirmConnectionInput struct {
 	_ struct{} `type:"structure"`
@@ -738,6 +811,19 @@ func (s ConfirmConnectionInput) String() string {
 // GoString returns the string representation
 func (s ConfirmConnectionInput) GoString() string {
 	return s.String()
+}
+
+// Validate inspects the fields of the type to determine if they are valid.
+func (s *ConfirmConnectionInput) Validate() error {
+	invalidParams := request.ErrInvalidParams{Context: "ConfirmConnectionInput"}
+	if s.ConnectionId == nil {
+		invalidParams.Add(request.NewErrParamRequired("ConnectionId"))
+	}
+
+	if invalidParams.Len() > 0 {
+		return invalidParams
+	}
+	return nil
 }
 
 // The response received when ConfirmConnection is called.
@@ -799,6 +885,22 @@ func (s ConfirmPrivateVirtualInterfaceInput) GoString() string {
 	return s.String()
 }
 
+// Validate inspects the fields of the type to determine if they are valid.
+func (s *ConfirmPrivateVirtualInterfaceInput) Validate() error {
+	invalidParams := request.ErrInvalidParams{Context: "ConfirmPrivateVirtualInterfaceInput"}
+	if s.VirtualGatewayId == nil {
+		invalidParams.Add(request.NewErrParamRequired("VirtualGatewayId"))
+	}
+	if s.VirtualInterfaceId == nil {
+		invalidParams.Add(request.NewErrParamRequired("VirtualInterfaceId"))
+	}
+
+	if invalidParams.Len() > 0 {
+		return invalidParams
+	}
+	return nil
+}
+
 // The response received when ConfirmPrivateVirtualInterface is called.
 type ConfirmPrivateVirtualInterfaceOutput struct {
 	_ struct{} `type:"structure"`
@@ -852,6 +954,19 @@ func (s ConfirmPublicVirtualInterfaceInput) String() string {
 // GoString returns the string representation
 func (s ConfirmPublicVirtualInterfaceInput) GoString() string {
 	return s.String()
+}
+
+// Validate inspects the fields of the type to determine if they are valid.
+func (s *ConfirmPublicVirtualInterfaceInput) Validate() error {
+	invalidParams := request.ErrInvalidParams{Context: "ConfirmPublicVirtualInterfaceInput"}
+	if s.VirtualInterfaceId == nil {
+		invalidParams.Add(request.NewErrParamRequired("VirtualInterfaceId"))
+	}
+
+	if invalidParams.Len() > 0 {
+		return invalidParams
+	}
+	return nil
 }
 
 // The response received when ConfirmPublicVirtualInterface is called.
@@ -1014,6 +1129,25 @@ func (s CreateConnectionInput) GoString() string {
 	return s.String()
 }
 
+// Validate inspects the fields of the type to determine if they are valid.
+func (s *CreateConnectionInput) Validate() error {
+	invalidParams := request.ErrInvalidParams{Context: "CreateConnectionInput"}
+	if s.Bandwidth == nil {
+		invalidParams.Add(request.NewErrParamRequired("Bandwidth"))
+	}
+	if s.ConnectionName == nil {
+		invalidParams.Add(request.NewErrParamRequired("ConnectionName"))
+	}
+	if s.Location == nil {
+		invalidParams.Add(request.NewErrParamRequired("Location"))
+	}
+
+	if invalidParams.Len() > 0 {
+		return invalidParams
+	}
+	return nil
+}
+
 // Container for the parameters to the CreateInterconnect operation.
 type CreateInterconnectInput struct {
 	_ struct{} `type:"structure"`
@@ -1052,6 +1186,25 @@ func (s CreateInterconnectInput) GoString() string {
 	return s.String()
 }
 
+// Validate inspects the fields of the type to determine if they are valid.
+func (s *CreateInterconnectInput) Validate() error {
+	invalidParams := request.ErrInvalidParams{Context: "CreateInterconnectInput"}
+	if s.Bandwidth == nil {
+		invalidParams.Add(request.NewErrParamRequired("Bandwidth"))
+	}
+	if s.InterconnectName == nil {
+		invalidParams.Add(request.NewErrParamRequired("InterconnectName"))
+	}
+	if s.Location == nil {
+		invalidParams.Add(request.NewErrParamRequired("Location"))
+	}
+
+	if invalidParams.Len() > 0 {
+		return invalidParams
+	}
+	return nil
+}
+
 // Container for the parameters to the CreatePrivateVirtualInterface operation.
 type CreatePrivateVirtualInterfaceInput struct {
 	_ struct{} `type:"structure"`
@@ -1077,6 +1230,27 @@ func (s CreatePrivateVirtualInterfaceInput) String() string {
 // GoString returns the string representation
 func (s CreatePrivateVirtualInterfaceInput) GoString() string {
 	return s.String()
+}
+
+// Validate inspects the fields of the type to determine if they are valid.
+func (s *CreatePrivateVirtualInterfaceInput) Validate() error {
+	invalidParams := request.ErrInvalidParams{Context: "CreatePrivateVirtualInterfaceInput"}
+	if s.ConnectionId == nil {
+		invalidParams.Add(request.NewErrParamRequired("ConnectionId"))
+	}
+	if s.NewPrivateVirtualInterface == nil {
+		invalidParams.Add(request.NewErrParamRequired("NewPrivateVirtualInterface"))
+	}
+	if s.NewPrivateVirtualInterface != nil {
+		if err := s.NewPrivateVirtualInterface.Validate(); err != nil {
+			invalidParams.AddNested("NewPrivateVirtualInterface", err.(request.ErrInvalidParams))
+		}
+	}
+
+	if invalidParams.Len() > 0 {
+		return invalidParams
+	}
+	return nil
 }
 
 // Container for the parameters to the CreatePublicVirtualInterface operation.
@@ -1106,6 +1280,27 @@ func (s CreatePublicVirtualInterfaceInput) GoString() string {
 	return s.String()
 }
 
+// Validate inspects the fields of the type to determine if they are valid.
+func (s *CreatePublicVirtualInterfaceInput) Validate() error {
+	invalidParams := request.ErrInvalidParams{Context: "CreatePublicVirtualInterfaceInput"}
+	if s.ConnectionId == nil {
+		invalidParams.Add(request.NewErrParamRequired("ConnectionId"))
+	}
+	if s.NewPublicVirtualInterface == nil {
+		invalidParams.Add(request.NewErrParamRequired("NewPublicVirtualInterface"))
+	}
+	if s.NewPublicVirtualInterface != nil {
+		if err := s.NewPublicVirtualInterface.Validate(); err != nil {
+			invalidParams.AddNested("NewPublicVirtualInterface", err.(request.ErrInvalidParams))
+		}
+	}
+
+	if invalidParams.Len() > 0 {
+		return invalidParams
+	}
+	return nil
+}
+
 // Container for the parameters to the DeleteConnection operation.
 type DeleteConnectionInput struct {
 	_ struct{} `type:"structure"`
@@ -1128,6 +1323,19 @@ func (s DeleteConnectionInput) GoString() string {
 	return s.String()
 }
 
+// Validate inspects the fields of the type to determine if they are valid.
+func (s *DeleteConnectionInput) Validate() error {
+	invalidParams := request.ErrInvalidParams{Context: "DeleteConnectionInput"}
+	if s.ConnectionId == nil {
+		invalidParams.Add(request.NewErrParamRequired("ConnectionId"))
+	}
+
+	if invalidParams.Len() > 0 {
+		return invalidParams
+	}
+	return nil
+}
+
 // Container for the parameters to the DeleteInterconnect operation.
 type DeleteInterconnectInput struct {
 	_ struct{} `type:"structure"`
@@ -1146,6 +1354,19 @@ func (s DeleteInterconnectInput) String() string {
 // GoString returns the string representation
 func (s DeleteInterconnectInput) GoString() string {
 	return s.String()
+}
+
+// Validate inspects the fields of the type to determine if they are valid.
+func (s *DeleteInterconnectInput) Validate() error {
+	invalidParams := request.ErrInvalidParams{Context: "DeleteInterconnectInput"}
+	if s.InterconnectId == nil {
+		invalidParams.Add(request.NewErrParamRequired("InterconnectId"))
+	}
+
+	if invalidParams.Len() > 0 {
+		return invalidParams
+	}
+	return nil
 }
 
 // The response received when DeleteInterconnect is called.
@@ -1191,6 +1412,19 @@ func (s DeleteVirtualInterfaceInput) String() string {
 // GoString returns the string representation
 func (s DeleteVirtualInterfaceInput) GoString() string {
 	return s.String()
+}
+
+// Validate inspects the fields of the type to determine if they are valid.
+func (s *DeleteVirtualInterfaceInput) Validate() error {
+	invalidParams := request.ErrInvalidParams{Context: "DeleteVirtualInterfaceInput"}
+	if s.VirtualInterfaceId == nil {
+		invalidParams.Add(request.NewErrParamRequired("VirtualInterfaceId"))
+	}
+
+	if invalidParams.Len() > 0 {
+		return invalidParams
+	}
+	return nil
 }
 
 // The response received when DeleteVirtualInterface is called.
@@ -1268,6 +1502,19 @@ func (s DescribeConnectionsOnInterconnectInput) String() string {
 // GoString returns the string representation
 func (s DescribeConnectionsOnInterconnectInput) GoString() string {
 	return s.String()
+}
+
+// Validate inspects the fields of the type to determine if they are valid.
+func (s *DescribeConnectionsOnInterconnectInput) Validate() error {
+	invalidParams := request.ErrInvalidParams{Context: "DescribeConnectionsOnInterconnectInput"}
+	if s.InterconnectId == nil {
+		invalidParams.Add(request.NewErrParamRequired("InterconnectId"))
+	}
+
+	if invalidParams.Len() > 0 {
+		return invalidParams
+	}
+	return nil
 }
 
 // Container for the parameters to the DescribeInterconnects operation.
@@ -1562,6 +1809,28 @@ func (s NewPrivateVirtualInterface) GoString() string {
 	return s.String()
 }
 
+// Validate inspects the fields of the type to determine if they are valid.
+func (s *NewPrivateVirtualInterface) Validate() error {
+	invalidParams := request.ErrInvalidParams{Context: "NewPrivateVirtualInterface"}
+	if s.Asn == nil {
+		invalidParams.Add(request.NewErrParamRequired("Asn"))
+	}
+	if s.VirtualGatewayId == nil {
+		invalidParams.Add(request.NewErrParamRequired("VirtualGatewayId"))
+	}
+	if s.VirtualInterfaceName == nil {
+		invalidParams.Add(request.NewErrParamRequired("VirtualInterfaceName"))
+	}
+	if s.Vlan == nil {
+		invalidParams.Add(request.NewErrParamRequired("Vlan"))
+	}
+
+	if invalidParams.Len() > 0 {
+		return invalidParams
+	}
+	return nil
+}
+
 // A structure containing information about a private virtual interface that
 // will be provisioned on a connection.
 type NewPrivateVirtualInterfaceAllocation struct {
@@ -1606,6 +1875,25 @@ func (s NewPrivateVirtualInterfaceAllocation) String() string {
 // GoString returns the string representation
 func (s NewPrivateVirtualInterfaceAllocation) GoString() string {
 	return s.String()
+}
+
+// Validate inspects the fields of the type to determine if they are valid.
+func (s *NewPrivateVirtualInterfaceAllocation) Validate() error {
+	invalidParams := request.ErrInvalidParams{Context: "NewPrivateVirtualInterfaceAllocation"}
+	if s.Asn == nil {
+		invalidParams.Add(request.NewErrParamRequired("Asn"))
+	}
+	if s.VirtualInterfaceName == nil {
+		invalidParams.Add(request.NewErrParamRequired("VirtualInterfaceName"))
+	}
+	if s.Vlan == nil {
+		invalidParams.Add(request.NewErrParamRequired("Vlan"))
+	}
+
+	if invalidParams.Len() > 0 {
+		return invalidParams
+	}
+	return nil
 }
 
 // A structure containing information about a new public virtual interface.
@@ -1657,6 +1945,34 @@ func (s NewPublicVirtualInterface) GoString() string {
 	return s.String()
 }
 
+// Validate inspects the fields of the type to determine if they are valid.
+func (s *NewPublicVirtualInterface) Validate() error {
+	invalidParams := request.ErrInvalidParams{Context: "NewPublicVirtualInterface"}
+	if s.AmazonAddress == nil {
+		invalidParams.Add(request.NewErrParamRequired("AmazonAddress"))
+	}
+	if s.Asn == nil {
+		invalidParams.Add(request.NewErrParamRequired("Asn"))
+	}
+	if s.CustomerAddress == nil {
+		invalidParams.Add(request.NewErrParamRequired("CustomerAddress"))
+	}
+	if s.RouteFilterPrefixes == nil {
+		invalidParams.Add(request.NewErrParamRequired("RouteFilterPrefixes"))
+	}
+	if s.VirtualInterfaceName == nil {
+		invalidParams.Add(request.NewErrParamRequired("VirtualInterfaceName"))
+	}
+	if s.Vlan == nil {
+		invalidParams.Add(request.NewErrParamRequired("Vlan"))
+	}
+
+	if invalidParams.Len() > 0 {
+		return invalidParams
+	}
+	return nil
+}
+
 // A structure containing information about a public virtual interface that
 // will be provisioned on a connection.
 type NewPublicVirtualInterfaceAllocation struct {
@@ -1705,6 +2021,34 @@ func (s NewPublicVirtualInterfaceAllocation) String() string {
 // GoString returns the string representation
 func (s NewPublicVirtualInterfaceAllocation) GoString() string {
 	return s.String()
+}
+
+// Validate inspects the fields of the type to determine if they are valid.
+func (s *NewPublicVirtualInterfaceAllocation) Validate() error {
+	invalidParams := request.ErrInvalidParams{Context: "NewPublicVirtualInterfaceAllocation"}
+	if s.AmazonAddress == nil {
+		invalidParams.Add(request.NewErrParamRequired("AmazonAddress"))
+	}
+	if s.Asn == nil {
+		invalidParams.Add(request.NewErrParamRequired("Asn"))
+	}
+	if s.CustomerAddress == nil {
+		invalidParams.Add(request.NewErrParamRequired("CustomerAddress"))
+	}
+	if s.RouteFilterPrefixes == nil {
+		invalidParams.Add(request.NewErrParamRequired("RouteFilterPrefixes"))
+	}
+	if s.VirtualInterfaceName == nil {
+		invalidParams.Add(request.NewErrParamRequired("VirtualInterfaceName"))
+	}
+	if s.Vlan == nil {
+		invalidParams.Add(request.NewErrParamRequired("Vlan"))
+	}
+
+	if invalidParams.Len() > 0 {
+		return invalidParams
+	}
+	return nil
 }
 
 // A route filter prefix that the customer can advertise through Border Gateway

--- a/service/directoryservice/api.go
+++ b/service/directoryservice/api.go
@@ -4,6 +4,7 @@
 package directoryservice
 
 import (
+	"fmt"
 	"time"
 
 	"github.com/aws/aws-sdk-go/aws/awsutil"
@@ -880,6 +881,19 @@ func (s Attribute) GoString() string {
 	return s.String()
 }
 
+// Validate inspects the fields of the type to determine if they are valid.
+func (s *Attribute) Validate() error {
+	invalidParams := request.ErrInvalidParams{Context: "Attribute"}
+	if s.Name != nil && len(*s.Name) < 1 {
+		invalidParams.Add(request.NewErrParamMinLen("Name", 1))
+	}
+
+	if invalidParams.Len() > 0 {
+		return invalidParams
+	}
+	return nil
+}
+
 // Contains information about a computer account in a directory.
 type Computer struct {
 	_ struct{} `type:"structure"`
@@ -970,6 +984,36 @@ func (s ConnectDirectoryInput) GoString() string {
 	return s.String()
 }
 
+// Validate inspects the fields of the type to determine if they are valid.
+func (s *ConnectDirectoryInput) Validate() error {
+	invalidParams := request.ErrInvalidParams{Context: "ConnectDirectoryInput"}
+	if s.ConnectSettings == nil {
+		invalidParams.Add(request.NewErrParamRequired("ConnectSettings"))
+	}
+	if s.Name == nil {
+		invalidParams.Add(request.NewErrParamRequired("Name"))
+	}
+	if s.Password == nil {
+		invalidParams.Add(request.NewErrParamRequired("Password"))
+	}
+	if s.Password != nil && len(*s.Password) < 1 {
+		invalidParams.Add(request.NewErrParamMinLen("Password", 1))
+	}
+	if s.Size == nil {
+		invalidParams.Add(request.NewErrParamRequired("Size"))
+	}
+	if s.ConnectSettings != nil {
+		if err := s.ConnectSettings.Validate(); err != nil {
+			invalidParams.AddNested("ConnectSettings", err.(request.ErrInvalidParams))
+		}
+	}
+
+	if invalidParams.Len() > 0 {
+		return invalidParams
+	}
+	return nil
+}
+
 // Contains the results of the ConnectDirectory operation.
 type ConnectDirectoryOutput struct {
 	_ struct{} `type:"structure"`
@@ -1010,6 +1054,25 @@ func (s CreateAliasInput) String() string {
 // GoString returns the string representation
 func (s CreateAliasInput) GoString() string {
 	return s.String()
+}
+
+// Validate inspects the fields of the type to determine if they are valid.
+func (s *CreateAliasInput) Validate() error {
+	invalidParams := request.ErrInvalidParams{Context: "CreateAliasInput"}
+	if s.Alias == nil {
+		invalidParams.Add(request.NewErrParamRequired("Alias"))
+	}
+	if s.Alias != nil && len(*s.Alias) < 1 {
+		invalidParams.Add(request.NewErrParamMinLen("Alias", 1))
+	}
+	if s.DirectoryId == nil {
+		invalidParams.Add(request.NewErrParamRequired("DirectoryId"))
+	}
+
+	if invalidParams.Len() > 0 {
+		return invalidParams
+	}
+	return nil
 }
 
 // Contains the results of the CreateAlias operation.
@@ -1066,6 +1129,44 @@ func (s CreateComputerInput) GoString() string {
 	return s.String()
 }
 
+// Validate inspects the fields of the type to determine if they are valid.
+func (s *CreateComputerInput) Validate() error {
+	invalidParams := request.ErrInvalidParams{Context: "CreateComputerInput"}
+	if s.ComputerName == nil {
+		invalidParams.Add(request.NewErrParamRequired("ComputerName"))
+	}
+	if s.ComputerName != nil && len(*s.ComputerName) < 1 {
+		invalidParams.Add(request.NewErrParamMinLen("ComputerName", 1))
+	}
+	if s.DirectoryId == nil {
+		invalidParams.Add(request.NewErrParamRequired("DirectoryId"))
+	}
+	if s.OrganizationalUnitDistinguishedName != nil && len(*s.OrganizationalUnitDistinguishedName) < 1 {
+		invalidParams.Add(request.NewErrParamMinLen("OrganizationalUnitDistinguishedName", 1))
+	}
+	if s.Password == nil {
+		invalidParams.Add(request.NewErrParamRequired("Password"))
+	}
+	if s.Password != nil && len(*s.Password) < 8 {
+		invalidParams.Add(request.NewErrParamMinLen("Password", 8))
+	}
+	if s.ComputerAttributes != nil {
+		for i, v := range s.ComputerAttributes {
+			if v == nil {
+				continue
+			}
+			if err := v.Validate(); err != nil {
+				invalidParams.AddNested(fmt.Sprintf("%s[%v]", "ComputerAttributes", i), err.(request.ErrInvalidParams))
+			}
+		}
+	}
+
+	if invalidParams.Len() > 0 {
+		return invalidParams
+	}
+	return nil
+}
+
 // Contains the results for the CreateComputer operation.
 type CreateComputerOutput struct {
 	_ struct{} `type:"structure"`
@@ -1110,6 +1211,25 @@ func (s CreateConditionalForwarderInput) String() string {
 // GoString returns the string representation
 func (s CreateConditionalForwarderInput) GoString() string {
 	return s.String()
+}
+
+// Validate inspects the fields of the type to determine if they are valid.
+func (s *CreateConditionalForwarderInput) Validate() error {
+	invalidParams := request.ErrInvalidParams{Context: "CreateConditionalForwarderInput"}
+	if s.DirectoryId == nil {
+		invalidParams.Add(request.NewErrParamRequired("DirectoryId"))
+	}
+	if s.DnsIpAddrs == nil {
+		invalidParams.Add(request.NewErrParamRequired("DnsIpAddrs"))
+	}
+	if s.RemoteDomainName == nil {
+		invalidParams.Add(request.NewErrParamRequired("RemoteDomainName"))
+	}
+
+	if invalidParams.Len() > 0 {
+		return invalidParams
+	}
+	return nil
 }
 
 type CreateConditionalForwarderOutput struct {
@@ -1160,6 +1280,30 @@ func (s CreateDirectoryInput) String() string {
 // GoString returns the string representation
 func (s CreateDirectoryInput) GoString() string {
 	return s.String()
+}
+
+// Validate inspects the fields of the type to determine if they are valid.
+func (s *CreateDirectoryInput) Validate() error {
+	invalidParams := request.ErrInvalidParams{Context: "CreateDirectoryInput"}
+	if s.Name == nil {
+		invalidParams.Add(request.NewErrParamRequired("Name"))
+	}
+	if s.Password == nil {
+		invalidParams.Add(request.NewErrParamRequired("Password"))
+	}
+	if s.Size == nil {
+		invalidParams.Add(request.NewErrParamRequired("Size"))
+	}
+	if s.VpcSettings != nil {
+		if err := s.VpcSettings.Validate(); err != nil {
+			invalidParams.AddNested("VpcSettings", err.(request.ErrInvalidParams))
+		}
+	}
+
+	if invalidParams.Len() > 0 {
+		return invalidParams
+	}
+	return nil
 }
 
 // Contains the results of the CreateDirectory operation.
@@ -1215,6 +1359,30 @@ func (s CreateMicrosoftADInput) GoString() string {
 	return s.String()
 }
 
+// Validate inspects the fields of the type to determine if they are valid.
+func (s *CreateMicrosoftADInput) Validate() error {
+	invalidParams := request.ErrInvalidParams{Context: "CreateMicrosoftADInput"}
+	if s.Name == nil {
+		invalidParams.Add(request.NewErrParamRequired("Name"))
+	}
+	if s.Password == nil {
+		invalidParams.Add(request.NewErrParamRequired("Password"))
+	}
+	if s.VpcSettings == nil {
+		invalidParams.Add(request.NewErrParamRequired("VpcSettings"))
+	}
+	if s.VpcSettings != nil {
+		if err := s.VpcSettings.Validate(); err != nil {
+			invalidParams.AddNested("VpcSettings", err.(request.ErrInvalidParams))
+		}
+	}
+
+	if invalidParams.Len() > 0 {
+		return invalidParams
+	}
+	return nil
+}
+
 type CreateMicrosoftADOutput struct {
 	_ struct{} `type:"structure"`
 
@@ -1251,6 +1419,19 @@ func (s CreateSnapshotInput) String() string {
 // GoString returns the string representation
 func (s CreateSnapshotInput) GoString() string {
 	return s.String()
+}
+
+// Validate inspects the fields of the type to determine if they are valid.
+func (s *CreateSnapshotInput) Validate() error {
+	invalidParams := request.ErrInvalidParams{Context: "CreateSnapshotInput"}
+	if s.DirectoryId == nil {
+		invalidParams.Add(request.NewErrParamRequired("DirectoryId"))
+	}
+
+	if invalidParams.Len() > 0 {
+		return invalidParams
+	}
+	return nil
 }
 
 // Contains the results of the CreateSnapshot operation.
@@ -1313,6 +1494,31 @@ func (s CreateTrustInput) GoString() string {
 	return s.String()
 }
 
+// Validate inspects the fields of the type to determine if they are valid.
+func (s *CreateTrustInput) Validate() error {
+	invalidParams := request.ErrInvalidParams{Context: "CreateTrustInput"}
+	if s.DirectoryId == nil {
+		invalidParams.Add(request.NewErrParamRequired("DirectoryId"))
+	}
+	if s.RemoteDomainName == nil {
+		invalidParams.Add(request.NewErrParamRequired("RemoteDomainName"))
+	}
+	if s.TrustDirection == nil {
+		invalidParams.Add(request.NewErrParamRequired("TrustDirection"))
+	}
+	if s.TrustPassword == nil {
+		invalidParams.Add(request.NewErrParamRequired("TrustPassword"))
+	}
+	if s.TrustPassword != nil && len(*s.TrustPassword) < 1 {
+		invalidParams.Add(request.NewErrParamMinLen("TrustPassword", 1))
+	}
+
+	if invalidParams.Len() > 0 {
+		return invalidParams
+	}
+	return nil
+}
+
 type CreateTrustOutput struct {
 	_ struct{} `type:"structure"`
 
@@ -1351,6 +1557,22 @@ func (s DeleteConditionalForwarderInput) GoString() string {
 	return s.String()
 }
 
+// Validate inspects the fields of the type to determine if they are valid.
+func (s *DeleteConditionalForwarderInput) Validate() error {
+	invalidParams := request.ErrInvalidParams{Context: "DeleteConditionalForwarderInput"}
+	if s.DirectoryId == nil {
+		invalidParams.Add(request.NewErrParamRequired("DirectoryId"))
+	}
+	if s.RemoteDomainName == nil {
+		invalidParams.Add(request.NewErrParamRequired("RemoteDomainName"))
+	}
+
+	if invalidParams.Len() > 0 {
+		return invalidParams
+	}
+	return nil
+}
+
 type DeleteConditionalForwarderOutput struct {
 	_ struct{} `type:"structure"`
 }
@@ -1381,6 +1603,19 @@ func (s DeleteDirectoryInput) String() string {
 // GoString returns the string representation
 func (s DeleteDirectoryInput) GoString() string {
 	return s.String()
+}
+
+// Validate inspects the fields of the type to determine if they are valid.
+func (s *DeleteDirectoryInput) Validate() error {
+	invalidParams := request.ErrInvalidParams{Context: "DeleteDirectoryInput"}
+	if s.DirectoryId == nil {
+		invalidParams.Add(request.NewErrParamRequired("DirectoryId"))
+	}
+
+	if invalidParams.Len() > 0 {
+		return invalidParams
+	}
+	return nil
 }
 
 // Contains the results of the DeleteDirectory operation.
@@ -1417,6 +1652,19 @@ func (s DeleteSnapshotInput) String() string {
 // GoString returns the string representation
 func (s DeleteSnapshotInput) GoString() string {
 	return s.String()
+}
+
+// Validate inspects the fields of the type to determine if they are valid.
+func (s *DeleteSnapshotInput) Validate() error {
+	invalidParams := request.ErrInvalidParams{Context: "DeleteSnapshotInput"}
+	if s.SnapshotId == nil {
+		invalidParams.Add(request.NewErrParamRequired("SnapshotId"))
+	}
+
+	if invalidParams.Len() > 0 {
+		return invalidParams
+	}
+	return nil
 }
 
 // Contains the results of the DeleteSnapshot operation.
@@ -1458,6 +1706,19 @@ func (s DeleteTrustInput) GoString() string {
 	return s.String()
 }
 
+// Validate inspects the fields of the type to determine if they are valid.
+func (s *DeleteTrustInput) Validate() error {
+	invalidParams := request.ErrInvalidParams{Context: "DeleteTrustInput"}
+	if s.TrustId == nil {
+		invalidParams.Add(request.NewErrParamRequired("TrustId"))
+	}
+
+	if invalidParams.Len() > 0 {
+		return invalidParams
+	}
+	return nil
+}
+
 type DeleteTrustOutput struct {
 	_ struct{} `type:"structure"`
 
@@ -1497,6 +1758,25 @@ func (s DeregisterEventTopicInput) GoString() string {
 	return s.String()
 }
 
+// Validate inspects the fields of the type to determine if they are valid.
+func (s *DeregisterEventTopicInput) Validate() error {
+	invalidParams := request.ErrInvalidParams{Context: "DeregisterEventTopicInput"}
+	if s.DirectoryId == nil {
+		invalidParams.Add(request.NewErrParamRequired("DirectoryId"))
+	}
+	if s.TopicName == nil {
+		invalidParams.Add(request.NewErrParamRequired("TopicName"))
+	}
+	if s.TopicName != nil && len(*s.TopicName) < 1 {
+		invalidParams.Add(request.NewErrParamMinLen("TopicName", 1))
+	}
+
+	if invalidParams.Len() > 0 {
+		return invalidParams
+	}
+	return nil
+}
+
 type DeregisterEventTopicOutput struct {
 	_ struct{} `type:"structure"`
 }
@@ -1531,6 +1811,19 @@ func (s DescribeConditionalForwardersInput) String() string {
 // GoString returns the string representation
 func (s DescribeConditionalForwardersInput) GoString() string {
 	return s.String()
+}
+
+// Validate inspects the fields of the type to determine if they are valid.
+func (s *DescribeConditionalForwardersInput) Validate() error {
+	invalidParams := request.ErrInvalidParams{Context: "DescribeConditionalForwardersInput"}
+	if s.DirectoryId == nil {
+		invalidParams.Add(request.NewErrParamRequired("DirectoryId"))
+	}
+
+	if invalidParams.Len() > 0 {
+		return invalidParams
+	}
+	return nil
 }
 
 type DescribeConditionalForwardersOutput struct {
@@ -1801,6 +2094,31 @@ func (s DirectoryConnectSettings) GoString() string {
 	return s.String()
 }
 
+// Validate inspects the fields of the type to determine if they are valid.
+func (s *DirectoryConnectSettings) Validate() error {
+	invalidParams := request.ErrInvalidParams{Context: "DirectoryConnectSettings"}
+	if s.CustomerDnsIps == nil {
+		invalidParams.Add(request.NewErrParamRequired("CustomerDnsIps"))
+	}
+	if s.CustomerUserName == nil {
+		invalidParams.Add(request.NewErrParamRequired("CustomerUserName"))
+	}
+	if s.CustomerUserName != nil && len(*s.CustomerUserName) < 1 {
+		invalidParams.Add(request.NewErrParamMinLen("CustomerUserName", 1))
+	}
+	if s.SubnetIds == nil {
+		invalidParams.Add(request.NewErrParamRequired("SubnetIds"))
+	}
+	if s.VpcId == nil {
+		invalidParams.Add(request.NewErrParamRequired("VpcId"))
+	}
+
+	if invalidParams.Len() > 0 {
+		return invalidParams
+	}
+	return nil
+}
+
 // Contains information about an AD Connector directory.
 type DirectoryConnectSettingsDescription struct {
 	_ struct{} `type:"structure"`
@@ -1981,6 +2299,22 @@ func (s DirectoryVpcSettings) GoString() string {
 	return s.String()
 }
 
+// Validate inspects the fields of the type to determine if they are valid.
+func (s *DirectoryVpcSettings) Validate() error {
+	invalidParams := request.ErrInvalidParams{Context: "DirectoryVpcSettings"}
+	if s.SubnetIds == nil {
+		invalidParams.Add(request.NewErrParamRequired("SubnetIds"))
+	}
+	if s.VpcId == nil {
+		invalidParams.Add(request.NewErrParamRequired("VpcId"))
+	}
+
+	if invalidParams.Len() > 0 {
+		return invalidParams
+	}
+	return nil
+}
+
 // Contains information about the directory.
 type DirectoryVpcSettingsDescription struct {
 	_ struct{} `type:"structure"`
@@ -2027,6 +2361,19 @@ func (s DisableRadiusInput) String() string {
 // GoString returns the string representation
 func (s DisableRadiusInput) GoString() string {
 	return s.String()
+}
+
+// Validate inspects the fields of the type to determine if they are valid.
+func (s *DisableRadiusInput) Validate() error {
+	invalidParams := request.ErrInvalidParams{Context: "DisableRadiusInput"}
+	if s.DirectoryId == nil {
+		invalidParams.Add(request.NewErrParamRequired("DirectoryId"))
+	}
+
+	if invalidParams.Len() > 0 {
+		return invalidParams
+	}
+	return nil
 }
 
 // Contains the results of the DisableRadius operation.
@@ -2078,6 +2425,25 @@ func (s DisableSsoInput) GoString() string {
 	return s.String()
 }
 
+// Validate inspects the fields of the type to determine if they are valid.
+func (s *DisableSsoInput) Validate() error {
+	invalidParams := request.ErrInvalidParams{Context: "DisableSsoInput"}
+	if s.DirectoryId == nil {
+		invalidParams.Add(request.NewErrParamRequired("DirectoryId"))
+	}
+	if s.Password != nil && len(*s.Password) < 1 {
+		invalidParams.Add(request.NewErrParamMinLen("Password", 1))
+	}
+	if s.UserName != nil && len(*s.UserName) < 1 {
+		invalidParams.Add(request.NewErrParamMinLen("UserName", 1))
+	}
+
+	if invalidParams.Len() > 0 {
+		return invalidParams
+	}
+	return nil
+}
+
 // Contains the results of the DisableSso operation.
 type DisableSsoOutput struct {
 	_ struct{} `type:"structure"`
@@ -2112,6 +2478,27 @@ func (s EnableRadiusInput) String() string {
 // GoString returns the string representation
 func (s EnableRadiusInput) GoString() string {
 	return s.String()
+}
+
+// Validate inspects the fields of the type to determine if they are valid.
+func (s *EnableRadiusInput) Validate() error {
+	invalidParams := request.ErrInvalidParams{Context: "EnableRadiusInput"}
+	if s.DirectoryId == nil {
+		invalidParams.Add(request.NewErrParamRequired("DirectoryId"))
+	}
+	if s.RadiusSettings == nil {
+		invalidParams.Add(request.NewErrParamRequired("RadiusSettings"))
+	}
+	if s.RadiusSettings != nil {
+		if err := s.RadiusSettings.Validate(); err != nil {
+			invalidParams.AddNested("RadiusSettings", err.(request.ErrInvalidParams))
+		}
+	}
+
+	if invalidParams.Len() > 0 {
+		return invalidParams
+	}
+	return nil
 }
 
 // Contains the results of the EnableRadius operation.
@@ -2161,6 +2548,25 @@ func (s EnableSsoInput) String() string {
 // GoString returns the string representation
 func (s EnableSsoInput) GoString() string {
 	return s.String()
+}
+
+// Validate inspects the fields of the type to determine if they are valid.
+func (s *EnableSsoInput) Validate() error {
+	invalidParams := request.ErrInvalidParams{Context: "EnableSsoInput"}
+	if s.DirectoryId == nil {
+		invalidParams.Add(request.NewErrParamRequired("DirectoryId"))
+	}
+	if s.Password != nil && len(*s.Password) < 1 {
+		invalidParams.Add(request.NewErrParamMinLen("Password", 1))
+	}
+	if s.UserName != nil && len(*s.UserName) < 1 {
+		invalidParams.Add(request.NewErrParamMinLen("UserName", 1))
+	}
+
+	if invalidParams.Len() > 0 {
+		return invalidParams
+	}
+	return nil
 }
 
 // Contains the results of the EnableSso operation.
@@ -2261,6 +2667,19 @@ func (s GetSnapshotLimitsInput) GoString() string {
 	return s.String()
 }
 
+// Validate inspects the fields of the type to determine if they are valid.
+func (s *GetSnapshotLimitsInput) Validate() error {
+	invalidParams := request.ErrInvalidParams{Context: "GetSnapshotLimitsInput"}
+	if s.DirectoryId == nil {
+		invalidParams.Add(request.NewErrParamRequired("DirectoryId"))
+	}
+
+	if invalidParams.Len() > 0 {
+		return invalidParams
+	}
+	return nil
+}
+
 // Contains the results of the GetSnapshotLimits operation.
 type GetSnapshotLimitsOutput struct {
 	_ struct{} `type:"structure"`
@@ -2325,6 +2744,28 @@ func (s RadiusSettings) GoString() string {
 	return s.String()
 }
 
+// Validate inspects the fields of the type to determine if they are valid.
+func (s *RadiusSettings) Validate() error {
+	invalidParams := request.ErrInvalidParams{Context: "RadiusSettings"}
+	if s.DisplayLabel != nil && len(*s.DisplayLabel) < 1 {
+		invalidParams.Add(request.NewErrParamMinLen("DisplayLabel", 1))
+	}
+	if s.RadiusPort != nil && *s.RadiusPort < 1025 {
+		invalidParams.Add(request.NewErrParamMinValue("RadiusPort", 1025))
+	}
+	if s.RadiusTimeout != nil && *s.RadiusTimeout < 1 {
+		invalidParams.Add(request.NewErrParamMinValue("RadiusTimeout", 1))
+	}
+	if s.SharedSecret != nil && len(*s.SharedSecret) < 8 {
+		invalidParams.Add(request.NewErrParamMinLen("SharedSecret", 8))
+	}
+
+	if invalidParams.Len() > 0 {
+		return invalidParams
+	}
+	return nil
+}
+
 type RegisterEventTopicInput struct {
 	_ struct{} `type:"structure"`
 
@@ -2344,6 +2785,25 @@ func (s RegisterEventTopicInput) String() string {
 // GoString returns the string representation
 func (s RegisterEventTopicInput) GoString() string {
 	return s.String()
+}
+
+// Validate inspects the fields of the type to determine if they are valid.
+func (s *RegisterEventTopicInput) Validate() error {
+	invalidParams := request.ErrInvalidParams{Context: "RegisterEventTopicInput"}
+	if s.DirectoryId == nil {
+		invalidParams.Add(request.NewErrParamRequired("DirectoryId"))
+	}
+	if s.TopicName == nil {
+		invalidParams.Add(request.NewErrParamRequired("TopicName"))
+	}
+	if s.TopicName != nil && len(*s.TopicName) < 1 {
+		invalidParams.Add(request.NewErrParamMinLen("TopicName", 1))
+	}
+
+	if invalidParams.Len() > 0 {
+		return invalidParams
+	}
+	return nil
 }
 
 type RegisterEventTopicOutput struct {
@@ -2376,6 +2836,19 @@ func (s RestoreFromSnapshotInput) String() string {
 // GoString returns the string representation
 func (s RestoreFromSnapshotInput) GoString() string {
 	return s.String()
+}
+
+// Validate inspects the fields of the type to determine if they are valid.
+func (s *RestoreFromSnapshotInput) Validate() error {
+	invalidParams := request.ErrInvalidParams{Context: "RestoreFromSnapshotInput"}
+	if s.SnapshotId == nil {
+		invalidParams.Add(request.NewErrParamRequired("SnapshotId"))
+	}
+
+	if invalidParams.Len() > 0 {
+		return invalidParams
+	}
+	return nil
 }
 
 // Contains the results of the RestoreFromSnapshot operation.
@@ -2523,6 +2996,25 @@ func (s UpdateConditionalForwarderInput) GoString() string {
 	return s.String()
 }
 
+// Validate inspects the fields of the type to determine if they are valid.
+func (s *UpdateConditionalForwarderInput) Validate() error {
+	invalidParams := request.ErrInvalidParams{Context: "UpdateConditionalForwarderInput"}
+	if s.DirectoryId == nil {
+		invalidParams.Add(request.NewErrParamRequired("DirectoryId"))
+	}
+	if s.DnsIpAddrs == nil {
+		invalidParams.Add(request.NewErrParamRequired("DnsIpAddrs"))
+	}
+	if s.RemoteDomainName == nil {
+		invalidParams.Add(request.NewErrParamRequired("RemoteDomainName"))
+	}
+
+	if invalidParams.Len() > 0 {
+		return invalidParams
+	}
+	return nil
+}
+
 type UpdateConditionalForwarderOutput struct {
 	_ struct{} `type:"structure"`
 }
@@ -2558,6 +3050,27 @@ func (s UpdateRadiusInput) GoString() string {
 	return s.String()
 }
 
+// Validate inspects the fields of the type to determine if they are valid.
+func (s *UpdateRadiusInput) Validate() error {
+	invalidParams := request.ErrInvalidParams{Context: "UpdateRadiusInput"}
+	if s.DirectoryId == nil {
+		invalidParams.Add(request.NewErrParamRequired("DirectoryId"))
+	}
+	if s.RadiusSettings == nil {
+		invalidParams.Add(request.NewErrParamRequired("RadiusSettings"))
+	}
+	if s.RadiusSettings != nil {
+		if err := s.RadiusSettings.Validate(); err != nil {
+			invalidParams.AddNested("RadiusSettings", err.(request.ErrInvalidParams))
+		}
+	}
+
+	if invalidParams.Len() > 0 {
+		return invalidParams
+	}
+	return nil
+}
+
 // Contains the results of the UpdateRadius operation.
 type UpdateRadiusOutput struct {
 	_ struct{} `type:"structure"`
@@ -2590,6 +3103,19 @@ func (s VerifyTrustInput) String() string {
 // GoString returns the string representation
 func (s VerifyTrustInput) GoString() string {
 	return s.String()
+}
+
+// Validate inspects the fields of the type to determine if they are valid.
+func (s *VerifyTrustInput) Validate() error {
+	invalidParams := request.ErrInvalidParams{Context: "VerifyTrustInput"}
+	if s.TrustId == nil {
+		invalidParams.Add(request.NewErrParamRequired("TrustId"))
+	}
+
+	if invalidParams.Len() > 0 {
+		return invalidParams
+	}
+	return nil
 }
 
 type VerifyTrustOutput struct {

--- a/service/dynamodb/api.go
+++ b/service/dynamodb/api.go
@@ -4,6 +4,7 @@
 package dynamodb
 
 import (
+	"fmt"
 	"time"
 
 	"github.com/aws/aws-sdk-go/aws/awsutil"
@@ -785,6 +786,25 @@ func (s AttributeDefinition) GoString() string {
 	return s.String()
 }
 
+// Validate inspects the fields of the type to determine if they are valid.
+func (s *AttributeDefinition) Validate() error {
+	invalidParams := request.ErrInvalidParams{Context: "AttributeDefinition"}
+	if s.AttributeName == nil {
+		invalidParams.Add(request.NewErrParamRequired("AttributeName"))
+	}
+	if s.AttributeName != nil && len(*s.AttributeName) < 1 {
+		invalidParams.Add(request.NewErrParamMinLen("AttributeName", 1))
+	}
+	if s.AttributeType == nil {
+		invalidParams.Add(request.NewErrParamRequired("AttributeType"))
+	}
+
+	if invalidParams.Len() > 0 {
+		return invalidParams
+	}
+	return nil
+}
+
 // Represents the data for an attribute. You can set one, and only one, of the
 // elements.
 //
@@ -1049,6 +1069,32 @@ func (s BatchGetItemInput) GoString() string {
 	return s.String()
 }
 
+// Validate inspects the fields of the type to determine if they are valid.
+func (s *BatchGetItemInput) Validate() error {
+	invalidParams := request.ErrInvalidParams{Context: "BatchGetItemInput"}
+	if s.RequestItems == nil {
+		invalidParams.Add(request.NewErrParamRequired("RequestItems"))
+	}
+	if s.RequestItems != nil && len(s.RequestItems) < 1 {
+		invalidParams.Add(request.NewErrParamMinLen("RequestItems", 1))
+	}
+	if s.RequestItems != nil {
+		for i, v := range s.RequestItems {
+			if v == nil {
+				continue
+			}
+			if err := v.Validate(); err != nil {
+				invalidParams.AddNested(fmt.Sprintf("%s[%v]", "RequestItems", i), err.(request.ErrInvalidParams))
+			}
+		}
+	}
+
+	if invalidParams.Len() > 0 {
+		return invalidParams
+	}
+	return nil
+}
+
 // Represents the output of a BatchGetItem operation.
 type BatchGetItemOutput struct {
 	_ struct{} `type:"structure"`
@@ -1164,6 +1210,22 @@ func (s BatchWriteItemInput) String() string {
 // GoString returns the string representation
 func (s BatchWriteItemInput) GoString() string {
 	return s.String()
+}
+
+// Validate inspects the fields of the type to determine if they are valid.
+func (s *BatchWriteItemInput) Validate() error {
+	invalidParams := request.ErrInvalidParams{Context: "BatchWriteItemInput"}
+	if s.RequestItems == nil {
+		invalidParams.Add(request.NewErrParamRequired("RequestItems"))
+	}
+	if s.RequestItems != nil && len(s.RequestItems) < 1 {
+		invalidParams.Add(request.NewErrParamMinLen("RequestItems", 1))
+	}
+
+	if invalidParams.Len() > 0 {
+		return invalidParams
+	}
+	return nil
 }
 
 // Represents the output of a BatchWriteItem operation.
@@ -1435,6 +1497,19 @@ func (s Condition) GoString() string {
 	return s.String()
 }
 
+// Validate inspects the fields of the type to determine if they are valid.
+func (s *Condition) Validate() error {
+	invalidParams := request.ErrInvalidParams{Context: "Condition"}
+	if s.ComparisonOperator == nil {
+		invalidParams.Add(request.NewErrParamRequired("ComparisonOperator"))
+	}
+
+	if invalidParams.Len() > 0 {
+		return invalidParams
+	}
+	return nil
+}
+
 // The capacity units consumed by an operation. The data returned includes the
 // total provisioned throughput consumed, along with statistics for the table
 // and any indexes involved in the operation. ConsumedCapacity is only returned
@@ -1502,6 +1577,54 @@ func (s CreateGlobalSecondaryIndexAction) String() string {
 // GoString returns the string representation
 func (s CreateGlobalSecondaryIndexAction) GoString() string {
 	return s.String()
+}
+
+// Validate inspects the fields of the type to determine if they are valid.
+func (s *CreateGlobalSecondaryIndexAction) Validate() error {
+	invalidParams := request.ErrInvalidParams{Context: "CreateGlobalSecondaryIndexAction"}
+	if s.IndexName == nil {
+		invalidParams.Add(request.NewErrParamRequired("IndexName"))
+	}
+	if s.IndexName != nil && len(*s.IndexName) < 3 {
+		invalidParams.Add(request.NewErrParamMinLen("IndexName", 3))
+	}
+	if s.KeySchema == nil {
+		invalidParams.Add(request.NewErrParamRequired("KeySchema"))
+	}
+	if s.KeySchema != nil && len(s.KeySchema) < 1 {
+		invalidParams.Add(request.NewErrParamMinLen("KeySchema", 1))
+	}
+	if s.Projection == nil {
+		invalidParams.Add(request.NewErrParamRequired("Projection"))
+	}
+	if s.ProvisionedThroughput == nil {
+		invalidParams.Add(request.NewErrParamRequired("ProvisionedThroughput"))
+	}
+	if s.KeySchema != nil {
+		for i, v := range s.KeySchema {
+			if v == nil {
+				continue
+			}
+			if err := v.Validate(); err != nil {
+				invalidParams.AddNested(fmt.Sprintf("%s[%v]", "KeySchema", i), err.(request.ErrInvalidParams))
+			}
+		}
+	}
+	if s.Projection != nil {
+		if err := s.Projection.Validate(); err != nil {
+			invalidParams.AddNested("Projection", err.(request.ErrInvalidParams))
+		}
+	}
+	if s.ProvisionedThroughput != nil {
+		if err := s.ProvisionedThroughput.Validate(); err != nil {
+			invalidParams.AddNested("ProvisionedThroughput", err.(request.ErrInvalidParams))
+		}
+	}
+
+	if invalidParams.Len() > 0 {
+		return invalidParams
+	}
+	return nil
 }
 
 // Represents the input of a CreateTable operation.
@@ -1656,6 +1779,79 @@ func (s CreateTableInput) GoString() string {
 	return s.String()
 }
 
+// Validate inspects the fields of the type to determine if they are valid.
+func (s *CreateTableInput) Validate() error {
+	invalidParams := request.ErrInvalidParams{Context: "CreateTableInput"}
+	if s.AttributeDefinitions == nil {
+		invalidParams.Add(request.NewErrParamRequired("AttributeDefinitions"))
+	}
+	if s.KeySchema == nil {
+		invalidParams.Add(request.NewErrParamRequired("KeySchema"))
+	}
+	if s.KeySchema != nil && len(s.KeySchema) < 1 {
+		invalidParams.Add(request.NewErrParamMinLen("KeySchema", 1))
+	}
+	if s.ProvisionedThroughput == nil {
+		invalidParams.Add(request.NewErrParamRequired("ProvisionedThroughput"))
+	}
+	if s.TableName == nil {
+		invalidParams.Add(request.NewErrParamRequired("TableName"))
+	}
+	if s.TableName != nil && len(*s.TableName) < 3 {
+		invalidParams.Add(request.NewErrParamMinLen("TableName", 3))
+	}
+	if s.AttributeDefinitions != nil {
+		for i, v := range s.AttributeDefinitions {
+			if v == nil {
+				continue
+			}
+			if err := v.Validate(); err != nil {
+				invalidParams.AddNested(fmt.Sprintf("%s[%v]", "AttributeDefinitions", i), err.(request.ErrInvalidParams))
+			}
+		}
+	}
+	if s.GlobalSecondaryIndexes != nil {
+		for i, v := range s.GlobalSecondaryIndexes {
+			if v == nil {
+				continue
+			}
+			if err := v.Validate(); err != nil {
+				invalidParams.AddNested(fmt.Sprintf("%s[%v]", "GlobalSecondaryIndexes", i), err.(request.ErrInvalidParams))
+			}
+		}
+	}
+	if s.KeySchema != nil {
+		for i, v := range s.KeySchema {
+			if v == nil {
+				continue
+			}
+			if err := v.Validate(); err != nil {
+				invalidParams.AddNested(fmt.Sprintf("%s[%v]", "KeySchema", i), err.(request.ErrInvalidParams))
+			}
+		}
+	}
+	if s.LocalSecondaryIndexes != nil {
+		for i, v := range s.LocalSecondaryIndexes {
+			if v == nil {
+				continue
+			}
+			if err := v.Validate(); err != nil {
+				invalidParams.AddNested(fmt.Sprintf("%s[%v]", "LocalSecondaryIndexes", i), err.(request.ErrInvalidParams))
+			}
+		}
+	}
+	if s.ProvisionedThroughput != nil {
+		if err := s.ProvisionedThroughput.Validate(); err != nil {
+			invalidParams.AddNested("ProvisionedThroughput", err.(request.ErrInvalidParams))
+		}
+	}
+
+	if invalidParams.Len() > 0 {
+		return invalidParams
+	}
+	return nil
+}
+
 // Represents the output of a CreateTable operation.
 type CreateTableOutput struct {
 	_ struct{} `type:"structure"`
@@ -1690,6 +1886,22 @@ func (s DeleteGlobalSecondaryIndexAction) String() string {
 // GoString returns the string representation
 func (s DeleteGlobalSecondaryIndexAction) GoString() string {
 	return s.String()
+}
+
+// Validate inspects the fields of the type to determine if they are valid.
+func (s *DeleteGlobalSecondaryIndexAction) Validate() error {
+	invalidParams := request.ErrInvalidParams{Context: "DeleteGlobalSecondaryIndexAction"}
+	if s.IndexName == nil {
+		invalidParams.Add(request.NewErrParamRequired("IndexName"))
+	}
+	if s.IndexName != nil && len(*s.IndexName) < 3 {
+		invalidParams.Add(request.NewErrParamMinLen("IndexName", 3))
+	}
+
+	if invalidParams.Len() > 0 {
+		return invalidParams
+	}
+	return nil
 }
 
 // Represents the input of a DeleteItem operation.
@@ -2046,6 +2258,25 @@ func (s DeleteItemInput) GoString() string {
 	return s.String()
 }
 
+// Validate inspects the fields of the type to determine if they are valid.
+func (s *DeleteItemInput) Validate() error {
+	invalidParams := request.ErrInvalidParams{Context: "DeleteItemInput"}
+	if s.Key == nil {
+		invalidParams.Add(request.NewErrParamRequired("Key"))
+	}
+	if s.TableName == nil {
+		invalidParams.Add(request.NewErrParamRequired("TableName"))
+	}
+	if s.TableName != nil && len(*s.TableName) < 3 {
+		invalidParams.Add(request.NewErrParamMinLen("TableName", 3))
+	}
+
+	if invalidParams.Len() > 0 {
+		return invalidParams
+	}
+	return nil
+}
+
 // Represents the output of a DeleteItem operation.
 type DeleteItemOutput struct {
 	_ struct{} `type:"structure"`
@@ -2133,6 +2364,22 @@ func (s DeleteTableInput) GoString() string {
 	return s.String()
 }
 
+// Validate inspects the fields of the type to determine if they are valid.
+func (s *DeleteTableInput) Validate() error {
+	invalidParams := request.ErrInvalidParams{Context: "DeleteTableInput"}
+	if s.TableName == nil {
+		invalidParams.Add(request.NewErrParamRequired("TableName"))
+	}
+	if s.TableName != nil && len(*s.TableName) < 3 {
+		invalidParams.Add(request.NewErrParamMinLen("TableName", 3))
+	}
+
+	if invalidParams.Len() > 0 {
+		return invalidParams
+	}
+	return nil
+}
+
 // Represents the output of a DeleteTable operation.
 type DeleteTableOutput struct {
 	_ struct{} `type:"structure"`
@@ -2215,6 +2462,22 @@ func (s DescribeTableInput) String() string {
 // GoString returns the string representation
 func (s DescribeTableInput) GoString() string {
 	return s.String()
+}
+
+// Validate inspects the fields of the type to determine if they are valid.
+func (s *DescribeTableInput) Validate() error {
+	invalidParams := request.ErrInvalidParams{Context: "DescribeTableInput"}
+	if s.TableName == nil {
+		invalidParams.Add(request.NewErrParamRequired("TableName"))
+	}
+	if s.TableName != nil && len(*s.TableName) < 3 {
+		invalidParams.Add(request.NewErrParamMinLen("TableName", 3))
+	}
+
+	if invalidParams.Len() > 0 {
+		return invalidParams
+	}
+	return nil
 }
 
 // Represents the output of a DescribeTable operation.
@@ -2564,6 +2827,28 @@ func (s GetItemInput) GoString() string {
 	return s.String()
 }
 
+// Validate inspects the fields of the type to determine if they are valid.
+func (s *GetItemInput) Validate() error {
+	invalidParams := request.ErrInvalidParams{Context: "GetItemInput"}
+	if s.AttributesToGet != nil && len(s.AttributesToGet) < 1 {
+		invalidParams.Add(request.NewErrParamMinLen("AttributesToGet", 1))
+	}
+	if s.Key == nil {
+		invalidParams.Add(request.NewErrParamRequired("Key"))
+	}
+	if s.TableName == nil {
+		invalidParams.Add(request.NewErrParamRequired("TableName"))
+	}
+	if s.TableName != nil && len(*s.TableName) < 3 {
+		invalidParams.Add(request.NewErrParamMinLen("TableName", 3))
+	}
+
+	if invalidParams.Len() > 0 {
+		return invalidParams
+	}
+	return nil
+}
+
 // Represents the output of a GetItem operation.
 type GetItemOutput struct {
 	_ struct{} `type:"structure"`
@@ -2637,6 +2922,54 @@ func (s GlobalSecondaryIndex) String() string {
 // GoString returns the string representation
 func (s GlobalSecondaryIndex) GoString() string {
 	return s.String()
+}
+
+// Validate inspects the fields of the type to determine if they are valid.
+func (s *GlobalSecondaryIndex) Validate() error {
+	invalidParams := request.ErrInvalidParams{Context: "GlobalSecondaryIndex"}
+	if s.IndexName == nil {
+		invalidParams.Add(request.NewErrParamRequired("IndexName"))
+	}
+	if s.IndexName != nil && len(*s.IndexName) < 3 {
+		invalidParams.Add(request.NewErrParamMinLen("IndexName", 3))
+	}
+	if s.KeySchema == nil {
+		invalidParams.Add(request.NewErrParamRequired("KeySchema"))
+	}
+	if s.KeySchema != nil && len(s.KeySchema) < 1 {
+		invalidParams.Add(request.NewErrParamMinLen("KeySchema", 1))
+	}
+	if s.Projection == nil {
+		invalidParams.Add(request.NewErrParamRequired("Projection"))
+	}
+	if s.ProvisionedThroughput == nil {
+		invalidParams.Add(request.NewErrParamRequired("ProvisionedThroughput"))
+	}
+	if s.KeySchema != nil {
+		for i, v := range s.KeySchema {
+			if v == nil {
+				continue
+			}
+			if err := v.Validate(); err != nil {
+				invalidParams.AddNested(fmt.Sprintf("%s[%v]", "KeySchema", i), err.(request.ErrInvalidParams))
+			}
+		}
+	}
+	if s.Projection != nil {
+		if err := s.Projection.Validate(); err != nil {
+			invalidParams.AddNested("Projection", err.(request.ErrInvalidParams))
+		}
+	}
+	if s.ProvisionedThroughput != nil {
+		if err := s.ProvisionedThroughput.Validate(); err != nil {
+			invalidParams.AddNested("ProvisionedThroughput", err.(request.ErrInvalidParams))
+		}
+	}
+
+	if invalidParams.Len() > 0 {
+		return invalidParams
+	}
+	return nil
 }
 
 // Represents the properties of a global secondary index.
@@ -2759,6 +3092,31 @@ func (s GlobalSecondaryIndexUpdate) GoString() string {
 	return s.String()
 }
 
+// Validate inspects the fields of the type to determine if they are valid.
+func (s *GlobalSecondaryIndexUpdate) Validate() error {
+	invalidParams := request.ErrInvalidParams{Context: "GlobalSecondaryIndexUpdate"}
+	if s.Create != nil {
+		if err := s.Create.Validate(); err != nil {
+			invalidParams.AddNested("Create", err.(request.ErrInvalidParams))
+		}
+	}
+	if s.Delete != nil {
+		if err := s.Delete.Validate(); err != nil {
+			invalidParams.AddNested("Delete", err.(request.ErrInvalidParams))
+		}
+	}
+	if s.Update != nil {
+		if err := s.Update.Validate(); err != nil {
+			invalidParams.AddNested("Update", err.(request.ErrInvalidParams))
+		}
+	}
+
+	if invalidParams.Len() > 0 {
+		return invalidParams
+	}
+	return nil
+}
+
 // Information about item collections, if any, that were affected by the operation.
 // ItemCollectionMetrics is only returned if the request asked for it. If the
 // table does not have any local secondary indexes, this information is not
@@ -2834,6 +3192,25 @@ func (s KeySchemaElement) String() string {
 // GoString returns the string representation
 func (s KeySchemaElement) GoString() string {
 	return s.String()
+}
+
+// Validate inspects the fields of the type to determine if they are valid.
+func (s *KeySchemaElement) Validate() error {
+	invalidParams := request.ErrInvalidParams{Context: "KeySchemaElement"}
+	if s.AttributeName == nil {
+		invalidParams.Add(request.NewErrParamRequired("AttributeName"))
+	}
+	if s.AttributeName != nil && len(*s.AttributeName) < 1 {
+		invalidParams.Add(request.NewErrParamMinLen("AttributeName", 1))
+	}
+	if s.KeyType == nil {
+		invalidParams.Add(request.NewErrParamRequired("KeyType"))
+	}
+
+	if invalidParams.Len() > 0 {
+		return invalidParams
+	}
+	return nil
 }
 
 // Represents a set of primary keys and, for each key, the attributes to retrieve
@@ -2920,6 +3297,25 @@ func (s KeysAndAttributes) GoString() string {
 	return s.String()
 }
 
+// Validate inspects the fields of the type to determine if they are valid.
+func (s *KeysAndAttributes) Validate() error {
+	invalidParams := request.ErrInvalidParams{Context: "KeysAndAttributes"}
+	if s.AttributesToGet != nil && len(s.AttributesToGet) < 1 {
+		invalidParams.Add(request.NewErrParamMinLen("AttributesToGet", 1))
+	}
+	if s.Keys == nil {
+		invalidParams.Add(request.NewErrParamRequired("Keys"))
+	}
+	if s.Keys != nil && len(s.Keys) < 1 {
+		invalidParams.Add(request.NewErrParamMinLen("Keys", 1))
+	}
+
+	if invalidParams.Len() > 0 {
+		return invalidParams
+	}
+	return nil
+}
+
 // Represents the input of a ListTables operation.
 type ListTablesInput struct {
 	_ struct{} `type:"structure"`
@@ -2942,6 +3338,22 @@ func (s ListTablesInput) String() string {
 // GoString returns the string representation
 func (s ListTablesInput) GoString() string {
 	return s.String()
+}
+
+// Validate inspects the fields of the type to determine if they are valid.
+func (s *ListTablesInput) Validate() error {
+	invalidParams := request.ErrInvalidParams{Context: "ListTablesInput"}
+	if s.ExclusiveStartTableName != nil && len(*s.ExclusiveStartTableName) < 3 {
+		invalidParams.Add(request.NewErrParamMinLen("ExclusiveStartTableName", 3))
+	}
+	if s.Limit != nil && *s.Limit < 1 {
+		invalidParams.Add(request.NewErrParamMinValue("Limit", 1))
+	}
+
+	if invalidParams.Len() > 0 {
+		return invalidParams
+	}
+	return nil
 }
 
 // Represents the output of a ListTables operation.
@@ -3014,6 +3426,46 @@ func (s LocalSecondaryIndex) String() string {
 // GoString returns the string representation
 func (s LocalSecondaryIndex) GoString() string {
 	return s.String()
+}
+
+// Validate inspects the fields of the type to determine if they are valid.
+func (s *LocalSecondaryIndex) Validate() error {
+	invalidParams := request.ErrInvalidParams{Context: "LocalSecondaryIndex"}
+	if s.IndexName == nil {
+		invalidParams.Add(request.NewErrParamRequired("IndexName"))
+	}
+	if s.IndexName != nil && len(*s.IndexName) < 3 {
+		invalidParams.Add(request.NewErrParamMinLen("IndexName", 3))
+	}
+	if s.KeySchema == nil {
+		invalidParams.Add(request.NewErrParamRequired("KeySchema"))
+	}
+	if s.KeySchema != nil && len(s.KeySchema) < 1 {
+		invalidParams.Add(request.NewErrParamMinLen("KeySchema", 1))
+	}
+	if s.Projection == nil {
+		invalidParams.Add(request.NewErrParamRequired("Projection"))
+	}
+	if s.KeySchema != nil {
+		for i, v := range s.KeySchema {
+			if v == nil {
+				continue
+			}
+			if err := v.Validate(); err != nil {
+				invalidParams.AddNested(fmt.Sprintf("%s[%v]", "KeySchema", i), err.(request.ErrInvalidParams))
+			}
+		}
+	}
+	if s.Projection != nil {
+		if err := s.Projection.Validate(); err != nil {
+			invalidParams.AddNested("Projection", err.(request.ErrInvalidParams))
+		}
+	}
+
+	if invalidParams.Len() > 0 {
+		return invalidParams
+	}
+	return nil
 }
 
 // Represents the properties of a local secondary index.
@@ -3103,6 +3555,19 @@ func (s Projection) GoString() string {
 	return s.String()
 }
 
+// Validate inspects the fields of the type to determine if they are valid.
+func (s *Projection) Validate() error {
+	invalidParams := request.ErrInvalidParams{Context: "Projection"}
+	if s.NonKeyAttributes != nil && len(s.NonKeyAttributes) < 1 {
+		invalidParams.Add(request.NewErrParamMinLen("NonKeyAttributes", 1))
+	}
+
+	if invalidParams.Len() > 0 {
+		return invalidParams
+	}
+	return nil
+}
+
 // Represents the provisioned throughput settings for a specified table or index.
 // The settings can be modified using the UpdateTable operation.
 //
@@ -3133,6 +3598,28 @@ func (s ProvisionedThroughput) String() string {
 // GoString returns the string representation
 func (s ProvisionedThroughput) GoString() string {
 	return s.String()
+}
+
+// Validate inspects the fields of the type to determine if they are valid.
+func (s *ProvisionedThroughput) Validate() error {
+	invalidParams := request.ErrInvalidParams{Context: "ProvisionedThroughput"}
+	if s.ReadCapacityUnits == nil {
+		invalidParams.Add(request.NewErrParamRequired("ReadCapacityUnits"))
+	}
+	if s.ReadCapacityUnits != nil && *s.ReadCapacityUnits < 1 {
+		invalidParams.Add(request.NewErrParamMinValue("ReadCapacityUnits", 1))
+	}
+	if s.WriteCapacityUnits == nil {
+		invalidParams.Add(request.NewErrParamRequired("WriteCapacityUnits"))
+	}
+	if s.WriteCapacityUnits != nil && *s.WriteCapacityUnits < 1 {
+		invalidParams.Add(request.NewErrParamMinValue("WriteCapacityUnits", 1))
+	}
+
+	if invalidParams.Len() > 0 {
+		return invalidParams
+	}
+	return nil
 }
 
 // Represents the provisioned throughput settings for the table, consisting
@@ -3537,6 +4024,25 @@ func (s PutItemInput) String() string {
 // GoString returns the string representation
 func (s PutItemInput) GoString() string {
 	return s.String()
+}
+
+// Validate inspects the fields of the type to determine if they are valid.
+func (s *PutItemInput) Validate() error {
+	invalidParams := request.ErrInvalidParams{Context: "PutItemInput"}
+	if s.Item == nil {
+		invalidParams.Add(request.NewErrParamRequired("Item"))
+	}
+	if s.TableName == nil {
+		invalidParams.Add(request.NewErrParamRequired("TableName"))
+	}
+	if s.TableName != nil && len(*s.TableName) < 3 {
+		invalidParams.Add(request.NewErrParamMinLen("TableName", 3))
+	}
+
+	if invalidParams.Len() > 0 {
+		return invalidParams
+	}
+	return nil
 }
 
 // Represents the output of a PutItem operation.
@@ -4103,6 +4609,51 @@ func (s QueryInput) GoString() string {
 	return s.String()
 }
 
+// Validate inspects the fields of the type to determine if they are valid.
+func (s *QueryInput) Validate() error {
+	invalidParams := request.ErrInvalidParams{Context: "QueryInput"}
+	if s.AttributesToGet != nil && len(s.AttributesToGet) < 1 {
+		invalidParams.Add(request.NewErrParamMinLen("AttributesToGet", 1))
+	}
+	if s.IndexName != nil && len(*s.IndexName) < 3 {
+		invalidParams.Add(request.NewErrParamMinLen("IndexName", 3))
+	}
+	if s.Limit != nil && *s.Limit < 1 {
+		invalidParams.Add(request.NewErrParamMinValue("Limit", 1))
+	}
+	if s.TableName == nil {
+		invalidParams.Add(request.NewErrParamRequired("TableName"))
+	}
+	if s.TableName != nil && len(*s.TableName) < 3 {
+		invalidParams.Add(request.NewErrParamMinLen("TableName", 3))
+	}
+	if s.KeyConditions != nil {
+		for i, v := range s.KeyConditions {
+			if v == nil {
+				continue
+			}
+			if err := v.Validate(); err != nil {
+				invalidParams.AddNested(fmt.Sprintf("%s[%v]", "KeyConditions", i), err.(request.ErrInvalidParams))
+			}
+		}
+	}
+	if s.QueryFilter != nil {
+		for i, v := range s.QueryFilter {
+			if v == nil {
+				continue
+			}
+			if err := v.Validate(); err != nil {
+				invalidParams.AddNested(fmt.Sprintf("%s[%v]", "QueryFilter", i), err.(request.ErrInvalidParams))
+			}
+		}
+	}
+
+	if invalidParams.Len() > 0 {
+		return invalidParams
+	}
+	return nil
+}
+
 // Represents the output of a Query operation.
 type QueryOutput struct {
 	_ struct{} `type:"structure"`
@@ -4460,6 +5011,44 @@ func (s ScanInput) GoString() string {
 	return s.String()
 }
 
+// Validate inspects the fields of the type to determine if they are valid.
+func (s *ScanInput) Validate() error {
+	invalidParams := request.ErrInvalidParams{Context: "ScanInput"}
+	if s.AttributesToGet != nil && len(s.AttributesToGet) < 1 {
+		invalidParams.Add(request.NewErrParamMinLen("AttributesToGet", 1))
+	}
+	if s.IndexName != nil && len(*s.IndexName) < 3 {
+		invalidParams.Add(request.NewErrParamMinLen("IndexName", 3))
+	}
+	if s.Limit != nil && *s.Limit < 1 {
+		invalidParams.Add(request.NewErrParamMinValue("Limit", 1))
+	}
+	if s.TableName == nil {
+		invalidParams.Add(request.NewErrParamRequired("TableName"))
+	}
+	if s.TableName != nil && len(*s.TableName) < 3 {
+		invalidParams.Add(request.NewErrParamMinLen("TableName", 3))
+	}
+	if s.TotalSegments != nil && *s.TotalSegments < 1 {
+		invalidParams.Add(request.NewErrParamMinValue("TotalSegments", 1))
+	}
+	if s.ScanFilter != nil {
+		for i, v := range s.ScanFilter {
+			if v == nil {
+				continue
+			}
+			if err := v.Validate(); err != nil {
+				invalidParams.AddNested(fmt.Sprintf("%s[%v]", "ScanFilter", i), err.(request.ErrInvalidParams))
+			}
+		}
+	}
+
+	if invalidParams.Len() > 0 {
+		return invalidParams
+	}
+	return nil
+}
+
 // Represents the output of a Scan operation.
 type ScanOutput struct {
 	_ struct{} `type:"structure"`
@@ -4791,6 +5380,30 @@ func (s UpdateGlobalSecondaryIndexAction) String() string {
 // GoString returns the string representation
 func (s UpdateGlobalSecondaryIndexAction) GoString() string {
 	return s.String()
+}
+
+// Validate inspects the fields of the type to determine if they are valid.
+func (s *UpdateGlobalSecondaryIndexAction) Validate() error {
+	invalidParams := request.ErrInvalidParams{Context: "UpdateGlobalSecondaryIndexAction"}
+	if s.IndexName == nil {
+		invalidParams.Add(request.NewErrParamRequired("IndexName"))
+	}
+	if s.IndexName != nil && len(*s.IndexName) < 3 {
+		invalidParams.Add(request.NewErrParamMinLen("IndexName", 3))
+	}
+	if s.ProvisionedThroughput == nil {
+		invalidParams.Add(request.NewErrParamRequired("ProvisionedThroughput"))
+	}
+	if s.ProvisionedThroughput != nil {
+		if err := s.ProvisionedThroughput.Validate(); err != nil {
+			invalidParams.AddNested("ProvisionedThroughput", err.(request.ErrInvalidParams))
+		}
+	}
+
+	if invalidParams.Len() > 0 {
+		return invalidParams
+	}
+	return nil
 }
 
 // Represents the input of an UpdateItem operation.
@@ -5326,6 +5939,25 @@ func (s UpdateItemInput) GoString() string {
 	return s.String()
 }
 
+// Validate inspects the fields of the type to determine if they are valid.
+func (s *UpdateItemInput) Validate() error {
+	invalidParams := request.ErrInvalidParams{Context: "UpdateItemInput"}
+	if s.Key == nil {
+		invalidParams.Add(request.NewErrParamRequired("Key"))
+	}
+	if s.TableName == nil {
+		invalidParams.Add(request.NewErrParamRequired("TableName"))
+	}
+	if s.TableName != nil && len(*s.TableName) < 3 {
+		invalidParams.Add(request.NewErrParamMinLen("TableName", 3))
+	}
+
+	if invalidParams.Len() > 0 {
+		return invalidParams
+	}
+	return nil
+}
+
 // Represents the output of an UpdateItem operation.
 type UpdateItemOutput struct {
 	_ struct{} `type:"structure"`
@@ -5410,6 +6042,47 @@ func (s UpdateTableInput) String() string {
 // GoString returns the string representation
 func (s UpdateTableInput) GoString() string {
 	return s.String()
+}
+
+// Validate inspects the fields of the type to determine if they are valid.
+func (s *UpdateTableInput) Validate() error {
+	invalidParams := request.ErrInvalidParams{Context: "UpdateTableInput"}
+	if s.TableName == nil {
+		invalidParams.Add(request.NewErrParamRequired("TableName"))
+	}
+	if s.TableName != nil && len(*s.TableName) < 3 {
+		invalidParams.Add(request.NewErrParamMinLen("TableName", 3))
+	}
+	if s.AttributeDefinitions != nil {
+		for i, v := range s.AttributeDefinitions {
+			if v == nil {
+				continue
+			}
+			if err := v.Validate(); err != nil {
+				invalidParams.AddNested(fmt.Sprintf("%s[%v]", "AttributeDefinitions", i), err.(request.ErrInvalidParams))
+			}
+		}
+	}
+	if s.GlobalSecondaryIndexUpdates != nil {
+		for i, v := range s.GlobalSecondaryIndexUpdates {
+			if v == nil {
+				continue
+			}
+			if err := v.Validate(); err != nil {
+				invalidParams.AddNested(fmt.Sprintf("%s[%v]", "GlobalSecondaryIndexUpdates", i), err.(request.ErrInvalidParams))
+			}
+		}
+	}
+	if s.ProvisionedThroughput != nil {
+		if err := s.ProvisionedThroughput.Validate(); err != nil {
+			invalidParams.AddNested("ProvisionedThroughput", err.(request.ErrInvalidParams))
+		}
+	}
+
+	if invalidParams.Len() > 0 {
+		return invalidParams
+	}
+	return nil
 }
 
 // Represents the output of an UpdateTable operation.

--- a/service/dynamodbstreams/api.go
+++ b/service/dynamodbstreams/api.go
@@ -172,6 +172,28 @@ func (s DescribeStreamInput) GoString() string {
 	return s.String()
 }
 
+// Validate inspects the fields of the type to determine if they are valid.
+func (s *DescribeStreamInput) Validate() error {
+	invalidParams := request.ErrInvalidParams{Context: "DescribeStreamInput"}
+	if s.ExclusiveStartShardId != nil && len(*s.ExclusiveStartShardId) < 28 {
+		invalidParams.Add(request.NewErrParamMinLen("ExclusiveStartShardId", 28))
+	}
+	if s.Limit != nil && *s.Limit < 1 {
+		invalidParams.Add(request.NewErrParamMinValue("Limit", 1))
+	}
+	if s.StreamArn == nil {
+		invalidParams.Add(request.NewErrParamRequired("StreamArn"))
+	}
+	if s.StreamArn != nil && len(*s.StreamArn) < 37 {
+		invalidParams.Add(request.NewErrParamMinLen("StreamArn", 37))
+	}
+
+	if invalidParams.Len() > 0 {
+		return invalidParams
+	}
+	return nil
+}
+
 // Represents the output of a DescribeStream operation.
 type DescribeStreamOutput struct {
 	_ struct{} `type:"structure"`
@@ -214,6 +236,25 @@ func (s GetRecordsInput) String() string {
 // GoString returns the string representation
 func (s GetRecordsInput) GoString() string {
 	return s.String()
+}
+
+// Validate inspects the fields of the type to determine if they are valid.
+func (s *GetRecordsInput) Validate() error {
+	invalidParams := request.ErrInvalidParams{Context: "GetRecordsInput"}
+	if s.Limit != nil && *s.Limit < 1 {
+		invalidParams.Add(request.NewErrParamMinValue("Limit", 1))
+	}
+	if s.ShardIterator == nil {
+		invalidParams.Add(request.NewErrParamRequired("ShardIterator"))
+	}
+	if s.ShardIterator != nil && len(*s.ShardIterator) < 1 {
+		invalidParams.Add(request.NewErrParamMinLen("ShardIterator", 1))
+	}
+
+	if invalidParams.Len() > 0 {
+		return invalidParams
+	}
+	return nil
 }
 
 // Represents the output of a GetRecords operation.
@@ -282,6 +323,34 @@ func (s GetShardIteratorInput) GoString() string {
 	return s.String()
 }
 
+// Validate inspects the fields of the type to determine if they are valid.
+func (s *GetShardIteratorInput) Validate() error {
+	invalidParams := request.ErrInvalidParams{Context: "GetShardIteratorInput"}
+	if s.SequenceNumber != nil && len(*s.SequenceNumber) < 21 {
+		invalidParams.Add(request.NewErrParamMinLen("SequenceNumber", 21))
+	}
+	if s.ShardId == nil {
+		invalidParams.Add(request.NewErrParamRequired("ShardId"))
+	}
+	if s.ShardId != nil && len(*s.ShardId) < 28 {
+		invalidParams.Add(request.NewErrParamMinLen("ShardId", 28))
+	}
+	if s.ShardIteratorType == nil {
+		invalidParams.Add(request.NewErrParamRequired("ShardIteratorType"))
+	}
+	if s.StreamArn == nil {
+		invalidParams.Add(request.NewErrParamRequired("StreamArn"))
+	}
+	if s.StreamArn != nil && len(*s.StreamArn) < 37 {
+		invalidParams.Add(request.NewErrParamMinLen("StreamArn", 37))
+	}
+
+	if invalidParams.Len() > 0 {
+		return invalidParams
+	}
+	return nil
+}
+
 // Represents the output of a GetShardIterator operation.
 type GetShardIteratorOutput struct {
 	_ struct{} `type:"structure"`
@@ -327,6 +396,25 @@ func (s ListStreamsInput) String() string {
 // GoString returns the string representation
 func (s ListStreamsInput) GoString() string {
 	return s.String()
+}
+
+// Validate inspects the fields of the type to determine if they are valid.
+func (s *ListStreamsInput) Validate() error {
+	invalidParams := request.ErrInvalidParams{Context: "ListStreamsInput"}
+	if s.ExclusiveStartStreamArn != nil && len(*s.ExclusiveStartStreamArn) < 37 {
+		invalidParams.Add(request.NewErrParamMinLen("ExclusiveStartStreamArn", 37))
+	}
+	if s.Limit != nil && *s.Limit < 1 {
+		invalidParams.Add(request.NewErrParamMinValue("Limit", 1))
+	}
+	if s.TableName != nil && len(*s.TableName) < 3 {
+		invalidParams.Add(request.NewErrParamMinLen("TableName", 3))
+	}
+
+	if invalidParams.Len() > 0 {
+		return invalidParams
+	}
+	return nil
 }
 
 // Represents the output of a ListStreams operation.

--- a/service/ec2/api.go
+++ b/service/ec2/api.go
@@ -4,6 +4,7 @@
 package ec2
 
 import (
+	"fmt"
 	"time"
 
 	"github.com/aws/aws-sdk-go/aws/awsutil"
@@ -7338,6 +7339,25 @@ func (s AllocateHostsInput) GoString() string {
 	return s.String()
 }
 
+// Validate inspects the fields of the type to determine if they are valid.
+func (s *AllocateHostsInput) Validate() error {
+	invalidParams := request.ErrInvalidParams{Context: "AllocateHostsInput"}
+	if s.AvailabilityZone == nil {
+		invalidParams.Add(request.NewErrParamRequired("AvailabilityZone"))
+	}
+	if s.InstanceType == nil {
+		invalidParams.Add(request.NewErrParamRequired("InstanceType"))
+	}
+	if s.Quantity == nil {
+		invalidParams.Add(request.NewErrParamRequired("Quantity"))
+	}
+
+	if invalidParams.Len() > 0 {
+		return invalidParams
+	}
+	return nil
+}
+
 // Contains the output of AllocateHosts.
 type AllocateHostsOutput struct {
 	_ struct{} `type:"structure"`
@@ -7389,6 +7409,19 @@ func (s AssignPrivateIpAddressesInput) String() string {
 // GoString returns the string representation
 func (s AssignPrivateIpAddressesInput) GoString() string {
 	return s.String()
+}
+
+// Validate inspects the fields of the type to determine if they are valid.
+func (s *AssignPrivateIpAddressesInput) Validate() error {
+	invalidParams := request.ErrInvalidParams{Context: "AssignPrivateIpAddressesInput"}
+	if s.NetworkInterfaceId == nil {
+		invalidParams.Add(request.NewErrParamRequired("NetworkInterfaceId"))
+	}
+
+	if invalidParams.Len() > 0 {
+		return invalidParams
+	}
+	return nil
 }
 
 type AssignPrivateIpAddressesOutput struct {
@@ -7502,6 +7535,22 @@ func (s AssociateDhcpOptionsInput) GoString() string {
 	return s.String()
 }
 
+// Validate inspects the fields of the type to determine if they are valid.
+func (s *AssociateDhcpOptionsInput) Validate() error {
+	invalidParams := request.ErrInvalidParams{Context: "AssociateDhcpOptionsInput"}
+	if s.DhcpOptionsId == nil {
+		invalidParams.Add(request.NewErrParamRequired("DhcpOptionsId"))
+	}
+	if s.VpcId == nil {
+		invalidParams.Add(request.NewErrParamRequired("VpcId"))
+	}
+
+	if invalidParams.Len() > 0 {
+		return invalidParams
+	}
+	return nil
+}
+
 type AssociateDhcpOptionsOutput struct {
 	_ struct{} `type:"structure"`
 }
@@ -7541,6 +7590,22 @@ func (s AssociateRouteTableInput) String() string {
 // GoString returns the string representation
 func (s AssociateRouteTableInput) GoString() string {
 	return s.String()
+}
+
+// Validate inspects the fields of the type to determine if they are valid.
+func (s *AssociateRouteTableInput) Validate() error {
+	invalidParams := request.ErrInvalidParams{Context: "AssociateRouteTableInput"}
+	if s.RouteTableId == nil {
+		invalidParams.Add(request.NewErrParamRequired("RouteTableId"))
+	}
+	if s.SubnetId == nil {
+		invalidParams.Add(request.NewErrParamRequired("SubnetId"))
+	}
+
+	if invalidParams.Len() > 0 {
+		return invalidParams
+	}
+	return nil
 }
 
 // Contains the output of AssociateRouteTable.
@@ -7592,6 +7657,25 @@ func (s AttachClassicLinkVpcInput) GoString() string {
 	return s.String()
 }
 
+// Validate inspects the fields of the type to determine if they are valid.
+func (s *AttachClassicLinkVpcInput) Validate() error {
+	invalidParams := request.ErrInvalidParams{Context: "AttachClassicLinkVpcInput"}
+	if s.Groups == nil {
+		invalidParams.Add(request.NewErrParamRequired("Groups"))
+	}
+	if s.InstanceId == nil {
+		invalidParams.Add(request.NewErrParamRequired("InstanceId"))
+	}
+	if s.VpcId == nil {
+		invalidParams.Add(request.NewErrParamRequired("VpcId"))
+	}
+
+	if invalidParams.Len() > 0 {
+		return invalidParams
+	}
+	return nil
+}
+
 // Contains the output of AttachClassicLinkVpc.
 type AttachClassicLinkVpcOutput struct {
 	_ struct{} `type:"structure"`
@@ -7637,6 +7721,22 @@ func (s AttachInternetGatewayInput) GoString() string {
 	return s.String()
 }
 
+// Validate inspects the fields of the type to determine if they are valid.
+func (s *AttachInternetGatewayInput) Validate() error {
+	invalidParams := request.ErrInvalidParams{Context: "AttachInternetGatewayInput"}
+	if s.InternetGatewayId == nil {
+		invalidParams.Add(request.NewErrParamRequired("InternetGatewayId"))
+	}
+	if s.VpcId == nil {
+		invalidParams.Add(request.NewErrParamRequired("VpcId"))
+	}
+
+	if invalidParams.Len() > 0 {
+		return invalidParams
+	}
+	return nil
+}
+
 type AttachInternetGatewayOutput struct {
 	_ struct{} `type:"structure"`
 }
@@ -7679,6 +7779,25 @@ func (s AttachNetworkInterfaceInput) String() string {
 // GoString returns the string representation
 func (s AttachNetworkInterfaceInput) GoString() string {
 	return s.String()
+}
+
+// Validate inspects the fields of the type to determine if they are valid.
+func (s *AttachNetworkInterfaceInput) Validate() error {
+	invalidParams := request.ErrInvalidParams{Context: "AttachNetworkInterfaceInput"}
+	if s.DeviceIndex == nil {
+		invalidParams.Add(request.NewErrParamRequired("DeviceIndex"))
+	}
+	if s.InstanceId == nil {
+		invalidParams.Add(request.NewErrParamRequired("InstanceId"))
+	}
+	if s.NetworkInterfaceId == nil {
+		invalidParams.Add(request.NewErrParamRequired("NetworkInterfaceId"))
+	}
+
+	if invalidParams.Len() > 0 {
+		return invalidParams
+	}
+	return nil
 }
 
 // Contains the output of AttachNetworkInterface.
@@ -7730,6 +7849,25 @@ func (s AttachVolumeInput) GoString() string {
 	return s.String()
 }
 
+// Validate inspects the fields of the type to determine if they are valid.
+func (s *AttachVolumeInput) Validate() error {
+	invalidParams := request.ErrInvalidParams{Context: "AttachVolumeInput"}
+	if s.Device == nil {
+		invalidParams.Add(request.NewErrParamRequired("Device"))
+	}
+	if s.InstanceId == nil {
+		invalidParams.Add(request.NewErrParamRequired("InstanceId"))
+	}
+	if s.VolumeId == nil {
+		invalidParams.Add(request.NewErrParamRequired("VolumeId"))
+	}
+
+	if invalidParams.Len() > 0 {
+		return invalidParams
+	}
+	return nil
+}
+
 // Contains the parameters for AttachVpnGateway.
 type AttachVpnGatewayInput struct {
 	_ struct{} `type:"structure"`
@@ -7755,6 +7893,22 @@ func (s AttachVpnGatewayInput) String() string {
 // GoString returns the string representation
 func (s AttachVpnGatewayInput) GoString() string {
 	return s.String()
+}
+
+// Validate inspects the fields of the type to determine if they are valid.
+func (s *AttachVpnGatewayInput) Validate() error {
+	invalidParams := request.ErrInvalidParams{Context: "AttachVpnGatewayInput"}
+	if s.VpcId == nil {
+		invalidParams.Add(request.NewErrParamRequired("VpcId"))
+	}
+	if s.VpnGatewayId == nil {
+		invalidParams.Add(request.NewErrParamRequired("VpnGatewayId"))
+	}
+
+	if invalidParams.Len() > 0 {
+		return invalidParams
+	}
+	return nil
 }
 
 // Contains the output of AttachVpnGateway.
@@ -7863,6 +8017,19 @@ func (s AuthorizeSecurityGroupEgressInput) String() string {
 // GoString returns the string representation
 func (s AuthorizeSecurityGroupEgressInput) GoString() string {
 	return s.String()
+}
+
+// Validate inspects the fields of the type to determine if they are valid.
+func (s *AuthorizeSecurityGroupEgressInput) Validate() error {
+	invalidParams := request.ErrInvalidParams{Context: "AuthorizeSecurityGroupEgressInput"}
+	if s.GroupId == nil {
+		invalidParams.Add(request.NewErrParamRequired("GroupId"))
+	}
+
+	if invalidParams.Len() > 0 {
+		return invalidParams
+	}
+	return nil
 }
 
 type AuthorizeSecurityGroupEgressOutput struct {
@@ -8113,6 +8280,22 @@ func (s BundleInstanceInput) GoString() string {
 	return s.String()
 }
 
+// Validate inspects the fields of the type to determine if they are valid.
+func (s *BundleInstanceInput) Validate() error {
+	invalidParams := request.ErrInvalidParams{Context: "BundleInstanceInput"}
+	if s.InstanceId == nil {
+		invalidParams.Add(request.NewErrParamRequired("InstanceId"))
+	}
+	if s.Storage == nil {
+		invalidParams.Add(request.NewErrParamRequired("Storage"))
+	}
+
+	if invalidParams.Len() > 0 {
+		return invalidParams
+	}
+	return nil
+}
+
 // Contains the output of BundleInstance.
 type BundleInstanceOutput struct {
 	_ struct{} `type:"structure"`
@@ -8215,6 +8398,19 @@ func (s CancelBundleTaskInput) GoString() string {
 	return s.String()
 }
 
+// Validate inspects the fields of the type to determine if they are valid.
+func (s *CancelBundleTaskInput) Validate() error {
+	invalidParams := request.ErrInvalidParams{Context: "CancelBundleTaskInput"}
+	if s.BundleId == nil {
+		invalidParams.Add(request.NewErrParamRequired("BundleId"))
+	}
+
+	if invalidParams.Len() > 0 {
+		return invalidParams
+	}
+	return nil
+}
+
 // Contains the output of CancelBundleTask.
 type CancelBundleTaskOutput struct {
 	_ struct{} `type:"structure"`
@@ -8260,6 +8456,19 @@ func (s CancelConversionTaskInput) GoString() string {
 	return s.String()
 }
 
+// Validate inspects the fields of the type to determine if they are valid.
+func (s *CancelConversionTaskInput) Validate() error {
+	invalidParams := request.ErrInvalidParams{Context: "CancelConversionTaskInput"}
+	if s.ConversionTaskId == nil {
+		invalidParams.Add(request.NewErrParamRequired("ConversionTaskId"))
+	}
+
+	if invalidParams.Len() > 0 {
+		return invalidParams
+	}
+	return nil
+}
+
 type CancelConversionTaskOutput struct {
 	_ struct{} `type:"structure"`
 }
@@ -8290,6 +8499,19 @@ func (s CancelExportTaskInput) String() string {
 // GoString returns the string representation
 func (s CancelExportTaskInput) GoString() string {
 	return s.String()
+}
+
+// Validate inspects the fields of the type to determine if they are valid.
+func (s *CancelExportTaskInput) Validate() error {
+	invalidParams := request.ErrInvalidParams{Context: "CancelExportTaskInput"}
+	if s.ExportTaskId == nil {
+		invalidParams.Add(request.NewErrParamRequired("ExportTaskId"))
+	}
+
+	if invalidParams.Len() > 0 {
+		return invalidParams
+	}
+	return nil
 }
 
 type CancelExportTaskOutput struct {
@@ -8373,6 +8595,19 @@ func (s CancelReservedInstancesListingInput) String() string {
 // GoString returns the string representation
 func (s CancelReservedInstancesListingInput) GoString() string {
 	return s.String()
+}
+
+// Validate inspects the fields of the type to determine if they are valid.
+func (s *CancelReservedInstancesListingInput) Validate() error {
+	invalidParams := request.ErrInvalidParams{Context: "CancelReservedInstancesListingInput"}
+	if s.ReservedInstancesListingId == nil {
+		invalidParams.Add(request.NewErrParamRequired("ReservedInstancesListingId"))
+	}
+
+	if invalidParams.Len() > 0 {
+		return invalidParams
+	}
+	return nil
 }
 
 // Contains the output of CancelReservedInstancesListing.
@@ -8463,6 +8698,22 @@ func (s CancelSpotFleetRequestsInput) GoString() string {
 	return s.String()
 }
 
+// Validate inspects the fields of the type to determine if they are valid.
+func (s *CancelSpotFleetRequestsInput) Validate() error {
+	invalidParams := request.ErrInvalidParams{Context: "CancelSpotFleetRequestsInput"}
+	if s.SpotFleetRequestIds == nil {
+		invalidParams.Add(request.NewErrParamRequired("SpotFleetRequestIds"))
+	}
+	if s.TerminateInstances == nil {
+		invalidParams.Add(request.NewErrParamRequired("TerminateInstances"))
+	}
+
+	if invalidParams.Len() > 0 {
+		return invalidParams
+	}
+	return nil
+}
+
 // Contains the output of CancelSpotFleetRequests.
 type CancelSpotFleetRequestsOutput struct {
 	_ struct{} `type:"structure"`
@@ -8530,6 +8781,19 @@ func (s CancelSpotInstanceRequestsInput) String() string {
 // GoString returns the string representation
 func (s CancelSpotInstanceRequestsInput) GoString() string {
 	return s.String()
+}
+
+// Validate inspects the fields of the type to determine if they are valid.
+func (s *CancelSpotInstanceRequestsInput) Validate() error {
+	invalidParams := request.ErrInvalidParams{Context: "CancelSpotInstanceRequestsInput"}
+	if s.SpotInstanceRequestIds == nil {
+		invalidParams.Add(request.NewErrParamRequired("SpotInstanceRequestIds"))
+	}
+
+	if invalidParams.Len() > 0 {
+		return invalidParams
+	}
+	return nil
 }
 
 // Contains the output of CancelSpotInstanceRequests.
@@ -8673,6 +8937,22 @@ func (s ConfirmProductInstanceInput) GoString() string {
 	return s.String()
 }
 
+// Validate inspects the fields of the type to determine if they are valid.
+func (s *ConfirmProductInstanceInput) Validate() error {
+	invalidParams := request.ErrInvalidParams{Context: "ConfirmProductInstanceInput"}
+	if s.InstanceId == nil {
+		invalidParams.Add(request.NewErrParamRequired("InstanceId"))
+	}
+	if s.ProductCode == nil {
+		invalidParams.Add(request.NewErrParamRequired("ProductCode"))
+	}
+
+	if invalidParams.Len() > 0 {
+		return invalidParams
+	}
+	return nil
+}
+
 // Contains the output of ConfirmProductInstance.
 type ConfirmProductInstanceOutput struct {
 	_ struct{} `type:"structure"`
@@ -8790,6 +9070,25 @@ func (s CopyImageInput) GoString() string {
 	return s.String()
 }
 
+// Validate inspects the fields of the type to determine if they are valid.
+func (s *CopyImageInput) Validate() error {
+	invalidParams := request.ErrInvalidParams{Context: "CopyImageInput"}
+	if s.Name == nil {
+		invalidParams.Add(request.NewErrParamRequired("Name"))
+	}
+	if s.SourceImageId == nil {
+		invalidParams.Add(request.NewErrParamRequired("SourceImageId"))
+	}
+	if s.SourceRegion == nil {
+		invalidParams.Add(request.NewErrParamRequired("SourceRegion"))
+	}
+
+	if invalidParams.Len() > 0 {
+		return invalidParams
+	}
+	return nil
+}
+
 // Contains the output of CopyImage.
 type CopyImageOutput struct {
 	_ struct{} `type:"structure"`
@@ -8881,6 +9180,22 @@ func (s CopySnapshotInput) GoString() string {
 	return s.String()
 }
 
+// Validate inspects the fields of the type to determine if they are valid.
+func (s *CopySnapshotInput) Validate() error {
+	invalidParams := request.ErrInvalidParams{Context: "CopySnapshotInput"}
+	if s.SourceRegion == nil {
+		invalidParams.Add(request.NewErrParamRequired("SourceRegion"))
+	}
+	if s.SourceSnapshotId == nil {
+		invalidParams.Add(request.NewErrParamRequired("SourceSnapshotId"))
+	}
+
+	if invalidParams.Len() > 0 {
+		return invalidParams
+	}
+	return nil
+}
+
 // Contains the output of CopySnapshot.
 type CopySnapshotOutput struct {
 	_ struct{} `type:"structure"`
@@ -8932,6 +9247,25 @@ func (s CreateCustomerGatewayInput) GoString() string {
 	return s.String()
 }
 
+// Validate inspects the fields of the type to determine if they are valid.
+func (s *CreateCustomerGatewayInput) Validate() error {
+	invalidParams := request.ErrInvalidParams{Context: "CreateCustomerGatewayInput"}
+	if s.BgpAsn == nil {
+		invalidParams.Add(request.NewErrParamRequired("BgpAsn"))
+	}
+	if s.PublicIp == nil {
+		invalidParams.Add(request.NewErrParamRequired("PublicIp"))
+	}
+	if s.Type == nil {
+		invalidParams.Add(request.NewErrParamRequired("Type"))
+	}
+
+	if invalidParams.Len() > 0 {
+		return invalidParams
+	}
+	return nil
+}
+
 // Contains the output of CreateCustomerGateway.
 type CreateCustomerGatewayOutput struct {
 	_ struct{} `type:"structure"`
@@ -8972,6 +9306,19 @@ func (s CreateDhcpOptionsInput) String() string {
 // GoString returns the string representation
 func (s CreateDhcpOptionsInput) GoString() string {
 	return s.String()
+}
+
+// Validate inspects the fields of the type to determine if they are valid.
+func (s *CreateDhcpOptionsInput) Validate() error {
+	invalidParams := request.ErrInvalidParams{Context: "CreateDhcpOptionsInput"}
+	if s.DhcpConfigurations == nil {
+		invalidParams.Add(request.NewErrParamRequired("DhcpConfigurations"))
+	}
+
+	if invalidParams.Len() > 0 {
+		return invalidParams
+	}
+	return nil
 }
 
 // Contains the output of CreateDhcpOptions.
@@ -9025,6 +9372,31 @@ func (s CreateFlowLogsInput) String() string {
 // GoString returns the string representation
 func (s CreateFlowLogsInput) GoString() string {
 	return s.String()
+}
+
+// Validate inspects the fields of the type to determine if they are valid.
+func (s *CreateFlowLogsInput) Validate() error {
+	invalidParams := request.ErrInvalidParams{Context: "CreateFlowLogsInput"}
+	if s.DeliverLogsPermissionArn == nil {
+		invalidParams.Add(request.NewErrParamRequired("DeliverLogsPermissionArn"))
+	}
+	if s.LogGroupName == nil {
+		invalidParams.Add(request.NewErrParamRequired("LogGroupName"))
+	}
+	if s.ResourceIds == nil {
+		invalidParams.Add(request.NewErrParamRequired("ResourceIds"))
+	}
+	if s.ResourceType == nil {
+		invalidParams.Add(request.NewErrParamRequired("ResourceType"))
+	}
+	if s.TrafficType == nil {
+		invalidParams.Add(request.NewErrParamRequired("TrafficType"))
+	}
+
+	if invalidParams.Len() > 0 {
+		return invalidParams
+	}
+	return nil
 }
 
 // Contains the output of CreateFlowLogs.
@@ -9096,6 +9468,22 @@ func (s CreateImageInput) GoString() string {
 	return s.String()
 }
 
+// Validate inspects the fields of the type to determine if they are valid.
+func (s *CreateImageInput) Validate() error {
+	invalidParams := request.ErrInvalidParams{Context: "CreateImageInput"}
+	if s.InstanceId == nil {
+		invalidParams.Add(request.NewErrParamRequired("InstanceId"))
+	}
+	if s.Name == nil {
+		invalidParams.Add(request.NewErrParamRequired("Name"))
+	}
+
+	if invalidParams.Len() > 0 {
+		return invalidParams
+	}
+	return nil
+}
+
 // Contains the output of CreateImage.
 type CreateImageOutput struct {
 	_ struct{} `type:"structure"`
@@ -9140,6 +9528,19 @@ func (s CreateInstanceExportTaskInput) String() string {
 // GoString returns the string representation
 func (s CreateInstanceExportTaskInput) GoString() string {
 	return s.String()
+}
+
+// Validate inspects the fields of the type to determine if they are valid.
+func (s *CreateInstanceExportTaskInput) Validate() error {
+	invalidParams := request.ErrInvalidParams{Context: "CreateInstanceExportTaskInput"}
+	if s.InstanceId == nil {
+		invalidParams.Add(request.NewErrParamRequired("InstanceId"))
+	}
+
+	if invalidParams.Len() > 0 {
+		return invalidParams
+	}
+	return nil
 }
 
 // Contains the output for CreateInstanceExportTask.
@@ -9225,6 +9626,19 @@ func (s CreateKeyPairInput) GoString() string {
 	return s.String()
 }
 
+// Validate inspects the fields of the type to determine if they are valid.
+func (s *CreateKeyPairInput) Validate() error {
+	invalidParams := request.ErrInvalidParams{Context: "CreateKeyPairInput"}
+	if s.KeyName == nil {
+		invalidParams.Add(request.NewErrParamRequired("KeyName"))
+	}
+
+	if invalidParams.Len() > 0 {
+		return invalidParams
+	}
+	return nil
+}
+
 // Describes a key pair.
 type CreateKeyPairOutput struct {
 	_ struct{} `type:"structure"`
@@ -9276,6 +9690,22 @@ func (s CreateNatGatewayInput) String() string {
 // GoString returns the string representation
 func (s CreateNatGatewayInput) GoString() string {
 	return s.String()
+}
+
+// Validate inspects the fields of the type to determine if they are valid.
+func (s *CreateNatGatewayInput) Validate() error {
+	invalidParams := request.ErrInvalidParams{Context: "CreateNatGatewayInput"}
+	if s.AllocationId == nil {
+		invalidParams.Add(request.NewErrParamRequired("AllocationId"))
+	}
+	if s.SubnetId == nil {
+		invalidParams.Add(request.NewErrParamRequired("SubnetId"))
+	}
+
+	if invalidParams.Len() > 0 {
+		return invalidParams
+	}
+	return nil
 }
 
 // Contains the output of CreateNatGateway.
@@ -9350,6 +9780,34 @@ func (s CreateNetworkAclEntryInput) GoString() string {
 	return s.String()
 }
 
+// Validate inspects the fields of the type to determine if they are valid.
+func (s *CreateNetworkAclEntryInput) Validate() error {
+	invalidParams := request.ErrInvalidParams{Context: "CreateNetworkAclEntryInput"}
+	if s.CidrBlock == nil {
+		invalidParams.Add(request.NewErrParamRequired("CidrBlock"))
+	}
+	if s.Egress == nil {
+		invalidParams.Add(request.NewErrParamRequired("Egress"))
+	}
+	if s.NetworkAclId == nil {
+		invalidParams.Add(request.NewErrParamRequired("NetworkAclId"))
+	}
+	if s.Protocol == nil {
+		invalidParams.Add(request.NewErrParamRequired("Protocol"))
+	}
+	if s.RuleAction == nil {
+		invalidParams.Add(request.NewErrParamRequired("RuleAction"))
+	}
+	if s.RuleNumber == nil {
+		invalidParams.Add(request.NewErrParamRequired("RuleNumber"))
+	}
+
+	if invalidParams.Len() > 0 {
+		return invalidParams
+	}
+	return nil
+}
+
 type CreateNetworkAclEntryOutput struct {
 	_ struct{} `type:"structure"`
 }
@@ -9386,6 +9844,19 @@ func (s CreateNetworkAclInput) String() string {
 // GoString returns the string representation
 func (s CreateNetworkAclInput) GoString() string {
 	return s.String()
+}
+
+// Validate inspects the fields of the type to determine if they are valid.
+func (s *CreateNetworkAclInput) Validate() error {
+	invalidParams := request.ErrInvalidParams{Context: "CreateNetworkAclInput"}
+	if s.VpcId == nil {
+		invalidParams.Add(request.NewErrParamRequired("VpcId"))
+	}
+
+	if invalidParams.Len() > 0 {
+		return invalidParams
+	}
+	return nil
 }
 
 // Contains the output of CreateNetworkAcl.
@@ -9456,6 +9927,29 @@ func (s CreateNetworkInterfaceInput) GoString() string {
 	return s.String()
 }
 
+// Validate inspects the fields of the type to determine if they are valid.
+func (s *CreateNetworkInterfaceInput) Validate() error {
+	invalidParams := request.ErrInvalidParams{Context: "CreateNetworkInterfaceInput"}
+	if s.SubnetId == nil {
+		invalidParams.Add(request.NewErrParamRequired("SubnetId"))
+	}
+	if s.PrivateIpAddresses != nil {
+		for i, v := range s.PrivateIpAddresses {
+			if v == nil {
+				continue
+			}
+			if err := v.Validate(); err != nil {
+				invalidParams.AddNested(fmt.Sprintf("%s[%v]", "PrivateIpAddresses", i), err.(request.ErrInvalidParams))
+			}
+		}
+	}
+
+	if invalidParams.Len() > 0 {
+		return invalidParams
+	}
+	return nil
+}
+
 // Contains the output of CreateNetworkInterface.
 type CreateNetworkInterfaceOutput struct {
 	_ struct{} `type:"structure"`
@@ -9503,6 +9997,22 @@ func (s CreatePlacementGroupInput) GoString() string {
 	return s.String()
 }
 
+// Validate inspects the fields of the type to determine if they are valid.
+func (s *CreatePlacementGroupInput) Validate() error {
+	invalidParams := request.ErrInvalidParams{Context: "CreatePlacementGroupInput"}
+	if s.GroupName == nil {
+		invalidParams.Add(request.NewErrParamRequired("GroupName"))
+	}
+	if s.Strategy == nil {
+		invalidParams.Add(request.NewErrParamRequired("Strategy"))
+	}
+
+	if invalidParams.Len() > 0 {
+		return invalidParams
+	}
+	return nil
+}
+
 type CreatePlacementGroupOutput struct {
 	_ struct{} `type:"structure"`
 }
@@ -9548,6 +10058,28 @@ func (s CreateReservedInstancesListingInput) String() string {
 // GoString returns the string representation
 func (s CreateReservedInstancesListingInput) GoString() string {
 	return s.String()
+}
+
+// Validate inspects the fields of the type to determine if they are valid.
+func (s *CreateReservedInstancesListingInput) Validate() error {
+	invalidParams := request.ErrInvalidParams{Context: "CreateReservedInstancesListingInput"}
+	if s.ClientToken == nil {
+		invalidParams.Add(request.NewErrParamRequired("ClientToken"))
+	}
+	if s.InstanceCount == nil {
+		invalidParams.Add(request.NewErrParamRequired("InstanceCount"))
+	}
+	if s.PriceSchedules == nil {
+		invalidParams.Add(request.NewErrParamRequired("PriceSchedules"))
+	}
+	if s.ReservedInstancesId == nil {
+		invalidParams.Add(request.NewErrParamRequired("ReservedInstancesId"))
+	}
+
+	if invalidParams.Len() > 0 {
+		return invalidParams
+	}
+	return nil
 }
 
 // Contains the output of CreateReservedInstancesListing.
@@ -9613,6 +10145,22 @@ func (s CreateRouteInput) GoString() string {
 	return s.String()
 }
 
+// Validate inspects the fields of the type to determine if they are valid.
+func (s *CreateRouteInput) Validate() error {
+	invalidParams := request.ErrInvalidParams{Context: "CreateRouteInput"}
+	if s.DestinationCidrBlock == nil {
+		invalidParams.Add(request.NewErrParamRequired("DestinationCidrBlock"))
+	}
+	if s.RouteTableId == nil {
+		invalidParams.Add(request.NewErrParamRequired("RouteTableId"))
+	}
+
+	if invalidParams.Len() > 0 {
+		return invalidParams
+	}
+	return nil
+}
+
 // Contains the output of CreateRoute.
 type CreateRouteOutput struct {
 	_ struct{} `type:"structure"`
@@ -9653,6 +10201,19 @@ func (s CreateRouteTableInput) String() string {
 // GoString returns the string representation
 func (s CreateRouteTableInput) GoString() string {
 	return s.String()
+}
+
+// Validate inspects the fields of the type to determine if they are valid.
+func (s *CreateRouteTableInput) Validate() error {
+	invalidParams := request.ErrInvalidParams{Context: "CreateRouteTableInput"}
+	if s.VpcId == nil {
+		invalidParams.Add(request.NewErrParamRequired("VpcId"))
+	}
+
+	if invalidParams.Len() > 0 {
+		return invalidParams
+	}
+	return nil
 }
 
 // Contains the output of CreateRouteTable.
@@ -9715,6 +10276,22 @@ func (s CreateSecurityGroupInput) GoString() string {
 	return s.String()
 }
 
+// Validate inspects the fields of the type to determine if they are valid.
+func (s *CreateSecurityGroupInput) Validate() error {
+	invalidParams := request.ErrInvalidParams{Context: "CreateSecurityGroupInput"}
+	if s.Description == nil {
+		invalidParams.Add(request.NewErrParamRequired("Description"))
+	}
+	if s.GroupName == nil {
+		invalidParams.Add(request.NewErrParamRequired("GroupName"))
+	}
+
+	if invalidParams.Len() > 0 {
+		return invalidParams
+	}
+	return nil
+}
+
 // Contains the output of CreateSecurityGroup.
 type CreateSecurityGroupOutput struct {
 	_ struct{} `type:"structure"`
@@ -9760,6 +10337,19 @@ func (s CreateSnapshotInput) GoString() string {
 	return s.String()
 }
 
+// Validate inspects the fields of the type to determine if they are valid.
+func (s *CreateSnapshotInput) Validate() error {
+	invalidParams := request.ErrInvalidParams{Context: "CreateSnapshotInput"}
+	if s.VolumeId == nil {
+		invalidParams.Add(request.NewErrParamRequired("VolumeId"))
+	}
+
+	if invalidParams.Len() > 0 {
+		return invalidParams
+	}
+	return nil
+}
+
 // Contains the parameters for CreateSpotDatafeedSubscription.
 type CreateSpotDatafeedSubscriptionInput struct {
 	_ struct{} `type:"structure"`
@@ -9785,6 +10375,19 @@ func (s CreateSpotDatafeedSubscriptionInput) String() string {
 // GoString returns the string representation
 func (s CreateSpotDatafeedSubscriptionInput) GoString() string {
 	return s.String()
+}
+
+// Validate inspects the fields of the type to determine if they are valid.
+func (s *CreateSpotDatafeedSubscriptionInput) Validate() error {
+	invalidParams := request.ErrInvalidParams{Context: "CreateSpotDatafeedSubscriptionInput"}
+	if s.Bucket == nil {
+		invalidParams.Add(request.NewErrParamRequired("Bucket"))
+	}
+
+	if invalidParams.Len() > 0 {
+		return invalidParams
+	}
+	return nil
 }
 
 // Contains the output of CreateSpotDatafeedSubscription.
@@ -9838,6 +10441,22 @@ func (s CreateSubnetInput) GoString() string {
 	return s.String()
 }
 
+// Validate inspects the fields of the type to determine if they are valid.
+func (s *CreateSubnetInput) Validate() error {
+	invalidParams := request.ErrInvalidParams{Context: "CreateSubnetInput"}
+	if s.CidrBlock == nil {
+		invalidParams.Add(request.NewErrParamRequired("CidrBlock"))
+	}
+	if s.VpcId == nil {
+		invalidParams.Add(request.NewErrParamRequired("VpcId"))
+	}
+
+	if invalidParams.Len() > 0 {
+		return invalidParams
+	}
+	return nil
+}
+
 // Contains the output of CreateSubnet.
 type CreateSubnetOutput struct {
 	_ struct{} `type:"structure"`
@@ -9883,6 +10502,22 @@ func (s CreateTagsInput) String() string {
 // GoString returns the string representation
 func (s CreateTagsInput) GoString() string {
 	return s.String()
+}
+
+// Validate inspects the fields of the type to determine if they are valid.
+func (s *CreateTagsInput) Validate() error {
+	invalidParams := request.ErrInvalidParams{Context: "CreateTagsInput"}
+	if s.Resources == nil {
+		invalidParams.Add(request.NewErrParamRequired("Resources"))
+	}
+	if s.Tags == nil {
+		invalidParams.Add(request.NewErrParamRequired("Tags"))
+	}
+
+	if invalidParams.Len() > 0 {
+		return invalidParams
+	}
+	return nil
 }
 
 type CreateTagsOutput struct {
@@ -9967,6 +10602,19 @@ func (s CreateVolumeInput) String() string {
 // GoString returns the string representation
 func (s CreateVolumeInput) GoString() string {
 	return s.String()
+}
+
+// Validate inspects the fields of the type to determine if they are valid.
+func (s *CreateVolumeInput) Validate() error {
+	invalidParams := request.ErrInvalidParams{Context: "CreateVolumeInput"}
+	if s.AvailabilityZone == nil {
+		invalidParams.Add(request.NewErrParamRequired("AvailabilityZone"))
+	}
+
+	if invalidParams.Len() > 0 {
+		return invalidParams
+	}
+	return nil
 }
 
 // Describes the user or group to be added or removed from the permissions for
@@ -10056,6 +10704,22 @@ func (s CreateVpcEndpointInput) GoString() string {
 	return s.String()
 }
 
+// Validate inspects the fields of the type to determine if they are valid.
+func (s *CreateVpcEndpointInput) Validate() error {
+	invalidParams := request.ErrInvalidParams{Context: "CreateVpcEndpointInput"}
+	if s.ServiceName == nil {
+		invalidParams.Add(request.NewErrParamRequired("ServiceName"))
+	}
+	if s.VpcId == nil {
+		invalidParams.Add(request.NewErrParamRequired("VpcId"))
+	}
+
+	if invalidParams.Len() > 0 {
+		return invalidParams
+	}
+	return nil
+}
+
 // Contains the output of CreateVpcEndpoint.
 type CreateVpcEndpointOutput struct {
 	_ struct{} `type:"structure"`
@@ -10112,6 +10776,19 @@ func (s CreateVpcInput) String() string {
 // GoString returns the string representation
 func (s CreateVpcInput) GoString() string {
 	return s.String()
+}
+
+// Validate inspects the fields of the type to determine if they are valid.
+func (s *CreateVpcInput) Validate() error {
+	invalidParams := request.ErrInvalidParams{Context: "CreateVpcInput"}
+	if s.CidrBlock == nil {
+		invalidParams.Add(request.NewErrParamRequired("CidrBlock"))
+	}
+
+	if invalidParams.Len() > 0 {
+		return invalidParams
+	}
+	return nil
 }
 
 // Contains the output of CreateVpc.
@@ -10219,6 +10896,25 @@ func (s CreateVpnConnectionInput) GoString() string {
 	return s.String()
 }
 
+// Validate inspects the fields of the type to determine if they are valid.
+func (s *CreateVpnConnectionInput) Validate() error {
+	invalidParams := request.ErrInvalidParams{Context: "CreateVpnConnectionInput"}
+	if s.CustomerGatewayId == nil {
+		invalidParams.Add(request.NewErrParamRequired("CustomerGatewayId"))
+	}
+	if s.Type == nil {
+		invalidParams.Add(request.NewErrParamRequired("Type"))
+	}
+	if s.VpnGatewayId == nil {
+		invalidParams.Add(request.NewErrParamRequired("VpnGatewayId"))
+	}
+
+	if invalidParams.Len() > 0 {
+		return invalidParams
+	}
+	return nil
+}
+
 // Contains the output of CreateVpnConnection.
 type CreateVpnConnectionOutput struct {
 	_ struct{} `type:"structure"`
@@ -10256,6 +10952,22 @@ func (s CreateVpnConnectionRouteInput) String() string {
 // GoString returns the string representation
 func (s CreateVpnConnectionRouteInput) GoString() string {
 	return s.String()
+}
+
+// Validate inspects the fields of the type to determine if they are valid.
+func (s *CreateVpnConnectionRouteInput) Validate() error {
+	invalidParams := request.ErrInvalidParams{Context: "CreateVpnConnectionRouteInput"}
+	if s.DestinationCidrBlock == nil {
+		invalidParams.Add(request.NewErrParamRequired("DestinationCidrBlock"))
+	}
+	if s.VpnConnectionId == nil {
+		invalidParams.Add(request.NewErrParamRequired("VpnConnectionId"))
+	}
+
+	if invalidParams.Len() > 0 {
+		return invalidParams
+	}
+	return nil
 }
 
 type CreateVpnConnectionRouteOutput struct {
@@ -10297,6 +11009,19 @@ func (s CreateVpnGatewayInput) String() string {
 // GoString returns the string representation
 func (s CreateVpnGatewayInput) GoString() string {
 	return s.String()
+}
+
+// Validate inspects the fields of the type to determine if they are valid.
+func (s *CreateVpnGatewayInput) Validate() error {
+	invalidParams := request.ErrInvalidParams{Context: "CreateVpnGatewayInput"}
+	if s.Type == nil {
+		invalidParams.Add(request.NewErrParamRequired("Type"))
+	}
+
+	if invalidParams.Len() > 0 {
+		return invalidParams
+	}
+	return nil
 }
 
 // Contains the output of CreateVpnGateway.
@@ -10376,6 +11101,19 @@ func (s DeleteCustomerGatewayInput) GoString() string {
 	return s.String()
 }
 
+// Validate inspects the fields of the type to determine if they are valid.
+func (s *DeleteCustomerGatewayInput) Validate() error {
+	invalidParams := request.ErrInvalidParams{Context: "DeleteCustomerGatewayInput"}
+	if s.CustomerGatewayId == nil {
+		invalidParams.Add(request.NewErrParamRequired("CustomerGatewayId"))
+	}
+
+	if invalidParams.Len() > 0 {
+		return invalidParams
+	}
+	return nil
+}
+
 type DeleteCustomerGatewayOutput struct {
 	_ struct{} `type:"structure"`
 }
@@ -10414,6 +11152,19 @@ func (s DeleteDhcpOptionsInput) GoString() string {
 	return s.String()
 }
 
+// Validate inspects the fields of the type to determine if they are valid.
+func (s *DeleteDhcpOptionsInput) Validate() error {
+	invalidParams := request.ErrInvalidParams{Context: "DeleteDhcpOptionsInput"}
+	if s.DhcpOptionsId == nil {
+		invalidParams.Add(request.NewErrParamRequired("DhcpOptionsId"))
+	}
+
+	if invalidParams.Len() > 0 {
+		return invalidParams
+	}
+	return nil
+}
+
 type DeleteDhcpOptionsOutput struct {
 	_ struct{} `type:"structure"`
 }
@@ -10444,6 +11195,19 @@ func (s DeleteFlowLogsInput) String() string {
 // GoString returns the string representation
 func (s DeleteFlowLogsInput) GoString() string {
 	return s.String()
+}
+
+// Validate inspects the fields of the type to determine if they are valid.
+func (s *DeleteFlowLogsInput) Validate() error {
+	invalidParams := request.ErrInvalidParams{Context: "DeleteFlowLogsInput"}
+	if s.FlowLogIds == nil {
+		invalidParams.Add(request.NewErrParamRequired("FlowLogIds"))
+	}
+
+	if invalidParams.Len() > 0 {
+		return invalidParams
+	}
+	return nil
 }
 
 // Contains the output of DeleteFlowLogs.
@@ -10488,6 +11252,19 @@ func (s DeleteInternetGatewayInput) GoString() string {
 	return s.String()
 }
 
+// Validate inspects the fields of the type to determine if they are valid.
+func (s *DeleteInternetGatewayInput) Validate() error {
+	invalidParams := request.ErrInvalidParams{Context: "DeleteInternetGatewayInput"}
+	if s.InternetGatewayId == nil {
+		invalidParams.Add(request.NewErrParamRequired("InternetGatewayId"))
+	}
+
+	if invalidParams.Len() > 0 {
+		return invalidParams
+	}
+	return nil
+}
+
 type DeleteInternetGatewayOutput struct {
 	_ struct{} `type:"structure"`
 }
@@ -10526,6 +11303,19 @@ func (s DeleteKeyPairInput) GoString() string {
 	return s.String()
 }
 
+// Validate inspects the fields of the type to determine if they are valid.
+func (s *DeleteKeyPairInput) Validate() error {
+	invalidParams := request.ErrInvalidParams{Context: "DeleteKeyPairInput"}
+	if s.KeyName == nil {
+		invalidParams.Add(request.NewErrParamRequired("KeyName"))
+	}
+
+	if invalidParams.Len() > 0 {
+		return invalidParams
+	}
+	return nil
+}
+
 type DeleteKeyPairOutput struct {
 	_ struct{} `type:"structure"`
 }
@@ -10556,6 +11346,19 @@ func (s DeleteNatGatewayInput) String() string {
 // GoString returns the string representation
 func (s DeleteNatGatewayInput) GoString() string {
 	return s.String()
+}
+
+// Validate inspects the fields of the type to determine if they are valid.
+func (s *DeleteNatGatewayInput) Validate() error {
+	invalidParams := request.ErrInvalidParams{Context: "DeleteNatGatewayInput"}
+	if s.NatGatewayId == nil {
+		invalidParams.Add(request.NewErrParamRequired("NatGatewayId"))
+	}
+
+	if invalidParams.Len() > 0 {
+		return invalidParams
+	}
+	return nil
 }
 
 // Contains the output of DeleteNatGateway.
@@ -10606,6 +11409,25 @@ func (s DeleteNetworkAclEntryInput) GoString() string {
 	return s.String()
 }
 
+// Validate inspects the fields of the type to determine if they are valid.
+func (s *DeleteNetworkAclEntryInput) Validate() error {
+	invalidParams := request.ErrInvalidParams{Context: "DeleteNetworkAclEntryInput"}
+	if s.Egress == nil {
+		invalidParams.Add(request.NewErrParamRequired("Egress"))
+	}
+	if s.NetworkAclId == nil {
+		invalidParams.Add(request.NewErrParamRequired("NetworkAclId"))
+	}
+	if s.RuleNumber == nil {
+		invalidParams.Add(request.NewErrParamRequired("RuleNumber"))
+	}
+
+	if invalidParams.Len() > 0 {
+		return invalidParams
+	}
+	return nil
+}
+
 type DeleteNetworkAclEntryOutput struct {
 	_ struct{} `type:"structure"`
 }
@@ -10642,6 +11464,19 @@ func (s DeleteNetworkAclInput) String() string {
 // GoString returns the string representation
 func (s DeleteNetworkAclInput) GoString() string {
 	return s.String()
+}
+
+// Validate inspects the fields of the type to determine if they are valid.
+func (s *DeleteNetworkAclInput) Validate() error {
+	invalidParams := request.ErrInvalidParams{Context: "DeleteNetworkAclInput"}
+	if s.NetworkAclId == nil {
+		invalidParams.Add(request.NewErrParamRequired("NetworkAclId"))
+	}
+
+	if invalidParams.Len() > 0 {
+		return invalidParams
+	}
+	return nil
 }
 
 type DeleteNetworkAclOutput struct {
@@ -10682,6 +11517,19 @@ func (s DeleteNetworkInterfaceInput) GoString() string {
 	return s.String()
 }
 
+// Validate inspects the fields of the type to determine if they are valid.
+func (s *DeleteNetworkInterfaceInput) Validate() error {
+	invalidParams := request.ErrInvalidParams{Context: "DeleteNetworkInterfaceInput"}
+	if s.NetworkInterfaceId == nil {
+		invalidParams.Add(request.NewErrParamRequired("NetworkInterfaceId"))
+	}
+
+	if invalidParams.Len() > 0 {
+		return invalidParams
+	}
+	return nil
+}
+
 type DeleteNetworkInterfaceOutput struct {
 	_ struct{} `type:"structure"`
 }
@@ -10718,6 +11566,19 @@ func (s DeletePlacementGroupInput) String() string {
 // GoString returns the string representation
 func (s DeletePlacementGroupInput) GoString() string {
 	return s.String()
+}
+
+// Validate inspects the fields of the type to determine if they are valid.
+func (s *DeletePlacementGroupInput) Validate() error {
+	invalidParams := request.ErrInvalidParams{Context: "DeletePlacementGroupInput"}
+	if s.GroupName == nil {
+		invalidParams.Add(request.NewErrParamRequired("GroupName"))
+	}
+
+	if invalidParams.Len() > 0 {
+		return invalidParams
+	}
+	return nil
 }
 
 type DeletePlacementGroupOutput struct {
@@ -10762,6 +11623,22 @@ func (s DeleteRouteInput) GoString() string {
 	return s.String()
 }
 
+// Validate inspects the fields of the type to determine if they are valid.
+func (s *DeleteRouteInput) Validate() error {
+	invalidParams := request.ErrInvalidParams{Context: "DeleteRouteInput"}
+	if s.DestinationCidrBlock == nil {
+		invalidParams.Add(request.NewErrParamRequired("DestinationCidrBlock"))
+	}
+	if s.RouteTableId == nil {
+		invalidParams.Add(request.NewErrParamRequired("RouteTableId"))
+	}
+
+	if invalidParams.Len() > 0 {
+		return invalidParams
+	}
+	return nil
+}
+
 type DeleteRouteOutput struct {
 	_ struct{} `type:"structure"`
 }
@@ -10798,6 +11675,19 @@ func (s DeleteRouteTableInput) String() string {
 // GoString returns the string representation
 func (s DeleteRouteTableInput) GoString() string {
 	return s.String()
+}
+
+// Validate inspects the fields of the type to determine if they are valid.
+func (s *DeleteRouteTableInput) Validate() error {
+	invalidParams := request.ErrInvalidParams{Context: "DeleteRouteTableInput"}
+	if s.RouteTableId == nil {
+		invalidParams.Add(request.NewErrParamRequired("RouteTableId"))
+	}
+
+	if invalidParams.Len() > 0 {
+		return invalidParams
+	}
+	return nil
 }
 
 type DeleteRouteTableOutput struct {
@@ -10880,6 +11770,19 @@ func (s DeleteSnapshotInput) GoString() string {
 	return s.String()
 }
 
+// Validate inspects the fields of the type to determine if they are valid.
+func (s *DeleteSnapshotInput) Validate() error {
+	invalidParams := request.ErrInvalidParams{Context: "DeleteSnapshotInput"}
+	if s.SnapshotId == nil {
+		invalidParams.Add(request.NewErrParamRequired("SnapshotId"))
+	}
+
+	if invalidParams.Len() > 0 {
+		return invalidParams
+	}
+	return nil
+}
+
 type DeleteSnapshotOutput struct {
 	_ struct{} `type:"structure"`
 }
@@ -10953,6 +11856,19 @@ func (s DeleteSubnetInput) GoString() string {
 	return s.String()
 }
 
+// Validate inspects the fields of the type to determine if they are valid.
+func (s *DeleteSubnetInput) Validate() error {
+	invalidParams := request.ErrInvalidParams{Context: "DeleteSubnetInput"}
+	if s.SubnetId == nil {
+		invalidParams.Add(request.NewErrParamRequired("SubnetId"))
+	}
+
+	if invalidParams.Len() > 0 {
+		return invalidParams
+	}
+	return nil
+}
+
 type DeleteSubnetOutput struct {
 	_ struct{} `type:"structure"`
 }
@@ -10997,6 +11913,19 @@ func (s DeleteTagsInput) GoString() string {
 	return s.String()
 }
 
+// Validate inspects the fields of the type to determine if they are valid.
+func (s *DeleteTagsInput) Validate() error {
+	invalidParams := request.ErrInvalidParams{Context: "DeleteTagsInput"}
+	if s.Resources == nil {
+		invalidParams.Add(request.NewErrParamRequired("Resources"))
+	}
+
+	if invalidParams.Len() > 0 {
+		return invalidParams
+	}
+	return nil
+}
+
 type DeleteTagsOutput struct {
 	_ struct{} `type:"structure"`
 }
@@ -11035,6 +11964,19 @@ func (s DeleteVolumeInput) GoString() string {
 	return s.String()
 }
 
+// Validate inspects the fields of the type to determine if they are valid.
+func (s *DeleteVolumeInput) Validate() error {
+	invalidParams := request.ErrInvalidParams{Context: "DeleteVolumeInput"}
+	if s.VolumeId == nil {
+		invalidParams.Add(request.NewErrParamRequired("VolumeId"))
+	}
+
+	if invalidParams.Len() > 0 {
+		return invalidParams
+	}
+	return nil
+}
+
 type DeleteVolumeOutput struct {
 	_ struct{} `type:"structure"`
 }
@@ -11071,6 +12013,19 @@ func (s DeleteVpcEndpointsInput) String() string {
 // GoString returns the string representation
 func (s DeleteVpcEndpointsInput) GoString() string {
 	return s.String()
+}
+
+// Validate inspects the fields of the type to determine if they are valid.
+func (s *DeleteVpcEndpointsInput) Validate() error {
+	invalidParams := request.ErrInvalidParams{Context: "DeleteVpcEndpointsInput"}
+	if s.VpcEndpointIds == nil {
+		invalidParams.Add(request.NewErrParamRequired("VpcEndpointIds"))
+	}
+
+	if invalidParams.Len() > 0 {
+		return invalidParams
+	}
+	return nil
 }
 
 // Contains the output of DeleteVpcEndpoints.
@@ -11115,6 +12070,19 @@ func (s DeleteVpcInput) GoString() string {
 	return s.String()
 }
 
+// Validate inspects the fields of the type to determine if they are valid.
+func (s *DeleteVpcInput) Validate() error {
+	invalidParams := request.ErrInvalidParams{Context: "DeleteVpcInput"}
+	if s.VpcId == nil {
+		invalidParams.Add(request.NewErrParamRequired("VpcId"))
+	}
+
+	if invalidParams.Len() > 0 {
+		return invalidParams
+	}
+	return nil
+}
+
 type DeleteVpcOutput struct {
 	_ struct{} `type:"structure"`
 }
@@ -11151,6 +12119,19 @@ func (s DeleteVpcPeeringConnectionInput) String() string {
 // GoString returns the string representation
 func (s DeleteVpcPeeringConnectionInput) GoString() string {
 	return s.String()
+}
+
+// Validate inspects the fields of the type to determine if they are valid.
+func (s *DeleteVpcPeeringConnectionInput) Validate() error {
+	invalidParams := request.ErrInvalidParams{Context: "DeleteVpcPeeringConnectionInput"}
+	if s.VpcPeeringConnectionId == nil {
+		invalidParams.Add(request.NewErrParamRequired("VpcPeeringConnectionId"))
+	}
+
+	if invalidParams.Len() > 0 {
+		return invalidParams
+	}
+	return nil
 }
 
 // Contains the output of DeleteVpcPeeringConnection.
@@ -11195,6 +12176,19 @@ func (s DeleteVpnConnectionInput) GoString() string {
 	return s.String()
 }
 
+// Validate inspects the fields of the type to determine if they are valid.
+func (s *DeleteVpnConnectionInput) Validate() error {
+	invalidParams := request.ErrInvalidParams{Context: "DeleteVpnConnectionInput"}
+	if s.VpnConnectionId == nil {
+		invalidParams.Add(request.NewErrParamRequired("VpnConnectionId"))
+	}
+
+	if invalidParams.Len() > 0 {
+		return invalidParams
+	}
+	return nil
+}
+
 type DeleteVpnConnectionOutput struct {
 	_ struct{} `type:"structure"`
 }
@@ -11228,6 +12222,22 @@ func (s DeleteVpnConnectionRouteInput) String() string {
 // GoString returns the string representation
 func (s DeleteVpnConnectionRouteInput) GoString() string {
 	return s.String()
+}
+
+// Validate inspects the fields of the type to determine if they are valid.
+func (s *DeleteVpnConnectionRouteInput) Validate() error {
+	invalidParams := request.ErrInvalidParams{Context: "DeleteVpnConnectionRouteInput"}
+	if s.DestinationCidrBlock == nil {
+		invalidParams.Add(request.NewErrParamRequired("DestinationCidrBlock"))
+	}
+	if s.VpnConnectionId == nil {
+		invalidParams.Add(request.NewErrParamRequired("VpnConnectionId"))
+	}
+
+	if invalidParams.Len() > 0 {
+		return invalidParams
+	}
+	return nil
 }
 
 type DeleteVpnConnectionRouteOutput struct {
@@ -11268,6 +12278,19 @@ func (s DeleteVpnGatewayInput) GoString() string {
 	return s.String()
 }
 
+// Validate inspects the fields of the type to determine if they are valid.
+func (s *DeleteVpnGatewayInput) Validate() error {
+	invalidParams := request.ErrInvalidParams{Context: "DeleteVpnGatewayInput"}
+	if s.VpnGatewayId == nil {
+		invalidParams.Add(request.NewErrParamRequired("VpnGatewayId"))
+	}
+
+	if invalidParams.Len() > 0 {
+		return invalidParams
+	}
+	return nil
+}
+
 type DeleteVpnGatewayOutput struct {
 	_ struct{} `type:"structure"`
 }
@@ -11304,6 +12327,19 @@ func (s DeregisterImageInput) String() string {
 // GoString returns the string representation
 func (s DeregisterImageInput) GoString() string {
 	return s.String()
+}
+
+// Validate inspects the fields of the type to determine if they are valid.
+func (s *DeregisterImageInput) Validate() error {
+	invalidParams := request.ErrInvalidParams{Context: "DeregisterImageInput"}
+	if s.ImageId == nil {
+		invalidParams.Add(request.NewErrParamRequired("ImageId"))
+	}
+
+	if invalidParams.Len() > 0 {
+		return invalidParams
+	}
+	return nil
 }
 
 type DeregisterImageOutput struct {
@@ -12055,6 +13091,22 @@ func (s DescribeImageAttributeInput) GoString() string {
 	return s.String()
 }
 
+// Validate inspects the fields of the type to determine if they are valid.
+func (s *DescribeImageAttributeInput) Validate() error {
+	invalidParams := request.ErrInvalidParams{Context: "DescribeImageAttributeInput"}
+	if s.Attribute == nil {
+		invalidParams.Add(request.NewErrParamRequired("Attribute"))
+	}
+	if s.ImageId == nil {
+		invalidParams.Add(request.NewErrParamRequired("ImageId"))
+	}
+
+	if invalidParams.Len() > 0 {
+		return invalidParams
+	}
+	return nil
+}
+
 // Describes an image attribute.
 type DescribeImageAttributeOutput struct {
 	_ struct{} `type:"structure"`
@@ -12359,6 +13411,22 @@ func (s DescribeInstanceAttributeInput) String() string {
 // GoString returns the string representation
 func (s DescribeInstanceAttributeInput) GoString() string {
 	return s.String()
+}
+
+// Validate inspects the fields of the type to determine if they are valid.
+func (s *DescribeInstanceAttributeInput) Validate() error {
+	invalidParams := request.ErrInvalidParams{Context: "DescribeInstanceAttributeInput"}
+	if s.Attribute == nil {
+		invalidParams.Add(request.NewErrParamRequired("Attribute"))
+	}
+	if s.InstanceId == nil {
+		invalidParams.Add(request.NewErrParamRequired("InstanceId"))
+	}
+
+	if invalidParams.Len() > 0 {
+		return invalidParams
+	}
+	return nil
 }
 
 // Describes an instance attribute.
@@ -13173,6 +14241,19 @@ func (s DescribeNetworkInterfaceAttributeInput) String() string {
 // GoString returns the string representation
 func (s DescribeNetworkInterfaceAttributeInput) GoString() string {
 	return s.String()
+}
+
+// Validate inspects the fields of the type to determine if they are valid.
+func (s *DescribeNetworkInterfaceAttributeInput) Validate() error {
+	invalidParams := request.ErrInvalidParams{Context: "DescribeNetworkInterfaceAttributeInput"}
+	if s.NetworkInterfaceId == nil {
+		invalidParams.Add(request.NewErrParamRequired("NetworkInterfaceId"))
+	}
+
+	if invalidParams.Len() > 0 {
+		return invalidParams
+	}
+	return nil
 }
 
 // Contains the output of DescribeNetworkInterfaceAttribute.
@@ -14038,6 +15119,27 @@ func (s DescribeScheduledInstanceAvailabilityInput) GoString() string {
 	return s.String()
 }
 
+// Validate inspects the fields of the type to determine if they are valid.
+func (s *DescribeScheduledInstanceAvailabilityInput) Validate() error {
+	invalidParams := request.ErrInvalidParams{Context: "DescribeScheduledInstanceAvailabilityInput"}
+	if s.FirstSlotStartTimeRange == nil {
+		invalidParams.Add(request.NewErrParamRequired("FirstSlotStartTimeRange"))
+	}
+	if s.Recurrence == nil {
+		invalidParams.Add(request.NewErrParamRequired("Recurrence"))
+	}
+	if s.FirstSlotStartTimeRange != nil {
+		if err := s.FirstSlotStartTimeRange.Validate(); err != nil {
+			invalidParams.AddNested("FirstSlotStartTimeRange", err.(request.ErrInvalidParams))
+		}
+	}
+
+	if invalidParams.Len() > 0 {
+		return invalidParams
+	}
+	return nil
+}
+
 // Contains the output of DescribeScheduledInstanceAvailability.
 type DescribeScheduledInstanceAvailabilityOutput struct {
 	_ struct{} `type:"structure"`
@@ -14250,6 +15352,22 @@ func (s DescribeSnapshotAttributeInput) GoString() string {
 	return s.String()
 }
 
+// Validate inspects the fields of the type to determine if they are valid.
+func (s *DescribeSnapshotAttributeInput) Validate() error {
+	invalidParams := request.ErrInvalidParams{Context: "DescribeSnapshotAttributeInput"}
+	if s.Attribute == nil {
+		invalidParams.Add(request.NewErrParamRequired("Attribute"))
+	}
+	if s.SnapshotId == nil {
+		invalidParams.Add(request.NewErrParamRequired("SnapshotId"))
+	}
+
+	if invalidParams.Len() > 0 {
+		return invalidParams
+	}
+	return nil
+}
+
 // Contains the output of DescribeSnapshotAttribute.
 type DescribeSnapshotAttributeOutput struct {
 	_ struct{} `type:"structure"`
@@ -14455,6 +15573,19 @@ func (s DescribeSpotFleetInstancesInput) GoString() string {
 	return s.String()
 }
 
+// Validate inspects the fields of the type to determine if they are valid.
+func (s *DescribeSpotFleetInstancesInput) Validate() error {
+	invalidParams := request.ErrInvalidParams{Context: "DescribeSpotFleetInstancesInput"}
+	if s.SpotFleetRequestId == nil {
+		invalidParams.Add(request.NewErrParamRequired("SpotFleetRequestId"))
+	}
+
+	if invalidParams.Len() > 0 {
+		return invalidParams
+	}
+	return nil
+}
+
 // Contains the output of DescribeSpotFleetInstances.
 type DescribeSpotFleetInstancesOutput struct {
 	_ struct{} `type:"structure"`
@@ -14517,6 +15648,22 @@ func (s DescribeSpotFleetRequestHistoryInput) String() string {
 // GoString returns the string representation
 func (s DescribeSpotFleetRequestHistoryInput) GoString() string {
 	return s.String()
+}
+
+// Validate inspects the fields of the type to determine if they are valid.
+func (s *DescribeSpotFleetRequestHistoryInput) Validate() error {
+	invalidParams := request.ErrInvalidParams{Context: "DescribeSpotFleetRequestHistoryInput"}
+	if s.SpotFleetRequestId == nil {
+		invalidParams.Add(request.NewErrParamRequired("SpotFleetRequestId"))
+	}
+	if s.StartTime == nil {
+		invalidParams.Add(request.NewErrParamRequired("StartTime"))
+	}
+
+	if invalidParams.Len() > 0 {
+		return invalidParams
+	}
+	return nil
 }
 
 // Contains the output of DescribeSpotFleetRequestHistory.
@@ -15016,6 +16163,19 @@ func (s DescribeVolumeAttributeInput) GoString() string {
 	return s.String()
 }
 
+// Validate inspects the fields of the type to determine if they are valid.
+func (s *DescribeVolumeAttributeInput) Validate() error {
+	invalidParams := request.ErrInvalidParams{Context: "DescribeVolumeAttributeInput"}
+	if s.VolumeId == nil {
+		invalidParams.Add(request.NewErrParamRequired("VolumeId"))
+	}
+
+	if invalidParams.Len() > 0 {
+		return invalidParams
+	}
+	return nil
+}
+
 // Contains the output of DescribeVolumeAttribute.
 type DescribeVolumeAttributeOutput struct {
 	_ struct{} `type:"structure"`
@@ -15277,6 +16437,22 @@ func (s DescribeVpcAttributeInput) GoString() string {
 	return s.String()
 }
 
+// Validate inspects the fields of the type to determine if they are valid.
+func (s *DescribeVpcAttributeInput) Validate() error {
+	invalidParams := request.ErrInvalidParams{Context: "DescribeVpcAttributeInput"}
+	if s.Attribute == nil {
+		invalidParams.Add(request.NewErrParamRequired("Attribute"))
+	}
+	if s.VpcId == nil {
+		invalidParams.Add(request.NewErrParamRequired("VpcId"))
+	}
+
+	if invalidParams.Len() > 0 {
+		return invalidParams
+	}
+	return nil
+}
+
 // Contains the output of DescribeVpcAttribute.
 type DescribeVpcAttributeOutput struct {
 	_ struct{} `type:"structure"`
@@ -15330,6 +16506,22 @@ func (s DescribeVpcClassicLinkDnsSupportInput) String() string {
 // GoString returns the string representation
 func (s DescribeVpcClassicLinkDnsSupportInput) GoString() string {
 	return s.String()
+}
+
+// Validate inspects the fields of the type to determine if they are valid.
+func (s *DescribeVpcClassicLinkDnsSupportInput) Validate() error {
+	invalidParams := request.ErrInvalidParams{Context: "DescribeVpcClassicLinkDnsSupportInput"}
+	if s.MaxResults != nil && *s.MaxResults < 5 {
+		invalidParams.Add(request.NewErrParamMinValue("MaxResults", 5))
+	}
+	if s.NextToken != nil && len(*s.NextToken) < 1 {
+		invalidParams.Add(request.NewErrParamMinLen("NextToken", 1))
+	}
+
+	if invalidParams.Len() > 0 {
+		return invalidParams
+	}
+	return nil
 }
 
 // Contains the output of DescribeVpcClassicLinkDnsSupport.
@@ -15878,6 +17070,22 @@ func (s DetachClassicLinkVpcInput) GoString() string {
 	return s.String()
 }
 
+// Validate inspects the fields of the type to determine if they are valid.
+func (s *DetachClassicLinkVpcInput) Validate() error {
+	invalidParams := request.ErrInvalidParams{Context: "DetachClassicLinkVpcInput"}
+	if s.InstanceId == nil {
+		invalidParams.Add(request.NewErrParamRequired("InstanceId"))
+	}
+	if s.VpcId == nil {
+		invalidParams.Add(request.NewErrParamRequired("VpcId"))
+	}
+
+	if invalidParams.Len() > 0 {
+		return invalidParams
+	}
+	return nil
+}
+
 // Contains the output of DetachClassicLinkVpc.
 type DetachClassicLinkVpcOutput struct {
 	_ struct{} `type:"structure"`
@@ -15923,6 +17131,22 @@ func (s DetachInternetGatewayInput) GoString() string {
 	return s.String()
 }
 
+// Validate inspects the fields of the type to determine if they are valid.
+func (s *DetachInternetGatewayInput) Validate() error {
+	invalidParams := request.ErrInvalidParams{Context: "DetachInternetGatewayInput"}
+	if s.InternetGatewayId == nil {
+		invalidParams.Add(request.NewErrParamRequired("InternetGatewayId"))
+	}
+	if s.VpcId == nil {
+		invalidParams.Add(request.NewErrParamRequired("VpcId"))
+	}
+
+	if invalidParams.Len() > 0 {
+		return invalidParams
+	}
+	return nil
+}
+
 type DetachInternetGatewayOutput struct {
 	_ struct{} `type:"structure"`
 }
@@ -15962,6 +17186,19 @@ func (s DetachNetworkInterfaceInput) String() string {
 // GoString returns the string representation
 func (s DetachNetworkInterfaceInput) GoString() string {
 	return s.String()
+}
+
+// Validate inspects the fields of the type to determine if they are valid.
+func (s *DetachNetworkInterfaceInput) Validate() error {
+	invalidParams := request.ErrInvalidParams{Context: "DetachNetworkInterfaceInput"}
+	if s.AttachmentId == nil {
+		invalidParams.Add(request.NewErrParamRequired("AttachmentId"))
+	}
+
+	if invalidParams.Len() > 0 {
+		return invalidParams
+	}
+	return nil
 }
 
 type DetachNetworkInterfaceOutput struct {
@@ -16017,6 +17254,19 @@ func (s DetachVolumeInput) GoString() string {
 	return s.String()
 }
 
+// Validate inspects the fields of the type to determine if they are valid.
+func (s *DetachVolumeInput) Validate() error {
+	invalidParams := request.ErrInvalidParams{Context: "DetachVolumeInput"}
+	if s.VolumeId == nil {
+		invalidParams.Add(request.NewErrParamRequired("VolumeId"))
+	}
+
+	if invalidParams.Len() > 0 {
+		return invalidParams
+	}
+	return nil
+}
+
 // Contains the parameters for DetachVpnGateway.
 type DetachVpnGatewayInput struct {
 	_ struct{} `type:"structure"`
@@ -16042,6 +17292,22 @@ func (s DetachVpnGatewayInput) String() string {
 // GoString returns the string representation
 func (s DetachVpnGatewayInput) GoString() string {
 	return s.String()
+}
+
+// Validate inspects the fields of the type to determine if they are valid.
+func (s *DetachVpnGatewayInput) Validate() error {
+	invalidParams := request.ErrInvalidParams{Context: "DetachVpnGatewayInput"}
+	if s.VpcId == nil {
+		invalidParams.Add(request.NewErrParamRequired("VpcId"))
+	}
+	if s.VpnGatewayId == nil {
+		invalidParams.Add(request.NewErrParamRequired("VpnGatewayId"))
+	}
+
+	if invalidParams.Len() > 0 {
+		return invalidParams
+	}
+	return nil
 }
 
 type DetachVpnGatewayOutput struct {
@@ -16124,6 +17390,22 @@ func (s DisableVgwRoutePropagationInput) GoString() string {
 	return s.String()
 }
 
+// Validate inspects the fields of the type to determine if they are valid.
+func (s *DisableVgwRoutePropagationInput) Validate() error {
+	invalidParams := request.ErrInvalidParams{Context: "DisableVgwRoutePropagationInput"}
+	if s.GatewayId == nil {
+		invalidParams.Add(request.NewErrParamRequired("GatewayId"))
+	}
+	if s.RouteTableId == nil {
+		invalidParams.Add(request.NewErrParamRequired("RouteTableId"))
+	}
+
+	if invalidParams.Len() > 0 {
+		return invalidParams
+	}
+	return nil
+}
+
 type DisableVgwRoutePropagationOutput struct {
 	_ struct{} `type:"structure"`
 }
@@ -16196,6 +17478,19 @@ func (s DisableVpcClassicLinkInput) String() string {
 // GoString returns the string representation
 func (s DisableVpcClassicLinkInput) GoString() string {
 	return s.String()
+}
+
+// Validate inspects the fields of the type to determine if they are valid.
+func (s *DisableVpcClassicLinkInput) Validate() error {
+	invalidParams := request.ErrInvalidParams{Context: "DisableVpcClassicLinkInput"}
+	if s.VpcId == nil {
+		invalidParams.Add(request.NewErrParamRequired("VpcId"))
+	}
+
+	if invalidParams.Len() > 0 {
+		return invalidParams
+	}
+	return nil
 }
 
 // Contains the output of DisableVpcClassicLink.
@@ -16282,6 +17577,19 @@ func (s DisassociateRouteTableInput) GoString() string {
 	return s.String()
 }
 
+// Validate inspects the fields of the type to determine if they are valid.
+func (s *DisassociateRouteTableInput) Validate() error {
+	invalidParams := request.ErrInvalidParams{Context: "DisassociateRouteTableInput"}
+	if s.AssociationId == nil {
+		invalidParams.Add(request.NewErrParamRequired("AssociationId"))
+	}
+
+	if invalidParams.Len() > 0 {
+		return invalidParams
+	}
+	return nil
+}
+
 type DisassociateRouteTableOutput struct {
 	_ struct{} `type:"structure"`
 }
@@ -16318,6 +17626,26 @@ func (s DiskImage) String() string {
 // GoString returns the string representation
 func (s DiskImage) GoString() string {
 	return s.String()
+}
+
+// Validate inspects the fields of the type to determine if they are valid.
+func (s *DiskImage) Validate() error {
+	invalidParams := request.ErrInvalidParams{Context: "DiskImage"}
+	if s.Image != nil {
+		if err := s.Image.Validate(); err != nil {
+			invalidParams.AddNested("Image", err.(request.ErrInvalidParams))
+		}
+	}
+	if s.Volume != nil {
+		if err := s.Volume.Validate(); err != nil {
+			invalidParams.AddNested("Volume", err.(request.ErrInvalidParams))
+		}
+	}
+
+	if invalidParams.Len() > 0 {
+		return invalidParams
+	}
+	return nil
 }
 
 // Describes a disk image.
@@ -16383,6 +17711,25 @@ func (s DiskImageDetail) String() string {
 // GoString returns the string representation
 func (s DiskImageDetail) GoString() string {
 	return s.String()
+}
+
+// Validate inspects the fields of the type to determine if they are valid.
+func (s *DiskImageDetail) Validate() error {
+	invalidParams := request.ErrInvalidParams{Context: "DiskImageDetail"}
+	if s.Bytes == nil {
+		invalidParams.Add(request.NewErrParamRequired("Bytes"))
+	}
+	if s.Format == nil {
+		invalidParams.Add(request.NewErrParamRequired("Format"))
+	}
+	if s.ImportManifestUrl == nil {
+		invalidParams.Add(request.NewErrParamRequired("ImportManifestUrl"))
+	}
+
+	if invalidParams.Len() > 0 {
+		return invalidParams
+	}
+	return nil
 }
 
 // Describes a disk image volume.
@@ -16533,6 +17880,22 @@ func (s EnableVgwRoutePropagationInput) GoString() string {
 	return s.String()
 }
 
+// Validate inspects the fields of the type to determine if they are valid.
+func (s *EnableVgwRoutePropagationInput) Validate() error {
+	invalidParams := request.ErrInvalidParams{Context: "EnableVgwRoutePropagationInput"}
+	if s.GatewayId == nil {
+		invalidParams.Add(request.NewErrParamRequired("GatewayId"))
+	}
+	if s.RouteTableId == nil {
+		invalidParams.Add(request.NewErrParamRequired("RouteTableId"))
+	}
+
+	if invalidParams.Len() > 0 {
+		return invalidParams
+	}
+	return nil
+}
+
 type EnableVgwRoutePropagationOutput struct {
 	_ struct{} `type:"structure"`
 }
@@ -16569,6 +17932,19 @@ func (s EnableVolumeIOInput) String() string {
 // GoString returns the string representation
 func (s EnableVolumeIOInput) GoString() string {
 	return s.String()
+}
+
+// Validate inspects the fields of the type to determine if they are valid.
+func (s *EnableVolumeIOInput) Validate() error {
+	invalidParams := request.ErrInvalidParams{Context: "EnableVolumeIOInput"}
+	if s.VolumeId == nil {
+		invalidParams.Add(request.NewErrParamRequired("VolumeId"))
+	}
+
+	if invalidParams.Len() > 0 {
+		return invalidParams
+	}
+	return nil
 }
 
 type EnableVolumeIOOutput struct {
@@ -16643,6 +18019,19 @@ func (s EnableVpcClassicLinkInput) String() string {
 // GoString returns the string representation
 func (s EnableVpcClassicLinkInput) GoString() string {
 	return s.String()
+}
+
+// Validate inspects the fields of the type to determine if they are valid.
+func (s *EnableVpcClassicLinkInput) Validate() error {
+	invalidParams := request.ErrInvalidParams{Context: "EnableVpcClassicLinkInput"}
+	if s.VpcId == nil {
+		invalidParams.Add(request.NewErrParamRequired("VpcId"))
+	}
+
+	if invalidParams.Len() > 0 {
+		return invalidParams
+	}
+	return nil
 }
 
 // Contains the output of EnableVpcClassicLink.
@@ -16925,6 +18314,19 @@ func (s GetConsoleOutputInput) GoString() string {
 	return s.String()
 }
 
+// Validate inspects the fields of the type to determine if they are valid.
+func (s *GetConsoleOutputInput) Validate() error {
+	invalidParams := request.ErrInvalidParams{Context: "GetConsoleOutputInput"}
+	if s.InstanceId == nil {
+		invalidParams.Add(request.NewErrParamRequired("InstanceId"))
+	}
+
+	if invalidParams.Len() > 0 {
+		return invalidParams
+	}
+	return nil
+}
+
 // Contains the output of GetConsoleOutput.
 type GetConsoleOutputOutput struct {
 	_ struct{} `type:"structure"`
@@ -16972,6 +18374,19 @@ func (s GetPasswordDataInput) String() string {
 // GoString returns the string representation
 func (s GetPasswordDataInput) GoString() string {
 	return s.String()
+}
+
+// Validate inspects the fields of the type to determine if they are valid.
+func (s *GetPasswordDataInput) Validate() error {
+	invalidParams := request.ErrInvalidParams{Context: "GetPasswordDataInput"}
+	if s.InstanceId == nil {
+		invalidParams.Add(request.NewErrParamRequired("InstanceId"))
+	}
+
+	if invalidParams.Len() > 0 {
+		return invalidParams
+	}
+	return nil
 }
 
 // Contains the output of GetPasswordData.
@@ -17553,6 +18968,29 @@ func (s ImportInstanceInput) GoString() string {
 	return s.String()
 }
 
+// Validate inspects the fields of the type to determine if they are valid.
+func (s *ImportInstanceInput) Validate() error {
+	invalidParams := request.ErrInvalidParams{Context: "ImportInstanceInput"}
+	if s.Platform == nil {
+		invalidParams.Add(request.NewErrParamRequired("Platform"))
+	}
+	if s.DiskImages != nil {
+		for i, v := range s.DiskImages {
+			if v == nil {
+				continue
+			}
+			if err := v.Validate(); err != nil {
+				invalidParams.AddNested(fmt.Sprintf("%s[%v]", "DiskImages", i), err.(request.ErrInvalidParams))
+			}
+		}
+	}
+
+	if invalidParams.Len() > 0 {
+		return invalidParams
+	}
+	return nil
+}
+
 // Describes the launch specification for VM import.
 type ImportInstanceLaunchSpecification struct {
 	_ struct{} `type:"structure"`
@@ -17715,6 +19153,22 @@ func (s ImportKeyPairInput) GoString() string {
 	return s.String()
 }
 
+// Validate inspects the fields of the type to determine if they are valid.
+func (s *ImportKeyPairInput) Validate() error {
+	invalidParams := request.ErrInvalidParams{Context: "ImportKeyPairInput"}
+	if s.KeyName == nil {
+		invalidParams.Add(request.NewErrParamRequired("KeyName"))
+	}
+	if s.PublicKeyMaterial == nil {
+		invalidParams.Add(request.NewErrParamRequired("PublicKeyMaterial"))
+	}
+
+	if invalidParams.Len() > 0 {
+		return invalidParams
+	}
+	return nil
+}
+
 // Contains the output of ImportKeyPair.
 type ImportKeyPairOutput struct {
 	_ struct{} `type:"structure"`
@@ -17851,6 +19305,35 @@ func (s ImportVolumeInput) String() string {
 // GoString returns the string representation
 func (s ImportVolumeInput) GoString() string {
 	return s.String()
+}
+
+// Validate inspects the fields of the type to determine if they are valid.
+func (s *ImportVolumeInput) Validate() error {
+	invalidParams := request.ErrInvalidParams{Context: "ImportVolumeInput"}
+	if s.AvailabilityZone == nil {
+		invalidParams.Add(request.NewErrParamRequired("AvailabilityZone"))
+	}
+	if s.Image == nil {
+		invalidParams.Add(request.NewErrParamRequired("Image"))
+	}
+	if s.Volume == nil {
+		invalidParams.Add(request.NewErrParamRequired("Volume"))
+	}
+	if s.Image != nil {
+		if err := s.Image.Validate(); err != nil {
+			invalidParams.AddNested("Image", err.(request.ErrInvalidParams))
+		}
+	}
+	if s.Volume != nil {
+		if err := s.Volume.Validate(); err != nil {
+			invalidParams.AddNested("Volume", err.(request.ErrInvalidParams))
+		}
+	}
+
+	if invalidParams.Len() > 0 {
+		return invalidParams
+	}
+	return nil
 }
 
 // Contains the output for ImportVolume.
@@ -18353,6 +19836,26 @@ func (s InstanceNetworkInterfaceSpecification) GoString() string {
 	return s.String()
 }
 
+// Validate inspects the fields of the type to determine if they are valid.
+func (s *InstanceNetworkInterfaceSpecification) Validate() error {
+	invalidParams := request.ErrInvalidParams{Context: "InstanceNetworkInterfaceSpecification"}
+	if s.PrivateIpAddresses != nil {
+		for i, v := range s.PrivateIpAddresses {
+			if v == nil {
+				continue
+			}
+			if err := v.Validate(); err != nil {
+				invalidParams.AddNested(fmt.Sprintf("%s[%v]", "PrivateIpAddresses", i), err.(request.ErrInvalidParams))
+			}
+		}
+	}
+
+	if invalidParams.Len() > 0 {
+		return invalidParams
+	}
+	return nil
+}
+
 // Describes a private IP address.
 type InstancePrivateIpAddress struct {
 	_ struct{} `type:"structure"`
@@ -18818,6 +20321,22 @@ func (s ModifyHostsInput) GoString() string {
 	return s.String()
 }
 
+// Validate inspects the fields of the type to determine if they are valid.
+func (s *ModifyHostsInput) Validate() error {
+	invalidParams := request.ErrInvalidParams{Context: "ModifyHostsInput"}
+	if s.AutoPlacement == nil {
+		invalidParams.Add(request.NewErrParamRequired("AutoPlacement"))
+	}
+	if s.HostIds == nil {
+		invalidParams.Add(request.NewErrParamRequired("HostIds"))
+	}
+
+	if invalidParams.Len() > 0 {
+		return invalidParams
+	}
+	return nil
+}
+
 // Contains the output of ModifyHosts.
 type ModifyHostsOutput struct {
 	_ struct{} `type:"structure"`
@@ -18859,6 +20378,22 @@ func (s ModifyIdFormatInput) String() string {
 // GoString returns the string representation
 func (s ModifyIdFormatInput) GoString() string {
 	return s.String()
+}
+
+// Validate inspects the fields of the type to determine if they are valid.
+func (s *ModifyIdFormatInput) Validate() error {
+	invalidParams := request.ErrInvalidParams{Context: "ModifyIdFormatInput"}
+	if s.Resource == nil {
+		invalidParams.Add(request.NewErrParamRequired("Resource"))
+	}
+	if s.UseLongIds == nil {
+		invalidParams.Add(request.NewErrParamRequired("UseLongIds"))
+	}
+
+	if invalidParams.Len() > 0 {
+		return invalidParams
+	}
+	return nil
 }
 
 type ModifyIdFormatOutput struct {
@@ -18925,6 +20460,19 @@ func (s ModifyImageAttributeInput) String() string {
 // GoString returns the string representation
 func (s ModifyImageAttributeInput) GoString() string {
 	return s.String()
+}
+
+// Validate inspects the fields of the type to determine if they are valid.
+func (s *ModifyImageAttributeInput) Validate() error {
+	invalidParams := request.ErrInvalidParams{Context: "ModifyImageAttributeInput"}
+	if s.ImageId == nil {
+		invalidParams.Add(request.NewErrParamRequired("ImageId"))
+	}
+
+	if invalidParams.Len() > 0 {
+		return invalidParams
+	}
+	return nil
 }
 
 type ModifyImageAttributeOutput struct {
@@ -19036,6 +20584,19 @@ func (s ModifyInstanceAttributeInput) GoString() string {
 	return s.String()
 }
 
+// Validate inspects the fields of the type to determine if they are valid.
+func (s *ModifyInstanceAttributeInput) Validate() error {
+	invalidParams := request.ErrInvalidParams{Context: "ModifyInstanceAttributeInput"}
+	if s.InstanceId == nil {
+		invalidParams.Add(request.NewErrParamRequired("InstanceId"))
+	}
+
+	if invalidParams.Len() > 0 {
+		return invalidParams
+	}
+	return nil
+}
+
 type ModifyInstanceAttributeOutput struct {
 	_ struct{} `type:"structure"`
 }
@@ -19075,6 +20636,19 @@ func (s ModifyInstancePlacementInput) String() string {
 // GoString returns the string representation
 func (s ModifyInstancePlacementInput) GoString() string {
 	return s.String()
+}
+
+// Validate inspects the fields of the type to determine if they are valid.
+func (s *ModifyInstancePlacementInput) Validate() error {
+	invalidParams := request.ErrInvalidParams{Context: "ModifyInstancePlacementInput"}
+	if s.InstanceId == nil {
+		invalidParams.Add(request.NewErrParamRequired("InstanceId"))
+	}
+
+	if invalidParams.Len() > 0 {
+		return invalidParams
+	}
+	return nil
 }
 
 // Contains the output of ModifyInstancePlacement.
@@ -19139,6 +20713,19 @@ func (s ModifyNetworkInterfaceAttributeInput) GoString() string {
 	return s.String()
 }
 
+// Validate inspects the fields of the type to determine if they are valid.
+func (s *ModifyNetworkInterfaceAttributeInput) Validate() error {
+	invalidParams := request.ErrInvalidParams{Context: "ModifyNetworkInterfaceAttributeInput"}
+	if s.NetworkInterfaceId == nil {
+		invalidParams.Add(request.NewErrParamRequired("NetworkInterfaceId"))
+	}
+
+	if invalidParams.Len() > 0 {
+		return invalidParams
+	}
+	return nil
+}
+
 type ModifyNetworkInterfaceAttributeOutput struct {
 	_ struct{} `type:"structure"`
 }
@@ -19176,6 +20763,22 @@ func (s ModifyReservedInstancesInput) String() string {
 // GoString returns the string representation
 func (s ModifyReservedInstancesInput) GoString() string {
 	return s.String()
+}
+
+// Validate inspects the fields of the type to determine if they are valid.
+func (s *ModifyReservedInstancesInput) Validate() error {
+	invalidParams := request.ErrInvalidParams{Context: "ModifyReservedInstancesInput"}
+	if s.ReservedInstancesIds == nil {
+		invalidParams.Add(request.NewErrParamRequired("ReservedInstancesIds"))
+	}
+	if s.TargetConfigurations == nil {
+		invalidParams.Add(request.NewErrParamRequired("TargetConfigurations"))
+	}
+
+	if invalidParams.Len() > 0 {
+		return invalidParams
+	}
+	return nil
 }
 
 // Contains the output of ModifyReservedInstances.
@@ -19237,6 +20840,19 @@ func (s ModifySnapshotAttributeInput) GoString() string {
 	return s.String()
 }
 
+// Validate inspects the fields of the type to determine if they are valid.
+func (s *ModifySnapshotAttributeInput) Validate() error {
+	invalidParams := request.ErrInvalidParams{Context: "ModifySnapshotAttributeInput"}
+	if s.SnapshotId == nil {
+		invalidParams.Add(request.NewErrParamRequired("SnapshotId"))
+	}
+
+	if invalidParams.Len() > 0 {
+		return invalidParams
+	}
+	return nil
+}
+
 type ModifySnapshotAttributeOutput struct {
 	_ struct{} `type:"structure"`
 }
@@ -19275,6 +20891,19 @@ func (s ModifySpotFleetRequestInput) String() string {
 // GoString returns the string representation
 func (s ModifySpotFleetRequestInput) GoString() string {
 	return s.String()
+}
+
+// Validate inspects the fields of the type to determine if they are valid.
+func (s *ModifySpotFleetRequestInput) Validate() error {
+	invalidParams := request.ErrInvalidParams{Context: "ModifySpotFleetRequestInput"}
+	if s.SpotFleetRequestId == nil {
+		invalidParams.Add(request.NewErrParamRequired("SpotFleetRequestId"))
+	}
+
+	if invalidParams.Len() > 0 {
+		return invalidParams
+	}
+	return nil
 }
 
 // Contains the output of ModifySpotFleetRequest.
@@ -19317,6 +20946,19 @@ func (s ModifySubnetAttributeInput) GoString() string {
 	return s.String()
 }
 
+// Validate inspects the fields of the type to determine if they are valid.
+func (s *ModifySubnetAttributeInput) Validate() error {
+	invalidParams := request.ErrInvalidParams{Context: "ModifySubnetAttributeInput"}
+	if s.SubnetId == nil {
+		invalidParams.Add(request.NewErrParamRequired("SubnetId"))
+	}
+
+	if invalidParams.Len() > 0 {
+		return invalidParams
+	}
+	return nil
+}
+
 type ModifySubnetAttributeOutput struct {
 	_ struct{} `type:"structure"`
 }
@@ -19356,6 +20998,19 @@ func (s ModifyVolumeAttributeInput) String() string {
 // GoString returns the string representation
 func (s ModifyVolumeAttributeInput) GoString() string {
 	return s.String()
+}
+
+// Validate inspects the fields of the type to determine if they are valid.
+func (s *ModifyVolumeAttributeInput) Validate() error {
+	invalidParams := request.ErrInvalidParams{Context: "ModifyVolumeAttributeInput"}
+	if s.VolumeId == nil {
+		invalidParams.Add(request.NewErrParamRequired("VolumeId"))
+	}
+
+	if invalidParams.Len() > 0 {
+		return invalidParams
+	}
+	return nil
 }
 
 type ModifyVolumeAttributeOutput struct {
@@ -19406,6 +21061,19 @@ func (s ModifyVpcAttributeInput) String() string {
 // GoString returns the string representation
 func (s ModifyVpcAttributeInput) GoString() string {
 	return s.String()
+}
+
+// Validate inspects the fields of the type to determine if they are valid.
+func (s *ModifyVpcAttributeInput) Validate() error {
+	invalidParams := request.ErrInvalidParams{Context: "ModifyVpcAttributeInput"}
+	if s.VpcId == nil {
+		invalidParams.Add(request.NewErrParamRequired("VpcId"))
+	}
+
+	if invalidParams.Len() > 0 {
+		return invalidParams
+	}
+	return nil
 }
 
 type ModifyVpcAttributeOutput struct {
@@ -19460,6 +21128,19 @@ func (s ModifyVpcEndpointInput) GoString() string {
 	return s.String()
 }
 
+// Validate inspects the fields of the type to determine if they are valid.
+func (s *ModifyVpcEndpointInput) Validate() error {
+	invalidParams := request.ErrInvalidParams{Context: "ModifyVpcEndpointInput"}
+	if s.VpcEndpointId == nil {
+		invalidParams.Add(request.NewErrParamRequired("VpcEndpointId"))
+	}
+
+	if invalidParams.Len() > 0 {
+		return invalidParams
+	}
+	return nil
+}
+
 // Contains the output of ModifyVpcEndpoint.
 type ModifyVpcEndpointOutput struct {
 	_ struct{} `type:"structure"`
@@ -19500,6 +21181,19 @@ func (s MonitorInstancesInput) String() string {
 // GoString returns the string representation
 func (s MonitorInstancesInput) GoString() string {
 	return s.String()
+}
+
+// Validate inspects the fields of the type to determine if they are valid.
+func (s *MonitorInstancesInput) Validate() error {
+	invalidParams := request.ErrInvalidParams{Context: "MonitorInstancesInput"}
+	if s.InstanceIds == nil {
+		invalidParams.Add(request.NewErrParamRequired("InstanceIds"))
+	}
+
+	if invalidParams.Len() > 0 {
+		return invalidParams
+	}
+	return nil
 }
 
 // Contains the output of MonitorInstances.
@@ -19560,6 +21254,19 @@ func (s MoveAddressToVpcInput) String() string {
 // GoString returns the string representation
 func (s MoveAddressToVpcInput) GoString() string {
 	return s.String()
+}
+
+// Validate inspects the fields of the type to determine if they are valid.
+func (s *MoveAddressToVpcInput) Validate() error {
+	invalidParams := request.ErrInvalidParams{Context: "MoveAddressToVpcInput"}
+	if s.PublicIp == nil {
+		invalidParams.Add(request.NewErrParamRequired("PublicIp"))
+	}
+
+	if invalidParams.Len() > 0 {
+		return invalidParams
+	}
+	return nil
 }
 
 // Contains the output of MoveAddressToVpc.
@@ -20227,6 +21934,19 @@ func (s PrivateIpAddressSpecification) GoString() string {
 	return s.String()
 }
 
+// Validate inspects the fields of the type to determine if they are valid.
+func (s *PrivateIpAddressSpecification) Validate() error {
+	invalidParams := request.ErrInvalidParams{Context: "PrivateIpAddressSpecification"}
+	if s.PrivateIpAddress == nil {
+		invalidParams.Add(request.NewErrParamRequired("PrivateIpAddress"))
+	}
+
+	if invalidParams.Len() > 0 {
+		return invalidParams
+	}
+	return nil
+}
+
 // Describes a product code.
 type ProductCode struct {
 	_ struct{} `type:"structure"`
@@ -20287,6 +22007,22 @@ func (s PurchaseRequest) GoString() string {
 	return s.String()
 }
 
+// Validate inspects the fields of the type to determine if they are valid.
+func (s *PurchaseRequest) Validate() error {
+	invalidParams := request.ErrInvalidParams{Context: "PurchaseRequest"}
+	if s.InstanceCount == nil {
+		invalidParams.Add(request.NewErrParamRequired("InstanceCount"))
+	}
+	if s.PurchaseToken == nil {
+		invalidParams.Add(request.NewErrParamRequired("PurchaseToken"))
+	}
+
+	if invalidParams.Len() > 0 {
+		return invalidParams
+	}
+	return nil
+}
+
 // Contains the parameters for PurchaseReservedInstancesOffering.
 type PurchaseReservedInstancesOfferingInput struct {
 	_ struct{} `type:"structure"`
@@ -20317,6 +22053,22 @@ func (s PurchaseReservedInstancesOfferingInput) String() string {
 // GoString returns the string representation
 func (s PurchaseReservedInstancesOfferingInput) GoString() string {
 	return s.String()
+}
+
+// Validate inspects the fields of the type to determine if they are valid.
+func (s *PurchaseReservedInstancesOfferingInput) Validate() error {
+	invalidParams := request.ErrInvalidParams{Context: "PurchaseReservedInstancesOfferingInput"}
+	if s.InstanceCount == nil {
+		invalidParams.Add(request.NewErrParamRequired("InstanceCount"))
+	}
+	if s.ReservedInstancesOfferingId == nil {
+		invalidParams.Add(request.NewErrParamRequired("ReservedInstancesOfferingId"))
+	}
+
+	if invalidParams.Len() > 0 {
+		return invalidParams
+	}
+	return nil
 }
 
 // Contains the output of PurchaseReservedInstancesOffering.
@@ -20365,6 +22117,32 @@ func (s PurchaseScheduledInstancesInput) GoString() string {
 	return s.String()
 }
 
+// Validate inspects the fields of the type to determine if they are valid.
+func (s *PurchaseScheduledInstancesInput) Validate() error {
+	invalidParams := request.ErrInvalidParams{Context: "PurchaseScheduledInstancesInput"}
+	if s.PurchaseRequests == nil {
+		invalidParams.Add(request.NewErrParamRequired("PurchaseRequests"))
+	}
+	if s.PurchaseRequests != nil && len(s.PurchaseRequests) < 1 {
+		invalidParams.Add(request.NewErrParamMinLen("PurchaseRequests", 1))
+	}
+	if s.PurchaseRequests != nil {
+		for i, v := range s.PurchaseRequests {
+			if v == nil {
+				continue
+			}
+			if err := v.Validate(); err != nil {
+				invalidParams.AddNested(fmt.Sprintf("%s[%v]", "PurchaseRequests", i), err.(request.ErrInvalidParams))
+			}
+		}
+	}
+
+	if invalidParams.Len() > 0 {
+		return invalidParams
+	}
+	return nil
+}
+
 // Contains the output of PurchaseScheduledInstances.
 type PurchaseScheduledInstancesOutput struct {
 	_ struct{} `type:"structure"`
@@ -20405,6 +22183,19 @@ func (s RebootInstancesInput) String() string {
 // GoString returns the string representation
 func (s RebootInstancesInput) GoString() string {
 	return s.String()
+}
+
+// Validate inspects the fields of the type to determine if they are valid.
+func (s *RebootInstancesInput) Validate() error {
+	invalidParams := request.ErrInvalidParams{Context: "RebootInstancesInput"}
+	if s.InstanceIds == nil {
+		invalidParams.Add(request.NewErrParamRequired("InstanceIds"))
+	}
+
+	if invalidParams.Len() > 0 {
+		return invalidParams
+	}
+	return nil
 }
 
 type RebootInstancesOutput struct {
@@ -20529,6 +22320,19 @@ func (s RegisterImageInput) GoString() string {
 	return s.String()
 }
 
+// Validate inspects the fields of the type to determine if they are valid.
+func (s *RegisterImageInput) Validate() error {
+	invalidParams := request.ErrInvalidParams{Context: "RegisterImageInput"}
+	if s.Name == nil {
+		invalidParams.Add(request.NewErrParamRequired("Name"))
+	}
+
+	if invalidParams.Len() > 0 {
+		return invalidParams
+	}
+	return nil
+}
+
 // Contains the output of RegisterImage.
 type RegisterImageOutput struct {
 	_ struct{} `type:"structure"`
@@ -20569,6 +22373,19 @@ func (s RejectVpcPeeringConnectionInput) String() string {
 // GoString returns the string representation
 func (s RejectVpcPeeringConnectionInput) GoString() string {
 	return s.String()
+}
+
+// Validate inspects the fields of the type to determine if they are valid.
+func (s *RejectVpcPeeringConnectionInput) Validate() error {
+	invalidParams := request.ErrInvalidParams{Context: "RejectVpcPeeringConnectionInput"}
+	if s.VpcPeeringConnectionId == nil {
+		invalidParams.Add(request.NewErrParamRequired("VpcPeeringConnectionId"))
+	}
+
+	if invalidParams.Len() > 0 {
+		return invalidParams
+	}
+	return nil
 }
 
 // Contains the output of RejectVpcPeeringConnection.
@@ -20648,6 +22465,19 @@ func (s ReleaseHostsInput) GoString() string {
 	return s.String()
 }
 
+// Validate inspects the fields of the type to determine if they are valid.
+func (s *ReleaseHostsInput) Validate() error {
+	invalidParams := request.ErrInvalidParams{Context: "ReleaseHostsInput"}
+	if s.HostIds == nil {
+		invalidParams.Add(request.NewErrParamRequired("HostIds"))
+	}
+
+	if invalidParams.Len() > 0 {
+		return invalidParams
+	}
+	return nil
+}
+
 // Contains the output of ReleaseHosts.
 type ReleaseHostsOutput struct {
 	_ struct{} `type:"structure"`
@@ -20696,6 +22526,22 @@ func (s ReplaceNetworkAclAssociationInput) String() string {
 // GoString returns the string representation
 func (s ReplaceNetworkAclAssociationInput) GoString() string {
 	return s.String()
+}
+
+// Validate inspects the fields of the type to determine if they are valid.
+func (s *ReplaceNetworkAclAssociationInput) Validate() error {
+	invalidParams := request.ErrInvalidParams{Context: "ReplaceNetworkAclAssociationInput"}
+	if s.AssociationId == nil {
+		invalidParams.Add(request.NewErrParamRequired("AssociationId"))
+	}
+	if s.NetworkAclId == nil {
+		invalidParams.Add(request.NewErrParamRequired("NetworkAclId"))
+	}
+
+	if invalidParams.Len() > 0 {
+		return invalidParams
+	}
+	return nil
 }
 
 // Contains the output of ReplaceNetworkAclAssociation.
@@ -20765,6 +22611,34 @@ func (s ReplaceNetworkAclEntryInput) GoString() string {
 	return s.String()
 }
 
+// Validate inspects the fields of the type to determine if they are valid.
+func (s *ReplaceNetworkAclEntryInput) Validate() error {
+	invalidParams := request.ErrInvalidParams{Context: "ReplaceNetworkAclEntryInput"}
+	if s.CidrBlock == nil {
+		invalidParams.Add(request.NewErrParamRequired("CidrBlock"))
+	}
+	if s.Egress == nil {
+		invalidParams.Add(request.NewErrParamRequired("Egress"))
+	}
+	if s.NetworkAclId == nil {
+		invalidParams.Add(request.NewErrParamRequired("NetworkAclId"))
+	}
+	if s.Protocol == nil {
+		invalidParams.Add(request.NewErrParamRequired("Protocol"))
+	}
+	if s.RuleAction == nil {
+		invalidParams.Add(request.NewErrParamRequired("RuleAction"))
+	}
+	if s.RuleNumber == nil {
+		invalidParams.Add(request.NewErrParamRequired("RuleNumber"))
+	}
+
+	if invalidParams.Len() > 0 {
+		return invalidParams
+	}
+	return nil
+}
+
 type ReplaceNetworkAclEntryOutput struct {
 	_ struct{} `type:"structure"`
 }
@@ -20822,6 +22696,22 @@ func (s ReplaceRouteInput) GoString() string {
 	return s.String()
 }
 
+// Validate inspects the fields of the type to determine if they are valid.
+func (s *ReplaceRouteInput) Validate() error {
+	invalidParams := request.ErrInvalidParams{Context: "ReplaceRouteInput"}
+	if s.DestinationCidrBlock == nil {
+		invalidParams.Add(request.NewErrParamRequired("DestinationCidrBlock"))
+	}
+	if s.RouteTableId == nil {
+		invalidParams.Add(request.NewErrParamRequired("RouteTableId"))
+	}
+
+	if invalidParams.Len() > 0 {
+		return invalidParams
+	}
+	return nil
+}
+
 type ReplaceRouteOutput struct {
 	_ struct{} `type:"structure"`
 }
@@ -20861,6 +22751,22 @@ func (s ReplaceRouteTableAssociationInput) String() string {
 // GoString returns the string representation
 func (s ReplaceRouteTableAssociationInput) GoString() string {
 	return s.String()
+}
+
+// Validate inspects the fields of the type to determine if they are valid.
+func (s *ReplaceRouteTableAssociationInput) Validate() error {
+	invalidParams := request.ErrInvalidParams{Context: "ReplaceRouteTableAssociationInput"}
+	if s.AssociationId == nil {
+		invalidParams.Add(request.NewErrParamRequired("AssociationId"))
+	}
+	if s.RouteTableId == nil {
+		invalidParams.Add(request.NewErrParamRequired("RouteTableId"))
+	}
+
+	if invalidParams.Len() > 0 {
+		return invalidParams
+	}
+	return nil
 }
 
 // Contains the output of ReplaceRouteTableAssociation.
@@ -20941,6 +22847,25 @@ func (s ReportInstanceStatusInput) GoString() string {
 	return s.String()
 }
 
+// Validate inspects the fields of the type to determine if they are valid.
+func (s *ReportInstanceStatusInput) Validate() error {
+	invalidParams := request.ErrInvalidParams{Context: "ReportInstanceStatusInput"}
+	if s.Instances == nil {
+		invalidParams.Add(request.NewErrParamRequired("Instances"))
+	}
+	if s.ReasonCodes == nil {
+		invalidParams.Add(request.NewErrParamRequired("ReasonCodes"))
+	}
+	if s.Status == nil {
+		invalidParams.Add(request.NewErrParamRequired("Status"))
+	}
+
+	if invalidParams.Len() > 0 {
+		return invalidParams
+	}
+	return nil
+}
+
 type ReportInstanceStatusOutput struct {
 	_ struct{} `type:"structure"`
 }
@@ -20977,6 +22902,24 @@ func (s RequestSpotFleetInput) String() string {
 // GoString returns the string representation
 func (s RequestSpotFleetInput) GoString() string {
 	return s.String()
+}
+
+// Validate inspects the fields of the type to determine if they are valid.
+func (s *RequestSpotFleetInput) Validate() error {
+	invalidParams := request.ErrInvalidParams{Context: "RequestSpotFleetInput"}
+	if s.SpotFleetRequestConfig == nil {
+		invalidParams.Add(request.NewErrParamRequired("SpotFleetRequestConfig"))
+	}
+	if s.SpotFleetRequestConfig != nil {
+		if err := s.SpotFleetRequestConfig.Validate(); err != nil {
+			invalidParams.AddNested("SpotFleetRequestConfig", err.(request.ErrInvalidParams))
+		}
+	}
+
+	if invalidParams.Len() > 0 {
+		return invalidParams
+	}
+	return nil
 }
 
 // Contains the output of RequestSpotFleet.
@@ -21097,6 +23040,24 @@ func (s RequestSpotInstancesInput) GoString() string {
 	return s.String()
 }
 
+// Validate inspects the fields of the type to determine if they are valid.
+func (s *RequestSpotInstancesInput) Validate() error {
+	invalidParams := request.ErrInvalidParams{Context: "RequestSpotInstancesInput"}
+	if s.SpotPrice == nil {
+		invalidParams.Add(request.NewErrParamRequired("SpotPrice"))
+	}
+	if s.LaunchSpecification != nil {
+		if err := s.LaunchSpecification.Validate(); err != nil {
+			invalidParams.AddNested("LaunchSpecification", err.(request.ErrInvalidParams))
+		}
+	}
+
+	if invalidParams.Len() > 0 {
+		return invalidParams
+	}
+	return nil
+}
+
 // Contains the output of RequestSpotInstances.
 type RequestSpotInstancesOutput struct {
 	_ struct{} `type:"structure"`
@@ -21183,6 +23144,31 @@ func (s RequestSpotLaunchSpecification) String() string {
 // GoString returns the string representation
 func (s RequestSpotLaunchSpecification) GoString() string {
 	return s.String()
+}
+
+// Validate inspects the fields of the type to determine if they are valid.
+func (s *RequestSpotLaunchSpecification) Validate() error {
+	invalidParams := request.ErrInvalidParams{Context: "RequestSpotLaunchSpecification"}
+	if s.Monitoring != nil {
+		if err := s.Monitoring.Validate(); err != nil {
+			invalidParams.AddNested("Monitoring", err.(request.ErrInvalidParams))
+		}
+	}
+	if s.NetworkInterfaces != nil {
+		for i, v := range s.NetworkInterfaces {
+			if v == nil {
+				continue
+			}
+			if err := v.Validate(); err != nil {
+				invalidParams.AddNested(fmt.Sprintf("%s[%v]", "NetworkInterfaces", i), err.(request.ErrInvalidParams))
+			}
+		}
+	}
+
+	if invalidParams.Len() > 0 {
+		return invalidParams
+	}
+	return nil
 }
 
 // Describes a reservation.
@@ -21549,6 +23535,22 @@ func (s ResetImageAttributeInput) GoString() string {
 	return s.String()
 }
 
+// Validate inspects the fields of the type to determine if they are valid.
+func (s *ResetImageAttributeInput) Validate() error {
+	invalidParams := request.ErrInvalidParams{Context: "ResetImageAttributeInput"}
+	if s.Attribute == nil {
+		invalidParams.Add(request.NewErrParamRequired("Attribute"))
+	}
+	if s.ImageId == nil {
+		invalidParams.Add(request.NewErrParamRequired("ImageId"))
+	}
+
+	if invalidParams.Len() > 0 {
+		return invalidParams
+	}
+	return nil
+}
+
 type ResetImageAttributeOutput struct {
 	_ struct{} `type:"structure"`
 }
@@ -21590,6 +23592,22 @@ func (s ResetInstanceAttributeInput) GoString() string {
 	return s.String()
 }
 
+// Validate inspects the fields of the type to determine if they are valid.
+func (s *ResetInstanceAttributeInput) Validate() error {
+	invalidParams := request.ErrInvalidParams{Context: "ResetInstanceAttributeInput"}
+	if s.Attribute == nil {
+		invalidParams.Add(request.NewErrParamRequired("Attribute"))
+	}
+	if s.InstanceId == nil {
+		invalidParams.Add(request.NewErrParamRequired("InstanceId"))
+	}
+
+	if invalidParams.Len() > 0 {
+		return invalidParams
+	}
+	return nil
+}
+
 type ResetInstanceAttributeOutput struct {
 	_ struct{} `type:"structure"`
 }
@@ -21629,6 +23647,19 @@ func (s ResetNetworkInterfaceAttributeInput) String() string {
 // GoString returns the string representation
 func (s ResetNetworkInterfaceAttributeInput) GoString() string {
 	return s.String()
+}
+
+// Validate inspects the fields of the type to determine if they are valid.
+func (s *ResetNetworkInterfaceAttributeInput) Validate() error {
+	invalidParams := request.ErrInvalidParams{Context: "ResetNetworkInterfaceAttributeInput"}
+	if s.NetworkInterfaceId == nil {
+		invalidParams.Add(request.NewErrParamRequired("NetworkInterfaceId"))
+	}
+
+	if invalidParams.Len() > 0 {
+		return invalidParams
+	}
+	return nil
 }
 
 type ResetNetworkInterfaceAttributeOutput struct {
@@ -21673,6 +23704,22 @@ func (s ResetSnapshotAttributeInput) GoString() string {
 	return s.String()
 }
 
+// Validate inspects the fields of the type to determine if they are valid.
+func (s *ResetSnapshotAttributeInput) Validate() error {
+	invalidParams := request.ErrInvalidParams{Context: "ResetSnapshotAttributeInput"}
+	if s.Attribute == nil {
+		invalidParams.Add(request.NewErrParamRequired("Attribute"))
+	}
+	if s.SnapshotId == nil {
+		invalidParams.Add(request.NewErrParamRequired("SnapshotId"))
+	}
+
+	if invalidParams.Len() > 0 {
+		return invalidParams
+	}
+	return nil
+}
+
 type ResetSnapshotAttributeOutput struct {
 	_ struct{} `type:"structure"`
 }
@@ -21709,6 +23756,19 @@ func (s RestoreAddressToClassicInput) String() string {
 // GoString returns the string representation
 func (s RestoreAddressToClassicInput) GoString() string {
 	return s.String()
+}
+
+// Validate inspects the fields of the type to determine if they are valid.
+func (s *RestoreAddressToClassicInput) Validate() error {
+	invalidParams := request.ErrInvalidParams{Context: "RestoreAddressToClassicInput"}
+	if s.PublicIp == nil {
+		invalidParams.Add(request.NewErrParamRequired("PublicIp"))
+	}
+
+	if invalidParams.Len() > 0 {
+		return invalidParams
+	}
+	return nil
 }
 
 // Contains the output of RestoreAddressToClassic.
@@ -21784,6 +23844,19 @@ func (s RevokeSecurityGroupEgressInput) String() string {
 // GoString returns the string representation
 func (s RevokeSecurityGroupEgressInput) GoString() string {
 	return s.String()
+}
+
+// Validate inspects the fields of the type to determine if they are valid.
+func (s *RevokeSecurityGroupEgressInput) Validate() error {
+	invalidParams := request.ErrInvalidParams{Context: "RevokeSecurityGroupEgressInput"}
+	if s.GroupId == nil {
+		invalidParams.Add(request.NewErrParamRequired("GroupId"))
+	}
+
+	if invalidParams.Len() > 0 {
+		return invalidParams
+	}
+	return nil
 }
 
 type RevokeSecurityGroupEgressOutput struct {
@@ -22146,6 +24219,40 @@ func (s RunInstancesInput) GoString() string {
 	return s.String()
 }
 
+// Validate inspects the fields of the type to determine if they are valid.
+func (s *RunInstancesInput) Validate() error {
+	invalidParams := request.ErrInvalidParams{Context: "RunInstancesInput"}
+	if s.ImageId == nil {
+		invalidParams.Add(request.NewErrParamRequired("ImageId"))
+	}
+	if s.MaxCount == nil {
+		invalidParams.Add(request.NewErrParamRequired("MaxCount"))
+	}
+	if s.MinCount == nil {
+		invalidParams.Add(request.NewErrParamRequired("MinCount"))
+	}
+	if s.Monitoring != nil {
+		if err := s.Monitoring.Validate(); err != nil {
+			invalidParams.AddNested("Monitoring", err.(request.ErrInvalidParams))
+		}
+	}
+	if s.NetworkInterfaces != nil {
+		for i, v := range s.NetworkInterfaces {
+			if v == nil {
+				continue
+			}
+			if err := v.Validate(); err != nil {
+				invalidParams.AddNested(fmt.Sprintf("%s[%v]", "NetworkInterfaces", i), err.(request.ErrInvalidParams))
+			}
+		}
+	}
+
+	if invalidParams.Len() > 0 {
+		return invalidParams
+	}
+	return nil
+}
+
 // Describes the monitoring for the instance.
 type RunInstancesMonitoringEnabled struct {
 	_ struct{} `type:"structure"`
@@ -22162,6 +24269,19 @@ func (s RunInstancesMonitoringEnabled) String() string {
 // GoString returns the string representation
 func (s RunInstancesMonitoringEnabled) GoString() string {
 	return s.String()
+}
+
+// Validate inspects the fields of the type to determine if they are valid.
+func (s *RunInstancesMonitoringEnabled) Validate() error {
+	invalidParams := request.ErrInvalidParams{Context: "RunInstancesMonitoringEnabled"}
+	if s.Enabled == nil {
+		invalidParams.Add(request.NewErrParamRequired("Enabled"))
+	}
+
+	if invalidParams.Len() > 0 {
+		return invalidParams
+	}
+	return nil
 }
 
 // Contains the parameters for RunScheduledInstances.
@@ -22198,6 +24318,27 @@ func (s RunScheduledInstancesInput) String() string {
 // GoString returns the string representation
 func (s RunScheduledInstancesInput) GoString() string {
 	return s.String()
+}
+
+// Validate inspects the fields of the type to determine if they are valid.
+func (s *RunScheduledInstancesInput) Validate() error {
+	invalidParams := request.ErrInvalidParams{Context: "RunScheduledInstancesInput"}
+	if s.LaunchSpecification == nil {
+		invalidParams.Add(request.NewErrParamRequired("LaunchSpecification"))
+	}
+	if s.ScheduledInstanceId == nil {
+		invalidParams.Add(request.NewErrParamRequired("ScheduledInstanceId"))
+	}
+	if s.LaunchSpecification != nil {
+		if err := s.LaunchSpecification.Validate(); err != nil {
+			invalidParams.AddNested("LaunchSpecification", err.(request.ErrInvalidParams))
+		}
+	}
+
+	if invalidParams.Len() > 0 {
+		return invalidParams
+	}
+	return nil
 }
 
 // Contains the output of RunScheduledInstances.
@@ -22621,6 +24762,19 @@ func (s ScheduledInstancesLaunchSpecification) GoString() string {
 	return s.String()
 }
 
+// Validate inspects the fields of the type to determine if they are valid.
+func (s *ScheduledInstancesLaunchSpecification) Validate() error {
+	invalidParams := request.ErrInvalidParams{Context: "ScheduledInstancesLaunchSpecification"}
+	if s.ImageId == nil {
+		invalidParams.Add(request.NewErrParamRequired("ImageId"))
+	}
+
+	if invalidParams.Len() > 0 {
+		return invalidParams
+	}
+	return nil
+}
+
 // Describes whether monitoring is enabled for a Scheduled Instance.
 type ScheduledInstancesMonitoring struct {
 	_ struct{} `type:"structure"`
@@ -22792,6 +24946,22 @@ func (s SlotDateTimeRangeRequest) String() string {
 // GoString returns the string representation
 func (s SlotDateTimeRangeRequest) GoString() string {
 	return s.String()
+}
+
+// Validate inspects the fields of the type to determine if they are valid.
+func (s *SlotDateTimeRangeRequest) Validate() error {
+	invalidParams := request.ErrInvalidParams{Context: "SlotDateTimeRangeRequest"}
+	if s.EarliestTime == nil {
+		invalidParams.Add(request.NewErrParamRequired("EarliestTime"))
+	}
+	if s.LatestTime == nil {
+		invalidParams.Add(request.NewErrParamRequired("LatestTime"))
+	}
+
+	if invalidParams.Len() > 0 {
+		return invalidParams
+	}
+	return nil
 }
 
 // Describes the time period for a Scheduled Instance to start its first schedule.
@@ -23116,6 +25286,26 @@ func (s SpotFleetLaunchSpecification) GoString() string {
 	return s.String()
 }
 
+// Validate inspects the fields of the type to determine if they are valid.
+func (s *SpotFleetLaunchSpecification) Validate() error {
+	invalidParams := request.ErrInvalidParams{Context: "SpotFleetLaunchSpecification"}
+	if s.NetworkInterfaces != nil {
+		for i, v := range s.NetworkInterfaces {
+			if v == nil {
+				continue
+			}
+			if err := v.Validate(); err != nil {
+				invalidParams.AddNested(fmt.Sprintf("%s[%v]", "NetworkInterfaces", i), err.(request.ErrInvalidParams))
+			}
+		}
+	}
+
+	if invalidParams.Len() > 0 {
+		return invalidParams
+	}
+	return nil
+}
+
 // Describes whether monitoring is enabled.
 type SpotFleetMonitoring struct {
 	_ struct{} `type:"structure"`
@@ -23219,6 +25409,41 @@ func (s SpotFleetRequestConfigData) String() string {
 // GoString returns the string representation
 func (s SpotFleetRequestConfigData) GoString() string {
 	return s.String()
+}
+
+// Validate inspects the fields of the type to determine if they are valid.
+func (s *SpotFleetRequestConfigData) Validate() error {
+	invalidParams := request.ErrInvalidParams{Context: "SpotFleetRequestConfigData"}
+	if s.IamFleetRole == nil {
+		invalidParams.Add(request.NewErrParamRequired("IamFleetRole"))
+	}
+	if s.LaunchSpecifications == nil {
+		invalidParams.Add(request.NewErrParamRequired("LaunchSpecifications"))
+	}
+	if s.LaunchSpecifications != nil && len(s.LaunchSpecifications) < 1 {
+		invalidParams.Add(request.NewErrParamMinLen("LaunchSpecifications", 1))
+	}
+	if s.SpotPrice == nil {
+		invalidParams.Add(request.NewErrParamRequired("SpotPrice"))
+	}
+	if s.TargetCapacity == nil {
+		invalidParams.Add(request.NewErrParamRequired("TargetCapacity"))
+	}
+	if s.LaunchSpecifications != nil {
+		for i, v := range s.LaunchSpecifications {
+			if v == nil {
+				continue
+			}
+			if err := v.Validate(); err != nil {
+				invalidParams.AddNested(fmt.Sprintf("%s[%v]", "LaunchSpecifications", i), err.(request.ErrInvalidParams))
+			}
+		}
+	}
+
+	if invalidParams.Len() > 0 {
+		return invalidParams
+	}
+	return nil
 }
 
 // Describes a Spot instance request.
@@ -23433,6 +25658,19 @@ func (s StartInstancesInput) GoString() string {
 	return s.String()
 }
 
+// Validate inspects the fields of the type to determine if they are valid.
+func (s *StartInstancesInput) Validate() error {
+	invalidParams := request.ErrInvalidParams{Context: "StartInstancesInput"}
+	if s.InstanceIds == nil {
+		invalidParams.Add(request.NewErrParamRequired("InstanceIds"))
+	}
+
+	if invalidParams.Len() > 0 {
+		return invalidParams
+	}
+	return nil
+}
+
 // Contains the output of StartInstances.
 type StartInstancesOutput struct {
 	_ struct{} `type:"structure"`
@@ -23526,6 +25764,19 @@ func (s StopInstancesInput) String() string {
 // GoString returns the string representation
 func (s StopInstancesInput) GoString() string {
 	return s.String()
+}
+
+// Validate inspects the fields of the type to determine if they are valid.
+func (s *StopInstancesInput) Validate() error {
+	invalidParams := request.ErrInvalidParams{Context: "StopInstancesInput"}
+	if s.InstanceIds == nil {
+		invalidParams.Add(request.NewErrParamRequired("InstanceIds"))
+	}
+
+	if invalidParams.Len() > 0 {
+		return invalidParams
+	}
+	return nil
 }
 
 // Contains the output of StopInstances.
@@ -23685,6 +25936,19 @@ func (s TerminateInstancesInput) GoString() string {
 	return s.String()
 }
 
+// Validate inspects the fields of the type to determine if they are valid.
+func (s *TerminateInstancesInput) Validate() error {
+	invalidParams := request.ErrInvalidParams{Context: "TerminateInstancesInput"}
+	if s.InstanceIds == nil {
+		invalidParams.Add(request.NewErrParamRequired("InstanceIds"))
+	}
+
+	if invalidParams.Len() > 0 {
+		return invalidParams
+	}
+	return nil
+}
+
 // Contains the output of TerminateInstances.
 type TerminateInstancesOutput struct {
 	_ struct{} `type:"structure"`
@@ -23725,6 +25989,22 @@ func (s UnassignPrivateIpAddressesInput) GoString() string {
 	return s.String()
 }
 
+// Validate inspects the fields of the type to determine if they are valid.
+func (s *UnassignPrivateIpAddressesInput) Validate() error {
+	invalidParams := request.ErrInvalidParams{Context: "UnassignPrivateIpAddressesInput"}
+	if s.NetworkInterfaceId == nil {
+		invalidParams.Add(request.NewErrParamRequired("NetworkInterfaceId"))
+	}
+	if s.PrivateIpAddresses == nil {
+		invalidParams.Add(request.NewErrParamRequired("PrivateIpAddresses"))
+	}
+
+	if invalidParams.Len() > 0 {
+		return invalidParams
+	}
+	return nil
+}
+
 type UnassignPrivateIpAddressesOutput struct {
 	_ struct{} `type:"structure"`
 }
@@ -23761,6 +26041,19 @@ func (s UnmonitorInstancesInput) String() string {
 // GoString returns the string representation
 func (s UnmonitorInstancesInput) GoString() string {
 	return s.String()
+}
+
+// Validate inspects the fields of the type to determine if they are valid.
+func (s *UnmonitorInstancesInput) Validate() error {
+	invalidParams := request.ErrInvalidParams{Context: "UnmonitorInstancesInput"}
+	if s.InstanceIds == nil {
+		invalidParams.Add(request.NewErrParamRequired("InstanceIds"))
+	}
+
+	if invalidParams.Len() > 0 {
+		return invalidParams
+	}
+	return nil
 }
 
 // Contains the output of UnmonitorInstances.
@@ -24068,6 +26361,19 @@ func (s VolumeDetail) String() string {
 // GoString returns the string representation
 func (s VolumeDetail) GoString() string {
 	return s.String()
+}
+
+// Validate inspects the fields of the type to determine if they are valid.
+func (s *VolumeDetail) Validate() error {
+	invalidParams := request.ErrInvalidParams{Context: "VolumeDetail"}
+	if s.Size == nil {
+		invalidParams.Add(request.NewErrParamRequired("Size"))
+	}
+
+	if invalidParams.Len() > 0 {
+		return invalidParams
+	}
+	return nil
 }
 
 // Describes a volume status operation code.

--- a/service/ecr/api.go
+++ b/service/ecr/api.go
@@ -527,6 +527,28 @@ func (s BatchCheckLayerAvailabilityInput) GoString() string {
 	return s.String()
 }
 
+// Validate inspects the fields of the type to determine if they are valid.
+func (s *BatchCheckLayerAvailabilityInput) Validate() error {
+	invalidParams := request.ErrInvalidParams{Context: "BatchCheckLayerAvailabilityInput"}
+	if s.LayerDigests == nil {
+		invalidParams.Add(request.NewErrParamRequired("LayerDigests"))
+	}
+	if s.LayerDigests != nil && len(s.LayerDigests) < 1 {
+		invalidParams.Add(request.NewErrParamMinLen("LayerDigests", 1))
+	}
+	if s.RepositoryName == nil {
+		invalidParams.Add(request.NewErrParamRequired("RepositoryName"))
+	}
+	if s.RepositoryName != nil && len(*s.RepositoryName) < 2 {
+		invalidParams.Add(request.NewErrParamMinLen("RepositoryName", 2))
+	}
+
+	if invalidParams.Len() > 0 {
+		return invalidParams
+	}
+	return nil
+}
+
 type BatchCheckLayerAvailabilityOutput struct {
 	_ struct{} `type:"structure"`
 
@@ -575,6 +597,28 @@ func (s BatchDeleteImageInput) GoString() string {
 	return s.String()
 }
 
+// Validate inspects the fields of the type to determine if they are valid.
+func (s *BatchDeleteImageInput) Validate() error {
+	invalidParams := request.ErrInvalidParams{Context: "BatchDeleteImageInput"}
+	if s.ImageIds == nil {
+		invalidParams.Add(request.NewErrParamRequired("ImageIds"))
+	}
+	if s.ImageIds != nil && len(s.ImageIds) < 1 {
+		invalidParams.Add(request.NewErrParamMinLen("ImageIds", 1))
+	}
+	if s.RepositoryName == nil {
+		invalidParams.Add(request.NewErrParamRequired("RepositoryName"))
+	}
+	if s.RepositoryName != nil && len(*s.RepositoryName) < 2 {
+		invalidParams.Add(request.NewErrParamMinLen("RepositoryName", 2))
+	}
+
+	if invalidParams.Len() > 0 {
+		return invalidParams
+	}
+	return nil
+}
+
 type BatchDeleteImageOutput struct {
 	_ struct{} `type:"structure"`
 
@@ -618,6 +662,28 @@ func (s BatchGetImageInput) String() string {
 // GoString returns the string representation
 func (s BatchGetImageInput) GoString() string {
 	return s.String()
+}
+
+// Validate inspects the fields of the type to determine if they are valid.
+func (s *BatchGetImageInput) Validate() error {
+	invalidParams := request.ErrInvalidParams{Context: "BatchGetImageInput"}
+	if s.ImageIds == nil {
+		invalidParams.Add(request.NewErrParamRequired("ImageIds"))
+	}
+	if s.ImageIds != nil && len(s.ImageIds) < 1 {
+		invalidParams.Add(request.NewErrParamMinLen("ImageIds", 1))
+	}
+	if s.RepositoryName == nil {
+		invalidParams.Add(request.NewErrParamRequired("RepositoryName"))
+	}
+	if s.RepositoryName != nil && len(*s.RepositoryName) < 2 {
+		invalidParams.Add(request.NewErrParamMinLen("RepositoryName", 2))
+	}
+
+	if invalidParams.Len() > 0 {
+		return invalidParams
+	}
+	return nil
 }
 
 type BatchGetImageOutput struct {
@@ -668,6 +734,31 @@ func (s CompleteLayerUploadInput) GoString() string {
 	return s.String()
 }
 
+// Validate inspects the fields of the type to determine if they are valid.
+func (s *CompleteLayerUploadInput) Validate() error {
+	invalidParams := request.ErrInvalidParams{Context: "CompleteLayerUploadInput"}
+	if s.LayerDigests == nil {
+		invalidParams.Add(request.NewErrParamRequired("LayerDigests"))
+	}
+	if s.LayerDigests != nil && len(s.LayerDigests) < 1 {
+		invalidParams.Add(request.NewErrParamMinLen("LayerDigests", 1))
+	}
+	if s.RepositoryName == nil {
+		invalidParams.Add(request.NewErrParamRequired("RepositoryName"))
+	}
+	if s.RepositoryName != nil && len(*s.RepositoryName) < 2 {
+		invalidParams.Add(request.NewErrParamMinLen("RepositoryName", 2))
+	}
+	if s.UploadId == nil {
+		invalidParams.Add(request.NewErrParamRequired("UploadId"))
+	}
+
+	if invalidParams.Len() > 0 {
+		return invalidParams
+	}
+	return nil
+}
+
 type CompleteLayerUploadOutput struct {
 	_ struct{} `type:"structure"`
 
@@ -713,6 +804,22 @@ func (s CreateRepositoryInput) GoString() string {
 	return s.String()
 }
 
+// Validate inspects the fields of the type to determine if they are valid.
+func (s *CreateRepositoryInput) Validate() error {
+	invalidParams := request.ErrInvalidParams{Context: "CreateRepositoryInput"}
+	if s.RepositoryName == nil {
+		invalidParams.Add(request.NewErrParamRequired("RepositoryName"))
+	}
+	if s.RepositoryName != nil && len(*s.RepositoryName) < 2 {
+		invalidParams.Add(request.NewErrParamMinLen("RepositoryName", 2))
+	}
+
+	if invalidParams.Len() > 0 {
+		return invalidParams
+	}
+	return nil
+}
+
 type CreateRepositoryOutput struct {
 	_ struct{} `type:"structure"`
 
@@ -754,6 +861,22 @@ func (s DeleteRepositoryInput) GoString() string {
 	return s.String()
 }
 
+// Validate inspects the fields of the type to determine if they are valid.
+func (s *DeleteRepositoryInput) Validate() error {
+	invalidParams := request.ErrInvalidParams{Context: "DeleteRepositoryInput"}
+	if s.RepositoryName == nil {
+		invalidParams.Add(request.NewErrParamRequired("RepositoryName"))
+	}
+	if s.RepositoryName != nil && len(*s.RepositoryName) < 2 {
+		invalidParams.Add(request.NewErrParamMinLen("RepositoryName", 2))
+	}
+
+	if invalidParams.Len() > 0 {
+		return invalidParams
+	}
+	return nil
+}
+
 type DeleteRepositoryOutput struct {
 	_ struct{} `type:"structure"`
 
@@ -792,6 +915,22 @@ func (s DeleteRepositoryPolicyInput) String() string {
 // GoString returns the string representation
 func (s DeleteRepositoryPolicyInput) GoString() string {
 	return s.String()
+}
+
+// Validate inspects the fields of the type to determine if they are valid.
+func (s *DeleteRepositoryPolicyInput) Validate() error {
+	invalidParams := request.ErrInvalidParams{Context: "DeleteRepositoryPolicyInput"}
+	if s.RepositoryName == nil {
+		invalidParams.Add(request.NewErrParamRequired("RepositoryName"))
+	}
+	if s.RepositoryName != nil && len(*s.RepositoryName) < 2 {
+		invalidParams.Add(request.NewErrParamMinLen("RepositoryName", 2))
+	}
+
+	if invalidParams.Len() > 0 {
+		return invalidParams
+	}
+	return nil
 }
 
 type DeleteRepositoryPolicyOutput struct {
@@ -856,6 +995,22 @@ func (s DescribeRepositoriesInput) GoString() string {
 	return s.String()
 }
 
+// Validate inspects the fields of the type to determine if they are valid.
+func (s *DescribeRepositoriesInput) Validate() error {
+	invalidParams := request.ErrInvalidParams{Context: "DescribeRepositoriesInput"}
+	if s.MaxResults != nil && *s.MaxResults < 1 {
+		invalidParams.Add(request.NewErrParamMinValue("MaxResults", 1))
+	}
+	if s.RepositoryNames != nil && len(s.RepositoryNames) < 1 {
+		invalidParams.Add(request.NewErrParamMinLen("RepositoryNames", 1))
+	}
+
+	if invalidParams.Len() > 0 {
+		return invalidParams
+	}
+	return nil
+}
+
 type DescribeRepositoriesOutput struct {
 	_ struct{} `type:"structure"`
 
@@ -896,6 +1051,19 @@ func (s GetAuthorizationTokenInput) String() string {
 // GoString returns the string representation
 func (s GetAuthorizationTokenInput) GoString() string {
 	return s.String()
+}
+
+// Validate inspects the fields of the type to determine if they are valid.
+func (s *GetAuthorizationTokenInput) Validate() error {
+	invalidParams := request.ErrInvalidParams{Context: "GetAuthorizationTokenInput"}
+	if s.RegistryIds != nil && len(s.RegistryIds) < 1 {
+		invalidParams.Add(request.NewErrParamMinLen("RegistryIds", 1))
+	}
+
+	if invalidParams.Len() > 0 {
+		return invalidParams
+	}
+	return nil
 }
 
 type GetAuthorizationTokenOutput struct {
@@ -940,6 +1108,25 @@ func (s GetDownloadUrlForLayerInput) GoString() string {
 	return s.String()
 }
 
+// Validate inspects the fields of the type to determine if they are valid.
+func (s *GetDownloadUrlForLayerInput) Validate() error {
+	invalidParams := request.ErrInvalidParams{Context: "GetDownloadUrlForLayerInput"}
+	if s.LayerDigest == nil {
+		invalidParams.Add(request.NewErrParamRequired("LayerDigest"))
+	}
+	if s.RepositoryName == nil {
+		invalidParams.Add(request.NewErrParamRequired("RepositoryName"))
+	}
+	if s.RepositoryName != nil && len(*s.RepositoryName) < 2 {
+		invalidParams.Add(request.NewErrParamMinLen("RepositoryName", 2))
+	}
+
+	if invalidParams.Len() > 0 {
+		return invalidParams
+	}
+	return nil
+}
+
 type GetDownloadUrlForLayerOutput struct {
 	_ struct{} `type:"structure"`
 
@@ -979,6 +1166,22 @@ func (s GetRepositoryPolicyInput) String() string {
 // GoString returns the string representation
 func (s GetRepositoryPolicyInput) GoString() string {
 	return s.String()
+}
+
+// Validate inspects the fields of the type to determine if they are valid.
+func (s *GetRepositoryPolicyInput) Validate() error {
+	invalidParams := request.ErrInvalidParams{Context: "GetRepositoryPolicyInput"}
+	if s.RepositoryName == nil {
+		invalidParams.Add(request.NewErrParamRequired("RepositoryName"))
+	}
+	if s.RepositoryName != nil && len(*s.RepositoryName) < 2 {
+		invalidParams.Add(request.NewErrParamMinLen("RepositoryName", 2))
+	}
+
+	if invalidParams.Len() > 0 {
+		return invalidParams
+	}
+	return nil
 }
 
 type GetRepositoryPolicyOutput struct {
@@ -1095,6 +1298,22 @@ func (s InitiateLayerUploadInput) GoString() string {
 	return s.String()
 }
 
+// Validate inspects the fields of the type to determine if they are valid.
+func (s *InitiateLayerUploadInput) Validate() error {
+	invalidParams := request.ErrInvalidParams{Context: "InitiateLayerUploadInput"}
+	if s.RepositoryName == nil {
+		invalidParams.Add(request.NewErrParamRequired("RepositoryName"))
+	}
+	if s.RepositoryName != nil && len(*s.RepositoryName) < 2 {
+		invalidParams.Add(request.NewErrParamMinLen("RepositoryName", 2))
+	}
+
+	if invalidParams.Len() > 0 {
+		return invalidParams
+	}
+	return nil
+}
+
 type InitiateLayerUploadOutput struct {
 	_ struct{} `type:"structure"`
 
@@ -1201,6 +1420,25 @@ func (s ListImagesInput) GoString() string {
 	return s.String()
 }
 
+// Validate inspects the fields of the type to determine if they are valid.
+func (s *ListImagesInput) Validate() error {
+	invalidParams := request.ErrInvalidParams{Context: "ListImagesInput"}
+	if s.MaxResults != nil && *s.MaxResults < 1 {
+		invalidParams.Add(request.NewErrParamMinValue("MaxResults", 1))
+	}
+	if s.RepositoryName == nil {
+		invalidParams.Add(request.NewErrParamRequired("RepositoryName"))
+	}
+	if s.RepositoryName != nil && len(*s.RepositoryName) < 2 {
+		invalidParams.Add(request.NewErrParamMinLen("RepositoryName", 2))
+	}
+
+	if invalidParams.Len() > 0 {
+		return invalidParams
+	}
+	return nil
+}
+
 type ListImagesOutput struct {
 	_ struct{} `type:"structure"`
 
@@ -1247,6 +1485,25 @@ func (s PutImageInput) String() string {
 // GoString returns the string representation
 func (s PutImageInput) GoString() string {
 	return s.String()
+}
+
+// Validate inspects the fields of the type to determine if they are valid.
+func (s *PutImageInput) Validate() error {
+	invalidParams := request.ErrInvalidParams{Context: "PutImageInput"}
+	if s.ImageManifest == nil {
+		invalidParams.Add(request.NewErrParamRequired("ImageManifest"))
+	}
+	if s.RepositoryName == nil {
+		invalidParams.Add(request.NewErrParamRequired("RepositoryName"))
+	}
+	if s.RepositoryName != nil && len(*s.RepositoryName) < 2 {
+		invalidParams.Add(request.NewErrParamMinLen("RepositoryName", 2))
+	}
+
+	if invalidParams.Len() > 0 {
+		return invalidParams
+	}
+	return nil
 }
 
 type PutImageOutput struct {
@@ -1322,6 +1579,25 @@ func (s SetRepositoryPolicyInput) GoString() string {
 	return s.String()
 }
 
+// Validate inspects the fields of the type to determine if they are valid.
+func (s *SetRepositoryPolicyInput) Validate() error {
+	invalidParams := request.ErrInvalidParams{Context: "SetRepositoryPolicyInput"}
+	if s.PolicyText == nil {
+		invalidParams.Add(request.NewErrParamRequired("PolicyText"))
+	}
+	if s.RepositoryName == nil {
+		invalidParams.Add(request.NewErrParamRequired("RepositoryName"))
+	}
+	if s.RepositoryName != nil && len(*s.RepositoryName) < 2 {
+		invalidParams.Add(request.NewErrParamMinLen("RepositoryName", 2))
+	}
+
+	if invalidParams.Len() > 0 {
+		return invalidParams
+	}
+	return nil
+}
+
 type SetRepositoryPolicyOutput struct {
 	_ struct{} `type:"structure"`
 
@@ -1379,6 +1655,34 @@ func (s UploadLayerPartInput) String() string {
 // GoString returns the string representation
 func (s UploadLayerPartInput) GoString() string {
 	return s.String()
+}
+
+// Validate inspects the fields of the type to determine if they are valid.
+func (s *UploadLayerPartInput) Validate() error {
+	invalidParams := request.ErrInvalidParams{Context: "UploadLayerPartInput"}
+	if s.LayerPartBlob == nil {
+		invalidParams.Add(request.NewErrParamRequired("LayerPartBlob"))
+	}
+	if s.PartFirstByte == nil {
+		invalidParams.Add(request.NewErrParamRequired("PartFirstByte"))
+	}
+	if s.PartLastByte == nil {
+		invalidParams.Add(request.NewErrParamRequired("PartLastByte"))
+	}
+	if s.RepositoryName == nil {
+		invalidParams.Add(request.NewErrParamRequired("RepositoryName"))
+	}
+	if s.RepositoryName != nil && len(*s.RepositoryName) < 2 {
+		invalidParams.Add(request.NewErrParamMinLen("RepositoryName", 2))
+	}
+	if s.UploadId == nil {
+		invalidParams.Add(request.NewErrParamRequired("UploadId"))
+	}
+
+	if invalidParams.Len() > 0 {
+		return invalidParams
+	}
+	return nil
 }
 
 type UploadLayerPartOutput struct {

--- a/service/ecs/api.go
+++ b/service/ecs/api.go
@@ -4,6 +4,7 @@
 package ecs
 
 import (
+	"fmt"
 	"time"
 
 	"github.com/aws/aws-sdk-go/aws/awsutil"
@@ -1034,6 +1035,19 @@ func (s Attribute) GoString() string {
 	return s.String()
 }
 
+// Validate inspects the fields of the type to determine if they are valid.
+func (s *Attribute) Validate() error {
+	invalidParams := request.ErrInvalidParams{Context: "Attribute"}
+	if s.Name == nil {
+		invalidParams.Add(request.NewErrParamRequired("Name"))
+	}
+
+	if invalidParams.Len() > 0 {
+		return invalidParams
+	}
+	return nil
+}
+
 // A regional grouping of one or more container instances on which you can run
 // task requests. Each account receives a default cluster the first time you
 // use the Amazon ECS service, but you may also create other clusters. Clusters
@@ -1392,6 +1406,41 @@ func (s ContainerDefinition) GoString() string {
 	return s.String()
 }
 
+// Validate inspects the fields of the type to determine if they are valid.
+func (s *ContainerDefinition) Validate() error {
+	invalidParams := request.ErrInvalidParams{Context: "ContainerDefinition"}
+	if s.ExtraHosts != nil {
+		for i, v := range s.ExtraHosts {
+			if v == nil {
+				continue
+			}
+			if err := v.Validate(); err != nil {
+				invalidParams.AddNested(fmt.Sprintf("%s[%v]", "ExtraHosts", i), err.(request.ErrInvalidParams))
+			}
+		}
+	}
+	if s.LogConfiguration != nil {
+		if err := s.LogConfiguration.Validate(); err != nil {
+			invalidParams.AddNested("LogConfiguration", err.(request.ErrInvalidParams))
+		}
+	}
+	if s.Ulimits != nil {
+		for i, v := range s.Ulimits {
+			if v == nil {
+				continue
+			}
+			if err := v.Validate(); err != nil {
+				invalidParams.AddNested(fmt.Sprintf("%s[%v]", "Ulimits", i), err.(request.ErrInvalidParams))
+			}
+		}
+	}
+
+	if invalidParams.Len() > 0 {
+		return invalidParams
+	}
+	return nil
+}
+
 // An EC2 instance that is running the Amazon ECS agent and has been registered
 // with a cluster.
 type ContainerInstance struct {
@@ -1569,6 +1618,25 @@ func (s CreateServiceInput) GoString() string {
 	return s.String()
 }
 
+// Validate inspects the fields of the type to determine if they are valid.
+func (s *CreateServiceInput) Validate() error {
+	invalidParams := request.ErrInvalidParams{Context: "CreateServiceInput"}
+	if s.DesiredCount == nil {
+		invalidParams.Add(request.NewErrParamRequired("DesiredCount"))
+	}
+	if s.ServiceName == nil {
+		invalidParams.Add(request.NewErrParamRequired("ServiceName"))
+	}
+	if s.TaskDefinition == nil {
+		invalidParams.Add(request.NewErrParamRequired("TaskDefinition"))
+	}
+
+	if invalidParams.Len() > 0 {
+		return invalidParams
+	}
+	return nil
+}
+
 type CreateServiceOutput struct {
 	_ struct{} `type:"structure"`
 
@@ -1601,6 +1669,19 @@ func (s DeleteClusterInput) String() string {
 // GoString returns the string representation
 func (s DeleteClusterInput) GoString() string {
 	return s.String()
+}
+
+// Validate inspects the fields of the type to determine if they are valid.
+func (s *DeleteClusterInput) Validate() error {
+	invalidParams := request.ErrInvalidParams{Context: "DeleteClusterInput"}
+	if s.Cluster == nil {
+		invalidParams.Add(request.NewErrParamRequired("Cluster"))
+	}
+
+	if invalidParams.Len() > 0 {
+		return invalidParams
+	}
+	return nil
 }
 
 type DeleteClusterOutput struct {
@@ -1639,6 +1720,19 @@ func (s DeleteServiceInput) String() string {
 // GoString returns the string representation
 func (s DeleteServiceInput) GoString() string {
 	return s.String()
+}
+
+// Validate inspects the fields of the type to determine if they are valid.
+func (s *DeleteServiceInput) Validate() error {
+	invalidParams := request.ErrInvalidParams{Context: "DeleteServiceInput"}
+	if s.Service == nil {
+		invalidParams.Add(request.NewErrParamRequired("Service"))
+	}
+
+	if invalidParams.Len() > 0 {
+		return invalidParams
+	}
+	return nil
 }
 
 type DeleteServiceOutput struct {
@@ -1766,6 +1860,19 @@ func (s DeregisterContainerInstanceInput) GoString() string {
 	return s.String()
 }
 
+// Validate inspects the fields of the type to determine if they are valid.
+func (s *DeregisterContainerInstanceInput) Validate() error {
+	invalidParams := request.ErrInvalidParams{Context: "DeregisterContainerInstanceInput"}
+	if s.ContainerInstance == nil {
+		invalidParams.Add(request.NewErrParamRequired("ContainerInstance"))
+	}
+
+	if invalidParams.Len() > 0 {
+		return invalidParams
+	}
+	return nil
+}
+
 type DeregisterContainerInstanceOutput struct {
 	_ struct{} `type:"structure"`
 
@@ -1800,6 +1907,19 @@ func (s DeregisterTaskDefinitionInput) String() string {
 // GoString returns the string representation
 func (s DeregisterTaskDefinitionInput) GoString() string {
 	return s.String()
+}
+
+// Validate inspects the fields of the type to determine if they are valid.
+func (s *DeregisterTaskDefinitionInput) Validate() error {
+	invalidParams := request.ErrInvalidParams{Context: "DeregisterTaskDefinitionInput"}
+	if s.TaskDefinition == nil {
+		invalidParams.Add(request.NewErrParamRequired("TaskDefinition"))
+	}
+
+	if invalidParams.Len() > 0 {
+		return invalidParams
+	}
+	return nil
 }
 
 type DeregisterTaskDefinitionOutput struct {
@@ -1880,6 +2000,19 @@ func (s DescribeContainerInstancesInput) GoString() string {
 	return s.String()
 }
 
+// Validate inspects the fields of the type to determine if they are valid.
+func (s *DescribeContainerInstancesInput) Validate() error {
+	invalidParams := request.ErrInvalidParams{Context: "DescribeContainerInstancesInput"}
+	if s.ContainerInstances == nil {
+		invalidParams.Add(request.NewErrParamRequired("ContainerInstances"))
+	}
+
+	if invalidParams.Len() > 0 {
+		return invalidParams
+	}
+	return nil
+}
+
 type DescribeContainerInstancesOutput struct {
 	_ struct{} `type:"structure"`
 
@@ -1921,6 +2054,19 @@ func (s DescribeServicesInput) GoString() string {
 	return s.String()
 }
 
+// Validate inspects the fields of the type to determine if they are valid.
+func (s *DescribeServicesInput) Validate() error {
+	invalidParams := request.ErrInvalidParams{Context: "DescribeServicesInput"}
+	if s.Services == nil {
+		invalidParams.Add(request.NewErrParamRequired("Services"))
+	}
+
+	if invalidParams.Len() > 0 {
+		return invalidParams
+	}
+	return nil
+}
+
 type DescribeServicesOutput struct {
 	_ struct{} `type:"structure"`
 
@@ -1960,6 +2106,19 @@ func (s DescribeTaskDefinitionInput) GoString() string {
 	return s.String()
 }
 
+// Validate inspects the fields of the type to determine if they are valid.
+func (s *DescribeTaskDefinitionInput) Validate() error {
+	invalidParams := request.ErrInvalidParams{Context: "DescribeTaskDefinitionInput"}
+	if s.TaskDefinition == nil {
+		invalidParams.Add(request.NewErrParamRequired("TaskDefinition"))
+	}
+
+	if invalidParams.Len() > 0 {
+		return invalidParams
+	}
+	return nil
+}
+
 type DescribeTaskDefinitionOutput struct {
 	_ struct{} `type:"structure"`
 
@@ -1997,6 +2156,19 @@ func (s DescribeTasksInput) String() string {
 // GoString returns the string representation
 func (s DescribeTasksInput) GoString() string {
 	return s.String()
+}
+
+// Validate inspects the fields of the type to determine if they are valid.
+func (s *DescribeTasksInput) Validate() error {
+	invalidParams := request.ErrInvalidParams{Context: "DescribeTasksInput"}
+	if s.Tasks == nil {
+		invalidParams.Add(request.NewErrParamRequired("Tasks"))
+	}
+
+	if invalidParams.Len() > 0 {
+		return invalidParams
+	}
+	return nil
 }
 
 type DescribeTasksOutput struct {
@@ -2104,6 +2276,22 @@ func (s HostEntry) String() string {
 // GoString returns the string representation
 func (s HostEntry) GoString() string {
 	return s.String()
+}
+
+// Validate inspects the fields of the type to determine if they are valid.
+func (s *HostEntry) Validate() error {
+	invalidParams := request.ErrInvalidParams{Context: "HostEntry"}
+	if s.Hostname == nil {
+		invalidParams.Add(request.NewErrParamRequired("Hostname"))
+	}
+	if s.IpAddress == nil {
+		invalidParams.Add(request.NewErrParamRequired("IpAddress"))
+	}
+
+	if invalidParams.Len() > 0 {
+		return invalidParams
+	}
+	return nil
 }
 
 // Details on a container instance host volume.
@@ -2595,6 +2783,19 @@ func (s LogConfiguration) GoString() string {
 	return s.String()
 }
 
+// Validate inspects the fields of the type to determine if they are valid.
+func (s *LogConfiguration) Validate() error {
+	invalidParams := request.ErrInvalidParams{Context: "LogConfiguration"}
+	if s.LogDriver == nil {
+		invalidParams.Add(request.NewErrParamRequired("LogDriver"))
+	}
+
+	if invalidParams.Len() > 0 {
+		return invalidParams
+	}
+	return nil
+}
+
 // Details on a volume mount point that is used in a container definition.
 type MountPoint struct {
 	_ struct{} `type:"structure"`
@@ -2745,6 +2946,26 @@ func (s RegisterContainerInstanceInput) GoString() string {
 	return s.String()
 }
 
+// Validate inspects the fields of the type to determine if they are valid.
+func (s *RegisterContainerInstanceInput) Validate() error {
+	invalidParams := request.ErrInvalidParams{Context: "RegisterContainerInstanceInput"}
+	if s.Attributes != nil {
+		for i, v := range s.Attributes {
+			if v == nil {
+				continue
+			}
+			if err := v.Validate(); err != nil {
+				invalidParams.AddNested(fmt.Sprintf("%s[%v]", "Attributes", i), err.(request.ErrInvalidParams))
+			}
+		}
+	}
+
+	if invalidParams.Len() > 0 {
+		return invalidParams
+	}
+	return nil
+}
+
 type RegisterContainerInstanceOutput struct {
 	_ struct{} `type:"structure"`
 
@@ -2789,6 +3010,32 @@ func (s RegisterTaskDefinitionInput) String() string {
 // GoString returns the string representation
 func (s RegisterTaskDefinitionInput) GoString() string {
 	return s.String()
+}
+
+// Validate inspects the fields of the type to determine if they are valid.
+func (s *RegisterTaskDefinitionInput) Validate() error {
+	invalidParams := request.ErrInvalidParams{Context: "RegisterTaskDefinitionInput"}
+	if s.ContainerDefinitions == nil {
+		invalidParams.Add(request.NewErrParamRequired("ContainerDefinitions"))
+	}
+	if s.Family == nil {
+		invalidParams.Add(request.NewErrParamRequired("Family"))
+	}
+	if s.ContainerDefinitions != nil {
+		for i, v := range s.ContainerDefinitions {
+			if v == nil {
+				continue
+			}
+			if err := v.Validate(); err != nil {
+				invalidParams.AddNested(fmt.Sprintf("%s[%v]", "ContainerDefinitions", i), err.(request.ErrInvalidParams))
+			}
+		}
+	}
+
+	if invalidParams.Len() > 0 {
+		return invalidParams
+	}
+	return nil
 }
 
 type RegisterTaskDefinitionOutput struct {
@@ -2893,6 +3140,19 @@ func (s RunTaskInput) String() string {
 // GoString returns the string representation
 func (s RunTaskInput) GoString() string {
 	return s.String()
+}
+
+// Validate inspects the fields of the type to determine if they are valid.
+func (s *RunTaskInput) Validate() error {
+	invalidParams := request.ErrInvalidParams{Context: "RunTaskInput"}
+	if s.TaskDefinition == nil {
+		invalidParams.Add(request.NewErrParamRequired("TaskDefinition"))
+	}
+
+	if invalidParams.Len() > 0 {
+		return invalidParams
+	}
+	return nil
 }
 
 type RunTaskOutput struct {
@@ -3062,6 +3322,22 @@ func (s StartTaskInput) GoString() string {
 	return s.String()
 }
 
+// Validate inspects the fields of the type to determine if they are valid.
+func (s *StartTaskInput) Validate() error {
+	invalidParams := request.ErrInvalidParams{Context: "StartTaskInput"}
+	if s.ContainerInstances == nil {
+		invalidParams.Add(request.NewErrParamRequired("ContainerInstances"))
+	}
+	if s.TaskDefinition == nil {
+		invalidParams.Add(request.NewErrParamRequired("TaskDefinition"))
+	}
+
+	if invalidParams.Len() > 0 {
+		return invalidParams
+	}
+	return nil
+}
+
 type StartTaskOutput struct {
 	_ struct{} `type:"structure"`
 
@@ -3109,6 +3385,19 @@ func (s StopTaskInput) String() string {
 // GoString returns the string representation
 func (s StopTaskInput) GoString() string {
 	return s.String()
+}
+
+// Validate inspects the fields of the type to determine if they are valid.
+func (s *StopTaskInput) Validate() error {
+	invalidParams := request.ErrInvalidParams{Context: "StopTaskInput"}
+	if s.Task == nil {
+		invalidParams.Add(request.NewErrParamRequired("Task"))
+	}
+
+	if invalidParams.Len() > 0 {
+		return invalidParams
+	}
+	return nil
 }
 
 type StopTaskOutput struct {
@@ -3374,6 +3663,25 @@ func (s Ulimit) GoString() string {
 	return s.String()
 }
 
+// Validate inspects the fields of the type to determine if they are valid.
+func (s *Ulimit) Validate() error {
+	invalidParams := request.ErrInvalidParams{Context: "Ulimit"}
+	if s.HardLimit == nil {
+		invalidParams.Add(request.NewErrParamRequired("HardLimit"))
+	}
+	if s.Name == nil {
+		invalidParams.Add(request.NewErrParamRequired("Name"))
+	}
+	if s.SoftLimit == nil {
+		invalidParams.Add(request.NewErrParamRequired("SoftLimit"))
+	}
+
+	if invalidParams.Len() > 0 {
+		return invalidParams
+	}
+	return nil
+}
+
 type UpdateContainerAgentInput struct {
 	_ struct{} `type:"structure"`
 
@@ -3396,6 +3704,19 @@ func (s UpdateContainerAgentInput) String() string {
 // GoString returns the string representation
 func (s UpdateContainerAgentInput) GoString() string {
 	return s.String()
+}
+
+// Validate inspects the fields of the type to determine if they are valid.
+func (s *UpdateContainerAgentInput) Validate() error {
+	invalidParams := request.ErrInvalidParams{Context: "UpdateContainerAgentInput"}
+	if s.ContainerInstance == nil {
+		invalidParams.Add(request.NewErrParamRequired("ContainerInstance"))
+	}
+
+	if invalidParams.Len() > 0 {
+		return invalidParams
+	}
+	return nil
 }
 
 type UpdateContainerAgentOutput struct {
@@ -3451,6 +3772,19 @@ func (s UpdateServiceInput) String() string {
 // GoString returns the string representation
 func (s UpdateServiceInput) GoString() string {
 	return s.String()
+}
+
+// Validate inspects the fields of the type to determine if they are valid.
+func (s *UpdateServiceInput) Validate() error {
+	invalidParams := request.ErrInvalidParams{Context: "UpdateServiceInput"}
+	if s.Service == nil {
+		invalidParams.Add(request.NewErrParamRequired("Service"))
+	}
+
+	if invalidParams.Len() > 0 {
+		return invalidParams
+	}
+	return nil
 }
 
 type UpdateServiceOutput struct {

--- a/service/efs/api.go
+++ b/service/efs/api.go
@@ -4,6 +4,7 @@
 package efs
 
 import (
+	"fmt"
 	"time"
 
 	"github.com/aws/aws-sdk-go/aws/awsutil"
@@ -548,6 +549,22 @@ func (s CreateFileSystemInput) GoString() string {
 	return s.String()
 }
 
+// Validate inspects the fields of the type to determine if they are valid.
+func (s *CreateFileSystemInput) Validate() error {
+	invalidParams := request.ErrInvalidParams{Context: "CreateFileSystemInput"}
+	if s.CreationToken == nil {
+		invalidParams.Add(request.NewErrParamRequired("CreationToken"))
+	}
+	if s.CreationToken != nil && len(*s.CreationToken) < 1 {
+		invalidParams.Add(request.NewErrParamMinLen("CreationToken", 1))
+	}
+
+	if invalidParams.Len() > 0 {
+		return invalidParams
+	}
+	return nil
+}
+
 type CreateMountTargetInput struct {
 	_ struct{} `type:"structure"`
 
@@ -575,6 +592,22 @@ func (s CreateMountTargetInput) GoString() string {
 	return s.String()
 }
 
+// Validate inspects the fields of the type to determine if they are valid.
+func (s *CreateMountTargetInput) Validate() error {
+	invalidParams := request.ErrInvalidParams{Context: "CreateMountTargetInput"}
+	if s.FileSystemId == nil {
+		invalidParams.Add(request.NewErrParamRequired("FileSystemId"))
+	}
+	if s.SubnetId == nil {
+		invalidParams.Add(request.NewErrParamRequired("SubnetId"))
+	}
+
+	if invalidParams.Len() > 0 {
+		return invalidParams
+	}
+	return nil
+}
+
 type CreateTagsInput struct {
 	_ struct{} `type:"structure"`
 
@@ -594,6 +627,32 @@ func (s CreateTagsInput) String() string {
 // GoString returns the string representation
 func (s CreateTagsInput) GoString() string {
 	return s.String()
+}
+
+// Validate inspects the fields of the type to determine if they are valid.
+func (s *CreateTagsInput) Validate() error {
+	invalidParams := request.ErrInvalidParams{Context: "CreateTagsInput"}
+	if s.FileSystemId == nil {
+		invalidParams.Add(request.NewErrParamRequired("FileSystemId"))
+	}
+	if s.Tags == nil {
+		invalidParams.Add(request.NewErrParamRequired("Tags"))
+	}
+	if s.Tags != nil {
+		for i, v := range s.Tags {
+			if v == nil {
+				continue
+			}
+			if err := v.Validate(); err != nil {
+				invalidParams.AddNested(fmt.Sprintf("%s[%v]", "Tags", i), err.(request.ErrInvalidParams))
+			}
+		}
+	}
+
+	if invalidParams.Len() > 0 {
+		return invalidParams
+	}
+	return nil
 }
 
 type CreateTagsOutput struct {
@@ -627,6 +686,19 @@ func (s DeleteFileSystemInput) GoString() string {
 	return s.String()
 }
 
+// Validate inspects the fields of the type to determine if they are valid.
+func (s *DeleteFileSystemInput) Validate() error {
+	invalidParams := request.ErrInvalidParams{Context: "DeleteFileSystemInput"}
+	if s.FileSystemId == nil {
+		invalidParams.Add(request.NewErrParamRequired("FileSystemId"))
+	}
+
+	if invalidParams.Len() > 0 {
+		return invalidParams
+	}
+	return nil
+}
+
 type DeleteFileSystemOutput struct {
 	_ struct{} `type:"structure"`
 }
@@ -656,6 +728,19 @@ func (s DeleteMountTargetInput) String() string {
 // GoString returns the string representation
 func (s DeleteMountTargetInput) GoString() string {
 	return s.String()
+}
+
+// Validate inspects the fields of the type to determine if they are valid.
+func (s *DeleteMountTargetInput) Validate() error {
+	invalidParams := request.ErrInvalidParams{Context: "DeleteMountTargetInput"}
+	if s.MountTargetId == nil {
+		invalidParams.Add(request.NewErrParamRequired("MountTargetId"))
+	}
+
+	if invalidParams.Len() > 0 {
+		return invalidParams
+	}
+	return nil
 }
 
 type DeleteMountTargetOutput struct {
@@ -690,6 +775,22 @@ func (s DeleteTagsInput) String() string {
 // GoString returns the string representation
 func (s DeleteTagsInput) GoString() string {
 	return s.String()
+}
+
+// Validate inspects the fields of the type to determine if they are valid.
+func (s *DeleteTagsInput) Validate() error {
+	invalidParams := request.ErrInvalidParams{Context: "DeleteTagsInput"}
+	if s.FileSystemId == nil {
+		invalidParams.Add(request.NewErrParamRequired("FileSystemId"))
+	}
+	if s.TagKeys == nil {
+		invalidParams.Add(request.NewErrParamRequired("TagKeys"))
+	}
+
+	if invalidParams.Len() > 0 {
+		return invalidParams
+	}
+	return nil
 }
 
 type DeleteTagsOutput struct {
@@ -740,6 +841,22 @@ func (s DescribeFileSystemsInput) GoString() string {
 	return s.String()
 }
 
+// Validate inspects the fields of the type to determine if they are valid.
+func (s *DescribeFileSystemsInput) Validate() error {
+	invalidParams := request.ErrInvalidParams{Context: "DescribeFileSystemsInput"}
+	if s.CreationToken != nil && len(*s.CreationToken) < 1 {
+		invalidParams.Add(request.NewErrParamMinLen("CreationToken", 1))
+	}
+	if s.MaxItems != nil && *s.MaxItems < 1 {
+		invalidParams.Add(request.NewErrParamMinValue("MaxItems", 1))
+	}
+
+	if invalidParams.Len() > 0 {
+		return invalidParams
+	}
+	return nil
+}
+
 type DescribeFileSystemsOutput struct {
 	_ struct{} `type:"structure"`
 
@@ -779,6 +896,19 @@ func (s DescribeMountTargetSecurityGroupsInput) String() string {
 // GoString returns the string representation
 func (s DescribeMountTargetSecurityGroupsInput) GoString() string {
 	return s.String()
+}
+
+// Validate inspects the fields of the type to determine if they are valid.
+func (s *DescribeMountTargetSecurityGroupsInput) Validate() error {
+	invalidParams := request.ErrInvalidParams{Context: "DescribeMountTargetSecurityGroupsInput"}
+	if s.MountTargetId == nil {
+		invalidParams.Add(request.NewErrParamRequired("MountTargetId"))
+	}
+
+	if invalidParams.Len() > 0 {
+		return invalidParams
+	}
+	return nil
 }
 
 type DescribeMountTargetSecurityGroupsOutput struct {
@@ -827,6 +957,19 @@ func (s DescribeMountTargetsInput) String() string {
 // GoString returns the string representation
 func (s DescribeMountTargetsInput) GoString() string {
 	return s.String()
+}
+
+// Validate inspects the fields of the type to determine if they are valid.
+func (s *DescribeMountTargetsInput) Validate() error {
+	invalidParams := request.ErrInvalidParams{Context: "DescribeMountTargetsInput"}
+	if s.MaxItems != nil && *s.MaxItems < 1 {
+		invalidParams.Add(request.NewErrParamMinValue("MaxItems", 1))
+	}
+
+	if invalidParams.Len() > 0 {
+		return invalidParams
+	}
+	return nil
 }
 
 type DescribeMountTargetsOutput struct {
@@ -880,6 +1023,22 @@ func (s DescribeTagsInput) String() string {
 // GoString returns the string representation
 func (s DescribeTagsInput) GoString() string {
 	return s.String()
+}
+
+// Validate inspects the fields of the type to determine if they are valid.
+func (s *DescribeTagsInput) Validate() error {
+	invalidParams := request.ErrInvalidParams{Context: "DescribeTagsInput"}
+	if s.FileSystemId == nil {
+		invalidParams.Add(request.NewErrParamRequired("FileSystemId"))
+	}
+	if s.MaxItems != nil && *s.MaxItems < 1 {
+		invalidParams.Add(request.NewErrParamMinValue("MaxItems", 1))
+	}
+
+	if invalidParams.Len() > 0 {
+		return invalidParams
+	}
+	return nil
 }
 
 type DescribeTagsOutput struct {
@@ -1009,6 +1168,19 @@ func (s ModifyMountTargetSecurityGroupsInput) GoString() string {
 	return s.String()
 }
 
+// Validate inspects the fields of the type to determine if they are valid.
+func (s *ModifyMountTargetSecurityGroupsInput) Validate() error {
+	invalidParams := request.ErrInvalidParams{Context: "ModifyMountTargetSecurityGroupsInput"}
+	if s.MountTargetId == nil {
+		invalidParams.Add(request.NewErrParamRequired("MountTargetId"))
+	}
+
+	if invalidParams.Len() > 0 {
+		return invalidParams
+	}
+	return nil
+}
+
 type ModifyMountTargetSecurityGroupsOutput struct {
 	_ struct{} `type:"structure"`
 }
@@ -1081,6 +1253,25 @@ func (s Tag) String() string {
 // GoString returns the string representation
 func (s Tag) GoString() string {
 	return s.String()
+}
+
+// Validate inspects the fields of the type to determine if they are valid.
+func (s *Tag) Validate() error {
+	invalidParams := request.ErrInvalidParams{Context: "Tag"}
+	if s.Key == nil {
+		invalidParams.Add(request.NewErrParamRequired("Key"))
+	}
+	if s.Key != nil && len(*s.Key) < 1 {
+		invalidParams.Add(request.NewErrParamMinLen("Key", 1))
+	}
+	if s.Value == nil {
+		invalidParams.Add(request.NewErrParamRequired("Value"))
+	}
+
+	if invalidParams.Len() > 0 {
+		return invalidParams
+	}
+	return nil
 }
 
 const (

--- a/service/elasticache/api.go
+++ b/service/elasticache/api.go
@@ -1379,6 +1379,22 @@ func (s AddTagsToResourceInput) GoString() string {
 	return s.String()
 }
 
+// Validate inspects the fields of the type to determine if they are valid.
+func (s *AddTagsToResourceInput) Validate() error {
+	invalidParams := request.ErrInvalidParams{Context: "AddTagsToResourceInput"}
+	if s.ResourceName == nil {
+		invalidParams.Add(request.NewErrParamRequired("ResourceName"))
+	}
+	if s.Tags == nil {
+		invalidParams.Add(request.NewErrParamRequired("Tags"))
+	}
+
+	if invalidParams.Len() > 0 {
+		return invalidParams
+	}
+	return nil
+}
+
 // Represents the input of an AuthorizeCacheSecurityGroupIngress action.
 type AuthorizeCacheSecurityGroupIngressInput struct {
 	_ struct{} `type:"structure"`
@@ -1404,6 +1420,25 @@ func (s AuthorizeCacheSecurityGroupIngressInput) String() string {
 // GoString returns the string representation
 func (s AuthorizeCacheSecurityGroupIngressInput) GoString() string {
 	return s.String()
+}
+
+// Validate inspects the fields of the type to determine if they are valid.
+func (s *AuthorizeCacheSecurityGroupIngressInput) Validate() error {
+	invalidParams := request.ErrInvalidParams{Context: "AuthorizeCacheSecurityGroupIngressInput"}
+	if s.CacheSecurityGroupName == nil {
+		invalidParams.Add(request.NewErrParamRequired("CacheSecurityGroupName"))
+	}
+	if s.EC2SecurityGroupName == nil {
+		invalidParams.Add(request.NewErrParamRequired("EC2SecurityGroupName"))
+	}
+	if s.EC2SecurityGroupOwnerId == nil {
+		invalidParams.Add(request.NewErrParamRequired("EC2SecurityGroupOwnerId"))
+	}
+
+	if invalidParams.Len() > 0 {
+		return invalidParams
+	}
+	return nil
 }
 
 type AuthorizeCacheSecurityGroupIngressOutput struct {
@@ -1898,6 +1933,22 @@ func (s CopySnapshotInput) GoString() string {
 	return s.String()
 }
 
+// Validate inspects the fields of the type to determine if they are valid.
+func (s *CopySnapshotInput) Validate() error {
+	invalidParams := request.ErrInvalidParams{Context: "CopySnapshotInput"}
+	if s.SourceSnapshotName == nil {
+		invalidParams.Add(request.NewErrParamRequired("SourceSnapshotName"))
+	}
+	if s.TargetSnapshotName == nil {
+		invalidParams.Add(request.NewErrParamRequired("TargetSnapshotName"))
+	}
+
+	if invalidParams.Len() > 0 {
+		return invalidParams
+	}
+	return nil
+}
+
 type CopySnapshotOutput struct {
 	_ struct{} `type:"structure"`
 
@@ -2126,6 +2177,19 @@ func (s CreateCacheClusterInput) GoString() string {
 	return s.String()
 }
 
+// Validate inspects the fields of the type to determine if they are valid.
+func (s *CreateCacheClusterInput) Validate() error {
+	invalidParams := request.ErrInvalidParams{Context: "CreateCacheClusterInput"}
+	if s.CacheClusterId == nil {
+		invalidParams.Add(request.NewErrParamRequired("CacheClusterId"))
+	}
+
+	if invalidParams.Len() > 0 {
+		return invalidParams
+	}
+	return nil
+}
+
 type CreateCacheClusterOutput struct {
 	_ struct{} `type:"structure"`
 
@@ -2170,6 +2234,25 @@ func (s CreateCacheParameterGroupInput) GoString() string {
 	return s.String()
 }
 
+// Validate inspects the fields of the type to determine if they are valid.
+func (s *CreateCacheParameterGroupInput) Validate() error {
+	invalidParams := request.ErrInvalidParams{Context: "CreateCacheParameterGroupInput"}
+	if s.CacheParameterGroupFamily == nil {
+		invalidParams.Add(request.NewErrParamRequired("CacheParameterGroupFamily"))
+	}
+	if s.CacheParameterGroupName == nil {
+		invalidParams.Add(request.NewErrParamRequired("CacheParameterGroupName"))
+	}
+	if s.Description == nil {
+		invalidParams.Add(request.NewErrParamRequired("Description"))
+	}
+
+	if invalidParams.Len() > 0 {
+		return invalidParams
+	}
+	return nil
+}
+
 type CreateCacheParameterGroupOutput struct {
 	_ struct{} `type:"structure"`
 
@@ -2212,6 +2295,22 @@ func (s CreateCacheSecurityGroupInput) String() string {
 // GoString returns the string representation
 func (s CreateCacheSecurityGroupInput) GoString() string {
 	return s.String()
+}
+
+// Validate inspects the fields of the type to determine if they are valid.
+func (s *CreateCacheSecurityGroupInput) Validate() error {
+	invalidParams := request.ErrInvalidParams{Context: "CreateCacheSecurityGroupInput"}
+	if s.CacheSecurityGroupName == nil {
+		invalidParams.Add(request.NewErrParamRequired("CacheSecurityGroupName"))
+	}
+	if s.Description == nil {
+		invalidParams.Add(request.NewErrParamRequired("Description"))
+	}
+
+	if invalidParams.Len() > 0 {
+		return invalidParams
+	}
+	return nil
 }
 
 type CreateCacheSecurityGroupOutput struct {
@@ -2259,6 +2358,25 @@ func (s CreateCacheSubnetGroupInput) String() string {
 // GoString returns the string representation
 func (s CreateCacheSubnetGroupInput) GoString() string {
 	return s.String()
+}
+
+// Validate inspects the fields of the type to determine if they are valid.
+func (s *CreateCacheSubnetGroupInput) Validate() error {
+	invalidParams := request.ErrInvalidParams{Context: "CreateCacheSubnetGroupInput"}
+	if s.CacheSubnetGroupDescription == nil {
+		invalidParams.Add(request.NewErrParamRequired("CacheSubnetGroupDescription"))
+	}
+	if s.CacheSubnetGroupName == nil {
+		invalidParams.Add(request.NewErrParamRequired("CacheSubnetGroupName"))
+	}
+	if s.SubnetIds == nil {
+		invalidParams.Add(request.NewErrParamRequired("SubnetIds"))
+	}
+
+	if invalidParams.Len() > 0 {
+		return invalidParams
+	}
+	return nil
 }
 
 type CreateCacheSubnetGroupOutput struct {
@@ -2469,6 +2587,22 @@ func (s CreateReplicationGroupInput) GoString() string {
 	return s.String()
 }
 
+// Validate inspects the fields of the type to determine if they are valid.
+func (s *CreateReplicationGroupInput) Validate() error {
+	invalidParams := request.ErrInvalidParams{Context: "CreateReplicationGroupInput"}
+	if s.ReplicationGroupDescription == nil {
+		invalidParams.Add(request.NewErrParamRequired("ReplicationGroupDescription"))
+	}
+	if s.ReplicationGroupId == nil {
+		invalidParams.Add(request.NewErrParamRequired("ReplicationGroupId"))
+	}
+
+	if invalidParams.Len() > 0 {
+		return invalidParams
+	}
+	return nil
+}
+
 type CreateReplicationGroupOutput struct {
 	_ struct{} `type:"structure"`
 
@@ -2506,6 +2640,22 @@ func (s CreateSnapshotInput) String() string {
 // GoString returns the string representation
 func (s CreateSnapshotInput) GoString() string {
 	return s.String()
+}
+
+// Validate inspects the fields of the type to determine if they are valid.
+func (s *CreateSnapshotInput) Validate() error {
+	invalidParams := request.ErrInvalidParams{Context: "CreateSnapshotInput"}
+	if s.CacheClusterId == nil {
+		invalidParams.Add(request.NewErrParamRequired("CacheClusterId"))
+	}
+	if s.SnapshotName == nil {
+		invalidParams.Add(request.NewErrParamRequired("SnapshotName"))
+	}
+
+	if invalidParams.Len() > 0 {
+		return invalidParams
+	}
+	return nil
 }
 
 type CreateSnapshotOutput struct {
@@ -2550,6 +2700,19 @@ func (s DeleteCacheClusterInput) GoString() string {
 	return s.String()
 }
 
+// Validate inspects the fields of the type to determine if they are valid.
+func (s *DeleteCacheClusterInput) Validate() error {
+	invalidParams := request.ErrInvalidParams{Context: "DeleteCacheClusterInput"}
+	if s.CacheClusterId == nil {
+		invalidParams.Add(request.NewErrParamRequired("CacheClusterId"))
+	}
+
+	if invalidParams.Len() > 0 {
+		return invalidParams
+	}
+	return nil
+}
+
 type DeleteCacheClusterOutput struct {
 	_ struct{} `type:"structure"`
 
@@ -2588,6 +2751,19 @@ func (s DeleteCacheParameterGroupInput) GoString() string {
 	return s.String()
 }
 
+// Validate inspects the fields of the type to determine if they are valid.
+func (s *DeleteCacheParameterGroupInput) Validate() error {
+	invalidParams := request.ErrInvalidParams{Context: "DeleteCacheParameterGroupInput"}
+	if s.CacheParameterGroupName == nil {
+		invalidParams.Add(request.NewErrParamRequired("CacheParameterGroupName"))
+	}
+
+	if invalidParams.Len() > 0 {
+		return invalidParams
+	}
+	return nil
+}
+
 type DeleteCacheParameterGroupOutput struct {
 	_ struct{} `type:"structure"`
 }
@@ -2622,6 +2798,19 @@ func (s DeleteCacheSecurityGroupInput) GoString() string {
 	return s.String()
 }
 
+// Validate inspects the fields of the type to determine if they are valid.
+func (s *DeleteCacheSecurityGroupInput) Validate() error {
+	invalidParams := request.ErrInvalidParams{Context: "DeleteCacheSecurityGroupInput"}
+	if s.CacheSecurityGroupName == nil {
+		invalidParams.Add(request.NewErrParamRequired("CacheSecurityGroupName"))
+	}
+
+	if invalidParams.Len() > 0 {
+		return invalidParams
+	}
+	return nil
+}
+
 type DeleteCacheSecurityGroupOutput struct {
 	_ struct{} `type:"structure"`
 }
@@ -2654,6 +2843,19 @@ func (s DeleteCacheSubnetGroupInput) String() string {
 // GoString returns the string representation
 func (s DeleteCacheSubnetGroupInput) GoString() string {
 	return s.String()
+}
+
+// Validate inspects the fields of the type to determine if they are valid.
+func (s *DeleteCacheSubnetGroupInput) Validate() error {
+	invalidParams := request.ErrInvalidParams{Context: "DeleteCacheSubnetGroupInput"}
+	if s.CacheSubnetGroupName == nil {
+		invalidParams.Add(request.NewErrParamRequired("CacheSubnetGroupName"))
+	}
+
+	if invalidParams.Len() > 0 {
+		return invalidParams
+	}
+	return nil
 }
 
 type DeleteCacheSubnetGroupOutput struct {
@@ -2699,6 +2901,19 @@ func (s DeleteReplicationGroupInput) GoString() string {
 	return s.String()
 }
 
+// Validate inspects the fields of the type to determine if they are valid.
+func (s *DeleteReplicationGroupInput) Validate() error {
+	invalidParams := request.ErrInvalidParams{Context: "DeleteReplicationGroupInput"}
+	if s.ReplicationGroupId == nil {
+		invalidParams.Add(request.NewErrParamRequired("ReplicationGroupId"))
+	}
+
+	if invalidParams.Len() > 0 {
+		return invalidParams
+	}
+	return nil
+}
+
 type DeleteReplicationGroupOutput struct {
 	_ struct{} `type:"structure"`
 
@@ -2732,6 +2947,19 @@ func (s DeleteSnapshotInput) String() string {
 // GoString returns the string representation
 func (s DeleteSnapshotInput) GoString() string {
 	return s.String()
+}
+
+// Validate inspects the fields of the type to determine if they are valid.
+func (s *DeleteSnapshotInput) Validate() error {
+	invalidParams := request.ErrInvalidParams{Context: "DeleteSnapshotInput"}
+	if s.SnapshotName == nil {
+		invalidParams.Add(request.NewErrParamRequired("SnapshotName"))
+	}
+
+	if invalidParams.Len() > 0 {
+		return invalidParams
+	}
+	return nil
 }
 
 type DeleteSnapshotOutput struct {
@@ -2974,6 +3202,19 @@ func (s DescribeCacheParametersInput) GoString() string {
 	return s.String()
 }
 
+// Validate inspects the fields of the type to determine if they are valid.
+func (s *DescribeCacheParametersInput) Validate() error {
+	invalidParams := request.ErrInvalidParams{Context: "DescribeCacheParametersInput"}
+	if s.CacheParameterGroupName == nil {
+		invalidParams.Add(request.NewErrParamRequired("CacheParameterGroupName"))
+	}
+
+	if invalidParams.Len() > 0 {
+		return invalidParams
+	}
+	return nil
+}
+
 // Represents the output of a DescribeCacheParameters action.
 type DescribeCacheParametersOutput struct {
 	_ struct{} `type:"structure"`
@@ -3138,6 +3379,19 @@ func (s DescribeEngineDefaultParametersInput) String() string {
 // GoString returns the string representation
 func (s DescribeEngineDefaultParametersInput) GoString() string {
 	return s.String()
+}
+
+// Validate inspects the fields of the type to determine if they are valid.
+func (s *DescribeEngineDefaultParametersInput) Validate() error {
+	invalidParams := request.ErrInvalidParams{Context: "DescribeEngineDefaultParametersInput"}
+	if s.CacheParameterGroupFamily == nil {
+		invalidParams.Add(request.NewErrParamRequired("CacheParameterGroupFamily"))
+	}
+
+	if invalidParams.Len() > 0 {
+		return invalidParams
+	}
+	return nil
 }
 
 type DescribeEngineDefaultParametersOutput struct {
@@ -3734,6 +3988,19 @@ func (s ListTagsForResourceInput) GoString() string {
 	return s.String()
 }
 
+// Validate inspects the fields of the type to determine if they are valid.
+func (s *ListTagsForResourceInput) Validate() error {
+	invalidParams := request.ErrInvalidParams{Context: "ListTagsForResourceInput"}
+	if s.ResourceName == nil {
+		invalidParams.Add(request.NewErrParamRequired("ResourceName"))
+	}
+
+	if invalidParams.Len() > 0 {
+		return invalidParams
+	}
+	return nil
+}
+
 // Represents the input of a ModifyCacheCluster action.
 type ModifyCacheClusterInput struct {
 	_ struct{} `type:"structure"`
@@ -3940,6 +4207,19 @@ func (s ModifyCacheClusterInput) GoString() string {
 	return s.String()
 }
 
+// Validate inspects the fields of the type to determine if they are valid.
+func (s *ModifyCacheClusterInput) Validate() error {
+	invalidParams := request.ErrInvalidParams{Context: "ModifyCacheClusterInput"}
+	if s.CacheClusterId == nil {
+		invalidParams.Add(request.NewErrParamRequired("CacheClusterId"))
+	}
+
+	if invalidParams.Len() > 0 {
+		return invalidParams
+	}
+	return nil
+}
+
 type ModifyCacheClusterOutput struct {
 	_ struct{} `type:"structure"`
 
@@ -3980,6 +4260,22 @@ func (s ModifyCacheParameterGroupInput) GoString() string {
 	return s.String()
 }
 
+// Validate inspects the fields of the type to determine if they are valid.
+func (s *ModifyCacheParameterGroupInput) Validate() error {
+	invalidParams := request.ErrInvalidParams{Context: "ModifyCacheParameterGroupInput"}
+	if s.CacheParameterGroupName == nil {
+		invalidParams.Add(request.NewErrParamRequired("CacheParameterGroupName"))
+	}
+	if s.ParameterNameValues == nil {
+		invalidParams.Add(request.NewErrParamRequired("ParameterNameValues"))
+	}
+
+	if invalidParams.Len() > 0 {
+		return invalidParams
+	}
+	return nil
+}
+
 // Represents the input of a ModifyCacheSubnetGroup action.
 type ModifyCacheSubnetGroupInput struct {
 	_ struct{} `type:"structure"`
@@ -4007,6 +4303,19 @@ func (s ModifyCacheSubnetGroupInput) String() string {
 // GoString returns the string representation
 func (s ModifyCacheSubnetGroupInput) GoString() string {
 	return s.String()
+}
+
+// Validate inspects the fields of the type to determine if they are valid.
+func (s *ModifyCacheSubnetGroupInput) Validate() error {
+	invalidParams := request.ErrInvalidParams{Context: "ModifyCacheSubnetGroupInput"}
+	if s.CacheSubnetGroupName == nil {
+		invalidParams.Add(request.NewErrParamRequired("CacheSubnetGroupName"))
+	}
+
+	if invalidParams.Len() > 0 {
+		return invalidParams
+	}
+	return nil
 }
 
 type ModifyCacheSubnetGroupOutput struct {
@@ -4159,6 +4468,19 @@ func (s ModifyReplicationGroupInput) String() string {
 // GoString returns the string representation
 func (s ModifyReplicationGroupInput) GoString() string {
 	return s.String()
+}
+
+// Validate inspects the fields of the type to determine if they are valid.
+func (s *ModifyReplicationGroupInput) Validate() error {
+	invalidParams := request.ErrInvalidParams{Context: "ModifyReplicationGroupInput"}
+	if s.ReplicationGroupId == nil {
+		invalidParams.Add(request.NewErrParamRequired("ReplicationGroupId"))
+	}
+
+	if invalidParams.Len() > 0 {
+		return invalidParams
+	}
+	return nil
 }
 
 type ModifyReplicationGroupOutput struct {
@@ -4420,6 +4742,19 @@ func (s PurchaseReservedCacheNodesOfferingInput) GoString() string {
 	return s.String()
 }
 
+// Validate inspects the fields of the type to determine if they are valid.
+func (s *PurchaseReservedCacheNodesOfferingInput) Validate() error {
+	invalidParams := request.ErrInvalidParams{Context: "PurchaseReservedCacheNodesOfferingInput"}
+	if s.ReservedCacheNodesOfferingId == nil {
+		invalidParams.Add(request.NewErrParamRequired("ReservedCacheNodesOfferingId"))
+	}
+
+	if invalidParams.Len() > 0 {
+		return invalidParams
+	}
+	return nil
+}
+
 type PurchaseReservedCacheNodesOfferingOutput struct {
 	_ struct{} `type:"structure"`
 
@@ -4458,6 +4793,22 @@ func (s RebootCacheClusterInput) String() string {
 // GoString returns the string representation
 func (s RebootCacheClusterInput) GoString() string {
 	return s.String()
+}
+
+// Validate inspects the fields of the type to determine if they are valid.
+func (s *RebootCacheClusterInput) Validate() error {
+	invalidParams := request.ErrInvalidParams{Context: "RebootCacheClusterInput"}
+	if s.CacheClusterId == nil {
+		invalidParams.Add(request.NewErrParamRequired("CacheClusterId"))
+	}
+	if s.CacheNodeIdsToReboot == nil {
+		invalidParams.Add(request.NewErrParamRequired("CacheNodeIdsToReboot"))
+	}
+
+	if invalidParams.Len() > 0 {
+		return invalidParams
+	}
+	return nil
 }
 
 type RebootCacheClusterOutput struct {
@@ -4525,6 +4876,22 @@ func (s RemoveTagsFromResourceInput) String() string {
 // GoString returns the string representation
 func (s RemoveTagsFromResourceInput) GoString() string {
 	return s.String()
+}
+
+// Validate inspects the fields of the type to determine if they are valid.
+func (s *RemoveTagsFromResourceInput) Validate() error {
+	invalidParams := request.ErrInvalidParams{Context: "RemoveTagsFromResourceInput"}
+	if s.ResourceName == nil {
+		invalidParams.Add(request.NewErrParamRequired("ResourceName"))
+	}
+	if s.TagKeys == nil {
+		invalidParams.Add(request.NewErrParamRequired("TagKeys"))
+	}
+
+	if invalidParams.Len() > 0 {
+		return invalidParams
+	}
+	return nil
 }
 
 // Contains all of the attributes of a specific replication group.
@@ -4754,6 +5121,22 @@ func (s ResetCacheParameterGroupInput) GoString() string {
 	return s.String()
 }
 
+// Validate inspects the fields of the type to determine if they are valid.
+func (s *ResetCacheParameterGroupInput) Validate() error {
+	invalidParams := request.ErrInvalidParams{Context: "ResetCacheParameterGroupInput"}
+	if s.CacheParameterGroupName == nil {
+		invalidParams.Add(request.NewErrParamRequired("CacheParameterGroupName"))
+	}
+	if s.ParameterNameValues == nil {
+		invalidParams.Add(request.NewErrParamRequired("ParameterNameValues"))
+	}
+
+	if invalidParams.Len() > 0 {
+		return invalidParams
+	}
+	return nil
+}
+
 // Represents the input of a RevokeCacheSecurityGroupIngress action.
 type RevokeCacheSecurityGroupIngressInput struct {
 	_ struct{} `type:"structure"`
@@ -4778,6 +5161,25 @@ func (s RevokeCacheSecurityGroupIngressInput) String() string {
 // GoString returns the string representation
 func (s RevokeCacheSecurityGroupIngressInput) GoString() string {
 	return s.String()
+}
+
+// Validate inspects the fields of the type to determine if they are valid.
+func (s *RevokeCacheSecurityGroupIngressInput) Validate() error {
+	invalidParams := request.ErrInvalidParams{Context: "RevokeCacheSecurityGroupIngressInput"}
+	if s.CacheSecurityGroupName == nil {
+		invalidParams.Add(request.NewErrParamRequired("CacheSecurityGroupName"))
+	}
+	if s.EC2SecurityGroupName == nil {
+		invalidParams.Add(request.NewErrParamRequired("EC2SecurityGroupName"))
+	}
+	if s.EC2SecurityGroupOwnerId == nil {
+		invalidParams.Add(request.NewErrParamRequired("EC2SecurityGroupOwnerId"))
+	}
+
+	if invalidParams.Len() > 0 {
+		return invalidParams
+	}
+	return nil
 }
 
 type RevokeCacheSecurityGroupIngressOutput struct {

--- a/service/elasticbeanstalk/api.go
+++ b/service/elasticbeanstalk/api.go
@@ -4,6 +4,7 @@
 package elasticbeanstalk
 
 import (
+	"fmt"
 	"time"
 
 	"github.com/aws/aws-sdk-go/aws/awsutil"
@@ -1150,6 +1151,19 @@ func (s AbortEnvironmentUpdateInput) GoString() string {
 	return s.String()
 }
 
+// Validate inspects the fields of the type to determine if they are valid.
+func (s *AbortEnvironmentUpdateInput) Validate() error {
+	invalidParams := request.ErrInvalidParams{Context: "AbortEnvironmentUpdateInput"}
+	if s.EnvironmentName != nil && len(*s.EnvironmentName) < 4 {
+		invalidParams.Add(request.NewErrParamMinLen("EnvironmentName", 4))
+	}
+
+	if invalidParams.Len() > 0 {
+		return invalidParams
+	}
+	return nil
+}
+
 type AbortEnvironmentUpdateOutput struct {
 	_ struct{} `type:"structure"`
 }
@@ -1325,6 +1339,19 @@ func (s ApplyEnvironmentManagedActionInput) GoString() string {
 	return s.String()
 }
 
+// Validate inspects the fields of the type to determine if they are valid.
+func (s *ApplyEnvironmentManagedActionInput) Validate() error {
+	invalidParams := request.ErrInvalidParams{Context: "ApplyEnvironmentManagedActionInput"}
+	if s.ActionId == nil {
+		invalidParams.Add(request.NewErrParamRequired("ActionId"))
+	}
+
+	if invalidParams.Len() > 0 {
+		return invalidParams
+	}
+	return nil
+}
+
 // The result message containing information about the managed action.
 type ApplyEnvironmentManagedActionOutput struct {
 	_ struct{} `type:"structure"`
@@ -1433,6 +1460,22 @@ func (s CheckDNSAvailabilityInput) GoString() string {
 	return s.String()
 }
 
+// Validate inspects the fields of the type to determine if they are valid.
+func (s *CheckDNSAvailabilityInput) Validate() error {
+	invalidParams := request.ErrInvalidParams{Context: "CheckDNSAvailabilityInput"}
+	if s.CNAMEPrefix == nil {
+		invalidParams.Add(request.NewErrParamRequired("CNAMEPrefix"))
+	}
+	if s.CNAMEPrefix != nil && len(*s.CNAMEPrefix) < 4 {
+		invalidParams.Add(request.NewErrParamMinLen("CNAMEPrefix", 4))
+	}
+
+	if invalidParams.Len() > 0 {
+		return invalidParams
+	}
+	return nil
+}
+
 // Indicates if the specified CNAME is available.
 type CheckDNSAvailabilityOutput struct {
 	_ struct{} `type:"structure"`
@@ -1487,6 +1530,22 @@ func (s ComposeEnvironmentsInput) String() string {
 // GoString returns the string representation
 func (s ComposeEnvironmentsInput) GoString() string {
 	return s.String()
+}
+
+// Validate inspects the fields of the type to determine if they are valid.
+func (s *ComposeEnvironmentsInput) Validate() error {
+	invalidParams := request.ErrInvalidParams{Context: "ComposeEnvironmentsInput"}
+	if s.ApplicationName != nil && len(*s.ApplicationName) < 1 {
+		invalidParams.Add(request.NewErrParamMinLen("ApplicationName", 1))
+	}
+	if s.GroupName != nil && len(*s.GroupName) < 1 {
+		invalidParams.Add(request.NewErrParamMinLen("GroupName", 1))
+	}
+
+	if invalidParams.Len() > 0 {
+		return invalidParams
+	}
+	return nil
 }
 
 // Describes the possible values for a configuration option.
@@ -1596,6 +1655,19 @@ func (s ConfigurationOptionSetting) GoString() string {
 	return s.String()
 }
 
+// Validate inspects the fields of the type to determine if they are valid.
+func (s *ConfigurationOptionSetting) Validate() error {
+	invalidParams := request.ErrInvalidParams{Context: "ConfigurationOptionSetting"}
+	if s.ResourceName != nil && len(*s.ResourceName) < 1 {
+		invalidParams.Add(request.NewErrParamMinLen("ResourceName", 1))
+	}
+
+	if invalidParams.Len() > 0 {
+		return invalidParams
+	}
+	return nil
+}
+
 // Describes the settings for a configuration set.
 type ConfigurationSettingsDescription struct {
 	_ struct{} `type:"structure"`
@@ -1671,6 +1743,22 @@ func (s CreateApplicationInput) GoString() string {
 	return s.String()
 }
 
+// Validate inspects the fields of the type to determine if they are valid.
+func (s *CreateApplicationInput) Validate() error {
+	invalidParams := request.ErrInvalidParams{Context: "CreateApplicationInput"}
+	if s.ApplicationName == nil {
+		invalidParams.Add(request.NewErrParamRequired("ApplicationName"))
+	}
+	if s.ApplicationName != nil && len(*s.ApplicationName) < 1 {
+		invalidParams.Add(request.NewErrParamMinLen("ApplicationName", 1))
+	}
+
+	if invalidParams.Len() > 0 {
+		return invalidParams
+	}
+	return nil
+}
+
 type CreateApplicationVersionInput struct {
 	_ struct{} `type:"structure"`
 
@@ -1726,6 +1814,28 @@ func (s CreateApplicationVersionInput) String() string {
 // GoString returns the string representation
 func (s CreateApplicationVersionInput) GoString() string {
 	return s.String()
+}
+
+// Validate inspects the fields of the type to determine if they are valid.
+func (s *CreateApplicationVersionInput) Validate() error {
+	invalidParams := request.ErrInvalidParams{Context: "CreateApplicationVersionInput"}
+	if s.ApplicationName == nil {
+		invalidParams.Add(request.NewErrParamRequired("ApplicationName"))
+	}
+	if s.ApplicationName != nil && len(*s.ApplicationName) < 1 {
+		invalidParams.Add(request.NewErrParamMinLen("ApplicationName", 1))
+	}
+	if s.VersionLabel == nil {
+		invalidParams.Add(request.NewErrParamRequired("VersionLabel"))
+	}
+	if s.VersionLabel != nil && len(*s.VersionLabel) < 1 {
+		invalidParams.Add(request.NewErrParamMinLen("VersionLabel", 1))
+	}
+
+	if invalidParams.Len() > 0 {
+		return invalidParams
+	}
+	return nil
 }
 
 // Request to create a configuration template.
@@ -1796,6 +1906,43 @@ func (s CreateConfigurationTemplateInput) String() string {
 // GoString returns the string representation
 func (s CreateConfigurationTemplateInput) GoString() string {
 	return s.String()
+}
+
+// Validate inspects the fields of the type to determine if they are valid.
+func (s *CreateConfigurationTemplateInput) Validate() error {
+	invalidParams := request.ErrInvalidParams{Context: "CreateConfigurationTemplateInput"}
+	if s.ApplicationName == nil {
+		invalidParams.Add(request.NewErrParamRequired("ApplicationName"))
+	}
+	if s.ApplicationName != nil && len(*s.ApplicationName) < 1 {
+		invalidParams.Add(request.NewErrParamMinLen("ApplicationName", 1))
+	}
+	if s.TemplateName == nil {
+		invalidParams.Add(request.NewErrParamRequired("TemplateName"))
+	}
+	if s.TemplateName != nil && len(*s.TemplateName) < 1 {
+		invalidParams.Add(request.NewErrParamMinLen("TemplateName", 1))
+	}
+	if s.OptionSettings != nil {
+		for i, v := range s.OptionSettings {
+			if v == nil {
+				continue
+			}
+			if err := v.Validate(); err != nil {
+				invalidParams.AddNested(fmt.Sprintf("%s[%v]", "OptionSettings", i), err.(request.ErrInvalidParams))
+			}
+		}
+	}
+	if s.SourceConfiguration != nil {
+		if err := s.SourceConfiguration.Validate(); err != nil {
+			invalidParams.AddNested("SourceConfiguration", err.(request.ErrInvalidParams))
+		}
+	}
+
+	if invalidParams.Len() > 0 {
+		return invalidParams
+	}
+	return nil
 }
 
 type CreateEnvironmentInput struct {
@@ -1889,6 +2036,67 @@ func (s CreateEnvironmentInput) GoString() string {
 	return s.String()
 }
 
+// Validate inspects the fields of the type to determine if they are valid.
+func (s *CreateEnvironmentInput) Validate() error {
+	invalidParams := request.ErrInvalidParams{Context: "CreateEnvironmentInput"}
+	if s.ApplicationName == nil {
+		invalidParams.Add(request.NewErrParamRequired("ApplicationName"))
+	}
+	if s.ApplicationName != nil && len(*s.ApplicationName) < 1 {
+		invalidParams.Add(request.NewErrParamMinLen("ApplicationName", 1))
+	}
+	if s.CNAMEPrefix != nil && len(*s.CNAMEPrefix) < 4 {
+		invalidParams.Add(request.NewErrParamMinLen("CNAMEPrefix", 4))
+	}
+	if s.EnvironmentName != nil && len(*s.EnvironmentName) < 4 {
+		invalidParams.Add(request.NewErrParamMinLen("EnvironmentName", 4))
+	}
+	if s.GroupName != nil && len(*s.GroupName) < 1 {
+		invalidParams.Add(request.NewErrParamMinLen("GroupName", 1))
+	}
+	if s.TemplateName != nil && len(*s.TemplateName) < 1 {
+		invalidParams.Add(request.NewErrParamMinLen("TemplateName", 1))
+	}
+	if s.VersionLabel != nil && len(*s.VersionLabel) < 1 {
+		invalidParams.Add(request.NewErrParamMinLen("VersionLabel", 1))
+	}
+	if s.OptionSettings != nil {
+		for i, v := range s.OptionSettings {
+			if v == nil {
+				continue
+			}
+			if err := v.Validate(); err != nil {
+				invalidParams.AddNested(fmt.Sprintf("%s[%v]", "OptionSettings", i), err.(request.ErrInvalidParams))
+			}
+		}
+	}
+	if s.OptionsToRemove != nil {
+		for i, v := range s.OptionsToRemove {
+			if v == nil {
+				continue
+			}
+			if err := v.Validate(); err != nil {
+				invalidParams.AddNested(fmt.Sprintf("%s[%v]", "OptionsToRemove", i), err.(request.ErrInvalidParams))
+			}
+		}
+	}
+	if s.Tags != nil {
+		for i, v := range s.Tags {
+			if v == nil {
+				continue
+			}
+			if err := v.Validate(); err != nil {
+				invalidParams.AddNested(fmt.Sprintf("%s[%v]", "Tags", i), err.(request.ErrInvalidParams))
+			}
+		}
+	}
+
+	if invalidParams.Len() > 0 {
+		return invalidParams
+	}
+	return nil
+}
+
 type CreateStorageLocationInput struct {
 	_ struct{} `type:"structure"`
 }
@@ -1943,6 +2151,22 @@ func (s DeleteApplicationInput) GoString() string {
 	return s.String()
 }
 
+// Validate inspects the fields of the type to determine if they are valid.
+func (s *DeleteApplicationInput) Validate() error {
+	invalidParams := request.ErrInvalidParams{Context: "DeleteApplicationInput"}
+	if s.ApplicationName == nil {
+		invalidParams.Add(request.NewErrParamRequired("ApplicationName"))
+	}
+	if s.ApplicationName != nil && len(*s.ApplicationName) < 1 {
+		invalidParams.Add(request.NewErrParamMinLen("ApplicationName", 1))
+	}
+
+	if invalidParams.Len() > 0 {
+		return invalidParams
+	}
+	return nil
+}
+
 type DeleteApplicationOutput struct {
 	_ struct{} `type:"structure"`
 }
@@ -1985,6 +2209,28 @@ func (s DeleteApplicationVersionInput) GoString() string {
 	return s.String()
 }
 
+// Validate inspects the fields of the type to determine if they are valid.
+func (s *DeleteApplicationVersionInput) Validate() error {
+	invalidParams := request.ErrInvalidParams{Context: "DeleteApplicationVersionInput"}
+	if s.ApplicationName == nil {
+		invalidParams.Add(request.NewErrParamRequired("ApplicationName"))
+	}
+	if s.ApplicationName != nil && len(*s.ApplicationName) < 1 {
+		invalidParams.Add(request.NewErrParamMinLen("ApplicationName", 1))
+	}
+	if s.VersionLabel == nil {
+		invalidParams.Add(request.NewErrParamRequired("VersionLabel"))
+	}
+	if s.VersionLabel != nil && len(*s.VersionLabel) < 1 {
+		invalidParams.Add(request.NewErrParamMinLen("VersionLabel", 1))
+	}
+
+	if invalidParams.Len() > 0 {
+		return invalidParams
+	}
+	return nil
+}
+
 type DeleteApplicationVersionOutput struct {
 	_ struct{} `type:"structure"`
 }
@@ -2020,6 +2266,28 @@ func (s DeleteConfigurationTemplateInput) GoString() string {
 	return s.String()
 }
 
+// Validate inspects the fields of the type to determine if they are valid.
+func (s *DeleteConfigurationTemplateInput) Validate() error {
+	invalidParams := request.ErrInvalidParams{Context: "DeleteConfigurationTemplateInput"}
+	if s.ApplicationName == nil {
+		invalidParams.Add(request.NewErrParamRequired("ApplicationName"))
+	}
+	if s.ApplicationName != nil && len(*s.ApplicationName) < 1 {
+		invalidParams.Add(request.NewErrParamMinLen("ApplicationName", 1))
+	}
+	if s.TemplateName == nil {
+		invalidParams.Add(request.NewErrParamRequired("TemplateName"))
+	}
+	if s.TemplateName != nil && len(*s.TemplateName) < 1 {
+		invalidParams.Add(request.NewErrParamMinLen("TemplateName", 1))
+	}
+
+	if invalidParams.Len() > 0 {
+		return invalidParams
+	}
+	return nil
+}
+
 type DeleteConfigurationTemplateOutput struct {
 	_ struct{} `type:"structure"`
 }
@@ -2053,6 +2321,28 @@ func (s DeleteEnvironmentConfigurationInput) String() string {
 // GoString returns the string representation
 func (s DeleteEnvironmentConfigurationInput) GoString() string {
 	return s.String()
+}
+
+// Validate inspects the fields of the type to determine if they are valid.
+func (s *DeleteEnvironmentConfigurationInput) Validate() error {
+	invalidParams := request.ErrInvalidParams{Context: "DeleteEnvironmentConfigurationInput"}
+	if s.ApplicationName == nil {
+		invalidParams.Add(request.NewErrParamRequired("ApplicationName"))
+	}
+	if s.ApplicationName != nil && len(*s.ApplicationName) < 1 {
+		invalidParams.Add(request.NewErrParamMinLen("ApplicationName", 1))
+	}
+	if s.EnvironmentName == nil {
+		invalidParams.Add(request.NewErrParamRequired("EnvironmentName"))
+	}
+	if s.EnvironmentName != nil && len(*s.EnvironmentName) < 4 {
+		invalidParams.Add(request.NewErrParamMinLen("EnvironmentName", 4))
+	}
+
+	if invalidParams.Len() > 0 {
+		return invalidParams
+	}
+	return nil
 }
 
 type DeleteEnvironmentConfigurationOutput struct {
@@ -2123,6 +2413,19 @@ func (s DescribeApplicationVersionsInput) String() string {
 // GoString returns the string representation
 func (s DescribeApplicationVersionsInput) GoString() string {
 	return s.String()
+}
+
+// Validate inspects the fields of the type to determine if they are valid.
+func (s *DescribeApplicationVersionsInput) Validate() error {
+	invalidParams := request.ErrInvalidParams{Context: "DescribeApplicationVersionsInput"}
+	if s.ApplicationName != nil && len(*s.ApplicationName) < 1 {
+		invalidParams.Add(request.NewErrParamMinLen("ApplicationName", 1))
+	}
+
+	if invalidParams.Len() > 0 {
+		return invalidParams
+	}
+	return nil
 }
 
 // Result message wrapping a list of application version descriptions.
@@ -2213,6 +2516,35 @@ func (s DescribeConfigurationOptionsInput) GoString() string {
 	return s.String()
 }
 
+// Validate inspects the fields of the type to determine if they are valid.
+func (s *DescribeConfigurationOptionsInput) Validate() error {
+	invalidParams := request.ErrInvalidParams{Context: "DescribeConfigurationOptionsInput"}
+	if s.ApplicationName != nil && len(*s.ApplicationName) < 1 {
+		invalidParams.Add(request.NewErrParamMinLen("ApplicationName", 1))
+	}
+	if s.EnvironmentName != nil && len(*s.EnvironmentName) < 4 {
+		invalidParams.Add(request.NewErrParamMinLen("EnvironmentName", 4))
+	}
+	if s.TemplateName != nil && len(*s.TemplateName) < 1 {
+		invalidParams.Add(request.NewErrParamMinLen("TemplateName", 1))
+	}
+	if s.Options != nil {
+		for i, v := range s.Options {
+			if v == nil {
+				continue
+			}
+			if err := v.Validate(); err != nil {
+				invalidParams.AddNested(fmt.Sprintf("%s[%v]", "Options", i), err.(request.ErrInvalidParams))
+			}
+		}
+	}
+
+	if invalidParams.Len() > 0 {
+		return invalidParams
+	}
+	return nil
+}
+
 // Describes the settings for a specified configuration set.
 type DescribeConfigurationOptionsOutput struct {
 	_ struct{} `type:"structure"`
@@ -2269,6 +2601,28 @@ func (s DescribeConfigurationSettingsInput) GoString() string {
 	return s.String()
 }
 
+// Validate inspects the fields of the type to determine if they are valid.
+func (s *DescribeConfigurationSettingsInput) Validate() error {
+	invalidParams := request.ErrInvalidParams{Context: "DescribeConfigurationSettingsInput"}
+	if s.ApplicationName == nil {
+		invalidParams.Add(request.NewErrParamRequired("ApplicationName"))
+	}
+	if s.ApplicationName != nil && len(*s.ApplicationName) < 1 {
+		invalidParams.Add(request.NewErrParamMinLen("ApplicationName", 1))
+	}
+	if s.EnvironmentName != nil && len(*s.EnvironmentName) < 4 {
+		invalidParams.Add(request.NewErrParamMinLen("EnvironmentName", 4))
+	}
+	if s.TemplateName != nil && len(*s.TemplateName) < 1 {
+		invalidParams.Add(request.NewErrParamMinLen("TemplateName", 1))
+	}
+
+	if invalidParams.Len() > 0 {
+		return invalidParams
+	}
+	return nil
+}
+
 // The results from a request to change the configuration settings of an environment.
 type DescribeConfigurationSettingsOutput struct {
 	_ struct{} `type:"structure"`
@@ -2318,6 +2672,19 @@ func (s DescribeEnvironmentHealthInput) String() string {
 // GoString returns the string representation
 func (s DescribeEnvironmentHealthInput) GoString() string {
 	return s.String()
+}
+
+// Validate inspects the fields of the type to determine if they are valid.
+func (s *DescribeEnvironmentHealthInput) Validate() error {
+	invalidParams := request.ErrInvalidParams{Context: "DescribeEnvironmentHealthInput"}
+	if s.EnvironmentName != nil && len(*s.EnvironmentName) < 4 {
+		invalidParams.Add(request.NewErrParamMinLen("EnvironmentName", 4))
+	}
+
+	if invalidParams.Len() > 0 {
+		return invalidParams
+	}
+	return nil
 }
 
 // See the example below for a sample response.
@@ -2387,6 +2754,19 @@ func (s DescribeEnvironmentManagedActionHistoryInput) String() string {
 // GoString returns the string representation
 func (s DescribeEnvironmentManagedActionHistoryInput) GoString() string {
 	return s.String()
+}
+
+// Validate inspects the fields of the type to determine if they are valid.
+func (s *DescribeEnvironmentManagedActionHistoryInput) Validate() error {
+	invalidParams := request.ErrInvalidParams{Context: "DescribeEnvironmentManagedActionHistoryInput"}
+	if s.EnvironmentName != nil && len(*s.EnvironmentName) < 4 {
+		invalidParams.Add(request.NewErrParamMinLen("EnvironmentName", 4))
+	}
+
+	if invalidParams.Len() > 0 {
+		return invalidParams
+	}
+	return nil
 }
 
 // A result message containing a list of completed and failed managed actions.
@@ -2482,6 +2862,19 @@ func (s DescribeEnvironmentResourcesInput) GoString() string {
 	return s.String()
 }
 
+// Validate inspects the fields of the type to determine if they are valid.
+func (s *DescribeEnvironmentResourcesInput) Validate() error {
+	invalidParams := request.ErrInvalidParams{Context: "DescribeEnvironmentResourcesInput"}
+	if s.EnvironmentName != nil && len(*s.EnvironmentName) < 4 {
+		invalidParams.Add(request.NewErrParamMinLen("EnvironmentName", 4))
+	}
+
+	if invalidParams.Len() > 0 {
+		return invalidParams
+	}
+	return nil
+}
+
 // Result message containing a list of environment resource descriptions.
 type DescribeEnvironmentResourcesOutput struct {
 	_ struct{} `type:"structure"`
@@ -2543,6 +2936,22 @@ func (s DescribeEnvironmentsInput) GoString() string {
 	return s.String()
 }
 
+// Validate inspects the fields of the type to determine if they are valid.
+func (s *DescribeEnvironmentsInput) Validate() error {
+	invalidParams := request.ErrInvalidParams{Context: "DescribeEnvironmentsInput"}
+	if s.ApplicationName != nil && len(*s.ApplicationName) < 1 {
+		invalidParams.Add(request.NewErrParamMinLen("ApplicationName", 1))
+	}
+	if s.VersionLabel != nil && len(*s.VersionLabel) < 1 {
+		invalidParams.Add(request.NewErrParamMinLen("VersionLabel", 1))
+	}
+
+	if invalidParams.Len() > 0 {
+		return invalidParams
+	}
+	return nil
+}
+
 // Request to retrieve a list of events for an environment.
 type DescribeEventsInput struct {
 	_ struct{} `type:"structure"`
@@ -2601,6 +3010,31 @@ func (s DescribeEventsInput) GoString() string {
 	return s.String()
 }
 
+// Validate inspects the fields of the type to determine if they are valid.
+func (s *DescribeEventsInput) Validate() error {
+	invalidParams := request.ErrInvalidParams{Context: "DescribeEventsInput"}
+	if s.ApplicationName != nil && len(*s.ApplicationName) < 1 {
+		invalidParams.Add(request.NewErrParamMinLen("ApplicationName", 1))
+	}
+	if s.EnvironmentName != nil && len(*s.EnvironmentName) < 4 {
+		invalidParams.Add(request.NewErrParamMinLen("EnvironmentName", 4))
+	}
+	if s.MaxRecords != nil && *s.MaxRecords < 1 {
+		invalidParams.Add(request.NewErrParamMinValue("MaxRecords", 1))
+	}
+	if s.TemplateName != nil && len(*s.TemplateName) < 1 {
+		invalidParams.Add(request.NewErrParamMinLen("TemplateName", 1))
+	}
+	if s.VersionLabel != nil && len(*s.VersionLabel) < 1 {
+		invalidParams.Add(request.NewErrParamMinLen("VersionLabel", 1))
+	}
+
+	if invalidParams.Len() > 0 {
+		return invalidParams
+	}
+	return nil
+}
+
 // Result message wrapping a list of event descriptions.
 type DescribeEventsOutput struct {
 	_ struct{} `type:"structure"`
@@ -2649,6 +3083,22 @@ func (s DescribeInstancesHealthInput) String() string {
 // GoString returns the string representation
 func (s DescribeInstancesHealthInput) GoString() string {
 	return s.String()
+}
+
+// Validate inspects the fields of the type to determine if they are valid.
+func (s *DescribeInstancesHealthInput) Validate() error {
+	invalidParams := request.ErrInvalidParams{Context: "DescribeInstancesHealthInput"}
+	if s.EnvironmentName != nil && len(*s.EnvironmentName) < 4 {
+		invalidParams.Add(request.NewErrParamMinLen("EnvironmentName", 4))
+	}
+	if s.NextToken != nil && len(*s.NextToken) < 1 {
+		invalidParams.Add(request.NewErrParamMinLen("NextToken", 1))
+	}
+
+	if invalidParams.Len() > 0 {
+		return invalidParams
+	}
+	return nil
 }
 
 // See the example below for a sample response.
@@ -3300,6 +3750,19 @@ func (s OptionSpecification) GoString() string {
 	return s.String()
 }
 
+// Validate inspects the fields of the type to determine if they are valid.
+func (s *OptionSpecification) Validate() error {
+	invalidParams := request.ErrInvalidParams{Context: "OptionSpecification"}
+	if s.ResourceName != nil && len(*s.ResourceName) < 1 {
+		invalidParams.Add(request.NewErrParamMinLen("ResourceName", 1))
+	}
+
+	if invalidParams.Len() > 0 {
+		return invalidParams
+	}
+	return nil
+}
+
 // Describes a queue.
 type Queue struct {
 	_ struct{} `type:"structure"`
@@ -3347,6 +3810,19 @@ func (s RebuildEnvironmentInput) String() string {
 // GoString returns the string representation
 func (s RebuildEnvironmentInput) GoString() string {
 	return s.String()
+}
+
+// Validate inspects the fields of the type to determine if they are valid.
+func (s *RebuildEnvironmentInput) Validate() error {
+	invalidParams := request.ErrInvalidParams{Context: "RebuildEnvironmentInput"}
+	if s.EnvironmentName != nil && len(*s.EnvironmentName) < 4 {
+		invalidParams.Add(request.NewErrParamMinLen("EnvironmentName", 4))
+	}
+
+	if invalidParams.Len() > 0 {
+		return invalidParams
+	}
+	return nil
 }
 
 type RebuildEnvironmentOutput struct {
@@ -3402,6 +3878,22 @@ func (s RequestEnvironmentInfoInput) GoString() string {
 	return s.String()
 }
 
+// Validate inspects the fields of the type to determine if they are valid.
+func (s *RequestEnvironmentInfoInput) Validate() error {
+	invalidParams := request.ErrInvalidParams{Context: "RequestEnvironmentInfoInput"}
+	if s.EnvironmentName != nil && len(*s.EnvironmentName) < 4 {
+		invalidParams.Add(request.NewErrParamMinLen("EnvironmentName", 4))
+	}
+	if s.InfoType == nil {
+		invalidParams.Add(request.NewErrParamRequired("InfoType"))
+	}
+
+	if invalidParams.Len() > 0 {
+		return invalidParams
+	}
+	return nil
+}
+
 type RequestEnvironmentInfoOutput struct {
 	_ struct{} `type:"structure"`
 }
@@ -3442,6 +3934,19 @@ func (s RestartAppServerInput) String() string {
 // GoString returns the string representation
 func (s RestartAppServerInput) GoString() string {
 	return s.String()
+}
+
+// Validate inspects the fields of the type to determine if they are valid.
+func (s *RestartAppServerInput) Validate() error {
+	invalidParams := request.ErrInvalidParams{Context: "RestartAppServerInput"}
+	if s.EnvironmentName != nil && len(*s.EnvironmentName) < 4 {
+		invalidParams.Add(request.NewErrParamMinLen("EnvironmentName", 4))
+	}
+
+	if invalidParams.Len() > 0 {
+		return invalidParams
+	}
+	return nil
 }
 
 type RestartAppServerOutput struct {
@@ -3492,6 +3997,22 @@ func (s RetrieveEnvironmentInfoInput) String() string {
 // GoString returns the string representation
 func (s RetrieveEnvironmentInfoInput) GoString() string {
 	return s.String()
+}
+
+// Validate inspects the fields of the type to determine if they are valid.
+func (s *RetrieveEnvironmentInfoInput) Validate() error {
+	invalidParams := request.ErrInvalidParams{Context: "RetrieveEnvironmentInfoInput"}
+	if s.EnvironmentName != nil && len(*s.EnvironmentName) < 4 {
+		invalidParams.Add(request.NewErrParamMinLen("EnvironmentName", 4))
+	}
+	if s.InfoType == nil {
+		invalidParams.Add(request.NewErrParamRequired("InfoType"))
+	}
+
+	if invalidParams.Len() > 0 {
+		return invalidParams
+	}
+	return nil
 }
 
 // Result message containing a description of the requested environment info.
@@ -3627,6 +4148,22 @@ func (s SourceConfiguration) GoString() string {
 	return s.String()
 }
 
+// Validate inspects the fields of the type to determine if they are valid.
+func (s *SourceConfiguration) Validate() error {
+	invalidParams := request.ErrInvalidParams{Context: "SourceConfiguration"}
+	if s.ApplicationName != nil && len(*s.ApplicationName) < 1 {
+		invalidParams.Add(request.NewErrParamMinLen("ApplicationName", 1))
+	}
+	if s.TemplateName != nil && len(*s.TemplateName) < 1 {
+		invalidParams.Add(request.NewErrParamMinLen("TemplateName", 1))
+	}
+
+	if invalidParams.Len() > 0 {
+		return invalidParams
+	}
+	return nil
+}
+
 // Represents the percentage of requests over the last 10 seconds that resulted
 // in each type of status code response. For more information, see Status Code
 // Definitions (http://www.w3.org/Protocols/rfc2616/rfc2616-sec10.html).
@@ -3703,6 +4240,22 @@ func (s SwapEnvironmentCNAMEsInput) GoString() string {
 	return s.String()
 }
 
+// Validate inspects the fields of the type to determine if they are valid.
+func (s *SwapEnvironmentCNAMEsInput) Validate() error {
+	invalidParams := request.ErrInvalidParams{Context: "SwapEnvironmentCNAMEsInput"}
+	if s.DestinationEnvironmentName != nil && len(*s.DestinationEnvironmentName) < 4 {
+		invalidParams.Add(request.NewErrParamMinLen("DestinationEnvironmentName", 4))
+	}
+	if s.SourceEnvironmentName != nil && len(*s.SourceEnvironmentName) < 4 {
+		invalidParams.Add(request.NewErrParamMinLen("SourceEnvironmentName", 4))
+	}
+
+	if invalidParams.Len() > 0 {
+		return invalidParams
+	}
+	return nil
+}
+
 type SwapEnvironmentCNAMEsOutput struct {
 	_ struct{} `type:"structure"`
 }
@@ -3763,6 +4316,22 @@ func (s Tag) GoString() string {
 	return s.String()
 }
 
+// Validate inspects the fields of the type to determine if they are valid.
+func (s *Tag) Validate() error {
+	invalidParams := request.ErrInvalidParams{Context: "Tag"}
+	if s.Key != nil && len(*s.Key) < 1 {
+		invalidParams.Add(request.NewErrParamMinLen("Key", 1))
+	}
+	if s.Value != nil && len(*s.Value) < 1 {
+		invalidParams.Add(request.NewErrParamMinLen("Value", 1))
+	}
+
+	if invalidParams.Len() > 0 {
+		return invalidParams
+	}
+	return nil
+}
+
 // Request to terminate an environment.
 type TerminateEnvironmentInput struct {
 	_ struct{} `type:"structure"`
@@ -3810,6 +4379,19 @@ func (s TerminateEnvironmentInput) GoString() string {
 	return s.String()
 }
 
+// Validate inspects the fields of the type to determine if they are valid.
+func (s *TerminateEnvironmentInput) Validate() error {
+	invalidParams := request.ErrInvalidParams{Context: "TerminateEnvironmentInput"}
+	if s.EnvironmentName != nil && len(*s.EnvironmentName) < 4 {
+		invalidParams.Add(request.NewErrParamMinLen("EnvironmentName", 4))
+	}
+
+	if invalidParams.Len() > 0 {
+		return invalidParams
+	}
+	return nil
+}
+
 // Describes a trigger.
 type Trigger struct {
 	_ struct{} `type:"structure"`
@@ -3852,6 +4434,22 @@ func (s UpdateApplicationInput) GoString() string {
 	return s.String()
 }
 
+// Validate inspects the fields of the type to determine if they are valid.
+func (s *UpdateApplicationInput) Validate() error {
+	invalidParams := request.ErrInvalidParams{Context: "UpdateApplicationInput"}
+	if s.ApplicationName == nil {
+		invalidParams.Add(request.NewErrParamRequired("ApplicationName"))
+	}
+	if s.ApplicationName != nil && len(*s.ApplicationName) < 1 {
+		invalidParams.Add(request.NewErrParamMinLen("ApplicationName", 1))
+	}
+
+	if invalidParams.Len() > 0 {
+		return invalidParams
+	}
+	return nil
+}
+
 type UpdateApplicationVersionInput struct {
 	_ struct{} `type:"structure"`
 
@@ -3879,6 +4477,28 @@ func (s UpdateApplicationVersionInput) String() string {
 // GoString returns the string representation
 func (s UpdateApplicationVersionInput) GoString() string {
 	return s.String()
+}
+
+// Validate inspects the fields of the type to determine if they are valid.
+func (s *UpdateApplicationVersionInput) Validate() error {
+	invalidParams := request.ErrInvalidParams{Context: "UpdateApplicationVersionInput"}
+	if s.ApplicationName == nil {
+		invalidParams.Add(request.NewErrParamRequired("ApplicationName"))
+	}
+	if s.ApplicationName != nil && len(*s.ApplicationName) < 1 {
+		invalidParams.Add(request.NewErrParamMinLen("ApplicationName", 1))
+	}
+	if s.VersionLabel == nil {
+		invalidParams.Add(request.NewErrParamRequired("VersionLabel"))
+	}
+	if s.VersionLabel != nil && len(*s.VersionLabel) < 1 {
+		invalidParams.Add(request.NewErrParamMinLen("VersionLabel", 1))
+	}
+
+	if invalidParams.Len() > 0 {
+		return invalidParams
+	}
+	return nil
 }
 
 // The result message containing the options for the specified solution stack.
@@ -3919,6 +4539,48 @@ func (s UpdateConfigurationTemplateInput) String() string {
 // GoString returns the string representation
 func (s UpdateConfigurationTemplateInput) GoString() string {
 	return s.String()
+}
+
+// Validate inspects the fields of the type to determine if they are valid.
+func (s *UpdateConfigurationTemplateInput) Validate() error {
+	invalidParams := request.ErrInvalidParams{Context: "UpdateConfigurationTemplateInput"}
+	if s.ApplicationName == nil {
+		invalidParams.Add(request.NewErrParamRequired("ApplicationName"))
+	}
+	if s.ApplicationName != nil && len(*s.ApplicationName) < 1 {
+		invalidParams.Add(request.NewErrParamMinLen("ApplicationName", 1))
+	}
+	if s.TemplateName == nil {
+		invalidParams.Add(request.NewErrParamRequired("TemplateName"))
+	}
+	if s.TemplateName != nil && len(*s.TemplateName) < 1 {
+		invalidParams.Add(request.NewErrParamMinLen("TemplateName", 1))
+	}
+	if s.OptionSettings != nil {
+		for i, v := range s.OptionSettings {
+			if v == nil {
+				continue
+			}
+			if err := v.Validate(); err != nil {
+				invalidParams.AddNested(fmt.Sprintf("%s[%v]", "OptionSettings", i), err.(request.ErrInvalidParams))
+			}
+		}
+	}
+	if s.OptionsToRemove != nil {
+		for i, v := range s.OptionsToRemove {
+			if v == nil {
+				continue
+			}
+			if err := v.Validate(); err != nil {
+				invalidParams.AddNested(fmt.Sprintf("%s[%v]", "OptionsToRemove", i), err.(request.ErrInvalidParams))
+			}
+		}
+	}
+
+	if invalidParams.Len() > 0 {
+		return invalidParams
+	}
+	return nil
 }
 
 // Request to update an environment.
@@ -3997,6 +4659,51 @@ func (s UpdateEnvironmentInput) GoString() string {
 	return s.String()
 }
 
+// Validate inspects the fields of the type to determine if they are valid.
+func (s *UpdateEnvironmentInput) Validate() error {
+	invalidParams := request.ErrInvalidParams{Context: "UpdateEnvironmentInput"}
+	if s.ApplicationName != nil && len(*s.ApplicationName) < 1 {
+		invalidParams.Add(request.NewErrParamMinLen("ApplicationName", 1))
+	}
+	if s.EnvironmentName != nil && len(*s.EnvironmentName) < 4 {
+		invalidParams.Add(request.NewErrParamMinLen("EnvironmentName", 4))
+	}
+	if s.GroupName != nil && len(*s.GroupName) < 1 {
+		invalidParams.Add(request.NewErrParamMinLen("GroupName", 1))
+	}
+	if s.TemplateName != nil && len(*s.TemplateName) < 1 {
+		invalidParams.Add(request.NewErrParamMinLen("TemplateName", 1))
+	}
+	if s.VersionLabel != nil && len(*s.VersionLabel) < 1 {
+		invalidParams.Add(request.NewErrParamMinLen("VersionLabel", 1))
+	}
+	if s.OptionSettings != nil {
+		for i, v := range s.OptionSettings {
+			if v == nil {
+				continue
+			}
+			if err := v.Validate(); err != nil {
+				invalidParams.AddNested(fmt.Sprintf("%s[%v]", "OptionSettings", i), err.(request.ErrInvalidParams))
+			}
+		}
+	}
+	if s.OptionsToRemove != nil {
+		for i, v := range s.OptionsToRemove {
+			if v == nil {
+				continue
+			}
+			if err := v.Validate(); err != nil {
+				invalidParams.AddNested(fmt.Sprintf("%s[%v]", "OptionsToRemove", i), err.(request.ErrInvalidParams))
+			}
+		}
+	}
+
+	if invalidParams.Len() > 0 {
+		return invalidParams
+	}
+	return nil
+}
+
 // A list of validation messages for a specified configuration template.
 type ValidateConfigurationSettingsInput struct {
 	_ struct{} `type:"structure"`
@@ -4027,6 +4734,41 @@ func (s ValidateConfigurationSettingsInput) String() string {
 // GoString returns the string representation
 func (s ValidateConfigurationSettingsInput) GoString() string {
 	return s.String()
+}
+
+// Validate inspects the fields of the type to determine if they are valid.
+func (s *ValidateConfigurationSettingsInput) Validate() error {
+	invalidParams := request.ErrInvalidParams{Context: "ValidateConfigurationSettingsInput"}
+	if s.ApplicationName == nil {
+		invalidParams.Add(request.NewErrParamRequired("ApplicationName"))
+	}
+	if s.ApplicationName != nil && len(*s.ApplicationName) < 1 {
+		invalidParams.Add(request.NewErrParamMinLen("ApplicationName", 1))
+	}
+	if s.EnvironmentName != nil && len(*s.EnvironmentName) < 4 {
+		invalidParams.Add(request.NewErrParamMinLen("EnvironmentName", 4))
+	}
+	if s.OptionSettings == nil {
+		invalidParams.Add(request.NewErrParamRequired("OptionSettings"))
+	}
+	if s.TemplateName != nil && len(*s.TemplateName) < 1 {
+		invalidParams.Add(request.NewErrParamMinLen("TemplateName", 1))
+	}
+	if s.OptionSettings != nil {
+		for i, v := range s.OptionSettings {
+			if v == nil {
+				continue
+			}
+			if err := v.Validate(); err != nil {
+				invalidParams.AddNested(fmt.Sprintf("%s[%v]", "OptionSettings", i), err.(request.ErrInvalidParams))
+			}
+		}
+	}
+
+	if invalidParams.Len() > 0 {
+		return invalidParams
+	}
+	return nil
 }
 
 // Provides a list of validation messages.

--- a/service/elasticsearchservice/api.go
+++ b/service/elasticsearchservice/api.go
@@ -4,6 +4,7 @@
 package elasticsearchservice
 
 import (
+	"fmt"
 	"time"
 
 	"github.com/aws/aws-sdk-go/aws/awsutil"
@@ -346,6 +347,32 @@ func (s AddTagsInput) GoString() string {
 	return s.String()
 }
 
+// Validate inspects the fields of the type to determine if they are valid.
+func (s *AddTagsInput) Validate() error {
+	invalidParams := request.ErrInvalidParams{Context: "AddTagsInput"}
+	if s.ARN == nil {
+		invalidParams.Add(request.NewErrParamRequired("ARN"))
+	}
+	if s.TagList == nil {
+		invalidParams.Add(request.NewErrParamRequired("TagList"))
+	}
+	if s.TagList != nil {
+		for i, v := range s.TagList {
+			if v == nil {
+				continue
+			}
+			if err := v.Validate(); err != nil {
+				invalidParams.AddNested(fmt.Sprintf("%s[%v]", "TagList", i), err.(request.ErrInvalidParams))
+			}
+		}
+	}
+
+	if invalidParams.Len() > 0 {
+		return invalidParams
+	}
+	return nil
+}
+
 type AddTagsOutput struct {
 	_ struct{} `type:"structure"`
 }
@@ -431,6 +458,22 @@ func (s CreateElasticsearchDomainInput) GoString() string {
 	return s.String()
 }
 
+// Validate inspects the fields of the type to determine if they are valid.
+func (s *CreateElasticsearchDomainInput) Validate() error {
+	invalidParams := request.ErrInvalidParams{Context: "CreateElasticsearchDomainInput"}
+	if s.DomainName == nil {
+		invalidParams.Add(request.NewErrParamRequired("DomainName"))
+	}
+	if s.DomainName != nil && len(*s.DomainName) < 3 {
+		invalidParams.Add(request.NewErrParamMinLen("DomainName", 3))
+	}
+
+	if invalidParams.Len() > 0 {
+		return invalidParams
+	}
+	return nil
+}
+
 // The result of a CreateElasticsearchDomain operation. Contains the status
 // of the newly created Elasticsearch domain.
 type CreateElasticsearchDomainOutput struct {
@@ -467,6 +510,22 @@ func (s DeleteElasticsearchDomainInput) String() string {
 // GoString returns the string representation
 func (s DeleteElasticsearchDomainInput) GoString() string {
 	return s.String()
+}
+
+// Validate inspects the fields of the type to determine if they are valid.
+func (s *DeleteElasticsearchDomainInput) Validate() error {
+	invalidParams := request.ErrInvalidParams{Context: "DeleteElasticsearchDomainInput"}
+	if s.DomainName == nil {
+		invalidParams.Add(request.NewErrParamRequired("DomainName"))
+	}
+	if s.DomainName != nil && len(*s.DomainName) < 3 {
+		invalidParams.Add(request.NewErrParamMinLen("DomainName", 3))
+	}
+
+	if invalidParams.Len() > 0 {
+		return invalidParams
+	}
+	return nil
 }
 
 // The result of a DeleteElasticsearchDomain request. Contains the status of
@@ -508,6 +567,22 @@ func (s DescribeElasticsearchDomainConfigInput) GoString() string {
 	return s.String()
 }
 
+// Validate inspects the fields of the type to determine if they are valid.
+func (s *DescribeElasticsearchDomainConfigInput) Validate() error {
+	invalidParams := request.ErrInvalidParams{Context: "DescribeElasticsearchDomainConfigInput"}
+	if s.DomainName == nil {
+		invalidParams.Add(request.NewErrParamRequired("DomainName"))
+	}
+	if s.DomainName != nil && len(*s.DomainName) < 3 {
+		invalidParams.Add(request.NewErrParamMinLen("DomainName", 3))
+	}
+
+	if invalidParams.Len() > 0 {
+		return invalidParams
+	}
+	return nil
+}
+
 // The result of a DescribeElasticsearchDomainConfig request. Contains the configuration
 // information of the requested domain.
 type DescribeElasticsearchDomainConfigOutput struct {
@@ -546,6 +621,22 @@ func (s DescribeElasticsearchDomainInput) GoString() string {
 	return s.String()
 }
 
+// Validate inspects the fields of the type to determine if they are valid.
+func (s *DescribeElasticsearchDomainInput) Validate() error {
+	invalidParams := request.ErrInvalidParams{Context: "DescribeElasticsearchDomainInput"}
+	if s.DomainName == nil {
+		invalidParams.Add(request.NewErrParamRequired("DomainName"))
+	}
+	if s.DomainName != nil && len(*s.DomainName) < 3 {
+		invalidParams.Add(request.NewErrParamMinLen("DomainName", 3))
+	}
+
+	if invalidParams.Len() > 0 {
+		return invalidParams
+	}
+	return nil
+}
+
 // The result of a DescribeElasticsearchDomain request. Contains the status
 // of the domain specified in the request.
 type DescribeElasticsearchDomainOutput struct {
@@ -582,6 +673,19 @@ func (s DescribeElasticsearchDomainsInput) String() string {
 // GoString returns the string representation
 func (s DescribeElasticsearchDomainsInput) GoString() string {
 	return s.String()
+}
+
+// Validate inspects the fields of the type to determine if they are valid.
+func (s *DescribeElasticsearchDomainsInput) Validate() error {
+	invalidParams := request.ErrInvalidParams{Context: "DescribeElasticsearchDomainsInput"}
+	if s.DomainNames == nil {
+		invalidParams.Add(request.NewErrParamRequired("DomainNames"))
+	}
+
+	if invalidParams.Len() > 0 {
+		return invalidParams
+	}
+	return nil
 }
 
 // The result of a DescribeElasticsearchDomains request. Contains the status
@@ -881,6 +985,19 @@ func (s ListTagsInput) GoString() string {
 	return s.String()
 }
 
+// Validate inspects the fields of the type to determine if they are valid.
+func (s *ListTagsInput) Validate() error {
+	invalidParams := request.ErrInvalidParams{Context: "ListTagsInput"}
+	if s.ARN == nil {
+		invalidParams.Add(request.NewErrParamRequired("ARN"))
+	}
+
+	if invalidParams.Len() > 0 {
+		return invalidParams
+	}
+	return nil
+}
+
 // The result of a ListTags operation. Contains tags for all requested Elasticsearch
 // domains.
 type ListTagsOutput struct {
@@ -953,6 +1070,22 @@ func (s RemoveTagsInput) String() string {
 // GoString returns the string representation
 func (s RemoveTagsInput) GoString() string {
 	return s.String()
+}
+
+// Validate inspects the fields of the type to determine if they are valid.
+func (s *RemoveTagsInput) Validate() error {
+	invalidParams := request.ErrInvalidParams{Context: "RemoveTagsInput"}
+	if s.ARN == nil {
+		invalidParams.Add(request.NewErrParamRequired("ARN"))
+	}
+	if s.TagKeys == nil {
+		invalidParams.Add(request.NewErrParamRequired("TagKeys"))
+	}
+
+	if invalidParams.Len() > 0 {
+		return invalidParams
+	}
+	return nil
 }
 
 type RemoveTagsOutput struct {
@@ -1035,6 +1168,25 @@ func (s Tag) GoString() string {
 	return s.String()
 }
 
+// Validate inspects the fields of the type to determine if they are valid.
+func (s *Tag) Validate() error {
+	invalidParams := request.ErrInvalidParams{Context: "Tag"}
+	if s.Key == nil {
+		invalidParams.Add(request.NewErrParamRequired("Key"))
+	}
+	if s.Key != nil && len(*s.Key) < 1 {
+		invalidParams.Add(request.NewErrParamMinLen("Key", 1))
+	}
+	if s.Value == nil {
+		invalidParams.Add(request.NewErrParamRequired("Value"))
+	}
+
+	if invalidParams.Len() > 0 {
+		return invalidParams
+	}
+	return nil
+}
+
 // Container for the parameters to the UpdateElasticsearchDomain operation.
 // Specifies the type and number of instances in the domain cluster.
 type UpdateElasticsearchDomainConfigInput struct {
@@ -1071,6 +1223,22 @@ func (s UpdateElasticsearchDomainConfigInput) String() string {
 // GoString returns the string representation
 func (s UpdateElasticsearchDomainConfigInput) GoString() string {
 	return s.String()
+}
+
+// Validate inspects the fields of the type to determine if they are valid.
+func (s *UpdateElasticsearchDomainConfigInput) Validate() error {
+	invalidParams := request.ErrInvalidParams{Context: "UpdateElasticsearchDomainConfigInput"}
+	if s.DomainName == nil {
+		invalidParams.Add(request.NewErrParamRequired("DomainName"))
+	}
+	if s.DomainName != nil && len(*s.DomainName) < 3 {
+		invalidParams.Add(request.NewErrParamMinLen("DomainName", 3))
+	}
+
+	if invalidParams.Len() > 0 {
+		return invalidParams
+	}
+	return nil
 }
 
 // The result of an UpdateElasticsearchDomain request. Contains the status of

--- a/service/elastictranscoder/api.go
+++ b/service/elastictranscoder/api.go
@@ -4,6 +4,8 @@
 package elastictranscoder
 
 import (
+	"fmt"
+
 	"github.com/aws/aws-sdk-go/aws/awsutil"
 	"github.com/aws/aws-sdk-go/aws/request"
 )
@@ -661,6 +663,19 @@ func (s Artwork) GoString() string {
 	return s.String()
 }
 
+// Validate inspects the fields of the type to determine if they are valid.
+func (s *Artwork) Validate() error {
+	invalidParams := request.ErrInvalidParams{Context: "Artwork"}
+	if s.InputKey != nil && len(*s.InputKey) < 1 {
+		invalidParams.Add(request.NewErrParamMinLen("InputKey", 1))
+	}
+
+	if invalidParams.Len() > 0 {
+		return invalidParams
+	}
+	return nil
+}
+
 // Options associated with your audio codec.
 type AudioCodecOptions struct {
 	_ struct{} `type:"structure"`
@@ -872,6 +887,19 @@ func (s CancelJobInput) GoString() string {
 	return s.String()
 }
 
+// Validate inspects the fields of the type to determine if they are valid.
+func (s *CancelJobInput) Validate() error {
+	invalidParams := request.ErrInvalidParams{Context: "CancelJobInput"}
+	if s.Id == nil {
+		invalidParams.Add(request.NewErrParamRequired("Id"))
+	}
+
+	if invalidParams.Len() > 0 {
+		return invalidParams
+	}
+	return nil
+}
+
 // The response body contains a JSON object. If the job is successfully canceled,
 // the value of Success is true.
 type CancelJobOutput struct {
@@ -997,6 +1025,25 @@ func (s CaptionSource) GoString() string {
 	return s.String()
 }
 
+// Validate inspects the fields of the type to determine if they are valid.
+func (s *CaptionSource) Validate() error {
+	invalidParams := request.ErrInvalidParams{Context: "CaptionSource"}
+	if s.Key != nil && len(*s.Key) < 1 {
+		invalidParams.Add(request.NewErrParamMinLen("Key", 1))
+	}
+	if s.Label != nil && len(*s.Label) < 1 {
+		invalidParams.Add(request.NewErrParamMinLen("Label", 1))
+	}
+	if s.Language != nil && len(*s.Language) < 1 {
+		invalidParams.Add(request.NewErrParamMinLen("Language", 1))
+	}
+
+	if invalidParams.Len() > 0 {
+		return invalidParams
+	}
+	return nil
+}
+
 // The captions to be created, if any.
 type Captions struct {
 	_ struct{} `type:"structure"`
@@ -1038,6 +1085,26 @@ func (s Captions) String() string {
 // GoString returns the string representation
 func (s Captions) GoString() string {
 	return s.String()
+}
+
+// Validate inspects the fields of the type to determine if they are valid.
+func (s *Captions) Validate() error {
+	invalidParams := request.ErrInvalidParams{Context: "Captions"}
+	if s.CaptionSources != nil {
+		for i, v := range s.CaptionSources {
+			if v == nil {
+				continue
+			}
+			if err := v.Validate(); err != nil {
+				invalidParams.AddNested(fmt.Sprintf("%s[%v]", "CaptionSources", i), err.(request.ErrInvalidParams))
+			}
+		}
+	}
+
+	if invalidParams.Len() > 0 {
+		return invalidParams
+	}
+	return nil
 }
 
 // Settings for one clip in a composition. All jobs in a playlist must have
@@ -1108,6 +1175,55 @@ func (s CreateJobInput) String() string {
 // GoString returns the string representation
 func (s CreateJobInput) GoString() string {
 	return s.String()
+}
+
+// Validate inspects the fields of the type to determine if they are valid.
+func (s *CreateJobInput) Validate() error {
+	invalidParams := request.ErrInvalidParams{Context: "CreateJobInput"}
+	if s.Input == nil {
+		invalidParams.Add(request.NewErrParamRequired("Input"))
+	}
+	if s.OutputKeyPrefix != nil && len(*s.OutputKeyPrefix) < 1 {
+		invalidParams.Add(request.NewErrParamMinLen("OutputKeyPrefix", 1))
+	}
+	if s.PipelineId == nil {
+		invalidParams.Add(request.NewErrParamRequired("PipelineId"))
+	}
+	if s.Input != nil {
+		if err := s.Input.Validate(); err != nil {
+			invalidParams.AddNested("Input", err.(request.ErrInvalidParams))
+		}
+	}
+	if s.Output != nil {
+		if err := s.Output.Validate(); err != nil {
+			invalidParams.AddNested("Output", err.(request.ErrInvalidParams))
+		}
+	}
+	if s.Outputs != nil {
+		for i, v := range s.Outputs {
+			if v == nil {
+				continue
+			}
+			if err := v.Validate(); err != nil {
+				invalidParams.AddNested(fmt.Sprintf("%s[%v]", "Outputs", i), err.(request.ErrInvalidParams))
+			}
+		}
+	}
+	if s.Playlists != nil {
+		for i, v := range s.Playlists {
+			if v == nil {
+				continue
+			}
+			if err := v.Validate(); err != nil {
+				invalidParams.AddNested(fmt.Sprintf("%s[%v]", "Playlists", i), err.(request.ErrInvalidParams))
+			}
+		}
+	}
+
+	if invalidParams.Len() > 0 {
+		return invalidParams
+	}
+	return nil
 }
 
 // The CreateJobOutput structure.
@@ -1263,6 +1379,39 @@ func (s CreateJobOutput) GoString() string {
 	return s.String()
 }
 
+// Validate inspects the fields of the type to determine if they are valid.
+func (s *CreateJobOutput) Validate() error {
+	invalidParams := request.ErrInvalidParams{Context: "CreateJobOutput"}
+	if s.Key != nil && len(*s.Key) < 1 {
+		invalidParams.Add(request.NewErrParamMinLen("Key", 1))
+	}
+	if s.AlbumArt != nil {
+		if err := s.AlbumArt.Validate(); err != nil {
+			invalidParams.AddNested("AlbumArt", err.(request.ErrInvalidParams))
+		}
+	}
+	if s.Captions != nil {
+		if err := s.Captions.Validate(); err != nil {
+			invalidParams.AddNested("Captions", err.(request.ErrInvalidParams))
+		}
+	}
+	if s.Watermarks != nil {
+		for i, v := range s.Watermarks {
+			if v == nil {
+				continue
+			}
+			if err := v.Validate(); err != nil {
+				invalidParams.AddNested(fmt.Sprintf("%s[%v]", "Watermarks", i), err.(request.ErrInvalidParams))
+			}
+		}
+	}
+
+	if invalidParams.Len() > 0 {
+		return invalidParams
+	}
+	return nil
+}
+
 // Information about the master playlist.
 type CreateJobPlaylist struct {
 	_ struct{} `type:"structure"`
@@ -1339,6 +1488,24 @@ func (s CreateJobPlaylist) String() string {
 // GoString returns the string representation
 func (s CreateJobPlaylist) GoString() string {
 	return s.String()
+}
+
+// Validate inspects the fields of the type to determine if they are valid.
+func (s *CreateJobPlaylist) Validate() error {
+	invalidParams := request.ErrInvalidParams{Context: "CreateJobPlaylist"}
+	if s.Name != nil && len(*s.Name) < 1 {
+		invalidParams.Add(request.NewErrParamMinLen("Name", 1))
+	}
+	if s.PlayReadyDrm != nil {
+		if err := s.PlayReadyDrm.Validate(); err != nil {
+			invalidParams.AddNested("PlayReadyDrm", err.(request.ErrInvalidParams))
+		}
+	}
+
+	if invalidParams.Len() > 0 {
+		return invalidParams
+	}
+	return nil
 }
 
 // The CreateJobResponse structure.
@@ -1526,6 +1693,38 @@ func (s CreatePipelineInput) GoString() string {
 	return s.String()
 }
 
+// Validate inspects the fields of the type to determine if they are valid.
+func (s *CreatePipelineInput) Validate() error {
+	invalidParams := request.ErrInvalidParams{Context: "CreatePipelineInput"}
+	if s.InputBucket == nil {
+		invalidParams.Add(request.NewErrParamRequired("InputBucket"))
+	}
+	if s.Name == nil {
+		invalidParams.Add(request.NewErrParamRequired("Name"))
+	}
+	if s.Name != nil && len(*s.Name) < 1 {
+		invalidParams.Add(request.NewErrParamMinLen("Name", 1))
+	}
+	if s.Role == nil {
+		invalidParams.Add(request.NewErrParamRequired("Role"))
+	}
+	if s.ContentConfig != nil {
+		if err := s.ContentConfig.Validate(); err != nil {
+			invalidParams.AddNested("ContentConfig", err.(request.ErrInvalidParams))
+		}
+	}
+	if s.ThumbnailConfig != nil {
+		if err := s.ThumbnailConfig.Validate(); err != nil {
+			invalidParams.AddNested("ThumbnailConfig", err.(request.ErrInvalidParams))
+		}
+	}
+
+	if invalidParams.Len() > 0 {
+		return invalidParams
+	}
+	return nil
+}
+
 // When you create a pipeline, Elastic Transcoder returns the values that you
 // specified in the request.
 type CreatePipelineOutput struct {
@@ -1590,6 +1789,30 @@ func (s CreatePresetInput) GoString() string {
 	return s.String()
 }
 
+// Validate inspects the fields of the type to determine if they are valid.
+func (s *CreatePresetInput) Validate() error {
+	invalidParams := request.ErrInvalidParams{Context: "CreatePresetInput"}
+	if s.Container == nil {
+		invalidParams.Add(request.NewErrParamRequired("Container"))
+	}
+	if s.Name == nil {
+		invalidParams.Add(request.NewErrParamRequired("Name"))
+	}
+	if s.Name != nil && len(*s.Name) < 1 {
+		invalidParams.Add(request.NewErrParamMinLen("Name", 1))
+	}
+	if s.Video != nil {
+		if err := s.Video.Validate(); err != nil {
+			invalidParams.AddNested("Video", err.(request.ErrInvalidParams))
+		}
+	}
+
+	if invalidParams.Len() > 0 {
+		return invalidParams
+	}
+	return nil
+}
+
 // The CreatePresetResponse structure.
 type CreatePresetOutput struct {
 	_ struct{} `type:"structure"`
@@ -1633,6 +1856,19 @@ func (s DeletePipelineInput) GoString() string {
 	return s.String()
 }
 
+// Validate inspects the fields of the type to determine if they are valid.
+func (s *DeletePipelineInput) Validate() error {
+	invalidParams := request.ErrInvalidParams{Context: "DeletePipelineInput"}
+	if s.Id == nil {
+		invalidParams.Add(request.NewErrParamRequired("Id"))
+	}
+
+	if invalidParams.Len() > 0 {
+		return invalidParams
+	}
+	return nil
+}
+
 // The DeletePipelineResponse structure.
 type DeletePipelineOutput struct {
 	_ struct{} `type:"structure"`
@@ -1664,6 +1900,19 @@ func (s DeletePresetInput) String() string {
 // GoString returns the string representation
 func (s DeletePresetInput) GoString() string {
 	return s.String()
+}
+
+// Validate inspects the fields of the type to determine if they are valid.
+func (s *DeletePresetInput) Validate() error {
+	invalidParams := request.ErrInvalidParams{Context: "DeletePresetInput"}
+	if s.Id == nil {
+		invalidParams.Add(request.NewErrParamRequired("Id"))
+	}
+
+	if invalidParams.Len() > 0 {
+		return invalidParams
+	}
+	return nil
 }
 
 // The DeletePresetResponse structure.
@@ -1969,6 +2218,26 @@ func (s JobAlbumArt) GoString() string {
 	return s.String()
 }
 
+// Validate inspects the fields of the type to determine if they are valid.
+func (s *JobAlbumArt) Validate() error {
+	invalidParams := request.ErrInvalidParams{Context: "JobAlbumArt"}
+	if s.Artwork != nil {
+		for i, v := range s.Artwork {
+			if v == nil {
+				continue
+			}
+			if err := v.Validate(); err != nil {
+				invalidParams.AddNested(fmt.Sprintf("%s[%v]", "Artwork", i), err.(request.ErrInvalidParams))
+			}
+		}
+	}
+
+	if invalidParams.Len() > 0 {
+		return invalidParams
+	}
+	return nil
+}
+
 // Information about the file that you're transcoding.
 type JobInput struct {
 	_ struct{} `type:"structure"`
@@ -2044,6 +2313,19 @@ func (s JobInput) String() string {
 // GoString returns the string representation
 func (s JobInput) GoString() string {
 	return s.String()
+}
+
+// Validate inspects the fields of the type to determine if they are valid.
+func (s *JobInput) Validate() error {
+	invalidParams := request.ErrInvalidParams{Context: "JobInput"}
+	if s.Key != nil && len(*s.Key) < 1 {
+		invalidParams.Add(request.NewErrParamMinLen("Key", 1))
+	}
+
+	if invalidParams.Len() > 0 {
+		return invalidParams
+	}
+	return nil
 }
 
 // Outputs recommended instead.If you specified one output for a job, information
@@ -2297,6 +2579,22 @@ func (s JobWatermark) GoString() string {
 	return s.String()
 }
 
+// Validate inspects the fields of the type to determine if they are valid.
+func (s *JobWatermark) Validate() error {
+	invalidParams := request.ErrInvalidParams{Context: "JobWatermark"}
+	if s.InputKey != nil && len(*s.InputKey) < 1 {
+		invalidParams.Add(request.NewErrParamMinLen("InputKey", 1))
+	}
+	if s.PresetWatermarkId != nil && len(*s.PresetWatermarkId) < 1 {
+		invalidParams.Add(request.NewErrParamMinLen("PresetWatermarkId", 1))
+	}
+
+	if invalidParams.Len() > 0 {
+		return invalidParams
+	}
+	return nil
+}
+
 // The ListJobsByPipelineRequest structure.
 type ListJobsByPipelineInput struct {
 	_ struct{} `type:"structure"`
@@ -2321,6 +2619,19 @@ func (s ListJobsByPipelineInput) String() string {
 // GoString returns the string representation
 func (s ListJobsByPipelineInput) GoString() string {
 	return s.String()
+}
+
+// Validate inspects the fields of the type to determine if they are valid.
+func (s *ListJobsByPipelineInput) Validate() error {
+	invalidParams := request.ErrInvalidParams{Context: "ListJobsByPipelineInput"}
+	if s.PipelineId == nil {
+		invalidParams.Add(request.NewErrParamRequired("PipelineId"))
+	}
+
+	if invalidParams.Len() > 0 {
+		return invalidParams
+	}
+	return nil
 }
 
 // The ListJobsByPipelineResponse structure.
@@ -2372,6 +2683,19 @@ func (s ListJobsByStatusInput) String() string {
 // GoString returns the string representation
 func (s ListJobsByStatusInput) GoString() string {
 	return s.String()
+}
+
+// Validate inspects the fields of the type to determine if they are valid.
+func (s *ListJobsByStatusInput) Validate() error {
+	invalidParams := request.ErrInvalidParams{Context: "ListJobsByStatusInput"}
+	if s.Status == nil {
+		invalidParams.Add(request.NewErrParamRequired("Status"))
+	}
+
+	if invalidParams.Len() > 0 {
+		return invalidParams
+	}
+	return nil
 }
 
 // The ListJobsByStatusResponse structure.
@@ -2566,6 +2890,19 @@ func (s Permission) GoString() string {
 	return s.String()
 }
 
+// Validate inspects the fields of the type to determine if they are valid.
+func (s *Permission) Validate() error {
+	invalidParams := request.ErrInvalidParams{Context: "Permission"}
+	if s.Grantee != nil && len(*s.Grantee) < 1 {
+		invalidParams.Add(request.NewErrParamMinLen("Grantee", 1))
+	}
+
+	if invalidParams.Len() > 0 {
+		return invalidParams
+	}
+	return nil
+}
+
 // The pipeline (queue) that is used to manage jobs.
 type Pipeline struct {
 	_ struct{} `type:"structure"`
@@ -2741,6 +3078,26 @@ func (s PipelineOutputConfig) GoString() string {
 	return s.String()
 }
 
+// Validate inspects the fields of the type to determine if they are valid.
+func (s *PipelineOutputConfig) Validate() error {
+	invalidParams := request.ErrInvalidParams{Context: "PipelineOutputConfig"}
+	if s.Permissions != nil {
+		for i, v := range s.Permissions {
+			if v == nil {
+				continue
+			}
+			if err := v.Validate(); err != nil {
+				invalidParams.AddNested(fmt.Sprintf("%s[%v]", "Permissions", i), err.(request.ErrInvalidParams))
+			}
+		}
+	}
+
+	if invalidParams.Len() > 0 {
+		return invalidParams
+	}
+	return nil
+}
+
 // The PlayReady DRM settings, if any, that you want Elastic Transcoder to apply
 // to the output files associated with this playlist.
 //
@@ -2801,6 +3158,19 @@ func (s PlayReadyDrm) String() string {
 // GoString returns the string representation
 func (s PlayReadyDrm) GoString() string {
 	return s.String()
+}
+
+// Validate inspects the fields of the type to determine if they are valid.
+func (s *PlayReadyDrm) Validate() error {
+	invalidParams := request.ErrInvalidParams{Context: "PlayReadyDrm"}
+	if s.LicenseAcquisitionUrl != nil && len(*s.LicenseAcquisitionUrl) < 1 {
+		invalidParams.Add(request.NewErrParamMinLen("LicenseAcquisitionUrl", 1))
+	}
+
+	if invalidParams.Len() > 0 {
+		return invalidParams
+	}
+	return nil
 }
 
 // Use Only for Fragmented MP4 or MPEG-TS Outputs. If you specify a preset for
@@ -3083,6 +3453,19 @@ func (s PresetWatermark) GoString() string {
 	return s.String()
 }
 
+// Validate inspects the fields of the type to determine if they are valid.
+func (s *PresetWatermark) Validate() error {
+	invalidParams := request.ErrInvalidParams{Context: "PresetWatermark"}
+	if s.Id != nil && len(*s.Id) < 1 {
+		invalidParams.Add(request.NewErrParamMinLen("Id", 1))
+	}
+
+	if invalidParams.Len() > 0 {
+		return invalidParams
+	}
+	return nil
+}
+
 // The ReadJobRequest structure.
 type ReadJobInput struct {
 	_ struct{} `type:"structure"`
@@ -3099,6 +3482,19 @@ func (s ReadJobInput) String() string {
 // GoString returns the string representation
 func (s ReadJobInput) GoString() string {
 	return s.String()
+}
+
+// Validate inspects the fields of the type to determine if they are valid.
+func (s *ReadJobInput) Validate() error {
+	invalidParams := request.ErrInvalidParams{Context: "ReadJobInput"}
+	if s.Id == nil {
+		invalidParams.Add(request.NewErrParamRequired("Id"))
+	}
+
+	if invalidParams.Len() > 0 {
+		return invalidParams
+	}
+	return nil
 }
 
 // The ReadJobResponse structure.
@@ -3135,6 +3531,19 @@ func (s ReadPipelineInput) String() string {
 // GoString returns the string representation
 func (s ReadPipelineInput) GoString() string {
 	return s.String()
+}
+
+// Validate inspects the fields of the type to determine if they are valid.
+func (s *ReadPipelineInput) Validate() error {
+	invalidParams := request.ErrInvalidParams{Context: "ReadPipelineInput"}
+	if s.Id == nil {
+		invalidParams.Add(request.NewErrParamRequired("Id"))
+	}
+
+	if invalidParams.Len() > 0 {
+		return invalidParams
+	}
+	return nil
 }
 
 // The ReadPipelineResponse structure.
@@ -3179,6 +3588,19 @@ func (s ReadPresetInput) String() string {
 // GoString returns the string representation
 func (s ReadPresetInput) GoString() string {
 	return s.String()
+}
+
+// Validate inspects the fields of the type to determine if they are valid.
+func (s *ReadPresetInput) Validate() error {
+	invalidParams := request.ErrInvalidParams{Context: "ReadPresetInput"}
+	if s.Id == nil {
+		invalidParams.Add(request.NewErrParamRequired("Id"))
+	}
+
+	if invalidParams.Len() > 0 {
+		return invalidParams
+	}
+	return nil
 }
 
 // The ReadPresetResponse structure.
@@ -3228,6 +3650,28 @@ func (s TestRoleInput) String() string {
 // GoString returns the string representation
 func (s TestRoleInput) GoString() string {
 	return s.String()
+}
+
+// Validate inspects the fields of the type to determine if they are valid.
+func (s *TestRoleInput) Validate() error {
+	invalidParams := request.ErrInvalidParams{Context: "TestRoleInput"}
+	if s.InputBucket == nil {
+		invalidParams.Add(request.NewErrParamRequired("InputBucket"))
+	}
+	if s.OutputBucket == nil {
+		invalidParams.Add(request.NewErrParamRequired("OutputBucket"))
+	}
+	if s.Role == nil {
+		invalidParams.Add(request.NewErrParamRequired("Role"))
+	}
+	if s.Topics == nil {
+		invalidParams.Add(request.NewErrParamRequired("Topics"))
+	}
+
+	if invalidParams.Len() > 0 {
+		return invalidParams
+	}
+	return nil
 }
 
 // The TestRoleResponse structure.
@@ -3532,6 +3976,32 @@ func (s UpdatePipelineInput) GoString() string {
 	return s.String()
 }
 
+// Validate inspects the fields of the type to determine if they are valid.
+func (s *UpdatePipelineInput) Validate() error {
+	invalidParams := request.ErrInvalidParams{Context: "UpdatePipelineInput"}
+	if s.Id == nil {
+		invalidParams.Add(request.NewErrParamRequired("Id"))
+	}
+	if s.Name != nil && len(*s.Name) < 1 {
+		invalidParams.Add(request.NewErrParamMinLen("Name", 1))
+	}
+	if s.ContentConfig != nil {
+		if err := s.ContentConfig.Validate(); err != nil {
+			invalidParams.AddNested("ContentConfig", err.(request.ErrInvalidParams))
+		}
+	}
+	if s.ThumbnailConfig != nil {
+		if err := s.ThumbnailConfig.Validate(); err != nil {
+			invalidParams.AddNested("ThumbnailConfig", err.(request.ErrInvalidParams))
+		}
+	}
+
+	if invalidParams.Len() > 0 {
+		return invalidParams
+	}
+	return nil
+}
+
 // The UpdatePipelineNotificationsRequest structure.
 type UpdatePipelineNotificationsInput struct {
 	_ struct{} `type:"structure"`
@@ -3567,6 +4037,22 @@ func (s UpdatePipelineNotificationsInput) String() string {
 // GoString returns the string representation
 func (s UpdatePipelineNotificationsInput) GoString() string {
 	return s.String()
+}
+
+// Validate inspects the fields of the type to determine if they are valid.
+func (s *UpdatePipelineNotificationsInput) Validate() error {
+	invalidParams := request.ErrInvalidParams{Context: "UpdatePipelineNotificationsInput"}
+	if s.Id == nil {
+		invalidParams.Add(request.NewErrParamRequired("Id"))
+	}
+	if s.Notifications == nil {
+		invalidParams.Add(request.NewErrParamRequired("Notifications"))
+	}
+
+	if invalidParams.Len() > 0 {
+		return invalidParams
+	}
+	return nil
 }
 
 // The UpdatePipelineNotificationsResponse structure.
@@ -3636,6 +4122,22 @@ func (s UpdatePipelineStatusInput) String() string {
 // GoString returns the string representation
 func (s UpdatePipelineStatusInput) GoString() string {
 	return s.String()
+}
+
+// Validate inspects the fields of the type to determine if they are valid.
+func (s *UpdatePipelineStatusInput) Validate() error {
+	invalidParams := request.ErrInvalidParams{Context: "UpdatePipelineStatusInput"}
+	if s.Id == nil {
+		invalidParams.Add(request.NewErrParamRequired("Id"))
+	}
+	if s.Status == nil {
+		invalidParams.Add(request.NewErrParamRequired("Status"))
+	}
+
+	if invalidParams.Len() > 0 {
+		return invalidParams
+	}
+	return nil
 }
 
 // When you update status for a pipeline, Elastic Transcoder returns the values
@@ -3965,6 +4467,26 @@ func (s VideoParameters) String() string {
 // GoString returns the string representation
 func (s VideoParameters) GoString() string {
 	return s.String()
+}
+
+// Validate inspects the fields of the type to determine if they are valid.
+func (s *VideoParameters) Validate() error {
+	invalidParams := request.ErrInvalidParams{Context: "VideoParameters"}
+	if s.Watermarks != nil {
+		for i, v := range s.Watermarks {
+			if v == nil {
+				continue
+			}
+			if err := v.Validate(); err != nil {
+				invalidParams.AddNested(fmt.Sprintf("%s[%v]", "Watermarks", i), err.(request.ErrInvalidParams))
+			}
+		}
+	}
+
+	if invalidParams.Len() > 0 {
+		return invalidParams
+	}
+	return nil
 }
 
 // Elastic Transcoder returns a warning if the resources used by your pipeline

--- a/service/elb/api.go
+++ b/service/elb/api.go
@@ -4,6 +4,7 @@
 package elb
 
 import (
+	"fmt"
 	"time"
 
 	"github.com/aws/aws-sdk-go/aws/awsutil"
@@ -999,6 +1000,19 @@ func (s AccessLog) GoString() string {
 	return s.String()
 }
 
+// Validate inspects the fields of the type to determine if they are valid.
+func (s *AccessLog) Validate() error {
+	invalidParams := request.ErrInvalidParams{Context: "AccessLog"}
+	if s.Enabled == nil {
+		invalidParams.Add(request.NewErrParamRequired("Enabled"))
+	}
+
+	if invalidParams.Len() > 0 {
+		return invalidParams
+	}
+	return nil
+}
+
 type AddTagsInput struct {
 	_ struct{} `type:"structure"`
 
@@ -1017,6 +1031,35 @@ func (s AddTagsInput) String() string {
 // GoString returns the string representation
 func (s AddTagsInput) GoString() string {
 	return s.String()
+}
+
+// Validate inspects the fields of the type to determine if they are valid.
+func (s *AddTagsInput) Validate() error {
+	invalidParams := request.ErrInvalidParams{Context: "AddTagsInput"}
+	if s.LoadBalancerNames == nil {
+		invalidParams.Add(request.NewErrParamRequired("LoadBalancerNames"))
+	}
+	if s.Tags == nil {
+		invalidParams.Add(request.NewErrParamRequired("Tags"))
+	}
+	if s.Tags != nil && len(s.Tags) < 1 {
+		invalidParams.Add(request.NewErrParamMinLen("Tags", 1))
+	}
+	if s.Tags != nil {
+		for i, v := range s.Tags {
+			if v == nil {
+				continue
+			}
+			if err := v.Validate(); err != nil {
+				invalidParams.AddNested(fmt.Sprintf("%s[%v]", "Tags", i), err.(request.ErrInvalidParams))
+			}
+		}
+	}
+
+	if invalidParams.Len() > 0 {
+		return invalidParams
+	}
+	return nil
 }
 
 type AddTagsOutput struct {
@@ -1097,6 +1140,22 @@ func (s ApplySecurityGroupsToLoadBalancerInput) GoString() string {
 	return s.String()
 }
 
+// Validate inspects the fields of the type to determine if they are valid.
+func (s *ApplySecurityGroupsToLoadBalancerInput) Validate() error {
+	invalidParams := request.ErrInvalidParams{Context: "ApplySecurityGroupsToLoadBalancerInput"}
+	if s.LoadBalancerName == nil {
+		invalidParams.Add(request.NewErrParamRequired("LoadBalancerName"))
+	}
+	if s.SecurityGroups == nil {
+		invalidParams.Add(request.NewErrParamRequired("SecurityGroups"))
+	}
+
+	if invalidParams.Len() > 0 {
+		return invalidParams
+	}
+	return nil
+}
+
 type ApplySecurityGroupsToLoadBalancerOutput struct {
 	_ struct{} `type:"structure"`
 
@@ -1133,6 +1192,22 @@ func (s AttachLoadBalancerToSubnetsInput) String() string {
 // GoString returns the string representation
 func (s AttachLoadBalancerToSubnetsInput) GoString() string {
 	return s.String()
+}
+
+// Validate inspects the fields of the type to determine if they are valid.
+func (s *AttachLoadBalancerToSubnetsInput) Validate() error {
+	invalidParams := request.ErrInvalidParams{Context: "AttachLoadBalancerToSubnetsInput"}
+	if s.LoadBalancerName == nil {
+		invalidParams.Add(request.NewErrParamRequired("LoadBalancerName"))
+	}
+	if s.Subnets == nil {
+		invalidParams.Add(request.NewErrParamRequired("Subnets"))
+	}
+
+	if invalidParams.Len() > 0 {
+		return invalidParams
+	}
+	return nil
 }
 
 type AttachLoadBalancerToSubnetsOutput struct {
@@ -1193,6 +1268,27 @@ func (s ConfigureHealthCheckInput) GoString() string {
 	return s.String()
 }
 
+// Validate inspects the fields of the type to determine if they are valid.
+func (s *ConfigureHealthCheckInput) Validate() error {
+	invalidParams := request.ErrInvalidParams{Context: "ConfigureHealthCheckInput"}
+	if s.HealthCheck == nil {
+		invalidParams.Add(request.NewErrParamRequired("HealthCheck"))
+	}
+	if s.LoadBalancerName == nil {
+		invalidParams.Add(request.NewErrParamRequired("LoadBalancerName"))
+	}
+	if s.HealthCheck != nil {
+		if err := s.HealthCheck.Validate(); err != nil {
+			invalidParams.AddNested("HealthCheck", err.(request.ErrInvalidParams))
+		}
+	}
+
+	if invalidParams.Len() > 0 {
+		return invalidParams
+	}
+	return nil
+}
+
 type ConfigureHealthCheckOutput struct {
 	_ struct{} `type:"structure"`
 
@@ -1232,6 +1328,19 @@ func (s ConnectionDraining) GoString() string {
 	return s.String()
 }
 
+// Validate inspects the fields of the type to determine if they are valid.
+func (s *ConnectionDraining) Validate() error {
+	invalidParams := request.ErrInvalidParams{Context: "ConnectionDraining"}
+	if s.Enabled == nil {
+		invalidParams.Add(request.NewErrParamRequired("Enabled"))
+	}
+
+	if invalidParams.Len() > 0 {
+		return invalidParams
+	}
+	return nil
+}
+
 // Information about the ConnectionSettings attribute.
 type ConnectionSettings struct {
 	_ struct{} `type:"structure"`
@@ -1249,6 +1358,22 @@ func (s ConnectionSettings) String() string {
 // GoString returns the string representation
 func (s ConnectionSettings) GoString() string {
 	return s.String()
+}
+
+// Validate inspects the fields of the type to determine if they are valid.
+func (s *ConnectionSettings) Validate() error {
+	invalidParams := request.ErrInvalidParams{Context: "ConnectionSettings"}
+	if s.IdleTimeout == nil {
+		invalidParams.Add(request.NewErrParamRequired("IdleTimeout"))
+	}
+	if s.IdleTimeout != nil && *s.IdleTimeout < 1 {
+		invalidParams.Add(request.NewErrParamMinValue("IdleTimeout", 1))
+	}
+
+	if invalidParams.Len() > 0 {
+		return invalidParams
+	}
+	return nil
 }
 
 type CreateAppCookieStickinessPolicyInput struct {
@@ -1274,6 +1399,25 @@ func (s CreateAppCookieStickinessPolicyInput) String() string {
 // GoString returns the string representation
 func (s CreateAppCookieStickinessPolicyInput) GoString() string {
 	return s.String()
+}
+
+// Validate inspects the fields of the type to determine if they are valid.
+func (s *CreateAppCookieStickinessPolicyInput) Validate() error {
+	invalidParams := request.ErrInvalidParams{Context: "CreateAppCookieStickinessPolicyInput"}
+	if s.CookieName == nil {
+		invalidParams.Add(request.NewErrParamRequired("CookieName"))
+	}
+	if s.LoadBalancerName == nil {
+		invalidParams.Add(request.NewErrParamRequired("LoadBalancerName"))
+	}
+	if s.PolicyName == nil {
+		invalidParams.Add(request.NewErrParamRequired("PolicyName"))
+	}
+
+	if invalidParams.Len() > 0 {
+		return invalidParams
+	}
+	return nil
 }
 
 type CreateAppCookieStickinessPolicyOutput struct {
@@ -1315,6 +1459,22 @@ func (s CreateLBCookieStickinessPolicyInput) String() string {
 // GoString returns the string representation
 func (s CreateLBCookieStickinessPolicyInput) GoString() string {
 	return s.String()
+}
+
+// Validate inspects the fields of the type to determine if they are valid.
+func (s *CreateLBCookieStickinessPolicyInput) Validate() error {
+	invalidParams := request.ErrInvalidParams{Context: "CreateLBCookieStickinessPolicyInput"}
+	if s.LoadBalancerName == nil {
+		invalidParams.Add(request.NewErrParamRequired("LoadBalancerName"))
+	}
+	if s.PolicyName == nil {
+		invalidParams.Add(request.NewErrParamRequired("PolicyName"))
+	}
+
+	if invalidParams.Len() > 0 {
+		return invalidParams
+	}
+	return nil
 }
 
 type CreateLBCookieStickinessPolicyOutput struct {
@@ -1392,6 +1552,45 @@ func (s CreateLoadBalancerInput) GoString() string {
 	return s.String()
 }
 
+// Validate inspects the fields of the type to determine if they are valid.
+func (s *CreateLoadBalancerInput) Validate() error {
+	invalidParams := request.ErrInvalidParams{Context: "CreateLoadBalancerInput"}
+	if s.Listeners == nil {
+		invalidParams.Add(request.NewErrParamRequired("Listeners"))
+	}
+	if s.LoadBalancerName == nil {
+		invalidParams.Add(request.NewErrParamRequired("LoadBalancerName"))
+	}
+	if s.Tags != nil && len(s.Tags) < 1 {
+		invalidParams.Add(request.NewErrParamMinLen("Tags", 1))
+	}
+	if s.Listeners != nil {
+		for i, v := range s.Listeners {
+			if v == nil {
+				continue
+			}
+			if err := v.Validate(); err != nil {
+				invalidParams.AddNested(fmt.Sprintf("%s[%v]", "Listeners", i), err.(request.ErrInvalidParams))
+			}
+		}
+	}
+	if s.Tags != nil {
+		for i, v := range s.Tags {
+			if v == nil {
+				continue
+			}
+			if err := v.Validate(); err != nil {
+				invalidParams.AddNested(fmt.Sprintf("%s[%v]", "Tags", i), err.(request.ErrInvalidParams))
+			}
+		}
+	}
+
+	if invalidParams.Len() > 0 {
+		return invalidParams
+	}
+	return nil
+}
+
 type CreateLoadBalancerListenersInput struct {
 	_ struct{} `type:"structure"`
 
@@ -1410,6 +1609,32 @@ func (s CreateLoadBalancerListenersInput) String() string {
 // GoString returns the string representation
 func (s CreateLoadBalancerListenersInput) GoString() string {
 	return s.String()
+}
+
+// Validate inspects the fields of the type to determine if they are valid.
+func (s *CreateLoadBalancerListenersInput) Validate() error {
+	invalidParams := request.ErrInvalidParams{Context: "CreateLoadBalancerListenersInput"}
+	if s.Listeners == nil {
+		invalidParams.Add(request.NewErrParamRequired("Listeners"))
+	}
+	if s.LoadBalancerName == nil {
+		invalidParams.Add(request.NewErrParamRequired("LoadBalancerName"))
+	}
+	if s.Listeners != nil {
+		for i, v := range s.Listeners {
+			if v == nil {
+				continue
+			}
+			if err := v.Validate(); err != nil {
+				invalidParams.AddNested(fmt.Sprintf("%s[%v]", "Listeners", i), err.(request.ErrInvalidParams))
+			}
+		}
+	}
+
+	if invalidParams.Len() > 0 {
+		return invalidParams
+	}
+	return nil
 }
 
 type CreateLoadBalancerListenersOutput struct {
@@ -1470,6 +1695,25 @@ func (s CreateLoadBalancerPolicyInput) GoString() string {
 	return s.String()
 }
 
+// Validate inspects the fields of the type to determine if they are valid.
+func (s *CreateLoadBalancerPolicyInput) Validate() error {
+	invalidParams := request.ErrInvalidParams{Context: "CreateLoadBalancerPolicyInput"}
+	if s.LoadBalancerName == nil {
+		invalidParams.Add(request.NewErrParamRequired("LoadBalancerName"))
+	}
+	if s.PolicyName == nil {
+		invalidParams.Add(request.NewErrParamRequired("PolicyName"))
+	}
+	if s.PolicyTypeName == nil {
+		invalidParams.Add(request.NewErrParamRequired("PolicyTypeName"))
+	}
+
+	if invalidParams.Len() > 0 {
+		return invalidParams
+	}
+	return nil
+}
+
 type CreateLoadBalancerPolicyOutput struct {
 	_ struct{} `type:"structure"`
 }
@@ -1502,6 +1746,19 @@ func (s CrossZoneLoadBalancing) GoString() string {
 	return s.String()
 }
 
+// Validate inspects the fields of the type to determine if they are valid.
+func (s *CrossZoneLoadBalancing) Validate() error {
+	invalidParams := request.ErrInvalidParams{Context: "CrossZoneLoadBalancing"}
+	if s.Enabled == nil {
+		invalidParams.Add(request.NewErrParamRequired("Enabled"))
+	}
+
+	if invalidParams.Len() > 0 {
+		return invalidParams
+	}
+	return nil
+}
+
 type DeleteLoadBalancerInput struct {
 	_ struct{} `type:"structure"`
 
@@ -1517,6 +1774,19 @@ func (s DeleteLoadBalancerInput) String() string {
 // GoString returns the string representation
 func (s DeleteLoadBalancerInput) GoString() string {
 	return s.String()
+}
+
+// Validate inspects the fields of the type to determine if they are valid.
+func (s *DeleteLoadBalancerInput) Validate() error {
+	invalidParams := request.ErrInvalidParams{Context: "DeleteLoadBalancerInput"}
+	if s.LoadBalancerName == nil {
+		invalidParams.Add(request.NewErrParamRequired("LoadBalancerName"))
+	}
+
+	if invalidParams.Len() > 0 {
+		return invalidParams
+	}
+	return nil
 }
 
 type DeleteLoadBalancerListenersInput struct {
@@ -1537,6 +1807,22 @@ func (s DeleteLoadBalancerListenersInput) String() string {
 // GoString returns the string representation
 func (s DeleteLoadBalancerListenersInput) GoString() string {
 	return s.String()
+}
+
+// Validate inspects the fields of the type to determine if they are valid.
+func (s *DeleteLoadBalancerListenersInput) Validate() error {
+	invalidParams := request.ErrInvalidParams{Context: "DeleteLoadBalancerListenersInput"}
+	if s.LoadBalancerName == nil {
+		invalidParams.Add(request.NewErrParamRequired("LoadBalancerName"))
+	}
+	if s.LoadBalancerPorts == nil {
+		invalidParams.Add(request.NewErrParamRequired("LoadBalancerPorts"))
+	}
+
+	if invalidParams.Len() > 0 {
+		return invalidParams
+	}
+	return nil
 }
 
 type DeleteLoadBalancerListenersOutput struct {
@@ -1588,6 +1874,22 @@ func (s DeleteLoadBalancerPolicyInput) GoString() string {
 	return s.String()
 }
 
+// Validate inspects the fields of the type to determine if they are valid.
+func (s *DeleteLoadBalancerPolicyInput) Validate() error {
+	invalidParams := request.ErrInvalidParams{Context: "DeleteLoadBalancerPolicyInput"}
+	if s.LoadBalancerName == nil {
+		invalidParams.Add(request.NewErrParamRequired("LoadBalancerName"))
+	}
+	if s.PolicyName == nil {
+		invalidParams.Add(request.NewErrParamRequired("PolicyName"))
+	}
+
+	if invalidParams.Len() > 0 {
+		return invalidParams
+	}
+	return nil
+}
+
 type DeleteLoadBalancerPolicyOutput struct {
 	_ struct{} `type:"structure"`
 }
@@ -1620,6 +1922,22 @@ func (s DeregisterInstancesFromLoadBalancerInput) String() string {
 // GoString returns the string representation
 func (s DeregisterInstancesFromLoadBalancerInput) GoString() string {
 	return s.String()
+}
+
+// Validate inspects the fields of the type to determine if they are valid.
+func (s *DeregisterInstancesFromLoadBalancerInput) Validate() error {
+	invalidParams := request.ErrInvalidParams{Context: "DeregisterInstancesFromLoadBalancerInput"}
+	if s.Instances == nil {
+		invalidParams.Add(request.NewErrParamRequired("Instances"))
+	}
+	if s.LoadBalancerName == nil {
+		invalidParams.Add(request.NewErrParamRequired("LoadBalancerName"))
+	}
+
+	if invalidParams.Len() > 0 {
+		return invalidParams
+	}
+	return nil
 }
 
 type DeregisterInstancesFromLoadBalancerOutput struct {
@@ -1659,6 +1977,19 @@ func (s DescribeInstanceHealthInput) GoString() string {
 	return s.String()
 }
 
+// Validate inspects the fields of the type to determine if they are valid.
+func (s *DescribeInstanceHealthInput) Validate() error {
+	invalidParams := request.ErrInvalidParams{Context: "DescribeInstanceHealthInput"}
+	if s.LoadBalancerName == nil {
+		invalidParams.Add(request.NewErrParamRequired("LoadBalancerName"))
+	}
+
+	if invalidParams.Len() > 0 {
+		return invalidParams
+	}
+	return nil
+}
+
 type DescribeInstanceHealthOutput struct {
 	_ struct{} `type:"structure"`
 
@@ -1691,6 +2022,19 @@ func (s DescribeLoadBalancerAttributesInput) String() string {
 // GoString returns the string representation
 func (s DescribeLoadBalancerAttributesInput) GoString() string {
 	return s.String()
+}
+
+// Validate inspects the fields of the type to determine if they are valid.
+func (s *DescribeLoadBalancerAttributesInput) Validate() error {
+	invalidParams := request.ErrInvalidParams{Context: "DescribeLoadBalancerAttributesInput"}
+	if s.LoadBalancerName == nil {
+		invalidParams.Add(request.NewErrParamRequired("LoadBalancerName"))
+	}
+
+	if invalidParams.Len() > 0 {
+		return invalidParams
+	}
+	return nil
 }
 
 type DescribeLoadBalancerAttributesOutput struct {
@@ -1807,6 +2151,19 @@ func (s DescribeLoadBalancersInput) GoString() string {
 	return s.String()
 }
 
+// Validate inspects the fields of the type to determine if they are valid.
+func (s *DescribeLoadBalancersInput) Validate() error {
+	invalidParams := request.ErrInvalidParams{Context: "DescribeLoadBalancersInput"}
+	if s.PageSize != nil && *s.PageSize < 1 {
+		invalidParams.Add(request.NewErrParamMinValue("PageSize", 1))
+	}
+
+	if invalidParams.Len() > 0 {
+		return invalidParams
+	}
+	return nil
+}
+
 type DescribeLoadBalancersOutput struct {
 	_ struct{} `type:"structure"`
 
@@ -1843,6 +2200,22 @@ func (s DescribeTagsInput) String() string {
 // GoString returns the string representation
 func (s DescribeTagsInput) GoString() string {
 	return s.String()
+}
+
+// Validate inspects the fields of the type to determine if they are valid.
+func (s *DescribeTagsInput) Validate() error {
+	invalidParams := request.ErrInvalidParams{Context: "DescribeTagsInput"}
+	if s.LoadBalancerNames == nil {
+		invalidParams.Add(request.NewErrParamRequired("LoadBalancerNames"))
+	}
+	if s.LoadBalancerNames != nil && len(s.LoadBalancerNames) < 1 {
+		invalidParams.Add(request.NewErrParamMinLen("LoadBalancerNames", 1))
+	}
+
+	if invalidParams.Len() > 0 {
+		return invalidParams
+	}
+	return nil
 }
 
 type DescribeTagsOutput struct {
@@ -1882,6 +2255,22 @@ func (s DetachLoadBalancerFromSubnetsInput) GoString() string {
 	return s.String()
 }
 
+// Validate inspects the fields of the type to determine if they are valid.
+func (s *DetachLoadBalancerFromSubnetsInput) Validate() error {
+	invalidParams := request.ErrInvalidParams{Context: "DetachLoadBalancerFromSubnetsInput"}
+	if s.LoadBalancerName == nil {
+		invalidParams.Add(request.NewErrParamRequired("LoadBalancerName"))
+	}
+	if s.Subnets == nil {
+		invalidParams.Add(request.NewErrParamRequired("Subnets"))
+	}
+
+	if invalidParams.Len() > 0 {
+		return invalidParams
+	}
+	return nil
+}
+
 type DetachLoadBalancerFromSubnetsOutput struct {
 	_ struct{} `type:"structure"`
 
@@ -1919,6 +2308,22 @@ func (s DisableAvailabilityZonesForLoadBalancerInput) GoString() string {
 	return s.String()
 }
 
+// Validate inspects the fields of the type to determine if they are valid.
+func (s *DisableAvailabilityZonesForLoadBalancerInput) Validate() error {
+	invalidParams := request.ErrInvalidParams{Context: "DisableAvailabilityZonesForLoadBalancerInput"}
+	if s.AvailabilityZones == nil {
+		invalidParams.Add(request.NewErrParamRequired("AvailabilityZones"))
+	}
+	if s.LoadBalancerName == nil {
+		invalidParams.Add(request.NewErrParamRequired("LoadBalancerName"))
+	}
+
+	if invalidParams.Len() > 0 {
+		return invalidParams
+	}
+	return nil
+}
+
 type DisableAvailabilityZonesForLoadBalancerOutput struct {
 	_ struct{} `type:"structure"`
 
@@ -1954,6 +2359,22 @@ func (s EnableAvailabilityZonesForLoadBalancerInput) String() string {
 // GoString returns the string representation
 func (s EnableAvailabilityZonesForLoadBalancerInput) GoString() string {
 	return s.String()
+}
+
+// Validate inspects the fields of the type to determine if they are valid.
+func (s *EnableAvailabilityZonesForLoadBalancerInput) Validate() error {
+	invalidParams := request.ErrInvalidParams{Context: "EnableAvailabilityZonesForLoadBalancerInput"}
+	if s.AvailabilityZones == nil {
+		invalidParams.Add(request.NewErrParamRequired("AvailabilityZones"))
+	}
+	if s.LoadBalancerName == nil {
+		invalidParams.Add(request.NewErrParamRequired("LoadBalancerName"))
+	}
+
+	if invalidParams.Len() > 0 {
+		return invalidParams
+	}
+	return nil
 }
 
 type EnableAvailabilityZonesForLoadBalancerOutput struct {
@@ -2024,6 +2445,43 @@ func (s HealthCheck) String() string {
 // GoString returns the string representation
 func (s HealthCheck) GoString() string {
 	return s.String()
+}
+
+// Validate inspects the fields of the type to determine if they are valid.
+func (s *HealthCheck) Validate() error {
+	invalidParams := request.ErrInvalidParams{Context: "HealthCheck"}
+	if s.HealthyThreshold == nil {
+		invalidParams.Add(request.NewErrParamRequired("HealthyThreshold"))
+	}
+	if s.HealthyThreshold != nil && *s.HealthyThreshold < 2 {
+		invalidParams.Add(request.NewErrParamMinValue("HealthyThreshold", 2))
+	}
+	if s.Interval == nil {
+		invalidParams.Add(request.NewErrParamRequired("Interval"))
+	}
+	if s.Interval != nil && *s.Interval < 1 {
+		invalidParams.Add(request.NewErrParamMinValue("Interval", 1))
+	}
+	if s.Target == nil {
+		invalidParams.Add(request.NewErrParamRequired("Target"))
+	}
+	if s.Timeout == nil {
+		invalidParams.Add(request.NewErrParamRequired("Timeout"))
+	}
+	if s.Timeout != nil && *s.Timeout < 1 {
+		invalidParams.Add(request.NewErrParamMinValue("Timeout", 1))
+	}
+	if s.UnhealthyThreshold == nil {
+		invalidParams.Add(request.NewErrParamRequired("UnhealthyThreshold"))
+	}
+	if s.UnhealthyThreshold != nil && *s.UnhealthyThreshold < 2 {
+		invalidParams.Add(request.NewErrParamMinValue("UnhealthyThreshold", 2))
+	}
+
+	if invalidParams.Len() > 0 {
+		return invalidParams
+	}
+	return nil
 }
 
 // The ID of a back-end instance.
@@ -2175,6 +2633,28 @@ func (s Listener) GoString() string {
 	return s.String()
 }
 
+// Validate inspects the fields of the type to determine if they are valid.
+func (s *Listener) Validate() error {
+	invalidParams := request.ErrInvalidParams{Context: "Listener"}
+	if s.InstancePort == nil {
+		invalidParams.Add(request.NewErrParamRequired("InstancePort"))
+	}
+	if s.InstancePort != nil && *s.InstancePort < 1 {
+		invalidParams.Add(request.NewErrParamMinValue("InstancePort", 1))
+	}
+	if s.LoadBalancerPort == nil {
+		invalidParams.Add(request.NewErrParamRequired("LoadBalancerPort"))
+	}
+	if s.Protocol == nil {
+		invalidParams.Add(request.NewErrParamRequired("Protocol"))
+	}
+
+	if invalidParams.Len() > 0 {
+		return invalidParams
+	}
+	return nil
+}
+
 // The policies enabled for a listener.
 type ListenerDescription struct {
 	_ struct{} `type:"structure"`
@@ -2247,6 +2727,36 @@ func (s LoadBalancerAttributes) String() string {
 // GoString returns the string representation
 func (s LoadBalancerAttributes) GoString() string {
 	return s.String()
+}
+
+// Validate inspects the fields of the type to determine if they are valid.
+func (s *LoadBalancerAttributes) Validate() error {
+	invalidParams := request.ErrInvalidParams{Context: "LoadBalancerAttributes"}
+	if s.AccessLog != nil {
+		if err := s.AccessLog.Validate(); err != nil {
+			invalidParams.AddNested("AccessLog", err.(request.ErrInvalidParams))
+		}
+	}
+	if s.ConnectionDraining != nil {
+		if err := s.ConnectionDraining.Validate(); err != nil {
+			invalidParams.AddNested("ConnectionDraining", err.(request.ErrInvalidParams))
+		}
+	}
+	if s.ConnectionSettings != nil {
+		if err := s.ConnectionSettings.Validate(); err != nil {
+			invalidParams.AddNested("ConnectionSettings", err.(request.ErrInvalidParams))
+		}
+	}
+	if s.CrossZoneLoadBalancing != nil {
+		if err := s.CrossZoneLoadBalancing.Validate(); err != nil {
+			invalidParams.AddNested("CrossZoneLoadBalancing", err.(request.ErrInvalidParams))
+		}
+	}
+
+	if invalidParams.Len() > 0 {
+		return invalidParams
+	}
+	return nil
 }
 
 // Information about a load balancer.
@@ -2344,6 +2854,27 @@ func (s ModifyLoadBalancerAttributesInput) String() string {
 // GoString returns the string representation
 func (s ModifyLoadBalancerAttributesInput) GoString() string {
 	return s.String()
+}
+
+// Validate inspects the fields of the type to determine if they are valid.
+func (s *ModifyLoadBalancerAttributesInput) Validate() error {
+	invalidParams := request.ErrInvalidParams{Context: "ModifyLoadBalancerAttributesInput"}
+	if s.LoadBalancerAttributes == nil {
+		invalidParams.Add(request.NewErrParamRequired("LoadBalancerAttributes"))
+	}
+	if s.LoadBalancerName == nil {
+		invalidParams.Add(request.NewErrParamRequired("LoadBalancerName"))
+	}
+	if s.LoadBalancerAttributes != nil {
+		if err := s.LoadBalancerAttributes.Validate(); err != nil {
+			invalidParams.AddNested("LoadBalancerAttributes", err.(request.ErrInvalidParams))
+		}
+	}
+
+	if invalidParams.Len() > 0 {
+		return invalidParams
+	}
+	return nil
 }
 
 type ModifyLoadBalancerAttributesOutput struct {
@@ -2537,6 +3068,22 @@ func (s RegisterInstancesWithLoadBalancerInput) GoString() string {
 	return s.String()
 }
 
+// Validate inspects the fields of the type to determine if they are valid.
+func (s *RegisterInstancesWithLoadBalancerInput) Validate() error {
+	invalidParams := request.ErrInvalidParams{Context: "RegisterInstancesWithLoadBalancerInput"}
+	if s.Instances == nil {
+		invalidParams.Add(request.NewErrParamRequired("Instances"))
+	}
+	if s.LoadBalancerName == nil {
+		invalidParams.Add(request.NewErrParamRequired("LoadBalancerName"))
+	}
+
+	if invalidParams.Len() > 0 {
+		return invalidParams
+	}
+	return nil
+}
+
 type RegisterInstancesWithLoadBalancerOutput struct {
 	_ struct{} `type:"structure"`
 
@@ -2575,6 +3122,35 @@ func (s RemoveTagsInput) GoString() string {
 	return s.String()
 }
 
+// Validate inspects the fields of the type to determine if they are valid.
+func (s *RemoveTagsInput) Validate() error {
+	invalidParams := request.ErrInvalidParams{Context: "RemoveTagsInput"}
+	if s.LoadBalancerNames == nil {
+		invalidParams.Add(request.NewErrParamRequired("LoadBalancerNames"))
+	}
+	if s.Tags == nil {
+		invalidParams.Add(request.NewErrParamRequired("Tags"))
+	}
+	if s.Tags != nil && len(s.Tags) < 1 {
+		invalidParams.Add(request.NewErrParamMinLen("Tags", 1))
+	}
+	if s.Tags != nil {
+		for i, v := range s.Tags {
+			if v == nil {
+				continue
+			}
+			if err := v.Validate(); err != nil {
+				invalidParams.AddNested(fmt.Sprintf("%s[%v]", "Tags", i), err.(request.ErrInvalidParams))
+			}
+		}
+	}
+
+	if invalidParams.Len() > 0 {
+		return invalidParams
+	}
+	return nil
+}
+
 type RemoveTagsOutput struct {
 	_ struct{} `type:"structure"`
 }
@@ -2610,6 +3186,25 @@ func (s SetLoadBalancerListenerSSLCertificateInput) String() string {
 // GoString returns the string representation
 func (s SetLoadBalancerListenerSSLCertificateInput) GoString() string {
 	return s.String()
+}
+
+// Validate inspects the fields of the type to determine if they are valid.
+func (s *SetLoadBalancerListenerSSLCertificateInput) Validate() error {
+	invalidParams := request.ErrInvalidParams{Context: "SetLoadBalancerListenerSSLCertificateInput"}
+	if s.LoadBalancerName == nil {
+		invalidParams.Add(request.NewErrParamRequired("LoadBalancerName"))
+	}
+	if s.LoadBalancerPort == nil {
+		invalidParams.Add(request.NewErrParamRequired("LoadBalancerPort"))
+	}
+	if s.SSLCertificateId == nil {
+		invalidParams.Add(request.NewErrParamRequired("SSLCertificateId"))
+	}
+
+	if invalidParams.Len() > 0 {
+		return invalidParams
+	}
+	return nil
 }
 
 type SetLoadBalancerListenerSSLCertificateOutput struct {
@@ -2650,6 +3245,25 @@ func (s SetLoadBalancerPoliciesForBackendServerInput) GoString() string {
 	return s.String()
 }
 
+// Validate inspects the fields of the type to determine if they are valid.
+func (s *SetLoadBalancerPoliciesForBackendServerInput) Validate() error {
+	invalidParams := request.ErrInvalidParams{Context: "SetLoadBalancerPoliciesForBackendServerInput"}
+	if s.InstancePort == nil {
+		invalidParams.Add(request.NewErrParamRequired("InstancePort"))
+	}
+	if s.LoadBalancerName == nil {
+		invalidParams.Add(request.NewErrParamRequired("LoadBalancerName"))
+	}
+	if s.PolicyNames == nil {
+		invalidParams.Add(request.NewErrParamRequired("PolicyNames"))
+	}
+
+	if invalidParams.Len() > 0 {
+		return invalidParams
+	}
+	return nil
+}
+
 type SetLoadBalancerPoliciesForBackendServerOutput struct {
 	_ struct{} `type:"structure"`
 }
@@ -2686,6 +3300,25 @@ func (s SetLoadBalancerPoliciesOfListenerInput) String() string {
 // GoString returns the string representation
 func (s SetLoadBalancerPoliciesOfListenerInput) GoString() string {
 	return s.String()
+}
+
+// Validate inspects the fields of the type to determine if they are valid.
+func (s *SetLoadBalancerPoliciesOfListenerInput) Validate() error {
+	invalidParams := request.ErrInvalidParams{Context: "SetLoadBalancerPoliciesOfListenerInput"}
+	if s.LoadBalancerName == nil {
+		invalidParams.Add(request.NewErrParamRequired("LoadBalancerName"))
+	}
+	if s.LoadBalancerPort == nil {
+		invalidParams.Add(request.NewErrParamRequired("LoadBalancerPort"))
+	}
+	if s.PolicyNames == nil {
+		invalidParams.Add(request.NewErrParamRequired("PolicyNames"))
+	}
+
+	if invalidParams.Len() > 0 {
+		return invalidParams
+	}
+	return nil
 }
 
 type SetLoadBalancerPoliciesOfListenerOutput struct {
@@ -2744,6 +3377,22 @@ func (s Tag) GoString() string {
 	return s.String()
 }
 
+// Validate inspects the fields of the type to determine if they are valid.
+func (s *Tag) Validate() error {
+	invalidParams := request.ErrInvalidParams{Context: "Tag"}
+	if s.Key == nil {
+		invalidParams.Add(request.NewErrParamRequired("Key"))
+	}
+	if s.Key != nil && len(*s.Key) < 1 {
+		invalidParams.Add(request.NewErrParamMinLen("Key", 1))
+	}
+
+	if invalidParams.Len() > 0 {
+		return invalidParams
+	}
+	return nil
+}
+
 // The tags associated with a load balancer.
 type TagDescription struct {
 	_ struct{} `type:"structure"`
@@ -2781,4 +3430,17 @@ func (s TagKeyOnly) String() string {
 // GoString returns the string representation
 func (s TagKeyOnly) GoString() string {
 	return s.String()
+}
+
+// Validate inspects the fields of the type to determine if they are valid.
+func (s *TagKeyOnly) Validate() error {
+	invalidParams := request.ErrInvalidParams{Context: "TagKeyOnly"}
+	if s.Key != nil && len(*s.Key) < 1 {
+		invalidParams.Add(request.NewErrParamMinLen("Key", 1))
+	}
+
+	if invalidParams.Len() > 0 {
+		return invalidParams
+	}
+	return nil
 }

--- a/service/emr/api.go
+++ b/service/emr/api.go
@@ -4,6 +4,7 @@
 package emr
 
 import (
+	"fmt"
 	"time"
 
 	"github.com/aws/aws-sdk-go/aws/awsutil"
@@ -684,6 +685,32 @@ func (s AddInstanceGroupsInput) GoString() string {
 	return s.String()
 }
 
+// Validate inspects the fields of the type to determine if they are valid.
+func (s *AddInstanceGroupsInput) Validate() error {
+	invalidParams := request.ErrInvalidParams{Context: "AddInstanceGroupsInput"}
+	if s.InstanceGroups == nil {
+		invalidParams.Add(request.NewErrParamRequired("InstanceGroups"))
+	}
+	if s.JobFlowId == nil {
+		invalidParams.Add(request.NewErrParamRequired("JobFlowId"))
+	}
+	if s.InstanceGroups != nil {
+		for i, v := range s.InstanceGroups {
+			if v == nil {
+				continue
+			}
+			if err := v.Validate(); err != nil {
+				invalidParams.AddNested(fmt.Sprintf("%s[%v]", "InstanceGroups", i), err.(request.ErrInvalidParams))
+			}
+		}
+	}
+
+	if invalidParams.Len() > 0 {
+		return invalidParams
+	}
+	return nil
+}
+
 // Output from an AddInstanceGroups call.
 type AddInstanceGroupsOutput struct {
 	_ struct{} `type:"structure"`
@@ -727,6 +754,32 @@ func (s AddJobFlowStepsInput) GoString() string {
 	return s.String()
 }
 
+// Validate inspects the fields of the type to determine if they are valid.
+func (s *AddJobFlowStepsInput) Validate() error {
+	invalidParams := request.ErrInvalidParams{Context: "AddJobFlowStepsInput"}
+	if s.JobFlowId == nil {
+		invalidParams.Add(request.NewErrParamRequired("JobFlowId"))
+	}
+	if s.Steps == nil {
+		invalidParams.Add(request.NewErrParamRequired("Steps"))
+	}
+	if s.Steps != nil {
+		for i, v := range s.Steps {
+			if v == nil {
+				continue
+			}
+			if err := v.Validate(); err != nil {
+				invalidParams.AddNested(fmt.Sprintf("%s[%v]", "Steps", i), err.(request.ErrInvalidParams))
+			}
+		}
+	}
+
+	if invalidParams.Len() > 0 {
+		return invalidParams
+	}
+	return nil
+}
+
 // The output for the AddJobFlowSteps operation.
 type AddJobFlowStepsOutput struct {
 	_ struct{} `type:"structure"`
@@ -768,6 +821,22 @@ func (s AddTagsInput) String() string {
 // GoString returns the string representation
 func (s AddTagsInput) GoString() string {
 	return s.String()
+}
+
+// Validate inspects the fields of the type to determine if they are valid.
+func (s *AddTagsInput) Validate() error {
+	invalidParams := request.ErrInvalidParams{Context: "AddTagsInput"}
+	if s.ResourceId == nil {
+		invalidParams.Add(request.NewErrParamRequired("ResourceId"))
+	}
+	if s.Tags == nil {
+		invalidParams.Add(request.NewErrParamRequired("Tags"))
+	}
+
+	if invalidParams.Len() > 0 {
+		return invalidParams
+	}
+	return nil
 }
 
 // This output indicates the result of adding tags to a resource.
@@ -845,6 +914,27 @@ func (s BootstrapActionConfig) String() string {
 // GoString returns the string representation
 func (s BootstrapActionConfig) GoString() string {
 	return s.String()
+}
+
+// Validate inspects the fields of the type to determine if they are valid.
+func (s *BootstrapActionConfig) Validate() error {
+	invalidParams := request.ErrInvalidParams{Context: "BootstrapActionConfig"}
+	if s.Name == nil {
+		invalidParams.Add(request.NewErrParamRequired("Name"))
+	}
+	if s.ScriptBootstrapAction == nil {
+		invalidParams.Add(request.NewErrParamRequired("ScriptBootstrapAction"))
+	}
+	if s.ScriptBootstrapAction != nil {
+		if err := s.ScriptBootstrapAction.Validate(); err != nil {
+			invalidParams.AddNested("ScriptBootstrapAction", err.(request.ErrInvalidParams))
+		}
+	}
+
+	if invalidParams.Len() > 0 {
+		return invalidParams
+	}
+	return nil
 }
 
 // Reports the configuration of a bootstrap action in a job flow.
@@ -1123,6 +1213,19 @@ func (s DescribeClusterInput) GoString() string {
 	return s.String()
 }
 
+// Validate inspects the fields of the type to determine if they are valid.
+func (s *DescribeClusterInput) Validate() error {
+	invalidParams := request.ErrInvalidParams{Context: "DescribeClusterInput"}
+	if s.ClusterId == nil {
+		invalidParams.Add(request.NewErrParamRequired("ClusterId"))
+	}
+
+	if invalidParams.Len() > 0 {
+		return invalidParams
+	}
+	return nil
+}
+
 // This output contains the description of the cluster.
 type DescribeClusterOutput struct {
 	_ struct{} `type:"structure"`
@@ -1207,6 +1310,22 @@ func (s DescribeStepInput) GoString() string {
 	return s.String()
 }
 
+// Validate inspects the fields of the type to determine if they are valid.
+func (s *DescribeStepInput) Validate() error {
+	invalidParams := request.ErrInvalidParams{Context: "DescribeStepInput"}
+	if s.ClusterId == nil {
+		invalidParams.Add(request.NewErrParamRequired("ClusterId"))
+	}
+	if s.StepId == nil {
+		invalidParams.Add(request.NewErrParamRequired("StepId"))
+	}
+
+	if invalidParams.Len() > 0 {
+		return invalidParams
+	}
+	return nil
+}
+
 // This output contains the description of the cluster step.
 type DescribeStepOutput struct {
 	_ struct{} `type:"structure"`
@@ -1272,6 +1391,24 @@ func (s EbsBlockDeviceConfig) GoString() string {
 	return s.String()
 }
 
+// Validate inspects the fields of the type to determine if they are valid.
+func (s *EbsBlockDeviceConfig) Validate() error {
+	invalidParams := request.ErrInvalidParams{Context: "EbsBlockDeviceConfig"}
+	if s.VolumeSpecification == nil {
+		invalidParams.Add(request.NewErrParamRequired("VolumeSpecification"))
+	}
+	if s.VolumeSpecification != nil {
+		if err := s.VolumeSpecification.Validate(); err != nil {
+			invalidParams.AddNested("VolumeSpecification", err.(request.ErrInvalidParams))
+		}
+	}
+
+	if invalidParams.Len() > 0 {
+		return invalidParams
+	}
+	return nil
+}
+
 type EbsConfiguration struct {
 	_ struct{} `type:"structure"`
 
@@ -1288,6 +1425,26 @@ func (s EbsConfiguration) String() string {
 // GoString returns the string representation
 func (s EbsConfiguration) GoString() string {
 	return s.String()
+}
+
+// Validate inspects the fields of the type to determine if they are valid.
+func (s *EbsConfiguration) Validate() error {
+	invalidParams := request.ErrInvalidParams{Context: "EbsConfiguration"}
+	if s.EbsBlockDeviceConfigs != nil {
+		for i, v := range s.EbsBlockDeviceConfigs {
+			if v == nil {
+				continue
+			}
+			if err := v.Validate(); err != nil {
+				invalidParams.AddNested(fmt.Sprintf("%s[%v]", "EbsBlockDeviceConfigs", i), err.(request.ErrInvalidParams))
+			}
+		}
+	}
+
+	if invalidParams.Len() > 0 {
+		return invalidParams
+	}
+	return nil
 }
 
 // EBS block device that's attached to an EC2 instance.
@@ -1394,6 +1551,19 @@ func (s HadoopJarStepConfig) String() string {
 // GoString returns the string representation
 func (s HadoopJarStepConfig) GoString() string {
 	return s.String()
+}
+
+// Validate inspects the fields of the type to determine if they are valid.
+func (s *HadoopJarStepConfig) Validate() error {
+	invalidParams := request.ErrInvalidParams{Context: "HadoopJarStepConfig"}
+	if s.Jar == nil {
+		invalidParams.Add(request.NewErrParamRequired("Jar"))
+	}
+
+	if invalidParams.Len() > 0 {
+		return invalidParams
+	}
+	return nil
 }
 
 // A cluster step consisting of a JAR file whose main function will be executed.
@@ -1578,6 +1748,33 @@ func (s InstanceGroupConfig) GoString() string {
 	return s.String()
 }
 
+// Validate inspects the fields of the type to determine if they are valid.
+func (s *InstanceGroupConfig) Validate() error {
+	invalidParams := request.ErrInvalidParams{Context: "InstanceGroupConfig"}
+	if s.InstanceCount == nil {
+		invalidParams.Add(request.NewErrParamRequired("InstanceCount"))
+	}
+	if s.InstanceRole == nil {
+		invalidParams.Add(request.NewErrParamRequired("InstanceRole"))
+	}
+	if s.InstanceType == nil {
+		invalidParams.Add(request.NewErrParamRequired("InstanceType"))
+	}
+	if s.InstanceType != nil && len(*s.InstanceType) < 1 {
+		invalidParams.Add(request.NewErrParamMinLen("InstanceType", 1))
+	}
+	if s.EbsConfiguration != nil {
+		if err := s.EbsConfiguration.Validate(); err != nil {
+			invalidParams.AddNested("EbsConfiguration", err.(request.ErrInvalidParams))
+		}
+	}
+
+	if invalidParams.Len() > 0 {
+		return invalidParams
+	}
+	return nil
+}
+
 // Detailed information about an instance group.
 type InstanceGroupDetail struct {
 	_ struct{} `type:"structure"`
@@ -1663,6 +1860,19 @@ func (s InstanceGroupModifyConfig) String() string {
 // GoString returns the string representation
 func (s InstanceGroupModifyConfig) GoString() string {
 	return s.String()
+}
+
+// Validate inspects the fields of the type to determine if they are valid.
+func (s *InstanceGroupModifyConfig) Validate() error {
+	invalidParams := request.ErrInvalidParams{Context: "InstanceGroupModifyConfig"}
+	if s.InstanceGroupId == nil {
+		invalidParams.Add(request.NewErrParamRequired("InstanceGroupId"))
+	}
+
+	if invalidParams.Len() > 0 {
+		return invalidParams
+	}
+	return nil
 }
 
 // The status change reason details for the instance group.
@@ -2005,6 +2215,37 @@ func (s JobFlowInstancesConfig) GoString() string {
 	return s.String()
 }
 
+// Validate inspects the fields of the type to determine if they are valid.
+func (s *JobFlowInstancesConfig) Validate() error {
+	invalidParams := request.ErrInvalidParams{Context: "JobFlowInstancesConfig"}
+	if s.MasterInstanceType != nil && len(*s.MasterInstanceType) < 1 {
+		invalidParams.Add(request.NewErrParamMinLen("MasterInstanceType", 1))
+	}
+	if s.SlaveInstanceType != nil && len(*s.SlaveInstanceType) < 1 {
+		invalidParams.Add(request.NewErrParamMinLen("SlaveInstanceType", 1))
+	}
+	if s.InstanceGroups != nil {
+		for i, v := range s.InstanceGroups {
+			if v == nil {
+				continue
+			}
+			if err := v.Validate(); err != nil {
+				invalidParams.AddNested(fmt.Sprintf("%s[%v]", "InstanceGroups", i), err.(request.ErrInvalidParams))
+			}
+		}
+	}
+	if s.Placement != nil {
+		if err := s.Placement.Validate(); err != nil {
+			invalidParams.AddNested("Placement", err.(request.ErrInvalidParams))
+		}
+	}
+
+	if invalidParams.Len() > 0 {
+		return invalidParams
+	}
+	return nil
+}
+
 // Specify the type of Amazon EC2 instances to run the job flow on.
 type JobFlowInstancesDetail struct {
 	_ struct{} `type:"structure"`
@@ -2112,6 +2353,19 @@ func (s ListBootstrapActionsInput) GoString() string {
 	return s.String()
 }
 
+// Validate inspects the fields of the type to determine if they are valid.
+func (s *ListBootstrapActionsInput) Validate() error {
+	invalidParams := request.ErrInvalidParams{Context: "ListBootstrapActionsInput"}
+	if s.ClusterId == nil {
+		invalidParams.Add(request.NewErrParamRequired("ClusterId"))
+	}
+
+	if invalidParams.Len() > 0 {
+		return invalidParams
+	}
+	return nil
+}
+
 // This output contains the boostrap actions detail .
 type ListBootstrapActionsOutput struct {
 	_ struct{} `type:"structure"`
@@ -2204,6 +2458,19 @@ func (s ListInstanceGroupsInput) GoString() string {
 	return s.String()
 }
 
+// Validate inspects the fields of the type to determine if they are valid.
+func (s *ListInstanceGroupsInput) Validate() error {
+	invalidParams := request.ErrInvalidParams{Context: "ListInstanceGroupsInput"}
+	if s.ClusterId == nil {
+		invalidParams.Add(request.NewErrParamRequired("ClusterId"))
+	}
+
+	if invalidParams.Len() > 0 {
+		return invalidParams
+	}
+	return nil
+}
+
 // This input determines which instance groups to retrieve.
 type ListInstanceGroupsOutput struct {
 	_ struct{} `type:"structure"`
@@ -2250,6 +2517,19 @@ func (s ListInstancesInput) String() string {
 // GoString returns the string representation
 func (s ListInstancesInput) GoString() string {
 	return s.String()
+}
+
+// Validate inspects the fields of the type to determine if they are valid.
+func (s *ListInstancesInput) Validate() error {
+	invalidParams := request.ErrInvalidParams{Context: "ListInstancesInput"}
+	if s.ClusterId == nil {
+		invalidParams.Add(request.NewErrParamRequired("ClusterId"))
+	}
+
+	if invalidParams.Len() > 0 {
+		return invalidParams
+	}
+	return nil
 }
 
 // This output contains the list of instances.
@@ -2300,6 +2580,19 @@ func (s ListStepsInput) GoString() string {
 	return s.String()
 }
 
+// Validate inspects the fields of the type to determine if they are valid.
+func (s *ListStepsInput) Validate() error {
+	invalidParams := request.ErrInvalidParams{Context: "ListStepsInput"}
+	if s.ClusterId == nil {
+		invalidParams.Add(request.NewErrParamRequired("ClusterId"))
+	}
+
+	if invalidParams.Len() > 0 {
+		return invalidParams
+	}
+	return nil
+}
+
 // This output contains the list of steps returned in reverse order. This means
 // that the last step is the first element in the list.
 type ListStepsOutput struct {
@@ -2340,6 +2633,26 @@ func (s ModifyInstanceGroupsInput) GoString() string {
 	return s.String()
 }
 
+// Validate inspects the fields of the type to determine if they are valid.
+func (s *ModifyInstanceGroupsInput) Validate() error {
+	invalidParams := request.ErrInvalidParams{Context: "ModifyInstanceGroupsInput"}
+	if s.InstanceGroups != nil {
+		for i, v := range s.InstanceGroups {
+			if v == nil {
+				continue
+			}
+			if err := v.Validate(); err != nil {
+				invalidParams.AddNested(fmt.Sprintf("%s[%v]", "InstanceGroups", i), err.(request.ErrInvalidParams))
+			}
+		}
+	}
+
+	if invalidParams.Len() > 0 {
+		return invalidParams
+	}
+	return nil
+}
+
 type ModifyInstanceGroupsOutput struct {
 	_ struct{} `type:"structure"`
 }
@@ -2372,6 +2685,19 @@ func (s PlacementType) GoString() string {
 	return s.String()
 }
 
+// Validate inspects the fields of the type to determine if they are valid.
+func (s *PlacementType) Validate() error {
+	invalidParams := request.ErrInvalidParams{Context: "PlacementType"}
+	if s.AvailabilityZone == nil {
+		invalidParams.Add(request.NewErrParamRequired("AvailabilityZone"))
+	}
+
+	if invalidParams.Len() > 0 {
+		return invalidParams
+	}
+	return nil
+}
+
 // This input identifies a cluster and a list of tags to remove.
 type RemoveTagsInput struct {
 	_ struct{} `type:"structure"`
@@ -2392,6 +2718,22 @@ func (s RemoveTagsInput) String() string {
 // GoString returns the string representation
 func (s RemoveTagsInput) GoString() string {
 	return s.String()
+}
+
+// Validate inspects the fields of the type to determine if they are valid.
+func (s *RemoveTagsInput) Validate() error {
+	invalidParams := request.ErrInvalidParams{Context: "RemoveTagsInput"}
+	if s.ResourceId == nil {
+		invalidParams.Add(request.NewErrParamRequired("ResourceId"))
+	}
+	if s.TagKeys == nil {
+		invalidParams.Add(request.NewErrParamRequired("TagKeys"))
+	}
+
+	if invalidParams.Len() > 0 {
+		return invalidParams
+	}
+	return nil
 }
 
 // This output indicates the result of removing tags from a resource.
@@ -2530,6 +2872,47 @@ func (s RunJobFlowInput) GoString() string {
 	return s.String()
 }
 
+// Validate inspects the fields of the type to determine if they are valid.
+func (s *RunJobFlowInput) Validate() error {
+	invalidParams := request.ErrInvalidParams{Context: "RunJobFlowInput"}
+	if s.Instances == nil {
+		invalidParams.Add(request.NewErrParamRequired("Instances"))
+	}
+	if s.Name == nil {
+		invalidParams.Add(request.NewErrParamRequired("Name"))
+	}
+	if s.BootstrapActions != nil {
+		for i, v := range s.BootstrapActions {
+			if v == nil {
+				continue
+			}
+			if err := v.Validate(); err != nil {
+				invalidParams.AddNested(fmt.Sprintf("%s[%v]", "BootstrapActions", i), err.(request.ErrInvalidParams))
+			}
+		}
+	}
+	if s.Instances != nil {
+		if err := s.Instances.Validate(); err != nil {
+			invalidParams.AddNested("Instances", err.(request.ErrInvalidParams))
+		}
+	}
+	if s.Steps != nil {
+		for i, v := range s.Steps {
+			if v == nil {
+				continue
+			}
+			if err := v.Validate(); err != nil {
+				invalidParams.AddNested(fmt.Sprintf("%s[%v]", "Steps", i), err.(request.ErrInvalidParams))
+			}
+		}
+	}
+
+	if invalidParams.Len() > 0 {
+		return invalidParams
+	}
+	return nil
+}
+
 // The result of the RunJobFlow operation.
 type RunJobFlowOutput struct {
 	_ struct{} `type:"structure"`
@@ -2570,6 +2953,19 @@ func (s ScriptBootstrapActionConfig) GoString() string {
 	return s.String()
 }
 
+// Validate inspects the fields of the type to determine if they are valid.
+func (s *ScriptBootstrapActionConfig) Validate() error {
+	invalidParams := request.ErrInvalidParams{Context: "ScriptBootstrapActionConfig"}
+	if s.Path == nil {
+		invalidParams.Add(request.NewErrParamRequired("Path"))
+	}
+
+	if invalidParams.Len() > 0 {
+		return invalidParams
+	}
+	return nil
+}
+
 // The input argument to the TerminationProtection operation.
 type SetTerminationProtectionInput struct {
 	_ struct{} `type:"structure"`
@@ -2593,6 +2989,22 @@ func (s SetTerminationProtectionInput) String() string {
 // GoString returns the string representation
 func (s SetTerminationProtectionInput) GoString() string {
 	return s.String()
+}
+
+// Validate inspects the fields of the type to determine if they are valid.
+func (s *SetTerminationProtectionInput) Validate() error {
+	invalidParams := request.ErrInvalidParams{Context: "SetTerminationProtectionInput"}
+	if s.JobFlowIds == nil {
+		invalidParams.Add(request.NewErrParamRequired("JobFlowIds"))
+	}
+	if s.TerminationProtected == nil {
+		invalidParams.Add(request.NewErrParamRequired("TerminationProtected"))
+	}
+
+	if invalidParams.Len() > 0 {
+		return invalidParams
+	}
+	return nil
 }
 
 type SetTerminationProtectionOutput struct {
@@ -2632,6 +3044,22 @@ func (s SetVisibleToAllUsersInput) String() string {
 // GoString returns the string representation
 func (s SetVisibleToAllUsersInput) GoString() string {
 	return s.String()
+}
+
+// Validate inspects the fields of the type to determine if they are valid.
+func (s *SetVisibleToAllUsersInput) Validate() error {
+	invalidParams := request.ErrInvalidParams{Context: "SetVisibleToAllUsersInput"}
+	if s.JobFlowIds == nil {
+		invalidParams.Add(request.NewErrParamRequired("JobFlowIds"))
+	}
+	if s.VisibleToAllUsers == nil {
+		invalidParams.Add(request.NewErrParamRequired("VisibleToAllUsers"))
+	}
+
+	if invalidParams.Len() > 0 {
+		return invalidParams
+	}
+	return nil
 }
 
 type SetVisibleToAllUsersOutput struct {
@@ -2725,6 +3153,27 @@ func (s StepConfig) String() string {
 // GoString returns the string representation
 func (s StepConfig) GoString() string {
 	return s.String()
+}
+
+// Validate inspects the fields of the type to determine if they are valid.
+func (s *StepConfig) Validate() error {
+	invalidParams := request.ErrInvalidParams{Context: "StepConfig"}
+	if s.HadoopJarStep == nil {
+		invalidParams.Add(request.NewErrParamRequired("HadoopJarStep"))
+	}
+	if s.Name == nil {
+		invalidParams.Add(request.NewErrParamRequired("Name"))
+	}
+	if s.HadoopJarStep != nil {
+		if err := s.HadoopJarStep.Validate(); err != nil {
+			invalidParams.AddNested("HadoopJarStep", err.(request.ErrInvalidParams))
+		}
+	}
+
+	if invalidParams.Len() > 0 {
+		return invalidParams
+	}
+	return nil
 }
 
 // Combines the execution state and configuration of a step.
@@ -2947,6 +3396,19 @@ func (s TerminateJobFlowsInput) GoString() string {
 	return s.String()
 }
 
+// Validate inspects the fields of the type to determine if they are valid.
+func (s *TerminateJobFlowsInput) Validate() error {
+	invalidParams := request.ErrInvalidParams{Context: "TerminateJobFlowsInput"}
+	if s.JobFlowIds == nil {
+		invalidParams.Add(request.NewErrParamRequired("JobFlowIds"))
+	}
+
+	if invalidParams.Len() > 0 {
+		return invalidParams
+	}
+	return nil
+}
+
 type TerminateJobFlowsOutput struct {
 	_ struct{} `type:"structure"`
 }
@@ -2985,6 +3447,22 @@ func (s VolumeSpecification) String() string {
 // GoString returns the string representation
 func (s VolumeSpecification) GoString() string {
 	return s.String()
+}
+
+// Validate inspects the fields of the type to determine if they are valid.
+func (s *VolumeSpecification) Validate() error {
+	invalidParams := request.ErrInvalidParams{Context: "VolumeSpecification"}
+	if s.SizeInGB == nil {
+		invalidParams.Add(request.NewErrParamRequired("SizeInGB"))
+	}
+	if s.VolumeType == nil {
+		invalidParams.Add(request.NewErrParamRequired("VolumeType"))
+	}
+
+	if invalidParams.Len() > 0 {
+		return invalidParams
+	}
+	return nil
 }
 
 const (

--- a/service/firehose/api.go
+++ b/service/firehose/api.go
@@ -4,6 +4,7 @@
 package firehose
 
 import (
+	"fmt"
 	"time"
 
 	"github.com/aws/aws-sdk-go/aws/awsutil"
@@ -413,6 +414,22 @@ func (s BufferingHints) GoString() string {
 	return s.String()
 }
 
+// Validate inspects the fields of the type to determine if they are valid.
+func (s *BufferingHints) Validate() error {
+	invalidParams := request.ErrInvalidParams{Context: "BufferingHints"}
+	if s.IntervalInSeconds != nil && *s.IntervalInSeconds < 60 {
+		invalidParams.Add(request.NewErrParamMinValue("IntervalInSeconds", 60))
+	}
+	if s.SizeInMBs != nil && *s.SizeInMBs < 1 {
+		invalidParams.Add(request.NewErrParamMinValue("SizeInMBs", 1))
+	}
+
+	if invalidParams.Len() > 0 {
+		return invalidParams
+	}
+	return nil
+}
+
 // Describes CloudWatch logging options for your delivery stream.
 type CloudWatchLoggingOptions struct {
 	_ struct{} `type:"structure"`
@@ -482,6 +499,22 @@ func (s CopyCommand) GoString() string {
 	return s.String()
 }
 
+// Validate inspects the fields of the type to determine if they are valid.
+func (s *CopyCommand) Validate() error {
+	invalidParams := request.ErrInvalidParams{Context: "CopyCommand"}
+	if s.DataTableName == nil {
+		invalidParams.Add(request.NewErrParamRequired("DataTableName"))
+	}
+	if s.DataTableName != nil && len(*s.DataTableName) < 1 {
+		invalidParams.Add(request.NewErrParamMinLen("DataTableName", 1))
+	}
+
+	if invalidParams.Len() > 0 {
+		return invalidParams
+	}
+	return nil
+}
+
 // Contains the parameters for CreateDeliveryStream.
 type CreateDeliveryStreamInput struct {
 	_ struct{} `type:"structure"`
@@ -512,6 +545,37 @@ func (s CreateDeliveryStreamInput) String() string {
 // GoString returns the string representation
 func (s CreateDeliveryStreamInput) GoString() string {
 	return s.String()
+}
+
+// Validate inspects the fields of the type to determine if they are valid.
+func (s *CreateDeliveryStreamInput) Validate() error {
+	invalidParams := request.ErrInvalidParams{Context: "CreateDeliveryStreamInput"}
+	if s.DeliveryStreamName == nil {
+		invalidParams.Add(request.NewErrParamRequired("DeliveryStreamName"))
+	}
+	if s.DeliveryStreamName != nil && len(*s.DeliveryStreamName) < 1 {
+		invalidParams.Add(request.NewErrParamMinLen("DeliveryStreamName", 1))
+	}
+	if s.ElasticsearchDestinationConfiguration != nil {
+		if err := s.ElasticsearchDestinationConfiguration.Validate(); err != nil {
+			invalidParams.AddNested("ElasticsearchDestinationConfiguration", err.(request.ErrInvalidParams))
+		}
+	}
+	if s.RedshiftDestinationConfiguration != nil {
+		if err := s.RedshiftDestinationConfiguration.Validate(); err != nil {
+			invalidParams.AddNested("RedshiftDestinationConfiguration", err.(request.ErrInvalidParams))
+		}
+	}
+	if s.S3DestinationConfiguration != nil {
+		if err := s.S3DestinationConfiguration.Validate(); err != nil {
+			invalidParams.AddNested("S3DestinationConfiguration", err.(request.ErrInvalidParams))
+		}
+	}
+
+	if invalidParams.Len() > 0 {
+		return invalidParams
+	}
+	return nil
 }
 
 // Contains the output of CreateDeliveryStream.
@@ -548,6 +612,22 @@ func (s DeleteDeliveryStreamInput) String() string {
 // GoString returns the string representation
 func (s DeleteDeliveryStreamInput) GoString() string {
 	return s.String()
+}
+
+// Validate inspects the fields of the type to determine if they are valid.
+func (s *DeleteDeliveryStreamInput) Validate() error {
+	invalidParams := request.ErrInvalidParams{Context: "DeleteDeliveryStreamInput"}
+	if s.DeliveryStreamName == nil {
+		invalidParams.Add(request.NewErrParamRequired("DeliveryStreamName"))
+	}
+	if s.DeliveryStreamName != nil && len(*s.DeliveryStreamName) < 1 {
+		invalidParams.Add(request.NewErrParamMinLen("DeliveryStreamName", 1))
+	}
+
+	if invalidParams.Len() > 0 {
+		return invalidParams
+	}
+	return nil
 }
 
 // Contains the output of DeleteDeliveryStream.
@@ -634,6 +714,28 @@ func (s DescribeDeliveryStreamInput) GoString() string {
 	return s.String()
 }
 
+// Validate inspects the fields of the type to determine if they are valid.
+func (s *DescribeDeliveryStreamInput) Validate() error {
+	invalidParams := request.ErrInvalidParams{Context: "DescribeDeliveryStreamInput"}
+	if s.DeliveryStreamName == nil {
+		invalidParams.Add(request.NewErrParamRequired("DeliveryStreamName"))
+	}
+	if s.DeliveryStreamName != nil && len(*s.DeliveryStreamName) < 1 {
+		invalidParams.Add(request.NewErrParamMinLen("DeliveryStreamName", 1))
+	}
+	if s.ExclusiveStartDestinationId != nil && len(*s.ExclusiveStartDestinationId) < 1 {
+		invalidParams.Add(request.NewErrParamMinLen("ExclusiveStartDestinationId", 1))
+	}
+	if s.Limit != nil && *s.Limit < 1 {
+		invalidParams.Add(request.NewErrParamMinValue("Limit", 1))
+	}
+
+	if invalidParams.Len() > 0 {
+		return invalidParams
+	}
+	return nil
+}
+
 // Contains the output of DescribeDeliveryStream.
 type DescribeDeliveryStreamOutput struct {
 	_ struct{} `type:"structure"`
@@ -707,6 +809,22 @@ func (s ElasticsearchBufferingHints) GoString() string {
 	return s.String()
 }
 
+// Validate inspects the fields of the type to determine if they are valid.
+func (s *ElasticsearchBufferingHints) Validate() error {
+	invalidParams := request.ErrInvalidParams{Context: "ElasticsearchBufferingHints"}
+	if s.IntervalInSeconds != nil && *s.IntervalInSeconds < 60 {
+		invalidParams.Add(request.NewErrParamMinValue("IntervalInSeconds", 60))
+	}
+	if s.SizeInMBs != nil && *s.SizeInMBs < 1 {
+		invalidParams.Add(request.NewErrParamMinValue("SizeInMBs", 1))
+	}
+
+	if invalidParams.Len() > 0 {
+		return invalidParams
+	}
+	return nil
+}
+
 // Describes the configuration of a destination in Amazon ES.
 type ElasticsearchDestinationConfiguration struct {
 	_ struct{} `type:"structure"`
@@ -766,6 +884,53 @@ func (s ElasticsearchDestinationConfiguration) String() string {
 // GoString returns the string representation
 func (s ElasticsearchDestinationConfiguration) GoString() string {
 	return s.String()
+}
+
+// Validate inspects the fields of the type to determine if they are valid.
+func (s *ElasticsearchDestinationConfiguration) Validate() error {
+	invalidParams := request.ErrInvalidParams{Context: "ElasticsearchDestinationConfiguration"}
+	if s.DomainARN == nil {
+		invalidParams.Add(request.NewErrParamRequired("DomainARN"))
+	}
+	if s.DomainARN != nil && len(*s.DomainARN) < 1 {
+		invalidParams.Add(request.NewErrParamMinLen("DomainARN", 1))
+	}
+	if s.IndexName == nil {
+		invalidParams.Add(request.NewErrParamRequired("IndexName"))
+	}
+	if s.IndexName != nil && len(*s.IndexName) < 1 {
+		invalidParams.Add(request.NewErrParamMinLen("IndexName", 1))
+	}
+	if s.RoleARN == nil {
+		invalidParams.Add(request.NewErrParamRequired("RoleARN"))
+	}
+	if s.RoleARN != nil && len(*s.RoleARN) < 1 {
+		invalidParams.Add(request.NewErrParamMinLen("RoleARN", 1))
+	}
+	if s.S3Configuration == nil {
+		invalidParams.Add(request.NewErrParamRequired("S3Configuration"))
+	}
+	if s.TypeName == nil {
+		invalidParams.Add(request.NewErrParamRequired("TypeName"))
+	}
+	if s.TypeName != nil && len(*s.TypeName) < 1 {
+		invalidParams.Add(request.NewErrParamMinLen("TypeName", 1))
+	}
+	if s.BufferingHints != nil {
+		if err := s.BufferingHints.Validate(); err != nil {
+			invalidParams.AddNested("BufferingHints", err.(request.ErrInvalidParams))
+		}
+	}
+	if s.S3Configuration != nil {
+		if err := s.S3Configuration.Validate(); err != nil {
+			invalidParams.AddNested("S3Configuration", err.(request.ErrInvalidParams))
+		}
+	}
+
+	if invalidParams.Len() > 0 {
+		return invalidParams
+	}
+	return nil
 }
 
 // The destination description in Amazon ES.
@@ -864,6 +1029,38 @@ func (s ElasticsearchDestinationUpdate) GoString() string {
 	return s.String()
 }
 
+// Validate inspects the fields of the type to determine if they are valid.
+func (s *ElasticsearchDestinationUpdate) Validate() error {
+	invalidParams := request.ErrInvalidParams{Context: "ElasticsearchDestinationUpdate"}
+	if s.DomainARN != nil && len(*s.DomainARN) < 1 {
+		invalidParams.Add(request.NewErrParamMinLen("DomainARN", 1))
+	}
+	if s.IndexName != nil && len(*s.IndexName) < 1 {
+		invalidParams.Add(request.NewErrParamMinLen("IndexName", 1))
+	}
+	if s.RoleARN != nil && len(*s.RoleARN) < 1 {
+		invalidParams.Add(request.NewErrParamMinLen("RoleARN", 1))
+	}
+	if s.TypeName != nil && len(*s.TypeName) < 1 {
+		invalidParams.Add(request.NewErrParamMinLen("TypeName", 1))
+	}
+	if s.BufferingHints != nil {
+		if err := s.BufferingHints.Validate(); err != nil {
+			invalidParams.AddNested("BufferingHints", err.(request.ErrInvalidParams))
+		}
+	}
+	if s.S3Update != nil {
+		if err := s.S3Update.Validate(); err != nil {
+			invalidParams.AddNested("S3Update", err.(request.ErrInvalidParams))
+		}
+	}
+
+	if invalidParams.Len() > 0 {
+		return invalidParams
+	}
+	return nil
+}
+
 // Configures retry behavior in the event that Firehose is unable to deliver
 // documents to Amazon ES.
 type ElasticsearchRetryOptions struct {
@@ -908,6 +1105,21 @@ func (s EncryptionConfiguration) GoString() string {
 	return s.String()
 }
 
+// Validate inspects the fields of the type to determine if they are valid.
+func (s *EncryptionConfiguration) Validate() error {
+	invalidParams := request.ErrInvalidParams{Context: "EncryptionConfiguration"}
+	if s.KMSEncryptionConfig != nil {
+		if err := s.KMSEncryptionConfig.Validate(); err != nil {
+			invalidParams.AddNested("KMSEncryptionConfig", err.(request.ErrInvalidParams))
+		}
+	}
+
+	if invalidParams.Len() > 0 {
+		return invalidParams
+	}
+	return nil
+}
+
 // Describes an encryption key for a destination in Amazon S3.
 type KMSEncryptionConfig struct {
 	_ struct{} `type:"structure"`
@@ -925,6 +1137,22 @@ func (s KMSEncryptionConfig) String() string {
 // GoString returns the string representation
 func (s KMSEncryptionConfig) GoString() string {
 	return s.String()
+}
+
+// Validate inspects the fields of the type to determine if they are valid.
+func (s *KMSEncryptionConfig) Validate() error {
+	invalidParams := request.ErrInvalidParams{Context: "KMSEncryptionConfig"}
+	if s.AWSKMSKeyARN == nil {
+		invalidParams.Add(request.NewErrParamRequired("AWSKMSKeyARN"))
+	}
+	if s.AWSKMSKeyARN != nil && len(*s.AWSKMSKeyARN) < 1 {
+		invalidParams.Add(request.NewErrParamMinLen("AWSKMSKeyARN", 1))
+	}
+
+	if invalidParams.Len() > 0 {
+		return invalidParams
+	}
+	return nil
 }
 
 // Contains the parameters for ListDeliveryStreams.
@@ -946,6 +1174,22 @@ func (s ListDeliveryStreamsInput) String() string {
 // GoString returns the string representation
 func (s ListDeliveryStreamsInput) GoString() string {
 	return s.String()
+}
+
+// Validate inspects the fields of the type to determine if they are valid.
+func (s *ListDeliveryStreamsInput) Validate() error {
+	invalidParams := request.ErrInvalidParams{Context: "ListDeliveryStreamsInput"}
+	if s.ExclusiveStartDeliveryStreamName != nil && len(*s.ExclusiveStartDeliveryStreamName) < 1 {
+		invalidParams.Add(request.NewErrParamMinLen("ExclusiveStartDeliveryStreamName", 1))
+	}
+	if s.Limit != nil && *s.Limit < 1 {
+		invalidParams.Add(request.NewErrParamMinValue("Limit", 1))
+	}
+
+	if invalidParams.Len() > 0 {
+		return invalidParams
+	}
+	return nil
 }
 
 // Contains the output of ListDeliveryStreams.
@@ -988,6 +1232,38 @@ func (s PutRecordBatchInput) String() string {
 // GoString returns the string representation
 func (s PutRecordBatchInput) GoString() string {
 	return s.String()
+}
+
+// Validate inspects the fields of the type to determine if they are valid.
+func (s *PutRecordBatchInput) Validate() error {
+	invalidParams := request.ErrInvalidParams{Context: "PutRecordBatchInput"}
+	if s.DeliveryStreamName == nil {
+		invalidParams.Add(request.NewErrParamRequired("DeliveryStreamName"))
+	}
+	if s.DeliveryStreamName != nil && len(*s.DeliveryStreamName) < 1 {
+		invalidParams.Add(request.NewErrParamMinLen("DeliveryStreamName", 1))
+	}
+	if s.Records == nil {
+		invalidParams.Add(request.NewErrParamRequired("Records"))
+	}
+	if s.Records != nil && len(s.Records) < 1 {
+		invalidParams.Add(request.NewErrParamMinLen("Records", 1))
+	}
+	if s.Records != nil {
+		for i, v := range s.Records {
+			if v == nil {
+				continue
+			}
+			if err := v.Validate(); err != nil {
+				invalidParams.AddNested(fmt.Sprintf("%s[%v]", "Records", i), err.(request.ErrInvalidParams))
+			}
+		}
+	}
+
+	if invalidParams.Len() > 0 {
+		return invalidParams
+	}
+	return nil
 }
 
 // Contains the output of PutRecordBatch.
@@ -1060,6 +1336,30 @@ func (s PutRecordInput) GoString() string {
 	return s.String()
 }
 
+// Validate inspects the fields of the type to determine if they are valid.
+func (s *PutRecordInput) Validate() error {
+	invalidParams := request.ErrInvalidParams{Context: "PutRecordInput"}
+	if s.DeliveryStreamName == nil {
+		invalidParams.Add(request.NewErrParamRequired("DeliveryStreamName"))
+	}
+	if s.DeliveryStreamName != nil && len(*s.DeliveryStreamName) < 1 {
+		invalidParams.Add(request.NewErrParamMinLen("DeliveryStreamName", 1))
+	}
+	if s.Record == nil {
+		invalidParams.Add(request.NewErrParamRequired("Record"))
+	}
+	if s.Record != nil {
+		if err := s.Record.Validate(); err != nil {
+			invalidParams.AddNested("Record", err.(request.ErrInvalidParams))
+		}
+	}
+
+	if invalidParams.Len() > 0 {
+		return invalidParams
+	}
+	return nil
+}
+
 // Contains the output of PutRecord.
 type PutRecordOutput struct {
 	_ struct{} `type:"structure"`
@@ -1097,6 +1397,19 @@ func (s Record) String() string {
 // GoString returns the string representation
 func (s Record) GoString() string {
 	return s.String()
+}
+
+// Validate inspects the fields of the type to determine if they are valid.
+func (s *Record) Validate() error {
+	invalidParams := request.ErrInvalidParams{Context: "Record"}
+	if s.Data == nil {
+		invalidParams.Add(request.NewErrParamRequired("Data"))
+	}
+
+	if invalidParams.Len() > 0 {
+		return invalidParams
+	}
+	return nil
 }
 
 // Describes the configuration of a destination in Amazon Redshift.
@@ -1138,6 +1451,56 @@ func (s RedshiftDestinationConfiguration) String() string {
 // GoString returns the string representation
 func (s RedshiftDestinationConfiguration) GoString() string {
 	return s.String()
+}
+
+// Validate inspects the fields of the type to determine if they are valid.
+func (s *RedshiftDestinationConfiguration) Validate() error {
+	invalidParams := request.ErrInvalidParams{Context: "RedshiftDestinationConfiguration"}
+	if s.ClusterJDBCURL == nil {
+		invalidParams.Add(request.NewErrParamRequired("ClusterJDBCURL"))
+	}
+	if s.ClusterJDBCURL != nil && len(*s.ClusterJDBCURL) < 1 {
+		invalidParams.Add(request.NewErrParamMinLen("ClusterJDBCURL", 1))
+	}
+	if s.CopyCommand == nil {
+		invalidParams.Add(request.NewErrParamRequired("CopyCommand"))
+	}
+	if s.Password == nil {
+		invalidParams.Add(request.NewErrParamRequired("Password"))
+	}
+	if s.Password != nil && len(*s.Password) < 6 {
+		invalidParams.Add(request.NewErrParamMinLen("Password", 6))
+	}
+	if s.RoleARN == nil {
+		invalidParams.Add(request.NewErrParamRequired("RoleARN"))
+	}
+	if s.RoleARN != nil && len(*s.RoleARN) < 1 {
+		invalidParams.Add(request.NewErrParamMinLen("RoleARN", 1))
+	}
+	if s.S3Configuration == nil {
+		invalidParams.Add(request.NewErrParamRequired("S3Configuration"))
+	}
+	if s.Username == nil {
+		invalidParams.Add(request.NewErrParamRequired("Username"))
+	}
+	if s.Username != nil && len(*s.Username) < 1 {
+		invalidParams.Add(request.NewErrParamMinLen("Username", 1))
+	}
+	if s.CopyCommand != nil {
+		if err := s.CopyCommand.Validate(); err != nil {
+			invalidParams.AddNested("CopyCommand", err.(request.ErrInvalidParams))
+		}
+	}
+	if s.S3Configuration != nil {
+		if err := s.S3Configuration.Validate(); err != nil {
+			invalidParams.AddNested("S3Configuration", err.(request.ErrInvalidParams))
+		}
+	}
+
+	if invalidParams.Len() > 0 {
+		return invalidParams
+	}
+	return nil
 }
 
 // Describes a destination in Amazon Redshift.
@@ -1213,6 +1576,38 @@ func (s RedshiftDestinationUpdate) GoString() string {
 	return s.String()
 }
 
+// Validate inspects the fields of the type to determine if they are valid.
+func (s *RedshiftDestinationUpdate) Validate() error {
+	invalidParams := request.ErrInvalidParams{Context: "RedshiftDestinationUpdate"}
+	if s.ClusterJDBCURL != nil && len(*s.ClusterJDBCURL) < 1 {
+		invalidParams.Add(request.NewErrParamMinLen("ClusterJDBCURL", 1))
+	}
+	if s.Password != nil && len(*s.Password) < 6 {
+		invalidParams.Add(request.NewErrParamMinLen("Password", 6))
+	}
+	if s.RoleARN != nil && len(*s.RoleARN) < 1 {
+		invalidParams.Add(request.NewErrParamMinLen("RoleARN", 1))
+	}
+	if s.Username != nil && len(*s.Username) < 1 {
+		invalidParams.Add(request.NewErrParamMinLen("Username", 1))
+	}
+	if s.CopyCommand != nil {
+		if err := s.CopyCommand.Validate(); err != nil {
+			invalidParams.AddNested("CopyCommand", err.(request.ErrInvalidParams))
+		}
+	}
+	if s.S3Update != nil {
+		if err := s.S3Update.Validate(); err != nil {
+			invalidParams.AddNested("S3Update", err.(request.ErrInvalidParams))
+		}
+	}
+
+	if invalidParams.Len() > 0 {
+		return invalidParams
+	}
+	return nil
+}
+
 // Describes the configuration of a destination in Amazon S3.
 type S3DestinationConfiguration struct {
 	_ struct{} `type:"structure"`
@@ -1258,6 +1653,38 @@ func (s S3DestinationConfiguration) String() string {
 // GoString returns the string representation
 func (s S3DestinationConfiguration) GoString() string {
 	return s.String()
+}
+
+// Validate inspects the fields of the type to determine if they are valid.
+func (s *S3DestinationConfiguration) Validate() error {
+	invalidParams := request.ErrInvalidParams{Context: "S3DestinationConfiguration"}
+	if s.BucketARN == nil {
+		invalidParams.Add(request.NewErrParamRequired("BucketARN"))
+	}
+	if s.BucketARN != nil && len(*s.BucketARN) < 1 {
+		invalidParams.Add(request.NewErrParamMinLen("BucketARN", 1))
+	}
+	if s.RoleARN == nil {
+		invalidParams.Add(request.NewErrParamRequired("RoleARN"))
+	}
+	if s.RoleARN != nil && len(*s.RoleARN) < 1 {
+		invalidParams.Add(request.NewErrParamMinLen("RoleARN", 1))
+	}
+	if s.BufferingHints != nil {
+		if err := s.BufferingHints.Validate(); err != nil {
+			invalidParams.AddNested("BufferingHints", err.(request.ErrInvalidParams))
+		}
+	}
+	if s.EncryptionConfiguration != nil {
+		if err := s.EncryptionConfiguration.Validate(); err != nil {
+			invalidParams.AddNested("EncryptionConfiguration", err.(request.ErrInvalidParams))
+		}
+	}
+
+	if invalidParams.Len() > 0 {
+		return invalidParams
+	}
+	return nil
 }
 
 // Describes a destination in Amazon S3.
@@ -1350,6 +1777,32 @@ func (s S3DestinationUpdate) GoString() string {
 	return s.String()
 }
 
+// Validate inspects the fields of the type to determine if they are valid.
+func (s *S3DestinationUpdate) Validate() error {
+	invalidParams := request.ErrInvalidParams{Context: "S3DestinationUpdate"}
+	if s.BucketARN != nil && len(*s.BucketARN) < 1 {
+		invalidParams.Add(request.NewErrParamMinLen("BucketARN", 1))
+	}
+	if s.RoleARN != nil && len(*s.RoleARN) < 1 {
+		invalidParams.Add(request.NewErrParamMinLen("RoleARN", 1))
+	}
+	if s.BufferingHints != nil {
+		if err := s.BufferingHints.Validate(); err != nil {
+			invalidParams.AddNested("BufferingHints", err.(request.ErrInvalidParams))
+		}
+	}
+	if s.EncryptionConfiguration != nil {
+		if err := s.EncryptionConfiguration.Validate(); err != nil {
+			invalidParams.AddNested("EncryptionConfiguration", err.(request.ErrInvalidParams))
+		}
+	}
+
+	if invalidParams.Len() > 0 {
+		return invalidParams
+	}
+	return nil
+}
+
 // Contains the parameters for UpdateDestination.
 type UpdateDestinationInput struct {
 	_ struct{} `type:"structure"`
@@ -1386,6 +1839,49 @@ func (s UpdateDestinationInput) String() string {
 // GoString returns the string representation
 func (s UpdateDestinationInput) GoString() string {
 	return s.String()
+}
+
+// Validate inspects the fields of the type to determine if they are valid.
+func (s *UpdateDestinationInput) Validate() error {
+	invalidParams := request.ErrInvalidParams{Context: "UpdateDestinationInput"}
+	if s.CurrentDeliveryStreamVersionId == nil {
+		invalidParams.Add(request.NewErrParamRequired("CurrentDeliveryStreamVersionId"))
+	}
+	if s.CurrentDeliveryStreamVersionId != nil && len(*s.CurrentDeliveryStreamVersionId) < 1 {
+		invalidParams.Add(request.NewErrParamMinLen("CurrentDeliveryStreamVersionId", 1))
+	}
+	if s.DeliveryStreamName == nil {
+		invalidParams.Add(request.NewErrParamRequired("DeliveryStreamName"))
+	}
+	if s.DeliveryStreamName != nil && len(*s.DeliveryStreamName) < 1 {
+		invalidParams.Add(request.NewErrParamMinLen("DeliveryStreamName", 1))
+	}
+	if s.DestinationId == nil {
+		invalidParams.Add(request.NewErrParamRequired("DestinationId"))
+	}
+	if s.DestinationId != nil && len(*s.DestinationId) < 1 {
+		invalidParams.Add(request.NewErrParamMinLen("DestinationId", 1))
+	}
+	if s.ElasticsearchDestinationUpdate != nil {
+		if err := s.ElasticsearchDestinationUpdate.Validate(); err != nil {
+			invalidParams.AddNested("ElasticsearchDestinationUpdate", err.(request.ErrInvalidParams))
+		}
+	}
+	if s.RedshiftDestinationUpdate != nil {
+		if err := s.RedshiftDestinationUpdate.Validate(); err != nil {
+			invalidParams.AddNested("RedshiftDestinationUpdate", err.(request.ErrInvalidParams))
+		}
+	}
+	if s.S3DestinationUpdate != nil {
+		if err := s.S3DestinationUpdate.Validate(); err != nil {
+			invalidParams.AddNested("S3DestinationUpdate", err.(request.ErrInvalidParams))
+		}
+	}
+
+	if invalidParams.Len() > 0 {
+		return invalidParams
+	}
+	return nil
 }
 
 // Contains the output of UpdateDestination.

--- a/service/gamelift/api.go
+++ b/service/gamelift/api.go
@@ -4,6 +4,7 @@
 package gamelift
 
 import (
+	"fmt"
 	"time"
 
 	"github.com/aws/aws-sdk-go/aws/awsutil"
@@ -1356,6 +1357,28 @@ func (s CreateAliasInput) GoString() string {
 	return s.String()
 }
 
+// Validate inspects the fields of the type to determine if they are valid.
+func (s *CreateAliasInput) Validate() error {
+	invalidParams := request.ErrInvalidParams{Context: "CreateAliasInput"}
+	if s.Description != nil && len(*s.Description) < 1 {
+		invalidParams.Add(request.NewErrParamMinLen("Description", 1))
+	}
+	if s.Name == nil {
+		invalidParams.Add(request.NewErrParamRequired("Name"))
+	}
+	if s.Name != nil && len(*s.Name) < 1 {
+		invalidParams.Add(request.NewErrParamMinLen("Name", 1))
+	}
+	if s.RoutingStrategy == nil {
+		invalidParams.Add(request.NewErrParamRequired("RoutingStrategy"))
+	}
+
+	if invalidParams.Len() > 0 {
+		return invalidParams
+	}
+	return nil
+}
+
 // Represents the returned data in response to a request action.
 type CreateAliasOutput struct {
 	_ struct{} `type:"structure"`
@@ -1401,6 +1424,27 @@ func (s CreateBuildInput) String() string {
 // GoString returns the string representation
 func (s CreateBuildInput) GoString() string {
 	return s.String()
+}
+
+// Validate inspects the fields of the type to determine if they are valid.
+func (s *CreateBuildInput) Validate() error {
+	invalidParams := request.ErrInvalidParams{Context: "CreateBuildInput"}
+	if s.Name != nil && len(*s.Name) < 1 {
+		invalidParams.Add(request.NewErrParamMinLen("Name", 1))
+	}
+	if s.Version != nil && len(*s.Version) < 1 {
+		invalidParams.Add(request.NewErrParamMinLen("Version", 1))
+	}
+	if s.StorageLocation != nil {
+		if err := s.StorageLocation.Validate(); err != nil {
+			invalidParams.AddNested("StorageLocation", err.(request.ErrInvalidParams))
+		}
+	}
+
+	if invalidParams.Len() > 0 {
+		return invalidParams
+	}
+	return nil
 }
 
 // Represents the returned data in response to a request action.
@@ -1491,6 +1535,50 @@ func (s CreateFleetInput) GoString() string {
 	return s.String()
 }
 
+// Validate inspects the fields of the type to determine if they are valid.
+func (s *CreateFleetInput) Validate() error {
+	invalidParams := request.ErrInvalidParams{Context: "CreateFleetInput"}
+	if s.BuildId == nil {
+		invalidParams.Add(request.NewErrParamRequired("BuildId"))
+	}
+	if s.Description != nil && len(*s.Description) < 1 {
+		invalidParams.Add(request.NewErrParamMinLen("Description", 1))
+	}
+	if s.EC2InstanceType == nil {
+		invalidParams.Add(request.NewErrParamRequired("EC2InstanceType"))
+	}
+	if s.Name == nil {
+		invalidParams.Add(request.NewErrParamRequired("Name"))
+	}
+	if s.Name != nil && len(*s.Name) < 1 {
+		invalidParams.Add(request.NewErrParamMinLen("Name", 1))
+	}
+	if s.ServerLaunchParameters != nil && len(*s.ServerLaunchParameters) < 1 {
+		invalidParams.Add(request.NewErrParamMinLen("ServerLaunchParameters", 1))
+	}
+	if s.ServerLaunchPath == nil {
+		invalidParams.Add(request.NewErrParamRequired("ServerLaunchPath"))
+	}
+	if s.ServerLaunchPath != nil && len(*s.ServerLaunchPath) < 1 {
+		invalidParams.Add(request.NewErrParamMinLen("ServerLaunchPath", 1))
+	}
+	if s.EC2InboundPermissions != nil {
+		for i, v := range s.EC2InboundPermissions {
+			if v == nil {
+				continue
+			}
+			if err := v.Validate(); err != nil {
+				invalidParams.AddNested(fmt.Sprintf("%s[%v]", "EC2InboundPermissions", i), err.(request.ErrInvalidParams))
+			}
+		}
+	}
+
+	if invalidParams.Len() > 0 {
+		return invalidParams
+	}
+	return nil
+}
+
 // Represents the returned data in response to a request action.
 type CreateFleetOutput struct {
 	_ struct{} `type:"structure"`
@@ -1544,6 +1632,32 @@ func (s CreateGameSessionInput) GoString() string {
 	return s.String()
 }
 
+// Validate inspects the fields of the type to determine if they are valid.
+func (s *CreateGameSessionInput) Validate() error {
+	invalidParams := request.ErrInvalidParams{Context: "CreateGameSessionInput"}
+	if s.MaximumPlayerSessionCount == nil {
+		invalidParams.Add(request.NewErrParamRequired("MaximumPlayerSessionCount"))
+	}
+	if s.Name != nil && len(*s.Name) < 1 {
+		invalidParams.Add(request.NewErrParamMinLen("Name", 1))
+	}
+	if s.GameProperties != nil {
+		for i, v := range s.GameProperties {
+			if v == nil {
+				continue
+			}
+			if err := v.Validate(); err != nil {
+				invalidParams.AddNested(fmt.Sprintf("%s[%v]", "GameProperties", i), err.(request.ErrInvalidParams))
+			}
+		}
+	}
+
+	if invalidParams.Len() > 0 {
+		return invalidParams
+	}
+	return nil
+}
+
 // Represents the returned data in response to a request action.
 type CreateGameSessionOutput struct {
 	_ struct{} `type:"structure"`
@@ -1582,6 +1696,25 @@ func (s CreatePlayerSessionInput) String() string {
 // GoString returns the string representation
 func (s CreatePlayerSessionInput) GoString() string {
 	return s.String()
+}
+
+// Validate inspects the fields of the type to determine if they are valid.
+func (s *CreatePlayerSessionInput) Validate() error {
+	invalidParams := request.ErrInvalidParams{Context: "CreatePlayerSessionInput"}
+	if s.GameSessionId == nil {
+		invalidParams.Add(request.NewErrParamRequired("GameSessionId"))
+	}
+	if s.PlayerId == nil {
+		invalidParams.Add(request.NewErrParamRequired("PlayerId"))
+	}
+	if s.PlayerId != nil && len(*s.PlayerId) < 1 {
+		invalidParams.Add(request.NewErrParamMinLen("PlayerId", 1))
+	}
+
+	if invalidParams.Len() > 0 {
+		return invalidParams
+	}
+	return nil
 }
 
 // Represents the returned data in response to a request action.
@@ -1623,6 +1756,25 @@ func (s CreatePlayerSessionsInput) GoString() string {
 	return s.String()
 }
 
+// Validate inspects the fields of the type to determine if they are valid.
+func (s *CreatePlayerSessionsInput) Validate() error {
+	invalidParams := request.ErrInvalidParams{Context: "CreatePlayerSessionsInput"}
+	if s.GameSessionId == nil {
+		invalidParams.Add(request.NewErrParamRequired("GameSessionId"))
+	}
+	if s.PlayerIds == nil {
+		invalidParams.Add(request.NewErrParamRequired("PlayerIds"))
+	}
+	if s.PlayerIds != nil && len(s.PlayerIds) < 1 {
+		invalidParams.Add(request.NewErrParamMinLen("PlayerIds", 1))
+	}
+
+	if invalidParams.Len() > 0 {
+		return invalidParams
+	}
+	return nil
+}
+
 // Represents the returned data in response to a request action.
 type CreatePlayerSessionsOutput struct {
 	_ struct{} `type:"structure"`
@@ -1659,6 +1811,19 @@ func (s DeleteAliasInput) GoString() string {
 	return s.String()
 }
 
+// Validate inspects the fields of the type to determine if they are valid.
+func (s *DeleteAliasInput) Validate() error {
+	invalidParams := request.ErrInvalidParams{Context: "DeleteAliasInput"}
+	if s.AliasId == nil {
+		invalidParams.Add(request.NewErrParamRequired("AliasId"))
+	}
+
+	if invalidParams.Len() > 0 {
+		return invalidParams
+	}
+	return nil
+}
+
 type DeleteAliasOutput struct {
 	_ struct{} `type:"structure"`
 }
@@ -1691,6 +1856,19 @@ func (s DeleteBuildInput) GoString() string {
 	return s.String()
 }
 
+// Validate inspects the fields of the type to determine if they are valid.
+func (s *DeleteBuildInput) Validate() error {
+	invalidParams := request.ErrInvalidParams{Context: "DeleteBuildInput"}
+	if s.BuildId == nil {
+		invalidParams.Add(request.NewErrParamRequired("BuildId"))
+	}
+
+	if invalidParams.Len() > 0 {
+		return invalidParams
+	}
+	return nil
+}
+
 type DeleteBuildOutput struct {
 	_ struct{} `type:"structure"`
 }
@@ -1721,6 +1899,19 @@ func (s DeleteFleetInput) String() string {
 // GoString returns the string representation
 func (s DeleteFleetInput) GoString() string {
 	return s.String()
+}
+
+// Validate inspects the fields of the type to determine if they are valid.
+func (s *DeleteFleetInput) Validate() error {
+	invalidParams := request.ErrInvalidParams{Context: "DeleteFleetInput"}
+	if s.FleetId == nil {
+		invalidParams.Add(request.NewErrParamRequired("FleetId"))
+	}
+
+	if invalidParams.Len() > 0 {
+		return invalidParams
+	}
+	return nil
 }
 
 type DeleteFleetOutput struct {
@@ -1759,6 +1950,25 @@ func (s DeleteScalingPolicyInput) GoString() string {
 	return s.String()
 }
 
+// Validate inspects the fields of the type to determine if they are valid.
+func (s *DeleteScalingPolicyInput) Validate() error {
+	invalidParams := request.ErrInvalidParams{Context: "DeleteScalingPolicyInput"}
+	if s.FleetId == nil {
+		invalidParams.Add(request.NewErrParamRequired("FleetId"))
+	}
+	if s.Name == nil {
+		invalidParams.Add(request.NewErrParamRequired("Name"))
+	}
+	if s.Name != nil && len(*s.Name) < 1 {
+		invalidParams.Add(request.NewErrParamMinLen("Name", 1))
+	}
+
+	if invalidParams.Len() > 0 {
+		return invalidParams
+	}
+	return nil
+}
+
 type DeleteScalingPolicyOutput struct {
 	_ struct{} `type:"structure"`
 }
@@ -1789,6 +1999,19 @@ func (s DescribeAliasInput) String() string {
 // GoString returns the string representation
 func (s DescribeAliasInput) GoString() string {
 	return s.String()
+}
+
+// Validate inspects the fields of the type to determine if they are valid.
+func (s *DescribeAliasInput) Validate() error {
+	invalidParams := request.ErrInvalidParams{Context: "DescribeAliasInput"}
+	if s.AliasId == nil {
+		invalidParams.Add(request.NewErrParamRequired("AliasId"))
+	}
+
+	if invalidParams.Len() > 0 {
+		return invalidParams
+	}
+	return nil
 }
 
 // Represents the returned data in response to a request action.
@@ -1825,6 +2048,19 @@ func (s DescribeBuildInput) String() string {
 // GoString returns the string representation
 func (s DescribeBuildInput) GoString() string {
 	return s.String()
+}
+
+// Validate inspects the fields of the type to determine if they are valid.
+func (s *DescribeBuildInput) Validate() error {
+	invalidParams := request.ErrInvalidParams{Context: "DescribeBuildInput"}
+	if s.BuildId == nil {
+		invalidParams.Add(request.NewErrParamRequired("BuildId"))
+	}
+
+	if invalidParams.Len() > 0 {
+		return invalidParams
+	}
+	return nil
 }
 
 // Represents the returned data in response to a request action.
@@ -1916,6 +2152,25 @@ func (s DescribeFleetAttributesInput) GoString() string {
 	return s.String()
 }
 
+// Validate inspects the fields of the type to determine if they are valid.
+func (s *DescribeFleetAttributesInput) Validate() error {
+	invalidParams := request.ErrInvalidParams{Context: "DescribeFleetAttributesInput"}
+	if s.FleetIds != nil && len(s.FleetIds) < 1 {
+		invalidParams.Add(request.NewErrParamMinLen("FleetIds", 1))
+	}
+	if s.Limit != nil && *s.Limit < 1 {
+		invalidParams.Add(request.NewErrParamMinValue("Limit", 1))
+	}
+	if s.NextToken != nil && len(*s.NextToken) < 1 {
+		invalidParams.Add(request.NewErrParamMinLen("NextToken", 1))
+	}
+
+	if invalidParams.Len() > 0 {
+		return invalidParams
+	}
+	return nil
+}
+
 // Represents the returned data in response to a request action.
 type DescribeFleetAttributesOutput struct {
 	_ struct{} `type:"structure"`
@@ -1970,6 +2225,25 @@ func (s DescribeFleetCapacityInput) String() string {
 // GoString returns the string representation
 func (s DescribeFleetCapacityInput) GoString() string {
 	return s.String()
+}
+
+// Validate inspects the fields of the type to determine if they are valid.
+func (s *DescribeFleetCapacityInput) Validate() error {
+	invalidParams := request.ErrInvalidParams{Context: "DescribeFleetCapacityInput"}
+	if s.FleetIds != nil && len(s.FleetIds) < 1 {
+		invalidParams.Add(request.NewErrParamMinLen("FleetIds", 1))
+	}
+	if s.Limit != nil && *s.Limit < 1 {
+		invalidParams.Add(request.NewErrParamMinValue("Limit", 1))
+	}
+	if s.NextToken != nil && len(*s.NextToken) < 1 {
+		invalidParams.Add(request.NewErrParamMinLen("NextToken", 1))
+	}
+
+	if invalidParams.Len() > 0 {
+		return invalidParams
+	}
+	return nil
 }
 
 // Represents the returned data in response to a request action.
@@ -2038,6 +2312,25 @@ func (s DescribeFleetEventsInput) GoString() string {
 	return s.String()
 }
 
+// Validate inspects the fields of the type to determine if they are valid.
+func (s *DescribeFleetEventsInput) Validate() error {
+	invalidParams := request.ErrInvalidParams{Context: "DescribeFleetEventsInput"}
+	if s.FleetId == nil {
+		invalidParams.Add(request.NewErrParamRequired("FleetId"))
+	}
+	if s.Limit != nil && *s.Limit < 1 {
+		invalidParams.Add(request.NewErrParamMinValue("Limit", 1))
+	}
+	if s.NextToken != nil && len(*s.NextToken) < 1 {
+		invalidParams.Add(request.NewErrParamMinLen("NextToken", 1))
+	}
+
+	if invalidParams.Len() > 0 {
+		return invalidParams
+	}
+	return nil
+}
+
 // Represents the returned data in response to a request action.
 type DescribeFleetEventsOutput struct {
 	_ struct{} `type:"structure"`
@@ -2079,6 +2372,19 @@ func (s DescribeFleetPortSettingsInput) String() string {
 // GoString returns the string representation
 func (s DescribeFleetPortSettingsInput) GoString() string {
 	return s.String()
+}
+
+// Validate inspects the fields of the type to determine if they are valid.
+func (s *DescribeFleetPortSettingsInput) Validate() error {
+	invalidParams := request.ErrInvalidParams{Context: "DescribeFleetPortSettingsInput"}
+	if s.FleetId == nil {
+		invalidParams.Add(request.NewErrParamRequired("FleetId"))
+	}
+
+	if invalidParams.Len() > 0 {
+		return invalidParams
+	}
+	return nil
 }
 
 // Represents the returned data in response to a request action.
@@ -2127,6 +2433,25 @@ func (s DescribeFleetUtilizationInput) String() string {
 // GoString returns the string representation
 func (s DescribeFleetUtilizationInput) GoString() string {
 	return s.String()
+}
+
+// Validate inspects the fields of the type to determine if they are valid.
+func (s *DescribeFleetUtilizationInput) Validate() error {
+	invalidParams := request.ErrInvalidParams{Context: "DescribeFleetUtilizationInput"}
+	if s.FleetIds != nil && len(s.FleetIds) < 1 {
+		invalidParams.Add(request.NewErrParamMinLen("FleetIds", 1))
+	}
+	if s.Limit != nil && *s.Limit < 1 {
+		invalidParams.Add(request.NewErrParamMinValue("Limit", 1))
+	}
+	if s.NextToken != nil && len(*s.NextToken) < 1 {
+		invalidParams.Add(request.NewErrParamMinLen("NextToken", 1))
+	}
+
+	if invalidParams.Len() > 0 {
+		return invalidParams
+	}
+	return nil
 }
 
 // Represents the returned data in response to a request action.
@@ -2195,6 +2520,25 @@ func (s DescribeGameSessionDetailsInput) GoString() string {
 	return s.String()
 }
 
+// Validate inspects the fields of the type to determine if they are valid.
+func (s *DescribeGameSessionDetailsInput) Validate() error {
+	invalidParams := request.ErrInvalidParams{Context: "DescribeGameSessionDetailsInput"}
+	if s.Limit != nil && *s.Limit < 1 {
+		invalidParams.Add(request.NewErrParamMinValue("Limit", 1))
+	}
+	if s.NextToken != nil && len(*s.NextToken) < 1 {
+		invalidParams.Add(request.NewErrParamMinLen("NextToken", 1))
+	}
+	if s.StatusFilter != nil && len(*s.StatusFilter) < 1 {
+		invalidParams.Add(request.NewErrParamMinLen("StatusFilter", 1))
+	}
+
+	if invalidParams.Len() > 0 {
+		return invalidParams
+	}
+	return nil
+}
+
 // Represents the returned data in response to a request action.
 type DescribeGameSessionDetailsOutput struct {
 	_ struct{} `type:"structure"`
@@ -2259,6 +2603,25 @@ func (s DescribeGameSessionsInput) String() string {
 // GoString returns the string representation
 func (s DescribeGameSessionsInput) GoString() string {
 	return s.String()
+}
+
+// Validate inspects the fields of the type to determine if they are valid.
+func (s *DescribeGameSessionsInput) Validate() error {
+	invalidParams := request.ErrInvalidParams{Context: "DescribeGameSessionsInput"}
+	if s.Limit != nil && *s.Limit < 1 {
+		invalidParams.Add(request.NewErrParamMinValue("Limit", 1))
+	}
+	if s.NextToken != nil && len(*s.NextToken) < 1 {
+		invalidParams.Add(request.NewErrParamMinLen("NextToken", 1))
+	}
+	if s.StatusFilter != nil && len(*s.StatusFilter) < 1 {
+		invalidParams.Add(request.NewErrParamMinLen("StatusFilter", 1))
+	}
+
+	if invalidParams.Len() > 0 {
+		return invalidParams
+	}
+	return nil
 }
 
 // Represents the returned data in response to a request action.
@@ -2331,6 +2694,28 @@ func (s DescribePlayerSessionsInput) GoString() string {
 	return s.String()
 }
 
+// Validate inspects the fields of the type to determine if they are valid.
+func (s *DescribePlayerSessionsInput) Validate() error {
+	invalidParams := request.ErrInvalidParams{Context: "DescribePlayerSessionsInput"}
+	if s.Limit != nil && *s.Limit < 1 {
+		invalidParams.Add(request.NewErrParamMinValue("Limit", 1))
+	}
+	if s.NextToken != nil && len(*s.NextToken) < 1 {
+		invalidParams.Add(request.NewErrParamMinLen("NextToken", 1))
+	}
+	if s.PlayerId != nil && len(*s.PlayerId) < 1 {
+		invalidParams.Add(request.NewErrParamMinLen("PlayerId", 1))
+	}
+	if s.PlayerSessionStatusFilter != nil && len(*s.PlayerSessionStatusFilter) < 1 {
+		invalidParams.Add(request.NewErrParamMinLen("PlayerSessionStatusFilter", 1))
+	}
+
+	if invalidParams.Len() > 0 {
+		return invalidParams
+	}
+	return nil
+}
+
 // Represents the returned data in response to a request action.
 type DescribePlayerSessionsOutput struct {
 	_ struct{} `type:"structure"`
@@ -2392,6 +2777,25 @@ func (s DescribeScalingPoliciesInput) String() string {
 // GoString returns the string representation
 func (s DescribeScalingPoliciesInput) GoString() string {
 	return s.String()
+}
+
+// Validate inspects the fields of the type to determine if they are valid.
+func (s *DescribeScalingPoliciesInput) Validate() error {
+	invalidParams := request.ErrInvalidParams{Context: "DescribeScalingPoliciesInput"}
+	if s.FleetId == nil {
+		invalidParams.Add(request.NewErrParamRequired("FleetId"))
+	}
+	if s.Limit != nil && *s.Limit < 1 {
+		invalidParams.Add(request.NewErrParamMinValue("Limit", 1))
+	}
+	if s.NextToken != nil && len(*s.NextToken) < 1 {
+		invalidParams.Add(request.NewErrParamMinLen("NextToken", 1))
+	}
+
+	if invalidParams.Len() > 0 {
+		return invalidParams
+	}
+	return nil
 }
 
 // Represents the returned data in response to a request action.
@@ -2672,6 +3076,22 @@ func (s GameProperty) GoString() string {
 	return s.String()
 }
 
+// Validate inspects the fields of the type to determine if they are valid.
+func (s *GameProperty) Validate() error {
+	invalidParams := request.ErrInvalidParams{Context: "GameProperty"}
+	if s.Key == nil {
+		invalidParams.Add(request.NewErrParamRequired("Key"))
+	}
+	if s.Value == nil {
+		invalidParams.Add(request.NewErrParamRequired("Value"))
+	}
+
+	if invalidParams.Len() > 0 {
+		return invalidParams
+	}
+	return nil
+}
+
 // Properties describing a game session.
 type GameSession struct {
 	_ struct{} `type:"structure"`
@@ -2767,6 +3187,19 @@ func (s GetGameSessionLogUrlInput) GoString() string {
 	return s.String()
 }
 
+// Validate inspects the fields of the type to determine if they are valid.
+func (s *GetGameSessionLogUrlInput) Validate() error {
+	invalidParams := request.ErrInvalidParams{Context: "GetGameSessionLogUrlInput"}
+	if s.GameSessionId == nil {
+		invalidParams.Add(request.NewErrParamRequired("GameSessionId"))
+	}
+
+	if invalidParams.Len() > 0 {
+		return invalidParams
+	}
+	return nil
+}
+
 // Represents the returned data in response to a request action.
 type GetGameSessionLogUrlOutput struct {
 	_ struct{} `type:"structure"`
@@ -2817,6 +3250,34 @@ func (s IpPermission) GoString() string {
 	return s.String()
 }
 
+// Validate inspects the fields of the type to determine if they are valid.
+func (s *IpPermission) Validate() error {
+	invalidParams := request.ErrInvalidParams{Context: "IpPermission"}
+	if s.FromPort == nil {
+		invalidParams.Add(request.NewErrParamRequired("FromPort"))
+	}
+	if s.FromPort != nil && *s.FromPort < 1025 {
+		invalidParams.Add(request.NewErrParamMinValue("FromPort", 1025))
+	}
+	if s.IpRange == nil {
+		invalidParams.Add(request.NewErrParamRequired("IpRange"))
+	}
+	if s.Protocol == nil {
+		invalidParams.Add(request.NewErrParamRequired("Protocol"))
+	}
+	if s.ToPort == nil {
+		invalidParams.Add(request.NewErrParamRequired("ToPort"))
+	}
+	if s.ToPort != nil && *s.ToPort < 1025 {
+		invalidParams.Add(request.NewErrParamMinValue("ToPort", 1025))
+	}
+
+	if invalidParams.Len() > 0 {
+		return invalidParams
+	}
+	return nil
+}
+
 // Represents the input for a request action.
 type ListAliasesInput struct {
 	_ struct{} `type:"structure"`
@@ -2852,6 +3313,25 @@ func (s ListAliasesInput) String() string {
 // GoString returns the string representation
 func (s ListAliasesInput) GoString() string {
 	return s.String()
+}
+
+// Validate inspects the fields of the type to determine if they are valid.
+func (s *ListAliasesInput) Validate() error {
+	invalidParams := request.ErrInvalidParams{Context: "ListAliasesInput"}
+	if s.Limit != nil && *s.Limit < 1 {
+		invalidParams.Add(request.NewErrParamMinValue("Limit", 1))
+	}
+	if s.Name != nil && len(*s.Name) < 1 {
+		invalidParams.Add(request.NewErrParamMinLen("Name", 1))
+	}
+	if s.NextToken != nil && len(*s.NextToken) < 1 {
+		invalidParams.Add(request.NewErrParamMinLen("NextToken", 1))
+	}
+
+	if invalidParams.Len() > 0 {
+		return invalidParams
+	}
+	return nil
 }
 
 // Represents the returned data in response to a request action.
@@ -2913,6 +3393,22 @@ func (s ListBuildsInput) GoString() string {
 	return s.String()
 }
 
+// Validate inspects the fields of the type to determine if they are valid.
+func (s *ListBuildsInput) Validate() error {
+	invalidParams := request.ErrInvalidParams{Context: "ListBuildsInput"}
+	if s.Limit != nil && *s.Limit < 1 {
+		invalidParams.Add(request.NewErrParamMinValue("Limit", 1))
+	}
+	if s.NextToken != nil && len(*s.NextToken) < 1 {
+		invalidParams.Add(request.NewErrParamMinLen("NextToken", 1))
+	}
+
+	if invalidParams.Len() > 0 {
+		return invalidParams
+	}
+	return nil
+}
+
 // Represents the returned data in response to a request action.
 type ListBuildsOutput struct {
 	_ struct{} `type:"structure"`
@@ -2965,6 +3461,22 @@ func (s ListFleetsInput) String() string {
 // GoString returns the string representation
 func (s ListFleetsInput) GoString() string {
 	return s.String()
+}
+
+// Validate inspects the fields of the type to determine if they are valid.
+func (s *ListFleetsInput) Validate() error {
+	invalidParams := request.ErrInvalidParams{Context: "ListFleetsInput"}
+	if s.Limit != nil && *s.Limit < 1 {
+		invalidParams.Add(request.NewErrParamMinValue("Limit", 1))
+	}
+	if s.NextToken != nil && len(*s.NextToken) < 1 {
+		invalidParams.Add(request.NewErrParamMinLen("NextToken", 1))
+	}
+
+	if invalidParams.Len() > 0 {
+		return invalidParams
+	}
+	return nil
 }
 
 // Represents the returned data in response to a request action.
@@ -3102,6 +3614,46 @@ func (s PutScalingPolicyInput) GoString() string {
 	return s.String()
 }
 
+// Validate inspects the fields of the type to determine if they are valid.
+func (s *PutScalingPolicyInput) Validate() error {
+	invalidParams := request.ErrInvalidParams{Context: "PutScalingPolicyInput"}
+	if s.ComparisonOperator == nil {
+		invalidParams.Add(request.NewErrParamRequired("ComparisonOperator"))
+	}
+	if s.EvaluationPeriods == nil {
+		invalidParams.Add(request.NewErrParamRequired("EvaluationPeriods"))
+	}
+	if s.EvaluationPeriods != nil && *s.EvaluationPeriods < 1 {
+		invalidParams.Add(request.NewErrParamMinValue("EvaluationPeriods", 1))
+	}
+	if s.FleetId == nil {
+		invalidParams.Add(request.NewErrParamRequired("FleetId"))
+	}
+	if s.MetricName == nil {
+		invalidParams.Add(request.NewErrParamRequired("MetricName"))
+	}
+	if s.Name == nil {
+		invalidParams.Add(request.NewErrParamRequired("Name"))
+	}
+	if s.Name != nil && len(*s.Name) < 1 {
+		invalidParams.Add(request.NewErrParamMinLen("Name", 1))
+	}
+	if s.ScalingAdjustment == nil {
+		invalidParams.Add(request.NewErrParamRequired("ScalingAdjustment"))
+	}
+	if s.ScalingAdjustmentType == nil {
+		invalidParams.Add(request.NewErrParamRequired("ScalingAdjustmentType"))
+	}
+	if s.Threshold == nil {
+		invalidParams.Add(request.NewErrParamRequired("Threshold"))
+	}
+
+	if invalidParams.Len() > 0 {
+		return invalidParams
+	}
+	return nil
+}
+
 // Represents the returned data in response to a request action.
 type PutScalingPolicyOutput struct {
 	_ struct{} `type:"structure"`
@@ -3137,6 +3689,19 @@ func (s RequestUploadCredentialsInput) String() string {
 // GoString returns the string representation
 func (s RequestUploadCredentialsInput) GoString() string {
 	return s.String()
+}
+
+// Validate inspects the fields of the type to determine if they are valid.
+func (s *RequestUploadCredentialsInput) Validate() error {
+	invalidParams := request.ErrInvalidParams{Context: "RequestUploadCredentialsInput"}
+	if s.BuildId == nil {
+		invalidParams.Add(request.NewErrParamRequired("BuildId"))
+	}
+
+	if invalidParams.Len() > 0 {
+		return invalidParams
+	}
+	return nil
 }
 
 // Represents the returned data in response to a request action.
@@ -3178,6 +3743,19 @@ func (s ResolveAliasInput) String() string {
 // GoString returns the string representation
 func (s ResolveAliasInput) GoString() string {
 	return s.String()
+}
+
+// Validate inspects the fields of the type to determine if they are valid.
+func (s *ResolveAliasInput) Validate() error {
+	invalidParams := request.ErrInvalidParams{Context: "ResolveAliasInput"}
+	if s.AliasId == nil {
+		invalidParams.Add(request.NewErrParamRequired("AliasId"))
+	}
+
+	if invalidParams.Len() > 0 {
+		return invalidParams
+	}
+	return nil
 }
 
 // Represents the returned data in response to a request action.
@@ -3250,6 +3828,25 @@ func (s S3Location) String() string {
 // GoString returns the string representation
 func (s S3Location) GoString() string {
 	return s.String()
+}
+
+// Validate inspects the fields of the type to determine if they are valid.
+func (s *S3Location) Validate() error {
+	invalidParams := request.ErrInvalidParams{Context: "S3Location"}
+	if s.Bucket != nil && len(*s.Bucket) < 1 {
+		invalidParams.Add(request.NewErrParamMinLen("Bucket", 1))
+	}
+	if s.Key != nil && len(*s.Key) < 1 {
+		invalidParams.Add(request.NewErrParamMinLen("Key", 1))
+	}
+	if s.RoleArn != nil && len(*s.RoleArn) < 1 {
+		invalidParams.Add(request.NewErrParamMinLen("RoleArn", 1))
+	}
+
+	if invalidParams.Len() > 0 {
+		return invalidParams
+	}
+	return nil
 }
 
 // Rule that controls how a fleet is scaled. Scaling policies are uniquely identified
@@ -3349,6 +3946,25 @@ func (s UpdateAliasInput) GoString() string {
 	return s.String()
 }
 
+// Validate inspects the fields of the type to determine if they are valid.
+func (s *UpdateAliasInput) Validate() error {
+	invalidParams := request.ErrInvalidParams{Context: "UpdateAliasInput"}
+	if s.AliasId == nil {
+		invalidParams.Add(request.NewErrParamRequired("AliasId"))
+	}
+	if s.Description != nil && len(*s.Description) < 1 {
+		invalidParams.Add(request.NewErrParamMinLen("Description", 1))
+	}
+	if s.Name != nil && len(*s.Name) < 1 {
+		invalidParams.Add(request.NewErrParamMinLen("Name", 1))
+	}
+
+	if invalidParams.Len() > 0 {
+		return invalidParams
+	}
+	return nil
+}
+
 // Represents the returned data in response to a request action.
 type UpdateAliasOutput struct {
 	_ struct{} `type:"structure"`
@@ -3391,6 +4007,25 @@ func (s UpdateBuildInput) String() string {
 // GoString returns the string representation
 func (s UpdateBuildInput) GoString() string {
 	return s.String()
+}
+
+// Validate inspects the fields of the type to determine if they are valid.
+func (s *UpdateBuildInput) Validate() error {
+	invalidParams := request.ErrInvalidParams{Context: "UpdateBuildInput"}
+	if s.BuildId == nil {
+		invalidParams.Add(request.NewErrParamRequired("BuildId"))
+	}
+	if s.Name != nil && len(*s.Name) < 1 {
+		invalidParams.Add(request.NewErrParamMinLen("Name", 1))
+	}
+	if s.Version != nil && len(*s.Version) < 1 {
+		invalidParams.Add(request.NewErrParamMinLen("Version", 1))
+	}
+
+	if invalidParams.Len() > 0 {
+		return invalidParams
+	}
+	return nil
 }
 
 // Represents the returned data in response to a request action.
@@ -3444,6 +4079,25 @@ func (s UpdateFleetAttributesInput) GoString() string {
 	return s.String()
 }
 
+// Validate inspects the fields of the type to determine if they are valid.
+func (s *UpdateFleetAttributesInput) Validate() error {
+	invalidParams := request.ErrInvalidParams{Context: "UpdateFleetAttributesInput"}
+	if s.Description != nil && len(*s.Description) < 1 {
+		invalidParams.Add(request.NewErrParamMinLen("Description", 1))
+	}
+	if s.FleetId == nil {
+		invalidParams.Add(request.NewErrParamRequired("FleetId"))
+	}
+	if s.Name != nil && len(*s.Name) < 1 {
+		invalidParams.Add(request.NewErrParamMinLen("Name", 1))
+	}
+
+	if invalidParams.Len() > 0 {
+		return invalidParams
+	}
+	return nil
+}
+
 // Represents the returned data in response to a request action.
 type UpdateFleetAttributesOutput struct {
 	_ struct{} `type:"structure"`
@@ -3491,6 +4145,19 @@ func (s UpdateFleetCapacityInput) GoString() string {
 	return s.String()
 }
 
+// Validate inspects the fields of the type to determine if they are valid.
+func (s *UpdateFleetCapacityInput) Validate() error {
+	invalidParams := request.ErrInvalidParams{Context: "UpdateFleetCapacityInput"}
+	if s.FleetId == nil {
+		invalidParams.Add(request.NewErrParamRequired("FleetId"))
+	}
+
+	if invalidParams.Len() > 0 {
+		return invalidParams
+	}
+	return nil
+}
+
 // Represents the returned data in response to a request action.
 type UpdateFleetCapacityOutput struct {
 	_ struct{} `type:"structure"`
@@ -3531,6 +4198,39 @@ func (s UpdateFleetPortSettingsInput) String() string {
 // GoString returns the string representation
 func (s UpdateFleetPortSettingsInput) GoString() string {
 	return s.String()
+}
+
+// Validate inspects the fields of the type to determine if they are valid.
+func (s *UpdateFleetPortSettingsInput) Validate() error {
+	invalidParams := request.ErrInvalidParams{Context: "UpdateFleetPortSettingsInput"}
+	if s.FleetId == nil {
+		invalidParams.Add(request.NewErrParamRequired("FleetId"))
+	}
+	if s.InboundPermissionAuthorizations != nil {
+		for i, v := range s.InboundPermissionAuthorizations {
+			if v == nil {
+				continue
+			}
+			if err := v.Validate(); err != nil {
+				invalidParams.AddNested(fmt.Sprintf("%s[%v]", "InboundPermissionAuthorizations", i), err.(request.ErrInvalidParams))
+			}
+		}
+	}
+	if s.InboundPermissionRevocations != nil {
+		for i, v := range s.InboundPermissionRevocations {
+			if v == nil {
+				continue
+			}
+			if err := v.Validate(); err != nil {
+				invalidParams.AddNested(fmt.Sprintf("%s[%v]", "InboundPermissionRevocations", i), err.(request.ErrInvalidParams))
+			}
+		}
+	}
+
+	if invalidParams.Len() > 0 {
+		return invalidParams
+	}
+	return nil
 }
 
 // Represents the returned data in response to a request action.
@@ -3585,6 +4285,22 @@ func (s UpdateGameSessionInput) String() string {
 // GoString returns the string representation
 func (s UpdateGameSessionInput) GoString() string {
 	return s.String()
+}
+
+// Validate inspects the fields of the type to determine if they are valid.
+func (s *UpdateGameSessionInput) Validate() error {
+	invalidParams := request.ErrInvalidParams{Context: "UpdateGameSessionInput"}
+	if s.GameSessionId == nil {
+		invalidParams.Add(request.NewErrParamRequired("GameSessionId"))
+	}
+	if s.Name != nil && len(*s.Name) < 1 {
+		invalidParams.Add(request.NewErrParamMinLen("Name", 1))
+	}
+
+	if invalidParams.Len() > 0 {
+		return invalidParams
+	}
+	return nil
 }
 
 // Represents the returned data in response to a request action.

--- a/service/glacier/api.go
+++ b/service/glacier/api.go
@@ -1682,6 +1682,25 @@ func (s AbortMultipartUploadInput) GoString() string {
 	return s.String()
 }
 
+// Validate inspects the fields of the type to determine if they are valid.
+func (s *AbortMultipartUploadInput) Validate() error {
+	invalidParams := request.ErrInvalidParams{Context: "AbortMultipartUploadInput"}
+	if s.AccountId == nil {
+		invalidParams.Add(request.NewErrParamRequired("AccountId"))
+	}
+	if s.UploadId == nil {
+		invalidParams.Add(request.NewErrParamRequired("UploadId"))
+	}
+	if s.VaultName == nil {
+		invalidParams.Add(request.NewErrParamRequired("VaultName"))
+	}
+
+	if invalidParams.Len() > 0 {
+		return invalidParams
+	}
+	return nil
+}
+
 type AbortMultipartUploadOutput struct {
 	_ struct{} `type:"structure"`
 }
@@ -1720,6 +1739,22 @@ func (s AbortVaultLockInput) String() string {
 // GoString returns the string representation
 func (s AbortVaultLockInput) GoString() string {
 	return s.String()
+}
+
+// Validate inspects the fields of the type to determine if they are valid.
+func (s *AbortVaultLockInput) Validate() error {
+	invalidParams := request.ErrInvalidParams{Context: "AbortVaultLockInput"}
+	if s.AccountId == nil {
+		invalidParams.Add(request.NewErrParamRequired("AccountId"))
+	}
+	if s.VaultName == nil {
+		invalidParams.Add(request.NewErrParamRequired("VaultName"))
+	}
+
+	if invalidParams.Len() > 0 {
+		return invalidParams
+	}
+	return nil
 }
 
 type AbortVaultLockOutput struct {
@@ -1763,6 +1798,22 @@ func (s AddTagsToVaultInput) String() string {
 // GoString returns the string representation
 func (s AddTagsToVaultInput) GoString() string {
 	return s.String()
+}
+
+// Validate inspects the fields of the type to determine if they are valid.
+func (s *AddTagsToVaultInput) Validate() error {
+	invalidParams := request.ErrInvalidParams{Context: "AddTagsToVaultInput"}
+	if s.AccountId == nil {
+		invalidParams.Add(request.NewErrParamRequired("AccountId"))
+	}
+	if s.VaultName == nil {
+		invalidParams.Add(request.NewErrParamRequired("VaultName"))
+	}
+
+	if invalidParams.Len() > 0 {
+		return invalidParams
+	}
+	return nil
 }
 
 type AddTagsToVaultOutput struct {
@@ -1849,6 +1900,25 @@ func (s CompleteMultipartUploadInput) GoString() string {
 	return s.String()
 }
 
+// Validate inspects the fields of the type to determine if they are valid.
+func (s *CompleteMultipartUploadInput) Validate() error {
+	invalidParams := request.ErrInvalidParams{Context: "CompleteMultipartUploadInput"}
+	if s.AccountId == nil {
+		invalidParams.Add(request.NewErrParamRequired("AccountId"))
+	}
+	if s.UploadId == nil {
+		invalidParams.Add(request.NewErrParamRequired("UploadId"))
+	}
+	if s.VaultName == nil {
+		invalidParams.Add(request.NewErrParamRequired("VaultName"))
+	}
+
+	if invalidParams.Len() > 0 {
+		return invalidParams
+	}
+	return nil
+}
+
 // The input values for CompleteVaultLock.
 type CompleteVaultLockInput struct {
 	_ struct{} `type:"structure"`
@@ -1876,6 +1946,25 @@ func (s CompleteVaultLockInput) String() string {
 // GoString returns the string representation
 func (s CompleteVaultLockInput) GoString() string {
 	return s.String()
+}
+
+// Validate inspects the fields of the type to determine if they are valid.
+func (s *CompleteVaultLockInput) Validate() error {
+	invalidParams := request.ErrInvalidParams{Context: "CompleteVaultLockInput"}
+	if s.AccountId == nil {
+		invalidParams.Add(request.NewErrParamRequired("AccountId"))
+	}
+	if s.LockId == nil {
+		invalidParams.Add(request.NewErrParamRequired("LockId"))
+	}
+	if s.VaultName == nil {
+		invalidParams.Add(request.NewErrParamRequired("VaultName"))
+	}
+
+	if invalidParams.Len() > 0 {
+		return invalidParams
+	}
+	return nil
 }
 
 type CompleteVaultLockOutput struct {
@@ -1916,6 +2005,22 @@ func (s CreateVaultInput) String() string {
 // GoString returns the string representation
 func (s CreateVaultInput) GoString() string {
 	return s.String()
+}
+
+// Validate inspects the fields of the type to determine if they are valid.
+func (s *CreateVaultInput) Validate() error {
+	invalidParams := request.ErrInvalidParams{Context: "CreateVaultInput"}
+	if s.AccountId == nil {
+		invalidParams.Add(request.NewErrParamRequired("AccountId"))
+	}
+	if s.VaultName == nil {
+		invalidParams.Add(request.NewErrParamRequired("VaultName"))
+	}
+
+	if invalidParams.Len() > 0 {
+		return invalidParams
+	}
+	return nil
 }
 
 // Contains the Amazon Glacier response to your request.
@@ -2010,6 +2115,25 @@ func (s DeleteArchiveInput) GoString() string {
 	return s.String()
 }
 
+// Validate inspects the fields of the type to determine if they are valid.
+func (s *DeleteArchiveInput) Validate() error {
+	invalidParams := request.ErrInvalidParams{Context: "DeleteArchiveInput"}
+	if s.AccountId == nil {
+		invalidParams.Add(request.NewErrParamRequired("AccountId"))
+	}
+	if s.ArchiveId == nil {
+		invalidParams.Add(request.NewErrParamRequired("ArchiveId"))
+	}
+	if s.VaultName == nil {
+		invalidParams.Add(request.NewErrParamRequired("VaultName"))
+	}
+
+	if invalidParams.Len() > 0 {
+		return invalidParams
+	}
+	return nil
+}
+
 type DeleteArchiveOutput struct {
 	_ struct{} `type:"structure"`
 }
@@ -2047,6 +2171,22 @@ func (s DeleteVaultAccessPolicyInput) String() string {
 // GoString returns the string representation
 func (s DeleteVaultAccessPolicyInput) GoString() string {
 	return s.String()
+}
+
+// Validate inspects the fields of the type to determine if they are valid.
+func (s *DeleteVaultAccessPolicyInput) Validate() error {
+	invalidParams := request.ErrInvalidParams{Context: "DeleteVaultAccessPolicyInput"}
+	if s.AccountId == nil {
+		invalidParams.Add(request.NewErrParamRequired("AccountId"))
+	}
+	if s.VaultName == nil {
+		invalidParams.Add(request.NewErrParamRequired("VaultName"))
+	}
+
+	if invalidParams.Len() > 0 {
+		return invalidParams
+	}
+	return nil
 }
 
 type DeleteVaultAccessPolicyOutput struct {
@@ -2088,6 +2228,22 @@ func (s DeleteVaultInput) GoString() string {
 	return s.String()
 }
 
+// Validate inspects the fields of the type to determine if they are valid.
+func (s *DeleteVaultInput) Validate() error {
+	invalidParams := request.ErrInvalidParams{Context: "DeleteVaultInput"}
+	if s.AccountId == nil {
+		invalidParams.Add(request.NewErrParamRequired("AccountId"))
+	}
+	if s.VaultName == nil {
+		invalidParams.Add(request.NewErrParamRequired("VaultName"))
+	}
+
+	if invalidParams.Len() > 0 {
+		return invalidParams
+	}
+	return nil
+}
+
 // Provides options for deleting a vault notification configuration from an
 // Amazon Glacier vault.
 type DeleteVaultNotificationsInput struct {
@@ -2112,6 +2268,22 @@ func (s DeleteVaultNotificationsInput) String() string {
 // GoString returns the string representation
 func (s DeleteVaultNotificationsInput) GoString() string {
 	return s.String()
+}
+
+// Validate inspects the fields of the type to determine if they are valid.
+func (s *DeleteVaultNotificationsInput) Validate() error {
+	invalidParams := request.ErrInvalidParams{Context: "DeleteVaultNotificationsInput"}
+	if s.AccountId == nil {
+		invalidParams.Add(request.NewErrParamRequired("AccountId"))
+	}
+	if s.VaultName == nil {
+		invalidParams.Add(request.NewErrParamRequired("VaultName"))
+	}
+
+	if invalidParams.Len() > 0 {
+		return invalidParams
+	}
+	return nil
 }
 
 type DeleteVaultNotificationsOutput struct {
@@ -2170,6 +2342,25 @@ func (s DescribeJobInput) GoString() string {
 	return s.String()
 }
 
+// Validate inspects the fields of the type to determine if they are valid.
+func (s *DescribeJobInput) Validate() error {
+	invalidParams := request.ErrInvalidParams{Context: "DescribeJobInput"}
+	if s.AccountId == nil {
+		invalidParams.Add(request.NewErrParamRequired("AccountId"))
+	}
+	if s.JobId == nil {
+		invalidParams.Add(request.NewErrParamRequired("JobId"))
+	}
+	if s.VaultName == nil {
+		invalidParams.Add(request.NewErrParamRequired("VaultName"))
+	}
+
+	if invalidParams.Len() > 0 {
+		return invalidParams
+	}
+	return nil
+}
+
 // Provides options for retrieving metadata for a specific vault in Amazon Glacier.
 type DescribeVaultInput struct {
 	_ struct{} `type:"structure"`
@@ -2193,6 +2384,22 @@ func (s DescribeVaultInput) String() string {
 // GoString returns the string representation
 func (s DescribeVaultInput) GoString() string {
 	return s.String()
+}
+
+// Validate inspects the fields of the type to determine if they are valid.
+func (s *DescribeVaultInput) Validate() error {
+	invalidParams := request.ErrInvalidParams{Context: "DescribeVaultInput"}
+	if s.AccountId == nil {
+		invalidParams.Add(request.NewErrParamRequired("AccountId"))
+	}
+	if s.VaultName == nil {
+		invalidParams.Add(request.NewErrParamRequired("VaultName"))
+	}
+
+	if invalidParams.Len() > 0 {
+		return invalidParams
+	}
+	return nil
 }
 
 // Contains the Amazon Glacier response to your request.
@@ -2257,6 +2464,19 @@ func (s GetDataRetrievalPolicyInput) GoString() string {
 	return s.String()
 }
 
+// Validate inspects the fields of the type to determine if they are valid.
+func (s *GetDataRetrievalPolicyInput) Validate() error {
+	invalidParams := request.ErrInvalidParams{Context: "GetDataRetrievalPolicyInput"}
+	if s.AccountId == nil {
+		invalidParams.Add(request.NewErrParamRequired("AccountId"))
+	}
+
+	if invalidParams.Len() > 0 {
+		return invalidParams
+	}
+	return nil
+}
+
 // Contains the Amazon Glacier response to the GetDataRetrievalPolicy request.
 type GetDataRetrievalPolicyOutput struct {
 	_ struct{} `type:"structure"`
@@ -2306,6 +2526,25 @@ func (s GetJobOutputInput) String() string {
 // GoString returns the string representation
 func (s GetJobOutputInput) GoString() string {
 	return s.String()
+}
+
+// Validate inspects the fields of the type to determine if they are valid.
+func (s *GetJobOutputInput) Validate() error {
+	invalidParams := request.ErrInvalidParams{Context: "GetJobOutputInput"}
+	if s.AccountId == nil {
+		invalidParams.Add(request.NewErrParamRequired("AccountId"))
+	}
+	if s.JobId == nil {
+		invalidParams.Add(request.NewErrParamRequired("JobId"))
+	}
+	if s.VaultName == nil {
+		invalidParams.Add(request.NewErrParamRequired("VaultName"))
+	}
+
+	if invalidParams.Len() > 0 {
+		return invalidParams
+	}
+	return nil
 }
 
 // Contains the Amazon Glacier response to your request.
@@ -2386,6 +2625,22 @@ func (s GetVaultAccessPolicyInput) GoString() string {
 	return s.String()
 }
 
+// Validate inspects the fields of the type to determine if they are valid.
+func (s *GetVaultAccessPolicyInput) Validate() error {
+	invalidParams := request.ErrInvalidParams{Context: "GetVaultAccessPolicyInput"}
+	if s.AccountId == nil {
+		invalidParams.Add(request.NewErrParamRequired("AccountId"))
+	}
+	if s.VaultName == nil {
+		invalidParams.Add(request.NewErrParamRequired("VaultName"))
+	}
+
+	if invalidParams.Len() > 0 {
+		return invalidParams
+	}
+	return nil
+}
+
 // Output for GetVaultAccessPolicy.
 type GetVaultAccessPolicyOutput struct {
 	_ struct{} `type:"structure" payload:"Policy"`
@@ -2427,6 +2682,22 @@ func (s GetVaultLockInput) String() string {
 // GoString returns the string representation
 func (s GetVaultLockInput) GoString() string {
 	return s.String()
+}
+
+// Validate inspects the fields of the type to determine if they are valid.
+func (s *GetVaultLockInput) Validate() error {
+	invalidParams := request.ErrInvalidParams{Context: "GetVaultLockInput"}
+	if s.AccountId == nil {
+		invalidParams.Add(request.NewErrParamRequired("AccountId"))
+	}
+	if s.VaultName == nil {
+		invalidParams.Add(request.NewErrParamRequired("VaultName"))
+	}
+
+	if invalidParams.Len() > 0 {
+		return invalidParams
+	}
+	return nil
 }
 
 // Contains the Amazon Glacier response to your request.
@@ -2484,6 +2755,22 @@ func (s GetVaultNotificationsInput) GoString() string {
 	return s.String()
 }
 
+// Validate inspects the fields of the type to determine if they are valid.
+func (s *GetVaultNotificationsInput) Validate() error {
+	invalidParams := request.ErrInvalidParams{Context: "GetVaultNotificationsInput"}
+	if s.AccountId == nil {
+		invalidParams.Add(request.NewErrParamRequired("AccountId"))
+	}
+	if s.VaultName == nil {
+		invalidParams.Add(request.NewErrParamRequired("VaultName"))
+	}
+
+	if invalidParams.Len() > 0 {
+		return invalidParams
+	}
+	return nil
+}
+
 // Contains the Amazon Glacier response to your request.
 type GetVaultNotificationsOutput struct {
 	_ struct{} `type:"structure" payload:"VaultNotificationConfig"`
@@ -2528,6 +2815,22 @@ func (s InitiateJobInput) String() string {
 // GoString returns the string representation
 func (s InitiateJobInput) GoString() string {
 	return s.String()
+}
+
+// Validate inspects the fields of the type to determine if they are valid.
+func (s *InitiateJobInput) Validate() error {
+	invalidParams := request.ErrInvalidParams{Context: "InitiateJobInput"}
+	if s.AccountId == nil {
+		invalidParams.Add(request.NewErrParamRequired("AccountId"))
+	}
+	if s.VaultName == nil {
+		invalidParams.Add(request.NewErrParamRequired("VaultName"))
+	}
+
+	if invalidParams.Len() > 0 {
+		return invalidParams
+	}
+	return nil
 }
 
 // Contains the Amazon Glacier response to your request.
@@ -2588,6 +2891,22 @@ func (s InitiateMultipartUploadInput) GoString() string {
 	return s.String()
 }
 
+// Validate inspects the fields of the type to determine if they are valid.
+func (s *InitiateMultipartUploadInput) Validate() error {
+	invalidParams := request.ErrInvalidParams{Context: "InitiateMultipartUploadInput"}
+	if s.AccountId == nil {
+		invalidParams.Add(request.NewErrParamRequired("AccountId"))
+	}
+	if s.VaultName == nil {
+		invalidParams.Add(request.NewErrParamRequired("VaultName"))
+	}
+
+	if invalidParams.Len() > 0 {
+		return invalidParams
+	}
+	return nil
+}
+
 // The Amazon Glacier response to your request.
 type InitiateMultipartUploadOutput struct {
 	_ struct{} `type:"structure"`
@@ -2637,6 +2956,22 @@ func (s InitiateVaultLockInput) String() string {
 // GoString returns the string representation
 func (s InitiateVaultLockInput) GoString() string {
 	return s.String()
+}
+
+// Validate inspects the fields of the type to determine if they are valid.
+func (s *InitiateVaultLockInput) Validate() error {
+	invalidParams := request.ErrInvalidParams{Context: "InitiateVaultLockInput"}
+	if s.AccountId == nil {
+		invalidParams.Add(request.NewErrParamRequired("AccountId"))
+	}
+	if s.VaultName == nil {
+		invalidParams.Add(request.NewErrParamRequired("VaultName"))
+	}
+
+	if invalidParams.Len() > 0 {
+		return invalidParams
+	}
+	return nil
 }
 
 // Contains the Amazon Glacier response to your request.
@@ -2924,6 +3259,22 @@ func (s ListJobsInput) GoString() string {
 	return s.String()
 }
 
+// Validate inspects the fields of the type to determine if they are valid.
+func (s *ListJobsInput) Validate() error {
+	invalidParams := request.ErrInvalidParams{Context: "ListJobsInput"}
+	if s.AccountId == nil {
+		invalidParams.Add(request.NewErrParamRequired("AccountId"))
+	}
+	if s.VaultName == nil {
+		invalidParams.Add(request.NewErrParamRequired("VaultName"))
+	}
+
+	if invalidParams.Len() > 0 {
+		return invalidParams
+	}
+	return nil
+}
+
 // Contains the Amazon Glacier response to your request.
 type ListJobsOutput struct {
 	_ struct{} `type:"structure"`
@@ -2982,6 +3333,22 @@ func (s ListMultipartUploadsInput) String() string {
 // GoString returns the string representation
 func (s ListMultipartUploadsInput) GoString() string {
 	return s.String()
+}
+
+// Validate inspects the fields of the type to determine if they are valid.
+func (s *ListMultipartUploadsInput) Validate() error {
+	invalidParams := request.ErrInvalidParams{Context: "ListMultipartUploadsInput"}
+	if s.AccountId == nil {
+		invalidParams.Add(request.NewErrParamRequired("AccountId"))
+	}
+	if s.VaultName == nil {
+		invalidParams.Add(request.NewErrParamRequired("VaultName"))
+	}
+
+	if invalidParams.Len() > 0 {
+		return invalidParams
+	}
+	return nil
 }
 
 // Contains the Amazon Glacier response to your request.
@@ -3045,6 +3412,25 @@ func (s ListPartsInput) String() string {
 // GoString returns the string representation
 func (s ListPartsInput) GoString() string {
 	return s.String()
+}
+
+// Validate inspects the fields of the type to determine if they are valid.
+func (s *ListPartsInput) Validate() error {
+	invalidParams := request.ErrInvalidParams{Context: "ListPartsInput"}
+	if s.AccountId == nil {
+		invalidParams.Add(request.NewErrParamRequired("AccountId"))
+	}
+	if s.UploadId == nil {
+		invalidParams.Add(request.NewErrParamRequired("UploadId"))
+	}
+	if s.VaultName == nil {
+		invalidParams.Add(request.NewErrParamRequired("VaultName"))
+	}
+
+	if invalidParams.Len() > 0 {
+		return invalidParams
+	}
+	return nil
 }
 
 // Contains the Amazon Glacier response to your request.
@@ -3112,6 +3498,22 @@ func (s ListTagsForVaultInput) GoString() string {
 	return s.String()
 }
 
+// Validate inspects the fields of the type to determine if they are valid.
+func (s *ListTagsForVaultInput) Validate() error {
+	invalidParams := request.ErrInvalidParams{Context: "ListTagsForVaultInput"}
+	if s.AccountId == nil {
+		invalidParams.Add(request.NewErrParamRequired("AccountId"))
+	}
+	if s.VaultName == nil {
+		invalidParams.Add(request.NewErrParamRequired("VaultName"))
+	}
+
+	if invalidParams.Len() > 0 {
+		return invalidParams
+	}
+	return nil
+}
+
 // Contains the Amazon Glacier response to your request.
 type ListTagsForVaultOutput struct {
 	_ struct{} `type:"structure"`
@@ -3160,6 +3562,19 @@ func (s ListVaultsInput) String() string {
 // GoString returns the string representation
 func (s ListVaultsInput) GoString() string {
 	return s.String()
+}
+
+// Validate inspects the fields of the type to determine if they are valid.
+func (s *ListVaultsInput) Validate() error {
+	invalidParams := request.ErrInvalidParams{Context: "ListVaultsInput"}
+	if s.AccountId == nil {
+		invalidParams.Add(request.NewErrParamRequired("AccountId"))
+	}
+
+	if invalidParams.Len() > 0 {
+		return invalidParams
+	}
+	return nil
 }
 
 // Contains the Amazon Glacier response to your request.
@@ -3234,6 +3649,22 @@ func (s RemoveTagsFromVaultInput) GoString() string {
 	return s.String()
 }
 
+// Validate inspects the fields of the type to determine if they are valid.
+func (s *RemoveTagsFromVaultInput) Validate() error {
+	invalidParams := request.ErrInvalidParams{Context: "RemoveTagsFromVaultInput"}
+	if s.AccountId == nil {
+		invalidParams.Add(request.NewErrParamRequired("AccountId"))
+	}
+	if s.VaultName == nil {
+		invalidParams.Add(request.NewErrParamRequired("VaultName"))
+	}
+
+	if invalidParams.Len() > 0 {
+		return invalidParams
+	}
+	return nil
+}
+
 type RemoveTagsFromVaultOutput struct {
 	_ struct{} `type:"structure"`
 }
@@ -3272,6 +3703,19 @@ func (s SetDataRetrievalPolicyInput) String() string {
 // GoString returns the string representation
 func (s SetDataRetrievalPolicyInput) GoString() string {
 	return s.String()
+}
+
+// Validate inspects the fields of the type to determine if they are valid.
+func (s *SetDataRetrievalPolicyInput) Validate() error {
+	invalidParams := request.ErrInvalidParams{Context: "SetDataRetrievalPolicyInput"}
+	if s.AccountId == nil {
+		invalidParams.Add(request.NewErrParamRequired("AccountId"))
+	}
+
+	if invalidParams.Len() > 0 {
+		return invalidParams
+	}
+	return nil
 }
 
 type SetDataRetrievalPolicyOutput struct {
@@ -3316,6 +3760,22 @@ func (s SetVaultAccessPolicyInput) GoString() string {
 	return s.String()
 }
 
+// Validate inspects the fields of the type to determine if they are valid.
+func (s *SetVaultAccessPolicyInput) Validate() error {
+	invalidParams := request.ErrInvalidParams{Context: "SetVaultAccessPolicyInput"}
+	if s.AccountId == nil {
+		invalidParams.Add(request.NewErrParamRequired("AccountId"))
+	}
+	if s.VaultName == nil {
+		invalidParams.Add(request.NewErrParamRequired("VaultName"))
+	}
+
+	if invalidParams.Len() > 0 {
+		return invalidParams
+	}
+	return nil
+}
+
 type SetVaultAccessPolicyOutput struct {
 	_ struct{} `type:"structure"`
 }
@@ -3357,6 +3817,22 @@ func (s SetVaultNotificationsInput) String() string {
 // GoString returns the string representation
 func (s SetVaultNotificationsInput) GoString() string {
 	return s.String()
+}
+
+// Validate inspects the fields of the type to determine if they are valid.
+func (s *SetVaultNotificationsInput) Validate() error {
+	invalidParams := request.ErrInvalidParams{Context: "SetVaultNotificationsInput"}
+	if s.AccountId == nil {
+		invalidParams.Add(request.NewErrParamRequired("AccountId"))
+	}
+	if s.VaultName == nil {
+		invalidParams.Add(request.NewErrParamRequired("VaultName"))
+	}
+
+	if invalidParams.Len() > 0 {
+		return invalidParams
+	}
+	return nil
 }
 
 type SetVaultNotificationsOutput struct {
@@ -3405,6 +3881,22 @@ func (s UploadArchiveInput) String() string {
 // GoString returns the string representation
 func (s UploadArchiveInput) GoString() string {
 	return s.String()
+}
+
+// Validate inspects the fields of the type to determine if they are valid.
+func (s *UploadArchiveInput) Validate() error {
+	invalidParams := request.ErrInvalidParams{Context: "UploadArchiveInput"}
+	if s.AccountId == nil {
+		invalidParams.Add(request.NewErrParamRequired("AccountId"))
+	}
+	if s.VaultName == nil {
+		invalidParams.Add(request.NewErrParamRequired("VaultName"))
+	}
+
+	if invalidParams.Len() > 0 {
+		return invalidParams
+	}
+	return nil
 }
 
 // A list of in-progress multipart uploads for a vault.
@@ -3478,6 +3970,25 @@ func (s UploadMultipartPartInput) String() string {
 // GoString returns the string representation
 func (s UploadMultipartPartInput) GoString() string {
 	return s.String()
+}
+
+// Validate inspects the fields of the type to determine if they are valid.
+func (s *UploadMultipartPartInput) Validate() error {
+	invalidParams := request.ErrInvalidParams{Context: "UploadMultipartPartInput"}
+	if s.AccountId == nil {
+		invalidParams.Add(request.NewErrParamRequired("AccountId"))
+	}
+	if s.UploadId == nil {
+		invalidParams.Add(request.NewErrParamRequired("UploadId"))
+	}
+	if s.VaultName == nil {
+		invalidParams.Add(request.NewErrParamRequired("VaultName"))
+	}
+
+	if invalidParams.Len() > 0 {
+		return invalidParams
+	}
+	return nil
 }
 
 // Contains the Amazon Glacier response to your request.

--- a/service/iam/api.go
+++ b/service/iam/api.go
@@ -4,6 +4,7 @@
 package iam
 
 import (
+	"fmt"
 	"time"
 
 	"github.com/aws/aws-sdk-go/aws/awsutil"
@@ -4452,6 +4453,28 @@ func (s AddClientIDToOpenIDConnectProviderInput) GoString() string {
 	return s.String()
 }
 
+// Validate inspects the fields of the type to determine if they are valid.
+func (s *AddClientIDToOpenIDConnectProviderInput) Validate() error {
+	invalidParams := request.ErrInvalidParams{Context: "AddClientIDToOpenIDConnectProviderInput"}
+	if s.ClientID == nil {
+		invalidParams.Add(request.NewErrParamRequired("ClientID"))
+	}
+	if s.ClientID != nil && len(*s.ClientID) < 1 {
+		invalidParams.Add(request.NewErrParamMinLen("ClientID", 1))
+	}
+	if s.OpenIDConnectProviderArn == nil {
+		invalidParams.Add(request.NewErrParamRequired("OpenIDConnectProviderArn"))
+	}
+	if s.OpenIDConnectProviderArn != nil && len(*s.OpenIDConnectProviderArn) < 20 {
+		invalidParams.Add(request.NewErrParamMinLen("OpenIDConnectProviderArn", 20))
+	}
+
+	if invalidParams.Len() > 0 {
+		return invalidParams
+	}
+	return nil
+}
+
 type AddClientIDToOpenIDConnectProviderOutput struct {
 	_ struct{} `type:"structure"`
 }
@@ -4486,6 +4509,28 @@ func (s AddRoleToInstanceProfileInput) GoString() string {
 	return s.String()
 }
 
+// Validate inspects the fields of the type to determine if they are valid.
+func (s *AddRoleToInstanceProfileInput) Validate() error {
+	invalidParams := request.ErrInvalidParams{Context: "AddRoleToInstanceProfileInput"}
+	if s.InstanceProfileName == nil {
+		invalidParams.Add(request.NewErrParamRequired("InstanceProfileName"))
+	}
+	if s.InstanceProfileName != nil && len(*s.InstanceProfileName) < 1 {
+		invalidParams.Add(request.NewErrParamMinLen("InstanceProfileName", 1))
+	}
+	if s.RoleName == nil {
+		invalidParams.Add(request.NewErrParamRequired("RoleName"))
+	}
+	if s.RoleName != nil && len(*s.RoleName) < 1 {
+		invalidParams.Add(request.NewErrParamMinLen("RoleName", 1))
+	}
+
+	if invalidParams.Len() > 0 {
+		return invalidParams
+	}
+	return nil
+}
+
 type AddRoleToInstanceProfileOutput struct {
 	_ struct{} `type:"structure"`
 }
@@ -4518,6 +4563,28 @@ func (s AddUserToGroupInput) String() string {
 // GoString returns the string representation
 func (s AddUserToGroupInput) GoString() string {
 	return s.String()
+}
+
+// Validate inspects the fields of the type to determine if they are valid.
+func (s *AddUserToGroupInput) Validate() error {
+	invalidParams := request.ErrInvalidParams{Context: "AddUserToGroupInput"}
+	if s.GroupName == nil {
+		invalidParams.Add(request.NewErrParamRequired("GroupName"))
+	}
+	if s.GroupName != nil && len(*s.GroupName) < 1 {
+		invalidParams.Add(request.NewErrParamMinLen("GroupName", 1))
+	}
+	if s.UserName == nil {
+		invalidParams.Add(request.NewErrParamRequired("UserName"))
+	}
+	if s.UserName != nil && len(*s.UserName) < 1 {
+		invalidParams.Add(request.NewErrParamMinLen("UserName", 1))
+	}
+
+	if invalidParams.Len() > 0 {
+		return invalidParams
+	}
+	return nil
 }
 
 type AddUserToGroupOutput struct {
@@ -4558,6 +4625,28 @@ func (s AttachGroupPolicyInput) GoString() string {
 	return s.String()
 }
 
+// Validate inspects the fields of the type to determine if they are valid.
+func (s *AttachGroupPolicyInput) Validate() error {
+	invalidParams := request.ErrInvalidParams{Context: "AttachGroupPolicyInput"}
+	if s.GroupName == nil {
+		invalidParams.Add(request.NewErrParamRequired("GroupName"))
+	}
+	if s.GroupName != nil && len(*s.GroupName) < 1 {
+		invalidParams.Add(request.NewErrParamMinLen("GroupName", 1))
+	}
+	if s.PolicyArn == nil {
+		invalidParams.Add(request.NewErrParamRequired("PolicyArn"))
+	}
+	if s.PolicyArn != nil && len(*s.PolicyArn) < 20 {
+		invalidParams.Add(request.NewErrParamMinLen("PolicyArn", 20))
+	}
+
+	if invalidParams.Len() > 0 {
+		return invalidParams
+	}
+	return nil
+}
+
 type AttachGroupPolicyOutput struct {
 	_ struct{} `type:"structure"`
 }
@@ -4596,6 +4685,28 @@ func (s AttachRolePolicyInput) GoString() string {
 	return s.String()
 }
 
+// Validate inspects the fields of the type to determine if they are valid.
+func (s *AttachRolePolicyInput) Validate() error {
+	invalidParams := request.ErrInvalidParams{Context: "AttachRolePolicyInput"}
+	if s.PolicyArn == nil {
+		invalidParams.Add(request.NewErrParamRequired("PolicyArn"))
+	}
+	if s.PolicyArn != nil && len(*s.PolicyArn) < 20 {
+		invalidParams.Add(request.NewErrParamMinLen("PolicyArn", 20))
+	}
+	if s.RoleName == nil {
+		invalidParams.Add(request.NewErrParamRequired("RoleName"))
+	}
+	if s.RoleName != nil && len(*s.RoleName) < 1 {
+		invalidParams.Add(request.NewErrParamMinLen("RoleName", 1))
+	}
+
+	if invalidParams.Len() > 0 {
+		return invalidParams
+	}
+	return nil
+}
+
 type AttachRolePolicyOutput struct {
 	_ struct{} `type:"structure"`
 }
@@ -4632,6 +4743,28 @@ func (s AttachUserPolicyInput) String() string {
 // GoString returns the string representation
 func (s AttachUserPolicyInput) GoString() string {
 	return s.String()
+}
+
+// Validate inspects the fields of the type to determine if they are valid.
+func (s *AttachUserPolicyInput) Validate() error {
+	invalidParams := request.ErrInvalidParams{Context: "AttachUserPolicyInput"}
+	if s.PolicyArn == nil {
+		invalidParams.Add(request.NewErrParamRequired("PolicyArn"))
+	}
+	if s.PolicyArn != nil && len(*s.PolicyArn) < 20 {
+		invalidParams.Add(request.NewErrParamMinLen("PolicyArn", 20))
+	}
+	if s.UserName == nil {
+		invalidParams.Add(request.NewErrParamRequired("UserName"))
+	}
+	if s.UserName != nil && len(*s.UserName) < 1 {
+		invalidParams.Add(request.NewErrParamMinLen("UserName", 1))
+	}
+
+	if invalidParams.Len() > 0 {
+		return invalidParams
+	}
+	return nil
 }
 
 type AttachUserPolicyOutput struct {
@@ -4703,6 +4836,28 @@ func (s ChangePasswordInput) GoString() string {
 	return s.String()
 }
 
+// Validate inspects the fields of the type to determine if they are valid.
+func (s *ChangePasswordInput) Validate() error {
+	invalidParams := request.ErrInvalidParams{Context: "ChangePasswordInput"}
+	if s.NewPassword == nil {
+		invalidParams.Add(request.NewErrParamRequired("NewPassword"))
+	}
+	if s.NewPassword != nil && len(*s.NewPassword) < 1 {
+		invalidParams.Add(request.NewErrParamMinLen("NewPassword", 1))
+	}
+	if s.OldPassword == nil {
+		invalidParams.Add(request.NewErrParamRequired("OldPassword"))
+	}
+	if s.OldPassword != nil && len(*s.OldPassword) < 1 {
+		invalidParams.Add(request.NewErrParamMinLen("OldPassword", 1))
+	}
+
+	if invalidParams.Len() > 0 {
+		return invalidParams
+	}
+	return nil
+}
+
 type ChangePasswordOutput struct {
 	_ struct{} `type:"structure"`
 }
@@ -4750,6 +4905,19 @@ func (s ContextEntry) GoString() string {
 	return s.String()
 }
 
+// Validate inspects the fields of the type to determine if they are valid.
+func (s *ContextEntry) Validate() error {
+	invalidParams := request.ErrInvalidParams{Context: "ContextEntry"}
+	if s.ContextKeyName != nil && len(*s.ContextKeyName) < 5 {
+		invalidParams.Add(request.NewErrParamMinLen("ContextKeyName", 5))
+	}
+
+	if invalidParams.Len() > 0 {
+		return invalidParams
+	}
+	return nil
+}
+
 type CreateAccessKeyInput struct {
 	_ struct{} `type:"structure"`
 
@@ -4765,6 +4933,19 @@ func (s CreateAccessKeyInput) String() string {
 // GoString returns the string representation
 func (s CreateAccessKeyInput) GoString() string {
 	return s.String()
+}
+
+// Validate inspects the fields of the type to determine if they are valid.
+func (s *CreateAccessKeyInput) Validate() error {
+	invalidParams := request.ErrInvalidParams{Context: "CreateAccessKeyInput"}
+	if s.UserName != nil && len(*s.UserName) < 1 {
+		invalidParams.Add(request.NewErrParamMinLen("UserName", 1))
+	}
+
+	if invalidParams.Len() > 0 {
+		return invalidParams
+	}
+	return nil
 }
 
 // Contains the response to a successful CreateAccessKey request.
@@ -4800,6 +4981,22 @@ func (s CreateAccountAliasInput) String() string {
 // GoString returns the string representation
 func (s CreateAccountAliasInput) GoString() string {
 	return s.String()
+}
+
+// Validate inspects the fields of the type to determine if they are valid.
+func (s *CreateAccountAliasInput) Validate() error {
+	invalidParams := request.ErrInvalidParams{Context: "CreateAccountAliasInput"}
+	if s.AccountAlias == nil {
+		invalidParams.Add(request.NewErrParamRequired("AccountAlias"))
+	}
+	if s.AccountAlias != nil && len(*s.AccountAlias) < 3 {
+		invalidParams.Add(request.NewErrParamMinLen("AccountAlias", 3))
+	}
+
+	if invalidParams.Len() > 0 {
+		return invalidParams
+	}
+	return nil
 }
 
 type CreateAccountAliasOutput struct {
@@ -4839,6 +5036,25 @@ func (s CreateGroupInput) String() string {
 // GoString returns the string representation
 func (s CreateGroupInput) GoString() string {
 	return s.String()
+}
+
+// Validate inspects the fields of the type to determine if they are valid.
+func (s *CreateGroupInput) Validate() error {
+	invalidParams := request.ErrInvalidParams{Context: "CreateGroupInput"}
+	if s.GroupName == nil {
+		invalidParams.Add(request.NewErrParamRequired("GroupName"))
+	}
+	if s.GroupName != nil && len(*s.GroupName) < 1 {
+		invalidParams.Add(request.NewErrParamMinLen("GroupName", 1))
+	}
+	if s.Path != nil && len(*s.Path) < 1 {
+		invalidParams.Add(request.NewErrParamMinLen("Path", 1))
+	}
+
+	if invalidParams.Len() > 0 {
+		return invalidParams
+	}
+	return nil
 }
 
 // Contains the response to a successful CreateGroup request.
@@ -4884,6 +5100,25 @@ func (s CreateInstanceProfileInput) GoString() string {
 	return s.String()
 }
 
+// Validate inspects the fields of the type to determine if they are valid.
+func (s *CreateInstanceProfileInput) Validate() error {
+	invalidParams := request.ErrInvalidParams{Context: "CreateInstanceProfileInput"}
+	if s.InstanceProfileName == nil {
+		invalidParams.Add(request.NewErrParamRequired("InstanceProfileName"))
+	}
+	if s.InstanceProfileName != nil && len(*s.InstanceProfileName) < 1 {
+		invalidParams.Add(request.NewErrParamMinLen("InstanceProfileName", 1))
+	}
+	if s.Path != nil && len(*s.Path) < 1 {
+		invalidParams.Add(request.NewErrParamMinLen("Path", 1))
+	}
+
+	if invalidParams.Len() > 0 {
+		return invalidParams
+	}
+	return nil
+}
+
 // Contains the response to a successful CreateInstanceProfile request.
 type CreateInstanceProfileOutput struct {
 	_ struct{} `type:"structure"`
@@ -4923,6 +5158,28 @@ func (s CreateLoginProfileInput) String() string {
 // GoString returns the string representation
 func (s CreateLoginProfileInput) GoString() string {
 	return s.String()
+}
+
+// Validate inspects the fields of the type to determine if they are valid.
+func (s *CreateLoginProfileInput) Validate() error {
+	invalidParams := request.ErrInvalidParams{Context: "CreateLoginProfileInput"}
+	if s.Password == nil {
+		invalidParams.Add(request.NewErrParamRequired("Password"))
+	}
+	if s.Password != nil && len(*s.Password) < 1 {
+		invalidParams.Add(request.NewErrParamMinLen("Password", 1))
+	}
+	if s.UserName == nil {
+		invalidParams.Add(request.NewErrParamRequired("UserName"))
+	}
+	if s.UserName != nil && len(*s.UserName) < 1 {
+		invalidParams.Add(request.NewErrParamMinLen("UserName", 1))
+	}
+
+	if invalidParams.Len() > 0 {
+		return invalidParams
+	}
+	return nil
 }
 
 // Contains the response to a successful CreateLoginProfile request.
@@ -5002,6 +5259,25 @@ func (s CreateOpenIDConnectProviderInput) GoString() string {
 	return s.String()
 }
 
+// Validate inspects the fields of the type to determine if they are valid.
+func (s *CreateOpenIDConnectProviderInput) Validate() error {
+	invalidParams := request.ErrInvalidParams{Context: "CreateOpenIDConnectProviderInput"}
+	if s.ThumbprintList == nil {
+		invalidParams.Add(request.NewErrParamRequired("ThumbprintList"))
+	}
+	if s.Url == nil {
+		invalidParams.Add(request.NewErrParamRequired("Url"))
+	}
+	if s.Url != nil && len(*s.Url) < 1 {
+		invalidParams.Add(request.NewErrParamMinLen("Url", 1))
+	}
+
+	if invalidParams.Len() > 0 {
+		return invalidParams
+	}
+	return nil
+}
+
 // Contains the response to a successful CreateOpenIDConnectProvider request.
 type CreateOpenIDConnectProviderOutput struct {
 	_ struct{} `type:"structure"`
@@ -5059,6 +5335,28 @@ func (s CreatePolicyInput) GoString() string {
 	return s.String()
 }
 
+// Validate inspects the fields of the type to determine if they are valid.
+func (s *CreatePolicyInput) Validate() error {
+	invalidParams := request.ErrInvalidParams{Context: "CreatePolicyInput"}
+	if s.PolicyDocument == nil {
+		invalidParams.Add(request.NewErrParamRequired("PolicyDocument"))
+	}
+	if s.PolicyDocument != nil && len(*s.PolicyDocument) < 1 {
+		invalidParams.Add(request.NewErrParamMinLen("PolicyDocument", 1))
+	}
+	if s.PolicyName == nil {
+		invalidParams.Add(request.NewErrParamRequired("PolicyName"))
+	}
+	if s.PolicyName != nil && len(*s.PolicyName) < 1 {
+		invalidParams.Add(request.NewErrParamMinLen("PolicyName", 1))
+	}
+
+	if invalidParams.Len() > 0 {
+		return invalidParams
+	}
+	return nil
+}
+
 // Contains the response to a successful CreatePolicy request.
 type CreatePolicyOutput struct {
 	_ struct{} `type:"structure"`
@@ -5112,6 +5410,28 @@ func (s CreatePolicyVersionInput) GoString() string {
 	return s.String()
 }
 
+// Validate inspects the fields of the type to determine if they are valid.
+func (s *CreatePolicyVersionInput) Validate() error {
+	invalidParams := request.ErrInvalidParams{Context: "CreatePolicyVersionInput"}
+	if s.PolicyArn == nil {
+		invalidParams.Add(request.NewErrParamRequired("PolicyArn"))
+	}
+	if s.PolicyArn != nil && len(*s.PolicyArn) < 20 {
+		invalidParams.Add(request.NewErrParamMinLen("PolicyArn", 20))
+	}
+	if s.PolicyDocument == nil {
+		invalidParams.Add(request.NewErrParamRequired("PolicyDocument"))
+	}
+	if s.PolicyDocument != nil && len(*s.PolicyDocument) < 1 {
+		invalidParams.Add(request.NewErrParamMinLen("PolicyDocument", 1))
+	}
+
+	if invalidParams.Len() > 0 {
+		return invalidParams
+	}
+	return nil
+}
+
 // Contains the response to a successful CreatePolicyVersion request.
 type CreatePolicyVersionOutput struct {
 	_ struct{} `type:"structure"`
@@ -5159,6 +5479,31 @@ func (s CreateRoleInput) GoString() string {
 	return s.String()
 }
 
+// Validate inspects the fields of the type to determine if they are valid.
+func (s *CreateRoleInput) Validate() error {
+	invalidParams := request.ErrInvalidParams{Context: "CreateRoleInput"}
+	if s.AssumeRolePolicyDocument == nil {
+		invalidParams.Add(request.NewErrParamRequired("AssumeRolePolicyDocument"))
+	}
+	if s.AssumeRolePolicyDocument != nil && len(*s.AssumeRolePolicyDocument) < 1 {
+		invalidParams.Add(request.NewErrParamMinLen("AssumeRolePolicyDocument", 1))
+	}
+	if s.Path != nil && len(*s.Path) < 1 {
+		invalidParams.Add(request.NewErrParamMinLen("Path", 1))
+	}
+	if s.RoleName == nil {
+		invalidParams.Add(request.NewErrParamRequired("RoleName"))
+	}
+	if s.RoleName != nil && len(*s.RoleName) < 1 {
+		invalidParams.Add(request.NewErrParamMinLen("RoleName", 1))
+	}
+
+	if invalidParams.Len() > 0 {
+		return invalidParams
+	}
+	return nil
+}
+
 // Contains the response to a successful CreateRole request.
 type CreateRoleOutput struct {
 	_ struct{} `type:"structure"`
@@ -5204,6 +5549,28 @@ func (s CreateSAMLProviderInput) GoString() string {
 	return s.String()
 }
 
+// Validate inspects the fields of the type to determine if they are valid.
+func (s *CreateSAMLProviderInput) Validate() error {
+	invalidParams := request.ErrInvalidParams{Context: "CreateSAMLProviderInput"}
+	if s.Name == nil {
+		invalidParams.Add(request.NewErrParamRequired("Name"))
+	}
+	if s.Name != nil && len(*s.Name) < 1 {
+		invalidParams.Add(request.NewErrParamMinLen("Name", 1))
+	}
+	if s.SAMLMetadataDocument == nil {
+		invalidParams.Add(request.NewErrParamRequired("SAMLMetadataDocument"))
+	}
+	if s.SAMLMetadataDocument != nil && len(*s.SAMLMetadataDocument) < 1000 {
+		invalidParams.Add(request.NewErrParamMinLen("SAMLMetadataDocument", 1000))
+	}
+
+	if invalidParams.Len() > 0 {
+		return invalidParams
+	}
+	return nil
+}
+
 // Contains the response to a successful CreateSAMLProvider request.
 type CreateSAMLProviderOutput struct {
 	_ struct{} `type:"structure"`
@@ -5245,6 +5612,25 @@ func (s CreateUserInput) String() string {
 // GoString returns the string representation
 func (s CreateUserInput) GoString() string {
 	return s.String()
+}
+
+// Validate inspects the fields of the type to determine if they are valid.
+func (s *CreateUserInput) Validate() error {
+	invalidParams := request.ErrInvalidParams{Context: "CreateUserInput"}
+	if s.Path != nil && len(*s.Path) < 1 {
+		invalidParams.Add(request.NewErrParamMinLen("Path", 1))
+	}
+	if s.UserName == nil {
+		invalidParams.Add(request.NewErrParamRequired("UserName"))
+	}
+	if s.UserName != nil && len(*s.UserName) < 1 {
+		invalidParams.Add(request.NewErrParamMinLen("UserName", 1))
+	}
+
+	if invalidParams.Len() > 0 {
+		return invalidParams
+	}
+	return nil
 }
 
 // Contains the response to a successful CreateUser request.
@@ -5291,6 +5677,25 @@ func (s CreateVirtualMFADeviceInput) GoString() string {
 	return s.String()
 }
 
+// Validate inspects the fields of the type to determine if they are valid.
+func (s *CreateVirtualMFADeviceInput) Validate() error {
+	invalidParams := request.ErrInvalidParams{Context: "CreateVirtualMFADeviceInput"}
+	if s.Path != nil && len(*s.Path) < 1 {
+		invalidParams.Add(request.NewErrParamMinLen("Path", 1))
+	}
+	if s.VirtualMFADeviceName == nil {
+		invalidParams.Add(request.NewErrParamRequired("VirtualMFADeviceName"))
+	}
+	if s.VirtualMFADeviceName != nil && len(*s.VirtualMFADeviceName) < 1 {
+		invalidParams.Add(request.NewErrParamMinLen("VirtualMFADeviceName", 1))
+	}
+
+	if invalidParams.Len() > 0 {
+		return invalidParams
+	}
+	return nil
+}
+
 // Contains the response to a successful CreateVirtualMFADevice request.
 type CreateVirtualMFADeviceOutput struct {
 	_ struct{} `type:"structure"`
@@ -5330,6 +5735,28 @@ func (s DeactivateMFADeviceInput) GoString() string {
 	return s.String()
 }
 
+// Validate inspects the fields of the type to determine if they are valid.
+func (s *DeactivateMFADeviceInput) Validate() error {
+	invalidParams := request.ErrInvalidParams{Context: "DeactivateMFADeviceInput"}
+	if s.SerialNumber == nil {
+		invalidParams.Add(request.NewErrParamRequired("SerialNumber"))
+	}
+	if s.SerialNumber != nil && len(*s.SerialNumber) < 9 {
+		invalidParams.Add(request.NewErrParamMinLen("SerialNumber", 9))
+	}
+	if s.UserName == nil {
+		invalidParams.Add(request.NewErrParamRequired("UserName"))
+	}
+	if s.UserName != nil && len(*s.UserName) < 1 {
+		invalidParams.Add(request.NewErrParamMinLen("UserName", 1))
+	}
+
+	if invalidParams.Len() > 0 {
+		return invalidParams
+	}
+	return nil
+}
+
 type DeactivateMFADeviceOutput struct {
 	_ struct{} `type:"structure"`
 }
@@ -5365,6 +5792,25 @@ func (s DeleteAccessKeyInput) GoString() string {
 	return s.String()
 }
 
+// Validate inspects the fields of the type to determine if they are valid.
+func (s *DeleteAccessKeyInput) Validate() error {
+	invalidParams := request.ErrInvalidParams{Context: "DeleteAccessKeyInput"}
+	if s.AccessKeyId == nil {
+		invalidParams.Add(request.NewErrParamRequired("AccessKeyId"))
+	}
+	if s.AccessKeyId != nil && len(*s.AccessKeyId) < 16 {
+		invalidParams.Add(request.NewErrParamMinLen("AccessKeyId", 16))
+	}
+	if s.UserName != nil && len(*s.UserName) < 1 {
+		invalidParams.Add(request.NewErrParamMinLen("UserName", 1))
+	}
+
+	if invalidParams.Len() > 0 {
+		return invalidParams
+	}
+	return nil
+}
+
 type DeleteAccessKeyOutput struct {
 	_ struct{} `type:"structure"`
 }
@@ -5394,6 +5840,22 @@ func (s DeleteAccountAliasInput) String() string {
 // GoString returns the string representation
 func (s DeleteAccountAliasInput) GoString() string {
 	return s.String()
+}
+
+// Validate inspects the fields of the type to determine if they are valid.
+func (s *DeleteAccountAliasInput) Validate() error {
+	invalidParams := request.ErrInvalidParams{Context: "DeleteAccountAliasInput"}
+	if s.AccountAlias == nil {
+		invalidParams.Add(request.NewErrParamRequired("AccountAlias"))
+	}
+	if s.AccountAlias != nil && len(*s.AccountAlias) < 3 {
+		invalidParams.Add(request.NewErrParamMinLen("AccountAlias", 3))
+	}
+
+	if invalidParams.Len() > 0 {
+		return invalidParams
+	}
+	return nil
 }
 
 type DeleteAccountAliasOutput struct {
@@ -5455,6 +5917,22 @@ func (s DeleteGroupInput) GoString() string {
 	return s.String()
 }
 
+// Validate inspects the fields of the type to determine if they are valid.
+func (s *DeleteGroupInput) Validate() error {
+	invalidParams := request.ErrInvalidParams{Context: "DeleteGroupInput"}
+	if s.GroupName == nil {
+		invalidParams.Add(request.NewErrParamRequired("GroupName"))
+	}
+	if s.GroupName != nil && len(*s.GroupName) < 1 {
+		invalidParams.Add(request.NewErrParamMinLen("GroupName", 1))
+	}
+
+	if invalidParams.Len() > 0 {
+		return invalidParams
+	}
+	return nil
+}
+
 type DeleteGroupOutput struct {
 	_ struct{} `type:"structure"`
 }
@@ -5490,6 +5968,28 @@ func (s DeleteGroupPolicyInput) GoString() string {
 	return s.String()
 }
 
+// Validate inspects the fields of the type to determine if they are valid.
+func (s *DeleteGroupPolicyInput) Validate() error {
+	invalidParams := request.ErrInvalidParams{Context: "DeleteGroupPolicyInput"}
+	if s.GroupName == nil {
+		invalidParams.Add(request.NewErrParamRequired("GroupName"))
+	}
+	if s.GroupName != nil && len(*s.GroupName) < 1 {
+		invalidParams.Add(request.NewErrParamMinLen("GroupName", 1))
+	}
+	if s.PolicyName == nil {
+		invalidParams.Add(request.NewErrParamRequired("PolicyName"))
+	}
+	if s.PolicyName != nil && len(*s.PolicyName) < 1 {
+		invalidParams.Add(request.NewErrParamMinLen("PolicyName", 1))
+	}
+
+	if invalidParams.Len() > 0 {
+		return invalidParams
+	}
+	return nil
+}
+
 type DeleteGroupPolicyOutput struct {
 	_ struct{} `type:"structure"`
 }
@@ -5521,6 +6021,22 @@ func (s DeleteInstanceProfileInput) GoString() string {
 	return s.String()
 }
 
+// Validate inspects the fields of the type to determine if they are valid.
+func (s *DeleteInstanceProfileInput) Validate() error {
+	invalidParams := request.ErrInvalidParams{Context: "DeleteInstanceProfileInput"}
+	if s.InstanceProfileName == nil {
+		invalidParams.Add(request.NewErrParamRequired("InstanceProfileName"))
+	}
+	if s.InstanceProfileName != nil && len(*s.InstanceProfileName) < 1 {
+		invalidParams.Add(request.NewErrParamMinLen("InstanceProfileName", 1))
+	}
+
+	if invalidParams.Len() > 0 {
+		return invalidParams
+	}
+	return nil
+}
+
 type DeleteInstanceProfileOutput struct {
 	_ struct{} `type:"structure"`
 }
@@ -5550,6 +6066,22 @@ func (s DeleteLoginProfileInput) String() string {
 // GoString returns the string representation
 func (s DeleteLoginProfileInput) GoString() string {
 	return s.String()
+}
+
+// Validate inspects the fields of the type to determine if they are valid.
+func (s *DeleteLoginProfileInput) Validate() error {
+	invalidParams := request.ErrInvalidParams{Context: "DeleteLoginProfileInput"}
+	if s.UserName == nil {
+		invalidParams.Add(request.NewErrParamRequired("UserName"))
+	}
+	if s.UserName != nil && len(*s.UserName) < 1 {
+		invalidParams.Add(request.NewErrParamMinLen("UserName", 1))
+	}
+
+	if invalidParams.Len() > 0 {
+		return invalidParams
+	}
+	return nil
 }
 
 type DeleteLoginProfileOutput struct {
@@ -5585,6 +6117,22 @@ func (s DeleteOpenIDConnectProviderInput) GoString() string {
 	return s.String()
 }
 
+// Validate inspects the fields of the type to determine if they are valid.
+func (s *DeleteOpenIDConnectProviderInput) Validate() error {
+	invalidParams := request.ErrInvalidParams{Context: "DeleteOpenIDConnectProviderInput"}
+	if s.OpenIDConnectProviderArn == nil {
+		invalidParams.Add(request.NewErrParamRequired("OpenIDConnectProviderArn"))
+	}
+	if s.OpenIDConnectProviderArn != nil && len(*s.OpenIDConnectProviderArn) < 20 {
+		invalidParams.Add(request.NewErrParamMinLen("OpenIDConnectProviderArn", 20))
+	}
+
+	if invalidParams.Len() > 0 {
+		return invalidParams
+	}
+	return nil
+}
+
 type DeleteOpenIDConnectProviderOutput struct {
 	_ struct{} `type:"structure"`
 }
@@ -5618,6 +6166,22 @@ func (s DeletePolicyInput) String() string {
 // GoString returns the string representation
 func (s DeletePolicyInput) GoString() string {
 	return s.String()
+}
+
+// Validate inspects the fields of the type to determine if they are valid.
+func (s *DeletePolicyInput) Validate() error {
+	invalidParams := request.ErrInvalidParams{Context: "DeletePolicyInput"}
+	if s.PolicyArn == nil {
+		invalidParams.Add(request.NewErrParamRequired("PolicyArn"))
+	}
+	if s.PolicyArn != nil && len(*s.PolicyArn) < 20 {
+		invalidParams.Add(request.NewErrParamMinLen("PolicyArn", 20))
+	}
+
+	if invalidParams.Len() > 0 {
+		return invalidParams
+	}
+	return nil
 }
 
 type DeletePolicyOutput struct {
@@ -5662,6 +6226,25 @@ func (s DeletePolicyVersionInput) GoString() string {
 	return s.String()
 }
 
+// Validate inspects the fields of the type to determine if they are valid.
+func (s *DeletePolicyVersionInput) Validate() error {
+	invalidParams := request.ErrInvalidParams{Context: "DeletePolicyVersionInput"}
+	if s.PolicyArn == nil {
+		invalidParams.Add(request.NewErrParamRequired("PolicyArn"))
+	}
+	if s.PolicyArn != nil && len(*s.PolicyArn) < 20 {
+		invalidParams.Add(request.NewErrParamMinLen("PolicyArn", 20))
+	}
+	if s.VersionId == nil {
+		invalidParams.Add(request.NewErrParamRequired("VersionId"))
+	}
+
+	if invalidParams.Len() > 0 {
+		return invalidParams
+	}
+	return nil
+}
+
 type DeletePolicyVersionOutput struct {
 	_ struct{} `type:"structure"`
 }
@@ -5691,6 +6274,22 @@ func (s DeleteRoleInput) String() string {
 // GoString returns the string representation
 func (s DeleteRoleInput) GoString() string {
 	return s.String()
+}
+
+// Validate inspects the fields of the type to determine if they are valid.
+func (s *DeleteRoleInput) Validate() error {
+	invalidParams := request.ErrInvalidParams{Context: "DeleteRoleInput"}
+	if s.RoleName == nil {
+		invalidParams.Add(request.NewErrParamRequired("RoleName"))
+	}
+	if s.RoleName != nil && len(*s.RoleName) < 1 {
+		invalidParams.Add(request.NewErrParamMinLen("RoleName", 1))
+	}
+
+	if invalidParams.Len() > 0 {
+		return invalidParams
+	}
+	return nil
 }
 
 type DeleteRoleOutput struct {
@@ -5728,6 +6327,28 @@ func (s DeleteRolePolicyInput) GoString() string {
 	return s.String()
 }
 
+// Validate inspects the fields of the type to determine if they are valid.
+func (s *DeleteRolePolicyInput) Validate() error {
+	invalidParams := request.ErrInvalidParams{Context: "DeleteRolePolicyInput"}
+	if s.PolicyName == nil {
+		invalidParams.Add(request.NewErrParamRequired("PolicyName"))
+	}
+	if s.PolicyName != nil && len(*s.PolicyName) < 1 {
+		invalidParams.Add(request.NewErrParamMinLen("PolicyName", 1))
+	}
+	if s.RoleName == nil {
+		invalidParams.Add(request.NewErrParamRequired("RoleName"))
+	}
+	if s.RoleName != nil && len(*s.RoleName) < 1 {
+		invalidParams.Add(request.NewErrParamMinLen("RoleName", 1))
+	}
+
+	if invalidParams.Len() > 0 {
+		return invalidParams
+	}
+	return nil
+}
+
 type DeleteRolePolicyOutput struct {
 	_ struct{} `type:"structure"`
 }
@@ -5757,6 +6378,22 @@ func (s DeleteSAMLProviderInput) String() string {
 // GoString returns the string representation
 func (s DeleteSAMLProviderInput) GoString() string {
 	return s.String()
+}
+
+// Validate inspects the fields of the type to determine if they are valid.
+func (s *DeleteSAMLProviderInput) Validate() error {
+	invalidParams := request.ErrInvalidParams{Context: "DeleteSAMLProviderInput"}
+	if s.SAMLProviderArn == nil {
+		invalidParams.Add(request.NewErrParamRequired("SAMLProviderArn"))
+	}
+	if s.SAMLProviderArn != nil && len(*s.SAMLProviderArn) < 20 {
+		invalidParams.Add(request.NewErrParamMinLen("SAMLProviderArn", 20))
+	}
+
+	if invalidParams.Len() > 0 {
+		return invalidParams
+	}
+	return nil
 }
 
 type DeleteSAMLProviderOutput struct {
@@ -5793,6 +6430,28 @@ func (s DeleteSSHPublicKeyInput) GoString() string {
 	return s.String()
 }
 
+// Validate inspects the fields of the type to determine if they are valid.
+func (s *DeleteSSHPublicKeyInput) Validate() error {
+	invalidParams := request.ErrInvalidParams{Context: "DeleteSSHPublicKeyInput"}
+	if s.SSHPublicKeyId == nil {
+		invalidParams.Add(request.NewErrParamRequired("SSHPublicKeyId"))
+	}
+	if s.SSHPublicKeyId != nil && len(*s.SSHPublicKeyId) < 20 {
+		invalidParams.Add(request.NewErrParamMinLen("SSHPublicKeyId", 20))
+	}
+	if s.UserName == nil {
+		invalidParams.Add(request.NewErrParamRequired("UserName"))
+	}
+	if s.UserName != nil && len(*s.UserName) < 1 {
+		invalidParams.Add(request.NewErrParamMinLen("UserName", 1))
+	}
+
+	if invalidParams.Len() > 0 {
+		return invalidParams
+	}
+	return nil
+}
+
 type DeleteSSHPublicKeyOutput struct {
 	_ struct{} `type:"structure"`
 }
@@ -5822,6 +6481,22 @@ func (s DeleteServerCertificateInput) String() string {
 // GoString returns the string representation
 func (s DeleteServerCertificateInput) GoString() string {
 	return s.String()
+}
+
+// Validate inspects the fields of the type to determine if they are valid.
+func (s *DeleteServerCertificateInput) Validate() error {
+	invalidParams := request.ErrInvalidParams{Context: "DeleteServerCertificateInput"}
+	if s.ServerCertificateName == nil {
+		invalidParams.Add(request.NewErrParamRequired("ServerCertificateName"))
+	}
+	if s.ServerCertificateName != nil && len(*s.ServerCertificateName) < 1 {
+		invalidParams.Add(request.NewErrParamMinLen("ServerCertificateName", 1))
+	}
+
+	if invalidParams.Len() > 0 {
+		return invalidParams
+	}
+	return nil
 }
 
 type DeleteServerCertificateOutput struct {
@@ -5858,6 +6533,25 @@ func (s DeleteSigningCertificateInput) GoString() string {
 	return s.String()
 }
 
+// Validate inspects the fields of the type to determine if they are valid.
+func (s *DeleteSigningCertificateInput) Validate() error {
+	invalidParams := request.ErrInvalidParams{Context: "DeleteSigningCertificateInput"}
+	if s.CertificateId == nil {
+		invalidParams.Add(request.NewErrParamRequired("CertificateId"))
+	}
+	if s.CertificateId != nil && len(*s.CertificateId) < 24 {
+		invalidParams.Add(request.NewErrParamMinLen("CertificateId", 24))
+	}
+	if s.UserName != nil && len(*s.UserName) < 1 {
+		invalidParams.Add(request.NewErrParamMinLen("UserName", 1))
+	}
+
+	if invalidParams.Len() > 0 {
+		return invalidParams
+	}
+	return nil
+}
+
 type DeleteSigningCertificateOutput struct {
 	_ struct{} `type:"structure"`
 }
@@ -5887,6 +6581,22 @@ func (s DeleteUserInput) String() string {
 // GoString returns the string representation
 func (s DeleteUserInput) GoString() string {
 	return s.String()
+}
+
+// Validate inspects the fields of the type to determine if they are valid.
+func (s *DeleteUserInput) Validate() error {
+	invalidParams := request.ErrInvalidParams{Context: "DeleteUserInput"}
+	if s.UserName == nil {
+		invalidParams.Add(request.NewErrParamRequired("UserName"))
+	}
+	if s.UserName != nil && len(*s.UserName) < 1 {
+		invalidParams.Add(request.NewErrParamMinLen("UserName", 1))
+	}
+
+	if invalidParams.Len() > 0 {
+		return invalidParams
+	}
+	return nil
 }
 
 type DeleteUserOutput struct {
@@ -5924,6 +6634,28 @@ func (s DeleteUserPolicyInput) GoString() string {
 	return s.String()
 }
 
+// Validate inspects the fields of the type to determine if they are valid.
+func (s *DeleteUserPolicyInput) Validate() error {
+	invalidParams := request.ErrInvalidParams{Context: "DeleteUserPolicyInput"}
+	if s.PolicyName == nil {
+		invalidParams.Add(request.NewErrParamRequired("PolicyName"))
+	}
+	if s.PolicyName != nil && len(*s.PolicyName) < 1 {
+		invalidParams.Add(request.NewErrParamMinLen("PolicyName", 1))
+	}
+	if s.UserName == nil {
+		invalidParams.Add(request.NewErrParamRequired("UserName"))
+	}
+	if s.UserName != nil && len(*s.UserName) < 1 {
+		invalidParams.Add(request.NewErrParamMinLen("UserName", 1))
+	}
+
+	if invalidParams.Len() > 0 {
+		return invalidParams
+	}
+	return nil
+}
+
 type DeleteUserPolicyOutput struct {
 	_ struct{} `type:"structure"`
 }
@@ -5954,6 +6686,22 @@ func (s DeleteVirtualMFADeviceInput) String() string {
 // GoString returns the string representation
 func (s DeleteVirtualMFADeviceInput) GoString() string {
 	return s.String()
+}
+
+// Validate inspects the fields of the type to determine if they are valid.
+func (s *DeleteVirtualMFADeviceInput) Validate() error {
+	invalidParams := request.ErrInvalidParams{Context: "DeleteVirtualMFADeviceInput"}
+	if s.SerialNumber == nil {
+		invalidParams.Add(request.NewErrParamRequired("SerialNumber"))
+	}
+	if s.SerialNumber != nil && len(*s.SerialNumber) < 9 {
+		invalidParams.Add(request.NewErrParamMinLen("SerialNumber", 9))
+	}
+
+	if invalidParams.Len() > 0 {
+		return invalidParams
+	}
+	return nil
 }
 
 type DeleteVirtualMFADeviceOutput struct {
@@ -5994,6 +6742,28 @@ func (s DetachGroupPolicyInput) GoString() string {
 	return s.String()
 }
 
+// Validate inspects the fields of the type to determine if they are valid.
+func (s *DetachGroupPolicyInput) Validate() error {
+	invalidParams := request.ErrInvalidParams{Context: "DetachGroupPolicyInput"}
+	if s.GroupName == nil {
+		invalidParams.Add(request.NewErrParamRequired("GroupName"))
+	}
+	if s.GroupName != nil && len(*s.GroupName) < 1 {
+		invalidParams.Add(request.NewErrParamMinLen("GroupName", 1))
+	}
+	if s.PolicyArn == nil {
+		invalidParams.Add(request.NewErrParamRequired("PolicyArn"))
+	}
+	if s.PolicyArn != nil && len(*s.PolicyArn) < 20 {
+		invalidParams.Add(request.NewErrParamMinLen("PolicyArn", 20))
+	}
+
+	if invalidParams.Len() > 0 {
+		return invalidParams
+	}
+	return nil
+}
+
 type DetachGroupPolicyOutput struct {
 	_ struct{} `type:"structure"`
 }
@@ -6032,6 +6802,28 @@ func (s DetachRolePolicyInput) GoString() string {
 	return s.String()
 }
 
+// Validate inspects the fields of the type to determine if they are valid.
+func (s *DetachRolePolicyInput) Validate() error {
+	invalidParams := request.ErrInvalidParams{Context: "DetachRolePolicyInput"}
+	if s.PolicyArn == nil {
+		invalidParams.Add(request.NewErrParamRequired("PolicyArn"))
+	}
+	if s.PolicyArn != nil && len(*s.PolicyArn) < 20 {
+		invalidParams.Add(request.NewErrParamMinLen("PolicyArn", 20))
+	}
+	if s.RoleName == nil {
+		invalidParams.Add(request.NewErrParamRequired("RoleName"))
+	}
+	if s.RoleName != nil && len(*s.RoleName) < 1 {
+		invalidParams.Add(request.NewErrParamMinLen("RoleName", 1))
+	}
+
+	if invalidParams.Len() > 0 {
+		return invalidParams
+	}
+	return nil
+}
+
 type DetachRolePolicyOutput struct {
 	_ struct{} `type:"structure"`
 }
@@ -6068,6 +6860,28 @@ func (s DetachUserPolicyInput) String() string {
 // GoString returns the string representation
 func (s DetachUserPolicyInput) GoString() string {
 	return s.String()
+}
+
+// Validate inspects the fields of the type to determine if they are valid.
+func (s *DetachUserPolicyInput) Validate() error {
+	invalidParams := request.ErrInvalidParams{Context: "DetachUserPolicyInput"}
+	if s.PolicyArn == nil {
+		invalidParams.Add(request.NewErrParamRequired("PolicyArn"))
+	}
+	if s.PolicyArn != nil && len(*s.PolicyArn) < 20 {
+		invalidParams.Add(request.NewErrParamMinLen("PolicyArn", 20))
+	}
+	if s.UserName == nil {
+		invalidParams.Add(request.NewErrParamRequired("UserName"))
+	}
+	if s.UserName != nil && len(*s.UserName) < 1 {
+		invalidParams.Add(request.NewErrParamMinLen("UserName", 1))
+	}
+
+	if invalidParams.Len() > 0 {
+		return invalidParams
+	}
+	return nil
 }
 
 type DetachUserPolicyOutput struct {
@@ -6109,6 +6923,40 @@ func (s EnableMFADeviceInput) String() string {
 // GoString returns the string representation
 func (s EnableMFADeviceInput) GoString() string {
 	return s.String()
+}
+
+// Validate inspects the fields of the type to determine if they are valid.
+func (s *EnableMFADeviceInput) Validate() error {
+	invalidParams := request.ErrInvalidParams{Context: "EnableMFADeviceInput"}
+	if s.AuthenticationCode1 == nil {
+		invalidParams.Add(request.NewErrParamRequired("AuthenticationCode1"))
+	}
+	if s.AuthenticationCode1 != nil && len(*s.AuthenticationCode1) < 6 {
+		invalidParams.Add(request.NewErrParamMinLen("AuthenticationCode1", 6))
+	}
+	if s.AuthenticationCode2 == nil {
+		invalidParams.Add(request.NewErrParamRequired("AuthenticationCode2"))
+	}
+	if s.AuthenticationCode2 != nil && len(*s.AuthenticationCode2) < 6 {
+		invalidParams.Add(request.NewErrParamMinLen("AuthenticationCode2", 6))
+	}
+	if s.SerialNumber == nil {
+		invalidParams.Add(request.NewErrParamRequired("SerialNumber"))
+	}
+	if s.SerialNumber != nil && len(*s.SerialNumber) < 9 {
+		invalidParams.Add(request.NewErrParamMinLen("SerialNumber", 9))
+	}
+	if s.UserName == nil {
+		invalidParams.Add(request.NewErrParamRequired("UserName"))
+	}
+	if s.UserName != nil && len(*s.UserName) < 1 {
+		invalidParams.Add(request.NewErrParamMinLen("UserName", 1))
+	}
+
+	if invalidParams.Len() > 0 {
+		return invalidParams
+	}
+	return nil
 }
 
 type EnableMFADeviceOutput struct {
@@ -6236,6 +7084,22 @@ func (s GetAccessKeyLastUsedInput) GoString() string {
 	return s.String()
 }
 
+// Validate inspects the fields of the type to determine if they are valid.
+func (s *GetAccessKeyLastUsedInput) Validate() error {
+	invalidParams := request.ErrInvalidParams{Context: "GetAccessKeyLastUsedInput"}
+	if s.AccessKeyId == nil {
+		invalidParams.Add(request.NewErrParamRequired("AccessKeyId"))
+	}
+	if s.AccessKeyId != nil && len(*s.AccessKeyId) < 16 {
+		invalidParams.Add(request.NewErrParamMinLen("AccessKeyId", 16))
+	}
+
+	if invalidParams.Len() > 0 {
+		return invalidParams
+	}
+	return nil
+}
+
 // Contains the response to a successful GetAccessKeyLastUsed request. It is
 // also returned as a member of the AccessKeyMetaData structure returned by
 // the ListAccessKeys action.
@@ -6292,6 +7156,22 @@ func (s GetAccountAuthorizationDetailsInput) String() string {
 // GoString returns the string representation
 func (s GetAccountAuthorizationDetailsInput) GoString() string {
 	return s.String()
+}
+
+// Validate inspects the fields of the type to determine if they are valid.
+func (s *GetAccountAuthorizationDetailsInput) Validate() error {
+	invalidParams := request.ErrInvalidParams{Context: "GetAccountAuthorizationDetailsInput"}
+	if s.Marker != nil && len(*s.Marker) < 1 {
+		invalidParams.Add(request.NewErrParamMinLen("Marker", 1))
+	}
+	if s.MaxItems != nil && *s.MaxItems < 1 {
+		invalidParams.Add(request.NewErrParamMinValue("MaxItems", 1))
+	}
+
+	if invalidParams.Len() > 0 {
+		return invalidParams
+	}
+	return nil
 }
 
 // Contains the response to a successful GetAccountAuthorizationDetails request.
@@ -6561,6 +7441,19 @@ func (s GetContextKeysForCustomPolicyInput) GoString() string {
 	return s.String()
 }
 
+// Validate inspects the fields of the type to determine if they are valid.
+func (s *GetContextKeysForCustomPolicyInput) Validate() error {
+	invalidParams := request.ErrInvalidParams{Context: "GetContextKeysForCustomPolicyInput"}
+	if s.PolicyInputList == nil {
+		invalidParams.Add(request.NewErrParamRequired("PolicyInputList"))
+	}
+
+	if invalidParams.Len() > 0 {
+		return invalidParams
+	}
+	return nil
+}
+
 // Contains the response to a successful GetContextKeysForPrincipalPolicy or
 // GetContextKeysForCustomPolicy request.
 type GetContextKeysForPolicyResponse struct {
@@ -6606,6 +7499,22 @@ func (s GetContextKeysForPrincipalPolicyInput) String() string {
 // GoString returns the string representation
 func (s GetContextKeysForPrincipalPolicyInput) GoString() string {
 	return s.String()
+}
+
+// Validate inspects the fields of the type to determine if they are valid.
+func (s *GetContextKeysForPrincipalPolicyInput) Validate() error {
+	invalidParams := request.ErrInvalidParams{Context: "GetContextKeysForPrincipalPolicyInput"}
+	if s.PolicySourceArn == nil {
+		invalidParams.Add(request.NewErrParamRequired("PolicySourceArn"))
+	}
+	if s.PolicySourceArn != nil && len(*s.PolicySourceArn) < 20 {
+		invalidParams.Add(request.NewErrParamMinLen("PolicySourceArn", 20))
+	}
+
+	if invalidParams.Len() > 0 {
+		return invalidParams
+	}
+	return nil
 }
 
 type GetCredentialReportInput struct {
@@ -6683,6 +7592,28 @@ func (s GetGroupInput) GoString() string {
 	return s.String()
 }
 
+// Validate inspects the fields of the type to determine if they are valid.
+func (s *GetGroupInput) Validate() error {
+	invalidParams := request.ErrInvalidParams{Context: "GetGroupInput"}
+	if s.GroupName == nil {
+		invalidParams.Add(request.NewErrParamRequired("GroupName"))
+	}
+	if s.GroupName != nil && len(*s.GroupName) < 1 {
+		invalidParams.Add(request.NewErrParamMinLen("GroupName", 1))
+	}
+	if s.Marker != nil && len(*s.Marker) < 1 {
+		invalidParams.Add(request.NewErrParamMinLen("Marker", 1))
+	}
+	if s.MaxItems != nil && *s.MaxItems < 1 {
+		invalidParams.Add(request.NewErrParamMinValue("MaxItems", 1))
+	}
+
+	if invalidParams.Len() > 0 {
+		return invalidParams
+	}
+	return nil
+}
+
 // Contains the response to a successful GetGroup request.
 type GetGroupOutput struct {
 	_ struct{} `type:"structure"`
@@ -6736,6 +7667,28 @@ func (s GetGroupPolicyInput) GoString() string {
 	return s.String()
 }
 
+// Validate inspects the fields of the type to determine if they are valid.
+func (s *GetGroupPolicyInput) Validate() error {
+	invalidParams := request.ErrInvalidParams{Context: "GetGroupPolicyInput"}
+	if s.GroupName == nil {
+		invalidParams.Add(request.NewErrParamRequired("GroupName"))
+	}
+	if s.GroupName != nil && len(*s.GroupName) < 1 {
+		invalidParams.Add(request.NewErrParamMinLen("GroupName", 1))
+	}
+	if s.PolicyName == nil {
+		invalidParams.Add(request.NewErrParamRequired("PolicyName"))
+	}
+	if s.PolicyName != nil && len(*s.PolicyName) < 1 {
+		invalidParams.Add(request.NewErrParamMinLen("PolicyName", 1))
+	}
+
+	if invalidParams.Len() > 0 {
+		return invalidParams
+	}
+	return nil
+}
+
 // Contains the response to a successful GetGroupPolicy request.
 type GetGroupPolicyOutput struct {
 	_ struct{} `type:"structure"`
@@ -6777,6 +7730,22 @@ func (s GetInstanceProfileInput) GoString() string {
 	return s.String()
 }
 
+// Validate inspects the fields of the type to determine if they are valid.
+func (s *GetInstanceProfileInput) Validate() error {
+	invalidParams := request.ErrInvalidParams{Context: "GetInstanceProfileInput"}
+	if s.InstanceProfileName == nil {
+		invalidParams.Add(request.NewErrParamRequired("InstanceProfileName"))
+	}
+	if s.InstanceProfileName != nil && len(*s.InstanceProfileName) < 1 {
+		invalidParams.Add(request.NewErrParamMinLen("InstanceProfileName", 1))
+	}
+
+	if invalidParams.Len() > 0 {
+		return invalidParams
+	}
+	return nil
+}
+
 // Contains the response to a successful GetInstanceProfile request.
 type GetInstanceProfileOutput struct {
 	_ struct{} `type:"structure"`
@@ -6810,6 +7779,22 @@ func (s GetLoginProfileInput) String() string {
 // GoString returns the string representation
 func (s GetLoginProfileInput) GoString() string {
 	return s.String()
+}
+
+// Validate inspects the fields of the type to determine if they are valid.
+func (s *GetLoginProfileInput) Validate() error {
+	invalidParams := request.ErrInvalidParams{Context: "GetLoginProfileInput"}
+	if s.UserName == nil {
+		invalidParams.Add(request.NewErrParamRequired("UserName"))
+	}
+	if s.UserName != nil && len(*s.UserName) < 1 {
+		invalidParams.Add(request.NewErrParamMinLen("UserName", 1))
+	}
+
+	if invalidParams.Len() > 0 {
+		return invalidParams
+	}
+	return nil
 }
 
 // Contains the response to a successful GetLoginProfile request.
@@ -6847,6 +7832,22 @@ func (s GetOpenIDConnectProviderInput) String() string {
 // GoString returns the string representation
 func (s GetOpenIDConnectProviderInput) GoString() string {
 	return s.String()
+}
+
+// Validate inspects the fields of the type to determine if they are valid.
+func (s *GetOpenIDConnectProviderInput) Validate() error {
+	invalidParams := request.ErrInvalidParams{Context: "GetOpenIDConnectProviderInput"}
+	if s.OpenIDConnectProviderArn == nil {
+		invalidParams.Add(request.NewErrParamRequired("OpenIDConnectProviderArn"))
+	}
+	if s.OpenIDConnectProviderArn != nil && len(*s.OpenIDConnectProviderArn) < 20 {
+		invalidParams.Add(request.NewErrParamMinLen("OpenIDConnectProviderArn", 20))
+	}
+
+	if invalidParams.Len() > 0 {
+		return invalidParams
+	}
+	return nil
 }
 
 // Contains the response to a successful GetOpenIDConnectProvider request.
@@ -6901,6 +7902,22 @@ func (s GetPolicyInput) GoString() string {
 	return s.String()
 }
 
+// Validate inspects the fields of the type to determine if they are valid.
+func (s *GetPolicyInput) Validate() error {
+	invalidParams := request.ErrInvalidParams{Context: "GetPolicyInput"}
+	if s.PolicyArn == nil {
+		invalidParams.Add(request.NewErrParamRequired("PolicyArn"))
+	}
+	if s.PolicyArn != nil && len(*s.PolicyArn) < 20 {
+		invalidParams.Add(request.NewErrParamMinLen("PolicyArn", 20))
+	}
+
+	if invalidParams.Len() > 0 {
+		return invalidParams
+	}
+	return nil
+}
+
 // Contains the response to a successful GetPolicy request.
 type GetPolicyOutput struct {
 	_ struct{} `type:"structure"`
@@ -6943,6 +7960,25 @@ func (s GetPolicyVersionInput) GoString() string {
 	return s.String()
 }
 
+// Validate inspects the fields of the type to determine if they are valid.
+func (s *GetPolicyVersionInput) Validate() error {
+	invalidParams := request.ErrInvalidParams{Context: "GetPolicyVersionInput"}
+	if s.PolicyArn == nil {
+		invalidParams.Add(request.NewErrParamRequired("PolicyArn"))
+	}
+	if s.PolicyArn != nil && len(*s.PolicyArn) < 20 {
+		invalidParams.Add(request.NewErrParamMinLen("PolicyArn", 20))
+	}
+	if s.VersionId == nil {
+		invalidParams.Add(request.NewErrParamRequired("VersionId"))
+	}
+
+	if invalidParams.Len() > 0 {
+		return invalidParams
+	}
+	return nil
+}
+
 // Contains the response to a successful GetPolicyVersion request.
 type GetPolicyVersionOutput struct {
 	_ struct{} `type:"structure"`
@@ -6982,6 +8018,22 @@ func (s GetRoleInput) GoString() string {
 	return s.String()
 }
 
+// Validate inspects the fields of the type to determine if they are valid.
+func (s *GetRoleInput) Validate() error {
+	invalidParams := request.ErrInvalidParams{Context: "GetRoleInput"}
+	if s.RoleName == nil {
+		invalidParams.Add(request.NewErrParamRequired("RoleName"))
+	}
+	if s.RoleName != nil && len(*s.RoleName) < 1 {
+		invalidParams.Add(request.NewErrParamMinLen("RoleName", 1))
+	}
+
+	if invalidParams.Len() > 0 {
+		return invalidParams
+	}
+	return nil
+}
+
 // Contains the response to a successful GetRole request.
 type GetRoleOutput struct {
 	_ struct{} `type:"structure"`
@@ -7018,6 +8070,28 @@ func (s GetRolePolicyInput) String() string {
 // GoString returns the string representation
 func (s GetRolePolicyInput) GoString() string {
 	return s.String()
+}
+
+// Validate inspects the fields of the type to determine if they are valid.
+func (s *GetRolePolicyInput) Validate() error {
+	invalidParams := request.ErrInvalidParams{Context: "GetRolePolicyInput"}
+	if s.PolicyName == nil {
+		invalidParams.Add(request.NewErrParamRequired("PolicyName"))
+	}
+	if s.PolicyName != nil && len(*s.PolicyName) < 1 {
+		invalidParams.Add(request.NewErrParamMinLen("PolicyName", 1))
+	}
+	if s.RoleName == nil {
+		invalidParams.Add(request.NewErrParamRequired("RoleName"))
+	}
+	if s.RoleName != nil && len(*s.RoleName) < 1 {
+		invalidParams.Add(request.NewErrParamMinLen("RoleName", 1))
+	}
+
+	if invalidParams.Len() > 0 {
+		return invalidParams
+	}
+	return nil
 }
 
 // Contains the response to a successful GetRolePolicy request.
@@ -7059,6 +8133,22 @@ func (s GetSAMLProviderInput) String() string {
 // GoString returns the string representation
 func (s GetSAMLProviderInput) GoString() string {
 	return s.String()
+}
+
+// Validate inspects the fields of the type to determine if they are valid.
+func (s *GetSAMLProviderInput) Validate() error {
+	invalidParams := request.ErrInvalidParams{Context: "GetSAMLProviderInput"}
+	if s.SAMLProviderArn == nil {
+		invalidParams.Add(request.NewErrParamRequired("SAMLProviderArn"))
+	}
+	if s.SAMLProviderArn != nil && len(*s.SAMLProviderArn) < 20 {
+		invalidParams.Add(request.NewErrParamMinLen("SAMLProviderArn", 20))
+	}
+
+	if invalidParams.Len() > 0 {
+		return invalidParams
+	}
+	return nil
 }
 
 // Contains the response to a successful GetSAMLProvider request.
@@ -7110,6 +8200,31 @@ func (s GetSSHPublicKeyInput) GoString() string {
 	return s.String()
 }
 
+// Validate inspects the fields of the type to determine if they are valid.
+func (s *GetSSHPublicKeyInput) Validate() error {
+	invalidParams := request.ErrInvalidParams{Context: "GetSSHPublicKeyInput"}
+	if s.Encoding == nil {
+		invalidParams.Add(request.NewErrParamRequired("Encoding"))
+	}
+	if s.SSHPublicKeyId == nil {
+		invalidParams.Add(request.NewErrParamRequired("SSHPublicKeyId"))
+	}
+	if s.SSHPublicKeyId != nil && len(*s.SSHPublicKeyId) < 20 {
+		invalidParams.Add(request.NewErrParamMinLen("SSHPublicKeyId", 20))
+	}
+	if s.UserName == nil {
+		invalidParams.Add(request.NewErrParamRequired("UserName"))
+	}
+	if s.UserName != nil && len(*s.UserName) < 1 {
+		invalidParams.Add(request.NewErrParamMinLen("UserName", 1))
+	}
+
+	if invalidParams.Len() > 0 {
+		return invalidParams
+	}
+	return nil
+}
+
 // Contains the response to a successful GetSSHPublicKey request.
 type GetSSHPublicKeyOutput struct {
 	_ struct{} `type:"structure"`
@@ -7143,6 +8258,22 @@ func (s GetServerCertificateInput) String() string {
 // GoString returns the string representation
 func (s GetServerCertificateInput) GoString() string {
 	return s.String()
+}
+
+// Validate inspects the fields of the type to determine if they are valid.
+func (s *GetServerCertificateInput) Validate() error {
+	invalidParams := request.ErrInvalidParams{Context: "GetServerCertificateInput"}
+	if s.ServerCertificateName == nil {
+		invalidParams.Add(request.NewErrParamRequired("ServerCertificateName"))
+	}
+	if s.ServerCertificateName != nil && len(*s.ServerCertificateName) < 1 {
+		invalidParams.Add(request.NewErrParamMinLen("ServerCertificateName", 1))
+	}
+
+	if invalidParams.Len() > 0 {
+		return invalidParams
+	}
+	return nil
 }
 
 // Contains the response to a successful GetServerCertificate request.
@@ -7183,6 +8314,19 @@ func (s GetUserInput) GoString() string {
 	return s.String()
 }
 
+// Validate inspects the fields of the type to determine if they are valid.
+func (s *GetUserInput) Validate() error {
+	invalidParams := request.ErrInvalidParams{Context: "GetUserInput"}
+	if s.UserName != nil && len(*s.UserName) < 1 {
+		invalidParams.Add(request.NewErrParamMinLen("UserName", 1))
+	}
+
+	if invalidParams.Len() > 0 {
+		return invalidParams
+	}
+	return nil
+}
+
 // Contains the response to a successful GetUser request.
 type GetUserOutput struct {
 	_ struct{} `type:"structure"`
@@ -7219,6 +8363,28 @@ func (s GetUserPolicyInput) String() string {
 // GoString returns the string representation
 func (s GetUserPolicyInput) GoString() string {
 	return s.String()
+}
+
+// Validate inspects the fields of the type to determine if they are valid.
+func (s *GetUserPolicyInput) Validate() error {
+	invalidParams := request.ErrInvalidParams{Context: "GetUserPolicyInput"}
+	if s.PolicyName == nil {
+		invalidParams.Add(request.NewErrParamRequired("PolicyName"))
+	}
+	if s.PolicyName != nil && len(*s.PolicyName) < 1 {
+		invalidParams.Add(request.NewErrParamMinLen("PolicyName", 1))
+	}
+	if s.UserName == nil {
+		invalidParams.Add(request.NewErrParamRequired("UserName"))
+	}
+	if s.UserName != nil && len(*s.UserName) < 1 {
+		invalidParams.Add(request.NewErrParamMinLen("UserName", 1))
+	}
+
+	if invalidParams.Len() > 0 {
+		return invalidParams
+	}
+	return nil
 }
 
 // Contains the response to a successful GetUserPolicy request.
@@ -7418,6 +8584,25 @@ func (s ListAccessKeysInput) GoString() string {
 	return s.String()
 }
 
+// Validate inspects the fields of the type to determine if they are valid.
+func (s *ListAccessKeysInput) Validate() error {
+	invalidParams := request.ErrInvalidParams{Context: "ListAccessKeysInput"}
+	if s.Marker != nil && len(*s.Marker) < 1 {
+		invalidParams.Add(request.NewErrParamMinLen("Marker", 1))
+	}
+	if s.MaxItems != nil && *s.MaxItems < 1 {
+		invalidParams.Add(request.NewErrParamMinValue("MaxItems", 1))
+	}
+	if s.UserName != nil && len(*s.UserName) < 1 {
+		invalidParams.Add(request.NewErrParamMinLen("UserName", 1))
+	}
+
+	if invalidParams.Len() > 0 {
+		return invalidParams
+	}
+	return nil
+}
+
 // Contains the response to a successful ListAccessKeys request.
 type ListAccessKeysOutput struct {
 	_ struct{} `type:"structure"`
@@ -7477,6 +8662,22 @@ func (s ListAccountAliasesInput) String() string {
 // GoString returns the string representation
 func (s ListAccountAliasesInput) GoString() string {
 	return s.String()
+}
+
+// Validate inspects the fields of the type to determine if they are valid.
+func (s *ListAccountAliasesInput) Validate() error {
+	invalidParams := request.ErrInvalidParams{Context: "ListAccountAliasesInput"}
+	if s.Marker != nil && len(*s.Marker) < 1 {
+		invalidParams.Add(request.NewErrParamMinLen("Marker", 1))
+	}
+	if s.MaxItems != nil && *s.MaxItems < 1 {
+		invalidParams.Add(request.NewErrParamMinValue("MaxItems", 1))
+	}
+
+	if invalidParams.Len() > 0 {
+		return invalidParams
+	}
+	return nil
 }
 
 // Contains the response to a successful ListAccountAliases request.
@@ -7549,6 +8750,28 @@ func (s ListAttachedGroupPoliciesInput) GoString() string {
 	return s.String()
 }
 
+// Validate inspects the fields of the type to determine if they are valid.
+func (s *ListAttachedGroupPoliciesInput) Validate() error {
+	invalidParams := request.ErrInvalidParams{Context: "ListAttachedGroupPoliciesInput"}
+	if s.GroupName == nil {
+		invalidParams.Add(request.NewErrParamRequired("GroupName"))
+	}
+	if s.GroupName != nil && len(*s.GroupName) < 1 {
+		invalidParams.Add(request.NewErrParamMinLen("GroupName", 1))
+	}
+	if s.Marker != nil && len(*s.Marker) < 1 {
+		invalidParams.Add(request.NewErrParamMinLen("Marker", 1))
+	}
+	if s.MaxItems != nil && *s.MaxItems < 1 {
+		invalidParams.Add(request.NewErrParamMinValue("MaxItems", 1))
+	}
+
+	if invalidParams.Len() > 0 {
+		return invalidParams
+	}
+	return nil
+}
+
 // Contains the response to a successful ListAttachedGroupPolicies request.
 type ListAttachedGroupPoliciesOutput struct {
 	_ struct{} `type:"structure"`
@@ -7617,6 +8840,28 @@ func (s ListAttachedRolePoliciesInput) GoString() string {
 	return s.String()
 }
 
+// Validate inspects the fields of the type to determine if they are valid.
+func (s *ListAttachedRolePoliciesInput) Validate() error {
+	invalidParams := request.ErrInvalidParams{Context: "ListAttachedRolePoliciesInput"}
+	if s.Marker != nil && len(*s.Marker) < 1 {
+		invalidParams.Add(request.NewErrParamMinLen("Marker", 1))
+	}
+	if s.MaxItems != nil && *s.MaxItems < 1 {
+		invalidParams.Add(request.NewErrParamMinValue("MaxItems", 1))
+	}
+	if s.RoleName == nil {
+		invalidParams.Add(request.NewErrParamRequired("RoleName"))
+	}
+	if s.RoleName != nil && len(*s.RoleName) < 1 {
+		invalidParams.Add(request.NewErrParamMinLen("RoleName", 1))
+	}
+
+	if invalidParams.Len() > 0 {
+		return invalidParams
+	}
+	return nil
+}
+
 // Contains the response to a successful ListAttachedRolePolicies request.
 type ListAttachedRolePoliciesOutput struct {
 	_ struct{} `type:"structure"`
@@ -7683,6 +8928,28 @@ func (s ListAttachedUserPoliciesInput) String() string {
 // GoString returns the string representation
 func (s ListAttachedUserPoliciesInput) GoString() string {
 	return s.String()
+}
+
+// Validate inspects the fields of the type to determine if they are valid.
+func (s *ListAttachedUserPoliciesInput) Validate() error {
+	invalidParams := request.ErrInvalidParams{Context: "ListAttachedUserPoliciesInput"}
+	if s.Marker != nil && len(*s.Marker) < 1 {
+		invalidParams.Add(request.NewErrParamMinLen("Marker", 1))
+	}
+	if s.MaxItems != nil && *s.MaxItems < 1 {
+		invalidParams.Add(request.NewErrParamMinValue("MaxItems", 1))
+	}
+	if s.UserName == nil {
+		invalidParams.Add(request.NewErrParamRequired("UserName"))
+	}
+	if s.UserName != nil && len(*s.UserName) < 1 {
+		invalidParams.Add(request.NewErrParamMinLen("UserName", 1))
+	}
+
+	if invalidParams.Len() > 0 {
+		return invalidParams
+	}
+	return nil
 }
 
 // Contains the response to a successful ListAttachedUserPolicies request.
@@ -7764,6 +9031,31 @@ func (s ListEntitiesForPolicyInput) GoString() string {
 	return s.String()
 }
 
+// Validate inspects the fields of the type to determine if they are valid.
+func (s *ListEntitiesForPolicyInput) Validate() error {
+	invalidParams := request.ErrInvalidParams{Context: "ListEntitiesForPolicyInput"}
+	if s.Marker != nil && len(*s.Marker) < 1 {
+		invalidParams.Add(request.NewErrParamMinLen("Marker", 1))
+	}
+	if s.MaxItems != nil && *s.MaxItems < 1 {
+		invalidParams.Add(request.NewErrParamMinValue("MaxItems", 1))
+	}
+	if s.PathPrefix != nil && len(*s.PathPrefix) < 1 {
+		invalidParams.Add(request.NewErrParamMinLen("PathPrefix", 1))
+	}
+	if s.PolicyArn == nil {
+		invalidParams.Add(request.NewErrParamRequired("PolicyArn"))
+	}
+	if s.PolicyArn != nil && len(*s.PolicyArn) < 20 {
+		invalidParams.Add(request.NewErrParamMinLen("PolicyArn", 20))
+	}
+
+	if invalidParams.Len() > 0 {
+		return invalidParams
+	}
+	return nil
+}
+
 // Contains the response to a successful ListEntitiesForPolicy request.
 type ListEntitiesForPolicyOutput struct {
 	_ struct{} `type:"structure"`
@@ -7834,6 +9126,28 @@ func (s ListGroupPoliciesInput) GoString() string {
 	return s.String()
 }
 
+// Validate inspects the fields of the type to determine if they are valid.
+func (s *ListGroupPoliciesInput) Validate() error {
+	invalidParams := request.ErrInvalidParams{Context: "ListGroupPoliciesInput"}
+	if s.GroupName == nil {
+		invalidParams.Add(request.NewErrParamRequired("GroupName"))
+	}
+	if s.GroupName != nil && len(*s.GroupName) < 1 {
+		invalidParams.Add(request.NewErrParamMinLen("GroupName", 1))
+	}
+	if s.Marker != nil && len(*s.Marker) < 1 {
+		invalidParams.Add(request.NewErrParamMinLen("Marker", 1))
+	}
+	if s.MaxItems != nil && *s.MaxItems < 1 {
+		invalidParams.Add(request.NewErrParamMinValue("MaxItems", 1))
+	}
+
+	if invalidParams.Len() > 0 {
+		return invalidParams
+	}
+	return nil
+}
+
 // Contains the response to a successful ListGroupPolicies request.
 type ListGroupPoliciesOutput struct {
 	_ struct{} `type:"structure"`
@@ -7896,6 +9210,28 @@ func (s ListGroupsForUserInput) String() string {
 // GoString returns the string representation
 func (s ListGroupsForUserInput) GoString() string {
 	return s.String()
+}
+
+// Validate inspects the fields of the type to determine if they are valid.
+func (s *ListGroupsForUserInput) Validate() error {
+	invalidParams := request.ErrInvalidParams{Context: "ListGroupsForUserInput"}
+	if s.Marker != nil && len(*s.Marker) < 1 {
+		invalidParams.Add(request.NewErrParamMinLen("Marker", 1))
+	}
+	if s.MaxItems != nil && *s.MaxItems < 1 {
+		invalidParams.Add(request.NewErrParamMinValue("MaxItems", 1))
+	}
+	if s.UserName == nil {
+		invalidParams.Add(request.NewErrParamRequired("UserName"))
+	}
+	if s.UserName != nil && len(*s.UserName) < 1 {
+		invalidParams.Add(request.NewErrParamMinLen("UserName", 1))
+	}
+
+	if invalidParams.Len() > 0 {
+		return invalidParams
+	}
+	return nil
 }
 
 // Contains the response to a successful ListGroupsForUser request.
@@ -7966,6 +9302,25 @@ func (s ListGroupsInput) GoString() string {
 	return s.String()
 }
 
+// Validate inspects the fields of the type to determine if they are valid.
+func (s *ListGroupsInput) Validate() error {
+	invalidParams := request.ErrInvalidParams{Context: "ListGroupsInput"}
+	if s.Marker != nil && len(*s.Marker) < 1 {
+		invalidParams.Add(request.NewErrParamMinLen("Marker", 1))
+	}
+	if s.MaxItems != nil && *s.MaxItems < 1 {
+		invalidParams.Add(request.NewErrParamMinValue("MaxItems", 1))
+	}
+	if s.PathPrefix != nil && len(*s.PathPrefix) < 1 {
+		invalidParams.Add(request.NewErrParamMinLen("PathPrefix", 1))
+	}
+
+	if invalidParams.Len() > 0 {
+		return invalidParams
+	}
+	return nil
+}
+
 // Contains the response to a successful ListGroups request.
 type ListGroupsOutput struct {
 	_ struct{} `type:"structure"`
@@ -8028,6 +9383,28 @@ func (s ListInstanceProfilesForRoleInput) String() string {
 // GoString returns the string representation
 func (s ListInstanceProfilesForRoleInput) GoString() string {
 	return s.String()
+}
+
+// Validate inspects the fields of the type to determine if they are valid.
+func (s *ListInstanceProfilesForRoleInput) Validate() error {
+	invalidParams := request.ErrInvalidParams{Context: "ListInstanceProfilesForRoleInput"}
+	if s.Marker != nil && len(*s.Marker) < 1 {
+		invalidParams.Add(request.NewErrParamMinLen("Marker", 1))
+	}
+	if s.MaxItems != nil && *s.MaxItems < 1 {
+		invalidParams.Add(request.NewErrParamMinValue("MaxItems", 1))
+	}
+	if s.RoleName == nil {
+		invalidParams.Add(request.NewErrParamRequired("RoleName"))
+	}
+	if s.RoleName != nil && len(*s.RoleName) < 1 {
+		invalidParams.Add(request.NewErrParamMinLen("RoleName", 1))
+	}
+
+	if invalidParams.Len() > 0 {
+		return invalidParams
+	}
+	return nil
 }
 
 // Contains the response to a successful ListInstanceProfilesForRole request.
@@ -8098,6 +9475,25 @@ func (s ListInstanceProfilesInput) GoString() string {
 	return s.String()
 }
 
+// Validate inspects the fields of the type to determine if they are valid.
+func (s *ListInstanceProfilesInput) Validate() error {
+	invalidParams := request.ErrInvalidParams{Context: "ListInstanceProfilesInput"}
+	if s.Marker != nil && len(*s.Marker) < 1 {
+		invalidParams.Add(request.NewErrParamMinLen("Marker", 1))
+	}
+	if s.MaxItems != nil && *s.MaxItems < 1 {
+		invalidParams.Add(request.NewErrParamMinValue("MaxItems", 1))
+	}
+	if s.PathPrefix != nil && len(*s.PathPrefix) < 1 {
+		invalidParams.Add(request.NewErrParamMinLen("PathPrefix", 1))
+	}
+
+	if invalidParams.Len() > 0 {
+		return invalidParams
+	}
+	return nil
+}
+
 // Contains the response to a successful ListInstanceProfiles request.
 type ListInstanceProfilesOutput struct {
 	_ struct{} `type:"structure"`
@@ -8160,6 +9556,25 @@ func (s ListMFADevicesInput) String() string {
 // GoString returns the string representation
 func (s ListMFADevicesInput) GoString() string {
 	return s.String()
+}
+
+// Validate inspects the fields of the type to determine if they are valid.
+func (s *ListMFADevicesInput) Validate() error {
+	invalidParams := request.ErrInvalidParams{Context: "ListMFADevicesInput"}
+	if s.Marker != nil && len(*s.Marker) < 1 {
+		invalidParams.Add(request.NewErrParamMinLen("Marker", 1))
+	}
+	if s.MaxItems != nil && *s.MaxItems < 1 {
+		invalidParams.Add(request.NewErrParamMinValue("MaxItems", 1))
+	}
+	if s.UserName != nil && len(*s.UserName) < 1 {
+		invalidParams.Add(request.NewErrParamMinLen("UserName", 1))
+	}
+
+	if invalidParams.Len() > 0 {
+		return invalidParams
+	}
+	return nil
 }
 
 // Contains the response to a successful ListMFADevices request.
@@ -8275,6 +9690,22 @@ func (s ListPoliciesInput) GoString() string {
 	return s.String()
 }
 
+// Validate inspects the fields of the type to determine if they are valid.
+func (s *ListPoliciesInput) Validate() error {
+	invalidParams := request.ErrInvalidParams{Context: "ListPoliciesInput"}
+	if s.Marker != nil && len(*s.Marker) < 1 {
+		invalidParams.Add(request.NewErrParamMinLen("Marker", 1))
+	}
+	if s.MaxItems != nil && *s.MaxItems < 1 {
+		invalidParams.Add(request.NewErrParamMinValue("MaxItems", 1))
+	}
+
+	if invalidParams.Len() > 0 {
+		return invalidParams
+	}
+	return nil
+}
+
 // Contains the response to a successful ListPolicies request.
 type ListPoliciesOutput struct {
 	_ struct{} `type:"structure"`
@@ -8341,6 +9772,28 @@ func (s ListPolicyVersionsInput) String() string {
 // GoString returns the string representation
 func (s ListPolicyVersionsInput) GoString() string {
 	return s.String()
+}
+
+// Validate inspects the fields of the type to determine if they are valid.
+func (s *ListPolicyVersionsInput) Validate() error {
+	invalidParams := request.ErrInvalidParams{Context: "ListPolicyVersionsInput"}
+	if s.Marker != nil && len(*s.Marker) < 1 {
+		invalidParams.Add(request.NewErrParamMinLen("Marker", 1))
+	}
+	if s.MaxItems != nil && *s.MaxItems < 1 {
+		invalidParams.Add(request.NewErrParamMinValue("MaxItems", 1))
+	}
+	if s.PolicyArn == nil {
+		invalidParams.Add(request.NewErrParamRequired("PolicyArn"))
+	}
+	if s.PolicyArn != nil && len(*s.PolicyArn) < 20 {
+		invalidParams.Add(request.NewErrParamMinLen("PolicyArn", 20))
+	}
+
+	if invalidParams.Len() > 0 {
+		return invalidParams
+	}
+	return nil
 }
 
 // Contains the response to a successful ListPolicyVersions request.
@@ -8411,6 +9864,28 @@ func (s ListRolePoliciesInput) GoString() string {
 	return s.String()
 }
 
+// Validate inspects the fields of the type to determine if they are valid.
+func (s *ListRolePoliciesInput) Validate() error {
+	invalidParams := request.ErrInvalidParams{Context: "ListRolePoliciesInput"}
+	if s.Marker != nil && len(*s.Marker) < 1 {
+		invalidParams.Add(request.NewErrParamMinLen("Marker", 1))
+	}
+	if s.MaxItems != nil && *s.MaxItems < 1 {
+		invalidParams.Add(request.NewErrParamMinValue("MaxItems", 1))
+	}
+	if s.RoleName == nil {
+		invalidParams.Add(request.NewErrParamRequired("RoleName"))
+	}
+	if s.RoleName != nil && len(*s.RoleName) < 1 {
+		invalidParams.Add(request.NewErrParamMinLen("RoleName", 1))
+	}
+
+	if invalidParams.Len() > 0 {
+		return invalidParams
+	}
+	return nil
+}
+
 // Contains the response to a successful ListRolePolicies request.
 type ListRolePoliciesOutput struct {
 	_ struct{} `type:"structure"`
@@ -8477,6 +9952,25 @@ func (s ListRolesInput) String() string {
 // GoString returns the string representation
 func (s ListRolesInput) GoString() string {
 	return s.String()
+}
+
+// Validate inspects the fields of the type to determine if they are valid.
+func (s *ListRolesInput) Validate() error {
+	invalidParams := request.ErrInvalidParams{Context: "ListRolesInput"}
+	if s.Marker != nil && len(*s.Marker) < 1 {
+		invalidParams.Add(request.NewErrParamMinLen("Marker", 1))
+	}
+	if s.MaxItems != nil && *s.MaxItems < 1 {
+		invalidParams.Add(request.NewErrParamMinValue("MaxItems", 1))
+	}
+	if s.PathPrefix != nil && len(*s.PathPrefix) < 1 {
+		invalidParams.Add(request.NewErrParamMinLen("PathPrefix", 1))
+	}
+
+	if invalidParams.Len() > 0 {
+		return invalidParams
+	}
+	return nil
 }
 
 // Contains the response to a successful ListRoles request.
@@ -8577,6 +10071,25 @@ func (s ListSSHPublicKeysInput) GoString() string {
 	return s.String()
 }
 
+// Validate inspects the fields of the type to determine if they are valid.
+func (s *ListSSHPublicKeysInput) Validate() error {
+	invalidParams := request.ErrInvalidParams{Context: "ListSSHPublicKeysInput"}
+	if s.Marker != nil && len(*s.Marker) < 1 {
+		invalidParams.Add(request.NewErrParamMinLen("Marker", 1))
+	}
+	if s.MaxItems != nil && *s.MaxItems < 1 {
+		invalidParams.Add(request.NewErrParamMinValue("MaxItems", 1))
+	}
+	if s.UserName != nil && len(*s.UserName) < 1 {
+		invalidParams.Add(request.NewErrParamMinLen("UserName", 1))
+	}
+
+	if invalidParams.Len() > 0 {
+		return invalidParams
+	}
+	return nil
+}
+
 // Contains the response to a successful ListSSHPublicKeys request.
 type ListSSHPublicKeysOutput struct {
 	_ struct{} `type:"structure"`
@@ -8645,6 +10158,25 @@ func (s ListServerCertificatesInput) GoString() string {
 	return s.String()
 }
 
+// Validate inspects the fields of the type to determine if they are valid.
+func (s *ListServerCertificatesInput) Validate() error {
+	invalidParams := request.ErrInvalidParams{Context: "ListServerCertificatesInput"}
+	if s.Marker != nil && len(*s.Marker) < 1 {
+		invalidParams.Add(request.NewErrParamMinLen("Marker", 1))
+	}
+	if s.MaxItems != nil && *s.MaxItems < 1 {
+		invalidParams.Add(request.NewErrParamMinValue("MaxItems", 1))
+	}
+	if s.PathPrefix != nil && len(*s.PathPrefix) < 1 {
+		invalidParams.Add(request.NewErrParamMinLen("PathPrefix", 1))
+	}
+
+	if invalidParams.Len() > 0 {
+		return invalidParams
+	}
+	return nil
+}
+
 // Contains the response to a successful ListServerCertificates request.
 type ListServerCertificatesOutput struct {
 	_ struct{} `type:"structure"`
@@ -8709,6 +10241,25 @@ func (s ListSigningCertificatesInput) GoString() string {
 	return s.String()
 }
 
+// Validate inspects the fields of the type to determine if they are valid.
+func (s *ListSigningCertificatesInput) Validate() error {
+	invalidParams := request.ErrInvalidParams{Context: "ListSigningCertificatesInput"}
+	if s.Marker != nil && len(*s.Marker) < 1 {
+		invalidParams.Add(request.NewErrParamMinLen("Marker", 1))
+	}
+	if s.MaxItems != nil && *s.MaxItems < 1 {
+		invalidParams.Add(request.NewErrParamMinValue("MaxItems", 1))
+	}
+	if s.UserName != nil && len(*s.UserName) < 1 {
+		invalidParams.Add(request.NewErrParamMinLen("UserName", 1))
+	}
+
+	if invalidParams.Len() > 0 {
+		return invalidParams
+	}
+	return nil
+}
+
 // Contains the response to a successful ListSigningCertificates request.
 type ListSigningCertificatesOutput struct {
 	_ struct{} `type:"structure"`
@@ -8771,6 +10322,28 @@ func (s ListUserPoliciesInput) String() string {
 // GoString returns the string representation
 func (s ListUserPoliciesInput) GoString() string {
 	return s.String()
+}
+
+// Validate inspects the fields of the type to determine if they are valid.
+func (s *ListUserPoliciesInput) Validate() error {
+	invalidParams := request.ErrInvalidParams{Context: "ListUserPoliciesInput"}
+	if s.Marker != nil && len(*s.Marker) < 1 {
+		invalidParams.Add(request.NewErrParamMinLen("Marker", 1))
+	}
+	if s.MaxItems != nil && *s.MaxItems < 1 {
+		invalidParams.Add(request.NewErrParamMinValue("MaxItems", 1))
+	}
+	if s.UserName == nil {
+		invalidParams.Add(request.NewErrParamRequired("UserName"))
+	}
+	if s.UserName != nil && len(*s.UserName) < 1 {
+		invalidParams.Add(request.NewErrParamMinLen("UserName", 1))
+	}
+
+	if invalidParams.Len() > 0 {
+		return invalidParams
+	}
+	return nil
 }
 
 // Contains the response to a successful ListUserPolicies request.
@@ -8841,6 +10414,25 @@ func (s ListUsersInput) GoString() string {
 	return s.String()
 }
 
+// Validate inspects the fields of the type to determine if they are valid.
+func (s *ListUsersInput) Validate() error {
+	invalidParams := request.ErrInvalidParams{Context: "ListUsersInput"}
+	if s.Marker != nil && len(*s.Marker) < 1 {
+		invalidParams.Add(request.NewErrParamMinLen("Marker", 1))
+	}
+	if s.MaxItems != nil && *s.MaxItems < 1 {
+		invalidParams.Add(request.NewErrParamMinValue("MaxItems", 1))
+	}
+	if s.PathPrefix != nil && len(*s.PathPrefix) < 1 {
+		invalidParams.Add(request.NewErrParamMinLen("PathPrefix", 1))
+	}
+
+	if invalidParams.Len() > 0 {
+		return invalidParams
+	}
+	return nil
+}
+
 // Contains the response to a successful ListUsers request.
 type ListUsersOutput struct {
 	_ struct{} `type:"structure"`
@@ -8905,6 +10497,22 @@ func (s ListVirtualMFADevicesInput) String() string {
 // GoString returns the string representation
 func (s ListVirtualMFADevicesInput) GoString() string {
 	return s.String()
+}
+
+// Validate inspects the fields of the type to determine if they are valid.
+func (s *ListVirtualMFADevicesInput) Validate() error {
+	invalidParams := request.ErrInvalidParams{Context: "ListVirtualMFADevicesInput"}
+	if s.Marker != nil && len(*s.Marker) < 1 {
+		invalidParams.Add(request.NewErrParamMinLen("Marker", 1))
+	}
+	if s.MaxItems != nil && *s.MaxItems < 1 {
+		invalidParams.Add(request.NewErrParamMinValue("MaxItems", 1))
+	}
+
+	if invalidParams.Len() > 0 {
+		return invalidParams
+	}
+	return nil
 }
 
 // Contains the response to a successful ListVirtualMFADevices request.
@@ -9424,6 +11032,34 @@ func (s PutGroupPolicyInput) GoString() string {
 	return s.String()
 }
 
+// Validate inspects the fields of the type to determine if they are valid.
+func (s *PutGroupPolicyInput) Validate() error {
+	invalidParams := request.ErrInvalidParams{Context: "PutGroupPolicyInput"}
+	if s.GroupName == nil {
+		invalidParams.Add(request.NewErrParamRequired("GroupName"))
+	}
+	if s.GroupName != nil && len(*s.GroupName) < 1 {
+		invalidParams.Add(request.NewErrParamMinLen("GroupName", 1))
+	}
+	if s.PolicyDocument == nil {
+		invalidParams.Add(request.NewErrParamRequired("PolicyDocument"))
+	}
+	if s.PolicyDocument != nil && len(*s.PolicyDocument) < 1 {
+		invalidParams.Add(request.NewErrParamMinLen("PolicyDocument", 1))
+	}
+	if s.PolicyName == nil {
+		invalidParams.Add(request.NewErrParamRequired("PolicyName"))
+	}
+	if s.PolicyName != nil && len(*s.PolicyName) < 1 {
+		invalidParams.Add(request.NewErrParamMinLen("PolicyName", 1))
+	}
+
+	if invalidParams.Len() > 0 {
+		return invalidParams
+	}
+	return nil
+}
+
 type PutGroupPolicyOutput struct {
 	_ struct{} `type:"structure"`
 }
@@ -9459,6 +11095,34 @@ func (s PutRolePolicyInput) String() string {
 // GoString returns the string representation
 func (s PutRolePolicyInput) GoString() string {
 	return s.String()
+}
+
+// Validate inspects the fields of the type to determine if they are valid.
+func (s *PutRolePolicyInput) Validate() error {
+	invalidParams := request.ErrInvalidParams{Context: "PutRolePolicyInput"}
+	if s.PolicyDocument == nil {
+		invalidParams.Add(request.NewErrParamRequired("PolicyDocument"))
+	}
+	if s.PolicyDocument != nil && len(*s.PolicyDocument) < 1 {
+		invalidParams.Add(request.NewErrParamMinLen("PolicyDocument", 1))
+	}
+	if s.PolicyName == nil {
+		invalidParams.Add(request.NewErrParamRequired("PolicyName"))
+	}
+	if s.PolicyName != nil && len(*s.PolicyName) < 1 {
+		invalidParams.Add(request.NewErrParamMinLen("PolicyName", 1))
+	}
+	if s.RoleName == nil {
+		invalidParams.Add(request.NewErrParamRequired("RoleName"))
+	}
+	if s.RoleName != nil && len(*s.RoleName) < 1 {
+		invalidParams.Add(request.NewErrParamMinLen("RoleName", 1))
+	}
+
+	if invalidParams.Len() > 0 {
+		return invalidParams
+	}
+	return nil
 }
 
 type PutRolePolicyOutput struct {
@@ -9498,6 +11162,34 @@ func (s PutUserPolicyInput) GoString() string {
 	return s.String()
 }
 
+// Validate inspects the fields of the type to determine if they are valid.
+func (s *PutUserPolicyInput) Validate() error {
+	invalidParams := request.ErrInvalidParams{Context: "PutUserPolicyInput"}
+	if s.PolicyDocument == nil {
+		invalidParams.Add(request.NewErrParamRequired("PolicyDocument"))
+	}
+	if s.PolicyDocument != nil && len(*s.PolicyDocument) < 1 {
+		invalidParams.Add(request.NewErrParamMinLen("PolicyDocument", 1))
+	}
+	if s.PolicyName == nil {
+		invalidParams.Add(request.NewErrParamRequired("PolicyName"))
+	}
+	if s.PolicyName != nil && len(*s.PolicyName) < 1 {
+		invalidParams.Add(request.NewErrParamMinLen("PolicyName", 1))
+	}
+	if s.UserName == nil {
+		invalidParams.Add(request.NewErrParamRequired("UserName"))
+	}
+	if s.UserName != nil && len(*s.UserName) < 1 {
+		invalidParams.Add(request.NewErrParamMinLen("UserName", 1))
+	}
+
+	if invalidParams.Len() > 0 {
+		return invalidParams
+	}
+	return nil
+}
+
 type PutUserPolicyOutput struct {
 	_ struct{} `type:"structure"`
 }
@@ -9535,6 +11227,28 @@ func (s RemoveClientIDFromOpenIDConnectProviderInput) GoString() string {
 	return s.String()
 }
 
+// Validate inspects the fields of the type to determine if they are valid.
+func (s *RemoveClientIDFromOpenIDConnectProviderInput) Validate() error {
+	invalidParams := request.ErrInvalidParams{Context: "RemoveClientIDFromOpenIDConnectProviderInput"}
+	if s.ClientID == nil {
+		invalidParams.Add(request.NewErrParamRequired("ClientID"))
+	}
+	if s.ClientID != nil && len(*s.ClientID) < 1 {
+		invalidParams.Add(request.NewErrParamMinLen("ClientID", 1))
+	}
+	if s.OpenIDConnectProviderArn == nil {
+		invalidParams.Add(request.NewErrParamRequired("OpenIDConnectProviderArn"))
+	}
+	if s.OpenIDConnectProviderArn != nil && len(*s.OpenIDConnectProviderArn) < 20 {
+		invalidParams.Add(request.NewErrParamMinLen("OpenIDConnectProviderArn", 20))
+	}
+
+	if invalidParams.Len() > 0 {
+		return invalidParams
+	}
+	return nil
+}
+
 type RemoveClientIDFromOpenIDConnectProviderOutput struct {
 	_ struct{} `type:"structure"`
 }
@@ -9569,6 +11283,28 @@ func (s RemoveRoleFromInstanceProfileInput) GoString() string {
 	return s.String()
 }
 
+// Validate inspects the fields of the type to determine if they are valid.
+func (s *RemoveRoleFromInstanceProfileInput) Validate() error {
+	invalidParams := request.ErrInvalidParams{Context: "RemoveRoleFromInstanceProfileInput"}
+	if s.InstanceProfileName == nil {
+		invalidParams.Add(request.NewErrParamRequired("InstanceProfileName"))
+	}
+	if s.InstanceProfileName != nil && len(*s.InstanceProfileName) < 1 {
+		invalidParams.Add(request.NewErrParamMinLen("InstanceProfileName", 1))
+	}
+	if s.RoleName == nil {
+		invalidParams.Add(request.NewErrParamRequired("RoleName"))
+	}
+	if s.RoleName != nil && len(*s.RoleName) < 1 {
+		invalidParams.Add(request.NewErrParamMinLen("RoleName", 1))
+	}
+
+	if invalidParams.Len() > 0 {
+		return invalidParams
+	}
+	return nil
+}
+
 type RemoveRoleFromInstanceProfileOutput struct {
 	_ struct{} `type:"structure"`
 }
@@ -9601,6 +11337,28 @@ func (s RemoveUserFromGroupInput) String() string {
 // GoString returns the string representation
 func (s RemoveUserFromGroupInput) GoString() string {
 	return s.String()
+}
+
+// Validate inspects the fields of the type to determine if they are valid.
+func (s *RemoveUserFromGroupInput) Validate() error {
+	invalidParams := request.ErrInvalidParams{Context: "RemoveUserFromGroupInput"}
+	if s.GroupName == nil {
+		invalidParams.Add(request.NewErrParamRequired("GroupName"))
+	}
+	if s.GroupName != nil && len(*s.GroupName) < 1 {
+		invalidParams.Add(request.NewErrParamMinLen("GroupName", 1))
+	}
+	if s.UserName == nil {
+		invalidParams.Add(request.NewErrParamRequired("UserName"))
+	}
+	if s.UserName != nil && len(*s.UserName) < 1 {
+		invalidParams.Add(request.NewErrParamMinLen("UserName", 1))
+	}
+
+	if invalidParams.Len() > 0 {
+		return invalidParams
+	}
+	return nil
 }
 
 type RemoveUserFromGroupOutput struct {
@@ -9690,6 +11448,40 @@ func (s ResyncMFADeviceInput) String() string {
 // GoString returns the string representation
 func (s ResyncMFADeviceInput) GoString() string {
 	return s.String()
+}
+
+// Validate inspects the fields of the type to determine if they are valid.
+func (s *ResyncMFADeviceInput) Validate() error {
+	invalidParams := request.ErrInvalidParams{Context: "ResyncMFADeviceInput"}
+	if s.AuthenticationCode1 == nil {
+		invalidParams.Add(request.NewErrParamRequired("AuthenticationCode1"))
+	}
+	if s.AuthenticationCode1 != nil && len(*s.AuthenticationCode1) < 6 {
+		invalidParams.Add(request.NewErrParamMinLen("AuthenticationCode1", 6))
+	}
+	if s.AuthenticationCode2 == nil {
+		invalidParams.Add(request.NewErrParamRequired("AuthenticationCode2"))
+	}
+	if s.AuthenticationCode2 != nil && len(*s.AuthenticationCode2) < 6 {
+		invalidParams.Add(request.NewErrParamMinLen("AuthenticationCode2", 6))
+	}
+	if s.SerialNumber == nil {
+		invalidParams.Add(request.NewErrParamRequired("SerialNumber"))
+	}
+	if s.SerialNumber != nil && len(*s.SerialNumber) < 9 {
+		invalidParams.Add(request.NewErrParamMinLen("SerialNumber", 9))
+	}
+	if s.UserName == nil {
+		invalidParams.Add(request.NewErrParamRequired("UserName"))
+	}
+	if s.UserName != nil && len(*s.UserName) < 1 {
+		invalidParams.Add(request.NewErrParamMinLen("UserName", 1))
+	}
+
+	if invalidParams.Len() > 0 {
+		return invalidParams
+	}
+	return nil
 }
 
 type ResyncMFADeviceOutput struct {
@@ -10003,6 +11795,25 @@ func (s SetDefaultPolicyVersionInput) GoString() string {
 	return s.String()
 }
 
+// Validate inspects the fields of the type to determine if they are valid.
+func (s *SetDefaultPolicyVersionInput) Validate() error {
+	invalidParams := request.ErrInvalidParams{Context: "SetDefaultPolicyVersionInput"}
+	if s.PolicyArn == nil {
+		invalidParams.Add(request.NewErrParamRequired("PolicyArn"))
+	}
+	if s.PolicyArn != nil && len(*s.PolicyArn) < 20 {
+		invalidParams.Add(request.NewErrParamMinLen("PolicyArn", 20))
+	}
+	if s.VersionId == nil {
+		invalidParams.Add(request.NewErrParamRequired("VersionId"))
+	}
+
+	if invalidParams.Len() > 0 {
+		return invalidParams
+	}
+	return nil
+}
+
 type SetDefaultPolicyVersionOutput struct {
 	_ struct{} `type:"structure"`
 }
@@ -10181,6 +11992,50 @@ func (s SimulateCustomPolicyInput) GoString() string {
 	return s.String()
 }
 
+// Validate inspects the fields of the type to determine if they are valid.
+func (s *SimulateCustomPolicyInput) Validate() error {
+	invalidParams := request.ErrInvalidParams{Context: "SimulateCustomPolicyInput"}
+	if s.ActionNames == nil {
+		invalidParams.Add(request.NewErrParamRequired("ActionNames"))
+	}
+	if s.CallerArn != nil && len(*s.CallerArn) < 1 {
+		invalidParams.Add(request.NewErrParamMinLen("CallerArn", 1))
+	}
+	if s.Marker != nil && len(*s.Marker) < 1 {
+		invalidParams.Add(request.NewErrParamMinLen("Marker", 1))
+	}
+	if s.MaxItems != nil && *s.MaxItems < 1 {
+		invalidParams.Add(request.NewErrParamMinValue("MaxItems", 1))
+	}
+	if s.PolicyInputList == nil {
+		invalidParams.Add(request.NewErrParamRequired("PolicyInputList"))
+	}
+	if s.ResourceHandlingOption != nil && len(*s.ResourceHandlingOption) < 1 {
+		invalidParams.Add(request.NewErrParamMinLen("ResourceHandlingOption", 1))
+	}
+	if s.ResourceOwner != nil && len(*s.ResourceOwner) < 1 {
+		invalidParams.Add(request.NewErrParamMinLen("ResourceOwner", 1))
+	}
+	if s.ResourcePolicy != nil && len(*s.ResourcePolicy) < 1 {
+		invalidParams.Add(request.NewErrParamMinLen("ResourcePolicy", 1))
+	}
+	if s.ContextEntries != nil {
+		for i, v := range s.ContextEntries {
+			if v == nil {
+				continue
+			}
+			if err := v.Validate(); err != nil {
+				invalidParams.AddNested(fmt.Sprintf("%s[%v]", "ContextEntries", i), err.(request.ErrInvalidParams))
+			}
+		}
+	}
+
+	if invalidParams.Len() > 0 {
+		return invalidParams
+	}
+	return nil
+}
+
 // Contains the response to a successful SimulatePrincipalPolicy or SimulateCustomPolicy
 // request.
 type SimulatePolicyResponse struct {
@@ -10348,6 +12203,53 @@ func (s SimulatePrincipalPolicyInput) GoString() string {
 	return s.String()
 }
 
+// Validate inspects the fields of the type to determine if they are valid.
+func (s *SimulatePrincipalPolicyInput) Validate() error {
+	invalidParams := request.ErrInvalidParams{Context: "SimulatePrincipalPolicyInput"}
+	if s.ActionNames == nil {
+		invalidParams.Add(request.NewErrParamRequired("ActionNames"))
+	}
+	if s.CallerArn != nil && len(*s.CallerArn) < 1 {
+		invalidParams.Add(request.NewErrParamMinLen("CallerArn", 1))
+	}
+	if s.Marker != nil && len(*s.Marker) < 1 {
+		invalidParams.Add(request.NewErrParamMinLen("Marker", 1))
+	}
+	if s.MaxItems != nil && *s.MaxItems < 1 {
+		invalidParams.Add(request.NewErrParamMinValue("MaxItems", 1))
+	}
+	if s.PolicySourceArn == nil {
+		invalidParams.Add(request.NewErrParamRequired("PolicySourceArn"))
+	}
+	if s.PolicySourceArn != nil && len(*s.PolicySourceArn) < 20 {
+		invalidParams.Add(request.NewErrParamMinLen("PolicySourceArn", 20))
+	}
+	if s.ResourceHandlingOption != nil && len(*s.ResourceHandlingOption) < 1 {
+		invalidParams.Add(request.NewErrParamMinLen("ResourceHandlingOption", 1))
+	}
+	if s.ResourceOwner != nil && len(*s.ResourceOwner) < 1 {
+		invalidParams.Add(request.NewErrParamMinLen("ResourceOwner", 1))
+	}
+	if s.ResourcePolicy != nil && len(*s.ResourcePolicy) < 1 {
+		invalidParams.Add(request.NewErrParamMinLen("ResourcePolicy", 1))
+	}
+	if s.ContextEntries != nil {
+		for i, v := range s.ContextEntries {
+			if v == nil {
+				continue
+			}
+			if err := v.Validate(); err != nil {
+				invalidParams.AddNested(fmt.Sprintf("%s[%v]", "ContextEntries", i), err.(request.ErrInvalidParams))
+			}
+		}
+	}
+
+	if invalidParams.Len() > 0 {
+		return invalidParams
+	}
+	return nil
+}
+
 // Contains a reference to a Statement element in a policy document that determines
 // the result of the simulation.
 //
@@ -10402,6 +12304,28 @@ func (s UpdateAccessKeyInput) String() string {
 // GoString returns the string representation
 func (s UpdateAccessKeyInput) GoString() string {
 	return s.String()
+}
+
+// Validate inspects the fields of the type to determine if they are valid.
+func (s *UpdateAccessKeyInput) Validate() error {
+	invalidParams := request.ErrInvalidParams{Context: "UpdateAccessKeyInput"}
+	if s.AccessKeyId == nil {
+		invalidParams.Add(request.NewErrParamRequired("AccessKeyId"))
+	}
+	if s.AccessKeyId != nil && len(*s.AccessKeyId) < 16 {
+		invalidParams.Add(request.NewErrParamMinLen("AccessKeyId", 16))
+	}
+	if s.Status == nil {
+		invalidParams.Add(request.NewErrParamRequired("Status"))
+	}
+	if s.UserName != nil && len(*s.UserName) < 1 {
+		invalidParams.Add(request.NewErrParamMinLen("UserName", 1))
+	}
+
+	if invalidParams.Len() > 0 {
+		return invalidParams
+	}
+	return nil
 }
 
 type UpdateAccessKeyOutput struct {
@@ -10489,6 +12413,25 @@ func (s UpdateAccountPasswordPolicyInput) GoString() string {
 	return s.String()
 }
 
+// Validate inspects the fields of the type to determine if they are valid.
+func (s *UpdateAccountPasswordPolicyInput) Validate() error {
+	invalidParams := request.ErrInvalidParams{Context: "UpdateAccountPasswordPolicyInput"}
+	if s.MaxPasswordAge != nil && *s.MaxPasswordAge < 1 {
+		invalidParams.Add(request.NewErrParamMinValue("MaxPasswordAge", 1))
+	}
+	if s.MinimumPasswordLength != nil && *s.MinimumPasswordLength < 6 {
+		invalidParams.Add(request.NewErrParamMinValue("MinimumPasswordLength", 6))
+	}
+	if s.PasswordReusePrevention != nil && *s.PasswordReusePrevention < 1 {
+		invalidParams.Add(request.NewErrParamMinValue("PasswordReusePrevention", 1))
+	}
+
+	if invalidParams.Len() > 0 {
+		return invalidParams
+	}
+	return nil
+}
+
 type UpdateAccountPasswordPolicyOutput struct {
 	_ struct{} `type:"structure"`
 }
@@ -10521,6 +12464,28 @@ func (s UpdateAssumeRolePolicyInput) String() string {
 // GoString returns the string representation
 func (s UpdateAssumeRolePolicyInput) GoString() string {
 	return s.String()
+}
+
+// Validate inspects the fields of the type to determine if they are valid.
+func (s *UpdateAssumeRolePolicyInput) Validate() error {
+	invalidParams := request.ErrInvalidParams{Context: "UpdateAssumeRolePolicyInput"}
+	if s.PolicyDocument == nil {
+		invalidParams.Add(request.NewErrParamRequired("PolicyDocument"))
+	}
+	if s.PolicyDocument != nil && len(*s.PolicyDocument) < 1 {
+		invalidParams.Add(request.NewErrParamMinLen("PolicyDocument", 1))
+	}
+	if s.RoleName == nil {
+		invalidParams.Add(request.NewErrParamRequired("RoleName"))
+	}
+	if s.RoleName != nil && len(*s.RoleName) < 1 {
+		invalidParams.Add(request.NewErrParamMinLen("RoleName", 1))
+	}
+
+	if invalidParams.Len() > 0 {
+		return invalidParams
+	}
+	return nil
 }
 
 type UpdateAssumeRolePolicyOutput struct {
@@ -10561,6 +12526,28 @@ func (s UpdateGroupInput) GoString() string {
 	return s.String()
 }
 
+// Validate inspects the fields of the type to determine if they are valid.
+func (s *UpdateGroupInput) Validate() error {
+	invalidParams := request.ErrInvalidParams{Context: "UpdateGroupInput"}
+	if s.GroupName == nil {
+		invalidParams.Add(request.NewErrParamRequired("GroupName"))
+	}
+	if s.GroupName != nil && len(*s.GroupName) < 1 {
+		invalidParams.Add(request.NewErrParamMinLen("GroupName", 1))
+	}
+	if s.NewGroupName != nil && len(*s.NewGroupName) < 1 {
+		invalidParams.Add(request.NewErrParamMinLen("NewGroupName", 1))
+	}
+	if s.NewPath != nil && len(*s.NewPath) < 1 {
+		invalidParams.Add(request.NewErrParamMinLen("NewPath", 1))
+	}
+
+	if invalidParams.Len() > 0 {
+		return invalidParams
+	}
+	return nil
+}
+
 type UpdateGroupOutput struct {
 	_ struct{} `type:"structure"`
 }
@@ -10596,6 +12583,25 @@ func (s UpdateLoginProfileInput) String() string {
 // GoString returns the string representation
 func (s UpdateLoginProfileInput) GoString() string {
 	return s.String()
+}
+
+// Validate inspects the fields of the type to determine if they are valid.
+func (s *UpdateLoginProfileInput) Validate() error {
+	invalidParams := request.ErrInvalidParams{Context: "UpdateLoginProfileInput"}
+	if s.Password != nil && len(*s.Password) < 1 {
+		invalidParams.Add(request.NewErrParamMinLen("Password", 1))
+	}
+	if s.UserName == nil {
+		invalidParams.Add(request.NewErrParamRequired("UserName"))
+	}
+	if s.UserName != nil && len(*s.UserName) < 1 {
+		invalidParams.Add(request.NewErrParamMinLen("UserName", 1))
+	}
+
+	if invalidParams.Len() > 0 {
+		return invalidParams
+	}
+	return nil
 }
 
 type UpdateLoginProfileOutput struct {
@@ -10635,6 +12641,25 @@ func (s UpdateOpenIDConnectProviderThumbprintInput) GoString() string {
 	return s.String()
 }
 
+// Validate inspects the fields of the type to determine if they are valid.
+func (s *UpdateOpenIDConnectProviderThumbprintInput) Validate() error {
+	invalidParams := request.ErrInvalidParams{Context: "UpdateOpenIDConnectProviderThumbprintInput"}
+	if s.OpenIDConnectProviderArn == nil {
+		invalidParams.Add(request.NewErrParamRequired("OpenIDConnectProviderArn"))
+	}
+	if s.OpenIDConnectProviderArn != nil && len(*s.OpenIDConnectProviderArn) < 20 {
+		invalidParams.Add(request.NewErrParamMinLen("OpenIDConnectProviderArn", 20))
+	}
+	if s.ThumbprintList == nil {
+		invalidParams.Add(request.NewErrParamRequired("ThumbprintList"))
+	}
+
+	if invalidParams.Len() > 0 {
+		return invalidParams
+	}
+	return nil
+}
+
 type UpdateOpenIDConnectProviderThumbprintOutput struct {
 	_ struct{} `type:"structure"`
 }
@@ -10671,6 +12696,28 @@ func (s UpdateSAMLProviderInput) String() string {
 // GoString returns the string representation
 func (s UpdateSAMLProviderInput) GoString() string {
 	return s.String()
+}
+
+// Validate inspects the fields of the type to determine if they are valid.
+func (s *UpdateSAMLProviderInput) Validate() error {
+	invalidParams := request.ErrInvalidParams{Context: "UpdateSAMLProviderInput"}
+	if s.SAMLMetadataDocument == nil {
+		invalidParams.Add(request.NewErrParamRequired("SAMLMetadataDocument"))
+	}
+	if s.SAMLMetadataDocument != nil && len(*s.SAMLMetadataDocument) < 1000 {
+		invalidParams.Add(request.NewErrParamMinLen("SAMLMetadataDocument", 1000))
+	}
+	if s.SAMLProviderArn == nil {
+		invalidParams.Add(request.NewErrParamRequired("SAMLProviderArn"))
+	}
+	if s.SAMLProviderArn != nil && len(*s.SAMLProviderArn) < 20 {
+		invalidParams.Add(request.NewErrParamMinLen("SAMLProviderArn", 20))
+	}
+
+	if invalidParams.Len() > 0 {
+		return invalidParams
+	}
+	return nil
 }
 
 // Contains the response to a successful UpdateSAMLProvider request.
@@ -10716,6 +12763,31 @@ func (s UpdateSSHPublicKeyInput) GoString() string {
 	return s.String()
 }
 
+// Validate inspects the fields of the type to determine if they are valid.
+func (s *UpdateSSHPublicKeyInput) Validate() error {
+	invalidParams := request.ErrInvalidParams{Context: "UpdateSSHPublicKeyInput"}
+	if s.SSHPublicKeyId == nil {
+		invalidParams.Add(request.NewErrParamRequired("SSHPublicKeyId"))
+	}
+	if s.SSHPublicKeyId != nil && len(*s.SSHPublicKeyId) < 20 {
+		invalidParams.Add(request.NewErrParamMinLen("SSHPublicKeyId", 20))
+	}
+	if s.Status == nil {
+		invalidParams.Add(request.NewErrParamRequired("Status"))
+	}
+	if s.UserName == nil {
+		invalidParams.Add(request.NewErrParamRequired("UserName"))
+	}
+	if s.UserName != nil && len(*s.UserName) < 1 {
+		invalidParams.Add(request.NewErrParamMinLen("UserName", 1))
+	}
+
+	if invalidParams.Len() > 0 {
+		return invalidParams
+	}
+	return nil
+}
+
 type UpdateSSHPublicKeyOutput struct {
 	_ struct{} `type:"structure"`
 }
@@ -10756,6 +12828,28 @@ func (s UpdateServerCertificateInput) GoString() string {
 	return s.String()
 }
 
+// Validate inspects the fields of the type to determine if they are valid.
+func (s *UpdateServerCertificateInput) Validate() error {
+	invalidParams := request.ErrInvalidParams{Context: "UpdateServerCertificateInput"}
+	if s.NewPath != nil && len(*s.NewPath) < 1 {
+		invalidParams.Add(request.NewErrParamMinLen("NewPath", 1))
+	}
+	if s.NewServerCertificateName != nil && len(*s.NewServerCertificateName) < 1 {
+		invalidParams.Add(request.NewErrParamMinLen("NewServerCertificateName", 1))
+	}
+	if s.ServerCertificateName == nil {
+		invalidParams.Add(request.NewErrParamRequired("ServerCertificateName"))
+	}
+	if s.ServerCertificateName != nil && len(*s.ServerCertificateName) < 1 {
+		invalidParams.Add(request.NewErrParamMinLen("ServerCertificateName", 1))
+	}
+
+	if invalidParams.Len() > 0 {
+		return invalidParams
+	}
+	return nil
+}
+
 type UpdateServerCertificateOutput struct {
 	_ struct{} `type:"structure"`
 }
@@ -10793,6 +12887,28 @@ func (s UpdateSigningCertificateInput) String() string {
 // GoString returns the string representation
 func (s UpdateSigningCertificateInput) GoString() string {
 	return s.String()
+}
+
+// Validate inspects the fields of the type to determine if they are valid.
+func (s *UpdateSigningCertificateInput) Validate() error {
+	invalidParams := request.ErrInvalidParams{Context: "UpdateSigningCertificateInput"}
+	if s.CertificateId == nil {
+		invalidParams.Add(request.NewErrParamRequired("CertificateId"))
+	}
+	if s.CertificateId != nil && len(*s.CertificateId) < 24 {
+		invalidParams.Add(request.NewErrParamMinLen("CertificateId", 24))
+	}
+	if s.Status == nil {
+		invalidParams.Add(request.NewErrParamRequired("Status"))
+	}
+	if s.UserName != nil && len(*s.UserName) < 1 {
+		invalidParams.Add(request.NewErrParamMinLen("UserName", 1))
+	}
+
+	if invalidParams.Len() > 0 {
+		return invalidParams
+	}
+	return nil
 }
 
 type UpdateSigningCertificateOutput struct {
@@ -10835,6 +12951,28 @@ func (s UpdateUserInput) GoString() string {
 	return s.String()
 }
 
+// Validate inspects the fields of the type to determine if they are valid.
+func (s *UpdateUserInput) Validate() error {
+	invalidParams := request.ErrInvalidParams{Context: "UpdateUserInput"}
+	if s.NewPath != nil && len(*s.NewPath) < 1 {
+		invalidParams.Add(request.NewErrParamMinLen("NewPath", 1))
+	}
+	if s.NewUserName != nil && len(*s.NewUserName) < 1 {
+		invalidParams.Add(request.NewErrParamMinLen("NewUserName", 1))
+	}
+	if s.UserName == nil {
+		invalidParams.Add(request.NewErrParamRequired("UserName"))
+	}
+	if s.UserName != nil && len(*s.UserName) < 1 {
+		invalidParams.Add(request.NewErrParamMinLen("UserName", 1))
+	}
+
+	if invalidParams.Len() > 0 {
+		return invalidParams
+	}
+	return nil
+}
+
 type UpdateUserOutput struct {
 	_ struct{} `type:"structure"`
 }
@@ -10868,6 +13006,28 @@ func (s UploadSSHPublicKeyInput) String() string {
 // GoString returns the string representation
 func (s UploadSSHPublicKeyInput) GoString() string {
 	return s.String()
+}
+
+// Validate inspects the fields of the type to determine if they are valid.
+func (s *UploadSSHPublicKeyInput) Validate() error {
+	invalidParams := request.ErrInvalidParams{Context: "UploadSSHPublicKeyInput"}
+	if s.SSHPublicKeyBody == nil {
+		invalidParams.Add(request.NewErrParamRequired("SSHPublicKeyBody"))
+	}
+	if s.SSHPublicKeyBody != nil && len(*s.SSHPublicKeyBody) < 1 {
+		invalidParams.Add(request.NewErrParamMinLen("SSHPublicKeyBody", 1))
+	}
+	if s.UserName == nil {
+		invalidParams.Add(request.NewErrParamRequired("UserName"))
+	}
+	if s.UserName != nil && len(*s.UserName) < 1 {
+		invalidParams.Add(request.NewErrParamMinLen("UserName", 1))
+	}
+
+	if invalidParams.Len() > 0 {
+		return invalidParams
+	}
+	return nil
 }
 
 // Contains the response to a successful UploadSSHPublicKey request.
@@ -10929,6 +13089,40 @@ func (s UploadServerCertificateInput) GoString() string {
 	return s.String()
 }
 
+// Validate inspects the fields of the type to determine if they are valid.
+func (s *UploadServerCertificateInput) Validate() error {
+	invalidParams := request.ErrInvalidParams{Context: "UploadServerCertificateInput"}
+	if s.CertificateBody == nil {
+		invalidParams.Add(request.NewErrParamRequired("CertificateBody"))
+	}
+	if s.CertificateBody != nil && len(*s.CertificateBody) < 1 {
+		invalidParams.Add(request.NewErrParamMinLen("CertificateBody", 1))
+	}
+	if s.CertificateChain != nil && len(*s.CertificateChain) < 1 {
+		invalidParams.Add(request.NewErrParamMinLen("CertificateChain", 1))
+	}
+	if s.Path != nil && len(*s.Path) < 1 {
+		invalidParams.Add(request.NewErrParamMinLen("Path", 1))
+	}
+	if s.PrivateKey == nil {
+		invalidParams.Add(request.NewErrParamRequired("PrivateKey"))
+	}
+	if s.PrivateKey != nil && len(*s.PrivateKey) < 1 {
+		invalidParams.Add(request.NewErrParamMinLen("PrivateKey", 1))
+	}
+	if s.ServerCertificateName == nil {
+		invalidParams.Add(request.NewErrParamRequired("ServerCertificateName"))
+	}
+	if s.ServerCertificateName != nil && len(*s.ServerCertificateName) < 1 {
+		invalidParams.Add(request.NewErrParamMinLen("ServerCertificateName", 1))
+	}
+
+	if invalidParams.Len() > 0 {
+		return invalidParams
+	}
+	return nil
+}
+
 // Contains the response to a successful UploadServerCertificate request.
 type UploadServerCertificateOutput struct {
 	_ struct{} `type:"structure"`
@@ -10966,6 +13160,25 @@ func (s UploadSigningCertificateInput) String() string {
 // GoString returns the string representation
 func (s UploadSigningCertificateInput) GoString() string {
 	return s.String()
+}
+
+// Validate inspects the fields of the type to determine if they are valid.
+func (s *UploadSigningCertificateInput) Validate() error {
+	invalidParams := request.ErrInvalidParams{Context: "UploadSigningCertificateInput"}
+	if s.CertificateBody == nil {
+		invalidParams.Add(request.NewErrParamRequired("CertificateBody"))
+	}
+	if s.CertificateBody != nil && len(*s.CertificateBody) < 1 {
+		invalidParams.Add(request.NewErrParamMinLen("CertificateBody", 1))
+	}
+	if s.UserName != nil && len(*s.UserName) < 1 {
+		invalidParams.Add(request.NewErrParamMinLen("UserName", 1))
+	}
+
+	if invalidParams.Len() > 0 {
+		return invalidParams
+	}
+	return nil
 }
 
 // Contains the response to a successful UploadSigningCertificate request.

--- a/service/inspector/api.go
+++ b/service/inspector/api.go
@@ -4,6 +4,7 @@
 package inspector
 
 import (
+	"fmt"
 	"time"
 
 	"github.com/aws/aws-sdk-go/aws/awsutil"
@@ -949,6 +950,35 @@ func (s AddAttributesToFindingsInput) GoString() string {
 	return s.String()
 }
 
+// Validate inspects the fields of the type to determine if they are valid.
+func (s *AddAttributesToFindingsInput) Validate() error {
+	invalidParams := request.ErrInvalidParams{Context: "AddAttributesToFindingsInput"}
+	if s.Attributes == nil {
+		invalidParams.Add(request.NewErrParamRequired("Attributes"))
+	}
+	if s.FindingArns == nil {
+		invalidParams.Add(request.NewErrParamRequired("FindingArns"))
+	}
+	if s.FindingArns != nil && len(s.FindingArns) < 1 {
+		invalidParams.Add(request.NewErrParamMinLen("FindingArns", 1))
+	}
+	if s.Attributes != nil {
+		for i, v := range s.Attributes {
+			if v == nil {
+				continue
+			}
+			if err := v.Validate(); err != nil {
+				invalidParams.AddNested(fmt.Sprintf("%s[%v]", "Attributes", i), err.(request.ErrInvalidParams))
+			}
+		}
+	}
+
+	if invalidParams.Len() > 0 {
+		return invalidParams
+	}
+	return nil
+}
+
 type AddAttributesToFindingsOutput struct {
 	_ struct{} `type:"structure"`
 
@@ -1012,6 +1042,22 @@ func (s AgentFilter) String() string {
 // GoString returns the string representation
 func (s AgentFilter) GoString() string {
 	return s.String()
+}
+
+// Validate inspects the fields of the type to determine if they are valid.
+func (s *AgentFilter) Validate() error {
+	invalidParams := request.ErrInvalidParams{Context: "AgentFilter"}
+	if s.AgentHealthCodes == nil {
+		invalidParams.Add(request.NewErrParamRequired("AgentHealthCodes"))
+	}
+	if s.AgentHealths == nil {
+		invalidParams.Add(request.NewErrParamRequired("AgentHealths"))
+	}
+
+	if invalidParams.Len() > 0 {
+		return invalidParams
+	}
+	return nil
 }
 
 // Used as a response element in the PreviewAgents action.
@@ -1189,6 +1235,24 @@ func (s AssessmentRunFilter) GoString() string {
 	return s.String()
 }
 
+// Validate inspects the fields of the type to determine if they are valid.
+func (s *AssessmentRunFilter) Validate() error {
+	invalidParams := request.ErrInvalidParams{Context: "AssessmentRunFilter"}
+	if s.NamePattern != nil && len(*s.NamePattern) < 1 {
+		invalidParams.Add(request.NewErrParamMinLen("NamePattern", 1))
+	}
+	if s.DurationRange != nil {
+		if err := s.DurationRange.Validate(); err != nil {
+			invalidParams.AddNested("DurationRange", err.(request.ErrInvalidParams))
+		}
+	}
+
+	if invalidParams.Len() > 0 {
+		return invalidParams
+	}
+	return nil
+}
+
 // Used as one of the elements of the AssessmentRun data type.
 type AssessmentRunNotification struct {
 	_ struct{} `type:"structure"`
@@ -1294,6 +1358,19 @@ func (s AssessmentTargetFilter) GoString() string {
 	return s.String()
 }
 
+// Validate inspects the fields of the type to determine if they are valid.
+func (s *AssessmentTargetFilter) Validate() error {
+	invalidParams := request.ErrInvalidParams{Context: "AssessmentTargetFilter"}
+	if s.AssessmentTargetNamePattern != nil && len(*s.AssessmentTargetNamePattern) < 1 {
+		invalidParams.Add(request.NewErrParamMinLen("AssessmentTargetNamePattern", 1))
+	}
+
+	if invalidParams.Len() > 0 {
+		return invalidParams
+	}
+	return nil
+}
+
 // Contains information about an Amazon Inspector assessment template. This
 // data type is used as the response element in the DescribeAssessmentTemplates
 // action.
@@ -1365,6 +1442,24 @@ func (s AssessmentTemplateFilter) GoString() string {
 	return s.String()
 }
 
+// Validate inspects the fields of the type to determine if they are valid.
+func (s *AssessmentTemplateFilter) Validate() error {
+	invalidParams := request.ErrInvalidParams{Context: "AssessmentTemplateFilter"}
+	if s.NamePattern != nil && len(*s.NamePattern) < 1 {
+		invalidParams.Add(request.NewErrParamMinLen("NamePattern", 1))
+	}
+	if s.DurationRange != nil {
+		if err := s.DurationRange.Validate(); err != nil {
+			invalidParams.AddNested("DurationRange", err.(request.ErrInvalidParams))
+		}
+	}
+
+	if invalidParams.Len() > 0 {
+		return invalidParams
+	}
+	return nil
+}
+
 // A collection of attributes of the host from which the finding is generated.
 type AssetAttributes struct {
 	_ struct{} `type:"structure"`
@@ -1422,6 +1517,25 @@ func (s Attribute) GoString() string {
 	return s.String()
 }
 
+// Validate inspects the fields of the type to determine if they are valid.
+func (s *Attribute) Validate() error {
+	invalidParams := request.ErrInvalidParams{Context: "Attribute"}
+	if s.Key == nil {
+		invalidParams.Add(request.NewErrParamRequired("Key"))
+	}
+	if s.Key != nil && len(*s.Key) < 1 {
+		invalidParams.Add(request.NewErrParamMinLen("Key", 1))
+	}
+	if s.Value != nil && len(*s.Value) < 1 {
+		invalidParams.Add(request.NewErrParamMinLen("Value", 1))
+	}
+
+	if invalidParams.Len() > 0 {
+		return invalidParams
+	}
+	return nil
+}
+
 type CreateAssessmentTargetInput struct {
 	_ struct{} `type:"structure"`
 
@@ -1442,6 +1556,28 @@ func (s CreateAssessmentTargetInput) String() string {
 // GoString returns the string representation
 func (s CreateAssessmentTargetInput) GoString() string {
 	return s.String()
+}
+
+// Validate inspects the fields of the type to determine if they are valid.
+func (s *CreateAssessmentTargetInput) Validate() error {
+	invalidParams := request.ErrInvalidParams{Context: "CreateAssessmentTargetInput"}
+	if s.AssessmentTargetName == nil {
+		invalidParams.Add(request.NewErrParamRequired("AssessmentTargetName"))
+	}
+	if s.AssessmentTargetName != nil && len(*s.AssessmentTargetName) < 1 {
+		invalidParams.Add(request.NewErrParamMinLen("AssessmentTargetName", 1))
+	}
+	if s.ResourceGroupArn == nil {
+		invalidParams.Add(request.NewErrParamRequired("ResourceGroupArn"))
+	}
+	if s.ResourceGroupArn != nil && len(*s.ResourceGroupArn) < 1 {
+		invalidParams.Add(request.NewErrParamMinLen("ResourceGroupArn", 1))
+	}
+
+	if invalidParams.Len() > 0 {
+		return invalidParams
+	}
+	return nil
 }
 
 type CreateAssessmentTargetOutput struct {
@@ -1497,6 +1633,47 @@ func (s CreateAssessmentTemplateInput) GoString() string {
 	return s.String()
 }
 
+// Validate inspects the fields of the type to determine if they are valid.
+func (s *CreateAssessmentTemplateInput) Validate() error {
+	invalidParams := request.ErrInvalidParams{Context: "CreateAssessmentTemplateInput"}
+	if s.AssessmentTargetArn == nil {
+		invalidParams.Add(request.NewErrParamRequired("AssessmentTargetArn"))
+	}
+	if s.AssessmentTargetArn != nil && len(*s.AssessmentTargetArn) < 1 {
+		invalidParams.Add(request.NewErrParamMinLen("AssessmentTargetArn", 1))
+	}
+	if s.AssessmentTemplateName == nil {
+		invalidParams.Add(request.NewErrParamRequired("AssessmentTemplateName"))
+	}
+	if s.AssessmentTemplateName != nil && len(*s.AssessmentTemplateName) < 1 {
+		invalidParams.Add(request.NewErrParamMinLen("AssessmentTemplateName", 1))
+	}
+	if s.DurationInSeconds == nil {
+		invalidParams.Add(request.NewErrParamRequired("DurationInSeconds"))
+	}
+	if s.DurationInSeconds != nil && *s.DurationInSeconds < 180 {
+		invalidParams.Add(request.NewErrParamMinValue("DurationInSeconds", 180))
+	}
+	if s.RulesPackageArns == nil {
+		invalidParams.Add(request.NewErrParamRequired("RulesPackageArns"))
+	}
+	if s.UserAttributesForFindings != nil {
+		for i, v := range s.UserAttributesForFindings {
+			if v == nil {
+				continue
+			}
+			if err := v.Validate(); err != nil {
+				invalidParams.AddNested(fmt.Sprintf("%s[%v]", "UserAttributesForFindings", i), err.(request.ErrInvalidParams))
+			}
+		}
+	}
+
+	if invalidParams.Len() > 0 {
+		return invalidParams
+	}
+	return nil
+}
+
 type CreateAssessmentTemplateOutput struct {
 	_ struct{} `type:"structure"`
 
@@ -1533,6 +1710,32 @@ func (s CreateResourceGroupInput) GoString() string {
 	return s.String()
 }
 
+// Validate inspects the fields of the type to determine if they are valid.
+func (s *CreateResourceGroupInput) Validate() error {
+	invalidParams := request.ErrInvalidParams{Context: "CreateResourceGroupInput"}
+	if s.ResourceGroupTags == nil {
+		invalidParams.Add(request.NewErrParamRequired("ResourceGroupTags"))
+	}
+	if s.ResourceGroupTags != nil && len(s.ResourceGroupTags) < 1 {
+		invalidParams.Add(request.NewErrParamMinLen("ResourceGroupTags", 1))
+	}
+	if s.ResourceGroupTags != nil {
+		for i, v := range s.ResourceGroupTags {
+			if v == nil {
+				continue
+			}
+			if err := v.Validate(); err != nil {
+				invalidParams.AddNested(fmt.Sprintf("%s[%v]", "ResourceGroupTags", i), err.(request.ErrInvalidParams))
+			}
+		}
+	}
+
+	if invalidParams.Len() > 0 {
+		return invalidParams
+	}
+	return nil
+}
+
 type CreateResourceGroupOutput struct {
 	_ struct{} `type:"structure"`
 
@@ -1567,6 +1770,22 @@ func (s DeleteAssessmentRunInput) GoString() string {
 	return s.String()
 }
 
+// Validate inspects the fields of the type to determine if they are valid.
+func (s *DeleteAssessmentRunInput) Validate() error {
+	invalidParams := request.ErrInvalidParams{Context: "DeleteAssessmentRunInput"}
+	if s.AssessmentRunArn == nil {
+		invalidParams.Add(request.NewErrParamRequired("AssessmentRunArn"))
+	}
+	if s.AssessmentRunArn != nil && len(*s.AssessmentRunArn) < 1 {
+		invalidParams.Add(request.NewErrParamMinLen("AssessmentRunArn", 1))
+	}
+
+	if invalidParams.Len() > 0 {
+		return invalidParams
+	}
+	return nil
+}
+
 type DeleteAssessmentRunOutput struct {
 	_ struct{} `type:"structure"`
 }
@@ -1596,6 +1815,22 @@ func (s DeleteAssessmentTargetInput) String() string {
 // GoString returns the string representation
 func (s DeleteAssessmentTargetInput) GoString() string {
 	return s.String()
+}
+
+// Validate inspects the fields of the type to determine if they are valid.
+func (s *DeleteAssessmentTargetInput) Validate() error {
+	invalidParams := request.ErrInvalidParams{Context: "DeleteAssessmentTargetInput"}
+	if s.AssessmentTargetArn == nil {
+		invalidParams.Add(request.NewErrParamRequired("AssessmentTargetArn"))
+	}
+	if s.AssessmentTargetArn != nil && len(*s.AssessmentTargetArn) < 1 {
+		invalidParams.Add(request.NewErrParamMinLen("AssessmentTargetArn", 1))
+	}
+
+	if invalidParams.Len() > 0 {
+		return invalidParams
+	}
+	return nil
 }
 
 type DeleteAssessmentTargetOutput struct {
@@ -1629,6 +1864,22 @@ func (s DeleteAssessmentTemplateInput) GoString() string {
 	return s.String()
 }
 
+// Validate inspects the fields of the type to determine if they are valid.
+func (s *DeleteAssessmentTemplateInput) Validate() error {
+	invalidParams := request.ErrInvalidParams{Context: "DeleteAssessmentTemplateInput"}
+	if s.AssessmentTemplateArn == nil {
+		invalidParams.Add(request.NewErrParamRequired("AssessmentTemplateArn"))
+	}
+	if s.AssessmentTemplateArn != nil && len(*s.AssessmentTemplateArn) < 1 {
+		invalidParams.Add(request.NewErrParamMinLen("AssessmentTemplateArn", 1))
+	}
+
+	if invalidParams.Len() > 0 {
+		return invalidParams
+	}
+	return nil
+}
+
 type DeleteAssessmentTemplateOutput struct {
 	_ struct{} `type:"structure"`
 }
@@ -1658,6 +1909,22 @@ func (s DescribeAssessmentRunsInput) String() string {
 // GoString returns the string representation
 func (s DescribeAssessmentRunsInput) GoString() string {
 	return s.String()
+}
+
+// Validate inspects the fields of the type to determine if they are valid.
+func (s *DescribeAssessmentRunsInput) Validate() error {
+	invalidParams := request.ErrInvalidParams{Context: "DescribeAssessmentRunsInput"}
+	if s.AssessmentRunArns == nil {
+		invalidParams.Add(request.NewErrParamRequired("AssessmentRunArns"))
+	}
+	if s.AssessmentRunArns != nil && len(s.AssessmentRunArns) < 1 {
+		invalidParams.Add(request.NewErrParamMinLen("AssessmentRunArns", 1))
+	}
+
+	if invalidParams.Len() > 0 {
+		return invalidParams
+	}
+	return nil
 }
 
 type DescribeAssessmentRunsOutput struct {
@@ -1698,6 +1965,22 @@ func (s DescribeAssessmentTargetsInput) GoString() string {
 	return s.String()
 }
 
+// Validate inspects the fields of the type to determine if they are valid.
+func (s *DescribeAssessmentTargetsInput) Validate() error {
+	invalidParams := request.ErrInvalidParams{Context: "DescribeAssessmentTargetsInput"}
+	if s.AssessmentTargetArns == nil {
+		invalidParams.Add(request.NewErrParamRequired("AssessmentTargetArns"))
+	}
+	if s.AssessmentTargetArns != nil && len(s.AssessmentTargetArns) < 1 {
+		invalidParams.Add(request.NewErrParamMinLen("AssessmentTargetArns", 1))
+	}
+
+	if invalidParams.Len() > 0 {
+		return invalidParams
+	}
+	return nil
+}
+
 type DescribeAssessmentTargetsOutput struct {
 	_ struct{} `type:"structure"`
 
@@ -1734,6 +2017,22 @@ func (s DescribeAssessmentTemplatesInput) String() string {
 // GoString returns the string representation
 func (s DescribeAssessmentTemplatesInput) GoString() string {
 	return s.String()
+}
+
+// Validate inspects the fields of the type to determine if they are valid.
+func (s *DescribeAssessmentTemplatesInput) Validate() error {
+	invalidParams := request.ErrInvalidParams{Context: "DescribeAssessmentTemplatesInput"}
+	if s.AssessmentTemplateArns == nil {
+		invalidParams.Add(request.NewErrParamRequired("AssessmentTemplateArns"))
+	}
+	if s.AssessmentTemplateArns != nil && len(s.AssessmentTemplateArns) < 1 {
+		invalidParams.Add(request.NewErrParamMinLen("AssessmentTemplateArns", 1))
+	}
+
+	if invalidParams.Len() > 0 {
+		return invalidParams
+	}
+	return nil
 }
 
 type DescribeAssessmentTemplatesOutput struct {
@@ -1817,6 +2116,22 @@ func (s DescribeFindingsInput) GoString() string {
 	return s.String()
 }
 
+// Validate inspects the fields of the type to determine if they are valid.
+func (s *DescribeFindingsInput) Validate() error {
+	invalidParams := request.ErrInvalidParams{Context: "DescribeFindingsInput"}
+	if s.FindingArns == nil {
+		invalidParams.Add(request.NewErrParamRequired("FindingArns"))
+	}
+	if s.FindingArns != nil && len(s.FindingArns) < 1 {
+		invalidParams.Add(request.NewErrParamMinLen("FindingArns", 1))
+	}
+
+	if invalidParams.Len() > 0 {
+		return invalidParams
+	}
+	return nil
+}
+
 type DescribeFindingsOutput struct {
 	_ struct{} `type:"structure"`
 
@@ -1853,6 +2168,22 @@ func (s DescribeResourceGroupsInput) String() string {
 // GoString returns the string representation
 func (s DescribeResourceGroupsInput) GoString() string {
 	return s.String()
+}
+
+// Validate inspects the fields of the type to determine if they are valid.
+func (s *DescribeResourceGroupsInput) Validate() error {
+	invalidParams := request.ErrInvalidParams{Context: "DescribeResourceGroupsInput"}
+	if s.ResourceGroupArns == nil {
+		invalidParams.Add(request.NewErrParamRequired("ResourceGroupArns"))
+	}
+	if s.ResourceGroupArns != nil && len(s.ResourceGroupArns) < 1 {
+		invalidParams.Add(request.NewErrParamMinLen("ResourceGroupArns", 1))
+	}
+
+	if invalidParams.Len() > 0 {
+		return invalidParams
+	}
+	return nil
 }
 
 type DescribeResourceGroupsOutput struct {
@@ -1896,6 +2227,22 @@ func (s DescribeRulesPackagesInput) GoString() string {
 	return s.String()
 }
 
+// Validate inspects the fields of the type to determine if they are valid.
+func (s *DescribeRulesPackagesInput) Validate() error {
+	invalidParams := request.ErrInvalidParams{Context: "DescribeRulesPackagesInput"}
+	if s.RulesPackageArns == nil {
+		invalidParams.Add(request.NewErrParamRequired("RulesPackageArns"))
+	}
+	if s.RulesPackageArns != nil && len(s.RulesPackageArns) < 1 {
+		invalidParams.Add(request.NewErrParamMinLen("RulesPackageArns", 1))
+	}
+
+	if invalidParams.Len() > 0 {
+		return invalidParams
+	}
+	return nil
+}
+
 type DescribeRulesPackagesOutput struct {
 	_ struct{} `type:"structure"`
 
@@ -1937,6 +2284,22 @@ func (s DurationRange) String() string {
 // GoString returns the string representation
 func (s DurationRange) GoString() string {
 	return s.String()
+}
+
+// Validate inspects the fields of the type to determine if they are valid.
+func (s *DurationRange) Validate() error {
+	invalidParams := request.ErrInvalidParams{Context: "DurationRange"}
+	if s.MaxSeconds != nil && *s.MaxSeconds < 180 {
+		invalidParams.Add(request.NewErrParamMinValue("MaxSeconds", 180))
+	}
+	if s.MinSeconds != nil && *s.MinSeconds < 180 {
+		invalidParams.Add(request.NewErrParamMinValue("MinSeconds", 180))
+	}
+
+	if invalidParams.Len() > 0 {
+		return invalidParams
+	}
+	return nil
 }
 
 // This data type is used in the Subscription data type.
@@ -2105,6 +2468,36 @@ func (s FindingFilter) GoString() string {
 	return s.String()
 }
 
+// Validate inspects the fields of the type to determine if they are valid.
+func (s *FindingFilter) Validate() error {
+	invalidParams := request.ErrInvalidParams{Context: "FindingFilter"}
+	if s.Attributes != nil {
+		for i, v := range s.Attributes {
+			if v == nil {
+				continue
+			}
+			if err := v.Validate(); err != nil {
+				invalidParams.AddNested(fmt.Sprintf("%s[%v]", "Attributes", i), err.(request.ErrInvalidParams))
+			}
+		}
+	}
+	if s.UserAttributes != nil {
+		for i, v := range s.UserAttributes {
+			if v == nil {
+				continue
+			}
+			if err := v.Validate(); err != nil {
+				invalidParams.AddNested(fmt.Sprintf("%s[%v]", "UserAttributes", i), err.(request.ErrInvalidParams))
+			}
+		}
+	}
+
+	if invalidParams.Len() > 0 {
+		return invalidParams
+	}
+	return nil
+}
+
 type GetTelemetryMetadataInput struct {
 	_ struct{} `type:"structure"`
 
@@ -2121,6 +2514,22 @@ func (s GetTelemetryMetadataInput) String() string {
 // GoString returns the string representation
 func (s GetTelemetryMetadataInput) GoString() string {
 	return s.String()
+}
+
+// Validate inspects the fields of the type to determine if they are valid.
+func (s *GetTelemetryMetadataInput) Validate() error {
+	invalidParams := request.ErrInvalidParams{Context: "GetTelemetryMetadataInput"}
+	if s.AssessmentRunArn == nil {
+		invalidParams.Add(request.NewErrParamRequired("AssessmentRunArn"))
+	}
+	if s.AssessmentRunArn != nil && len(*s.AssessmentRunArn) < 1 {
+		invalidParams.Add(request.NewErrParamMinLen("AssessmentRunArn", 1))
+	}
+
+	if invalidParams.Len() > 0 {
+		return invalidParams
+	}
+	return nil
 }
 
 type GetTelemetryMetadataOutput struct {
@@ -2173,6 +2582,30 @@ func (s ListAssessmentRunAgentsInput) String() string {
 // GoString returns the string representation
 func (s ListAssessmentRunAgentsInput) GoString() string {
 	return s.String()
+}
+
+// Validate inspects the fields of the type to determine if they are valid.
+func (s *ListAssessmentRunAgentsInput) Validate() error {
+	invalidParams := request.ErrInvalidParams{Context: "ListAssessmentRunAgentsInput"}
+	if s.AssessmentRunArn == nil {
+		invalidParams.Add(request.NewErrParamRequired("AssessmentRunArn"))
+	}
+	if s.AssessmentRunArn != nil && len(*s.AssessmentRunArn) < 1 {
+		invalidParams.Add(request.NewErrParamMinLen("AssessmentRunArn", 1))
+	}
+	if s.NextToken != nil && len(*s.NextToken) < 1 {
+		invalidParams.Add(request.NewErrParamMinLen("NextToken", 1))
+	}
+	if s.Filter != nil {
+		if err := s.Filter.Validate(); err != nil {
+			invalidParams.AddNested("Filter", err.(request.ErrInvalidParams))
+		}
+	}
+
+	if invalidParams.Len() > 0 {
+		return invalidParams
+	}
+	return nil
 }
 
 type ListAssessmentRunAgentsOutput struct {
@@ -2234,6 +2667,24 @@ func (s ListAssessmentRunsInput) GoString() string {
 	return s.String()
 }
 
+// Validate inspects the fields of the type to determine if they are valid.
+func (s *ListAssessmentRunsInput) Validate() error {
+	invalidParams := request.ErrInvalidParams{Context: "ListAssessmentRunsInput"}
+	if s.NextToken != nil && len(*s.NextToken) < 1 {
+		invalidParams.Add(request.NewErrParamMinLen("NextToken", 1))
+	}
+	if s.Filter != nil {
+		if err := s.Filter.Validate(); err != nil {
+			invalidParams.AddNested("Filter", err.(request.ErrInvalidParams))
+		}
+	}
+
+	if invalidParams.Len() > 0 {
+		return invalidParams
+	}
+	return nil
+}
+
 type ListAssessmentRunsOutput struct {
 	_ struct{} `type:"structure"`
 
@@ -2288,6 +2739,24 @@ func (s ListAssessmentTargetsInput) String() string {
 // GoString returns the string representation
 func (s ListAssessmentTargetsInput) GoString() string {
 	return s.String()
+}
+
+// Validate inspects the fields of the type to determine if they are valid.
+func (s *ListAssessmentTargetsInput) Validate() error {
+	invalidParams := request.ErrInvalidParams{Context: "ListAssessmentTargetsInput"}
+	if s.NextToken != nil && len(*s.NextToken) < 1 {
+		invalidParams.Add(request.NewErrParamMinLen("NextToken", 1))
+	}
+	if s.Filter != nil {
+		if err := s.Filter.Validate(); err != nil {
+			invalidParams.AddNested("Filter", err.(request.ErrInvalidParams))
+		}
+	}
+
+	if invalidParams.Len() > 0 {
+		return invalidParams
+	}
+	return nil
 }
 
 type ListAssessmentTargetsOutput struct {
@@ -2350,6 +2819,24 @@ func (s ListAssessmentTemplatesInput) GoString() string {
 	return s.String()
 }
 
+// Validate inspects the fields of the type to determine if they are valid.
+func (s *ListAssessmentTemplatesInput) Validate() error {
+	invalidParams := request.ErrInvalidParams{Context: "ListAssessmentTemplatesInput"}
+	if s.NextToken != nil && len(*s.NextToken) < 1 {
+		invalidParams.Add(request.NewErrParamMinLen("NextToken", 1))
+	}
+	if s.Filter != nil {
+		if err := s.Filter.Validate(); err != nil {
+			invalidParams.AddNested("Filter", err.(request.ErrInvalidParams))
+		}
+	}
+
+	if invalidParams.Len() > 0 {
+		return invalidParams
+	}
+	return nil
+}
+
 type ListAssessmentTemplatesOutput struct {
 	_ struct{} `type:"structure"`
 
@@ -2399,6 +2886,22 @@ func (s ListEventSubscriptionsInput) String() string {
 // GoString returns the string representation
 func (s ListEventSubscriptionsInput) GoString() string {
 	return s.String()
+}
+
+// Validate inspects the fields of the type to determine if they are valid.
+func (s *ListEventSubscriptionsInput) Validate() error {
+	invalidParams := request.ErrInvalidParams{Context: "ListEventSubscriptionsInput"}
+	if s.NextToken != nil && len(*s.NextToken) < 1 {
+		invalidParams.Add(request.NewErrParamMinLen("NextToken", 1))
+	}
+	if s.ResourceArn != nil && len(*s.ResourceArn) < 1 {
+		invalidParams.Add(request.NewErrParamMinLen("ResourceArn", 1))
+	}
+
+	if invalidParams.Len() > 0 {
+		return invalidParams
+	}
+	return nil
 }
 
 type ListEventSubscriptionsOutput struct {
@@ -2460,6 +2963,24 @@ func (s ListFindingsInput) GoString() string {
 	return s.String()
 }
 
+// Validate inspects the fields of the type to determine if they are valid.
+func (s *ListFindingsInput) Validate() error {
+	invalidParams := request.ErrInvalidParams{Context: "ListFindingsInput"}
+	if s.NextToken != nil && len(*s.NextToken) < 1 {
+		invalidParams.Add(request.NewErrParamMinLen("NextToken", 1))
+	}
+	if s.Filter != nil {
+		if err := s.Filter.Validate(); err != nil {
+			invalidParams.AddNested("Filter", err.(request.ErrInvalidParams))
+		}
+	}
+
+	if invalidParams.Len() > 0 {
+		return invalidParams
+	}
+	return nil
+}
+
 type ListFindingsOutput struct {
 	_ struct{} `type:"structure"`
 
@@ -2507,6 +3028,19 @@ func (s ListRulesPackagesInput) GoString() string {
 	return s.String()
 }
 
+// Validate inspects the fields of the type to determine if they are valid.
+func (s *ListRulesPackagesInput) Validate() error {
+	invalidParams := request.ErrInvalidParams{Context: "ListRulesPackagesInput"}
+	if s.NextToken != nil && len(*s.NextToken) < 1 {
+		invalidParams.Add(request.NewErrParamMinLen("NextToken", 1))
+	}
+
+	if invalidParams.Len() > 0 {
+		return invalidParams
+	}
+	return nil
+}
+
 type ListRulesPackagesOutput struct {
 	_ struct{} `type:"structure"`
 
@@ -2545,6 +3079,22 @@ func (s ListTagsForResourceInput) String() string {
 // GoString returns the string representation
 func (s ListTagsForResourceInput) GoString() string {
 	return s.String()
+}
+
+// Validate inspects the fields of the type to determine if they are valid.
+func (s *ListTagsForResourceInput) Validate() error {
+	invalidParams := request.ErrInvalidParams{Context: "ListTagsForResourceInput"}
+	if s.ResourceArn == nil {
+		invalidParams.Add(request.NewErrParamRequired("ResourceArn"))
+	}
+	if s.ResourceArn != nil && len(*s.ResourceArn) < 1 {
+		invalidParams.Add(request.NewErrParamMinLen("ResourceArn", 1))
+	}
+
+	if invalidParams.Len() > 0 {
+		return invalidParams
+	}
+	return nil
 }
 
 type ListTagsForResourceOutput struct {
@@ -2591,6 +3141,25 @@ func (s PreviewAgentsInput) GoString() string {
 	return s.String()
 }
 
+// Validate inspects the fields of the type to determine if they are valid.
+func (s *PreviewAgentsInput) Validate() error {
+	invalidParams := request.ErrInvalidParams{Context: "PreviewAgentsInput"}
+	if s.NextToken != nil && len(*s.NextToken) < 1 {
+		invalidParams.Add(request.NewErrParamMinLen("NextToken", 1))
+	}
+	if s.PreviewAgentsArn == nil {
+		invalidParams.Add(request.NewErrParamRequired("PreviewAgentsArn"))
+	}
+	if s.PreviewAgentsArn != nil && len(*s.PreviewAgentsArn) < 1 {
+		invalidParams.Add(request.NewErrParamMinLen("PreviewAgentsArn", 1))
+	}
+
+	if invalidParams.Len() > 0 {
+		return invalidParams
+	}
+	return nil
+}
+
 type PreviewAgentsOutput struct {
 	_ struct{} `type:"structure"`
 
@@ -2632,6 +3201,22 @@ func (s RegisterCrossAccountAccessRoleInput) GoString() string {
 	return s.String()
 }
 
+// Validate inspects the fields of the type to determine if they are valid.
+func (s *RegisterCrossAccountAccessRoleInput) Validate() error {
+	invalidParams := request.ErrInvalidParams{Context: "RegisterCrossAccountAccessRoleInput"}
+	if s.RoleArn == nil {
+		invalidParams.Add(request.NewErrParamRequired("RoleArn"))
+	}
+	if s.RoleArn != nil && len(*s.RoleArn) < 1 {
+		invalidParams.Add(request.NewErrParamMinLen("RoleArn", 1))
+	}
+
+	if invalidParams.Len() > 0 {
+		return invalidParams
+	}
+	return nil
+}
+
 type RegisterCrossAccountAccessRoleOutput struct {
 	_ struct{} `type:"structure"`
 }
@@ -2664,6 +3249,25 @@ func (s RemoveAttributesFromFindingsInput) String() string {
 // GoString returns the string representation
 func (s RemoveAttributesFromFindingsInput) GoString() string {
 	return s.String()
+}
+
+// Validate inspects the fields of the type to determine if they are valid.
+func (s *RemoveAttributesFromFindingsInput) Validate() error {
+	invalidParams := request.ErrInvalidParams{Context: "RemoveAttributesFromFindingsInput"}
+	if s.AttributeKeys == nil {
+		invalidParams.Add(request.NewErrParamRequired("AttributeKeys"))
+	}
+	if s.FindingArns == nil {
+		invalidParams.Add(request.NewErrParamRequired("FindingArns"))
+	}
+	if s.FindingArns != nil && len(s.FindingArns) < 1 {
+		invalidParams.Add(request.NewErrParamMinLen("FindingArns", 1))
+	}
+
+	if invalidParams.Len() > 0 {
+		return invalidParams
+	}
+	return nil
 }
 
 type RemoveAttributesFromFindingsOutput struct {
@@ -2731,6 +3335,25 @@ func (s ResourceGroupTag) String() string {
 // GoString returns the string representation
 func (s ResourceGroupTag) GoString() string {
 	return s.String()
+}
+
+// Validate inspects the fields of the type to determine if they are valid.
+func (s *ResourceGroupTag) Validate() error {
+	invalidParams := request.ErrInvalidParams{Context: "ResourceGroupTag"}
+	if s.Key == nil {
+		invalidParams.Add(request.NewErrParamRequired("Key"))
+	}
+	if s.Key != nil && len(*s.Key) < 1 {
+		invalidParams.Add(request.NewErrParamMinLen("Key", 1))
+	}
+	if s.Value != nil && len(*s.Value) < 1 {
+		invalidParams.Add(request.NewErrParamMinLen("Value", 1))
+	}
+
+	if invalidParams.Len() > 0 {
+		return invalidParams
+	}
+	return nil
 }
 
 // Contains information about an Amazon Inspector rules package. This data type
@@ -2809,6 +3432,32 @@ func (s SetTagsForResourceInput) GoString() string {
 	return s.String()
 }
 
+// Validate inspects the fields of the type to determine if they are valid.
+func (s *SetTagsForResourceInput) Validate() error {
+	invalidParams := request.ErrInvalidParams{Context: "SetTagsForResourceInput"}
+	if s.ResourceArn == nil {
+		invalidParams.Add(request.NewErrParamRequired("ResourceArn"))
+	}
+	if s.ResourceArn != nil && len(*s.ResourceArn) < 1 {
+		invalidParams.Add(request.NewErrParamMinLen("ResourceArn", 1))
+	}
+	if s.Tags != nil {
+		for i, v := range s.Tags {
+			if v == nil {
+				continue
+			}
+			if err := v.Validate(); err != nil {
+				invalidParams.AddNested(fmt.Sprintf("%s[%v]", "Tags", i), err.(request.ErrInvalidParams))
+			}
+		}
+	}
+
+	if invalidParams.Len() > 0 {
+		return invalidParams
+	}
+	return nil
+}
+
 type SetTagsForResourceOutput struct {
 	_ struct{} `type:"structure"`
 }
@@ -2846,6 +3495,25 @@ func (s StartAssessmentRunInput) GoString() string {
 	return s.String()
 }
 
+// Validate inspects the fields of the type to determine if they are valid.
+func (s *StartAssessmentRunInput) Validate() error {
+	invalidParams := request.ErrInvalidParams{Context: "StartAssessmentRunInput"}
+	if s.AssessmentRunName != nil && len(*s.AssessmentRunName) < 1 {
+		invalidParams.Add(request.NewErrParamMinLen("AssessmentRunName", 1))
+	}
+	if s.AssessmentTemplateArn == nil {
+		invalidParams.Add(request.NewErrParamRequired("AssessmentTemplateArn"))
+	}
+	if s.AssessmentTemplateArn != nil && len(*s.AssessmentTemplateArn) < 1 {
+		invalidParams.Add(request.NewErrParamMinLen("AssessmentTemplateArn", 1))
+	}
+
+	if invalidParams.Len() > 0 {
+		return invalidParams
+	}
+	return nil
+}
+
 type StartAssessmentRunOutput struct {
 	_ struct{} `type:"structure"`
 
@@ -2878,6 +3546,22 @@ func (s StopAssessmentRunInput) String() string {
 // GoString returns the string representation
 func (s StopAssessmentRunInput) GoString() string {
 	return s.String()
+}
+
+// Validate inspects the fields of the type to determine if they are valid.
+func (s *StopAssessmentRunInput) Validate() error {
+	invalidParams := request.ErrInvalidParams{Context: "StopAssessmentRunInput"}
+	if s.AssessmentRunArn == nil {
+		invalidParams.Add(request.NewErrParamRequired("AssessmentRunArn"))
+	}
+	if s.AssessmentRunArn != nil && len(*s.AssessmentRunArn) < 1 {
+		invalidParams.Add(request.NewErrParamMinLen("AssessmentRunArn", 1))
+	}
+
+	if invalidParams.Len() > 0 {
+		return invalidParams
+	}
+	return nil
 }
 
 type StopAssessmentRunOutput struct {
@@ -2916,6 +3600,31 @@ func (s SubscribeToEventInput) String() string {
 // GoString returns the string representation
 func (s SubscribeToEventInput) GoString() string {
 	return s.String()
+}
+
+// Validate inspects the fields of the type to determine if they are valid.
+func (s *SubscribeToEventInput) Validate() error {
+	invalidParams := request.ErrInvalidParams{Context: "SubscribeToEventInput"}
+	if s.Event == nil {
+		invalidParams.Add(request.NewErrParamRequired("Event"))
+	}
+	if s.ResourceArn == nil {
+		invalidParams.Add(request.NewErrParamRequired("ResourceArn"))
+	}
+	if s.ResourceArn != nil && len(*s.ResourceArn) < 1 {
+		invalidParams.Add(request.NewErrParamMinLen("ResourceArn", 1))
+	}
+	if s.TopicArn == nil {
+		invalidParams.Add(request.NewErrParamRequired("TopicArn"))
+	}
+	if s.TopicArn != nil && len(*s.TopicArn) < 1 {
+		invalidParams.Add(request.NewErrParamMinLen("TopicArn", 1))
+	}
+
+	if invalidParams.Len() > 0 {
+		return invalidParams
+	}
+	return nil
 }
 
 type SubscribeToEventOutput struct {
@@ -2980,6 +3689,25 @@ func (s Tag) String() string {
 // GoString returns the string representation
 func (s Tag) GoString() string {
 	return s.String()
+}
+
+// Validate inspects the fields of the type to determine if they are valid.
+func (s *Tag) Validate() error {
+	invalidParams := request.ErrInvalidParams{Context: "Tag"}
+	if s.Key == nil {
+		invalidParams.Add(request.NewErrParamRequired("Key"))
+	}
+	if s.Key != nil && len(*s.Key) < 1 {
+		invalidParams.Add(request.NewErrParamMinLen("Key", 1))
+	}
+	if s.Value != nil && len(*s.Value) < 1 {
+		invalidParams.Add(request.NewErrParamMinLen("Value", 1))
+	}
+
+	if invalidParams.Len() > 0 {
+		return invalidParams
+	}
+	return nil
 }
 
 // The metadata about the Amazon Inspector application data metrics collected
@@ -3053,6 +3781,31 @@ func (s UnsubscribeFromEventInput) GoString() string {
 	return s.String()
 }
 
+// Validate inspects the fields of the type to determine if they are valid.
+func (s *UnsubscribeFromEventInput) Validate() error {
+	invalidParams := request.ErrInvalidParams{Context: "UnsubscribeFromEventInput"}
+	if s.Event == nil {
+		invalidParams.Add(request.NewErrParamRequired("Event"))
+	}
+	if s.ResourceArn == nil {
+		invalidParams.Add(request.NewErrParamRequired("ResourceArn"))
+	}
+	if s.ResourceArn != nil && len(*s.ResourceArn) < 1 {
+		invalidParams.Add(request.NewErrParamMinLen("ResourceArn", 1))
+	}
+	if s.TopicArn == nil {
+		invalidParams.Add(request.NewErrParamRequired("TopicArn"))
+	}
+	if s.TopicArn != nil && len(*s.TopicArn) < 1 {
+		invalidParams.Add(request.NewErrParamMinLen("TopicArn", 1))
+	}
+
+	if invalidParams.Len() > 0 {
+		return invalidParams
+	}
+	return nil
+}
+
 type UnsubscribeFromEventOutput struct {
 	_ struct{} `type:"structure"`
 }
@@ -3089,6 +3842,34 @@ func (s UpdateAssessmentTargetInput) String() string {
 // GoString returns the string representation
 func (s UpdateAssessmentTargetInput) GoString() string {
 	return s.String()
+}
+
+// Validate inspects the fields of the type to determine if they are valid.
+func (s *UpdateAssessmentTargetInput) Validate() error {
+	invalidParams := request.ErrInvalidParams{Context: "UpdateAssessmentTargetInput"}
+	if s.AssessmentTargetArn == nil {
+		invalidParams.Add(request.NewErrParamRequired("AssessmentTargetArn"))
+	}
+	if s.AssessmentTargetArn != nil && len(*s.AssessmentTargetArn) < 1 {
+		invalidParams.Add(request.NewErrParamMinLen("AssessmentTargetArn", 1))
+	}
+	if s.AssessmentTargetName == nil {
+		invalidParams.Add(request.NewErrParamRequired("AssessmentTargetName"))
+	}
+	if s.AssessmentTargetName != nil && len(*s.AssessmentTargetName) < 1 {
+		invalidParams.Add(request.NewErrParamMinLen("AssessmentTargetName", 1))
+	}
+	if s.ResourceGroupArn == nil {
+		invalidParams.Add(request.NewErrParamRequired("ResourceGroupArn"))
+	}
+	if s.ResourceGroupArn != nil && len(*s.ResourceGroupArn) < 1 {
+		invalidParams.Add(request.NewErrParamMinLen("ResourceGroupArn", 1))
+	}
+
+	if invalidParams.Len() > 0 {
+		return invalidParams
+	}
+	return nil
 }
 
 type UpdateAssessmentTargetOutput struct {

--- a/service/iot/api.go
+++ b/service/iot/api.go
@@ -4,6 +4,7 @@
 package iot
 
 import (
+	"fmt"
 	"time"
 
 	"github.com/aws/aws-sdk-go/aws/awsutil"
@@ -1553,6 +1554,22 @@ func (s AcceptCertificateTransferInput) GoString() string {
 	return s.String()
 }
 
+// Validate inspects the fields of the type to determine if they are valid.
+func (s *AcceptCertificateTransferInput) Validate() error {
+	invalidParams := request.ErrInvalidParams{Context: "AcceptCertificateTransferInput"}
+	if s.CertificateId == nil {
+		invalidParams.Add(request.NewErrParamRequired("CertificateId"))
+	}
+	if s.CertificateId != nil && len(*s.CertificateId) < 64 {
+		invalidParams.Add(request.NewErrParamMinLen("CertificateId", 64))
+	}
+
+	if invalidParams.Len() > 0 {
+		return invalidParams
+	}
+	return nil
+}
+
 type AcceptCertificateTransferOutput struct {
 	_ struct{} `type:"structure"`
 }
@@ -1615,6 +1632,71 @@ func (s Action) GoString() string {
 	return s.String()
 }
 
+// Validate inspects the fields of the type to determine if they are valid.
+func (s *Action) Validate() error {
+	invalidParams := request.ErrInvalidParams{Context: "Action"}
+	if s.CloudwatchAlarm != nil {
+		if err := s.CloudwatchAlarm.Validate(); err != nil {
+			invalidParams.AddNested("CloudwatchAlarm", err.(request.ErrInvalidParams))
+		}
+	}
+	if s.CloudwatchMetric != nil {
+		if err := s.CloudwatchMetric.Validate(); err != nil {
+			invalidParams.AddNested("CloudwatchMetric", err.(request.ErrInvalidParams))
+		}
+	}
+	if s.DynamoDB != nil {
+		if err := s.DynamoDB.Validate(); err != nil {
+			invalidParams.AddNested("DynamoDB", err.(request.ErrInvalidParams))
+		}
+	}
+	if s.Elasticsearch != nil {
+		if err := s.Elasticsearch.Validate(); err != nil {
+			invalidParams.AddNested("Elasticsearch", err.(request.ErrInvalidParams))
+		}
+	}
+	if s.Firehose != nil {
+		if err := s.Firehose.Validate(); err != nil {
+			invalidParams.AddNested("Firehose", err.(request.ErrInvalidParams))
+		}
+	}
+	if s.Kinesis != nil {
+		if err := s.Kinesis.Validate(); err != nil {
+			invalidParams.AddNested("Kinesis", err.(request.ErrInvalidParams))
+		}
+	}
+	if s.Lambda != nil {
+		if err := s.Lambda.Validate(); err != nil {
+			invalidParams.AddNested("Lambda", err.(request.ErrInvalidParams))
+		}
+	}
+	if s.Republish != nil {
+		if err := s.Republish.Validate(); err != nil {
+			invalidParams.AddNested("Republish", err.(request.ErrInvalidParams))
+		}
+	}
+	if s.S3 != nil {
+		if err := s.S3.Validate(); err != nil {
+			invalidParams.AddNested("S3", err.(request.ErrInvalidParams))
+		}
+	}
+	if s.Sns != nil {
+		if err := s.Sns.Validate(); err != nil {
+			invalidParams.AddNested("Sns", err.(request.ErrInvalidParams))
+		}
+	}
+	if s.Sqs != nil {
+		if err := s.Sqs.Validate(); err != nil {
+			invalidParams.AddNested("Sqs", err.(request.ErrInvalidParams))
+		}
+	}
+
+	if invalidParams.Len() > 0 {
+		return invalidParams
+	}
+	return nil
+}
+
 // The input for the AttachPrincipalPolicy operation.
 type AttachPrincipalPolicyInput struct {
 	_ struct{} `type:"structure"`
@@ -1635,6 +1717,25 @@ func (s AttachPrincipalPolicyInput) String() string {
 // GoString returns the string representation
 func (s AttachPrincipalPolicyInput) GoString() string {
 	return s.String()
+}
+
+// Validate inspects the fields of the type to determine if they are valid.
+func (s *AttachPrincipalPolicyInput) Validate() error {
+	invalidParams := request.ErrInvalidParams{Context: "AttachPrincipalPolicyInput"}
+	if s.PolicyName == nil {
+		invalidParams.Add(request.NewErrParamRequired("PolicyName"))
+	}
+	if s.PolicyName != nil && len(*s.PolicyName) < 1 {
+		invalidParams.Add(request.NewErrParamMinLen("PolicyName", 1))
+	}
+	if s.Principal == nil {
+		invalidParams.Add(request.NewErrParamRequired("Principal"))
+	}
+
+	if invalidParams.Len() > 0 {
+		return invalidParams
+	}
+	return nil
 }
 
 type AttachPrincipalPolicyOutput struct {
@@ -1670,6 +1771,25 @@ func (s AttachThingPrincipalInput) String() string {
 // GoString returns the string representation
 func (s AttachThingPrincipalInput) GoString() string {
 	return s.String()
+}
+
+// Validate inspects the fields of the type to determine if they are valid.
+func (s *AttachThingPrincipalInput) Validate() error {
+	invalidParams := request.ErrInvalidParams{Context: "AttachThingPrincipalInput"}
+	if s.Principal == nil {
+		invalidParams.Add(request.NewErrParamRequired("Principal"))
+	}
+	if s.ThingName == nil {
+		invalidParams.Add(request.NewErrParamRequired("ThingName"))
+	}
+	if s.ThingName != nil && len(*s.ThingName) < 1 {
+		invalidParams.Add(request.NewErrParamMinLen("ThingName", 1))
+	}
+
+	if invalidParams.Len() > 0 {
+		return invalidParams
+	}
+	return nil
 }
 
 // The output from the AttachThingPrincipal operation.
@@ -1785,6 +1905,22 @@ func (s CancelCertificateTransferInput) GoString() string {
 	return s.String()
 }
 
+// Validate inspects the fields of the type to determine if they are valid.
+func (s *CancelCertificateTransferInput) Validate() error {
+	invalidParams := request.ErrInvalidParams{Context: "CancelCertificateTransferInput"}
+	if s.CertificateId == nil {
+		invalidParams.Add(request.NewErrParamRequired("CertificateId"))
+	}
+	if s.CertificateId != nil && len(*s.CertificateId) < 64 {
+		invalidParams.Add(request.NewErrParamMinLen("CertificateId", 64))
+	}
+
+	if invalidParams.Len() > 0 {
+		return invalidParams
+	}
+	return nil
+}
+
 type CancelCertificateTransferOutput struct {
 	_ struct{} `type:"structure"`
 }
@@ -1898,6 +2034,28 @@ func (s CloudwatchAlarmAction) GoString() string {
 	return s.String()
 }
 
+// Validate inspects the fields of the type to determine if they are valid.
+func (s *CloudwatchAlarmAction) Validate() error {
+	invalidParams := request.ErrInvalidParams{Context: "CloudwatchAlarmAction"}
+	if s.AlarmName == nil {
+		invalidParams.Add(request.NewErrParamRequired("AlarmName"))
+	}
+	if s.RoleArn == nil {
+		invalidParams.Add(request.NewErrParamRequired("RoleArn"))
+	}
+	if s.StateReason == nil {
+		invalidParams.Add(request.NewErrParamRequired("StateReason"))
+	}
+	if s.StateValue == nil {
+		invalidParams.Add(request.NewErrParamRequired("StateValue"))
+	}
+
+	if invalidParams.Len() > 0 {
+		return invalidParams
+	}
+	return nil
+}
+
 // Describes an action that captures a CloudWatch metric.
 type CloudwatchMetricAction struct {
 	_ struct{} `type:"structure"`
@@ -1932,6 +2090,31 @@ func (s CloudwatchMetricAction) GoString() string {
 	return s.String()
 }
 
+// Validate inspects the fields of the type to determine if they are valid.
+func (s *CloudwatchMetricAction) Validate() error {
+	invalidParams := request.ErrInvalidParams{Context: "CloudwatchMetricAction"}
+	if s.MetricName == nil {
+		invalidParams.Add(request.NewErrParamRequired("MetricName"))
+	}
+	if s.MetricNamespace == nil {
+		invalidParams.Add(request.NewErrParamRequired("MetricNamespace"))
+	}
+	if s.MetricUnit == nil {
+		invalidParams.Add(request.NewErrParamRequired("MetricUnit"))
+	}
+	if s.MetricValue == nil {
+		invalidParams.Add(request.NewErrParamRequired("MetricValue"))
+	}
+	if s.RoleArn == nil {
+		invalidParams.Add(request.NewErrParamRequired("RoleArn"))
+	}
+
+	if invalidParams.Len() > 0 {
+		return invalidParams
+	}
+	return nil
+}
+
 // The input for the CreateCertificateFromCsr operation.
 type CreateCertificateFromCsrInput struct {
 	_ struct{} `type:"structure"`
@@ -1951,6 +2134,22 @@ func (s CreateCertificateFromCsrInput) String() string {
 // GoString returns the string representation
 func (s CreateCertificateFromCsrInput) GoString() string {
 	return s.String()
+}
+
+// Validate inspects the fields of the type to determine if they are valid.
+func (s *CreateCertificateFromCsrInput) Validate() error {
+	invalidParams := request.ErrInvalidParams{Context: "CreateCertificateFromCsrInput"}
+	if s.CertificateSigningRequest == nil {
+		invalidParams.Add(request.NewErrParamRequired("CertificateSigningRequest"))
+	}
+	if s.CertificateSigningRequest != nil && len(*s.CertificateSigningRequest) < 1 {
+		invalidParams.Add(request.NewErrParamMinLen("CertificateSigningRequest", 1))
+	}
+
+	if invalidParams.Len() > 0 {
+		return invalidParams
+	}
+	return nil
 }
 
 // The output from the CreateCertificateFromCsr operation.
@@ -2047,6 +2246,25 @@ func (s CreatePolicyInput) GoString() string {
 	return s.String()
 }
 
+// Validate inspects the fields of the type to determine if they are valid.
+func (s *CreatePolicyInput) Validate() error {
+	invalidParams := request.ErrInvalidParams{Context: "CreatePolicyInput"}
+	if s.PolicyDocument == nil {
+		invalidParams.Add(request.NewErrParamRequired("PolicyDocument"))
+	}
+	if s.PolicyName == nil {
+		invalidParams.Add(request.NewErrParamRequired("PolicyName"))
+	}
+	if s.PolicyName != nil && len(*s.PolicyName) < 1 {
+		invalidParams.Add(request.NewErrParamMinLen("PolicyName", 1))
+	}
+
+	if invalidParams.Len() > 0 {
+		return invalidParams
+	}
+	return nil
+}
+
 // The output from the CreatePolicy operation.
 type CreatePolicyOutput struct {
 	_ struct{} `type:"structure"`
@@ -2101,6 +2319,25 @@ func (s CreatePolicyVersionInput) GoString() string {
 	return s.String()
 }
 
+// Validate inspects the fields of the type to determine if they are valid.
+func (s *CreatePolicyVersionInput) Validate() error {
+	invalidParams := request.ErrInvalidParams{Context: "CreatePolicyVersionInput"}
+	if s.PolicyDocument == nil {
+		invalidParams.Add(request.NewErrParamRequired("PolicyDocument"))
+	}
+	if s.PolicyName == nil {
+		invalidParams.Add(request.NewErrParamRequired("PolicyName"))
+	}
+	if s.PolicyName != nil && len(*s.PolicyName) < 1 {
+		invalidParams.Add(request.NewErrParamMinLen("PolicyName", 1))
+	}
+
+	if invalidParams.Len() > 0 {
+		return invalidParams
+	}
+	return nil
+}
+
 // The output of the CreatePolicyVersion operation.
 type CreatePolicyVersionOutput struct {
 	_ struct{} `type:"structure"`
@@ -2150,6 +2387,22 @@ func (s CreateThingInput) GoString() string {
 	return s.String()
 }
 
+// Validate inspects the fields of the type to determine if they are valid.
+func (s *CreateThingInput) Validate() error {
+	invalidParams := request.ErrInvalidParams{Context: "CreateThingInput"}
+	if s.ThingName == nil {
+		invalidParams.Add(request.NewErrParamRequired("ThingName"))
+	}
+	if s.ThingName != nil && len(*s.ThingName) < 1 {
+		invalidParams.Add(request.NewErrParamMinLen("ThingName", 1))
+	}
+
+	if invalidParams.Len() > 0 {
+		return invalidParams
+	}
+	return nil
+}
+
 // The output of the CreateThing operation.
 type CreateThingOutput struct {
 	_ struct{} `type:"structure"`
@@ -2192,6 +2445,30 @@ func (s CreateTopicRuleInput) GoString() string {
 	return s.String()
 }
 
+// Validate inspects the fields of the type to determine if they are valid.
+func (s *CreateTopicRuleInput) Validate() error {
+	invalidParams := request.ErrInvalidParams{Context: "CreateTopicRuleInput"}
+	if s.RuleName == nil {
+		invalidParams.Add(request.NewErrParamRequired("RuleName"))
+	}
+	if s.RuleName != nil && len(*s.RuleName) < 1 {
+		invalidParams.Add(request.NewErrParamMinLen("RuleName", 1))
+	}
+	if s.TopicRulePayload == nil {
+		invalidParams.Add(request.NewErrParamRequired("TopicRulePayload"))
+	}
+	if s.TopicRulePayload != nil {
+		if err := s.TopicRulePayload.Validate(); err != nil {
+			invalidParams.AddNested("TopicRulePayload", err.(request.ErrInvalidParams))
+		}
+	}
+
+	if invalidParams.Len() > 0 {
+		return invalidParams
+	}
+	return nil
+}
+
 type CreateTopicRuleOutput struct {
 	_ struct{} `type:"structure"`
 }
@@ -2222,6 +2499,22 @@ func (s DeleteCACertificateInput) String() string {
 // GoString returns the string representation
 func (s DeleteCACertificateInput) GoString() string {
 	return s.String()
+}
+
+// Validate inspects the fields of the type to determine if they are valid.
+func (s *DeleteCACertificateInput) Validate() error {
+	invalidParams := request.ErrInvalidParams{Context: "DeleteCACertificateInput"}
+	if s.CertificateId == nil {
+		invalidParams.Add(request.NewErrParamRequired("CertificateId"))
+	}
+	if s.CertificateId != nil && len(*s.CertificateId) < 64 {
+		invalidParams.Add(request.NewErrParamMinLen("CertificateId", 64))
+	}
+
+	if invalidParams.Len() > 0 {
+		return invalidParams
+	}
+	return nil
 }
 
 // The output for the DeleteCACertificate operation.
@@ -2257,6 +2550,22 @@ func (s DeleteCertificateInput) GoString() string {
 	return s.String()
 }
 
+// Validate inspects the fields of the type to determine if they are valid.
+func (s *DeleteCertificateInput) Validate() error {
+	invalidParams := request.ErrInvalidParams{Context: "DeleteCertificateInput"}
+	if s.CertificateId == nil {
+		invalidParams.Add(request.NewErrParamRequired("CertificateId"))
+	}
+	if s.CertificateId != nil && len(*s.CertificateId) < 64 {
+		invalidParams.Add(request.NewErrParamMinLen("CertificateId", 64))
+	}
+
+	if invalidParams.Len() > 0 {
+		return invalidParams
+	}
+	return nil
+}
+
 type DeleteCertificateOutput struct {
 	_ struct{} `type:"structure"`
 }
@@ -2287,6 +2596,22 @@ func (s DeletePolicyInput) String() string {
 // GoString returns the string representation
 func (s DeletePolicyInput) GoString() string {
 	return s.String()
+}
+
+// Validate inspects the fields of the type to determine if they are valid.
+func (s *DeletePolicyInput) Validate() error {
+	invalidParams := request.ErrInvalidParams{Context: "DeletePolicyInput"}
+	if s.PolicyName == nil {
+		invalidParams.Add(request.NewErrParamRequired("PolicyName"))
+	}
+	if s.PolicyName != nil && len(*s.PolicyName) < 1 {
+		invalidParams.Add(request.NewErrParamMinLen("PolicyName", 1))
+	}
+
+	if invalidParams.Len() > 0 {
+		return invalidParams
+	}
+	return nil
 }
 
 type DeletePolicyOutput struct {
@@ -2322,6 +2647,25 @@ func (s DeletePolicyVersionInput) String() string {
 // GoString returns the string representation
 func (s DeletePolicyVersionInput) GoString() string {
 	return s.String()
+}
+
+// Validate inspects the fields of the type to determine if they are valid.
+func (s *DeletePolicyVersionInput) Validate() error {
+	invalidParams := request.ErrInvalidParams{Context: "DeletePolicyVersionInput"}
+	if s.PolicyName == nil {
+		invalidParams.Add(request.NewErrParamRequired("PolicyName"))
+	}
+	if s.PolicyName != nil && len(*s.PolicyName) < 1 {
+		invalidParams.Add(request.NewErrParamMinLen("PolicyName", 1))
+	}
+	if s.PolicyVersionId == nil {
+		invalidParams.Add(request.NewErrParamRequired("PolicyVersionId"))
+	}
+
+	if invalidParams.Len() > 0 {
+		return invalidParams
+	}
+	return nil
 }
 
 type DeletePolicyVersionOutput struct {
@@ -2386,6 +2730,22 @@ func (s DeleteThingInput) GoString() string {
 	return s.String()
 }
 
+// Validate inspects the fields of the type to determine if they are valid.
+func (s *DeleteThingInput) Validate() error {
+	invalidParams := request.ErrInvalidParams{Context: "DeleteThingInput"}
+	if s.ThingName == nil {
+		invalidParams.Add(request.NewErrParamRequired("ThingName"))
+	}
+	if s.ThingName != nil && len(*s.ThingName) < 1 {
+		invalidParams.Add(request.NewErrParamMinLen("ThingName", 1))
+	}
+
+	if invalidParams.Len() > 0 {
+		return invalidParams
+	}
+	return nil
+}
+
 // The output of the DeleteThing operation.
 type DeleteThingOutput struct {
 	_ struct{} `type:"structure"`
@@ -2419,6 +2779,22 @@ func (s DeleteTopicRuleInput) GoString() string {
 	return s.String()
 }
 
+// Validate inspects the fields of the type to determine if they are valid.
+func (s *DeleteTopicRuleInput) Validate() error {
+	invalidParams := request.ErrInvalidParams{Context: "DeleteTopicRuleInput"}
+	if s.RuleName == nil {
+		invalidParams.Add(request.NewErrParamRequired("RuleName"))
+	}
+	if s.RuleName != nil && len(*s.RuleName) < 1 {
+		invalidParams.Add(request.NewErrParamMinLen("RuleName", 1))
+	}
+
+	if invalidParams.Len() > 0 {
+		return invalidParams
+	}
+	return nil
+}
+
 type DeleteTopicRuleOutput struct {
 	_ struct{} `type:"structure"`
 }
@@ -2449,6 +2825,22 @@ func (s DescribeCACertificateInput) String() string {
 // GoString returns the string representation
 func (s DescribeCACertificateInput) GoString() string {
 	return s.String()
+}
+
+// Validate inspects the fields of the type to determine if they are valid.
+func (s *DescribeCACertificateInput) Validate() error {
+	invalidParams := request.ErrInvalidParams{Context: "DescribeCACertificateInput"}
+	if s.CertificateId == nil {
+		invalidParams.Add(request.NewErrParamRequired("CertificateId"))
+	}
+	if s.CertificateId != nil && len(*s.CertificateId) < 64 {
+		invalidParams.Add(request.NewErrParamMinLen("CertificateId", 64))
+	}
+
+	if invalidParams.Len() > 0 {
+		return invalidParams
+	}
+	return nil
 }
 
 // The output from the DescribeCACertificate operation.
@@ -2485,6 +2877,22 @@ func (s DescribeCertificateInput) String() string {
 // GoString returns the string representation
 func (s DescribeCertificateInput) GoString() string {
 	return s.String()
+}
+
+// Validate inspects the fields of the type to determine if they are valid.
+func (s *DescribeCertificateInput) Validate() error {
+	invalidParams := request.ErrInvalidParams{Context: "DescribeCertificateInput"}
+	if s.CertificateId == nil {
+		invalidParams.Add(request.NewErrParamRequired("CertificateId"))
+	}
+	if s.CertificateId != nil && len(*s.CertificateId) < 64 {
+		invalidParams.Add(request.NewErrParamMinLen("CertificateId", 64))
+	}
+
+	if invalidParams.Len() > 0 {
+		return invalidParams
+	}
+	return nil
 }
 
 // The output of the DescribeCertificate operation.
@@ -2556,6 +2964,22 @@ func (s DescribeThingInput) GoString() string {
 	return s.String()
 }
 
+// Validate inspects the fields of the type to determine if they are valid.
+func (s *DescribeThingInput) Validate() error {
+	invalidParams := request.ErrInvalidParams{Context: "DescribeThingInput"}
+	if s.ThingName == nil {
+		invalidParams.Add(request.NewErrParamRequired("ThingName"))
+	}
+	if s.ThingName != nil && len(*s.ThingName) < 1 {
+		invalidParams.Add(request.NewErrParamMinLen("ThingName", 1))
+	}
+
+	if invalidParams.Len() > 0 {
+		return invalidParams
+	}
+	return nil
+}
+
 // The output from the DescribeThing operation.
 type DescribeThingOutput struct {
 	_ struct{} `type:"structure"`
@@ -2605,6 +3029,25 @@ func (s DetachPrincipalPolicyInput) GoString() string {
 	return s.String()
 }
 
+// Validate inspects the fields of the type to determine if they are valid.
+func (s *DetachPrincipalPolicyInput) Validate() error {
+	invalidParams := request.ErrInvalidParams{Context: "DetachPrincipalPolicyInput"}
+	if s.PolicyName == nil {
+		invalidParams.Add(request.NewErrParamRequired("PolicyName"))
+	}
+	if s.PolicyName != nil && len(*s.PolicyName) < 1 {
+		invalidParams.Add(request.NewErrParamMinLen("PolicyName", 1))
+	}
+	if s.Principal == nil {
+		invalidParams.Add(request.NewErrParamRequired("Principal"))
+	}
+
+	if invalidParams.Len() > 0 {
+		return invalidParams
+	}
+	return nil
+}
+
 type DetachPrincipalPolicyOutput struct {
 	_ struct{} `type:"structure"`
 }
@@ -2640,6 +3083,25 @@ func (s DetachThingPrincipalInput) GoString() string {
 	return s.String()
 }
 
+// Validate inspects the fields of the type to determine if they are valid.
+func (s *DetachThingPrincipalInput) Validate() error {
+	invalidParams := request.ErrInvalidParams{Context: "DetachThingPrincipalInput"}
+	if s.Principal == nil {
+		invalidParams.Add(request.NewErrParamRequired("Principal"))
+	}
+	if s.ThingName == nil {
+		invalidParams.Add(request.NewErrParamRequired("ThingName"))
+	}
+	if s.ThingName != nil && len(*s.ThingName) < 1 {
+		invalidParams.Add(request.NewErrParamMinLen("ThingName", 1))
+	}
+
+	if invalidParams.Len() > 0 {
+		return invalidParams
+	}
+	return nil
+}
+
 // The output from the DetachThingPrincipal operation.
 type DetachThingPrincipalOutput struct {
 	_ struct{} `type:"structure"`
@@ -2671,6 +3133,22 @@ func (s DisableTopicRuleInput) String() string {
 // GoString returns the string representation
 func (s DisableTopicRuleInput) GoString() string {
 	return s.String()
+}
+
+// Validate inspects the fields of the type to determine if they are valid.
+func (s *DisableTopicRuleInput) Validate() error {
+	invalidParams := request.ErrInvalidParams{Context: "DisableTopicRuleInput"}
+	if s.RuleName == nil {
+		invalidParams.Add(request.NewErrParamRequired("RuleName"))
+	}
+	if s.RuleName != nil && len(*s.RuleName) < 1 {
+		invalidParams.Add(request.NewErrParamMinLen("RuleName", 1))
+	}
+
+	if invalidParams.Len() > 0 {
+		return invalidParams
+	}
+	return nil
 }
 
 type DisableTopicRuleOutput struct {
@@ -2739,6 +3217,34 @@ func (s DynamoDBAction) GoString() string {
 	return s.String()
 }
 
+// Validate inspects the fields of the type to determine if they are valid.
+func (s *DynamoDBAction) Validate() error {
+	invalidParams := request.ErrInvalidParams{Context: "DynamoDBAction"}
+	if s.HashKeyField == nil {
+		invalidParams.Add(request.NewErrParamRequired("HashKeyField"))
+	}
+	if s.HashKeyValue == nil {
+		invalidParams.Add(request.NewErrParamRequired("HashKeyValue"))
+	}
+	if s.RangeKeyField == nil {
+		invalidParams.Add(request.NewErrParamRequired("RangeKeyField"))
+	}
+	if s.RangeKeyValue == nil {
+		invalidParams.Add(request.NewErrParamRequired("RangeKeyValue"))
+	}
+	if s.RoleArn == nil {
+		invalidParams.Add(request.NewErrParamRequired("RoleArn"))
+	}
+	if s.TableName == nil {
+		invalidParams.Add(request.NewErrParamRequired("TableName"))
+	}
+
+	if invalidParams.Len() > 0 {
+		return invalidParams
+	}
+	return nil
+}
+
 // Describes an action that writes data to an Amazon Elasticsearch Service;
 // domain.
 type ElasticsearchAction struct {
@@ -2770,6 +3276,31 @@ func (s ElasticsearchAction) GoString() string {
 	return s.String()
 }
 
+// Validate inspects the fields of the type to determine if they are valid.
+func (s *ElasticsearchAction) Validate() error {
+	invalidParams := request.ErrInvalidParams{Context: "ElasticsearchAction"}
+	if s.Endpoint == nil {
+		invalidParams.Add(request.NewErrParamRequired("Endpoint"))
+	}
+	if s.Id == nil {
+		invalidParams.Add(request.NewErrParamRequired("Id"))
+	}
+	if s.Index == nil {
+		invalidParams.Add(request.NewErrParamRequired("Index"))
+	}
+	if s.RoleArn == nil {
+		invalidParams.Add(request.NewErrParamRequired("RoleArn"))
+	}
+	if s.Type == nil {
+		invalidParams.Add(request.NewErrParamRequired("Type"))
+	}
+
+	if invalidParams.Len() > 0 {
+		return invalidParams
+	}
+	return nil
+}
+
 // The input for the EnableTopicRuleRequest operation.
 type EnableTopicRuleInput struct {
 	_ struct{} `type:"structure"`
@@ -2786,6 +3317,22 @@ func (s EnableTopicRuleInput) String() string {
 // GoString returns the string representation
 func (s EnableTopicRuleInput) GoString() string {
 	return s.String()
+}
+
+// Validate inspects the fields of the type to determine if they are valid.
+func (s *EnableTopicRuleInput) Validate() error {
+	invalidParams := request.ErrInvalidParams{Context: "EnableTopicRuleInput"}
+	if s.RuleName == nil {
+		invalidParams.Add(request.NewErrParamRequired("RuleName"))
+	}
+	if s.RuleName != nil && len(*s.RuleName) < 1 {
+		invalidParams.Add(request.NewErrParamMinLen("RuleName", 1))
+	}
+
+	if invalidParams.Len() > 0 {
+		return invalidParams
+	}
+	return nil
 }
 
 type EnableTopicRuleOutput struct {
@@ -2821,6 +3368,22 @@ func (s FirehoseAction) String() string {
 // GoString returns the string representation
 func (s FirehoseAction) GoString() string {
 	return s.String()
+}
+
+// Validate inspects the fields of the type to determine if they are valid.
+func (s *FirehoseAction) Validate() error {
+	invalidParams := request.ErrInvalidParams{Context: "FirehoseAction"}
+	if s.DeliveryStreamName == nil {
+		invalidParams.Add(request.NewErrParamRequired("DeliveryStreamName"))
+	}
+	if s.RoleArn == nil {
+		invalidParams.Add(request.NewErrParamRequired("RoleArn"))
+	}
+
+	if invalidParams.Len() > 0 {
+		return invalidParams
+	}
+	return nil
 }
 
 // The input for the GetLoggingOptions operation.
@@ -2877,6 +3440,22 @@ func (s GetPolicyInput) GoString() string {
 	return s.String()
 }
 
+// Validate inspects the fields of the type to determine if they are valid.
+func (s *GetPolicyInput) Validate() error {
+	invalidParams := request.ErrInvalidParams{Context: "GetPolicyInput"}
+	if s.PolicyName == nil {
+		invalidParams.Add(request.NewErrParamRequired("PolicyName"))
+	}
+	if s.PolicyName != nil && len(*s.PolicyName) < 1 {
+		invalidParams.Add(request.NewErrParamMinLen("PolicyName", 1))
+	}
+
+	if invalidParams.Len() > 0 {
+		return invalidParams
+	}
+	return nil
+}
+
 // The output from the GetPolicy operation.
 type GetPolicyOutput struct {
 	_ struct{} `type:"structure"`
@@ -2923,6 +3502,25 @@ func (s GetPolicyVersionInput) String() string {
 // GoString returns the string representation
 func (s GetPolicyVersionInput) GoString() string {
 	return s.String()
+}
+
+// Validate inspects the fields of the type to determine if they are valid.
+func (s *GetPolicyVersionInput) Validate() error {
+	invalidParams := request.ErrInvalidParams{Context: "GetPolicyVersionInput"}
+	if s.PolicyName == nil {
+		invalidParams.Add(request.NewErrParamRequired("PolicyName"))
+	}
+	if s.PolicyName != nil && len(*s.PolicyName) < 1 {
+		invalidParams.Add(request.NewErrParamMinLen("PolicyName", 1))
+	}
+	if s.PolicyVersionId == nil {
+		invalidParams.Add(request.NewErrParamRequired("PolicyVersionId"))
+	}
+
+	if invalidParams.Len() > 0 {
+		return invalidParams
+	}
+	return nil
 }
 
 // The output from the GetPolicyVersion operation.
@@ -3006,6 +3604,22 @@ func (s GetTopicRuleInput) GoString() string {
 	return s.String()
 }
 
+// Validate inspects the fields of the type to determine if they are valid.
+func (s *GetTopicRuleInput) Validate() error {
+	invalidParams := request.ErrInvalidParams{Context: "GetTopicRuleInput"}
+	if s.RuleName == nil {
+		invalidParams.Add(request.NewErrParamRequired("RuleName"))
+	}
+	if s.RuleName != nil && len(*s.RuleName) < 1 {
+		invalidParams.Add(request.NewErrParamMinLen("RuleName", 1))
+	}
+
+	if invalidParams.Len() > 0 {
+		return invalidParams
+	}
+	return nil
+}
+
 // The output from the GetTopicRule operation.
 type GetTopicRuleOutput struct {
 	_ struct{} `type:"structure"`
@@ -3072,6 +3686,22 @@ func (s KinesisAction) GoString() string {
 	return s.String()
 }
 
+// Validate inspects the fields of the type to determine if they are valid.
+func (s *KinesisAction) Validate() error {
+	invalidParams := request.ErrInvalidParams{Context: "KinesisAction"}
+	if s.RoleArn == nil {
+		invalidParams.Add(request.NewErrParamRequired("RoleArn"))
+	}
+	if s.StreamName == nil {
+		invalidParams.Add(request.NewErrParamRequired("StreamName"))
+	}
+
+	if invalidParams.Len() > 0 {
+		return invalidParams
+	}
+	return nil
+}
+
 // Describes an action to invoke a Lambda function.
 type LambdaAction struct {
 	_ struct{} `type:"structure"`
@@ -3088,6 +3718,19 @@ func (s LambdaAction) String() string {
 // GoString returns the string representation
 func (s LambdaAction) GoString() string {
 	return s.String()
+}
+
+// Validate inspects the fields of the type to determine if they are valid.
+func (s *LambdaAction) Validate() error {
+	invalidParams := request.ErrInvalidParams{Context: "LambdaAction"}
+	if s.FunctionArn == nil {
+		invalidParams.Add(request.NewErrParamRequired("FunctionArn"))
+	}
+
+	if invalidParams.Len() > 0 {
+		return invalidParams
+	}
+	return nil
 }
 
 // Input for the ListCACertificates operation.
@@ -3112,6 +3755,19 @@ func (s ListCACertificatesInput) String() string {
 // GoString returns the string representation
 func (s ListCACertificatesInput) GoString() string {
 	return s.String()
+}
+
+// Validate inspects the fields of the type to determine if they are valid.
+func (s *ListCACertificatesInput) Validate() error {
+	invalidParams := request.ErrInvalidParams{Context: "ListCACertificatesInput"}
+	if s.PageSize != nil && *s.PageSize < 1 {
+		invalidParams.Add(request.NewErrParamMinValue("PageSize", 1))
+	}
+
+	if invalidParams.Len() > 0 {
+		return invalidParams
+	}
+	return nil
 }
 
 // The output from the ListCACertificates operation.
@@ -3164,6 +3820,25 @@ func (s ListCertificatesByCAInput) GoString() string {
 	return s.String()
 }
 
+// Validate inspects the fields of the type to determine if they are valid.
+func (s *ListCertificatesByCAInput) Validate() error {
+	invalidParams := request.ErrInvalidParams{Context: "ListCertificatesByCAInput"}
+	if s.CaCertificateId == nil {
+		invalidParams.Add(request.NewErrParamRequired("CaCertificateId"))
+	}
+	if s.CaCertificateId != nil && len(*s.CaCertificateId) < 64 {
+		invalidParams.Add(request.NewErrParamMinLen("CaCertificateId", 64))
+	}
+	if s.PageSize != nil && *s.PageSize < 1 {
+		invalidParams.Add(request.NewErrParamMinValue("PageSize", 1))
+	}
+
+	if invalidParams.Len() > 0 {
+		return invalidParams
+	}
+	return nil
+}
+
 // The output of the ListCertificatesByCA operation.
 type ListCertificatesByCAOutput struct {
 	_ struct{} `type:"structure"`
@@ -3209,6 +3884,19 @@ func (s ListCertificatesInput) String() string {
 // GoString returns the string representation
 func (s ListCertificatesInput) GoString() string {
 	return s.String()
+}
+
+// Validate inspects the fields of the type to determine if they are valid.
+func (s *ListCertificatesInput) Validate() error {
+	invalidParams := request.ErrInvalidParams{Context: "ListCertificatesInput"}
+	if s.PageSize != nil && *s.PageSize < 1 {
+		invalidParams.Add(request.NewErrParamMinValue("PageSize", 1))
+	}
+
+	if invalidParams.Len() > 0 {
+		return invalidParams
+	}
+	return nil
 }
 
 // The output of the ListCertificates operation.
@@ -3258,6 +3946,19 @@ func (s ListPoliciesInput) GoString() string {
 	return s.String()
 }
 
+// Validate inspects the fields of the type to determine if they are valid.
+func (s *ListPoliciesInput) Validate() error {
+	invalidParams := request.ErrInvalidParams{Context: "ListPoliciesInput"}
+	if s.PageSize != nil && *s.PageSize < 1 {
+		invalidParams.Add(request.NewErrParamMinValue("PageSize", 1))
+	}
+
+	if invalidParams.Len() > 0 {
+		return invalidParams
+	}
+	return nil
+}
+
 // The output from the ListPolicies operation.
 type ListPoliciesOutput struct {
 	_ struct{} `type:"structure"`
@@ -3296,6 +3997,22 @@ func (s ListPolicyVersionsInput) String() string {
 // GoString returns the string representation
 func (s ListPolicyVersionsInput) GoString() string {
 	return s.String()
+}
+
+// Validate inspects the fields of the type to determine if they are valid.
+func (s *ListPolicyVersionsInput) Validate() error {
+	invalidParams := request.ErrInvalidParams{Context: "ListPolicyVersionsInput"}
+	if s.PolicyName == nil {
+		invalidParams.Add(request.NewErrParamRequired("PolicyName"))
+	}
+	if s.PolicyName != nil && len(*s.PolicyName) < 1 {
+		invalidParams.Add(request.NewErrParamMinLen("PolicyName", 1))
+	}
+
+	if invalidParams.Len() > 0 {
+		return invalidParams
+	}
+	return nil
 }
 
 // The output from the ListPolicyVersions operation.
@@ -3344,6 +4061,22 @@ func (s ListPrincipalPoliciesInput) GoString() string {
 	return s.String()
 }
 
+// Validate inspects the fields of the type to determine if they are valid.
+func (s *ListPrincipalPoliciesInput) Validate() error {
+	invalidParams := request.ErrInvalidParams{Context: "ListPrincipalPoliciesInput"}
+	if s.PageSize != nil && *s.PageSize < 1 {
+		invalidParams.Add(request.NewErrParamMinValue("PageSize", 1))
+	}
+	if s.Principal == nil {
+		invalidParams.Add(request.NewErrParamRequired("Principal"))
+	}
+
+	if invalidParams.Len() > 0 {
+		return invalidParams
+	}
+	return nil
+}
+
 // The output from the ListPrincipalPolicies operation.
 type ListPrincipalPoliciesOutput struct {
 	_ struct{} `type:"structure"`
@@ -3390,6 +4123,22 @@ func (s ListPrincipalThingsInput) GoString() string {
 	return s.String()
 }
 
+// Validate inspects the fields of the type to determine if they are valid.
+func (s *ListPrincipalThingsInput) Validate() error {
+	invalidParams := request.ErrInvalidParams{Context: "ListPrincipalThingsInput"}
+	if s.MaxResults != nil && *s.MaxResults < 1 {
+		invalidParams.Add(request.NewErrParamMinValue("MaxResults", 1))
+	}
+	if s.Principal == nil {
+		invalidParams.Add(request.NewErrParamRequired("Principal"))
+	}
+
+	if invalidParams.Len() > 0 {
+		return invalidParams
+	}
+	return nil
+}
+
 // The output from the ListPrincipalThings operation.
 type ListPrincipalThingsOutput struct {
 	_ struct{} `type:"structure"`
@@ -3427,6 +4176,22 @@ func (s ListThingPrincipalsInput) String() string {
 // GoString returns the string representation
 func (s ListThingPrincipalsInput) GoString() string {
 	return s.String()
+}
+
+// Validate inspects the fields of the type to determine if they are valid.
+func (s *ListThingPrincipalsInput) Validate() error {
+	invalidParams := request.ErrInvalidParams{Context: "ListThingPrincipalsInput"}
+	if s.ThingName == nil {
+		invalidParams.Add(request.NewErrParamRequired("ThingName"))
+	}
+	if s.ThingName != nil && len(*s.ThingName) < 1 {
+		invalidParams.Add(request.NewErrParamMinLen("ThingName", 1))
+	}
+
+	if invalidParams.Len() > 0 {
+		return invalidParams
+	}
+	return nil
 }
 
 // The output from the ListThingPrincipals operation.
@@ -3472,6 +4237,19 @@ func (s ListThingsInput) String() string {
 // GoString returns the string representation
 func (s ListThingsInput) GoString() string {
 	return s.String()
+}
+
+// Validate inspects the fields of the type to determine if they are valid.
+func (s *ListThingsInput) Validate() error {
+	invalidParams := request.ErrInvalidParams{Context: "ListThingsInput"}
+	if s.MaxResults != nil && *s.MaxResults < 1 {
+		invalidParams.Add(request.NewErrParamMinValue("MaxResults", 1))
+	}
+
+	if invalidParams.Len() > 0 {
+		return invalidParams
+	}
+	return nil
 }
 
 // The output from the ListThings operation.
@@ -3522,6 +4300,19 @@ func (s ListTopicRulesInput) GoString() string {
 	return s.String()
 }
 
+// Validate inspects the fields of the type to determine if they are valid.
+func (s *ListTopicRulesInput) Validate() error {
+	invalidParams := request.ErrInvalidParams{Context: "ListTopicRulesInput"}
+	if s.MaxResults != nil && *s.MaxResults < 1 {
+		invalidParams.Add(request.NewErrParamMinValue("MaxResults", 1))
+	}
+
+	if invalidParams.Len() > 0 {
+		return invalidParams
+	}
+	return nil
+}
+
 // The output from the ListTopicRules operation.
 type ListTopicRulesOutput struct {
 	_ struct{} `type:"structure"`
@@ -3562,6 +4353,19 @@ func (s LoggingOptionsPayload) String() string {
 // GoString returns the string representation
 func (s LoggingOptionsPayload) GoString() string {
 	return s.String()
+}
+
+// Validate inspects the fields of the type to determine if they are valid.
+func (s *LoggingOptionsPayload) Validate() error {
+	invalidParams := request.ErrInvalidParams{Context: "LoggingOptionsPayload"}
+	if s.RoleArn == nil {
+		invalidParams.Add(request.NewErrParamRequired("RoleArn"))
+	}
+
+	if invalidParams.Len() > 0 {
+		return invalidParams
+	}
+	return nil
 }
 
 // Describes an AWS IoT policy.
@@ -3633,6 +4437,28 @@ func (s RegisterCACertificateInput) GoString() string {
 	return s.String()
 }
 
+// Validate inspects the fields of the type to determine if they are valid.
+func (s *RegisterCACertificateInput) Validate() error {
+	invalidParams := request.ErrInvalidParams{Context: "RegisterCACertificateInput"}
+	if s.CaCertificate == nil {
+		invalidParams.Add(request.NewErrParamRequired("CaCertificate"))
+	}
+	if s.CaCertificate != nil && len(*s.CaCertificate) < 1 {
+		invalidParams.Add(request.NewErrParamMinLen("CaCertificate", 1))
+	}
+	if s.VerificationCertificate == nil {
+		invalidParams.Add(request.NewErrParamRequired("VerificationCertificate"))
+	}
+	if s.VerificationCertificate != nil && len(*s.VerificationCertificate) < 1 {
+		invalidParams.Add(request.NewErrParamMinLen("VerificationCertificate", 1))
+	}
+
+	if invalidParams.Len() > 0 {
+		return invalidParams
+	}
+	return nil
+}
+
 // The output from the RegisterCACertificateResponse operation.
 type RegisterCACertificateOutput struct {
 	_ struct{} `type:"structure"`
@@ -3678,6 +4504,25 @@ func (s RegisterCertificateInput) GoString() string {
 	return s.String()
 }
 
+// Validate inspects the fields of the type to determine if they are valid.
+func (s *RegisterCertificateInput) Validate() error {
+	invalidParams := request.ErrInvalidParams{Context: "RegisterCertificateInput"}
+	if s.CaCertificatePem != nil && len(*s.CaCertificatePem) < 1 {
+		invalidParams.Add(request.NewErrParamMinLen("CaCertificatePem", 1))
+	}
+	if s.CertificatePem == nil {
+		invalidParams.Add(request.NewErrParamRequired("CertificatePem"))
+	}
+	if s.CertificatePem != nil && len(*s.CertificatePem) < 1 {
+		invalidParams.Add(request.NewErrParamMinLen("CertificatePem", 1))
+	}
+
+	if invalidParams.Len() > 0 {
+		return invalidParams
+	}
+	return nil
+}
+
 // The output from the RegisterCertificate operation.
 type RegisterCertificateOutput struct {
 	_ struct{} `type:"structure"`
@@ -3720,6 +4565,22 @@ func (s RejectCertificateTransferInput) GoString() string {
 	return s.String()
 }
 
+// Validate inspects the fields of the type to determine if they are valid.
+func (s *RejectCertificateTransferInput) Validate() error {
+	invalidParams := request.ErrInvalidParams{Context: "RejectCertificateTransferInput"}
+	if s.CertificateId == nil {
+		invalidParams.Add(request.NewErrParamRequired("CertificateId"))
+	}
+	if s.CertificateId != nil && len(*s.CertificateId) < 64 {
+		invalidParams.Add(request.NewErrParamMinLen("CertificateId", 64))
+	}
+
+	if invalidParams.Len() > 0 {
+		return invalidParams
+	}
+	return nil
+}
+
 type RejectCertificateTransferOutput struct {
 	_ struct{} `type:"structure"`
 }
@@ -3753,6 +4614,30 @@ func (s ReplaceTopicRuleInput) String() string {
 // GoString returns the string representation
 func (s ReplaceTopicRuleInput) GoString() string {
 	return s.String()
+}
+
+// Validate inspects the fields of the type to determine if they are valid.
+func (s *ReplaceTopicRuleInput) Validate() error {
+	invalidParams := request.ErrInvalidParams{Context: "ReplaceTopicRuleInput"}
+	if s.RuleName == nil {
+		invalidParams.Add(request.NewErrParamRequired("RuleName"))
+	}
+	if s.RuleName != nil && len(*s.RuleName) < 1 {
+		invalidParams.Add(request.NewErrParamMinLen("RuleName", 1))
+	}
+	if s.TopicRulePayload == nil {
+		invalidParams.Add(request.NewErrParamRequired("TopicRulePayload"))
+	}
+	if s.TopicRulePayload != nil {
+		if err := s.TopicRulePayload.Validate(); err != nil {
+			invalidParams.AddNested("TopicRulePayload", err.(request.ErrInvalidParams))
+		}
+	}
+
+	if invalidParams.Len() > 0 {
+		return invalidParams
+	}
+	return nil
 }
 
 type ReplaceTopicRuleOutput struct {
@@ -3790,6 +4675,22 @@ func (s RepublishAction) GoString() string {
 	return s.String()
 }
 
+// Validate inspects the fields of the type to determine if they are valid.
+func (s *RepublishAction) Validate() error {
+	invalidParams := request.ErrInvalidParams{Context: "RepublishAction"}
+	if s.RoleArn == nil {
+		invalidParams.Add(request.NewErrParamRequired("RoleArn"))
+	}
+	if s.Topic == nil {
+		invalidParams.Add(request.NewErrParamRequired("Topic"))
+	}
+
+	if invalidParams.Len() > 0 {
+		return invalidParams
+	}
+	return nil
+}
+
 // Describes an action to write data to an Amazon S3 bucket.
 type S3Action struct {
 	_ struct{} `type:"structure"`
@@ -3814,6 +4715,25 @@ func (s S3Action) GoString() string {
 	return s.String()
 }
 
+// Validate inspects the fields of the type to determine if they are valid.
+func (s *S3Action) Validate() error {
+	invalidParams := request.ErrInvalidParams{Context: "S3Action"}
+	if s.BucketName == nil {
+		invalidParams.Add(request.NewErrParamRequired("BucketName"))
+	}
+	if s.Key == nil {
+		invalidParams.Add(request.NewErrParamRequired("Key"))
+	}
+	if s.RoleArn == nil {
+		invalidParams.Add(request.NewErrParamRequired("RoleArn"))
+	}
+
+	if invalidParams.Len() > 0 {
+		return invalidParams
+	}
+	return nil
+}
+
 // The input for the SetDefaultPolicyVersion operation.
 type SetDefaultPolicyVersionInput struct {
 	_ struct{} `type:"structure"`
@@ -3833,6 +4753,25 @@ func (s SetDefaultPolicyVersionInput) String() string {
 // GoString returns the string representation
 func (s SetDefaultPolicyVersionInput) GoString() string {
 	return s.String()
+}
+
+// Validate inspects the fields of the type to determine if they are valid.
+func (s *SetDefaultPolicyVersionInput) Validate() error {
+	invalidParams := request.ErrInvalidParams{Context: "SetDefaultPolicyVersionInput"}
+	if s.PolicyName == nil {
+		invalidParams.Add(request.NewErrParamRequired("PolicyName"))
+	}
+	if s.PolicyName != nil && len(*s.PolicyName) < 1 {
+		invalidParams.Add(request.NewErrParamMinLen("PolicyName", 1))
+	}
+	if s.PolicyVersionId == nil {
+		invalidParams.Add(request.NewErrParamRequired("PolicyVersionId"))
+	}
+
+	if invalidParams.Len() > 0 {
+		return invalidParams
+	}
+	return nil
 }
 
 type SetDefaultPolicyVersionOutput struct {
@@ -3865,6 +4804,24 @@ func (s SetLoggingOptionsInput) String() string {
 // GoString returns the string representation
 func (s SetLoggingOptionsInput) GoString() string {
 	return s.String()
+}
+
+// Validate inspects the fields of the type to determine if they are valid.
+func (s *SetLoggingOptionsInput) Validate() error {
+	invalidParams := request.ErrInvalidParams{Context: "SetLoggingOptionsInput"}
+	if s.LoggingOptionsPayload == nil {
+		invalidParams.Add(request.NewErrParamRequired("LoggingOptionsPayload"))
+	}
+	if s.LoggingOptionsPayload != nil {
+		if err := s.LoggingOptionsPayload.Validate(); err != nil {
+			invalidParams.AddNested("LoggingOptionsPayload", err.(request.ErrInvalidParams))
+		}
+	}
+
+	if invalidParams.Len() > 0 {
+		return invalidParams
+	}
+	return nil
 }
 
 type SetLoggingOptionsOutput struct {
@@ -3909,6 +4866,22 @@ func (s SnsAction) GoString() string {
 	return s.String()
 }
 
+// Validate inspects the fields of the type to determine if they are valid.
+func (s *SnsAction) Validate() error {
+	invalidParams := request.ErrInvalidParams{Context: "SnsAction"}
+	if s.RoleArn == nil {
+		invalidParams.Add(request.NewErrParamRequired("RoleArn"))
+	}
+	if s.TargetArn == nil {
+		invalidParams.Add(request.NewErrParamRequired("TargetArn"))
+	}
+
+	if invalidParams.Len() > 0 {
+		return invalidParams
+	}
+	return nil
+}
+
 // Describes an action to publish data to an Amazon SQS queue.
 type SqsAction struct {
 	_ struct{} `type:"structure"`
@@ -3931,6 +4904,22 @@ func (s SqsAction) String() string {
 // GoString returns the string representation
 func (s SqsAction) GoString() string {
 	return s.String()
+}
+
+// Validate inspects the fields of the type to determine if they are valid.
+func (s *SqsAction) Validate() error {
+	invalidParams := request.ErrInvalidParams{Context: "SqsAction"}
+	if s.QueueUrl == nil {
+		invalidParams.Add(request.NewErrParamRequired("QueueUrl"))
+	}
+	if s.RoleArn == nil {
+		invalidParams.Add(request.NewErrParamRequired("RoleArn"))
+	}
+
+	if invalidParams.Len() > 0 {
+		return invalidParams
+	}
+	return nil
 }
 
 // Describes a thing attribute.
@@ -4053,6 +5042,32 @@ func (s TopicRulePayload) GoString() string {
 	return s.String()
 }
 
+// Validate inspects the fields of the type to determine if they are valid.
+func (s *TopicRulePayload) Validate() error {
+	invalidParams := request.ErrInvalidParams{Context: "TopicRulePayload"}
+	if s.Actions == nil {
+		invalidParams.Add(request.NewErrParamRequired("Actions"))
+	}
+	if s.Sql == nil {
+		invalidParams.Add(request.NewErrParamRequired("Sql"))
+	}
+	if s.Actions != nil {
+		for i, v := range s.Actions {
+			if v == nil {
+				continue
+			}
+			if err := v.Validate(); err != nil {
+				invalidParams.AddNested(fmt.Sprintf("%s[%v]", "Actions", i), err.(request.ErrInvalidParams))
+			}
+		}
+	}
+
+	if invalidParams.Len() > 0 {
+		return invalidParams
+	}
+	return nil
+}
+
 // The input for the TransferCertificate operation.
 type TransferCertificateInput struct {
 	_ struct{} `type:"structure"`
@@ -4075,6 +5090,25 @@ func (s TransferCertificateInput) String() string {
 // GoString returns the string representation
 func (s TransferCertificateInput) GoString() string {
 	return s.String()
+}
+
+// Validate inspects the fields of the type to determine if they are valid.
+func (s *TransferCertificateInput) Validate() error {
+	invalidParams := request.ErrInvalidParams{Context: "TransferCertificateInput"}
+	if s.CertificateId == nil {
+		invalidParams.Add(request.NewErrParamRequired("CertificateId"))
+	}
+	if s.CertificateId != nil && len(*s.CertificateId) < 64 {
+		invalidParams.Add(request.NewErrParamMinLen("CertificateId", 64))
+	}
+	if s.TargetAwsAccount == nil {
+		invalidParams.Add(request.NewErrParamRequired("TargetAwsAccount"))
+	}
+
+	if invalidParams.Len() > 0 {
+		return invalidParams
+	}
+	return nil
 }
 
 // The output from the TransferCertificate operation.
@@ -4146,6 +5180,25 @@ func (s UpdateCACertificateInput) GoString() string {
 	return s.String()
 }
 
+// Validate inspects the fields of the type to determine if they are valid.
+func (s *UpdateCACertificateInput) Validate() error {
+	invalidParams := request.ErrInvalidParams{Context: "UpdateCACertificateInput"}
+	if s.CertificateId == nil {
+		invalidParams.Add(request.NewErrParamRequired("CertificateId"))
+	}
+	if s.CertificateId != nil && len(*s.CertificateId) < 64 {
+		invalidParams.Add(request.NewErrParamMinLen("CertificateId", 64))
+	}
+	if s.NewStatus == nil {
+		invalidParams.Add(request.NewErrParamRequired("NewStatus"))
+	}
+
+	if invalidParams.Len() > 0 {
+		return invalidParams
+	}
+	return nil
+}
+
 type UpdateCACertificateOutput struct {
 	_ struct{} `type:"structure"`
 }
@@ -4185,6 +5238,25 @@ func (s UpdateCertificateInput) GoString() string {
 	return s.String()
 }
 
+// Validate inspects the fields of the type to determine if they are valid.
+func (s *UpdateCertificateInput) Validate() error {
+	invalidParams := request.ErrInvalidParams{Context: "UpdateCertificateInput"}
+	if s.CertificateId == nil {
+		invalidParams.Add(request.NewErrParamRequired("CertificateId"))
+	}
+	if s.CertificateId != nil && len(*s.CertificateId) < 64 {
+		invalidParams.Add(request.NewErrParamMinLen("CertificateId", 64))
+	}
+	if s.NewStatus == nil {
+		invalidParams.Add(request.NewErrParamRequired("NewStatus"))
+	}
+
+	if invalidParams.Len() > 0 {
+		return invalidParams
+	}
+	return nil
+}
+
 type UpdateCertificateOutput struct {
 	_ struct{} `type:"structure"`
 }
@@ -4219,6 +5291,25 @@ func (s UpdateThingInput) String() string {
 // GoString returns the string representation
 func (s UpdateThingInput) GoString() string {
 	return s.String()
+}
+
+// Validate inspects the fields of the type to determine if they are valid.
+func (s *UpdateThingInput) Validate() error {
+	invalidParams := request.ErrInvalidParams{Context: "UpdateThingInput"}
+	if s.AttributePayload == nil {
+		invalidParams.Add(request.NewErrParamRequired("AttributePayload"))
+	}
+	if s.ThingName == nil {
+		invalidParams.Add(request.NewErrParamRequired("ThingName"))
+	}
+	if s.ThingName != nil && len(*s.ThingName) < 1 {
+		invalidParams.Add(request.NewErrParamMinLen("ThingName", 1))
+	}
+
+	if invalidParams.Len() > 0 {
+		return invalidParams
+	}
+	return nil
 }
 
 // The output from the UpdateThing operation.

--- a/service/iotdataplane/api.go
+++ b/service/iotdataplane/api.go
@@ -150,6 +150,22 @@ func (s DeleteThingShadowInput) GoString() string {
 	return s.String()
 }
 
+// Validate inspects the fields of the type to determine if they are valid.
+func (s *DeleteThingShadowInput) Validate() error {
+	invalidParams := request.ErrInvalidParams{Context: "DeleteThingShadowInput"}
+	if s.ThingName == nil {
+		invalidParams.Add(request.NewErrParamRequired("ThingName"))
+	}
+	if s.ThingName != nil && len(*s.ThingName) < 1 {
+		invalidParams.Add(request.NewErrParamMinLen("ThingName", 1))
+	}
+
+	if invalidParams.Len() > 0 {
+		return invalidParams
+	}
+	return nil
+}
+
 // The output from the DeleteThingShadow operation.
 type DeleteThingShadowOutput struct {
 	_ struct{} `type:"structure" payload:"Payload"`
@@ -184,6 +200,22 @@ func (s GetThingShadowInput) String() string {
 // GoString returns the string representation
 func (s GetThingShadowInput) GoString() string {
 	return s.String()
+}
+
+// Validate inspects the fields of the type to determine if they are valid.
+func (s *GetThingShadowInput) Validate() error {
+	invalidParams := request.ErrInvalidParams{Context: "GetThingShadowInput"}
+	if s.ThingName == nil {
+		invalidParams.Add(request.NewErrParamRequired("ThingName"))
+	}
+	if s.ThingName != nil && len(*s.ThingName) < 1 {
+		invalidParams.Add(request.NewErrParamMinLen("ThingName", 1))
+	}
+
+	if invalidParams.Len() > 0 {
+		return invalidParams
+	}
+	return nil
 }
 
 // The output from the GetThingShadow operation.
@@ -228,6 +260,19 @@ func (s PublishInput) GoString() string {
 	return s.String()
 }
 
+// Validate inspects the fields of the type to determine if they are valid.
+func (s *PublishInput) Validate() error {
+	invalidParams := request.ErrInvalidParams{Context: "PublishInput"}
+	if s.Topic == nil {
+		invalidParams.Add(request.NewErrParamRequired("Topic"))
+	}
+
+	if invalidParams.Len() > 0 {
+		return invalidParams
+	}
+	return nil
+}
+
 type PublishOutput struct {
 	_ struct{} `type:"structure"`
 }
@@ -261,6 +306,25 @@ func (s UpdateThingShadowInput) String() string {
 // GoString returns the string representation
 func (s UpdateThingShadowInput) GoString() string {
 	return s.String()
+}
+
+// Validate inspects the fields of the type to determine if they are valid.
+func (s *UpdateThingShadowInput) Validate() error {
+	invalidParams := request.ErrInvalidParams{Context: "UpdateThingShadowInput"}
+	if s.Payload == nil {
+		invalidParams.Add(request.NewErrParamRequired("Payload"))
+	}
+	if s.ThingName == nil {
+		invalidParams.Add(request.NewErrParamRequired("ThingName"))
+	}
+	if s.ThingName != nil && len(*s.ThingName) < 1 {
+		invalidParams.Add(request.NewErrParamMinLen("ThingName", 1))
+	}
+
+	if invalidParams.Len() > 0 {
+		return invalidParams
+	}
+	return nil
 }
 
 // The output from the UpdateThingShadow operation.

--- a/service/kinesis/api.go
+++ b/service/kinesis/api.go
@@ -4,6 +4,7 @@
 package kinesis
 
 import (
+	"fmt"
 	"time"
 
 	"github.com/aws/aws-sdk-go/aws/awsutil"
@@ -917,6 +918,28 @@ func (s AddTagsToStreamInput) GoString() string {
 	return s.String()
 }
 
+// Validate inspects the fields of the type to determine if they are valid.
+func (s *AddTagsToStreamInput) Validate() error {
+	invalidParams := request.ErrInvalidParams{Context: "AddTagsToStreamInput"}
+	if s.StreamName == nil {
+		invalidParams.Add(request.NewErrParamRequired("StreamName"))
+	}
+	if s.StreamName != nil && len(*s.StreamName) < 1 {
+		invalidParams.Add(request.NewErrParamMinLen("StreamName", 1))
+	}
+	if s.Tags == nil {
+		invalidParams.Add(request.NewErrParamRequired("Tags"))
+	}
+	if s.Tags != nil && len(s.Tags) < 1 {
+		invalidParams.Add(request.NewErrParamMinLen("Tags", 1))
+	}
+
+	if invalidParams.Len() > 0 {
+		return invalidParams
+	}
+	return nil
+}
+
 type AddTagsToStreamOutput struct {
 	_ struct{} `type:"structure"`
 }
@@ -960,6 +983,28 @@ func (s CreateStreamInput) GoString() string {
 	return s.String()
 }
 
+// Validate inspects the fields of the type to determine if they are valid.
+func (s *CreateStreamInput) Validate() error {
+	invalidParams := request.ErrInvalidParams{Context: "CreateStreamInput"}
+	if s.ShardCount == nil {
+		invalidParams.Add(request.NewErrParamRequired("ShardCount"))
+	}
+	if s.ShardCount != nil && *s.ShardCount < 1 {
+		invalidParams.Add(request.NewErrParamMinValue("ShardCount", 1))
+	}
+	if s.StreamName == nil {
+		invalidParams.Add(request.NewErrParamRequired("StreamName"))
+	}
+	if s.StreamName != nil && len(*s.StreamName) < 1 {
+		invalidParams.Add(request.NewErrParamMinLen("StreamName", 1))
+	}
+
+	if invalidParams.Len() > 0 {
+		return invalidParams
+	}
+	return nil
+}
+
 type CreateStreamOutput struct {
 	_ struct{} `type:"structure"`
 }
@@ -996,6 +1041,28 @@ func (s DecreaseStreamRetentionPeriodInput) GoString() string {
 	return s.String()
 }
 
+// Validate inspects the fields of the type to determine if they are valid.
+func (s *DecreaseStreamRetentionPeriodInput) Validate() error {
+	invalidParams := request.ErrInvalidParams{Context: "DecreaseStreamRetentionPeriodInput"}
+	if s.RetentionPeriodHours == nil {
+		invalidParams.Add(request.NewErrParamRequired("RetentionPeriodHours"))
+	}
+	if s.RetentionPeriodHours != nil && *s.RetentionPeriodHours < 24 {
+		invalidParams.Add(request.NewErrParamMinValue("RetentionPeriodHours", 24))
+	}
+	if s.StreamName == nil {
+		invalidParams.Add(request.NewErrParamRequired("StreamName"))
+	}
+	if s.StreamName != nil && len(*s.StreamName) < 1 {
+		invalidParams.Add(request.NewErrParamMinLen("StreamName", 1))
+	}
+
+	if invalidParams.Len() > 0 {
+		return invalidParams
+	}
+	return nil
+}
+
 type DecreaseStreamRetentionPeriodOutput struct {
 	_ struct{} `type:"structure"`
 }
@@ -1026,6 +1093,22 @@ func (s DeleteStreamInput) String() string {
 // GoString returns the string representation
 func (s DeleteStreamInput) GoString() string {
 	return s.String()
+}
+
+// Validate inspects the fields of the type to determine if they are valid.
+func (s *DeleteStreamInput) Validate() error {
+	invalidParams := request.ErrInvalidParams{Context: "DeleteStreamInput"}
+	if s.StreamName == nil {
+		invalidParams.Add(request.NewErrParamRequired("StreamName"))
+	}
+	if s.StreamName != nil && len(*s.StreamName) < 1 {
+		invalidParams.Add(request.NewErrParamMinLen("StreamName", 1))
+	}
+
+	if invalidParams.Len() > 0 {
+		return invalidParams
+	}
+	return nil
 }
 
 type DeleteStreamOutput struct {
@@ -1064,6 +1147,28 @@ func (s DescribeStreamInput) String() string {
 // GoString returns the string representation
 func (s DescribeStreamInput) GoString() string {
 	return s.String()
+}
+
+// Validate inspects the fields of the type to determine if they are valid.
+func (s *DescribeStreamInput) Validate() error {
+	invalidParams := request.ErrInvalidParams{Context: "DescribeStreamInput"}
+	if s.ExclusiveStartShardId != nil && len(*s.ExclusiveStartShardId) < 1 {
+		invalidParams.Add(request.NewErrParamMinLen("ExclusiveStartShardId", 1))
+	}
+	if s.Limit != nil && *s.Limit < 1 {
+		invalidParams.Add(request.NewErrParamMinValue("Limit", 1))
+	}
+	if s.StreamName == nil {
+		invalidParams.Add(request.NewErrParamRequired("StreamName"))
+	}
+	if s.StreamName != nil && len(*s.StreamName) < 1 {
+		invalidParams.Add(request.NewErrParamMinLen("StreamName", 1))
+	}
+
+	if invalidParams.Len() > 0 {
+		return invalidParams
+	}
+	return nil
 }
 
 // Represents the output for DescribeStream.
@@ -1115,6 +1220,28 @@ func (s DisableEnhancedMonitoringInput) GoString() string {
 	return s.String()
 }
 
+// Validate inspects the fields of the type to determine if they are valid.
+func (s *DisableEnhancedMonitoringInput) Validate() error {
+	invalidParams := request.ErrInvalidParams{Context: "DisableEnhancedMonitoringInput"}
+	if s.ShardLevelMetrics == nil {
+		invalidParams.Add(request.NewErrParamRequired("ShardLevelMetrics"))
+	}
+	if s.ShardLevelMetrics != nil && len(s.ShardLevelMetrics) < 1 {
+		invalidParams.Add(request.NewErrParamMinLen("ShardLevelMetrics", 1))
+	}
+	if s.StreamName == nil {
+		invalidParams.Add(request.NewErrParamRequired("StreamName"))
+	}
+	if s.StreamName != nil && len(*s.StreamName) < 1 {
+		invalidParams.Add(request.NewErrParamMinLen("StreamName", 1))
+	}
+
+	if invalidParams.Len() > 0 {
+		return invalidParams
+	}
+	return nil
+}
+
 // Represents the input for EnableEnhancedMonitoring.
 type EnableEnhancedMonitoringInput struct {
 	_ struct{} `type:"structure"`
@@ -1143,6 +1270,28 @@ func (s EnableEnhancedMonitoringInput) String() string {
 // GoString returns the string representation
 func (s EnableEnhancedMonitoringInput) GoString() string {
 	return s.String()
+}
+
+// Validate inspects the fields of the type to determine if they are valid.
+func (s *EnableEnhancedMonitoringInput) Validate() error {
+	invalidParams := request.ErrInvalidParams{Context: "EnableEnhancedMonitoringInput"}
+	if s.ShardLevelMetrics == nil {
+		invalidParams.Add(request.NewErrParamRequired("ShardLevelMetrics"))
+	}
+	if s.ShardLevelMetrics != nil && len(s.ShardLevelMetrics) < 1 {
+		invalidParams.Add(request.NewErrParamMinLen("ShardLevelMetrics", 1))
+	}
+	if s.StreamName == nil {
+		invalidParams.Add(request.NewErrParamRequired("StreamName"))
+	}
+	if s.StreamName != nil && len(*s.StreamName) < 1 {
+		invalidParams.Add(request.NewErrParamMinLen("StreamName", 1))
+	}
+
+	if invalidParams.Len() > 0 {
+		return invalidParams
+	}
+	return nil
 }
 
 // Represents enhanced metrics types.
@@ -1220,6 +1369,25 @@ func (s GetRecordsInput) String() string {
 // GoString returns the string representation
 func (s GetRecordsInput) GoString() string {
 	return s.String()
+}
+
+// Validate inspects the fields of the type to determine if they are valid.
+func (s *GetRecordsInput) Validate() error {
+	invalidParams := request.ErrInvalidParams{Context: "GetRecordsInput"}
+	if s.Limit != nil && *s.Limit < 1 {
+		invalidParams.Add(request.NewErrParamMinValue("Limit", 1))
+	}
+	if s.ShardIterator == nil {
+		invalidParams.Add(request.NewErrParamRequired("ShardIterator"))
+	}
+	if s.ShardIterator != nil && len(*s.ShardIterator) < 1 {
+		invalidParams.Add(request.NewErrParamMinLen("ShardIterator", 1))
+	}
+
+	if invalidParams.Len() > 0 {
+		return invalidParams
+	}
+	return nil
 }
 
 // Represents the output for GetRecords.
@@ -1301,6 +1469,31 @@ func (s GetShardIteratorInput) GoString() string {
 	return s.String()
 }
 
+// Validate inspects the fields of the type to determine if they are valid.
+func (s *GetShardIteratorInput) Validate() error {
+	invalidParams := request.ErrInvalidParams{Context: "GetShardIteratorInput"}
+	if s.ShardId == nil {
+		invalidParams.Add(request.NewErrParamRequired("ShardId"))
+	}
+	if s.ShardId != nil && len(*s.ShardId) < 1 {
+		invalidParams.Add(request.NewErrParamMinLen("ShardId", 1))
+	}
+	if s.ShardIteratorType == nil {
+		invalidParams.Add(request.NewErrParamRequired("ShardIteratorType"))
+	}
+	if s.StreamName == nil {
+		invalidParams.Add(request.NewErrParamRequired("StreamName"))
+	}
+	if s.StreamName != nil && len(*s.StreamName) < 1 {
+		invalidParams.Add(request.NewErrParamMinLen("StreamName", 1))
+	}
+
+	if invalidParams.Len() > 0 {
+		return invalidParams
+	}
+	return nil
+}
+
 // Represents the output for GetShardIterator.
 type GetShardIteratorOutput struct {
 	_ struct{} `type:"structure"`
@@ -1365,6 +1558,28 @@ func (s IncreaseStreamRetentionPeriodInput) GoString() string {
 	return s.String()
 }
 
+// Validate inspects the fields of the type to determine if they are valid.
+func (s *IncreaseStreamRetentionPeriodInput) Validate() error {
+	invalidParams := request.ErrInvalidParams{Context: "IncreaseStreamRetentionPeriodInput"}
+	if s.RetentionPeriodHours == nil {
+		invalidParams.Add(request.NewErrParamRequired("RetentionPeriodHours"))
+	}
+	if s.RetentionPeriodHours != nil && *s.RetentionPeriodHours < 24 {
+		invalidParams.Add(request.NewErrParamMinValue("RetentionPeriodHours", 24))
+	}
+	if s.StreamName == nil {
+		invalidParams.Add(request.NewErrParamRequired("StreamName"))
+	}
+	if s.StreamName != nil && len(*s.StreamName) < 1 {
+		invalidParams.Add(request.NewErrParamMinLen("StreamName", 1))
+	}
+
+	if invalidParams.Len() > 0 {
+		return invalidParams
+	}
+	return nil
+}
+
 type IncreaseStreamRetentionPeriodOutput struct {
 	_ struct{} `type:"structure"`
 }
@@ -1398,6 +1613,22 @@ func (s ListStreamsInput) String() string {
 // GoString returns the string representation
 func (s ListStreamsInput) GoString() string {
 	return s.String()
+}
+
+// Validate inspects the fields of the type to determine if they are valid.
+func (s *ListStreamsInput) Validate() error {
+	invalidParams := request.ErrInvalidParams{Context: "ListStreamsInput"}
+	if s.ExclusiveStartStreamName != nil && len(*s.ExclusiveStartStreamName) < 1 {
+		invalidParams.Add(request.NewErrParamMinLen("ExclusiveStartStreamName", 1))
+	}
+	if s.Limit != nil && *s.Limit < 1 {
+		invalidParams.Add(request.NewErrParamMinValue("Limit", 1))
+	}
+
+	if invalidParams.Len() > 0 {
+		return invalidParams
+	}
+	return nil
 }
 
 // Represents the output for ListStreams.
@@ -1449,6 +1680,28 @@ func (s ListTagsForStreamInput) GoString() string {
 	return s.String()
 }
 
+// Validate inspects the fields of the type to determine if they are valid.
+func (s *ListTagsForStreamInput) Validate() error {
+	invalidParams := request.ErrInvalidParams{Context: "ListTagsForStreamInput"}
+	if s.ExclusiveStartTagKey != nil && len(*s.ExclusiveStartTagKey) < 1 {
+		invalidParams.Add(request.NewErrParamMinLen("ExclusiveStartTagKey", 1))
+	}
+	if s.Limit != nil && *s.Limit < 1 {
+		invalidParams.Add(request.NewErrParamMinValue("Limit", 1))
+	}
+	if s.StreamName == nil {
+		invalidParams.Add(request.NewErrParamRequired("StreamName"))
+	}
+	if s.StreamName != nil && len(*s.StreamName) < 1 {
+		invalidParams.Add(request.NewErrParamMinLen("StreamName", 1))
+	}
+
+	if invalidParams.Len() > 0 {
+		return invalidParams
+	}
+	return nil
+}
+
 // Represents the output for ListTagsForStream.
 type ListTagsForStreamOutput struct {
 	_ struct{} `type:"structure"`
@@ -1494,6 +1747,34 @@ func (s MergeShardsInput) String() string {
 // GoString returns the string representation
 func (s MergeShardsInput) GoString() string {
 	return s.String()
+}
+
+// Validate inspects the fields of the type to determine if they are valid.
+func (s *MergeShardsInput) Validate() error {
+	invalidParams := request.ErrInvalidParams{Context: "MergeShardsInput"}
+	if s.AdjacentShardToMerge == nil {
+		invalidParams.Add(request.NewErrParamRequired("AdjacentShardToMerge"))
+	}
+	if s.AdjacentShardToMerge != nil && len(*s.AdjacentShardToMerge) < 1 {
+		invalidParams.Add(request.NewErrParamMinLen("AdjacentShardToMerge", 1))
+	}
+	if s.ShardToMerge == nil {
+		invalidParams.Add(request.NewErrParamRequired("ShardToMerge"))
+	}
+	if s.ShardToMerge != nil && len(*s.ShardToMerge) < 1 {
+		invalidParams.Add(request.NewErrParamMinLen("ShardToMerge", 1))
+	}
+	if s.StreamName == nil {
+		invalidParams.Add(request.NewErrParamRequired("StreamName"))
+	}
+	if s.StreamName != nil && len(*s.StreamName) < 1 {
+		invalidParams.Add(request.NewErrParamMinLen("StreamName", 1))
+	}
+
+	if invalidParams.Len() > 0 {
+		return invalidParams
+	}
+	return nil
 }
 
 type MergeShardsOutput struct {
@@ -1557,6 +1838,31 @@ func (s PutRecordInput) GoString() string {
 	return s.String()
 }
 
+// Validate inspects the fields of the type to determine if they are valid.
+func (s *PutRecordInput) Validate() error {
+	invalidParams := request.ErrInvalidParams{Context: "PutRecordInput"}
+	if s.Data == nil {
+		invalidParams.Add(request.NewErrParamRequired("Data"))
+	}
+	if s.PartitionKey == nil {
+		invalidParams.Add(request.NewErrParamRequired("PartitionKey"))
+	}
+	if s.PartitionKey != nil && len(*s.PartitionKey) < 1 {
+		invalidParams.Add(request.NewErrParamMinLen("PartitionKey", 1))
+	}
+	if s.StreamName == nil {
+		invalidParams.Add(request.NewErrParamRequired("StreamName"))
+	}
+	if s.StreamName != nil && len(*s.StreamName) < 1 {
+		invalidParams.Add(request.NewErrParamMinLen("StreamName", 1))
+	}
+
+	if invalidParams.Len() > 0 {
+		return invalidParams
+	}
+	return nil
+}
+
 // Represents the output for PutRecord.
 type PutRecordOutput struct {
 	_ struct{} `type:"structure"`
@@ -1600,6 +1906,38 @@ func (s PutRecordsInput) String() string {
 // GoString returns the string representation
 func (s PutRecordsInput) GoString() string {
 	return s.String()
+}
+
+// Validate inspects the fields of the type to determine if they are valid.
+func (s *PutRecordsInput) Validate() error {
+	invalidParams := request.ErrInvalidParams{Context: "PutRecordsInput"}
+	if s.Records == nil {
+		invalidParams.Add(request.NewErrParamRequired("Records"))
+	}
+	if s.Records != nil && len(s.Records) < 1 {
+		invalidParams.Add(request.NewErrParamMinLen("Records", 1))
+	}
+	if s.StreamName == nil {
+		invalidParams.Add(request.NewErrParamRequired("StreamName"))
+	}
+	if s.StreamName != nil && len(*s.StreamName) < 1 {
+		invalidParams.Add(request.NewErrParamMinLen("StreamName", 1))
+	}
+	if s.Records != nil {
+		for i, v := range s.Records {
+			if v == nil {
+				continue
+			}
+			if err := v.Validate(); err != nil {
+				invalidParams.AddNested(fmt.Sprintf("%s[%v]", "Records", i), err.(request.ErrInvalidParams))
+			}
+		}
+	}
+
+	if invalidParams.Len() > 0 {
+		return invalidParams
+	}
+	return nil
 }
 
 // PutRecords results.
@@ -1662,6 +2000,25 @@ func (s PutRecordsRequestEntry) String() string {
 // GoString returns the string representation
 func (s PutRecordsRequestEntry) GoString() string {
 	return s.String()
+}
+
+// Validate inspects the fields of the type to determine if they are valid.
+func (s *PutRecordsRequestEntry) Validate() error {
+	invalidParams := request.ErrInvalidParams{Context: "PutRecordsRequestEntry"}
+	if s.Data == nil {
+		invalidParams.Add(request.NewErrParamRequired("Data"))
+	}
+	if s.PartitionKey == nil {
+		invalidParams.Add(request.NewErrParamRequired("PartitionKey"))
+	}
+	if s.PartitionKey != nil && len(*s.PartitionKey) < 1 {
+		invalidParams.Add(request.NewErrParamMinLen("PartitionKey", 1))
+	}
+
+	if invalidParams.Len() > 0 {
+		return invalidParams
+	}
+	return nil
 }
 
 // Represents the result of an individual record from a PutRecords request.
@@ -1751,6 +2108,28 @@ func (s RemoveTagsFromStreamInput) String() string {
 // GoString returns the string representation
 func (s RemoveTagsFromStreamInput) GoString() string {
 	return s.String()
+}
+
+// Validate inspects the fields of the type to determine if they are valid.
+func (s *RemoveTagsFromStreamInput) Validate() error {
+	invalidParams := request.ErrInvalidParams{Context: "RemoveTagsFromStreamInput"}
+	if s.StreamName == nil {
+		invalidParams.Add(request.NewErrParamRequired("StreamName"))
+	}
+	if s.StreamName != nil && len(*s.StreamName) < 1 {
+		invalidParams.Add(request.NewErrParamMinLen("StreamName", 1))
+	}
+	if s.TagKeys == nil {
+		invalidParams.Add(request.NewErrParamRequired("TagKeys"))
+	}
+	if s.TagKeys != nil && len(s.TagKeys) < 1 {
+		invalidParams.Add(request.NewErrParamMinLen("TagKeys", 1))
+	}
+
+	if invalidParams.Len() > 0 {
+		return invalidParams
+	}
+	return nil
 }
 
 type RemoveTagsFromStreamOutput struct {
@@ -1848,6 +2227,31 @@ func (s SplitShardInput) String() string {
 // GoString returns the string representation
 func (s SplitShardInput) GoString() string {
 	return s.String()
+}
+
+// Validate inspects the fields of the type to determine if they are valid.
+func (s *SplitShardInput) Validate() error {
+	invalidParams := request.ErrInvalidParams{Context: "SplitShardInput"}
+	if s.NewStartingHashKey == nil {
+		invalidParams.Add(request.NewErrParamRequired("NewStartingHashKey"))
+	}
+	if s.ShardToSplit == nil {
+		invalidParams.Add(request.NewErrParamRequired("ShardToSplit"))
+	}
+	if s.ShardToSplit != nil && len(*s.ShardToSplit) < 1 {
+		invalidParams.Add(request.NewErrParamMinLen("ShardToSplit", 1))
+	}
+	if s.StreamName == nil {
+		invalidParams.Add(request.NewErrParamRequired("StreamName"))
+	}
+	if s.StreamName != nil && len(*s.StreamName) < 1 {
+		invalidParams.Add(request.NewErrParamMinLen("StreamName", 1))
+	}
+
+	if invalidParams.Len() > 0 {
+		return invalidParams
+	}
+	return nil
 }
 
 type SplitShardOutput struct {

--- a/service/kms/api.go
+++ b/service/kms/api.go
@@ -1063,6 +1063,22 @@ func (s CancelKeyDeletionInput) GoString() string {
 	return s.String()
 }
 
+// Validate inspects the fields of the type to determine if they are valid.
+func (s *CancelKeyDeletionInput) Validate() error {
+	invalidParams := request.ErrInvalidParams{Context: "CancelKeyDeletionInput"}
+	if s.KeyId == nil {
+		invalidParams.Add(request.NewErrParamRequired("KeyId"))
+	}
+	if s.KeyId != nil && len(*s.KeyId) < 1 {
+		invalidParams.Add(request.NewErrParamMinLen("KeyId", 1))
+	}
+
+	if invalidParams.Len() > 0 {
+		return invalidParams
+	}
+	return nil
+}
+
 type CancelKeyDeletionOutput struct {
 	_ struct{} `type:"structure"`
 
@@ -1103,6 +1119,28 @@ func (s CreateAliasInput) String() string {
 // GoString returns the string representation
 func (s CreateAliasInput) GoString() string {
 	return s.String()
+}
+
+// Validate inspects the fields of the type to determine if they are valid.
+func (s *CreateAliasInput) Validate() error {
+	invalidParams := request.ErrInvalidParams{Context: "CreateAliasInput"}
+	if s.AliasName == nil {
+		invalidParams.Add(request.NewErrParamRequired("AliasName"))
+	}
+	if s.AliasName != nil && len(*s.AliasName) < 1 {
+		invalidParams.Add(request.NewErrParamMinLen("AliasName", 1))
+	}
+	if s.TargetKeyId == nil {
+		invalidParams.Add(request.NewErrParamRequired("TargetKeyId"))
+	}
+	if s.TargetKeyId != nil && len(*s.TargetKeyId) < 1 {
+		invalidParams.Add(request.NewErrParamMinLen("TargetKeyId", 1))
+	}
+
+	if invalidParams.Len() > 0 {
+		return invalidParams
+	}
+	return nil
 }
 
 type CreateAliasOutput struct {
@@ -1196,6 +1234,34 @@ func (s CreateGrantInput) GoString() string {
 	return s.String()
 }
 
+// Validate inspects the fields of the type to determine if they are valid.
+func (s *CreateGrantInput) Validate() error {
+	invalidParams := request.ErrInvalidParams{Context: "CreateGrantInput"}
+	if s.GranteePrincipal == nil {
+		invalidParams.Add(request.NewErrParamRequired("GranteePrincipal"))
+	}
+	if s.GranteePrincipal != nil && len(*s.GranteePrincipal) < 1 {
+		invalidParams.Add(request.NewErrParamMinLen("GranteePrincipal", 1))
+	}
+	if s.KeyId == nil {
+		invalidParams.Add(request.NewErrParamRequired("KeyId"))
+	}
+	if s.KeyId != nil && len(*s.KeyId) < 1 {
+		invalidParams.Add(request.NewErrParamMinLen("KeyId", 1))
+	}
+	if s.Name != nil && len(*s.Name) < 1 {
+		invalidParams.Add(request.NewErrParamMinLen("Name", 1))
+	}
+	if s.RetiringPrincipal != nil && len(*s.RetiringPrincipal) < 1 {
+		invalidParams.Add(request.NewErrParamMinLen("RetiringPrincipal", 1))
+	}
+
+	if invalidParams.Len() > 0 {
+		return invalidParams
+	}
+	return nil
+}
+
 type CreateGrantOutput struct {
 	_ struct{} `type:"structure"`
 
@@ -1247,6 +1313,19 @@ func (s CreateKeyInput) GoString() string {
 	return s.String()
 }
 
+// Validate inspects the fields of the type to determine if they are valid.
+func (s *CreateKeyInput) Validate() error {
+	invalidParams := request.ErrInvalidParams{Context: "CreateKeyInput"}
+	if s.Policy != nil && len(*s.Policy) < 1 {
+		invalidParams.Add(request.NewErrParamMinLen("Policy", 1))
+	}
+
+	if invalidParams.Len() > 0 {
+		return invalidParams
+	}
+	return nil
+}
+
 type CreateKeyOutput struct {
 	_ struct{} `type:"structure"`
 
@@ -1294,6 +1373,22 @@ func (s DecryptInput) GoString() string {
 	return s.String()
 }
 
+// Validate inspects the fields of the type to determine if they are valid.
+func (s *DecryptInput) Validate() error {
+	invalidParams := request.ErrInvalidParams{Context: "DecryptInput"}
+	if s.CiphertextBlob == nil {
+		invalidParams.Add(request.NewErrParamRequired("CiphertextBlob"))
+	}
+	if s.CiphertextBlob != nil && len(s.CiphertextBlob) < 1 {
+		invalidParams.Add(request.NewErrParamMinLen("CiphertextBlob", 1))
+	}
+
+	if invalidParams.Len() > 0 {
+		return invalidParams
+	}
+	return nil
+}
+
 type DecryptOutput struct {
 	_ struct{} `type:"structure"`
 
@@ -1334,6 +1429,22 @@ func (s DeleteAliasInput) String() string {
 // GoString returns the string representation
 func (s DeleteAliasInput) GoString() string {
 	return s.String()
+}
+
+// Validate inspects the fields of the type to determine if they are valid.
+func (s *DeleteAliasInput) Validate() error {
+	invalidParams := request.ErrInvalidParams{Context: "DeleteAliasInput"}
+	if s.AliasName == nil {
+		invalidParams.Add(request.NewErrParamRequired("AliasName"))
+	}
+	if s.AliasName != nil && len(*s.AliasName) < 1 {
+		invalidParams.Add(request.NewErrParamMinLen("AliasName", 1))
+	}
+
+	if invalidParams.Len() > 0 {
+		return invalidParams
+	}
+	return nil
 }
 
 type DeleteAliasOutput struct {
@@ -1378,6 +1489,22 @@ func (s DescribeKeyInput) GoString() string {
 	return s.String()
 }
 
+// Validate inspects the fields of the type to determine if they are valid.
+func (s *DescribeKeyInput) Validate() error {
+	invalidParams := request.ErrInvalidParams{Context: "DescribeKeyInput"}
+	if s.KeyId == nil {
+		invalidParams.Add(request.NewErrParamRequired("KeyId"))
+	}
+	if s.KeyId != nil && len(*s.KeyId) < 1 {
+		invalidParams.Add(request.NewErrParamMinLen("KeyId", 1))
+	}
+
+	if invalidParams.Len() > 0 {
+		return invalidParams
+	}
+	return nil
+}
+
 type DescribeKeyOutput struct {
 	_ struct{} `type:"structure"`
 
@@ -1415,6 +1542,22 @@ func (s DisableKeyInput) GoString() string {
 	return s.String()
 }
 
+// Validate inspects the fields of the type to determine if they are valid.
+func (s *DisableKeyInput) Validate() error {
+	invalidParams := request.ErrInvalidParams{Context: "DisableKeyInput"}
+	if s.KeyId == nil {
+		invalidParams.Add(request.NewErrParamRequired("KeyId"))
+	}
+	if s.KeyId != nil && len(*s.KeyId) < 1 {
+		invalidParams.Add(request.NewErrParamMinLen("KeyId", 1))
+	}
+
+	if invalidParams.Len() > 0 {
+		return invalidParams
+	}
+	return nil
+}
+
 type DisableKeyOutput struct {
 	_ struct{} `type:"structure"`
 }
@@ -1447,6 +1590,22 @@ func (s DisableKeyRotationInput) String() string {
 // GoString returns the string representation
 func (s DisableKeyRotationInput) GoString() string {
 	return s.String()
+}
+
+// Validate inspects the fields of the type to determine if they are valid.
+func (s *DisableKeyRotationInput) Validate() error {
+	invalidParams := request.ErrInvalidParams{Context: "DisableKeyRotationInput"}
+	if s.KeyId == nil {
+		invalidParams.Add(request.NewErrParamRequired("KeyId"))
+	}
+	if s.KeyId != nil && len(*s.KeyId) < 1 {
+		invalidParams.Add(request.NewErrParamMinLen("KeyId", 1))
+	}
+
+	if invalidParams.Len() > 0 {
+		return invalidParams
+	}
+	return nil
 }
 
 type DisableKeyRotationOutput struct {
@@ -1483,6 +1642,22 @@ func (s EnableKeyInput) GoString() string {
 	return s.String()
 }
 
+// Validate inspects the fields of the type to determine if they are valid.
+func (s *EnableKeyInput) Validate() error {
+	invalidParams := request.ErrInvalidParams{Context: "EnableKeyInput"}
+	if s.KeyId == nil {
+		invalidParams.Add(request.NewErrParamRequired("KeyId"))
+	}
+	if s.KeyId != nil && len(*s.KeyId) < 1 {
+		invalidParams.Add(request.NewErrParamMinLen("KeyId", 1))
+	}
+
+	if invalidParams.Len() > 0 {
+		return invalidParams
+	}
+	return nil
+}
+
 type EnableKeyOutput struct {
 	_ struct{} `type:"structure"`
 }
@@ -1515,6 +1690,22 @@ func (s EnableKeyRotationInput) String() string {
 // GoString returns the string representation
 func (s EnableKeyRotationInput) GoString() string {
 	return s.String()
+}
+
+// Validate inspects the fields of the type to determine if they are valid.
+func (s *EnableKeyRotationInput) Validate() error {
+	invalidParams := request.ErrInvalidParams{Context: "EnableKeyRotationInput"}
+	if s.KeyId == nil {
+		invalidParams.Add(request.NewErrParamRequired("KeyId"))
+	}
+	if s.KeyId != nil && len(*s.KeyId) < 1 {
+		invalidParams.Add(request.NewErrParamMinLen("KeyId", 1))
+	}
+
+	if invalidParams.Len() > 0 {
+		return invalidParams
+	}
+	return nil
 }
 
 type EnableKeyRotationOutput struct {
@@ -1568,6 +1759,28 @@ func (s EncryptInput) String() string {
 // GoString returns the string representation
 func (s EncryptInput) GoString() string {
 	return s.String()
+}
+
+// Validate inspects the fields of the type to determine if they are valid.
+func (s *EncryptInput) Validate() error {
+	invalidParams := request.ErrInvalidParams{Context: "EncryptInput"}
+	if s.KeyId == nil {
+		invalidParams.Add(request.NewErrParamRequired("KeyId"))
+	}
+	if s.KeyId != nil && len(*s.KeyId) < 1 {
+		invalidParams.Add(request.NewErrParamMinLen("KeyId", 1))
+	}
+	if s.Plaintext == nil {
+		invalidParams.Add(request.NewErrParamRequired("Plaintext"))
+	}
+	if s.Plaintext != nil && len(s.Plaintext) < 1 {
+		invalidParams.Add(request.NewErrParamMinLen("Plaintext", 1))
+	}
+
+	if invalidParams.Len() > 0 {
+		return invalidParams
+	}
+	return nil
 }
 
 type EncryptOutput struct {
@@ -1633,6 +1846,25 @@ func (s GenerateDataKeyInput) String() string {
 // GoString returns the string representation
 func (s GenerateDataKeyInput) GoString() string {
 	return s.String()
+}
+
+// Validate inspects the fields of the type to determine if they are valid.
+func (s *GenerateDataKeyInput) Validate() error {
+	invalidParams := request.ErrInvalidParams{Context: "GenerateDataKeyInput"}
+	if s.KeyId == nil {
+		invalidParams.Add(request.NewErrParamRequired("KeyId"))
+	}
+	if s.KeyId != nil && len(*s.KeyId) < 1 {
+		invalidParams.Add(request.NewErrParamMinLen("KeyId", 1))
+	}
+	if s.NumberOfBytes != nil && *s.NumberOfBytes < 1 {
+		invalidParams.Add(request.NewErrParamMinValue("NumberOfBytes", 1))
+	}
+
+	if invalidParams.Len() > 0 {
+		return invalidParams
+	}
+	return nil
 }
 
 type GenerateDataKeyOutput struct {
@@ -1712,6 +1944,25 @@ func (s GenerateDataKeyWithoutPlaintextInput) GoString() string {
 	return s.String()
 }
 
+// Validate inspects the fields of the type to determine if they are valid.
+func (s *GenerateDataKeyWithoutPlaintextInput) Validate() error {
+	invalidParams := request.ErrInvalidParams{Context: "GenerateDataKeyWithoutPlaintextInput"}
+	if s.KeyId == nil {
+		invalidParams.Add(request.NewErrParamRequired("KeyId"))
+	}
+	if s.KeyId != nil && len(*s.KeyId) < 1 {
+		invalidParams.Add(request.NewErrParamMinLen("KeyId", 1))
+	}
+	if s.NumberOfBytes != nil && *s.NumberOfBytes < 1 {
+		invalidParams.Add(request.NewErrParamMinValue("NumberOfBytes", 1))
+	}
+
+	if invalidParams.Len() > 0 {
+		return invalidParams
+	}
+	return nil
+}
+
 type GenerateDataKeyWithoutPlaintextOutput struct {
 	_ struct{} `type:"structure"`
 
@@ -1757,6 +2008,19 @@ func (s GenerateRandomInput) GoString() string {
 	return s.String()
 }
 
+// Validate inspects the fields of the type to determine if they are valid.
+func (s *GenerateRandomInput) Validate() error {
+	invalidParams := request.ErrInvalidParams{Context: "GenerateRandomInput"}
+	if s.NumberOfBytes != nil && *s.NumberOfBytes < 1 {
+		invalidParams.Add(request.NewErrParamMinValue("NumberOfBytes", 1))
+	}
+
+	if invalidParams.Len() > 0 {
+		return invalidParams
+	}
+	return nil
+}
+
 type GenerateRandomOutput struct {
 	_ struct{} `type:"structure"`
 
@@ -1800,6 +2064,28 @@ func (s GetKeyPolicyInput) GoString() string {
 	return s.String()
 }
 
+// Validate inspects the fields of the type to determine if they are valid.
+func (s *GetKeyPolicyInput) Validate() error {
+	invalidParams := request.ErrInvalidParams{Context: "GetKeyPolicyInput"}
+	if s.KeyId == nil {
+		invalidParams.Add(request.NewErrParamRequired("KeyId"))
+	}
+	if s.KeyId != nil && len(*s.KeyId) < 1 {
+		invalidParams.Add(request.NewErrParamMinLen("KeyId", 1))
+	}
+	if s.PolicyName == nil {
+		invalidParams.Add(request.NewErrParamRequired("PolicyName"))
+	}
+	if s.PolicyName != nil && len(*s.PolicyName) < 1 {
+		invalidParams.Add(request.NewErrParamMinLen("PolicyName", 1))
+	}
+
+	if invalidParams.Len() > 0 {
+		return invalidParams
+	}
+	return nil
+}
+
 type GetKeyPolicyOutput struct {
 	_ struct{} `type:"structure"`
 
@@ -1835,6 +2121,22 @@ func (s GetKeyRotationStatusInput) String() string {
 // GoString returns the string representation
 func (s GetKeyRotationStatusInput) GoString() string {
 	return s.String()
+}
+
+// Validate inspects the fields of the type to determine if they are valid.
+func (s *GetKeyRotationStatusInput) Validate() error {
+	invalidParams := request.ErrInvalidParams{Context: "GetKeyRotationStatusInput"}
+	if s.KeyId == nil {
+		invalidParams.Add(request.NewErrParamRequired("KeyId"))
+	}
+	if s.KeyId != nil && len(*s.KeyId) < 1 {
+		invalidParams.Add(request.NewErrParamMinLen("KeyId", 1))
+	}
+
+	if invalidParams.Len() > 0 {
+		return invalidParams
+	}
+	return nil
 }
 
 type GetKeyRotationStatusOutput struct {
@@ -2037,6 +2339,22 @@ func (s ListAliasesInput) GoString() string {
 	return s.String()
 }
 
+// Validate inspects the fields of the type to determine if they are valid.
+func (s *ListAliasesInput) Validate() error {
+	invalidParams := request.ErrInvalidParams{Context: "ListAliasesInput"}
+	if s.Limit != nil && *s.Limit < 1 {
+		invalidParams.Add(request.NewErrParamMinValue("Limit", 1))
+	}
+	if s.Marker != nil && len(*s.Marker) < 1 {
+		invalidParams.Add(request.NewErrParamMinLen("Marker", 1))
+	}
+
+	if invalidParams.Len() > 0 {
+		return invalidParams
+	}
+	return nil
+}
+
 type ListAliasesOutput struct {
 	_ struct{} `type:"structure"`
 
@@ -2094,6 +2412,28 @@ func (s ListGrantsInput) String() string {
 // GoString returns the string representation
 func (s ListGrantsInput) GoString() string {
 	return s.String()
+}
+
+// Validate inspects the fields of the type to determine if they are valid.
+func (s *ListGrantsInput) Validate() error {
+	invalidParams := request.ErrInvalidParams{Context: "ListGrantsInput"}
+	if s.KeyId == nil {
+		invalidParams.Add(request.NewErrParamRequired("KeyId"))
+	}
+	if s.KeyId != nil && len(*s.KeyId) < 1 {
+		invalidParams.Add(request.NewErrParamMinLen("KeyId", 1))
+	}
+	if s.Limit != nil && *s.Limit < 1 {
+		invalidParams.Add(request.NewErrParamMinValue("Limit", 1))
+	}
+	if s.Marker != nil && len(*s.Marker) < 1 {
+		invalidParams.Add(request.NewErrParamMinLen("Marker", 1))
+	}
+
+	if invalidParams.Len() > 0 {
+		return invalidParams
+	}
+	return nil
 }
 
 type ListGrantsResponse struct {
@@ -2159,6 +2499,28 @@ func (s ListKeyPoliciesInput) GoString() string {
 	return s.String()
 }
 
+// Validate inspects the fields of the type to determine if they are valid.
+func (s *ListKeyPoliciesInput) Validate() error {
+	invalidParams := request.ErrInvalidParams{Context: "ListKeyPoliciesInput"}
+	if s.KeyId == nil {
+		invalidParams.Add(request.NewErrParamRequired("KeyId"))
+	}
+	if s.KeyId != nil && len(*s.KeyId) < 1 {
+		invalidParams.Add(request.NewErrParamMinLen("KeyId", 1))
+	}
+	if s.Limit != nil && *s.Limit < 1 {
+		invalidParams.Add(request.NewErrParamMinValue("Limit", 1))
+	}
+	if s.Marker != nil && len(*s.Marker) < 1 {
+		invalidParams.Add(request.NewErrParamMinLen("Marker", 1))
+	}
+
+	if invalidParams.Len() > 0 {
+		return invalidParams
+	}
+	return nil
+}
+
 type ListKeyPoliciesOutput struct {
 	_ struct{} `type:"structure"`
 
@@ -2211,6 +2573,22 @@ func (s ListKeysInput) String() string {
 // GoString returns the string representation
 func (s ListKeysInput) GoString() string {
 	return s.String()
+}
+
+// Validate inspects the fields of the type to determine if they are valid.
+func (s *ListKeysInput) Validate() error {
+	invalidParams := request.ErrInvalidParams{Context: "ListKeysInput"}
+	if s.Limit != nil && *s.Limit < 1 {
+		invalidParams.Add(request.NewErrParamMinValue("Limit", 1))
+	}
+	if s.Marker != nil && len(*s.Marker) < 1 {
+		invalidParams.Add(request.NewErrParamMinLen("Marker", 1))
+	}
+
+	if invalidParams.Len() > 0 {
+		return invalidParams
+	}
+	return nil
 }
 
 type ListKeysOutput struct {
@@ -2276,6 +2654,28 @@ func (s ListRetirableGrantsInput) GoString() string {
 	return s.String()
 }
 
+// Validate inspects the fields of the type to determine if they are valid.
+func (s *ListRetirableGrantsInput) Validate() error {
+	invalidParams := request.ErrInvalidParams{Context: "ListRetirableGrantsInput"}
+	if s.Limit != nil && *s.Limit < 1 {
+		invalidParams.Add(request.NewErrParamMinValue("Limit", 1))
+	}
+	if s.Marker != nil && len(*s.Marker) < 1 {
+		invalidParams.Add(request.NewErrParamMinLen("Marker", 1))
+	}
+	if s.RetiringPrincipal == nil {
+		invalidParams.Add(request.NewErrParamRequired("RetiringPrincipal"))
+	}
+	if s.RetiringPrincipal != nil && len(*s.RetiringPrincipal) < 1 {
+		invalidParams.Add(request.NewErrParamMinLen("RetiringPrincipal", 1))
+	}
+
+	if invalidParams.Len() > 0 {
+		return invalidParams
+	}
+	return nil
+}
+
 type PutKeyPolicyInput struct {
 	_ struct{} `type:"structure"`
 
@@ -2303,6 +2703,34 @@ func (s PutKeyPolicyInput) String() string {
 // GoString returns the string representation
 func (s PutKeyPolicyInput) GoString() string {
 	return s.String()
+}
+
+// Validate inspects the fields of the type to determine if they are valid.
+func (s *PutKeyPolicyInput) Validate() error {
+	invalidParams := request.ErrInvalidParams{Context: "PutKeyPolicyInput"}
+	if s.KeyId == nil {
+		invalidParams.Add(request.NewErrParamRequired("KeyId"))
+	}
+	if s.KeyId != nil && len(*s.KeyId) < 1 {
+		invalidParams.Add(request.NewErrParamMinLen("KeyId", 1))
+	}
+	if s.Policy == nil {
+		invalidParams.Add(request.NewErrParamRequired("Policy"))
+	}
+	if s.Policy != nil && len(*s.Policy) < 1 {
+		invalidParams.Add(request.NewErrParamMinLen("Policy", 1))
+	}
+	if s.PolicyName == nil {
+		invalidParams.Add(request.NewErrParamRequired("PolicyName"))
+	}
+	if s.PolicyName != nil && len(*s.PolicyName) < 1 {
+		invalidParams.Add(request.NewErrParamMinLen("PolicyName", 1))
+	}
+
+	if invalidParams.Len() > 0 {
+		return invalidParams
+	}
+	return nil
 }
 
 type PutKeyPolicyOutput struct {
@@ -2360,6 +2788,28 @@ func (s ReEncryptInput) GoString() string {
 	return s.String()
 }
 
+// Validate inspects the fields of the type to determine if they are valid.
+func (s *ReEncryptInput) Validate() error {
+	invalidParams := request.ErrInvalidParams{Context: "ReEncryptInput"}
+	if s.CiphertextBlob == nil {
+		invalidParams.Add(request.NewErrParamRequired("CiphertextBlob"))
+	}
+	if s.CiphertextBlob != nil && len(s.CiphertextBlob) < 1 {
+		invalidParams.Add(request.NewErrParamMinLen("CiphertextBlob", 1))
+	}
+	if s.DestinationKeyId == nil {
+		invalidParams.Add(request.NewErrParamRequired("DestinationKeyId"))
+	}
+	if s.DestinationKeyId != nil && len(*s.DestinationKeyId) < 1 {
+		invalidParams.Add(request.NewErrParamMinLen("DestinationKeyId", 1))
+	}
+
+	if invalidParams.Len() > 0 {
+		return invalidParams
+	}
+	return nil
+}
+
 type ReEncryptOutput struct {
 	_ struct{} `type:"structure"`
 
@@ -2413,6 +2863,25 @@ func (s RetireGrantInput) GoString() string {
 	return s.String()
 }
 
+// Validate inspects the fields of the type to determine if they are valid.
+func (s *RetireGrantInput) Validate() error {
+	invalidParams := request.ErrInvalidParams{Context: "RetireGrantInput"}
+	if s.GrantId != nil && len(*s.GrantId) < 1 {
+		invalidParams.Add(request.NewErrParamMinLen("GrantId", 1))
+	}
+	if s.GrantToken != nil && len(*s.GrantToken) < 1 {
+		invalidParams.Add(request.NewErrParamMinLen("GrantToken", 1))
+	}
+	if s.KeyId != nil && len(*s.KeyId) < 1 {
+		invalidParams.Add(request.NewErrParamMinLen("KeyId", 1))
+	}
+
+	if invalidParams.Len() > 0 {
+		return invalidParams
+	}
+	return nil
+}
+
 type RetireGrantOutput struct {
 	_ struct{} `type:"structure"`
 }
@@ -2448,6 +2917,28 @@ func (s RevokeGrantInput) String() string {
 // GoString returns the string representation
 func (s RevokeGrantInput) GoString() string {
 	return s.String()
+}
+
+// Validate inspects the fields of the type to determine if they are valid.
+func (s *RevokeGrantInput) Validate() error {
+	invalidParams := request.ErrInvalidParams{Context: "RevokeGrantInput"}
+	if s.GrantId == nil {
+		invalidParams.Add(request.NewErrParamRequired("GrantId"))
+	}
+	if s.GrantId != nil && len(*s.GrantId) < 1 {
+		invalidParams.Add(request.NewErrParamMinLen("GrantId", 1))
+	}
+	if s.KeyId == nil {
+		invalidParams.Add(request.NewErrParamRequired("KeyId"))
+	}
+	if s.KeyId != nil && len(*s.KeyId) < 1 {
+		invalidParams.Add(request.NewErrParamMinLen("KeyId", 1))
+	}
+
+	if invalidParams.Len() > 0 {
+		return invalidParams
+	}
+	return nil
 }
 
 type RevokeGrantOutput struct {
@@ -2494,6 +2985,25 @@ func (s ScheduleKeyDeletionInput) String() string {
 // GoString returns the string representation
 func (s ScheduleKeyDeletionInput) GoString() string {
 	return s.String()
+}
+
+// Validate inspects the fields of the type to determine if they are valid.
+func (s *ScheduleKeyDeletionInput) Validate() error {
+	invalidParams := request.ErrInvalidParams{Context: "ScheduleKeyDeletionInput"}
+	if s.KeyId == nil {
+		invalidParams.Add(request.NewErrParamRequired("KeyId"))
+	}
+	if s.KeyId != nil && len(*s.KeyId) < 1 {
+		invalidParams.Add(request.NewErrParamMinLen("KeyId", 1))
+	}
+	if s.PendingWindowInDays != nil && *s.PendingWindowInDays < 1 {
+		invalidParams.Add(request.NewErrParamMinValue("PendingWindowInDays", 1))
+	}
+
+	if invalidParams.Len() > 0 {
+		return invalidParams
+	}
+	return nil
 }
 
 type ScheduleKeyDeletionOutput struct {
@@ -2545,6 +3055,28 @@ func (s UpdateAliasInput) GoString() string {
 	return s.String()
 }
 
+// Validate inspects the fields of the type to determine if they are valid.
+func (s *UpdateAliasInput) Validate() error {
+	invalidParams := request.ErrInvalidParams{Context: "UpdateAliasInput"}
+	if s.AliasName == nil {
+		invalidParams.Add(request.NewErrParamRequired("AliasName"))
+	}
+	if s.AliasName != nil && len(*s.AliasName) < 1 {
+		invalidParams.Add(request.NewErrParamMinLen("AliasName", 1))
+	}
+	if s.TargetKeyId == nil {
+		invalidParams.Add(request.NewErrParamRequired("TargetKeyId"))
+	}
+	if s.TargetKeyId != nil && len(*s.TargetKeyId) < 1 {
+		invalidParams.Add(request.NewErrParamMinLen("TargetKeyId", 1))
+	}
+
+	if invalidParams.Len() > 0 {
+		return invalidParams
+	}
+	return nil
+}
+
 type UpdateAliasOutput struct {
 	_ struct{} `type:"structure"`
 }
@@ -2580,6 +3112,25 @@ func (s UpdateKeyDescriptionInput) String() string {
 // GoString returns the string representation
 func (s UpdateKeyDescriptionInput) GoString() string {
 	return s.String()
+}
+
+// Validate inspects the fields of the type to determine if they are valid.
+func (s *UpdateKeyDescriptionInput) Validate() error {
+	invalidParams := request.ErrInvalidParams{Context: "UpdateKeyDescriptionInput"}
+	if s.Description == nil {
+		invalidParams.Add(request.NewErrParamRequired("Description"))
+	}
+	if s.KeyId == nil {
+		invalidParams.Add(request.NewErrParamRequired("KeyId"))
+	}
+	if s.KeyId != nil && len(*s.KeyId) < 1 {
+		invalidParams.Add(request.NewErrParamMinLen("KeyId", 1))
+	}
+
+	if invalidParams.Len() > 0 {
+		return invalidParams
+	}
+	return nil
 }
 
 type UpdateKeyDescriptionOutput struct {

--- a/service/lambda/api.go
+++ b/service/lambda/api.go
@@ -983,6 +983,37 @@ func (s AddPermissionInput) GoString() string {
 	return s.String()
 }
 
+// Validate inspects the fields of the type to determine if they are valid.
+func (s *AddPermissionInput) Validate() error {
+	invalidParams := request.ErrInvalidParams{Context: "AddPermissionInput"}
+	if s.Action == nil {
+		invalidParams.Add(request.NewErrParamRequired("Action"))
+	}
+	if s.FunctionName == nil {
+		invalidParams.Add(request.NewErrParamRequired("FunctionName"))
+	}
+	if s.FunctionName != nil && len(*s.FunctionName) < 1 {
+		invalidParams.Add(request.NewErrParamMinLen("FunctionName", 1))
+	}
+	if s.Principal == nil {
+		invalidParams.Add(request.NewErrParamRequired("Principal"))
+	}
+	if s.Qualifier != nil && len(*s.Qualifier) < 1 {
+		invalidParams.Add(request.NewErrParamMinLen("Qualifier", 1))
+	}
+	if s.StatementId == nil {
+		invalidParams.Add(request.NewErrParamRequired("StatementId"))
+	}
+	if s.StatementId != nil && len(*s.StatementId) < 1 {
+		invalidParams.Add(request.NewErrParamMinLen("StatementId", 1))
+	}
+
+	if invalidParams.Len() > 0 {
+		return invalidParams
+	}
+	return nil
+}
+
 type AddPermissionOutput struct {
 	_ struct{} `type:"structure"`
 
@@ -1057,6 +1088,34 @@ func (s CreateAliasInput) GoString() string {
 	return s.String()
 }
 
+// Validate inspects the fields of the type to determine if they are valid.
+func (s *CreateAliasInput) Validate() error {
+	invalidParams := request.ErrInvalidParams{Context: "CreateAliasInput"}
+	if s.FunctionName == nil {
+		invalidParams.Add(request.NewErrParamRequired("FunctionName"))
+	}
+	if s.FunctionName != nil && len(*s.FunctionName) < 1 {
+		invalidParams.Add(request.NewErrParamMinLen("FunctionName", 1))
+	}
+	if s.FunctionVersion == nil {
+		invalidParams.Add(request.NewErrParamRequired("FunctionVersion"))
+	}
+	if s.FunctionVersion != nil && len(*s.FunctionVersion) < 1 {
+		invalidParams.Add(request.NewErrParamMinLen("FunctionVersion", 1))
+	}
+	if s.Name == nil {
+		invalidParams.Add(request.NewErrParamRequired("Name"))
+	}
+	if s.Name != nil && len(*s.Name) < 1 {
+		invalidParams.Add(request.NewErrParamMinLen("Name", 1))
+	}
+
+	if invalidParams.Len() > 0 {
+		return invalidParams
+	}
+	return nil
+}
+
 type CreateEventSourceMappingInput struct {
 	_ struct{} `type:"structure"`
 
@@ -1107,6 +1166,31 @@ func (s CreateEventSourceMappingInput) String() string {
 // GoString returns the string representation
 func (s CreateEventSourceMappingInput) GoString() string {
 	return s.String()
+}
+
+// Validate inspects the fields of the type to determine if they are valid.
+func (s *CreateEventSourceMappingInput) Validate() error {
+	invalidParams := request.ErrInvalidParams{Context: "CreateEventSourceMappingInput"}
+	if s.BatchSize != nil && *s.BatchSize < 1 {
+		invalidParams.Add(request.NewErrParamMinValue("BatchSize", 1))
+	}
+	if s.EventSourceArn == nil {
+		invalidParams.Add(request.NewErrParamRequired("EventSourceArn"))
+	}
+	if s.FunctionName == nil {
+		invalidParams.Add(request.NewErrParamRequired("FunctionName"))
+	}
+	if s.FunctionName != nil && len(*s.FunctionName) < 1 {
+		invalidParams.Add(request.NewErrParamMinLen("FunctionName", 1))
+	}
+	if s.StartingPosition == nil {
+		invalidParams.Add(request.NewErrParamRequired("StartingPosition"))
+	}
+
+	if invalidParams.Len() > 0 {
+		return invalidParams
+	}
+	return nil
 }
 
 type CreateFunctionInput struct {
@@ -1172,6 +1256,45 @@ func (s CreateFunctionInput) GoString() string {
 	return s.String()
 }
 
+// Validate inspects the fields of the type to determine if they are valid.
+func (s *CreateFunctionInput) Validate() error {
+	invalidParams := request.ErrInvalidParams{Context: "CreateFunctionInput"}
+	if s.Code == nil {
+		invalidParams.Add(request.NewErrParamRequired("Code"))
+	}
+	if s.FunctionName == nil {
+		invalidParams.Add(request.NewErrParamRequired("FunctionName"))
+	}
+	if s.FunctionName != nil && len(*s.FunctionName) < 1 {
+		invalidParams.Add(request.NewErrParamMinLen("FunctionName", 1))
+	}
+	if s.Handler == nil {
+		invalidParams.Add(request.NewErrParamRequired("Handler"))
+	}
+	if s.MemorySize != nil && *s.MemorySize < 128 {
+		invalidParams.Add(request.NewErrParamMinValue("MemorySize", 128))
+	}
+	if s.Role == nil {
+		invalidParams.Add(request.NewErrParamRequired("Role"))
+	}
+	if s.Runtime == nil {
+		invalidParams.Add(request.NewErrParamRequired("Runtime"))
+	}
+	if s.Timeout != nil && *s.Timeout < 1 {
+		invalidParams.Add(request.NewErrParamMinValue("Timeout", 1))
+	}
+	if s.Code != nil {
+		if err := s.Code.Validate(); err != nil {
+			invalidParams.AddNested("Code", err.(request.ErrInvalidParams))
+		}
+	}
+
+	if invalidParams.Len() > 0 {
+		return invalidParams
+	}
+	return nil
+}
+
 type DeleteAliasInput struct {
 	_ struct{} `type:"structure"`
 
@@ -1191,6 +1314,28 @@ func (s DeleteAliasInput) String() string {
 // GoString returns the string representation
 func (s DeleteAliasInput) GoString() string {
 	return s.String()
+}
+
+// Validate inspects the fields of the type to determine if they are valid.
+func (s *DeleteAliasInput) Validate() error {
+	invalidParams := request.ErrInvalidParams{Context: "DeleteAliasInput"}
+	if s.FunctionName == nil {
+		invalidParams.Add(request.NewErrParamRequired("FunctionName"))
+	}
+	if s.FunctionName != nil && len(*s.FunctionName) < 1 {
+		invalidParams.Add(request.NewErrParamMinLen("FunctionName", 1))
+	}
+	if s.Name == nil {
+		invalidParams.Add(request.NewErrParamRequired("Name"))
+	}
+	if s.Name != nil && len(*s.Name) < 1 {
+		invalidParams.Add(request.NewErrParamMinLen("Name", 1))
+	}
+
+	if invalidParams.Len() > 0 {
+		return invalidParams
+	}
+	return nil
 }
 
 type DeleteAliasOutput struct {
@@ -1222,6 +1367,19 @@ func (s DeleteEventSourceMappingInput) String() string {
 // GoString returns the string representation
 func (s DeleteEventSourceMappingInput) GoString() string {
 	return s.String()
+}
+
+// Validate inspects the fields of the type to determine if they are valid.
+func (s *DeleteEventSourceMappingInput) Validate() error {
+	invalidParams := request.ErrInvalidParams{Context: "DeleteEventSourceMappingInput"}
+	if s.UUID == nil {
+		invalidParams.Add(request.NewErrParamRequired("UUID"))
+	}
+
+	if invalidParams.Len() > 0 {
+		return invalidParams
+	}
+	return nil
 }
 
 type DeleteFunctionInput struct {
@@ -1263,6 +1421,25 @@ func (s DeleteFunctionInput) String() string {
 // GoString returns the string representation
 func (s DeleteFunctionInput) GoString() string {
 	return s.String()
+}
+
+// Validate inspects the fields of the type to determine if they are valid.
+func (s *DeleteFunctionInput) Validate() error {
+	invalidParams := request.ErrInvalidParams{Context: "DeleteFunctionInput"}
+	if s.FunctionName == nil {
+		invalidParams.Add(request.NewErrParamRequired("FunctionName"))
+	}
+	if s.FunctionName != nil && len(*s.FunctionName) < 1 {
+		invalidParams.Add(request.NewErrParamMinLen("FunctionName", 1))
+	}
+	if s.Qualifier != nil && len(*s.Qualifier) < 1 {
+		invalidParams.Add(request.NewErrParamMinLen("Qualifier", 1))
+	}
+
+	if invalidParams.Len() > 0 {
+		return invalidParams
+	}
+	return nil
 }
 
 type DeleteFunctionOutput struct {
@@ -1356,6 +1533,25 @@ func (s FunctionCode) String() string {
 // GoString returns the string representation
 func (s FunctionCode) GoString() string {
 	return s.String()
+}
+
+// Validate inspects the fields of the type to determine if they are valid.
+func (s *FunctionCode) Validate() error {
+	invalidParams := request.ErrInvalidParams{Context: "FunctionCode"}
+	if s.S3Bucket != nil && len(*s.S3Bucket) < 3 {
+		invalidParams.Add(request.NewErrParamMinLen("S3Bucket", 3))
+	}
+	if s.S3Key != nil && len(*s.S3Key) < 1 {
+		invalidParams.Add(request.NewErrParamMinLen("S3Key", 1))
+	}
+	if s.S3ObjectVersion != nil && len(*s.S3ObjectVersion) < 1 {
+		invalidParams.Add(request.NewErrParamMinLen("S3ObjectVersion", 1))
+	}
+
+	if invalidParams.Len() > 0 {
+		return invalidParams
+	}
+	return nil
 }
 
 // The object for the Lambda function location.
@@ -1460,6 +1656,28 @@ func (s GetAliasInput) GoString() string {
 	return s.String()
 }
 
+// Validate inspects the fields of the type to determine if they are valid.
+func (s *GetAliasInput) Validate() error {
+	invalidParams := request.ErrInvalidParams{Context: "GetAliasInput"}
+	if s.FunctionName == nil {
+		invalidParams.Add(request.NewErrParamRequired("FunctionName"))
+	}
+	if s.FunctionName != nil && len(*s.FunctionName) < 1 {
+		invalidParams.Add(request.NewErrParamMinLen("FunctionName", 1))
+	}
+	if s.Name == nil {
+		invalidParams.Add(request.NewErrParamRequired("Name"))
+	}
+	if s.Name != nil && len(*s.Name) < 1 {
+		invalidParams.Add(request.NewErrParamMinLen("Name", 1))
+	}
+
+	if invalidParams.Len() > 0 {
+		return invalidParams
+	}
+	return nil
+}
+
 type GetEventSourceMappingInput struct {
 	_ struct{} `type:"structure"`
 
@@ -1475,6 +1693,19 @@ func (s GetEventSourceMappingInput) String() string {
 // GoString returns the string representation
 func (s GetEventSourceMappingInput) GoString() string {
 	return s.String()
+}
+
+// Validate inspects the fields of the type to determine if they are valid.
+func (s *GetEventSourceMappingInput) Validate() error {
+	invalidParams := request.ErrInvalidParams{Context: "GetEventSourceMappingInput"}
+	if s.UUID == nil {
+		invalidParams.Add(request.NewErrParamRequired("UUID"))
+	}
+
+	if invalidParams.Len() > 0 {
+		return invalidParams
+	}
+	return nil
 }
 
 type GetFunctionConfigurationInput struct {
@@ -1511,6 +1742,25 @@ func (s GetFunctionConfigurationInput) GoString() string {
 	return s.String()
 }
 
+// Validate inspects the fields of the type to determine if they are valid.
+func (s *GetFunctionConfigurationInput) Validate() error {
+	invalidParams := request.ErrInvalidParams{Context: "GetFunctionConfigurationInput"}
+	if s.FunctionName == nil {
+		invalidParams.Add(request.NewErrParamRequired("FunctionName"))
+	}
+	if s.FunctionName != nil && len(*s.FunctionName) < 1 {
+		invalidParams.Add(request.NewErrParamMinLen("FunctionName", 1))
+	}
+	if s.Qualifier != nil && len(*s.Qualifier) < 1 {
+		invalidParams.Add(request.NewErrParamMinLen("Qualifier", 1))
+	}
+
+	if invalidParams.Len() > 0 {
+		return invalidParams
+	}
+	return nil
+}
+
 type GetFunctionInput struct {
 	_ struct{} `type:"structure"`
 
@@ -1541,6 +1791,25 @@ func (s GetFunctionInput) String() string {
 // GoString returns the string representation
 func (s GetFunctionInput) GoString() string {
 	return s.String()
+}
+
+// Validate inspects the fields of the type to determine if they are valid.
+func (s *GetFunctionInput) Validate() error {
+	invalidParams := request.ErrInvalidParams{Context: "GetFunctionInput"}
+	if s.FunctionName == nil {
+		invalidParams.Add(request.NewErrParamRequired("FunctionName"))
+	}
+	if s.FunctionName != nil && len(*s.FunctionName) < 1 {
+		invalidParams.Add(request.NewErrParamMinLen("FunctionName", 1))
+	}
+	if s.Qualifier != nil && len(*s.Qualifier) < 1 {
+		invalidParams.Add(request.NewErrParamMinLen("Qualifier", 1))
+	}
+
+	if invalidParams.Len() > 0 {
+		return invalidParams
+	}
+	return nil
 }
 
 // This response contains the object for the Lambda function location (see API_FunctionCodeLocation.
@@ -1596,6 +1865,25 @@ func (s GetPolicyInput) GoString() string {
 	return s.String()
 }
 
+// Validate inspects the fields of the type to determine if they are valid.
+func (s *GetPolicyInput) Validate() error {
+	invalidParams := request.ErrInvalidParams{Context: "GetPolicyInput"}
+	if s.FunctionName == nil {
+		invalidParams.Add(request.NewErrParamRequired("FunctionName"))
+	}
+	if s.FunctionName != nil && len(*s.FunctionName) < 1 {
+		invalidParams.Add(request.NewErrParamMinLen("FunctionName", 1))
+	}
+	if s.Qualifier != nil && len(*s.Qualifier) < 1 {
+		invalidParams.Add(request.NewErrParamMinLen("Qualifier", 1))
+	}
+
+	if invalidParams.Len() > 0 {
+		return invalidParams
+	}
+	return nil
+}
+
 type GetPolicyOutput struct {
 	_ struct{} `type:"structure"`
 
@@ -1633,6 +1921,25 @@ func (s InvokeAsyncInput) String() string {
 // GoString returns the string representation
 func (s InvokeAsyncInput) GoString() string {
 	return s.String()
+}
+
+// Validate inspects the fields of the type to determine if they are valid.
+func (s *InvokeAsyncInput) Validate() error {
+	invalidParams := request.ErrInvalidParams{Context: "InvokeAsyncInput"}
+	if s.FunctionName == nil {
+		invalidParams.Add(request.NewErrParamRequired("FunctionName"))
+	}
+	if s.FunctionName != nil && len(*s.FunctionName) < 1 {
+		invalidParams.Add(request.NewErrParamMinLen("FunctionName", 1))
+	}
+	if s.InvokeArgs == nil {
+		invalidParams.Add(request.NewErrParamRequired("InvokeArgs"))
+	}
+
+	if invalidParams.Len() > 0 {
+		return invalidParams
+	}
+	return nil
 }
 
 // Upon success, it returns empty response. Otherwise, throws an exception.
@@ -1713,6 +2020,25 @@ func (s InvokeInput) GoString() string {
 	return s.String()
 }
 
+// Validate inspects the fields of the type to determine if they are valid.
+func (s *InvokeInput) Validate() error {
+	invalidParams := request.ErrInvalidParams{Context: "InvokeInput"}
+	if s.FunctionName == nil {
+		invalidParams.Add(request.NewErrParamRequired("FunctionName"))
+	}
+	if s.FunctionName != nil && len(*s.FunctionName) < 1 {
+		invalidParams.Add(request.NewErrParamMinLen("FunctionName", 1))
+	}
+	if s.Qualifier != nil && len(*s.Qualifier) < 1 {
+		invalidParams.Add(request.NewErrParamMinLen("Qualifier", 1))
+	}
+
+	if invalidParams.Len() > 0 {
+		return invalidParams
+	}
+	return nil
+}
+
 // Upon success, returns an empty response. Otherwise, throws an exception.
 type InvokeOutput struct {
 	_ struct{} `type:"structure" payload:"Payload"`
@@ -1785,6 +2111,28 @@ func (s ListAliasesInput) GoString() string {
 	return s.String()
 }
 
+// Validate inspects the fields of the type to determine if they are valid.
+func (s *ListAliasesInput) Validate() error {
+	invalidParams := request.ErrInvalidParams{Context: "ListAliasesInput"}
+	if s.FunctionName == nil {
+		invalidParams.Add(request.NewErrParamRequired("FunctionName"))
+	}
+	if s.FunctionName != nil && len(*s.FunctionName) < 1 {
+		invalidParams.Add(request.NewErrParamMinLen("FunctionName", 1))
+	}
+	if s.FunctionVersion != nil && len(*s.FunctionVersion) < 1 {
+		invalidParams.Add(request.NewErrParamMinLen("FunctionVersion", 1))
+	}
+	if s.MaxItems != nil && *s.MaxItems < 1 {
+		invalidParams.Add(request.NewErrParamMinValue("MaxItems", 1))
+	}
+
+	if invalidParams.Len() > 0 {
+		return invalidParams
+	}
+	return nil
+}
+
 type ListAliasesOutput struct {
 	_ struct{} `type:"structure"`
 
@@ -1843,6 +2191,22 @@ func (s ListEventSourceMappingsInput) GoString() string {
 	return s.String()
 }
 
+// Validate inspects the fields of the type to determine if they are valid.
+func (s *ListEventSourceMappingsInput) Validate() error {
+	invalidParams := request.ErrInvalidParams{Context: "ListEventSourceMappingsInput"}
+	if s.FunctionName != nil && len(*s.FunctionName) < 1 {
+		invalidParams.Add(request.NewErrParamMinLen("FunctionName", 1))
+	}
+	if s.MaxItems != nil && *s.MaxItems < 1 {
+		invalidParams.Add(request.NewErrParamMinValue("MaxItems", 1))
+	}
+
+	if invalidParams.Len() > 0 {
+		return invalidParams
+	}
+	return nil
+}
+
 // Contains a list of event sources (see API_EventSourceMappingConfiguration)
 type ListEventSourceMappingsOutput struct {
 	_ struct{} `type:"structure"`
@@ -1884,6 +2248,19 @@ func (s ListFunctionsInput) String() string {
 // GoString returns the string representation
 func (s ListFunctionsInput) GoString() string {
 	return s.String()
+}
+
+// Validate inspects the fields of the type to determine if they are valid.
+func (s *ListFunctionsInput) Validate() error {
+	invalidParams := request.ErrInvalidParams{Context: "ListFunctionsInput"}
+	if s.MaxItems != nil && *s.MaxItems < 1 {
+		invalidParams.Add(request.NewErrParamMinValue("MaxItems", 1))
+	}
+
+	if invalidParams.Len() > 0 {
+		return invalidParams
+	}
+	return nil
 }
 
 // Contains a list of AWS Lambda function configurations (see FunctionConfiguration.
@@ -1935,6 +2312,25 @@ func (s ListVersionsByFunctionInput) String() string {
 // GoString returns the string representation
 func (s ListVersionsByFunctionInput) GoString() string {
 	return s.String()
+}
+
+// Validate inspects the fields of the type to determine if they are valid.
+func (s *ListVersionsByFunctionInput) Validate() error {
+	invalidParams := request.ErrInvalidParams{Context: "ListVersionsByFunctionInput"}
+	if s.FunctionName == nil {
+		invalidParams.Add(request.NewErrParamRequired("FunctionName"))
+	}
+	if s.FunctionName != nil && len(*s.FunctionName) < 1 {
+		invalidParams.Add(request.NewErrParamMinLen("FunctionName", 1))
+	}
+	if s.MaxItems != nil && *s.MaxItems < 1 {
+		invalidParams.Add(request.NewErrParamMinValue("MaxItems", 1))
+	}
+
+	if invalidParams.Len() > 0 {
+		return invalidParams
+	}
+	return nil
 }
 
 type ListVersionsByFunctionOutput struct {
@@ -1989,6 +2385,22 @@ func (s PublishVersionInput) GoString() string {
 	return s.String()
 }
 
+// Validate inspects the fields of the type to determine if they are valid.
+func (s *PublishVersionInput) Validate() error {
+	invalidParams := request.ErrInvalidParams{Context: "PublishVersionInput"}
+	if s.FunctionName == nil {
+		invalidParams.Add(request.NewErrParamRequired("FunctionName"))
+	}
+	if s.FunctionName != nil && len(*s.FunctionName) < 1 {
+		invalidParams.Add(request.NewErrParamMinLen("FunctionName", 1))
+	}
+
+	if invalidParams.Len() > 0 {
+		return invalidParams
+	}
+	return nil
+}
+
 type RemovePermissionInput struct {
 	_ struct{} `type:"structure"`
 
@@ -2019,6 +2431,31 @@ func (s RemovePermissionInput) String() string {
 // GoString returns the string representation
 func (s RemovePermissionInput) GoString() string {
 	return s.String()
+}
+
+// Validate inspects the fields of the type to determine if they are valid.
+func (s *RemovePermissionInput) Validate() error {
+	invalidParams := request.ErrInvalidParams{Context: "RemovePermissionInput"}
+	if s.FunctionName == nil {
+		invalidParams.Add(request.NewErrParamRequired("FunctionName"))
+	}
+	if s.FunctionName != nil && len(*s.FunctionName) < 1 {
+		invalidParams.Add(request.NewErrParamMinLen("FunctionName", 1))
+	}
+	if s.Qualifier != nil && len(*s.Qualifier) < 1 {
+		invalidParams.Add(request.NewErrParamMinLen("Qualifier", 1))
+	}
+	if s.StatementId == nil {
+		invalidParams.Add(request.NewErrParamRequired("StatementId"))
+	}
+	if s.StatementId != nil && len(*s.StatementId) < 1 {
+		invalidParams.Add(request.NewErrParamMinLen("StatementId", 1))
+	}
+
+	if invalidParams.Len() > 0 {
+		return invalidParams
+	}
+	return nil
 }
 
 type RemovePermissionOutput struct {
@@ -2062,6 +2499,31 @@ func (s UpdateAliasInput) GoString() string {
 	return s.String()
 }
 
+// Validate inspects the fields of the type to determine if they are valid.
+func (s *UpdateAliasInput) Validate() error {
+	invalidParams := request.ErrInvalidParams{Context: "UpdateAliasInput"}
+	if s.FunctionName == nil {
+		invalidParams.Add(request.NewErrParamRequired("FunctionName"))
+	}
+	if s.FunctionName != nil && len(*s.FunctionName) < 1 {
+		invalidParams.Add(request.NewErrParamMinLen("FunctionName", 1))
+	}
+	if s.FunctionVersion != nil && len(*s.FunctionVersion) < 1 {
+		invalidParams.Add(request.NewErrParamMinLen("FunctionVersion", 1))
+	}
+	if s.Name == nil {
+		invalidParams.Add(request.NewErrParamRequired("Name"))
+	}
+	if s.Name != nil && len(*s.Name) < 1 {
+		invalidParams.Add(request.NewErrParamMinLen("Name", 1))
+	}
+
+	if invalidParams.Len() > 0 {
+		return invalidParams
+	}
+	return nil
+}
+
 type UpdateEventSourceMappingInput struct {
 	_ struct{} `type:"structure"`
 
@@ -2100,6 +2562,25 @@ func (s UpdateEventSourceMappingInput) String() string {
 // GoString returns the string representation
 func (s UpdateEventSourceMappingInput) GoString() string {
 	return s.String()
+}
+
+// Validate inspects the fields of the type to determine if they are valid.
+func (s *UpdateEventSourceMappingInput) Validate() error {
+	invalidParams := request.ErrInvalidParams{Context: "UpdateEventSourceMappingInput"}
+	if s.BatchSize != nil && *s.BatchSize < 1 {
+		invalidParams.Add(request.NewErrParamMinValue("BatchSize", 1))
+	}
+	if s.FunctionName != nil && len(*s.FunctionName) < 1 {
+		invalidParams.Add(request.NewErrParamMinLen("FunctionName", 1))
+	}
+	if s.UUID == nil {
+		invalidParams.Add(request.NewErrParamRequired("UUID"))
+	}
+
+	if invalidParams.Len() > 0 {
+		return invalidParams
+	}
+	return nil
 }
 
 type UpdateFunctionCodeInput struct {
@@ -2143,6 +2624,31 @@ func (s UpdateFunctionCodeInput) String() string {
 // GoString returns the string representation
 func (s UpdateFunctionCodeInput) GoString() string {
 	return s.String()
+}
+
+// Validate inspects the fields of the type to determine if they are valid.
+func (s *UpdateFunctionCodeInput) Validate() error {
+	invalidParams := request.ErrInvalidParams{Context: "UpdateFunctionCodeInput"}
+	if s.FunctionName == nil {
+		invalidParams.Add(request.NewErrParamRequired("FunctionName"))
+	}
+	if s.FunctionName != nil && len(*s.FunctionName) < 1 {
+		invalidParams.Add(request.NewErrParamMinLen("FunctionName", 1))
+	}
+	if s.S3Bucket != nil && len(*s.S3Bucket) < 3 {
+		invalidParams.Add(request.NewErrParamMinLen("S3Bucket", 3))
+	}
+	if s.S3Key != nil && len(*s.S3Key) < 1 {
+		invalidParams.Add(request.NewErrParamMinLen("S3Key", 1))
+	}
+	if s.S3ObjectVersion != nil && len(*s.S3ObjectVersion) < 1 {
+		invalidParams.Add(request.NewErrParamMinLen("S3ObjectVersion", 1))
+	}
+
+	if invalidParams.Len() > 0 {
+		return invalidParams
+	}
+	return nil
 }
 
 type UpdateFunctionConfigurationInput struct {
@@ -2199,6 +2705,28 @@ func (s UpdateFunctionConfigurationInput) String() string {
 // GoString returns the string representation
 func (s UpdateFunctionConfigurationInput) GoString() string {
 	return s.String()
+}
+
+// Validate inspects the fields of the type to determine if they are valid.
+func (s *UpdateFunctionConfigurationInput) Validate() error {
+	invalidParams := request.ErrInvalidParams{Context: "UpdateFunctionConfigurationInput"}
+	if s.FunctionName == nil {
+		invalidParams.Add(request.NewErrParamRequired("FunctionName"))
+	}
+	if s.FunctionName != nil && len(*s.FunctionName) < 1 {
+		invalidParams.Add(request.NewErrParamMinLen("FunctionName", 1))
+	}
+	if s.MemorySize != nil && *s.MemorySize < 128 {
+		invalidParams.Add(request.NewErrParamMinValue("MemorySize", 128))
+	}
+	if s.Timeout != nil && *s.Timeout < 1 {
+		invalidParams.Add(request.NewErrParamMinValue("Timeout", 1))
+	}
+
+	if invalidParams.Len() > 0 {
+		return invalidParams
+	}
+	return nil
 }
 
 // If your Lambda function accesses resources in a VPC, you provide this parameter

--- a/service/machinelearning/api.go
+++ b/service/machinelearning/api.go
@@ -1009,6 +1009,37 @@ func (s CreateBatchPredictionInput) GoString() string {
 	return s.String()
 }
 
+// Validate inspects the fields of the type to determine if they are valid.
+func (s *CreateBatchPredictionInput) Validate() error {
+	invalidParams := request.ErrInvalidParams{Context: "CreateBatchPredictionInput"}
+	if s.BatchPredictionDataSourceId == nil {
+		invalidParams.Add(request.NewErrParamRequired("BatchPredictionDataSourceId"))
+	}
+	if s.BatchPredictionDataSourceId != nil && len(*s.BatchPredictionDataSourceId) < 1 {
+		invalidParams.Add(request.NewErrParamMinLen("BatchPredictionDataSourceId", 1))
+	}
+	if s.BatchPredictionId == nil {
+		invalidParams.Add(request.NewErrParamRequired("BatchPredictionId"))
+	}
+	if s.BatchPredictionId != nil && len(*s.BatchPredictionId) < 1 {
+		invalidParams.Add(request.NewErrParamMinLen("BatchPredictionId", 1))
+	}
+	if s.MLModelId == nil {
+		invalidParams.Add(request.NewErrParamRequired("MLModelId"))
+	}
+	if s.MLModelId != nil && len(*s.MLModelId) < 1 {
+		invalidParams.Add(request.NewErrParamMinLen("MLModelId", 1))
+	}
+	if s.OutputUri == nil {
+		invalidParams.Add(request.NewErrParamRequired("OutputUri"))
+	}
+
+	if invalidParams.Len() > 0 {
+		return invalidParams
+	}
+	return nil
+}
+
 // Represents the output of a CreateBatchPrediction operation, and is an acknowledgement
 // that Amazon ML received the request.
 //
@@ -1106,6 +1137,36 @@ func (s CreateDataSourceFromRDSInput) GoString() string {
 	return s.String()
 }
 
+// Validate inspects the fields of the type to determine if they are valid.
+func (s *CreateDataSourceFromRDSInput) Validate() error {
+	invalidParams := request.ErrInvalidParams{Context: "CreateDataSourceFromRDSInput"}
+	if s.DataSourceId == nil {
+		invalidParams.Add(request.NewErrParamRequired("DataSourceId"))
+	}
+	if s.DataSourceId != nil && len(*s.DataSourceId) < 1 {
+		invalidParams.Add(request.NewErrParamMinLen("DataSourceId", 1))
+	}
+	if s.RDSData == nil {
+		invalidParams.Add(request.NewErrParamRequired("RDSData"))
+	}
+	if s.RoleARN == nil {
+		invalidParams.Add(request.NewErrParamRequired("RoleARN"))
+	}
+	if s.RoleARN != nil && len(*s.RoleARN) < 1 {
+		invalidParams.Add(request.NewErrParamMinLen("RoleARN", 1))
+	}
+	if s.RDSData != nil {
+		if err := s.RDSData.Validate(); err != nil {
+			invalidParams.AddNested("RDSData", err.(request.ErrInvalidParams))
+		}
+	}
+
+	if invalidParams.Len() > 0 {
+		return invalidParams
+	}
+	return nil
+}
+
 // Represents the output of a CreateDataSourceFromRDS operation, and is an acknowledgement
 // that Amazon ML received the request.
 //
@@ -1195,6 +1256,36 @@ func (s CreateDataSourceFromRedshiftInput) GoString() string {
 	return s.String()
 }
 
+// Validate inspects the fields of the type to determine if they are valid.
+func (s *CreateDataSourceFromRedshiftInput) Validate() error {
+	invalidParams := request.ErrInvalidParams{Context: "CreateDataSourceFromRedshiftInput"}
+	if s.DataSourceId == nil {
+		invalidParams.Add(request.NewErrParamRequired("DataSourceId"))
+	}
+	if s.DataSourceId != nil && len(*s.DataSourceId) < 1 {
+		invalidParams.Add(request.NewErrParamMinLen("DataSourceId", 1))
+	}
+	if s.DataSpec == nil {
+		invalidParams.Add(request.NewErrParamRequired("DataSpec"))
+	}
+	if s.RoleARN == nil {
+		invalidParams.Add(request.NewErrParamRequired("RoleARN"))
+	}
+	if s.RoleARN != nil && len(*s.RoleARN) < 1 {
+		invalidParams.Add(request.NewErrParamMinLen("RoleARN", 1))
+	}
+	if s.DataSpec != nil {
+		if err := s.DataSpec.Validate(); err != nil {
+			invalidParams.AddNested("DataSpec", err.(request.ErrInvalidParams))
+		}
+	}
+
+	if invalidParams.Len() > 0 {
+		return invalidParams
+	}
+	return nil
+}
+
 // Represents the output of a CreateDataSourceFromRedshift operation, and is
 // an acknowledgement that Amazon ML received the request.
 //
@@ -1261,6 +1352,30 @@ func (s CreateDataSourceFromS3Input) GoString() string {
 	return s.String()
 }
 
+// Validate inspects the fields of the type to determine if they are valid.
+func (s *CreateDataSourceFromS3Input) Validate() error {
+	invalidParams := request.ErrInvalidParams{Context: "CreateDataSourceFromS3Input"}
+	if s.DataSourceId == nil {
+		invalidParams.Add(request.NewErrParamRequired("DataSourceId"))
+	}
+	if s.DataSourceId != nil && len(*s.DataSourceId) < 1 {
+		invalidParams.Add(request.NewErrParamMinLen("DataSourceId", 1))
+	}
+	if s.DataSpec == nil {
+		invalidParams.Add(request.NewErrParamRequired("DataSpec"))
+	}
+	if s.DataSpec != nil {
+		if err := s.DataSpec.Validate(); err != nil {
+			invalidParams.AddNested("DataSpec", err.(request.ErrInvalidParams))
+		}
+	}
+
+	if invalidParams.Len() > 0 {
+		return invalidParams
+	}
+	return nil
+}
+
 // Represents the output of a CreateDataSourceFromS3 operation, and is an acknowledgement
 // that Amazon ML received the request.
 //
@@ -1312,6 +1427,34 @@ func (s CreateEvaluationInput) String() string {
 // GoString returns the string representation
 func (s CreateEvaluationInput) GoString() string {
 	return s.String()
+}
+
+// Validate inspects the fields of the type to determine if they are valid.
+func (s *CreateEvaluationInput) Validate() error {
+	invalidParams := request.ErrInvalidParams{Context: "CreateEvaluationInput"}
+	if s.EvaluationDataSourceId == nil {
+		invalidParams.Add(request.NewErrParamRequired("EvaluationDataSourceId"))
+	}
+	if s.EvaluationDataSourceId != nil && len(*s.EvaluationDataSourceId) < 1 {
+		invalidParams.Add(request.NewErrParamMinLen("EvaluationDataSourceId", 1))
+	}
+	if s.EvaluationId == nil {
+		invalidParams.Add(request.NewErrParamRequired("EvaluationId"))
+	}
+	if s.EvaluationId != nil && len(*s.EvaluationId) < 1 {
+		invalidParams.Add(request.NewErrParamMinLen("EvaluationId", 1))
+	}
+	if s.MLModelId == nil {
+		invalidParams.Add(request.NewErrParamRequired("MLModelId"))
+	}
+	if s.MLModelId != nil && len(*s.MLModelId) < 1 {
+		invalidParams.Add(request.NewErrParamMinLen("MLModelId", 1))
+	}
+
+	if invalidParams.Len() > 0 {
+		return invalidParams
+	}
+	return nil
 }
 
 // Represents the output of a CreateEvaluation operation, and is an acknowledgement
@@ -1413,6 +1556,31 @@ func (s CreateMLModelInput) GoString() string {
 	return s.String()
 }
 
+// Validate inspects the fields of the type to determine if they are valid.
+func (s *CreateMLModelInput) Validate() error {
+	invalidParams := request.ErrInvalidParams{Context: "CreateMLModelInput"}
+	if s.MLModelId == nil {
+		invalidParams.Add(request.NewErrParamRequired("MLModelId"))
+	}
+	if s.MLModelId != nil && len(*s.MLModelId) < 1 {
+		invalidParams.Add(request.NewErrParamMinLen("MLModelId", 1))
+	}
+	if s.MLModelType == nil {
+		invalidParams.Add(request.NewErrParamRequired("MLModelType"))
+	}
+	if s.TrainingDataSourceId == nil {
+		invalidParams.Add(request.NewErrParamRequired("TrainingDataSourceId"))
+	}
+	if s.TrainingDataSourceId != nil && len(*s.TrainingDataSourceId) < 1 {
+		invalidParams.Add(request.NewErrParamMinLen("TrainingDataSourceId", 1))
+	}
+
+	if invalidParams.Len() > 0 {
+		return invalidParams
+	}
+	return nil
+}
+
 // Represents the output of a CreateMLModel operation, and is an acknowledgement
 // that Amazon ML received the request.
 //
@@ -1451,6 +1619,22 @@ func (s CreateRealtimeEndpointInput) String() string {
 // GoString returns the string representation
 func (s CreateRealtimeEndpointInput) GoString() string {
 	return s.String()
+}
+
+// Validate inspects the fields of the type to determine if they are valid.
+func (s *CreateRealtimeEndpointInput) Validate() error {
+	invalidParams := request.ErrInvalidParams{Context: "CreateRealtimeEndpointInput"}
+	if s.MLModelId == nil {
+		invalidParams.Add(request.NewErrParamRequired("MLModelId"))
+	}
+	if s.MLModelId != nil && len(*s.MLModelId) < 1 {
+		invalidParams.Add(request.NewErrParamMinLen("MLModelId", 1))
+	}
+
+	if invalidParams.Len() > 0 {
+		return invalidParams
+	}
+	return nil
 }
 
 // Represents the output of an CreateRealtimeEndpoint operation.
@@ -1575,6 +1759,22 @@ func (s DeleteBatchPredictionInput) GoString() string {
 	return s.String()
 }
 
+// Validate inspects the fields of the type to determine if they are valid.
+func (s *DeleteBatchPredictionInput) Validate() error {
+	invalidParams := request.ErrInvalidParams{Context: "DeleteBatchPredictionInput"}
+	if s.BatchPredictionId == nil {
+		invalidParams.Add(request.NewErrParamRequired("BatchPredictionId"))
+	}
+	if s.BatchPredictionId != nil && len(*s.BatchPredictionId) < 1 {
+		invalidParams.Add(request.NewErrParamMinLen("BatchPredictionId", 1))
+	}
+
+	if invalidParams.Len() > 0 {
+		return invalidParams
+	}
+	return nil
+}
+
 // Represents the output of a DeleteBatchPrediction operation.
 //
 // You can use the GetBatchPrediction operation and check the value of the
@@ -1614,6 +1814,22 @@ func (s DeleteDataSourceInput) GoString() string {
 	return s.String()
 }
 
+// Validate inspects the fields of the type to determine if they are valid.
+func (s *DeleteDataSourceInput) Validate() error {
+	invalidParams := request.ErrInvalidParams{Context: "DeleteDataSourceInput"}
+	if s.DataSourceId == nil {
+		invalidParams.Add(request.NewErrParamRequired("DataSourceId"))
+	}
+	if s.DataSourceId != nil && len(*s.DataSourceId) < 1 {
+		invalidParams.Add(request.NewErrParamMinLen("DataSourceId", 1))
+	}
+
+	if invalidParams.Len() > 0 {
+		return invalidParams
+	}
+	return nil
+}
+
 // Represents the output of a DeleteDataSource operation.
 type DeleteDataSourceOutput struct {
 	_ struct{} `type:"structure"`
@@ -1648,6 +1864,22 @@ func (s DeleteEvaluationInput) String() string {
 // GoString returns the string representation
 func (s DeleteEvaluationInput) GoString() string {
 	return s.String()
+}
+
+// Validate inspects the fields of the type to determine if they are valid.
+func (s *DeleteEvaluationInput) Validate() error {
+	invalidParams := request.ErrInvalidParams{Context: "DeleteEvaluationInput"}
+	if s.EvaluationId == nil {
+		invalidParams.Add(request.NewErrParamRequired("EvaluationId"))
+	}
+	if s.EvaluationId != nil && len(*s.EvaluationId) < 1 {
+		invalidParams.Add(request.NewErrParamMinLen("EvaluationId", 1))
+	}
+
+	if invalidParams.Len() > 0 {
+		return invalidParams
+	}
+	return nil
 }
 
 // Represents the output of a DeleteEvaluation operation. The output indicates
@@ -1690,6 +1922,22 @@ func (s DeleteMLModelInput) GoString() string {
 	return s.String()
 }
 
+// Validate inspects the fields of the type to determine if they are valid.
+func (s *DeleteMLModelInput) Validate() error {
+	invalidParams := request.ErrInvalidParams{Context: "DeleteMLModelInput"}
+	if s.MLModelId == nil {
+		invalidParams.Add(request.NewErrParamRequired("MLModelId"))
+	}
+	if s.MLModelId != nil && len(*s.MLModelId) < 1 {
+		invalidParams.Add(request.NewErrParamMinLen("MLModelId", 1))
+	}
+
+	if invalidParams.Len() > 0 {
+		return invalidParams
+	}
+	return nil
+}
+
 // Represents the output of a DeleteMLModel operation.
 //
 // You can use the GetMLModel operation and check the value of the Status parameter
@@ -1727,6 +1975,22 @@ func (s DeleteRealtimeEndpointInput) String() string {
 // GoString returns the string representation
 func (s DeleteRealtimeEndpointInput) GoString() string {
 	return s.String()
+}
+
+// Validate inspects the fields of the type to determine if they are valid.
+func (s *DeleteRealtimeEndpointInput) Validate() error {
+	invalidParams := request.ErrInvalidParams{Context: "DeleteRealtimeEndpointInput"}
+	if s.MLModelId == nil {
+		invalidParams.Add(request.NewErrParamRequired("MLModelId"))
+	}
+	if s.MLModelId != nil && len(*s.MLModelId) < 1 {
+		invalidParams.Add(request.NewErrParamMinLen("MLModelId", 1))
+	}
+
+	if invalidParams.Len() > 0 {
+		return invalidParams
+	}
+	return nil
 }
 
 // Represents the output of an DeleteRealtimeEndpoint operation.
@@ -1833,6 +2097,19 @@ func (s DescribeBatchPredictionsInput) GoString() string {
 	return s.String()
 }
 
+// Validate inspects the fields of the type to determine if they are valid.
+func (s *DescribeBatchPredictionsInput) Validate() error {
+	invalidParams := request.ErrInvalidParams{Context: "DescribeBatchPredictionsInput"}
+	if s.Limit != nil && *s.Limit < 1 {
+		invalidParams.Add(request.NewErrParamMinValue("Limit", 1))
+	}
+
+	if invalidParams.Len() > 0 {
+		return invalidParams
+	}
+	return nil
+}
+
 // Represents the output of a DescribeBatchPredictions operation. The content
 // is essentially a list of BatchPredictions.
 type DescribeBatchPredictionsOutput struct {
@@ -1929,6 +2206,19 @@ func (s DescribeDataSourcesInput) String() string {
 // GoString returns the string representation
 func (s DescribeDataSourcesInput) GoString() string {
 	return s.String()
+}
+
+// Validate inspects the fields of the type to determine if they are valid.
+func (s *DescribeDataSourcesInput) Validate() error {
+	invalidParams := request.ErrInvalidParams{Context: "DescribeDataSourcesInput"}
+	if s.Limit != nil && *s.Limit < 1 {
+		invalidParams.Add(request.NewErrParamMinValue("Limit", 1))
+	}
+
+	if invalidParams.Len() > 0 {
+		return invalidParams
+	}
+	return nil
 }
 
 // Represents the query results from a DescribeDataSources operation. The content
@@ -2029,6 +2319,19 @@ func (s DescribeEvaluationsInput) String() string {
 // GoString returns the string representation
 func (s DescribeEvaluationsInput) GoString() string {
 	return s.String()
+}
+
+// Validate inspects the fields of the type to determine if they are valid.
+func (s *DescribeEvaluationsInput) Validate() error {
+	invalidParams := request.ErrInvalidParams{Context: "DescribeEvaluationsInput"}
+	if s.Limit != nil && *s.Limit < 1 {
+		invalidParams.Add(request.NewErrParamMinValue("Limit", 1))
+	}
+
+	if invalidParams.Len() > 0 {
+		return invalidParams
+	}
+	return nil
 }
 
 // Represents the query results from a DescribeEvaluations operation. The content
@@ -2132,6 +2435,19 @@ func (s DescribeMLModelsInput) String() string {
 // GoString returns the string representation
 func (s DescribeMLModelsInput) GoString() string {
 	return s.String()
+}
+
+// Validate inspects the fields of the type to determine if they are valid.
+func (s *DescribeMLModelsInput) Validate() error {
+	invalidParams := request.ErrInvalidParams{Context: "DescribeMLModelsInput"}
+	if s.Limit != nil && *s.Limit < 1 {
+		invalidParams.Add(request.NewErrParamMinValue("Limit", 1))
+	}
+
+	if invalidParams.Len() > 0 {
+		return invalidParams
+	}
+	return nil
 }
 
 // Represents the output of a DescribeMLModels operation. The content is essentially
@@ -2252,6 +2568,22 @@ func (s GetBatchPredictionInput) GoString() string {
 	return s.String()
 }
 
+// Validate inspects the fields of the type to determine if they are valid.
+func (s *GetBatchPredictionInput) Validate() error {
+	invalidParams := request.ErrInvalidParams{Context: "GetBatchPredictionInput"}
+	if s.BatchPredictionId == nil {
+		invalidParams.Add(request.NewErrParamRequired("BatchPredictionId"))
+	}
+	if s.BatchPredictionId != nil && len(*s.BatchPredictionId) < 1 {
+		invalidParams.Add(request.NewErrParamMinLen("BatchPredictionId", 1))
+	}
+
+	if invalidParams.Len() > 0 {
+		return invalidParams
+	}
+	return nil
+}
+
 // Represents the output of a GetBatchPrediction operation and describes a BatchPrediction.
 type GetBatchPredictionOutput struct {
 	_ struct{} `type:"structure"`
@@ -2340,6 +2672,22 @@ func (s GetDataSourceInput) String() string {
 // GoString returns the string representation
 func (s GetDataSourceInput) GoString() string {
 	return s.String()
+}
+
+// Validate inspects the fields of the type to determine if they are valid.
+func (s *GetDataSourceInput) Validate() error {
+	invalidParams := request.ErrInvalidParams{Context: "GetDataSourceInput"}
+	if s.DataSourceId == nil {
+		invalidParams.Add(request.NewErrParamRequired("DataSourceId"))
+	}
+	if s.DataSourceId != nil && len(*s.DataSourceId) < 1 {
+		invalidParams.Add(request.NewErrParamMinLen("DataSourceId", 1))
+	}
+
+	if invalidParams.Len() > 0 {
+		return invalidParams
+	}
+	return nil
 }
 
 // Represents the output of a GetDataSource operation and describes a DataSource.
@@ -2444,6 +2792,22 @@ func (s GetEvaluationInput) GoString() string {
 	return s.String()
 }
 
+// Validate inspects the fields of the type to determine if they are valid.
+func (s *GetEvaluationInput) Validate() error {
+	invalidParams := request.ErrInvalidParams{Context: "GetEvaluationInput"}
+	if s.EvaluationId == nil {
+		invalidParams.Add(request.NewErrParamRequired("EvaluationId"))
+	}
+	if s.EvaluationId != nil && len(*s.EvaluationId) < 1 {
+		invalidParams.Add(request.NewErrParamMinLen("EvaluationId", 1))
+	}
+
+	if invalidParams.Len() > 0 {
+		return invalidParams
+	}
+	return nil
+}
+
 // Represents the output of a GetEvaluation operation and describes an Evaluation.
 type GetEvaluationOutput struct {
 	_ struct{} `type:"structure"`
@@ -2544,6 +2908,22 @@ func (s GetMLModelInput) String() string {
 // GoString returns the string representation
 func (s GetMLModelInput) GoString() string {
 	return s.String()
+}
+
+// Validate inspects the fields of the type to determine if they are valid.
+func (s *GetMLModelInput) Validate() error {
+	invalidParams := request.ErrInvalidParams{Context: "GetMLModelInput"}
+	if s.MLModelId == nil {
+		invalidParams.Add(request.NewErrParamRequired("MLModelId"))
+	}
+	if s.MLModelId != nil && len(*s.MLModelId) < 1 {
+		invalidParams.Add(request.NewErrParamMinLen("MLModelId", 1))
+	}
+
+	if invalidParams.Len() > 0 {
+		return invalidParams
+	}
+	return nil
 }
 
 // Represents the output of a GetMLModel operation, and provides detailed information
@@ -2844,6 +3224,28 @@ func (s PredictInput) GoString() string {
 	return s.String()
 }
 
+// Validate inspects the fields of the type to determine if they are valid.
+func (s *PredictInput) Validate() error {
+	invalidParams := request.ErrInvalidParams{Context: "PredictInput"}
+	if s.MLModelId == nil {
+		invalidParams.Add(request.NewErrParamRequired("MLModelId"))
+	}
+	if s.MLModelId != nil && len(*s.MLModelId) < 1 {
+		invalidParams.Add(request.NewErrParamMinLen("MLModelId", 1))
+	}
+	if s.PredictEndpoint == nil {
+		invalidParams.Add(request.NewErrParamRequired("PredictEndpoint"))
+	}
+	if s.Record == nil {
+		invalidParams.Add(request.NewErrParamRequired("Record"))
+	}
+
+	if invalidParams.Len() > 0 {
+		return invalidParams
+	}
+	return nil
+}
+
 type PredictOutput struct {
 	_ struct{} `type:"structure"`
 
@@ -3004,6 +3406,62 @@ func (s RDSDataSpec) GoString() string {
 	return s.String()
 }
 
+// Validate inspects the fields of the type to determine if they are valid.
+func (s *RDSDataSpec) Validate() error {
+	invalidParams := request.ErrInvalidParams{Context: "RDSDataSpec"}
+	if s.DatabaseCredentials == nil {
+		invalidParams.Add(request.NewErrParamRequired("DatabaseCredentials"))
+	}
+	if s.DatabaseInformation == nil {
+		invalidParams.Add(request.NewErrParamRequired("DatabaseInformation"))
+	}
+	if s.ResourceRole == nil {
+		invalidParams.Add(request.NewErrParamRequired("ResourceRole"))
+	}
+	if s.ResourceRole != nil && len(*s.ResourceRole) < 1 {
+		invalidParams.Add(request.NewErrParamMinLen("ResourceRole", 1))
+	}
+	if s.S3StagingLocation == nil {
+		invalidParams.Add(request.NewErrParamRequired("S3StagingLocation"))
+	}
+	if s.SecurityGroupIds == nil {
+		invalidParams.Add(request.NewErrParamRequired("SecurityGroupIds"))
+	}
+	if s.SelectSqlQuery == nil {
+		invalidParams.Add(request.NewErrParamRequired("SelectSqlQuery"))
+	}
+	if s.SelectSqlQuery != nil && len(*s.SelectSqlQuery) < 1 {
+		invalidParams.Add(request.NewErrParamMinLen("SelectSqlQuery", 1))
+	}
+	if s.ServiceRole == nil {
+		invalidParams.Add(request.NewErrParamRequired("ServiceRole"))
+	}
+	if s.ServiceRole != nil && len(*s.ServiceRole) < 1 {
+		invalidParams.Add(request.NewErrParamMinLen("ServiceRole", 1))
+	}
+	if s.SubnetId == nil {
+		invalidParams.Add(request.NewErrParamRequired("SubnetId"))
+	}
+	if s.SubnetId != nil && len(*s.SubnetId) < 1 {
+		invalidParams.Add(request.NewErrParamMinLen("SubnetId", 1))
+	}
+	if s.DatabaseCredentials != nil {
+		if err := s.DatabaseCredentials.Validate(); err != nil {
+			invalidParams.AddNested("DatabaseCredentials", err.(request.ErrInvalidParams))
+		}
+	}
+	if s.DatabaseInformation != nil {
+		if err := s.DatabaseInformation.Validate(); err != nil {
+			invalidParams.AddNested("DatabaseInformation", err.(request.ErrInvalidParams))
+		}
+	}
+
+	if invalidParams.Len() > 0 {
+		return invalidParams
+	}
+	return nil
+}
+
 // The database details of an Amazon RDS database.
 type RDSDatabase struct {
 	_ struct{} `type:"structure"`
@@ -3023,6 +3481,28 @@ func (s RDSDatabase) String() string {
 // GoString returns the string representation
 func (s RDSDatabase) GoString() string {
 	return s.String()
+}
+
+// Validate inspects the fields of the type to determine if they are valid.
+func (s *RDSDatabase) Validate() error {
+	invalidParams := request.ErrInvalidParams{Context: "RDSDatabase"}
+	if s.DatabaseName == nil {
+		invalidParams.Add(request.NewErrParamRequired("DatabaseName"))
+	}
+	if s.DatabaseName != nil && len(*s.DatabaseName) < 1 {
+		invalidParams.Add(request.NewErrParamMinLen("DatabaseName", 1))
+	}
+	if s.InstanceIdentifier == nil {
+		invalidParams.Add(request.NewErrParamRequired("InstanceIdentifier"))
+	}
+	if s.InstanceIdentifier != nil && len(*s.InstanceIdentifier) < 1 {
+		invalidParams.Add(request.NewErrParamMinLen("InstanceIdentifier", 1))
+	}
+
+	if invalidParams.Len() > 0 {
+		return invalidParams
+	}
+	return nil
 }
 
 // The database credentials to connect to a database on an RDS DB instance.
@@ -3048,6 +3528,28 @@ func (s RDSDatabaseCredentials) String() string {
 // GoString returns the string representation
 func (s RDSDatabaseCredentials) GoString() string {
 	return s.String()
+}
+
+// Validate inspects the fields of the type to determine if they are valid.
+func (s *RDSDatabaseCredentials) Validate() error {
+	invalidParams := request.ErrInvalidParams{Context: "RDSDatabaseCredentials"}
+	if s.Password == nil {
+		invalidParams.Add(request.NewErrParamRequired("Password"))
+	}
+	if s.Password != nil && len(*s.Password) < 8 {
+		invalidParams.Add(request.NewErrParamMinLen("Password", 8))
+	}
+	if s.Username == nil {
+		invalidParams.Add(request.NewErrParamRequired("Username"))
+	}
+	if s.Username != nil && len(*s.Username) < 1 {
+		invalidParams.Add(request.NewErrParamMinLen("Username", 1))
+	}
+
+	if invalidParams.Len() > 0 {
+		return invalidParams
+	}
+	return nil
 }
 
 // The datasource details that are specific to Amazon RDS.
@@ -3202,6 +3704,41 @@ func (s RedshiftDataSpec) GoString() string {
 	return s.String()
 }
 
+// Validate inspects the fields of the type to determine if they are valid.
+func (s *RedshiftDataSpec) Validate() error {
+	invalidParams := request.ErrInvalidParams{Context: "RedshiftDataSpec"}
+	if s.DatabaseCredentials == nil {
+		invalidParams.Add(request.NewErrParamRequired("DatabaseCredentials"))
+	}
+	if s.DatabaseInformation == nil {
+		invalidParams.Add(request.NewErrParamRequired("DatabaseInformation"))
+	}
+	if s.S3StagingLocation == nil {
+		invalidParams.Add(request.NewErrParamRequired("S3StagingLocation"))
+	}
+	if s.SelectSqlQuery == nil {
+		invalidParams.Add(request.NewErrParamRequired("SelectSqlQuery"))
+	}
+	if s.SelectSqlQuery != nil && len(*s.SelectSqlQuery) < 1 {
+		invalidParams.Add(request.NewErrParamMinLen("SelectSqlQuery", 1))
+	}
+	if s.DatabaseCredentials != nil {
+		if err := s.DatabaseCredentials.Validate(); err != nil {
+			invalidParams.AddNested("DatabaseCredentials", err.(request.ErrInvalidParams))
+		}
+	}
+	if s.DatabaseInformation != nil {
+		if err := s.DatabaseInformation.Validate(); err != nil {
+			invalidParams.AddNested("DatabaseInformation", err.(request.ErrInvalidParams))
+		}
+	}
+
+	if invalidParams.Len() > 0 {
+		return invalidParams
+	}
+	return nil
+}
+
 // Describes the database details required to connect to an Amazon Redshift
 // database.
 type RedshiftDatabase struct {
@@ -3222,6 +3759,28 @@ func (s RedshiftDatabase) String() string {
 // GoString returns the string representation
 func (s RedshiftDatabase) GoString() string {
 	return s.String()
+}
+
+// Validate inspects the fields of the type to determine if they are valid.
+func (s *RedshiftDatabase) Validate() error {
+	invalidParams := request.ErrInvalidParams{Context: "RedshiftDatabase"}
+	if s.ClusterIdentifier == nil {
+		invalidParams.Add(request.NewErrParamRequired("ClusterIdentifier"))
+	}
+	if s.ClusterIdentifier != nil && len(*s.ClusterIdentifier) < 1 {
+		invalidParams.Add(request.NewErrParamMinLen("ClusterIdentifier", 1))
+	}
+	if s.DatabaseName == nil {
+		invalidParams.Add(request.NewErrParamRequired("DatabaseName"))
+	}
+	if s.DatabaseName != nil && len(*s.DatabaseName) < 1 {
+		invalidParams.Add(request.NewErrParamMinLen("DatabaseName", 1))
+	}
+
+	if invalidParams.Len() > 0 {
+		return invalidParams
+	}
+	return nil
 }
 
 // Describes the database credentials for connecting to a database on an Amazon
@@ -3250,6 +3809,28 @@ func (s RedshiftDatabaseCredentials) String() string {
 // GoString returns the string representation
 func (s RedshiftDatabaseCredentials) GoString() string {
 	return s.String()
+}
+
+// Validate inspects the fields of the type to determine if they are valid.
+func (s *RedshiftDatabaseCredentials) Validate() error {
+	invalidParams := request.ErrInvalidParams{Context: "RedshiftDatabaseCredentials"}
+	if s.Password == nil {
+		invalidParams.Add(request.NewErrParamRequired("Password"))
+	}
+	if s.Password != nil && len(*s.Password) < 8 {
+		invalidParams.Add(request.NewErrParamMinLen("Password", 8))
+	}
+	if s.Username == nil {
+		invalidParams.Add(request.NewErrParamRequired("Username"))
+	}
+	if s.Username != nil && len(*s.Username) < 1 {
+		invalidParams.Add(request.NewErrParamMinLen("Username", 1))
+	}
+
+	if invalidParams.Len() > 0 {
+		return invalidParams
+	}
+	return nil
 }
 
 // Describes the DataSource details specific to Amazon Redshift.
@@ -3339,6 +3920,19 @@ func (s S3DataSpec) GoString() string {
 	return s.String()
 }
 
+// Validate inspects the fields of the type to determine if they are valid.
+func (s *S3DataSpec) Validate() error {
+	invalidParams := request.ErrInvalidParams{Context: "S3DataSpec"}
+	if s.DataLocationS3 == nil {
+		invalidParams.Add(request.NewErrParamRequired("DataLocationS3"))
+	}
+
+	if invalidParams.Len() > 0 {
+		return invalidParams
+	}
+	return nil
+}
+
 type UpdateBatchPredictionInput struct {
 	_ struct{} `type:"structure"`
 
@@ -3357,6 +3951,25 @@ func (s UpdateBatchPredictionInput) String() string {
 // GoString returns the string representation
 func (s UpdateBatchPredictionInput) GoString() string {
 	return s.String()
+}
+
+// Validate inspects the fields of the type to determine if they are valid.
+func (s *UpdateBatchPredictionInput) Validate() error {
+	invalidParams := request.ErrInvalidParams{Context: "UpdateBatchPredictionInput"}
+	if s.BatchPredictionId == nil {
+		invalidParams.Add(request.NewErrParamRequired("BatchPredictionId"))
+	}
+	if s.BatchPredictionId != nil && len(*s.BatchPredictionId) < 1 {
+		invalidParams.Add(request.NewErrParamMinLen("BatchPredictionId", 1))
+	}
+	if s.BatchPredictionName == nil {
+		invalidParams.Add(request.NewErrParamRequired("BatchPredictionName"))
+	}
+
+	if invalidParams.Len() > 0 {
+		return invalidParams
+	}
+	return nil
 }
 
 // Represents the output of an UpdateBatchPrediction operation.
@@ -3401,6 +4014,25 @@ func (s UpdateDataSourceInput) GoString() string {
 	return s.String()
 }
 
+// Validate inspects the fields of the type to determine if they are valid.
+func (s *UpdateDataSourceInput) Validate() error {
+	invalidParams := request.ErrInvalidParams{Context: "UpdateDataSourceInput"}
+	if s.DataSourceId == nil {
+		invalidParams.Add(request.NewErrParamRequired("DataSourceId"))
+	}
+	if s.DataSourceId != nil && len(*s.DataSourceId) < 1 {
+		invalidParams.Add(request.NewErrParamMinLen("DataSourceId", 1))
+	}
+	if s.DataSourceName == nil {
+		invalidParams.Add(request.NewErrParamRequired("DataSourceName"))
+	}
+
+	if invalidParams.Len() > 0 {
+		return invalidParams
+	}
+	return nil
+}
+
 // Represents the output of an UpdateDataSource operation.
 //
 // You can see the updated content by using the GetBatchPrediction operation.
@@ -3441,6 +4073,25 @@ func (s UpdateEvaluationInput) String() string {
 // GoString returns the string representation
 func (s UpdateEvaluationInput) GoString() string {
 	return s.String()
+}
+
+// Validate inspects the fields of the type to determine if they are valid.
+func (s *UpdateEvaluationInput) Validate() error {
+	invalidParams := request.ErrInvalidParams{Context: "UpdateEvaluationInput"}
+	if s.EvaluationId == nil {
+		invalidParams.Add(request.NewErrParamRequired("EvaluationId"))
+	}
+	if s.EvaluationId != nil && len(*s.EvaluationId) < 1 {
+		invalidParams.Add(request.NewErrParamMinLen("EvaluationId", 1))
+	}
+	if s.EvaluationName == nil {
+		invalidParams.Add(request.NewErrParamRequired("EvaluationName"))
+	}
+
+	if invalidParams.Len() > 0 {
+		return invalidParams
+	}
+	return nil
 }
 
 // Represents the output of an UpdateEvaluation operation.
@@ -3490,6 +4141,22 @@ func (s UpdateMLModelInput) String() string {
 // GoString returns the string representation
 func (s UpdateMLModelInput) GoString() string {
 	return s.String()
+}
+
+// Validate inspects the fields of the type to determine if they are valid.
+func (s *UpdateMLModelInput) Validate() error {
+	invalidParams := request.ErrInvalidParams{Context: "UpdateMLModelInput"}
+	if s.MLModelId == nil {
+		invalidParams.Add(request.NewErrParamRequired("MLModelId"))
+	}
+	if s.MLModelId != nil && len(*s.MLModelId) < 1 {
+		invalidParams.Add(request.NewErrParamMinLen("MLModelId", 1))
+	}
+
+	if invalidParams.Len() > 0 {
+		return invalidParams
+	}
+	return nil
 }
 
 // Represents the output of an UpdateMLModel operation.

--- a/service/marketplacecommerceanalytics/api.go
+++ b/service/marketplacecommerceanalytics/api.go
@@ -120,6 +120,46 @@ func (s GenerateDataSetInput) GoString() string {
 	return s.String()
 }
 
+// Validate inspects the fields of the type to determine if they are valid.
+func (s *GenerateDataSetInput) Validate() error {
+	invalidParams := request.ErrInvalidParams{Context: "GenerateDataSetInput"}
+	if s.CustomerDefinedValues != nil && len(s.CustomerDefinedValues) < 1 {
+		invalidParams.Add(request.NewErrParamMinLen("CustomerDefinedValues", 1))
+	}
+	if s.DataSetPublicationDate == nil {
+		invalidParams.Add(request.NewErrParamRequired("DataSetPublicationDate"))
+	}
+	if s.DataSetType == nil {
+		invalidParams.Add(request.NewErrParamRequired("DataSetType"))
+	}
+	if s.DataSetType != nil && len(*s.DataSetType) < 1 {
+		invalidParams.Add(request.NewErrParamMinLen("DataSetType", 1))
+	}
+	if s.DestinationS3BucketName == nil {
+		invalidParams.Add(request.NewErrParamRequired("DestinationS3BucketName"))
+	}
+	if s.DestinationS3BucketName != nil && len(*s.DestinationS3BucketName) < 1 {
+		invalidParams.Add(request.NewErrParamMinLen("DestinationS3BucketName", 1))
+	}
+	if s.RoleNameArn == nil {
+		invalidParams.Add(request.NewErrParamRequired("RoleNameArn"))
+	}
+	if s.RoleNameArn != nil && len(*s.RoleNameArn) < 1 {
+		invalidParams.Add(request.NewErrParamMinLen("RoleNameArn", 1))
+	}
+	if s.SnsTopicArn == nil {
+		invalidParams.Add(request.NewErrParamRequired("SnsTopicArn"))
+	}
+	if s.SnsTopicArn != nil && len(*s.SnsTopicArn) < 1 {
+		invalidParams.Add(request.NewErrParamMinLen("SnsTopicArn", 1))
+	}
+
+	if invalidParams.Len() > 0 {
+		return invalidParams
+	}
+	return nil
+}
+
 // Container for the result of the GenerateDataSet operation.
 type GenerateDataSetOutput struct {
 	_ struct{} `type:"structure"`

--- a/service/marketplacemetering/api.go
+++ b/service/marketplacemetering/api.go
@@ -73,6 +73,37 @@ func (s MeterUsageInput) GoString() string {
 	return s.String()
 }
 
+// Validate inspects the fields of the type to determine if they are valid.
+func (s *MeterUsageInput) Validate() error {
+	invalidParams := request.ErrInvalidParams{Context: "MeterUsageInput"}
+	if s.DryRun == nil {
+		invalidParams.Add(request.NewErrParamRequired("DryRun"))
+	}
+	if s.ProductCode == nil {
+		invalidParams.Add(request.NewErrParamRequired("ProductCode"))
+	}
+	if s.ProductCode != nil && len(*s.ProductCode) < 1 {
+		invalidParams.Add(request.NewErrParamMinLen("ProductCode", 1))
+	}
+	if s.Timestamp == nil {
+		invalidParams.Add(request.NewErrParamRequired("Timestamp"))
+	}
+	if s.UsageDimension == nil {
+		invalidParams.Add(request.NewErrParamRequired("UsageDimension"))
+	}
+	if s.UsageDimension != nil && len(*s.UsageDimension) < 1 {
+		invalidParams.Add(request.NewErrParamMinLen("UsageDimension", 1))
+	}
+	if s.UsageQuantity == nil {
+		invalidParams.Add(request.NewErrParamRequired("UsageQuantity"))
+	}
+
+	if invalidParams.Len() > 0 {
+		return invalidParams
+	}
+	return nil
+}
+
 type MeterUsageOutput struct {
 	_ struct{} `type:"structure"`
 

--- a/service/mobileanalytics/api.go
+++ b/service/mobileanalytics/api.go
@@ -4,6 +4,8 @@
 package mobileanalytics
 
 import (
+	"fmt"
+
 	"github.com/aws/aws-sdk-go/aws/awsutil"
 	"github.com/aws/aws-sdk-go/aws/request"
 	"github.com/aws/aws-sdk-go/private/protocol"
@@ -82,6 +84,33 @@ func (s Event) GoString() string {
 	return s.String()
 }
 
+// Validate inspects the fields of the type to determine if they are valid.
+func (s *Event) Validate() error {
+	invalidParams := request.ErrInvalidParams{Context: "Event"}
+	if s.EventType == nil {
+		invalidParams.Add(request.NewErrParamRequired("EventType"))
+	}
+	if s.EventType != nil && len(*s.EventType) < 1 {
+		invalidParams.Add(request.NewErrParamMinLen("EventType", 1))
+	}
+	if s.Timestamp == nil {
+		invalidParams.Add(request.NewErrParamRequired("Timestamp"))
+	}
+	if s.Version != nil && len(*s.Version) < 1 {
+		invalidParams.Add(request.NewErrParamMinLen("Version", 1))
+	}
+	if s.Session != nil {
+		if err := s.Session.Validate(); err != nil {
+			invalidParams.AddNested("Session", err.(request.ErrInvalidParams))
+		}
+	}
+
+	if invalidParams.Len() > 0 {
+		return invalidParams
+	}
+	return nil
+}
+
 // A container for the data needed for a PutEvent operation
 type PutEventsInput struct {
 	_ struct{} `type:"structure"`
@@ -105,6 +134,32 @@ func (s PutEventsInput) String() string {
 // GoString returns the string representation
 func (s PutEventsInput) GoString() string {
 	return s.String()
+}
+
+// Validate inspects the fields of the type to determine if they are valid.
+func (s *PutEventsInput) Validate() error {
+	invalidParams := request.ErrInvalidParams{Context: "PutEventsInput"}
+	if s.ClientContext == nil {
+		invalidParams.Add(request.NewErrParamRequired("ClientContext"))
+	}
+	if s.Events == nil {
+		invalidParams.Add(request.NewErrParamRequired("Events"))
+	}
+	if s.Events != nil {
+		for i, v := range s.Events {
+			if v == nil {
+				continue
+			}
+			if err := v.Validate(); err != nil {
+				invalidParams.AddNested(fmt.Sprintf("%s[%v]", "Events", i), err.(request.ErrInvalidParams))
+			}
+		}
+	}
+
+	if invalidParams.Len() > 0 {
+		return invalidParams
+	}
+	return nil
 }
 
 type PutEventsOutput struct {
@@ -148,4 +203,17 @@ func (s Session) String() string {
 // GoString returns the string representation
 func (s Session) GoString() string {
 	return s.String()
+}
+
+// Validate inspects the fields of the type to determine if they are valid.
+func (s *Session) Validate() error {
+	invalidParams := request.ErrInvalidParams{Context: "Session"}
+	if s.Id != nil && len(*s.Id) < 1 {
+		invalidParams.Add(request.NewErrParamMinLen("Id", 1))
+	}
+
+	if invalidParams.Len() > 0 {
+		return invalidParams
+	}
+	return nil
 }

--- a/service/opsworks/api.go
+++ b/service/opsworks/api.go
@@ -4,6 +4,8 @@
 package opsworks
 
 import (
+	"fmt"
+
 	"github.com/aws/aws-sdk-go/aws/awsutil"
 	"github.com/aws/aws-sdk-go/aws/request"
 	"github.com/aws/aws-sdk-go/private/protocol"
@@ -2534,6 +2536,22 @@ func (s AssignInstanceInput) GoString() string {
 	return s.String()
 }
 
+// Validate inspects the fields of the type to determine if they are valid.
+func (s *AssignInstanceInput) Validate() error {
+	invalidParams := request.ErrInvalidParams{Context: "AssignInstanceInput"}
+	if s.InstanceId == nil {
+		invalidParams.Add(request.NewErrParamRequired("InstanceId"))
+	}
+	if s.LayerIds == nil {
+		invalidParams.Add(request.NewErrParamRequired("LayerIds"))
+	}
+
+	if invalidParams.Len() > 0 {
+		return invalidParams
+	}
+	return nil
+}
+
 type AssignInstanceOutput struct {
 	_ struct{} `type:"structure"`
 }
@@ -2566,6 +2584,19 @@ func (s AssignVolumeInput) String() string {
 // GoString returns the string representation
 func (s AssignVolumeInput) GoString() string {
 	return s.String()
+}
+
+// Validate inspects the fields of the type to determine if they are valid.
+func (s *AssignVolumeInput) Validate() error {
+	invalidParams := request.ErrInvalidParams{Context: "AssignVolumeInput"}
+	if s.VolumeId == nil {
+		invalidParams.Add(request.NewErrParamRequired("VolumeId"))
+	}
+
+	if invalidParams.Len() > 0 {
+		return invalidParams
+	}
+	return nil
 }
 
 type AssignVolumeOutput struct {
@@ -2602,6 +2633,19 @@ func (s AssociateElasticIpInput) GoString() string {
 	return s.String()
 }
 
+// Validate inspects the fields of the type to determine if they are valid.
+func (s *AssociateElasticIpInput) Validate() error {
+	invalidParams := request.ErrInvalidParams{Context: "AssociateElasticIpInput"}
+	if s.ElasticIp == nil {
+		invalidParams.Add(request.NewErrParamRequired("ElasticIp"))
+	}
+
+	if invalidParams.Len() > 0 {
+		return invalidParams
+	}
+	return nil
+}
+
 type AssociateElasticIpOutput struct {
 	_ struct{} `type:"structure"`
 }
@@ -2635,6 +2679,22 @@ func (s AttachElasticLoadBalancerInput) String() string {
 // GoString returns the string representation
 func (s AttachElasticLoadBalancerInput) GoString() string {
 	return s.String()
+}
+
+// Validate inspects the fields of the type to determine if they are valid.
+func (s *AttachElasticLoadBalancerInput) Validate() error {
+	invalidParams := request.ErrInvalidParams{Context: "AttachElasticLoadBalancerInput"}
+	if s.ElasticLoadBalancerName == nil {
+		invalidParams.Add(request.NewErrParamRequired("ElasticLoadBalancerName"))
+	}
+	if s.LayerId == nil {
+		invalidParams.Add(request.NewErrParamRequired("LayerId"))
+	}
+
+	if invalidParams.Len() > 0 {
+		return invalidParams
+	}
+	return nil
 }
 
 type AttachElasticLoadBalancerOutput struct {
@@ -2704,6 +2764,22 @@ func (s AutoScalingThresholds) String() string {
 // GoString returns the string representation
 func (s AutoScalingThresholds) GoString() string {
 	return s.String()
+}
+
+// Validate inspects the fields of the type to determine if they are valid.
+func (s *AutoScalingThresholds) Validate() error {
+	invalidParams := request.ErrInvalidParams{Context: "AutoScalingThresholds"}
+	if s.IgnoreMetricsTime != nil && *s.IgnoreMetricsTime < 1 {
+		invalidParams.Add(request.NewErrParamMinValue("IgnoreMetricsTime", 1))
+	}
+	if s.ThresholdsWaitTime != nil && *s.ThresholdsWaitTime < 1 {
+		invalidParams.Add(request.NewErrParamMinValue("ThresholdsWaitTime", 1))
+	}
+
+	if invalidParams.Len() > 0 {
+		return invalidParams
+	}
+	return nil
 }
 
 // Describes a block device mapping. This data type maps directly to the Amazon
@@ -2949,6 +3025,22 @@ func (s CloneStackInput) GoString() string {
 	return s.String()
 }
 
+// Validate inspects the fields of the type to determine if they are valid.
+func (s *CloneStackInput) Validate() error {
+	invalidParams := request.ErrInvalidParams{Context: "CloneStackInput"}
+	if s.ServiceRoleArn == nil {
+		invalidParams.Add(request.NewErrParamRequired("ServiceRoleArn"))
+	}
+	if s.SourceStackId == nil {
+		invalidParams.Add(request.NewErrParamRequired("SourceStackId"))
+	}
+
+	if invalidParams.Len() > 0 {
+		return invalidParams
+	}
+	return nil
+}
+
 // Contains the response to a CloneStack request.
 type CloneStackOutput struct {
 	_ struct{} `type:"structure"`
@@ -3085,6 +3177,40 @@ func (s CreateAppInput) GoString() string {
 	return s.String()
 }
 
+// Validate inspects the fields of the type to determine if they are valid.
+func (s *CreateAppInput) Validate() error {
+	invalidParams := request.ErrInvalidParams{Context: "CreateAppInput"}
+	if s.Name == nil {
+		invalidParams.Add(request.NewErrParamRequired("Name"))
+	}
+	if s.StackId == nil {
+		invalidParams.Add(request.NewErrParamRequired("StackId"))
+	}
+	if s.Type == nil {
+		invalidParams.Add(request.NewErrParamRequired("Type"))
+	}
+	if s.Environment != nil {
+		for i, v := range s.Environment {
+			if v == nil {
+				continue
+			}
+			if err := v.Validate(); err != nil {
+				invalidParams.AddNested(fmt.Sprintf("%s[%v]", "Environment", i), err.(request.ErrInvalidParams))
+			}
+		}
+	}
+	if s.SslConfiguration != nil {
+		if err := s.SslConfiguration.Validate(); err != nil {
+			invalidParams.AddNested("SslConfiguration", err.(request.ErrInvalidParams))
+		}
+	}
+
+	if invalidParams.Len() > 0 {
+		return invalidParams
+	}
+	return nil
+}
+
 // Contains the response to a CreateApp request.
 type CreateAppOutput struct {
 	_ struct{} `type:"structure"`
@@ -3142,6 +3268,27 @@ func (s CreateDeploymentInput) String() string {
 // GoString returns the string representation
 func (s CreateDeploymentInput) GoString() string {
 	return s.String()
+}
+
+// Validate inspects the fields of the type to determine if they are valid.
+func (s *CreateDeploymentInput) Validate() error {
+	invalidParams := request.ErrInvalidParams{Context: "CreateDeploymentInput"}
+	if s.Command == nil {
+		invalidParams.Add(request.NewErrParamRequired("Command"))
+	}
+	if s.StackId == nil {
+		invalidParams.Add(request.NewErrParamRequired("StackId"))
+	}
+	if s.Command != nil {
+		if err := s.Command.Validate(); err != nil {
+			invalidParams.AddNested("Command", err.(request.ErrInvalidParams))
+		}
+	}
+
+	if invalidParams.Len() > 0 {
+		return invalidParams
+	}
+	return nil
 }
 
 // Contains the response to a CreateDeployment request.
@@ -3276,6 +3423,25 @@ func (s CreateInstanceInput) GoString() string {
 	return s.String()
 }
 
+// Validate inspects the fields of the type to determine if they are valid.
+func (s *CreateInstanceInput) Validate() error {
+	invalidParams := request.ErrInvalidParams{Context: "CreateInstanceInput"}
+	if s.InstanceType == nil {
+		invalidParams.Add(request.NewErrParamRequired("InstanceType"))
+	}
+	if s.LayerIds == nil {
+		invalidParams.Add(request.NewErrParamRequired("LayerIds"))
+	}
+	if s.StackId == nil {
+		invalidParams.Add(request.NewErrParamRequired("StackId"))
+	}
+
+	if invalidParams.Len() > 0 {
+		return invalidParams
+	}
+	return nil
+}
+
 // Contains the response to a CreateInstance request.
 type CreateInstanceOutput struct {
 	_ struct{} `type:"structure"`
@@ -3384,6 +3550,38 @@ func (s CreateLayerInput) String() string {
 // GoString returns the string representation
 func (s CreateLayerInput) GoString() string {
 	return s.String()
+}
+
+// Validate inspects the fields of the type to determine if they are valid.
+func (s *CreateLayerInput) Validate() error {
+	invalidParams := request.ErrInvalidParams{Context: "CreateLayerInput"}
+	if s.Name == nil {
+		invalidParams.Add(request.NewErrParamRequired("Name"))
+	}
+	if s.Shortname == nil {
+		invalidParams.Add(request.NewErrParamRequired("Shortname"))
+	}
+	if s.StackId == nil {
+		invalidParams.Add(request.NewErrParamRequired("StackId"))
+	}
+	if s.Type == nil {
+		invalidParams.Add(request.NewErrParamRequired("Type"))
+	}
+	if s.VolumeConfigurations != nil {
+		for i, v := range s.VolumeConfigurations {
+			if v == nil {
+				continue
+			}
+			if err := v.Validate(); err != nil {
+				invalidParams.AddNested(fmt.Sprintf("%s[%v]", "VolumeConfigurations", i), err.(request.ErrInvalidParams))
+			}
+		}
+	}
+
+	if invalidParams.Len() > 0 {
+		return invalidParams
+	}
+	return nil
 }
 
 // Contains the response to a CreateLayer request.
@@ -3579,6 +3777,28 @@ func (s CreateStackInput) GoString() string {
 	return s.String()
 }
 
+// Validate inspects the fields of the type to determine if they are valid.
+func (s *CreateStackInput) Validate() error {
+	invalidParams := request.ErrInvalidParams{Context: "CreateStackInput"}
+	if s.DefaultInstanceProfileArn == nil {
+		invalidParams.Add(request.NewErrParamRequired("DefaultInstanceProfileArn"))
+	}
+	if s.Name == nil {
+		invalidParams.Add(request.NewErrParamRequired("Name"))
+	}
+	if s.Region == nil {
+		invalidParams.Add(request.NewErrParamRequired("Region"))
+	}
+	if s.ServiceRoleArn == nil {
+		invalidParams.Add(request.NewErrParamRequired("ServiceRoleArn"))
+	}
+
+	if invalidParams.Len() > 0 {
+		return invalidParams
+	}
+	return nil
+}
+
 // Contains the response to a CreateStack request.
 type CreateStackOutput struct {
 	_ struct{} `type:"structure"`
@@ -3627,6 +3847,19 @@ func (s CreateUserProfileInput) String() string {
 // GoString returns the string representation
 func (s CreateUserProfileInput) GoString() string {
 	return s.String()
+}
+
+// Validate inspects the fields of the type to determine if they are valid.
+func (s *CreateUserProfileInput) Validate() error {
+	invalidParams := request.ErrInvalidParams{Context: "CreateUserProfileInput"}
+	if s.IamUserArn == nil {
+		invalidParams.Add(request.NewErrParamRequired("IamUserArn"))
+	}
+
+	if invalidParams.Len() > 0 {
+		return invalidParams
+	}
+	return nil
 }
 
 // Contains the response to a CreateUserProfile request.
@@ -3689,6 +3922,19 @@ func (s DeleteAppInput) GoString() string {
 	return s.String()
 }
 
+// Validate inspects the fields of the type to determine if they are valid.
+func (s *DeleteAppInput) Validate() error {
+	invalidParams := request.ErrInvalidParams{Context: "DeleteAppInput"}
+	if s.AppId == nil {
+		invalidParams.Add(request.NewErrParamRequired("AppId"))
+	}
+
+	if invalidParams.Len() > 0 {
+		return invalidParams
+	}
+	return nil
+}
+
 type DeleteAppOutput struct {
 	_ struct{} `type:"structure"`
 }
@@ -3726,6 +3972,19 @@ func (s DeleteInstanceInput) GoString() string {
 	return s.String()
 }
 
+// Validate inspects the fields of the type to determine if they are valid.
+func (s *DeleteInstanceInput) Validate() error {
+	invalidParams := request.ErrInvalidParams{Context: "DeleteInstanceInput"}
+	if s.InstanceId == nil {
+		invalidParams.Add(request.NewErrParamRequired("InstanceId"))
+	}
+
+	if invalidParams.Len() > 0 {
+		return invalidParams
+	}
+	return nil
+}
+
 type DeleteInstanceOutput struct {
 	_ struct{} `type:"structure"`
 }
@@ -3755,6 +4014,19 @@ func (s DeleteLayerInput) String() string {
 // GoString returns the string representation
 func (s DeleteLayerInput) GoString() string {
 	return s.String()
+}
+
+// Validate inspects the fields of the type to determine if they are valid.
+func (s *DeleteLayerInput) Validate() error {
+	invalidParams := request.ErrInvalidParams{Context: "DeleteLayerInput"}
+	if s.LayerId == nil {
+		invalidParams.Add(request.NewErrParamRequired("LayerId"))
+	}
+
+	if invalidParams.Len() > 0 {
+		return invalidParams
+	}
+	return nil
 }
 
 type DeleteLayerOutput struct {
@@ -3788,6 +4060,19 @@ func (s DeleteStackInput) GoString() string {
 	return s.String()
 }
 
+// Validate inspects the fields of the type to determine if they are valid.
+func (s *DeleteStackInput) Validate() error {
+	invalidParams := request.ErrInvalidParams{Context: "DeleteStackInput"}
+	if s.StackId == nil {
+		invalidParams.Add(request.NewErrParamRequired("StackId"))
+	}
+
+	if invalidParams.Len() > 0 {
+		return invalidParams
+	}
+	return nil
+}
+
 type DeleteStackOutput struct {
 	_ struct{} `type:"structure"`
 }
@@ -3817,6 +4102,19 @@ func (s DeleteUserProfileInput) String() string {
 // GoString returns the string representation
 func (s DeleteUserProfileInput) GoString() string {
 	return s.String()
+}
+
+// Validate inspects the fields of the type to determine if they are valid.
+func (s *DeleteUserProfileInput) Validate() error {
+	invalidParams := request.ErrInvalidParams{Context: "DeleteUserProfileInput"}
+	if s.IamUserArn == nil {
+		invalidParams.Add(request.NewErrParamRequired("IamUserArn"))
+	}
+
+	if invalidParams.Len() > 0 {
+		return invalidParams
+	}
+	return nil
 }
 
 type DeleteUserProfileOutput struct {
@@ -3952,6 +4250,19 @@ func (s DeploymentCommand) GoString() string {
 	return s.String()
 }
 
+// Validate inspects the fields of the type to determine if they are valid.
+func (s *DeploymentCommand) Validate() error {
+	invalidParams := request.ErrInvalidParams{Context: "DeploymentCommand"}
+	if s.Name == nil {
+		invalidParams.Add(request.NewErrParamRequired("Name"))
+	}
+
+	if invalidParams.Len() > 0 {
+		return invalidParams
+	}
+	return nil
+}
+
 type DeregisterEcsClusterInput struct {
 	_ struct{} `type:"structure"`
 
@@ -3967,6 +4278,19 @@ func (s DeregisterEcsClusterInput) String() string {
 // GoString returns the string representation
 func (s DeregisterEcsClusterInput) GoString() string {
 	return s.String()
+}
+
+// Validate inspects the fields of the type to determine if they are valid.
+func (s *DeregisterEcsClusterInput) Validate() error {
+	invalidParams := request.ErrInvalidParams{Context: "DeregisterEcsClusterInput"}
+	if s.EcsClusterArn == nil {
+		invalidParams.Add(request.NewErrParamRequired("EcsClusterArn"))
+	}
+
+	if invalidParams.Len() > 0 {
+		return invalidParams
+	}
+	return nil
 }
 
 type DeregisterEcsClusterOutput struct {
@@ -4000,6 +4324,19 @@ func (s DeregisterElasticIpInput) GoString() string {
 	return s.String()
 }
 
+// Validate inspects the fields of the type to determine if they are valid.
+func (s *DeregisterElasticIpInput) Validate() error {
+	invalidParams := request.ErrInvalidParams{Context: "DeregisterElasticIpInput"}
+	if s.ElasticIp == nil {
+		invalidParams.Add(request.NewErrParamRequired("ElasticIp"))
+	}
+
+	if invalidParams.Len() > 0 {
+		return invalidParams
+	}
+	return nil
+}
+
 type DeregisterElasticIpOutput struct {
 	_ struct{} `type:"structure"`
 }
@@ -4029,6 +4366,19 @@ func (s DeregisterInstanceInput) String() string {
 // GoString returns the string representation
 func (s DeregisterInstanceInput) GoString() string {
 	return s.String()
+}
+
+// Validate inspects the fields of the type to determine if they are valid.
+func (s *DeregisterInstanceInput) Validate() error {
+	invalidParams := request.ErrInvalidParams{Context: "DeregisterInstanceInput"}
+	if s.InstanceId == nil {
+		invalidParams.Add(request.NewErrParamRequired("InstanceId"))
+	}
+
+	if invalidParams.Len() > 0 {
+		return invalidParams
+	}
+	return nil
 }
 
 type DeregisterInstanceOutput struct {
@@ -4062,6 +4412,19 @@ func (s DeregisterRdsDbInstanceInput) GoString() string {
 	return s.String()
 }
 
+// Validate inspects the fields of the type to determine if they are valid.
+func (s *DeregisterRdsDbInstanceInput) Validate() error {
+	invalidParams := request.ErrInvalidParams{Context: "DeregisterRdsDbInstanceInput"}
+	if s.RdsDbInstanceArn == nil {
+		invalidParams.Add(request.NewErrParamRequired("RdsDbInstanceArn"))
+	}
+
+	if invalidParams.Len() > 0 {
+		return invalidParams
+	}
+	return nil
+}
+
 type DeregisterRdsDbInstanceOutput struct {
 	_ struct{} `type:"structure"`
 }
@@ -4093,6 +4456,19 @@ func (s DeregisterVolumeInput) String() string {
 // GoString returns the string representation
 func (s DeregisterVolumeInput) GoString() string {
 	return s.String()
+}
+
+// Validate inspects the fields of the type to determine if they are valid.
+func (s *DeregisterVolumeInput) Validate() error {
+	invalidParams := request.ErrInvalidParams{Context: "DeregisterVolumeInput"}
+	if s.VolumeId == nil {
+		invalidParams.Add(request.NewErrParamRequired("VolumeId"))
+	}
+
+	if invalidParams.Len() > 0 {
+		return invalidParams
+	}
+	return nil
 }
 
 type DeregisterVolumeOutput struct {
@@ -4526,6 +4902,19 @@ func (s DescribeLoadBasedAutoScalingInput) GoString() string {
 	return s.String()
 }
 
+// Validate inspects the fields of the type to determine if they are valid.
+func (s *DescribeLoadBasedAutoScalingInput) Validate() error {
+	invalidParams := request.ErrInvalidParams{Context: "DescribeLoadBasedAutoScalingInput"}
+	if s.LayerIds == nil {
+		invalidParams.Add(request.NewErrParamRequired("LayerIds"))
+	}
+
+	if invalidParams.Len() > 0 {
+		return invalidParams
+	}
+	return nil
+}
+
 // Contains the response to a DescribeLoadBasedAutoScaling request.
 type DescribeLoadBasedAutoScalingOutput struct {
 	_ struct{} `type:"structure"`
@@ -4688,6 +5077,19 @@ func (s DescribeRdsDbInstancesInput) GoString() string {
 	return s.String()
 }
 
+// Validate inspects the fields of the type to determine if they are valid.
+func (s *DescribeRdsDbInstancesInput) Validate() error {
+	invalidParams := request.ErrInvalidParams{Context: "DescribeRdsDbInstancesInput"}
+	if s.StackId == nil {
+		invalidParams.Add(request.NewErrParamRequired("StackId"))
+	}
+
+	if invalidParams.Len() > 0 {
+		return invalidParams
+	}
+	return nil
+}
+
 // Contains the response to a DescribeRdsDbInstances request.
 type DescribeRdsDbInstancesOutput struct {
 	_ struct{} `type:"structure"`
@@ -4768,6 +5170,19 @@ func (s DescribeStackProvisioningParametersInput) GoString() string {
 	return s.String()
 }
 
+// Validate inspects the fields of the type to determine if they are valid.
+func (s *DescribeStackProvisioningParametersInput) Validate() error {
+	invalidParams := request.ErrInvalidParams{Context: "DescribeStackProvisioningParametersInput"}
+	if s.StackId == nil {
+		invalidParams.Add(request.NewErrParamRequired("StackId"))
+	}
+
+	if invalidParams.Len() > 0 {
+		return invalidParams
+	}
+	return nil
+}
+
 // Contains the response to a DescribeStackProvisioningParameters request.
 type DescribeStackProvisioningParametersOutput struct {
 	_ struct{} `type:"structure"`
@@ -4804,6 +5219,19 @@ func (s DescribeStackSummaryInput) String() string {
 // GoString returns the string representation
 func (s DescribeStackSummaryInput) GoString() string {
 	return s.String()
+}
+
+// Validate inspects the fields of the type to determine if they are valid.
+func (s *DescribeStackSummaryInput) Validate() error {
+	invalidParams := request.ErrInvalidParams{Context: "DescribeStackSummaryInput"}
+	if s.StackId == nil {
+		invalidParams.Add(request.NewErrParamRequired("StackId"))
+	}
+
+	if invalidParams.Len() > 0 {
+		return invalidParams
+	}
+	return nil
 }
 
 // Contains the response to a DescribeStackSummary request.
@@ -4875,6 +5303,19 @@ func (s DescribeTimeBasedAutoScalingInput) String() string {
 // GoString returns the string representation
 func (s DescribeTimeBasedAutoScalingInput) GoString() string {
 	return s.String()
+}
+
+// Validate inspects the fields of the type to determine if they are valid.
+func (s *DescribeTimeBasedAutoScalingInput) Validate() error {
+	invalidParams := request.ErrInvalidParams{Context: "DescribeTimeBasedAutoScalingInput"}
+	if s.InstanceIds == nil {
+		invalidParams.Add(request.NewErrParamRequired("InstanceIds"))
+	}
+
+	if invalidParams.Len() > 0 {
+		return invalidParams
+	}
+	return nil
 }
 
 // Contains the response to a DescribeTimeBasedAutoScaling request.
@@ -5000,6 +5441,22 @@ func (s DetachElasticLoadBalancerInput) GoString() string {
 	return s.String()
 }
 
+// Validate inspects the fields of the type to determine if they are valid.
+func (s *DetachElasticLoadBalancerInput) Validate() error {
+	invalidParams := request.ErrInvalidParams{Context: "DetachElasticLoadBalancerInput"}
+	if s.ElasticLoadBalancerName == nil {
+		invalidParams.Add(request.NewErrParamRequired("ElasticLoadBalancerName"))
+	}
+	if s.LayerId == nil {
+		invalidParams.Add(request.NewErrParamRequired("LayerId"))
+	}
+
+	if invalidParams.Len() > 0 {
+		return invalidParams
+	}
+	return nil
+}
+
 type DetachElasticLoadBalancerOutput struct {
 	_ struct{} `type:"structure"`
 }
@@ -5029,6 +5486,19 @@ func (s DisassociateElasticIpInput) String() string {
 // GoString returns the string representation
 func (s DisassociateElasticIpInput) GoString() string {
 	return s.String()
+}
+
+// Validate inspects the fields of the type to determine if they are valid.
+func (s *DisassociateElasticIpInput) Validate() error {
+	invalidParams := request.ErrInvalidParams{Context: "DisassociateElasticIpInput"}
+	if s.ElasticIp == nil {
+		invalidParams.Add(request.NewErrParamRequired("ElasticIp"))
+	}
+
+	if invalidParams.Len() > 0 {
+		return invalidParams
+	}
+	return nil
 }
 
 type DisassociateElasticIpOutput struct {
@@ -5211,6 +5681,22 @@ func (s EnvironmentVariable) GoString() string {
 	return s.String()
 }
 
+// Validate inspects the fields of the type to determine if they are valid.
+func (s *EnvironmentVariable) Validate() error {
+	invalidParams := request.ErrInvalidParams{Context: "EnvironmentVariable"}
+	if s.Key == nil {
+		invalidParams.Add(request.NewErrParamRequired("Key"))
+	}
+	if s.Value == nil {
+		invalidParams.Add(request.NewErrParamRequired("Value"))
+	}
+
+	if invalidParams.Len() > 0 {
+		return invalidParams
+	}
+	return nil
+}
+
 type GetHostnameSuggestionInput struct {
 	_ struct{} `type:"structure"`
 
@@ -5226,6 +5712,19 @@ func (s GetHostnameSuggestionInput) String() string {
 // GoString returns the string representation
 func (s GetHostnameSuggestionInput) GoString() string {
 	return s.String()
+}
+
+// Validate inspects the fields of the type to determine if they are valid.
+func (s *GetHostnameSuggestionInput) Validate() error {
+	invalidParams := request.ErrInvalidParams{Context: "GetHostnameSuggestionInput"}
+	if s.LayerId == nil {
+		invalidParams.Add(request.NewErrParamRequired("LayerId"))
+	}
+
+	if invalidParams.Len() > 0 {
+		return invalidParams
+	}
+	return nil
 }
 
 // Contains the response to a GetHostnameSuggestion request.
@@ -5270,6 +5769,22 @@ func (s GrantAccessInput) String() string {
 // GoString returns the string representation
 func (s GrantAccessInput) GoString() string {
 	return s.String()
+}
+
+// Validate inspects the fields of the type to determine if they are valid.
+func (s *GrantAccessInput) Validate() error {
+	invalidParams := request.ErrInvalidParams{Context: "GrantAccessInput"}
+	if s.InstanceId == nil {
+		invalidParams.Add(request.NewErrParamRequired("InstanceId"))
+	}
+	if s.ValidForInMinutes != nil && *s.ValidForInMinutes < 60 {
+		invalidParams.Add(request.NewErrParamMinValue("ValidForInMinutes", 60))
+	}
+
+	if invalidParams.Len() > 0 {
+		return invalidParams
+	}
+	return nil
 }
 
 // Contains the response to a GrantAccess request.
@@ -5837,6 +6352,19 @@ func (s RebootInstanceInput) GoString() string {
 	return s.String()
 }
 
+// Validate inspects the fields of the type to determine if they are valid.
+func (s *RebootInstanceInput) Validate() error {
+	invalidParams := request.ErrInvalidParams{Context: "RebootInstanceInput"}
+	if s.InstanceId == nil {
+		invalidParams.Add(request.NewErrParamRequired("InstanceId"))
+	}
+
+	if invalidParams.Len() > 0 {
+		return invalidParams
+	}
+	return nil
+}
+
 type RebootInstanceOutput struct {
 	_ struct{} `type:"structure"`
 }
@@ -5911,6 +6439,22 @@ func (s RegisterEcsClusterInput) GoString() string {
 	return s.String()
 }
 
+// Validate inspects the fields of the type to determine if they are valid.
+func (s *RegisterEcsClusterInput) Validate() error {
+	invalidParams := request.ErrInvalidParams{Context: "RegisterEcsClusterInput"}
+	if s.EcsClusterArn == nil {
+		invalidParams.Add(request.NewErrParamRequired("EcsClusterArn"))
+	}
+	if s.StackId == nil {
+		invalidParams.Add(request.NewErrParamRequired("StackId"))
+	}
+
+	if invalidParams.Len() > 0 {
+		return invalidParams
+	}
+	return nil
+}
+
 // Contains the response to a RegisterEcsCluster request.
 type RegisterEcsClusterOutput struct {
 	_ struct{} `type:"structure"`
@@ -5947,6 +6491,22 @@ func (s RegisterElasticIpInput) String() string {
 // GoString returns the string representation
 func (s RegisterElasticIpInput) GoString() string {
 	return s.String()
+}
+
+// Validate inspects the fields of the type to determine if they are valid.
+func (s *RegisterElasticIpInput) Validate() error {
+	invalidParams := request.ErrInvalidParams{Context: "RegisterElasticIpInput"}
+	if s.ElasticIp == nil {
+		invalidParams.Add(request.NewErrParamRequired("ElasticIp"))
+	}
+	if s.StackId == nil {
+		invalidParams.Add(request.NewErrParamRequired("StackId"))
+	}
+
+	if invalidParams.Len() > 0 {
+		return invalidParams
+	}
+	return nil
 }
 
 // Contains the response to a RegisterElasticIp request.
@@ -6003,6 +6563,19 @@ func (s RegisterInstanceInput) GoString() string {
 	return s.String()
 }
 
+// Validate inspects the fields of the type to determine if they are valid.
+func (s *RegisterInstanceInput) Validate() error {
+	invalidParams := request.ErrInvalidParams{Context: "RegisterInstanceInput"}
+	if s.StackId == nil {
+		invalidParams.Add(request.NewErrParamRequired("StackId"))
+	}
+
+	if invalidParams.Len() > 0 {
+		return invalidParams
+	}
+	return nil
+}
+
 // Contains the response to a RegisterInstanceResult request.
 type RegisterInstanceOutput struct {
 	_ struct{} `type:"structure"`
@@ -6047,6 +6620,28 @@ func (s RegisterRdsDbInstanceInput) GoString() string {
 	return s.String()
 }
 
+// Validate inspects the fields of the type to determine if they are valid.
+func (s *RegisterRdsDbInstanceInput) Validate() error {
+	invalidParams := request.ErrInvalidParams{Context: "RegisterRdsDbInstanceInput"}
+	if s.DbPassword == nil {
+		invalidParams.Add(request.NewErrParamRequired("DbPassword"))
+	}
+	if s.DbUser == nil {
+		invalidParams.Add(request.NewErrParamRequired("DbUser"))
+	}
+	if s.RdsDbInstanceArn == nil {
+		invalidParams.Add(request.NewErrParamRequired("RdsDbInstanceArn"))
+	}
+	if s.StackId == nil {
+		invalidParams.Add(request.NewErrParamRequired("StackId"))
+	}
+
+	if invalidParams.Len() > 0 {
+		return invalidParams
+	}
+	return nil
+}
+
 type RegisterRdsDbInstanceOutput struct {
 	_ struct{} `type:"structure"`
 }
@@ -6079,6 +6674,19 @@ func (s RegisterVolumeInput) String() string {
 // GoString returns the string representation
 func (s RegisterVolumeInput) GoString() string {
 	return s.String()
+}
+
+// Validate inspects the fields of the type to determine if they are valid.
+func (s *RegisterVolumeInput) Validate() error {
+	invalidParams := request.ErrInvalidParams{Context: "RegisterVolumeInput"}
+	if s.StackId == nil {
+		invalidParams.Add(request.NewErrParamRequired("StackId"))
+	}
+
+	if invalidParams.Len() > 0 {
+		return invalidParams
+	}
+	return nil
 }
 
 // Contains the response to a RegisterVolume request.
@@ -6213,6 +6821,29 @@ func (s SetLoadBasedAutoScalingInput) GoString() string {
 	return s.String()
 }
 
+// Validate inspects the fields of the type to determine if they are valid.
+func (s *SetLoadBasedAutoScalingInput) Validate() error {
+	invalidParams := request.ErrInvalidParams{Context: "SetLoadBasedAutoScalingInput"}
+	if s.LayerId == nil {
+		invalidParams.Add(request.NewErrParamRequired("LayerId"))
+	}
+	if s.DownScaling != nil {
+		if err := s.DownScaling.Validate(); err != nil {
+			invalidParams.AddNested("DownScaling", err.(request.ErrInvalidParams))
+		}
+	}
+	if s.UpScaling != nil {
+		if err := s.UpScaling.Validate(); err != nil {
+			invalidParams.AddNested("UpScaling", err.(request.ErrInvalidParams))
+		}
+	}
+
+	if invalidParams.Len() > 0 {
+		return invalidParams
+	}
+	return nil
+}
+
 type SetLoadBasedAutoScalingOutput struct {
 	_ struct{} `type:"structure"`
 }
@@ -6260,6 +6891,22 @@ func (s SetPermissionInput) GoString() string {
 	return s.String()
 }
 
+// Validate inspects the fields of the type to determine if they are valid.
+func (s *SetPermissionInput) Validate() error {
+	invalidParams := request.ErrInvalidParams{Context: "SetPermissionInput"}
+	if s.IamUserArn == nil {
+		invalidParams.Add(request.NewErrParamRequired("IamUserArn"))
+	}
+	if s.StackId == nil {
+		invalidParams.Add(request.NewErrParamRequired("StackId"))
+	}
+
+	if invalidParams.Len() > 0 {
+		return invalidParams
+	}
+	return nil
+}
+
 type SetPermissionOutput struct {
 	_ struct{} `type:"structure"`
 }
@@ -6292,6 +6939,19 @@ func (s SetTimeBasedAutoScalingInput) String() string {
 // GoString returns the string representation
 func (s SetTimeBasedAutoScalingInput) GoString() string {
 	return s.String()
+}
+
+// Validate inspects the fields of the type to determine if they are valid.
+func (s *SetTimeBasedAutoScalingInput) Validate() error {
+	invalidParams := request.ErrInvalidParams{Context: "SetTimeBasedAutoScalingInput"}
+	if s.InstanceId == nil {
+		invalidParams.Add(request.NewErrParamRequired("InstanceId"))
+	}
+
+	if invalidParams.Len() > 0 {
+		return invalidParams
+	}
+	return nil
 }
 
 type SetTimeBasedAutoScalingOutput struct {
@@ -6406,6 +7066,22 @@ func (s SslConfiguration) String() string {
 // GoString returns the string representation
 func (s SslConfiguration) GoString() string {
 	return s.String()
+}
+
+// Validate inspects the fields of the type to determine if they are valid.
+func (s *SslConfiguration) Validate() error {
+	invalidParams := request.ErrInvalidParams{Context: "SslConfiguration"}
+	if s.Certificate == nil {
+		invalidParams.Add(request.NewErrParamRequired("Certificate"))
+	}
+	if s.PrivateKey == nil {
+		invalidParams.Add(request.NewErrParamRequired("PrivateKey"))
+	}
+
+	if invalidParams.Len() > 0 {
+		return invalidParams
+	}
+	return nil
 }
 
 // Describes a stack.
@@ -6583,6 +7259,19 @@ func (s StartInstanceInput) GoString() string {
 	return s.String()
 }
 
+// Validate inspects the fields of the type to determine if they are valid.
+func (s *StartInstanceInput) Validate() error {
+	invalidParams := request.ErrInvalidParams{Context: "StartInstanceInput"}
+	if s.InstanceId == nil {
+		invalidParams.Add(request.NewErrParamRequired("InstanceId"))
+	}
+
+	if invalidParams.Len() > 0 {
+		return invalidParams
+	}
+	return nil
+}
+
 type StartInstanceOutput struct {
 	_ struct{} `type:"structure"`
 }
@@ -6612,6 +7301,19 @@ func (s StartStackInput) String() string {
 // GoString returns the string representation
 func (s StartStackInput) GoString() string {
 	return s.String()
+}
+
+// Validate inspects the fields of the type to determine if they are valid.
+func (s *StartStackInput) Validate() error {
+	invalidParams := request.ErrInvalidParams{Context: "StartStackInput"}
+	if s.StackId == nil {
+		invalidParams.Add(request.NewErrParamRequired("StackId"))
+	}
+
+	if invalidParams.Len() > 0 {
+		return invalidParams
+	}
+	return nil
 }
 
 type StartStackOutput struct {
@@ -6645,6 +7347,19 @@ func (s StopInstanceInput) GoString() string {
 	return s.String()
 }
 
+// Validate inspects the fields of the type to determine if they are valid.
+func (s *StopInstanceInput) Validate() error {
+	invalidParams := request.ErrInvalidParams{Context: "StopInstanceInput"}
+	if s.InstanceId == nil {
+		invalidParams.Add(request.NewErrParamRequired("InstanceId"))
+	}
+
+	if invalidParams.Len() > 0 {
+		return invalidParams
+	}
+	return nil
+}
+
 type StopInstanceOutput struct {
 	_ struct{} `type:"structure"`
 }
@@ -6674,6 +7389,19 @@ func (s StopStackInput) String() string {
 // GoString returns the string representation
 func (s StopStackInput) GoString() string {
 	return s.String()
+}
+
+// Validate inspects the fields of the type to determine if they are valid.
+func (s *StopStackInput) Validate() error {
+	invalidParams := request.ErrInvalidParams{Context: "StopStackInput"}
+	if s.StackId == nil {
+		invalidParams.Add(request.NewErrParamRequired("StackId"))
+	}
+
+	if invalidParams.Len() > 0 {
+		return invalidParams
+	}
+	return nil
 }
 
 type StopStackOutput struct {
@@ -6759,6 +7487,19 @@ func (s UnassignInstanceInput) GoString() string {
 	return s.String()
 }
 
+// Validate inspects the fields of the type to determine if they are valid.
+func (s *UnassignInstanceInput) Validate() error {
+	invalidParams := request.ErrInvalidParams{Context: "UnassignInstanceInput"}
+	if s.InstanceId == nil {
+		invalidParams.Add(request.NewErrParamRequired("InstanceId"))
+	}
+
+	if invalidParams.Len() > 0 {
+		return invalidParams
+	}
+	return nil
+}
+
 type UnassignInstanceOutput struct {
 	_ struct{} `type:"structure"`
 }
@@ -6788,6 +7529,19 @@ func (s UnassignVolumeInput) String() string {
 // GoString returns the string representation
 func (s UnassignVolumeInput) GoString() string {
 	return s.String()
+}
+
+// Validate inspects the fields of the type to determine if they are valid.
+func (s *UnassignVolumeInput) Validate() error {
+	invalidParams := request.ErrInvalidParams{Context: "UnassignVolumeInput"}
+	if s.VolumeId == nil {
+		invalidParams.Add(request.NewErrParamRequired("VolumeId"))
+	}
+
+	if invalidParams.Len() > 0 {
+		return invalidParams
+	}
+	return nil
 }
 
 type UnassignVolumeOutput struct {
@@ -6865,6 +7619,34 @@ func (s UpdateAppInput) GoString() string {
 	return s.String()
 }
 
+// Validate inspects the fields of the type to determine if they are valid.
+func (s *UpdateAppInput) Validate() error {
+	invalidParams := request.ErrInvalidParams{Context: "UpdateAppInput"}
+	if s.AppId == nil {
+		invalidParams.Add(request.NewErrParamRequired("AppId"))
+	}
+	if s.Environment != nil {
+		for i, v := range s.Environment {
+			if v == nil {
+				continue
+			}
+			if err := v.Validate(); err != nil {
+				invalidParams.AddNested(fmt.Sprintf("%s[%v]", "Environment", i), err.(request.ErrInvalidParams))
+			}
+		}
+	}
+	if s.SslConfiguration != nil {
+		if err := s.SslConfiguration.Validate(); err != nil {
+			invalidParams.AddNested("SslConfiguration", err.(request.ErrInvalidParams))
+		}
+	}
+
+	if invalidParams.Len() > 0 {
+		return invalidParams
+	}
+	return nil
+}
+
 type UpdateAppOutput struct {
 	_ struct{} `type:"structure"`
 }
@@ -6897,6 +7679,19 @@ func (s UpdateElasticIpInput) String() string {
 // GoString returns the string representation
 func (s UpdateElasticIpInput) GoString() string {
 	return s.String()
+}
+
+// Validate inspects the fields of the type to determine if they are valid.
+func (s *UpdateElasticIpInput) Validate() error {
+	invalidParams := request.ErrInvalidParams{Context: "UpdateElasticIpInput"}
+	if s.ElasticIp == nil {
+		invalidParams.Add(request.NewErrParamRequired("ElasticIp"))
+	}
+
+	if invalidParams.Len() > 0 {
+		return invalidParams
+	}
+	return nil
 }
 
 type UpdateElasticIpOutput struct {
@@ -7007,6 +7802,19 @@ func (s UpdateInstanceInput) GoString() string {
 	return s.String()
 }
 
+// Validate inspects the fields of the type to determine if they are valid.
+func (s *UpdateInstanceInput) Validate() error {
+	invalidParams := request.ErrInvalidParams{Context: "UpdateInstanceInput"}
+	if s.InstanceId == nil {
+		invalidParams.Add(request.NewErrParamRequired("InstanceId"))
+	}
+
+	if invalidParams.Len() > 0 {
+		return invalidParams
+	}
+	return nil
+}
+
 type UpdateInstanceOutput struct {
 	_ struct{} `type:"structure"`
 }
@@ -7102,6 +7910,29 @@ func (s UpdateLayerInput) GoString() string {
 	return s.String()
 }
 
+// Validate inspects the fields of the type to determine if they are valid.
+func (s *UpdateLayerInput) Validate() error {
+	invalidParams := request.ErrInvalidParams{Context: "UpdateLayerInput"}
+	if s.LayerId == nil {
+		invalidParams.Add(request.NewErrParamRequired("LayerId"))
+	}
+	if s.VolumeConfigurations != nil {
+		for i, v := range s.VolumeConfigurations {
+			if v == nil {
+				continue
+			}
+			if err := v.Validate(); err != nil {
+				invalidParams.AddNested(fmt.Sprintf("%s[%v]", "VolumeConfigurations", i), err.(request.ErrInvalidParams))
+			}
+		}
+	}
+
+	if invalidParams.Len() > 0 {
+		return invalidParams
+	}
+	return nil
+}
+
 type UpdateLayerOutput struct {
 	_ struct{} `type:"structure"`
 }
@@ -7168,6 +7999,19 @@ func (s UpdateRdsDbInstanceInput) String() string {
 // GoString returns the string representation
 func (s UpdateRdsDbInstanceInput) GoString() string {
 	return s.String()
+}
+
+// Validate inspects the fields of the type to determine if they are valid.
+func (s *UpdateRdsDbInstanceInput) Validate() error {
+	invalidParams := request.ErrInvalidParams{Context: "UpdateRdsDbInstanceInput"}
+	if s.RdsDbInstanceArn == nil {
+		invalidParams.Add(request.NewErrParamRequired("RdsDbInstanceArn"))
+	}
+
+	if invalidParams.Len() > 0 {
+		return invalidParams
+	}
+	return nil
 }
 
 type UpdateRdsDbInstanceOutput struct {
@@ -7329,6 +8173,19 @@ func (s UpdateStackInput) GoString() string {
 	return s.String()
 }
 
+// Validate inspects the fields of the type to determine if they are valid.
+func (s *UpdateStackInput) Validate() error {
+	invalidParams := request.ErrInvalidParams{Context: "UpdateStackInput"}
+	if s.StackId == nil {
+		invalidParams.Add(request.NewErrParamRequired("StackId"))
+	}
+
+	if invalidParams.Len() > 0 {
+		return invalidParams
+	}
+	return nil
+}
+
 type UpdateStackOutput struct {
 	_ struct{} `type:"structure"`
 }
@@ -7374,6 +8231,19 @@ func (s UpdateUserProfileInput) GoString() string {
 	return s.String()
 }
 
+// Validate inspects the fields of the type to determine if they are valid.
+func (s *UpdateUserProfileInput) Validate() error {
+	invalidParams := request.ErrInvalidParams{Context: "UpdateUserProfileInput"}
+	if s.IamUserArn == nil {
+		invalidParams.Add(request.NewErrParamRequired("IamUserArn"))
+	}
+
+	if invalidParams.Len() > 0 {
+		return invalidParams
+	}
+	return nil
+}
+
 type UpdateUserProfileOutput struct {
 	_ struct{} `type:"structure"`
 }
@@ -7409,6 +8279,19 @@ func (s UpdateVolumeInput) String() string {
 // GoString returns the string representation
 func (s UpdateVolumeInput) GoString() string {
 	return s.String()
+}
+
+// Validate inspects the fields of the type to determine if they are valid.
+func (s *UpdateVolumeInput) Validate() error {
+	invalidParams := request.ErrInvalidParams{Context: "UpdateVolumeInput"}
+	if s.VolumeId == nil {
+		invalidParams.Add(request.NewErrParamRequired("VolumeId"))
+	}
+
+	if invalidParams.Len() > 0 {
+		return invalidParams
+	}
+	return nil
 }
 
 type UpdateVolumeOutput struct {
@@ -7546,6 +8429,25 @@ func (s VolumeConfiguration) String() string {
 // GoString returns the string representation
 func (s VolumeConfiguration) GoString() string {
 	return s.String()
+}
+
+// Validate inspects the fields of the type to determine if they are valid.
+func (s *VolumeConfiguration) Validate() error {
+	invalidParams := request.ErrInvalidParams{Context: "VolumeConfiguration"}
+	if s.MountPoint == nil {
+		invalidParams.Add(request.NewErrParamRequired("MountPoint"))
+	}
+	if s.NumberOfDisks == nil {
+		invalidParams.Add(request.NewErrParamRequired("NumberOfDisks"))
+	}
+	if s.Size == nil {
+		invalidParams.Add(request.NewErrParamRequired("Size"))
+	}
+
+	if invalidParams.Len() > 0 {
+		return invalidParams
+	}
+	return nil
 }
 
 // Describes a time-based instance's auto scaling schedule. The schedule consists

--- a/service/rds/api.go
+++ b/service/rds/api.go
@@ -4,6 +4,7 @@
 package rds
 
 import (
+	"fmt"
 	"time"
 
 	"github.com/aws/aws-sdk-go/aws/awsutil"
@@ -2794,6 +2795,22 @@ func (s AddSourceIdentifierToSubscriptionInput) GoString() string {
 	return s.String()
 }
 
+// Validate inspects the fields of the type to determine if they are valid.
+func (s *AddSourceIdentifierToSubscriptionInput) Validate() error {
+	invalidParams := request.ErrInvalidParams{Context: "AddSourceIdentifierToSubscriptionInput"}
+	if s.SourceIdentifier == nil {
+		invalidParams.Add(request.NewErrParamRequired("SourceIdentifier"))
+	}
+	if s.SubscriptionName == nil {
+		invalidParams.Add(request.NewErrParamRequired("SubscriptionName"))
+	}
+
+	if invalidParams.Len() > 0 {
+		return invalidParams
+	}
+	return nil
+}
+
 type AddSourceIdentifierToSubscriptionOutput struct {
 	_ struct{} `type:"structure"`
 
@@ -2832,6 +2849,22 @@ func (s AddTagsToResourceInput) String() string {
 // GoString returns the string representation
 func (s AddTagsToResourceInput) GoString() string {
 	return s.String()
+}
+
+// Validate inspects the fields of the type to determine if they are valid.
+func (s *AddTagsToResourceInput) Validate() error {
+	invalidParams := request.ErrInvalidParams{Context: "AddTagsToResourceInput"}
+	if s.ResourceName == nil {
+		invalidParams.Add(request.NewErrParamRequired("ResourceName"))
+	}
+	if s.Tags == nil {
+		invalidParams.Add(request.NewErrParamRequired("Tags"))
+	}
+
+	if invalidParams.Len() > 0 {
+		return invalidParams
+	}
+	return nil
 }
 
 type AddTagsToResourceOutput struct {
@@ -2880,6 +2913,25 @@ func (s ApplyPendingMaintenanceActionInput) String() string {
 // GoString returns the string representation
 func (s ApplyPendingMaintenanceActionInput) GoString() string {
 	return s.String()
+}
+
+// Validate inspects the fields of the type to determine if they are valid.
+func (s *ApplyPendingMaintenanceActionInput) Validate() error {
+	invalidParams := request.ErrInvalidParams{Context: "ApplyPendingMaintenanceActionInput"}
+	if s.ApplyAction == nil {
+		invalidParams.Add(request.NewErrParamRequired("ApplyAction"))
+	}
+	if s.OptInType == nil {
+		invalidParams.Add(request.NewErrParamRequired("OptInType"))
+	}
+	if s.ResourceIdentifier == nil {
+		invalidParams.Add(request.NewErrParamRequired("ResourceIdentifier"))
+	}
+
+	if invalidParams.Len() > 0 {
+		return invalidParams
+	}
+	return nil
 }
 
 type ApplyPendingMaintenanceActionOutput struct {
@@ -2934,6 +2986,19 @@ func (s AuthorizeDBSecurityGroupIngressInput) String() string {
 // GoString returns the string representation
 func (s AuthorizeDBSecurityGroupIngressInput) GoString() string {
 	return s.String()
+}
+
+// Validate inspects the fields of the type to determine if they are valid.
+func (s *AuthorizeDBSecurityGroupIngressInput) Validate() error {
+	invalidParams := request.ErrInvalidParams{Context: "AuthorizeDBSecurityGroupIngressInput"}
+	if s.DBSecurityGroupName == nil {
+		invalidParams.Add(request.NewErrParamRequired("DBSecurityGroupName"))
+	}
+
+	if invalidParams.Len() > 0 {
+		return invalidParams
+	}
+	return nil
 }
 
 type AuthorizeDBSecurityGroupIngressOutput struct {
@@ -3065,6 +3130,22 @@ func (s CopyDBClusterSnapshotInput) GoString() string {
 	return s.String()
 }
 
+// Validate inspects the fields of the type to determine if they are valid.
+func (s *CopyDBClusterSnapshotInput) Validate() error {
+	invalidParams := request.ErrInvalidParams{Context: "CopyDBClusterSnapshotInput"}
+	if s.SourceDBClusterSnapshotIdentifier == nil {
+		invalidParams.Add(request.NewErrParamRequired("SourceDBClusterSnapshotIdentifier"))
+	}
+	if s.TargetDBClusterSnapshotIdentifier == nil {
+		invalidParams.Add(request.NewErrParamRequired("TargetDBClusterSnapshotIdentifier"))
+	}
+
+	if invalidParams.Len() > 0 {
+		return invalidParams
+	}
+	return nil
+}
+
 type CopyDBClusterSnapshotOutput struct {
 	_ struct{} `type:"structure"`
 
@@ -3125,6 +3206,25 @@ func (s CopyDBParameterGroupInput) String() string {
 // GoString returns the string representation
 func (s CopyDBParameterGroupInput) GoString() string {
 	return s.String()
+}
+
+// Validate inspects the fields of the type to determine if they are valid.
+func (s *CopyDBParameterGroupInput) Validate() error {
+	invalidParams := request.ErrInvalidParams{Context: "CopyDBParameterGroupInput"}
+	if s.SourceDBParameterGroupIdentifier == nil {
+		invalidParams.Add(request.NewErrParamRequired("SourceDBParameterGroupIdentifier"))
+	}
+	if s.TargetDBParameterGroupDescription == nil {
+		invalidParams.Add(request.NewErrParamRequired("TargetDBParameterGroupDescription"))
+	}
+	if s.TargetDBParameterGroupIdentifier == nil {
+		invalidParams.Add(request.NewErrParamRequired("TargetDBParameterGroupIdentifier"))
+	}
+
+	if invalidParams.Len() > 0 {
+		return invalidParams
+	}
+	return nil
 }
 
 type CopyDBParameterGroupOutput struct {
@@ -3212,6 +3312,22 @@ func (s CopyDBSnapshotInput) GoString() string {
 	return s.String()
 }
 
+// Validate inspects the fields of the type to determine if they are valid.
+func (s *CopyDBSnapshotInput) Validate() error {
+	invalidParams := request.ErrInvalidParams{Context: "CopyDBSnapshotInput"}
+	if s.SourceDBSnapshotIdentifier == nil {
+		invalidParams.Add(request.NewErrParamRequired("SourceDBSnapshotIdentifier"))
+	}
+	if s.TargetDBSnapshotIdentifier == nil {
+		invalidParams.Add(request.NewErrParamRequired("TargetDBSnapshotIdentifier"))
+	}
+
+	if invalidParams.Len() > 0 {
+		return invalidParams
+	}
+	return nil
+}
+
 type CopyDBSnapshotOutput struct {
 	_ struct{} `type:"structure"`
 
@@ -3270,6 +3386,25 @@ func (s CopyOptionGroupInput) String() string {
 // GoString returns the string representation
 func (s CopyOptionGroupInput) GoString() string {
 	return s.String()
+}
+
+// Validate inspects the fields of the type to determine if they are valid.
+func (s *CopyOptionGroupInput) Validate() error {
+	invalidParams := request.ErrInvalidParams{Context: "CopyOptionGroupInput"}
+	if s.SourceOptionGroupIdentifier == nil {
+		invalidParams.Add(request.NewErrParamRequired("SourceOptionGroupIdentifier"))
+	}
+	if s.TargetOptionGroupDescription == nil {
+		invalidParams.Add(request.NewErrParamRequired("TargetOptionGroupDescription"))
+	}
+	if s.TargetOptionGroupIdentifier == nil {
+		invalidParams.Add(request.NewErrParamRequired("TargetOptionGroupIdentifier"))
+	}
+
+	if invalidParams.Len() > 0 {
+		return invalidParams
+	}
+	return nil
 }
 
 type CopyOptionGroupOutput struct {
@@ -3443,6 +3578,28 @@ func (s CreateDBClusterInput) GoString() string {
 	return s.String()
 }
 
+// Validate inspects the fields of the type to determine if they are valid.
+func (s *CreateDBClusterInput) Validate() error {
+	invalidParams := request.ErrInvalidParams{Context: "CreateDBClusterInput"}
+	if s.DBClusterIdentifier == nil {
+		invalidParams.Add(request.NewErrParamRequired("DBClusterIdentifier"))
+	}
+	if s.Engine == nil {
+		invalidParams.Add(request.NewErrParamRequired("Engine"))
+	}
+	if s.MasterUserPassword == nil {
+		invalidParams.Add(request.NewErrParamRequired("MasterUserPassword"))
+	}
+	if s.MasterUsername == nil {
+		invalidParams.Add(request.NewErrParamRequired("MasterUsername"))
+	}
+
+	if invalidParams.Len() > 0 {
+		return invalidParams
+	}
+	return nil
+}
+
 type CreateDBClusterOutput struct {
 	_ struct{} `type:"structure"`
 
@@ -3497,6 +3654,25 @@ func (s CreateDBClusterParameterGroupInput) String() string {
 // GoString returns the string representation
 func (s CreateDBClusterParameterGroupInput) GoString() string {
 	return s.String()
+}
+
+// Validate inspects the fields of the type to determine if they are valid.
+func (s *CreateDBClusterParameterGroupInput) Validate() error {
+	invalidParams := request.ErrInvalidParams{Context: "CreateDBClusterParameterGroupInput"}
+	if s.DBClusterParameterGroupName == nil {
+		invalidParams.Add(request.NewErrParamRequired("DBClusterParameterGroupName"))
+	}
+	if s.DBParameterGroupFamily == nil {
+		invalidParams.Add(request.NewErrParamRequired("DBParameterGroupFamily"))
+	}
+	if s.Description == nil {
+		invalidParams.Add(request.NewErrParamRequired("Description"))
+	}
+
+	if invalidParams.Len() > 0 {
+		return invalidParams
+	}
+	return nil
 }
 
 type CreateDBClusterParameterGroupOutput struct {
@@ -3556,6 +3732,22 @@ func (s CreateDBClusterSnapshotInput) String() string {
 // GoString returns the string representation
 func (s CreateDBClusterSnapshotInput) GoString() string {
 	return s.String()
+}
+
+// Validate inspects the fields of the type to determine if they are valid.
+func (s *CreateDBClusterSnapshotInput) Validate() error {
+	invalidParams := request.ErrInvalidParams{Context: "CreateDBClusterSnapshotInput"}
+	if s.DBClusterIdentifier == nil {
+		invalidParams.Add(request.NewErrParamRequired("DBClusterIdentifier"))
+	}
+	if s.DBClusterSnapshotIdentifier == nil {
+		invalidParams.Add(request.NewErrParamRequired("DBClusterSnapshotIdentifier"))
+	}
+
+	if invalidParams.Len() > 0 {
+		return invalidParams
+	}
+	return nil
 }
 
 type CreateDBClusterSnapshotOutput struct {
@@ -4099,6 +4291,25 @@ func (s CreateDBInstanceInput) GoString() string {
 	return s.String()
 }
 
+// Validate inspects the fields of the type to determine if they are valid.
+func (s *CreateDBInstanceInput) Validate() error {
+	invalidParams := request.ErrInvalidParams{Context: "CreateDBInstanceInput"}
+	if s.DBInstanceClass == nil {
+		invalidParams.Add(request.NewErrParamRequired("DBInstanceClass"))
+	}
+	if s.DBInstanceIdentifier == nil {
+		invalidParams.Add(request.NewErrParamRequired("DBInstanceIdentifier"))
+	}
+	if s.Engine == nil {
+		invalidParams.Add(request.NewErrParamRequired("Engine"))
+	}
+
+	if invalidParams.Len() > 0 {
+		return invalidParams
+	}
+	return nil
+}
+
 type CreateDBInstanceOutput struct {
 	_ struct{} `type:"structure"`
 
@@ -4264,6 +4475,22 @@ func (s CreateDBInstanceReadReplicaInput) GoString() string {
 	return s.String()
 }
 
+// Validate inspects the fields of the type to determine if they are valid.
+func (s *CreateDBInstanceReadReplicaInput) Validate() error {
+	invalidParams := request.ErrInvalidParams{Context: "CreateDBInstanceReadReplicaInput"}
+	if s.DBInstanceIdentifier == nil {
+		invalidParams.Add(request.NewErrParamRequired("DBInstanceIdentifier"))
+	}
+	if s.SourceDBInstanceIdentifier == nil {
+		invalidParams.Add(request.NewErrParamRequired("SourceDBInstanceIdentifier"))
+	}
+
+	if invalidParams.Len() > 0 {
+		return invalidParams
+	}
+	return nil
+}
+
 type CreateDBInstanceReadReplicaOutput struct {
 	_ struct{} `type:"structure"`
 
@@ -4319,6 +4546,25 @@ func (s CreateDBParameterGroupInput) GoString() string {
 	return s.String()
 }
 
+// Validate inspects the fields of the type to determine if they are valid.
+func (s *CreateDBParameterGroupInput) Validate() error {
+	invalidParams := request.ErrInvalidParams{Context: "CreateDBParameterGroupInput"}
+	if s.DBParameterGroupFamily == nil {
+		invalidParams.Add(request.NewErrParamRequired("DBParameterGroupFamily"))
+	}
+	if s.DBParameterGroupName == nil {
+		invalidParams.Add(request.NewErrParamRequired("DBParameterGroupName"))
+	}
+	if s.Description == nil {
+		invalidParams.Add(request.NewErrParamRequired("Description"))
+	}
+
+	if invalidParams.Len() > 0 {
+		return invalidParams
+	}
+	return nil
+}
+
 type CreateDBParameterGroupOutput struct {
 	_ struct{} `type:"structure"`
 
@@ -4367,6 +4613,22 @@ func (s CreateDBSecurityGroupInput) String() string {
 // GoString returns the string representation
 func (s CreateDBSecurityGroupInput) GoString() string {
 	return s.String()
+}
+
+// Validate inspects the fields of the type to determine if they are valid.
+func (s *CreateDBSecurityGroupInput) Validate() error {
+	invalidParams := request.ErrInvalidParams{Context: "CreateDBSecurityGroupInput"}
+	if s.DBSecurityGroupDescription == nil {
+		invalidParams.Add(request.NewErrParamRequired("DBSecurityGroupDescription"))
+	}
+	if s.DBSecurityGroupName == nil {
+		invalidParams.Add(request.NewErrParamRequired("DBSecurityGroupName"))
+	}
+
+	if invalidParams.Len() > 0 {
+		return invalidParams
+	}
+	return nil
 }
 
 type CreateDBSecurityGroupOutput struct {
@@ -4424,6 +4686,22 @@ func (s CreateDBSnapshotInput) GoString() string {
 	return s.String()
 }
 
+// Validate inspects the fields of the type to determine if they are valid.
+func (s *CreateDBSnapshotInput) Validate() error {
+	invalidParams := request.ErrInvalidParams{Context: "CreateDBSnapshotInput"}
+	if s.DBInstanceIdentifier == nil {
+		invalidParams.Add(request.NewErrParamRequired("DBInstanceIdentifier"))
+	}
+	if s.DBSnapshotIdentifier == nil {
+		invalidParams.Add(request.NewErrParamRequired("DBSnapshotIdentifier"))
+	}
+
+	if invalidParams.Len() > 0 {
+		return invalidParams
+	}
+	return nil
+}
+
 type CreateDBSnapshotOutput struct {
 	_ struct{} `type:"structure"`
 
@@ -4473,6 +4751,25 @@ func (s CreateDBSubnetGroupInput) String() string {
 // GoString returns the string representation
 func (s CreateDBSubnetGroupInput) GoString() string {
 	return s.String()
+}
+
+// Validate inspects the fields of the type to determine if they are valid.
+func (s *CreateDBSubnetGroupInput) Validate() error {
+	invalidParams := request.ErrInvalidParams{Context: "CreateDBSubnetGroupInput"}
+	if s.DBSubnetGroupDescription == nil {
+		invalidParams.Add(request.NewErrParamRequired("DBSubnetGroupDescription"))
+	}
+	if s.DBSubnetGroupName == nil {
+		invalidParams.Add(request.NewErrParamRequired("DBSubnetGroupName"))
+	}
+	if s.SubnetIds == nil {
+		invalidParams.Add(request.NewErrParamRequired("SubnetIds"))
+	}
+
+	if invalidParams.Len() > 0 {
+		return invalidParams
+	}
+	return nil
 }
 
 type CreateDBSubnetGroupOutput struct {
@@ -4557,6 +4854,22 @@ func (s CreateEventSubscriptionInput) GoString() string {
 	return s.String()
 }
 
+// Validate inspects the fields of the type to determine if they are valid.
+func (s *CreateEventSubscriptionInput) Validate() error {
+	invalidParams := request.ErrInvalidParams{Context: "CreateEventSubscriptionInput"}
+	if s.SnsTopicArn == nil {
+		invalidParams.Add(request.NewErrParamRequired("SnsTopicArn"))
+	}
+	if s.SubscriptionName == nil {
+		invalidParams.Add(request.NewErrParamRequired("SubscriptionName"))
+	}
+
+	if invalidParams.Len() > 0 {
+		return invalidParams
+	}
+	return nil
+}
+
 type CreateEventSubscriptionOutput struct {
 	_ struct{} `type:"structure"`
 
@@ -4610,6 +4923,28 @@ func (s CreateOptionGroupInput) String() string {
 // GoString returns the string representation
 func (s CreateOptionGroupInput) GoString() string {
 	return s.String()
+}
+
+// Validate inspects the fields of the type to determine if they are valid.
+func (s *CreateOptionGroupInput) Validate() error {
+	invalidParams := request.ErrInvalidParams{Context: "CreateOptionGroupInput"}
+	if s.EngineName == nil {
+		invalidParams.Add(request.NewErrParamRequired("EngineName"))
+	}
+	if s.MajorEngineVersion == nil {
+		invalidParams.Add(request.NewErrParamRequired("MajorEngineVersion"))
+	}
+	if s.OptionGroupDescription == nil {
+		invalidParams.Add(request.NewErrParamRequired("OptionGroupDescription"))
+	}
+	if s.OptionGroupName == nil {
+		invalidParams.Add(request.NewErrParamRequired("OptionGroupName"))
+	}
+
+	if invalidParams.Len() > 0 {
+		return invalidParams
+	}
+	return nil
 }
 
 type CreateOptionGroupOutput struct {
@@ -5560,6 +5895,19 @@ func (s DeleteDBClusterInput) GoString() string {
 	return s.String()
 }
 
+// Validate inspects the fields of the type to determine if they are valid.
+func (s *DeleteDBClusterInput) Validate() error {
+	invalidParams := request.ErrInvalidParams{Context: "DeleteDBClusterInput"}
+	if s.DBClusterIdentifier == nil {
+		invalidParams.Add(request.NewErrParamRequired("DBClusterIdentifier"))
+	}
+
+	if invalidParams.Len() > 0 {
+		return invalidParams
+	}
+	return nil
+}
+
 type DeleteDBClusterOutput struct {
 	_ struct{} `type:"structure"`
 
@@ -5604,6 +5952,19 @@ func (s DeleteDBClusterParameterGroupInput) GoString() string {
 	return s.String()
 }
 
+// Validate inspects the fields of the type to determine if they are valid.
+func (s *DeleteDBClusterParameterGroupInput) Validate() error {
+	invalidParams := request.ErrInvalidParams{Context: "DeleteDBClusterParameterGroupInput"}
+	if s.DBClusterParameterGroupName == nil {
+		invalidParams.Add(request.NewErrParamRequired("DBClusterParameterGroupName"))
+	}
+
+	if invalidParams.Len() > 0 {
+		return invalidParams
+	}
+	return nil
+}
+
 type DeleteDBClusterParameterGroupOutput struct {
 	_ struct{} `type:"structure"`
 }
@@ -5636,6 +5997,19 @@ func (s DeleteDBClusterSnapshotInput) String() string {
 // GoString returns the string representation
 func (s DeleteDBClusterSnapshotInput) GoString() string {
 	return s.String()
+}
+
+// Validate inspects the fields of the type to determine if they are valid.
+func (s *DeleteDBClusterSnapshotInput) Validate() error {
+	invalidParams := request.ErrInvalidParams{Context: "DeleteDBClusterSnapshotInput"}
+	if s.DBClusterSnapshotIdentifier == nil {
+		invalidParams.Add(request.NewErrParamRequired("DBClusterSnapshotIdentifier"))
+	}
+
+	if invalidParams.Len() > 0 {
+		return invalidParams
+	}
+	return nil
 }
 
 type DeleteDBClusterSnapshotOutput struct {
@@ -5706,6 +6080,19 @@ func (s DeleteDBInstanceInput) GoString() string {
 	return s.String()
 }
 
+// Validate inspects the fields of the type to determine if they are valid.
+func (s *DeleteDBInstanceInput) Validate() error {
+	invalidParams := request.ErrInvalidParams{Context: "DeleteDBInstanceInput"}
+	if s.DBInstanceIdentifier == nil {
+		invalidParams.Add(request.NewErrParamRequired("DBInstanceIdentifier"))
+	}
+
+	if invalidParams.Len() > 0 {
+		return invalidParams
+	}
+	return nil
+}
+
 type DeleteDBInstanceOutput struct {
 	_ struct{} `type:"structure"`
 
@@ -5748,6 +6135,19 @@ func (s DeleteDBParameterGroupInput) GoString() string {
 	return s.String()
 }
 
+// Validate inspects the fields of the type to determine if they are valid.
+func (s *DeleteDBParameterGroupInput) Validate() error {
+	invalidParams := request.ErrInvalidParams{Context: "DeleteDBParameterGroupInput"}
+	if s.DBParameterGroupName == nil {
+		invalidParams.Add(request.NewErrParamRequired("DBParameterGroupName"))
+	}
+
+	if invalidParams.Len() > 0 {
+		return invalidParams
+	}
+	return nil
+}
+
 type DeleteDBParameterGroupOutput struct {
 	_ struct{} `type:"structure"`
 }
@@ -5785,6 +6185,19 @@ func (s DeleteDBSecurityGroupInput) GoString() string {
 	return s.String()
 }
 
+// Validate inspects the fields of the type to determine if they are valid.
+func (s *DeleteDBSecurityGroupInput) Validate() error {
+	invalidParams := request.ErrInvalidParams{Context: "DeleteDBSecurityGroupInput"}
+	if s.DBSecurityGroupName == nil {
+		invalidParams.Add(request.NewErrParamRequired("DBSecurityGroupName"))
+	}
+
+	if invalidParams.Len() > 0 {
+		return invalidParams
+	}
+	return nil
+}
+
 type DeleteDBSecurityGroupOutput struct {
 	_ struct{} `type:"structure"`
 }
@@ -5817,6 +6230,19 @@ func (s DeleteDBSnapshotInput) String() string {
 // GoString returns the string representation
 func (s DeleteDBSnapshotInput) GoString() string {
 	return s.String()
+}
+
+// Validate inspects the fields of the type to determine if they are valid.
+func (s *DeleteDBSnapshotInput) Validate() error {
+	invalidParams := request.ErrInvalidParams{Context: "DeleteDBSnapshotInput"}
+	if s.DBSnapshotIdentifier == nil {
+		invalidParams.Add(request.NewErrParamRequired("DBSnapshotIdentifier"))
+	}
+
+	if invalidParams.Len() > 0 {
+		return invalidParams
+	}
+	return nil
 }
 
 type DeleteDBSnapshotOutput struct {
@@ -5863,6 +6289,19 @@ func (s DeleteDBSubnetGroupInput) GoString() string {
 	return s.String()
 }
 
+// Validate inspects the fields of the type to determine if they are valid.
+func (s *DeleteDBSubnetGroupInput) Validate() error {
+	invalidParams := request.ErrInvalidParams{Context: "DeleteDBSubnetGroupInput"}
+	if s.DBSubnetGroupName == nil {
+		invalidParams.Add(request.NewErrParamRequired("DBSubnetGroupName"))
+	}
+
+	if invalidParams.Len() > 0 {
+		return invalidParams
+	}
+	return nil
+}
+
 type DeleteDBSubnetGroupOutput struct {
 	_ struct{} `type:"structure"`
 }
@@ -5892,6 +6331,19 @@ func (s DeleteEventSubscriptionInput) String() string {
 // GoString returns the string representation
 func (s DeleteEventSubscriptionInput) GoString() string {
 	return s.String()
+}
+
+// Validate inspects the fields of the type to determine if they are valid.
+func (s *DeleteEventSubscriptionInput) Validate() error {
+	invalidParams := request.ErrInvalidParams{Context: "DeleteEventSubscriptionInput"}
+	if s.SubscriptionName == nil {
+		invalidParams.Add(request.NewErrParamRequired("SubscriptionName"))
+	}
+
+	if invalidParams.Len() > 0 {
+		return invalidParams
+	}
+	return nil
 }
 
 type DeleteEventSubscriptionOutput struct {
@@ -5929,6 +6381,19 @@ func (s DeleteOptionGroupInput) String() string {
 // GoString returns the string representation
 func (s DeleteOptionGroupInput) GoString() string {
 	return s.String()
+}
+
+// Validate inspects the fields of the type to determine if they are valid.
+func (s *DeleteOptionGroupInput) Validate() error {
+	invalidParams := request.ErrInvalidParams{Context: "DeleteOptionGroupInput"}
+	if s.OptionGroupName == nil {
+		invalidParams.Add(request.NewErrParamRequired("OptionGroupName"))
+	}
+
+	if invalidParams.Len() > 0 {
+		return invalidParams
+	}
+	return nil
 }
 
 type DeleteOptionGroupOutput struct {
@@ -6019,6 +6484,26 @@ func (s DescribeCertificatesInput) GoString() string {
 	return s.String()
 }
 
+// Validate inspects the fields of the type to determine if they are valid.
+func (s *DescribeCertificatesInput) Validate() error {
+	invalidParams := request.ErrInvalidParams{Context: "DescribeCertificatesInput"}
+	if s.Filters != nil {
+		for i, v := range s.Filters {
+			if v == nil {
+				continue
+			}
+			if err := v.Validate(); err != nil {
+				invalidParams.AddNested(fmt.Sprintf("%s[%v]", "Filters", i), err.(request.ErrInvalidParams))
+			}
+		}
+	}
+
+	if invalidParams.Len() > 0 {
+		return invalidParams
+	}
+	return nil
+}
+
 // Data returned by the DescribeCertificates action.
 type DescribeCertificatesOutput struct {
 	_ struct{} `type:"structure"`
@@ -6079,6 +6564,26 @@ func (s DescribeDBClusterParameterGroupsInput) String() string {
 // GoString returns the string representation
 func (s DescribeDBClusterParameterGroupsInput) GoString() string {
 	return s.String()
+}
+
+// Validate inspects the fields of the type to determine if they are valid.
+func (s *DescribeDBClusterParameterGroupsInput) Validate() error {
+	invalidParams := request.ErrInvalidParams{Context: "DescribeDBClusterParameterGroupsInput"}
+	if s.Filters != nil {
+		for i, v := range s.Filters {
+			if v == nil {
+				continue
+			}
+			if err := v.Validate(); err != nil {
+				invalidParams.AddNested(fmt.Sprintf("%s[%v]", "Filters", i), err.(request.ErrInvalidParams))
+			}
+		}
+	}
+
+	if invalidParams.Len() > 0 {
+		return invalidParams
+	}
+	return nil
 }
 
 type DescribeDBClusterParameterGroupsOutput struct {
@@ -6145,6 +6650,29 @@ func (s DescribeDBClusterParametersInput) String() string {
 // GoString returns the string representation
 func (s DescribeDBClusterParametersInput) GoString() string {
 	return s.String()
+}
+
+// Validate inspects the fields of the type to determine if they are valid.
+func (s *DescribeDBClusterParametersInput) Validate() error {
+	invalidParams := request.ErrInvalidParams{Context: "DescribeDBClusterParametersInput"}
+	if s.DBClusterParameterGroupName == nil {
+		invalidParams.Add(request.NewErrParamRequired("DBClusterParameterGroupName"))
+	}
+	if s.Filters != nil {
+		for i, v := range s.Filters {
+			if v == nil {
+				continue
+			}
+			if err := v.Validate(); err != nil {
+				invalidParams.AddNested(fmt.Sprintf("%s[%v]", "Filters", i), err.(request.ErrInvalidParams))
+			}
+		}
+	}
+
+	if invalidParams.Len() > 0 {
+		return invalidParams
+	}
+	return nil
 }
 
 // Provides details about a DB cluster parameter group including the parameters
@@ -6229,6 +6757,26 @@ func (s DescribeDBClusterSnapshotsInput) GoString() string {
 	return s.String()
 }
 
+// Validate inspects the fields of the type to determine if they are valid.
+func (s *DescribeDBClusterSnapshotsInput) Validate() error {
+	invalidParams := request.ErrInvalidParams{Context: "DescribeDBClusterSnapshotsInput"}
+	if s.Filters != nil {
+		for i, v := range s.Filters {
+			if v == nil {
+				continue
+			}
+			if err := v.Validate(); err != nil {
+				invalidParams.AddNested(fmt.Sprintf("%s[%v]", "Filters", i), err.(request.ErrInvalidParams))
+			}
+		}
+	}
+
+	if invalidParams.Len() > 0 {
+		return invalidParams
+	}
+	return nil
+}
+
 // Provides a list of DB cluster snapshots for the user as the result of a call
 // to the DescribeDBClusterSnapshots action.
 type DescribeDBClusterSnapshotsOutput struct {
@@ -6292,6 +6840,26 @@ func (s DescribeDBClustersInput) String() string {
 // GoString returns the string representation
 func (s DescribeDBClustersInput) GoString() string {
 	return s.String()
+}
+
+// Validate inspects the fields of the type to determine if they are valid.
+func (s *DescribeDBClustersInput) Validate() error {
+	invalidParams := request.ErrInvalidParams{Context: "DescribeDBClustersInput"}
+	if s.Filters != nil {
+		for i, v := range s.Filters {
+			if v == nil {
+				continue
+			}
+			if err := v.Validate(); err != nil {
+				invalidParams.AddNested(fmt.Sprintf("%s[%v]", "Filters", i), err.(request.ErrInvalidParams))
+			}
+		}
+	}
+
+	if invalidParams.Len() > 0 {
+		return invalidParams
+	}
+	return nil
 }
 
 // Contains the result of a successful invocation of the DescribeDBClusters
@@ -6372,6 +6940,26 @@ func (s DescribeDBEngineVersionsInput) GoString() string {
 	return s.String()
 }
 
+// Validate inspects the fields of the type to determine if they are valid.
+func (s *DescribeDBEngineVersionsInput) Validate() error {
+	invalidParams := request.ErrInvalidParams{Context: "DescribeDBEngineVersionsInput"}
+	if s.Filters != nil {
+		for i, v := range s.Filters {
+			if v == nil {
+				continue
+			}
+			if err := v.Validate(); err != nil {
+				invalidParams.AddNested(fmt.Sprintf("%s[%v]", "Filters", i), err.(request.ErrInvalidParams))
+			}
+		}
+	}
+
+	if invalidParams.Len() > 0 {
+		return invalidParams
+	}
+	return nil
+}
+
 // Contains the result of a successful invocation of the DescribeDBEngineVersions
 // action.
 type DescribeDBEngineVersionsOutput struct {
@@ -6434,6 +7022,26 @@ func (s DescribeDBInstancesInput) String() string {
 // GoString returns the string representation
 func (s DescribeDBInstancesInput) GoString() string {
 	return s.String()
+}
+
+// Validate inspects the fields of the type to determine if they are valid.
+func (s *DescribeDBInstancesInput) Validate() error {
+	invalidParams := request.ErrInvalidParams{Context: "DescribeDBInstancesInput"}
+	if s.Filters != nil {
+		for i, v := range s.Filters {
+			if v == nil {
+				continue
+			}
+			if err := v.Validate(); err != nil {
+				invalidParams.AddNested(fmt.Sprintf("%s[%v]", "Filters", i), err.(request.ErrInvalidParams))
+			}
+		}
+	}
+
+	if invalidParams.Len() > 0 {
+		return invalidParams
+	}
+	return nil
 }
 
 // Contains the result of a successful invocation of the DescribeDBInstances
@@ -6531,6 +7139,29 @@ func (s DescribeDBLogFilesInput) GoString() string {
 	return s.String()
 }
 
+// Validate inspects the fields of the type to determine if they are valid.
+func (s *DescribeDBLogFilesInput) Validate() error {
+	invalidParams := request.ErrInvalidParams{Context: "DescribeDBLogFilesInput"}
+	if s.DBInstanceIdentifier == nil {
+		invalidParams.Add(request.NewErrParamRequired("DBInstanceIdentifier"))
+	}
+	if s.Filters != nil {
+		for i, v := range s.Filters {
+			if v == nil {
+				continue
+			}
+			if err := v.Validate(); err != nil {
+				invalidParams.AddNested(fmt.Sprintf("%s[%v]", "Filters", i), err.(request.ErrInvalidParams))
+			}
+		}
+	}
+
+	if invalidParams.Len() > 0 {
+		return invalidParams
+	}
+	return nil
+}
+
 // The response from a call to DescribeDBLogFiles.
 type DescribeDBLogFilesOutput struct {
 	_ struct{} `type:"structure"`
@@ -6589,6 +7220,26 @@ func (s DescribeDBParameterGroupsInput) String() string {
 // GoString returns the string representation
 func (s DescribeDBParameterGroupsInput) GoString() string {
 	return s.String()
+}
+
+// Validate inspects the fields of the type to determine if they are valid.
+func (s *DescribeDBParameterGroupsInput) Validate() error {
+	invalidParams := request.ErrInvalidParams{Context: "DescribeDBParameterGroupsInput"}
+	if s.Filters != nil {
+		for i, v := range s.Filters {
+			if v == nil {
+				continue
+			}
+			if err := v.Validate(); err != nil {
+				invalidParams.AddNested(fmt.Sprintf("%s[%v]", "Filters", i), err.(request.ErrInvalidParams))
+			}
+		}
+	}
+
+	if invalidParams.Len() > 0 {
+		return invalidParams
+	}
+	return nil
 }
 
 // Contains the result of a successful invocation of the DescribeDBParameterGroups
@@ -6661,6 +7312,29 @@ func (s DescribeDBParametersInput) GoString() string {
 	return s.String()
 }
 
+// Validate inspects the fields of the type to determine if they are valid.
+func (s *DescribeDBParametersInput) Validate() error {
+	invalidParams := request.ErrInvalidParams{Context: "DescribeDBParametersInput"}
+	if s.DBParameterGroupName == nil {
+		invalidParams.Add(request.NewErrParamRequired("DBParameterGroupName"))
+	}
+	if s.Filters != nil {
+		for i, v := range s.Filters {
+			if v == nil {
+				continue
+			}
+			if err := v.Validate(); err != nil {
+				invalidParams.AddNested(fmt.Sprintf("%s[%v]", "Filters", i), err.(request.ErrInvalidParams))
+			}
+		}
+	}
+
+	if invalidParams.Len() > 0 {
+		return invalidParams
+	}
+	return nil
+}
+
 // Contains the result of a successful invocation of the DescribeDBParameters
 // action.
 type DescribeDBParametersOutput struct {
@@ -6717,6 +7391,26 @@ func (s DescribeDBSecurityGroupsInput) String() string {
 // GoString returns the string representation
 func (s DescribeDBSecurityGroupsInput) GoString() string {
 	return s.String()
+}
+
+// Validate inspects the fields of the type to determine if they are valid.
+func (s *DescribeDBSecurityGroupsInput) Validate() error {
+	invalidParams := request.ErrInvalidParams{Context: "DescribeDBSecurityGroupsInput"}
+	if s.Filters != nil {
+		for i, v := range s.Filters {
+			if v == nil {
+				continue
+			}
+			if err := v.Validate(); err != nil {
+				invalidParams.AddNested(fmt.Sprintf("%s[%v]", "Filters", i), err.(request.ErrInvalidParams))
+			}
+		}
+	}
+
+	if invalidParams.Len() > 0 {
+		return invalidParams
+	}
+	return nil
 }
 
 // Contains the result of a successful invocation of the DescribeDBSecurityGroups
@@ -6869,6 +7563,26 @@ func (s DescribeDBSnapshotsInput) GoString() string {
 	return s.String()
 }
 
+// Validate inspects the fields of the type to determine if they are valid.
+func (s *DescribeDBSnapshotsInput) Validate() error {
+	invalidParams := request.ErrInvalidParams{Context: "DescribeDBSnapshotsInput"}
+	if s.Filters != nil {
+		for i, v := range s.Filters {
+			if v == nil {
+				continue
+			}
+			if err := v.Validate(); err != nil {
+				invalidParams.AddNested(fmt.Sprintf("%s[%v]", "Filters", i), err.(request.ErrInvalidParams))
+			}
+		}
+	}
+
+	if invalidParams.Len() > 0 {
+		return invalidParams
+	}
+	return nil
+}
+
 // Contains the result of a successful invocation of the DescribeDBSnapshots
 // action.
 type DescribeDBSnapshotsOutput struct {
@@ -6925,6 +7639,26 @@ func (s DescribeDBSubnetGroupsInput) String() string {
 // GoString returns the string representation
 func (s DescribeDBSubnetGroupsInput) GoString() string {
 	return s.String()
+}
+
+// Validate inspects the fields of the type to determine if they are valid.
+func (s *DescribeDBSubnetGroupsInput) Validate() error {
+	invalidParams := request.ErrInvalidParams{Context: "DescribeDBSubnetGroupsInput"}
+	if s.Filters != nil {
+		for i, v := range s.Filters {
+			if v == nil {
+				continue
+			}
+			if err := v.Validate(); err != nil {
+				invalidParams.AddNested(fmt.Sprintf("%s[%v]", "Filters", i), err.(request.ErrInvalidParams))
+			}
+		}
+	}
+
+	if invalidParams.Len() > 0 {
+		return invalidParams
+	}
+	return nil
 }
 
 // Contains the result of a successful invocation of the DescribeDBSubnetGroups
@@ -6986,6 +7720,29 @@ func (s DescribeEngineDefaultClusterParametersInput) GoString() string {
 	return s.String()
 }
 
+// Validate inspects the fields of the type to determine if they are valid.
+func (s *DescribeEngineDefaultClusterParametersInput) Validate() error {
+	invalidParams := request.ErrInvalidParams{Context: "DescribeEngineDefaultClusterParametersInput"}
+	if s.DBParameterGroupFamily == nil {
+		invalidParams.Add(request.NewErrParamRequired("DBParameterGroupFamily"))
+	}
+	if s.Filters != nil {
+		for i, v := range s.Filters {
+			if v == nil {
+				continue
+			}
+			if err := v.Validate(); err != nil {
+				invalidParams.AddNested(fmt.Sprintf("%s[%v]", "Filters", i), err.(request.ErrInvalidParams))
+			}
+		}
+	}
+
+	if invalidParams.Len() > 0 {
+		return invalidParams
+	}
+	return nil
+}
+
 type DescribeEngineDefaultClusterParametersOutput struct {
 	_ struct{} `type:"structure"`
 
@@ -7038,6 +7795,29 @@ func (s DescribeEngineDefaultParametersInput) GoString() string {
 	return s.String()
 }
 
+// Validate inspects the fields of the type to determine if they are valid.
+func (s *DescribeEngineDefaultParametersInput) Validate() error {
+	invalidParams := request.ErrInvalidParams{Context: "DescribeEngineDefaultParametersInput"}
+	if s.DBParameterGroupFamily == nil {
+		invalidParams.Add(request.NewErrParamRequired("DBParameterGroupFamily"))
+	}
+	if s.Filters != nil {
+		for i, v := range s.Filters {
+			if v == nil {
+				continue
+			}
+			if err := v.Validate(); err != nil {
+				invalidParams.AddNested(fmt.Sprintf("%s[%v]", "Filters", i), err.(request.ErrInvalidParams))
+			}
+		}
+	}
+
+	if invalidParams.Len() > 0 {
+		return invalidParams
+	}
+	return nil
+}
+
 type DescribeEngineDefaultParametersOutput struct {
 	_ struct{} `type:"structure"`
 
@@ -7076,6 +7856,26 @@ func (s DescribeEventCategoriesInput) String() string {
 // GoString returns the string representation
 func (s DescribeEventCategoriesInput) GoString() string {
 	return s.String()
+}
+
+// Validate inspects the fields of the type to determine if they are valid.
+func (s *DescribeEventCategoriesInput) Validate() error {
+	invalidParams := request.ErrInvalidParams{Context: "DescribeEventCategoriesInput"}
+	if s.Filters != nil {
+		for i, v := range s.Filters {
+			if v == nil {
+				continue
+			}
+			if err := v.Validate(); err != nil {
+				invalidParams.AddNested(fmt.Sprintf("%s[%v]", "Filters", i), err.(request.ErrInvalidParams))
+			}
+		}
+	}
+
+	if invalidParams.Len() > 0 {
+		return invalidParams
+	}
+	return nil
 }
 
 // Data returned from the DescribeEventCategories action.
@@ -7128,6 +7928,26 @@ func (s DescribeEventSubscriptionsInput) String() string {
 // GoString returns the string representation
 func (s DescribeEventSubscriptionsInput) GoString() string {
 	return s.String()
+}
+
+// Validate inspects the fields of the type to determine if they are valid.
+func (s *DescribeEventSubscriptionsInput) Validate() error {
+	invalidParams := request.ErrInvalidParams{Context: "DescribeEventSubscriptionsInput"}
+	if s.Filters != nil {
+		for i, v := range s.Filters {
+			if v == nil {
+				continue
+			}
+			if err := v.Validate(); err != nil {
+				invalidParams.AddNested(fmt.Sprintf("%s[%v]", "Filters", i), err.(request.ErrInvalidParams))
+			}
+		}
+	}
+
+	if invalidParams.Len() > 0 {
+		return invalidParams
+	}
+	return nil
 }
 
 // Data returned by the DescribeEventSubscriptions action.
@@ -7224,6 +8044,26 @@ func (s DescribeEventsInput) GoString() string {
 	return s.String()
 }
 
+// Validate inspects the fields of the type to determine if they are valid.
+func (s *DescribeEventsInput) Validate() error {
+	invalidParams := request.ErrInvalidParams{Context: "DescribeEventsInput"}
+	if s.Filters != nil {
+		for i, v := range s.Filters {
+			if v == nil {
+				continue
+			}
+			if err := v.Validate(); err != nil {
+				invalidParams.AddNested(fmt.Sprintf("%s[%v]", "Filters", i), err.(request.ErrInvalidParams))
+			}
+		}
+	}
+
+	if invalidParams.Len() > 0 {
+		return invalidParams
+	}
+	return nil
+}
+
 // Contains the result of a successful invocation of the DescribeEvents action.
 type DescribeEventsOutput struct {
 	_ struct{} `type:"structure"`
@@ -7284,6 +8124,29 @@ func (s DescribeOptionGroupOptionsInput) String() string {
 // GoString returns the string representation
 func (s DescribeOptionGroupOptionsInput) GoString() string {
 	return s.String()
+}
+
+// Validate inspects the fields of the type to determine if they are valid.
+func (s *DescribeOptionGroupOptionsInput) Validate() error {
+	invalidParams := request.ErrInvalidParams{Context: "DescribeOptionGroupOptionsInput"}
+	if s.EngineName == nil {
+		invalidParams.Add(request.NewErrParamRequired("EngineName"))
+	}
+	if s.Filters != nil {
+		for i, v := range s.Filters {
+			if v == nil {
+				continue
+			}
+			if err := v.Validate(); err != nil {
+				invalidParams.AddNested(fmt.Sprintf("%s[%v]", "Filters", i), err.(request.ErrInvalidParams))
+			}
+		}
+	}
+
+	if invalidParams.Len() > 0 {
+		return invalidParams
+	}
+	return nil
 }
 
 type DescribeOptionGroupOptionsOutput struct {
@@ -7350,6 +8213,26 @@ func (s DescribeOptionGroupsInput) String() string {
 // GoString returns the string representation
 func (s DescribeOptionGroupsInput) GoString() string {
 	return s.String()
+}
+
+// Validate inspects the fields of the type to determine if they are valid.
+func (s *DescribeOptionGroupsInput) Validate() error {
+	invalidParams := request.ErrInvalidParams{Context: "DescribeOptionGroupsInput"}
+	if s.Filters != nil {
+		for i, v := range s.Filters {
+			if v == nil {
+				continue
+			}
+			if err := v.Validate(); err != nil {
+				invalidParams.AddNested(fmt.Sprintf("%s[%v]", "Filters", i), err.(request.ErrInvalidParams))
+			}
+		}
+	}
+
+	if invalidParams.Len() > 0 {
+		return invalidParams
+	}
+	return nil
 }
 
 // List of option groups.
@@ -7425,6 +8308,29 @@ func (s DescribeOrderableDBInstanceOptionsInput) GoString() string {
 	return s.String()
 }
 
+// Validate inspects the fields of the type to determine if they are valid.
+func (s *DescribeOrderableDBInstanceOptionsInput) Validate() error {
+	invalidParams := request.ErrInvalidParams{Context: "DescribeOrderableDBInstanceOptionsInput"}
+	if s.Engine == nil {
+		invalidParams.Add(request.NewErrParamRequired("Engine"))
+	}
+	if s.Filters != nil {
+		for i, v := range s.Filters {
+			if v == nil {
+				continue
+			}
+			if err := v.Validate(); err != nil {
+				invalidParams.AddNested(fmt.Sprintf("%s[%v]", "Filters", i), err.(request.ErrInvalidParams))
+			}
+		}
+	}
+
+	if invalidParams.Len() > 0 {
+		return invalidParams
+	}
+	return nil
+}
+
 // Contains the result of a successful invocation of the DescribeOrderableDBInstanceOptions
 // action.
 type DescribeOrderableDBInstanceOptionsOutput struct {
@@ -7489,6 +8395,26 @@ func (s DescribePendingMaintenanceActionsInput) String() string {
 // GoString returns the string representation
 func (s DescribePendingMaintenanceActionsInput) GoString() string {
 	return s.String()
+}
+
+// Validate inspects the fields of the type to determine if they are valid.
+func (s *DescribePendingMaintenanceActionsInput) Validate() error {
+	invalidParams := request.ErrInvalidParams{Context: "DescribePendingMaintenanceActionsInput"}
+	if s.Filters != nil {
+		for i, v := range s.Filters {
+			if v == nil {
+				continue
+			}
+			if err := v.Validate(); err != nil {
+				invalidParams.AddNested(fmt.Sprintf("%s[%v]", "Filters", i), err.(request.ErrInvalidParams))
+			}
+		}
+	}
+
+	if invalidParams.Len() > 0 {
+		return invalidParams
+	}
+	return nil
 }
 
 // Data returned from the DescribePendingMaintenanceActions action.
@@ -7577,6 +8503,26 @@ func (s DescribeReservedDBInstancesInput) GoString() string {
 	return s.String()
 }
 
+// Validate inspects the fields of the type to determine if they are valid.
+func (s *DescribeReservedDBInstancesInput) Validate() error {
+	invalidParams := request.ErrInvalidParams{Context: "DescribeReservedDBInstancesInput"}
+	if s.Filters != nil {
+		for i, v := range s.Filters {
+			if v == nil {
+				continue
+			}
+			if err := v.Validate(); err != nil {
+				invalidParams.AddNested(fmt.Sprintf("%s[%v]", "Filters", i), err.(request.ErrInvalidParams))
+			}
+		}
+	}
+
+	if invalidParams.Len() > 0 {
+		return invalidParams
+	}
+	return nil
+}
+
 type DescribeReservedDBInstancesOfferingsInput struct {
 	_ struct{} `type:"structure"`
 
@@ -7636,6 +8582,26 @@ func (s DescribeReservedDBInstancesOfferingsInput) String() string {
 // GoString returns the string representation
 func (s DescribeReservedDBInstancesOfferingsInput) GoString() string {
 	return s.String()
+}
+
+// Validate inspects the fields of the type to determine if they are valid.
+func (s *DescribeReservedDBInstancesOfferingsInput) Validate() error {
+	invalidParams := request.ErrInvalidParams{Context: "DescribeReservedDBInstancesOfferingsInput"}
+	if s.Filters != nil {
+		for i, v := range s.Filters {
+			if v == nil {
+				continue
+			}
+			if err := v.Validate(); err != nil {
+				invalidParams.AddNested(fmt.Sprintf("%s[%v]", "Filters", i), err.(request.ErrInvalidParams))
+			}
+		}
+	}
+
+	if invalidParams.Len() > 0 {
+		return invalidParams
+	}
+	return nil
 }
 
 // Contains the result of a successful invocation of the DescribeReservedDBInstancesOfferings
@@ -7766,6 +8732,22 @@ func (s DownloadDBLogFilePortionInput) String() string {
 // GoString returns the string representation
 func (s DownloadDBLogFilePortionInput) GoString() string {
 	return s.String()
+}
+
+// Validate inspects the fields of the type to determine if they are valid.
+func (s *DownloadDBLogFilePortionInput) Validate() error {
+	invalidParams := request.ErrInvalidParams{Context: "DownloadDBLogFilePortionInput"}
+	if s.DBInstanceIdentifier == nil {
+		invalidParams.Add(request.NewErrParamRequired("DBInstanceIdentifier"))
+	}
+	if s.LogFileName == nil {
+		invalidParams.Add(request.NewErrParamRequired("LogFileName"))
+	}
+
+	if invalidParams.Len() > 0 {
+		return invalidParams
+	}
+	return nil
 }
 
 // This data type is used as a response element to DownloadDBLogFilePortion.
@@ -8046,6 +9028,22 @@ func (s Filter) GoString() string {
 	return s.String()
 }
 
+// Validate inspects the fields of the type to determine if they are valid.
+func (s *Filter) Validate() error {
+	invalidParams := request.ErrInvalidParams{Context: "Filter"}
+	if s.Name == nil {
+		invalidParams.Add(request.NewErrParamRequired("Name"))
+	}
+	if s.Values == nil {
+		invalidParams.Add(request.NewErrParamRequired("Values"))
+	}
+
+	if invalidParams.Len() > 0 {
+		return invalidParams
+	}
+	return nil
+}
+
 // This data type is used as a response element in the DescribeDBSecurityGroups
 // action.
 type IPRange struct {
@@ -8089,6 +9087,29 @@ func (s ListTagsForResourceInput) String() string {
 // GoString returns the string representation
 func (s ListTagsForResourceInput) GoString() string {
 	return s.String()
+}
+
+// Validate inspects the fields of the type to determine if they are valid.
+func (s *ListTagsForResourceInput) Validate() error {
+	invalidParams := request.ErrInvalidParams{Context: "ListTagsForResourceInput"}
+	if s.ResourceName == nil {
+		invalidParams.Add(request.NewErrParamRequired("ResourceName"))
+	}
+	if s.Filters != nil {
+		for i, v := range s.Filters {
+			if v == nil {
+				continue
+			}
+			if err := v.Validate(); err != nil {
+				invalidParams.AddNested(fmt.Sprintf("%s[%v]", "Filters", i), err.(request.ErrInvalidParams))
+			}
+		}
+	}
+
+	if invalidParams.Len() > 0 {
+		return invalidParams
+	}
+	return nil
 }
 
 type ListTagsForResourceOutput struct {
@@ -8229,6 +9250,19 @@ func (s ModifyDBClusterInput) GoString() string {
 	return s.String()
 }
 
+// Validate inspects the fields of the type to determine if they are valid.
+func (s *ModifyDBClusterInput) Validate() error {
+	invalidParams := request.ErrInvalidParams{Context: "ModifyDBClusterInput"}
+	if s.DBClusterIdentifier == nil {
+		invalidParams.Add(request.NewErrParamRequired("DBClusterIdentifier"))
+	}
+
+	if invalidParams.Len() > 0 {
+		return invalidParams
+	}
+	return nil
+}
+
 type ModifyDBClusterOutput struct {
 	_ struct{} `type:"structure"`
 
@@ -8268,6 +9302,22 @@ func (s ModifyDBClusterParameterGroupInput) String() string {
 // GoString returns the string representation
 func (s ModifyDBClusterParameterGroupInput) GoString() string {
 	return s.String()
+}
+
+// Validate inspects the fields of the type to determine if they are valid.
+func (s *ModifyDBClusterParameterGroupInput) Validate() error {
+	invalidParams := request.ErrInvalidParams{Context: "ModifyDBClusterParameterGroupInput"}
+	if s.DBClusterParameterGroupName == nil {
+		invalidParams.Add(request.NewErrParamRequired("DBClusterParameterGroupName"))
+	}
+	if s.Parameters == nil {
+		invalidParams.Add(request.NewErrParamRequired("Parameters"))
+	}
+
+	if invalidParams.Len() > 0 {
+		return invalidParams
+	}
+	return nil
 }
 
 type ModifyDBInstanceInput struct {
@@ -8722,6 +9772,19 @@ func (s ModifyDBInstanceInput) GoString() string {
 	return s.String()
 }
 
+// Validate inspects the fields of the type to determine if they are valid.
+func (s *ModifyDBInstanceInput) Validate() error {
+	invalidParams := request.ErrInvalidParams{Context: "ModifyDBInstanceInput"}
+	if s.DBInstanceIdentifier == nil {
+		invalidParams.Add(request.NewErrParamRequired("DBInstanceIdentifier"))
+	}
+
+	if invalidParams.Len() > 0 {
+		return invalidParams
+	}
+	return nil
+}
+
 type ModifyDBInstanceOutput struct {
 	_ struct{} `type:"structure"`
 
@@ -8777,6 +9840,22 @@ func (s ModifyDBParameterGroupInput) GoString() string {
 	return s.String()
 }
 
+// Validate inspects the fields of the type to determine if they are valid.
+func (s *ModifyDBParameterGroupInput) Validate() error {
+	invalidParams := request.ErrInvalidParams{Context: "ModifyDBParameterGroupInput"}
+	if s.DBParameterGroupName == nil {
+		invalidParams.Add(request.NewErrParamRequired("DBParameterGroupName"))
+	}
+	if s.Parameters == nil {
+		invalidParams.Add(request.NewErrParamRequired("Parameters"))
+	}
+
+	if invalidParams.Len() > 0 {
+		return invalidParams
+	}
+	return nil
+}
+
 type ModifyDBSnapshotAttributeInput struct {
 	_ struct{} `type:"structure"`
 
@@ -8817,6 +9896,19 @@ func (s ModifyDBSnapshotAttributeInput) String() string {
 // GoString returns the string representation
 func (s ModifyDBSnapshotAttributeInput) GoString() string {
 	return s.String()
+}
+
+// Validate inspects the fields of the type to determine if they are valid.
+func (s *ModifyDBSnapshotAttributeInput) Validate() error {
+	invalidParams := request.ErrInvalidParams{Context: "ModifyDBSnapshotAttributeInput"}
+	if s.DBSnapshotIdentifier == nil {
+		invalidParams.Add(request.NewErrParamRequired("DBSnapshotIdentifier"))
+	}
+
+	if invalidParams.Len() > 0 {
+		return invalidParams
+	}
+	return nil
 }
 
 type ModifyDBSnapshotAttributeOutput struct {
@@ -8867,6 +9959,22 @@ func (s ModifyDBSubnetGroupInput) String() string {
 // GoString returns the string representation
 func (s ModifyDBSubnetGroupInput) GoString() string {
 	return s.String()
+}
+
+// Validate inspects the fields of the type to determine if they are valid.
+func (s *ModifyDBSubnetGroupInput) Validate() error {
+	invalidParams := request.ErrInvalidParams{Context: "ModifyDBSubnetGroupInput"}
+	if s.DBSubnetGroupName == nil {
+		invalidParams.Add(request.NewErrParamRequired("DBSubnetGroupName"))
+	}
+	if s.SubnetIds == nil {
+		invalidParams.Add(request.NewErrParamRequired("SubnetIds"))
+	}
+
+	if invalidParams.Len() > 0 {
+		return invalidParams
+	}
+	return nil
 }
 
 type ModifyDBSubnetGroupOutput struct {
@@ -8930,6 +10038,19 @@ func (s ModifyEventSubscriptionInput) GoString() string {
 	return s.String()
 }
 
+// Validate inspects the fields of the type to determine if they are valid.
+func (s *ModifyEventSubscriptionInput) Validate() error {
+	invalidParams := request.ErrInvalidParams{Context: "ModifyEventSubscriptionInput"}
+	if s.SubscriptionName == nil {
+		invalidParams.Add(request.NewErrParamRequired("SubscriptionName"))
+	}
+
+	if invalidParams.Len() > 0 {
+		return invalidParams
+	}
+	return nil
+}
+
 type ModifyEventSubscriptionOutput struct {
 	_ struct{} `type:"structure"`
 
@@ -8978,6 +10099,29 @@ func (s ModifyOptionGroupInput) String() string {
 // GoString returns the string representation
 func (s ModifyOptionGroupInput) GoString() string {
 	return s.String()
+}
+
+// Validate inspects the fields of the type to determine if they are valid.
+func (s *ModifyOptionGroupInput) Validate() error {
+	invalidParams := request.ErrInvalidParams{Context: "ModifyOptionGroupInput"}
+	if s.OptionGroupName == nil {
+		invalidParams.Add(request.NewErrParamRequired("OptionGroupName"))
+	}
+	if s.OptionsToInclude != nil {
+		for i, v := range s.OptionsToInclude {
+			if v == nil {
+				continue
+			}
+			if err := v.Validate(); err != nil {
+				invalidParams.AddNested(fmt.Sprintf("%s[%v]", "OptionsToInclude", i), err.(request.ErrInvalidParams))
+			}
+		}
+	}
+
+	if invalidParams.Len() > 0 {
+		return invalidParams
+	}
+	return nil
 }
 
 type ModifyOptionGroupOutput struct {
@@ -9065,6 +10209,19 @@ func (s OptionConfiguration) String() string {
 // GoString returns the string representation
 func (s OptionConfiguration) GoString() string {
 	return s.String()
+}
+
+// Validate inspects the fields of the type to determine if they are valid.
+func (s *OptionConfiguration) Validate() error {
+	invalidParams := request.ErrInvalidParams{Context: "OptionConfiguration"}
+	if s.OptionName == nil {
+		invalidParams.Add(request.NewErrParamRequired("OptionName"))
+	}
+
+	if invalidParams.Len() > 0 {
+		return invalidParams
+	}
+	return nil
 }
 
 type OptionGroup struct {
@@ -9519,6 +10676,19 @@ func (s PromoteReadReplicaInput) GoString() string {
 	return s.String()
 }
 
+// Validate inspects the fields of the type to determine if they are valid.
+func (s *PromoteReadReplicaInput) Validate() error {
+	invalidParams := request.ErrInvalidParams{Context: "PromoteReadReplicaInput"}
+	if s.DBInstanceIdentifier == nil {
+		invalidParams.Add(request.NewErrParamRequired("DBInstanceIdentifier"))
+	}
+
+	if invalidParams.Len() > 0 {
+		return invalidParams
+	}
+	return nil
+}
+
 type PromoteReadReplicaOutput struct {
 	_ struct{} `type:"structure"`
 
@@ -9571,6 +10741,19 @@ func (s PurchaseReservedDBInstancesOfferingInput) GoString() string {
 	return s.String()
 }
 
+// Validate inspects the fields of the type to determine if they are valid.
+func (s *PurchaseReservedDBInstancesOfferingInput) Validate() error {
+	invalidParams := request.ErrInvalidParams{Context: "PurchaseReservedDBInstancesOfferingInput"}
+	if s.ReservedDBInstancesOfferingId == nil {
+		invalidParams.Add(request.NewErrParamRequired("ReservedDBInstancesOfferingId"))
+	}
+
+	if invalidParams.Len() > 0 {
+		return invalidParams
+	}
+	return nil
+}
+
 type PurchaseReservedDBInstancesOfferingOutput struct {
 	_ struct{} `type:"structure"`
 
@@ -9615,6 +10798,19 @@ func (s RebootDBInstanceInput) String() string {
 // GoString returns the string representation
 func (s RebootDBInstanceInput) GoString() string {
 	return s.String()
+}
+
+// Validate inspects the fields of the type to determine if they are valid.
+func (s *RebootDBInstanceInput) Validate() error {
+	invalidParams := request.ErrInvalidParams{Context: "RebootDBInstanceInput"}
+	if s.DBInstanceIdentifier == nil {
+		invalidParams.Add(request.NewErrParamRequired("DBInstanceIdentifier"))
+	}
+
+	if invalidParams.Len() > 0 {
+		return invalidParams
+	}
+	return nil
 }
 
 type RebootDBInstanceOutput struct {
@@ -9681,6 +10877,22 @@ func (s RemoveSourceIdentifierFromSubscriptionInput) GoString() string {
 	return s.String()
 }
 
+// Validate inspects the fields of the type to determine if they are valid.
+func (s *RemoveSourceIdentifierFromSubscriptionInput) Validate() error {
+	invalidParams := request.ErrInvalidParams{Context: "RemoveSourceIdentifierFromSubscriptionInput"}
+	if s.SourceIdentifier == nil {
+		invalidParams.Add(request.NewErrParamRequired("SourceIdentifier"))
+	}
+	if s.SubscriptionName == nil {
+		invalidParams.Add(request.NewErrParamRequired("SubscriptionName"))
+	}
+
+	if invalidParams.Len() > 0 {
+		return invalidParams
+	}
+	return nil
+}
+
 type RemoveSourceIdentifierFromSubscriptionOutput struct {
 	_ struct{} `type:"structure"`
 
@@ -9719,6 +10931,22 @@ func (s RemoveTagsFromResourceInput) String() string {
 // GoString returns the string representation
 func (s RemoveTagsFromResourceInput) GoString() string {
 	return s.String()
+}
+
+// Validate inspects the fields of the type to determine if they are valid.
+func (s *RemoveTagsFromResourceInput) Validate() error {
+	invalidParams := request.ErrInvalidParams{Context: "RemoveTagsFromResourceInput"}
+	if s.ResourceName == nil {
+		invalidParams.Add(request.NewErrParamRequired("ResourceName"))
+	}
+	if s.TagKeys == nil {
+		invalidParams.Add(request.NewErrParamRequired("TagKeys"))
+	}
+
+	if invalidParams.Len() > 0 {
+		return invalidParams
+	}
+	return nil
 }
 
 type RemoveTagsFromResourceOutput struct {
@@ -9866,6 +11094,19 @@ func (s ResetDBClusterParameterGroupInput) GoString() string {
 	return s.String()
 }
 
+// Validate inspects the fields of the type to determine if they are valid.
+func (s *ResetDBClusterParameterGroupInput) Validate() error {
+	invalidParams := request.ErrInvalidParams{Context: "ResetDBClusterParameterGroupInput"}
+	if s.DBClusterParameterGroupName == nil {
+		invalidParams.Add(request.NewErrParamRequired("DBClusterParameterGroupName"))
+	}
+
+	if invalidParams.Len() > 0 {
+		return invalidParams
+	}
+	return nil
+}
+
 type ResetDBParameterGroupInput struct {
 	_ struct{} `type:"structure"`
 
@@ -9918,6 +11159,19 @@ func (s ResetDBParameterGroupInput) String() string {
 // GoString returns the string representation
 func (s ResetDBParameterGroupInput) GoString() string {
 	return s.String()
+}
+
+// Validate inspects the fields of the type to determine if they are valid.
+func (s *ResetDBParameterGroupInput) Validate() error {
+	invalidParams := request.ErrInvalidParams{Context: "ResetDBParameterGroupInput"}
+	if s.DBParameterGroupName == nil {
+		invalidParams.Add(request.NewErrParamRequired("DBParameterGroupName"))
+	}
+
+	if invalidParams.Len() > 0 {
+		return invalidParams
+	}
+	return nil
 }
 
 // Describes the pending maintenance actions for a resource.
@@ -10032,6 +11286,25 @@ func (s RestoreDBClusterFromSnapshotInput) String() string {
 // GoString returns the string representation
 func (s RestoreDBClusterFromSnapshotInput) GoString() string {
 	return s.String()
+}
+
+// Validate inspects the fields of the type to determine if they are valid.
+func (s *RestoreDBClusterFromSnapshotInput) Validate() error {
+	invalidParams := request.ErrInvalidParams{Context: "RestoreDBClusterFromSnapshotInput"}
+	if s.DBClusterIdentifier == nil {
+		invalidParams.Add(request.NewErrParamRequired("DBClusterIdentifier"))
+	}
+	if s.Engine == nil {
+		invalidParams.Add(request.NewErrParamRequired("Engine"))
+	}
+	if s.SnapshotIdentifier == nil {
+		invalidParams.Add(request.NewErrParamRequired("SnapshotIdentifier"))
+	}
+
+	if invalidParams.Len() > 0 {
+		return invalidParams
+	}
+	return nil
 }
 
 type RestoreDBClusterFromSnapshotOutput struct {
@@ -10149,6 +11422,22 @@ func (s RestoreDBClusterToPointInTimeInput) String() string {
 // GoString returns the string representation
 func (s RestoreDBClusterToPointInTimeInput) GoString() string {
 	return s.String()
+}
+
+// Validate inspects the fields of the type to determine if they are valid.
+func (s *RestoreDBClusterToPointInTimeInput) Validate() error {
+	invalidParams := request.ErrInvalidParams{Context: "RestoreDBClusterToPointInTimeInput"}
+	if s.DBClusterIdentifier == nil {
+		invalidParams.Add(request.NewErrParamRequired("DBClusterIdentifier"))
+	}
+	if s.SourceDBClusterIdentifier == nil {
+		invalidParams.Add(request.NewErrParamRequired("SourceDBClusterIdentifier"))
+	}
+
+	if invalidParams.Len() > 0 {
+		return invalidParams
+	}
+	return nil
 }
 
 type RestoreDBClusterToPointInTimeOutput struct {
@@ -10336,6 +11625,22 @@ func (s RestoreDBInstanceFromDBSnapshotInput) String() string {
 // GoString returns the string representation
 func (s RestoreDBInstanceFromDBSnapshotInput) GoString() string {
 	return s.String()
+}
+
+// Validate inspects the fields of the type to determine if they are valid.
+func (s *RestoreDBInstanceFromDBSnapshotInput) Validate() error {
+	invalidParams := request.ErrInvalidParams{Context: "RestoreDBInstanceFromDBSnapshotInput"}
+	if s.DBInstanceIdentifier == nil {
+		invalidParams.Add(request.NewErrParamRequired("DBInstanceIdentifier"))
+	}
+	if s.DBSnapshotIdentifier == nil {
+		invalidParams.Add(request.NewErrParamRequired("DBSnapshotIdentifier"))
+	}
+
+	if invalidParams.Len() > 0 {
+		return invalidParams
+	}
+	return nil
 }
 
 type RestoreDBInstanceFromDBSnapshotOutput struct {
@@ -10537,6 +11842,22 @@ func (s RestoreDBInstanceToPointInTimeInput) GoString() string {
 	return s.String()
 }
 
+// Validate inspects the fields of the type to determine if they are valid.
+func (s *RestoreDBInstanceToPointInTimeInput) Validate() error {
+	invalidParams := request.ErrInvalidParams{Context: "RestoreDBInstanceToPointInTimeInput"}
+	if s.SourceDBInstanceIdentifier == nil {
+		invalidParams.Add(request.NewErrParamRequired("SourceDBInstanceIdentifier"))
+	}
+	if s.TargetDBInstanceIdentifier == nil {
+		invalidParams.Add(request.NewErrParamRequired("TargetDBInstanceIdentifier"))
+	}
+
+	if invalidParams.Len() > 0 {
+		return invalidParams
+	}
+	return nil
+}
+
 type RestoreDBInstanceToPointInTimeOutput struct {
 	_ struct{} `type:"structure"`
 
@@ -10594,6 +11915,19 @@ func (s RevokeDBSecurityGroupIngressInput) String() string {
 // GoString returns the string representation
 func (s RevokeDBSecurityGroupIngressInput) GoString() string {
 	return s.String()
+}
+
+// Validate inspects the fields of the type to determine if they are valid.
+func (s *RevokeDBSecurityGroupIngressInput) Validate() error {
+	invalidParams := request.ErrInvalidParams{Context: "RevokeDBSecurityGroupIngressInput"}
+	if s.DBSecurityGroupName == nil {
+		invalidParams.Add(request.NewErrParamRequired("DBSecurityGroupName"))
+	}
+
+	if invalidParams.Len() > 0 {
+		return invalidParams
+	}
+	return nil
 }
 
 type RevokeDBSecurityGroupIngressOutput struct {

--- a/service/redshift/api.go
+++ b/service/redshift/api.go
@@ -2365,6 +2365,19 @@ func (s AuthorizeClusterSecurityGroupIngressInput) GoString() string {
 	return s.String()
 }
 
+// Validate inspects the fields of the type to determine if they are valid.
+func (s *AuthorizeClusterSecurityGroupIngressInput) Validate() error {
+	invalidParams := request.ErrInvalidParams{Context: "AuthorizeClusterSecurityGroupIngressInput"}
+	if s.ClusterSecurityGroupName == nil {
+		invalidParams.Add(request.NewErrParamRequired("ClusterSecurityGroupName"))
+	}
+
+	if invalidParams.Len() > 0 {
+		return invalidParams
+	}
+	return nil
+}
+
 type AuthorizeClusterSecurityGroupIngressOutput struct {
 	_ struct{} `type:"structure"`
 
@@ -2406,6 +2419,22 @@ func (s AuthorizeSnapshotAccessInput) String() string {
 // GoString returns the string representation
 func (s AuthorizeSnapshotAccessInput) GoString() string {
 	return s.String()
+}
+
+// Validate inspects the fields of the type to determine if they are valid.
+func (s *AuthorizeSnapshotAccessInput) Validate() error {
+	invalidParams := request.ErrInvalidParams{Context: "AuthorizeSnapshotAccessInput"}
+	if s.AccountWithRestoreAccess == nil {
+		invalidParams.Add(request.NewErrParamRequired("AccountWithRestoreAccess"))
+	}
+	if s.SnapshotIdentifier == nil {
+		invalidParams.Add(request.NewErrParamRequired("SnapshotIdentifier"))
+	}
+
+	if invalidParams.Len() > 0 {
+		return invalidParams
+	}
+	return nil
 }
 
 type AuthorizeSnapshotAccessOutput struct {
@@ -2925,6 +2954,22 @@ func (s CopyClusterSnapshotInput) GoString() string {
 	return s.String()
 }
 
+// Validate inspects the fields of the type to determine if they are valid.
+func (s *CopyClusterSnapshotInput) Validate() error {
+	invalidParams := request.ErrInvalidParams{Context: "CopyClusterSnapshotInput"}
+	if s.SourceSnapshotIdentifier == nil {
+		invalidParams.Add(request.NewErrParamRequired("SourceSnapshotIdentifier"))
+	}
+	if s.TargetSnapshotIdentifier == nil {
+		invalidParams.Add(request.NewErrParamRequired("TargetSnapshotIdentifier"))
+	}
+
+	if invalidParams.Len() > 0 {
+		return invalidParams
+	}
+	return nil
+}
+
 type CopyClusterSnapshotOutput struct {
 	_ struct{} `type:"structure"`
 
@@ -3180,6 +3225,28 @@ func (s CreateClusterInput) GoString() string {
 	return s.String()
 }
 
+// Validate inspects the fields of the type to determine if they are valid.
+func (s *CreateClusterInput) Validate() error {
+	invalidParams := request.ErrInvalidParams{Context: "CreateClusterInput"}
+	if s.ClusterIdentifier == nil {
+		invalidParams.Add(request.NewErrParamRequired("ClusterIdentifier"))
+	}
+	if s.MasterUserPassword == nil {
+		invalidParams.Add(request.NewErrParamRequired("MasterUserPassword"))
+	}
+	if s.MasterUsername == nil {
+		invalidParams.Add(request.NewErrParamRequired("MasterUsername"))
+	}
+	if s.NodeType == nil {
+		invalidParams.Add(request.NewErrParamRequired("NodeType"))
+	}
+
+	if invalidParams.Len() > 0 {
+		return invalidParams
+	}
+	return nil
+}
+
 type CreateClusterOutput struct {
 	_ struct{} `type:"structure"`
 
@@ -3238,6 +3305,25 @@ func (s CreateClusterParameterGroupInput) GoString() string {
 	return s.String()
 }
 
+// Validate inspects the fields of the type to determine if they are valid.
+func (s *CreateClusterParameterGroupInput) Validate() error {
+	invalidParams := request.ErrInvalidParams{Context: "CreateClusterParameterGroupInput"}
+	if s.Description == nil {
+		invalidParams.Add(request.NewErrParamRequired("Description"))
+	}
+	if s.ParameterGroupFamily == nil {
+		invalidParams.Add(request.NewErrParamRequired("ParameterGroupFamily"))
+	}
+	if s.ParameterGroupName == nil {
+		invalidParams.Add(request.NewErrParamRequired("ParameterGroupName"))
+	}
+
+	if invalidParams.Len() > 0 {
+		return invalidParams
+	}
+	return nil
+}
+
 type CreateClusterParameterGroupOutput struct {
 	_ struct{} `type:"structure"`
 
@@ -3285,6 +3371,22 @@ func (s CreateClusterSecurityGroupInput) GoString() string {
 	return s.String()
 }
 
+// Validate inspects the fields of the type to determine if they are valid.
+func (s *CreateClusterSecurityGroupInput) Validate() error {
+	invalidParams := request.ErrInvalidParams{Context: "CreateClusterSecurityGroupInput"}
+	if s.ClusterSecurityGroupName == nil {
+		invalidParams.Add(request.NewErrParamRequired("ClusterSecurityGroupName"))
+	}
+	if s.Description == nil {
+		invalidParams.Add(request.NewErrParamRequired("Description"))
+	}
+
+	if invalidParams.Len() > 0 {
+		return invalidParams
+	}
+	return nil
+}
+
 type CreateClusterSecurityGroupOutput struct {
 	_ struct{} `type:"structure"`
 
@@ -3330,6 +3432,22 @@ func (s CreateClusterSnapshotInput) String() string {
 // GoString returns the string representation
 func (s CreateClusterSnapshotInput) GoString() string {
 	return s.String()
+}
+
+// Validate inspects the fields of the type to determine if they are valid.
+func (s *CreateClusterSnapshotInput) Validate() error {
+	invalidParams := request.ErrInvalidParams{Context: "CreateClusterSnapshotInput"}
+	if s.ClusterIdentifier == nil {
+		invalidParams.Add(request.NewErrParamRequired("ClusterIdentifier"))
+	}
+	if s.SnapshotIdentifier == nil {
+		invalidParams.Add(request.NewErrParamRequired("SnapshotIdentifier"))
+	}
+
+	if invalidParams.Len() > 0 {
+		return invalidParams
+	}
+	return nil
 }
 
 type CreateClusterSnapshotOutput struct {
@@ -3381,6 +3499,25 @@ func (s CreateClusterSubnetGroupInput) String() string {
 // GoString returns the string representation
 func (s CreateClusterSubnetGroupInput) GoString() string {
 	return s.String()
+}
+
+// Validate inspects the fields of the type to determine if they are valid.
+func (s *CreateClusterSubnetGroupInput) Validate() error {
+	invalidParams := request.ErrInvalidParams{Context: "CreateClusterSubnetGroupInput"}
+	if s.ClusterSubnetGroupName == nil {
+		invalidParams.Add(request.NewErrParamRequired("ClusterSubnetGroupName"))
+	}
+	if s.Description == nil {
+		invalidParams.Add(request.NewErrParamRequired("Description"))
+	}
+	if s.SubnetIds == nil {
+		invalidParams.Add(request.NewErrParamRequired("SubnetIds"))
+	}
+
+	if invalidParams.Len() > 0 {
+		return invalidParams
+	}
+	return nil
 }
 
 type CreateClusterSubnetGroupOutput struct {
@@ -3468,6 +3605,22 @@ func (s CreateEventSubscriptionInput) GoString() string {
 	return s.String()
 }
 
+// Validate inspects the fields of the type to determine if they are valid.
+func (s *CreateEventSubscriptionInput) Validate() error {
+	invalidParams := request.ErrInvalidParams{Context: "CreateEventSubscriptionInput"}
+	if s.SnsTopicArn == nil {
+		invalidParams.Add(request.NewErrParamRequired("SnsTopicArn"))
+	}
+	if s.SubscriptionName == nil {
+		invalidParams.Add(request.NewErrParamRequired("SubscriptionName"))
+	}
+
+	if invalidParams.Len() > 0 {
+		return invalidParams
+	}
+	return nil
+}
+
 type CreateEventSubscriptionOutput struct {
 	_ struct{} `type:"structure"`
 
@@ -3504,6 +3657,19 @@ func (s CreateHsmClientCertificateInput) String() string {
 // GoString returns the string representation
 func (s CreateHsmClientCertificateInput) GoString() string {
 	return s.String()
+}
+
+// Validate inspects the fields of the type to determine if they are valid.
+func (s *CreateHsmClientCertificateInput) Validate() error {
+	invalidParams := request.ErrInvalidParams{Context: "CreateHsmClientCertificateInput"}
+	if s.HsmClientCertificateIdentifier == nil {
+		invalidParams.Add(request.NewErrParamRequired("HsmClientCertificateIdentifier"))
+	}
+
+	if invalidParams.Len() > 0 {
+		return invalidParams
+	}
+	return nil
 }
 
 type CreateHsmClientCertificateOutput struct {
@@ -3562,6 +3728,34 @@ func (s CreateHsmConfigurationInput) GoString() string {
 	return s.String()
 }
 
+// Validate inspects the fields of the type to determine if they are valid.
+func (s *CreateHsmConfigurationInput) Validate() error {
+	invalidParams := request.ErrInvalidParams{Context: "CreateHsmConfigurationInput"}
+	if s.Description == nil {
+		invalidParams.Add(request.NewErrParamRequired("Description"))
+	}
+	if s.HsmConfigurationIdentifier == nil {
+		invalidParams.Add(request.NewErrParamRequired("HsmConfigurationIdentifier"))
+	}
+	if s.HsmIpAddress == nil {
+		invalidParams.Add(request.NewErrParamRequired("HsmIpAddress"))
+	}
+	if s.HsmPartitionName == nil {
+		invalidParams.Add(request.NewErrParamRequired("HsmPartitionName"))
+	}
+	if s.HsmPartitionPassword == nil {
+		invalidParams.Add(request.NewErrParamRequired("HsmPartitionPassword"))
+	}
+	if s.HsmServerPublicCertificate == nil {
+		invalidParams.Add(request.NewErrParamRequired("HsmServerPublicCertificate"))
+	}
+
+	if invalidParams.Len() > 0 {
+		return invalidParams
+	}
+	return nil
+}
+
 type CreateHsmConfigurationOutput struct {
 	_ struct{} `type:"structure"`
 
@@ -3614,6 +3808,19 @@ func (s CreateSnapshotCopyGrantInput) GoString() string {
 	return s.String()
 }
 
+// Validate inspects the fields of the type to determine if they are valid.
+func (s *CreateSnapshotCopyGrantInput) Validate() error {
+	invalidParams := request.ErrInvalidParams{Context: "CreateSnapshotCopyGrantInput"}
+	if s.SnapshotCopyGrantName == nil {
+		invalidParams.Add(request.NewErrParamRequired("SnapshotCopyGrantName"))
+	}
+
+	if invalidParams.Len() > 0 {
+		return invalidParams
+	}
+	return nil
+}
+
 type CreateSnapshotCopyGrantOutput struct {
 	_ struct{} `type:"structure"`
 
@@ -3661,6 +3868,22 @@ func (s CreateTagsInput) String() string {
 // GoString returns the string representation
 func (s CreateTagsInput) GoString() string {
 	return s.String()
+}
+
+// Validate inspects the fields of the type to determine if they are valid.
+func (s *CreateTagsInput) Validate() error {
+	invalidParams := request.ErrInvalidParams{Context: "CreateTagsInput"}
+	if s.ResourceName == nil {
+		invalidParams.Add(request.NewErrParamRequired("ResourceName"))
+	}
+	if s.Tags == nil {
+		invalidParams.Add(request.NewErrParamRequired("Tags"))
+	}
+
+	if invalidParams.Len() > 0 {
+		return invalidParams
+	}
+	return nil
 }
 
 type CreateTagsOutput struct {
@@ -3747,6 +3970,19 @@ func (s DeleteClusterInput) GoString() string {
 	return s.String()
 }
 
+// Validate inspects the fields of the type to determine if they are valid.
+func (s *DeleteClusterInput) Validate() error {
+	invalidParams := request.ErrInvalidParams{Context: "DeleteClusterInput"}
+	if s.ClusterIdentifier == nil {
+		invalidParams.Add(request.NewErrParamRequired("ClusterIdentifier"))
+	}
+
+	if invalidParams.Len() > 0 {
+		return invalidParams
+	}
+	return nil
+}
+
 type DeleteClusterOutput struct {
 	_ struct{} `type:"structure"`
 
@@ -3786,6 +4022,19 @@ func (s DeleteClusterParameterGroupInput) GoString() string {
 	return s.String()
 }
 
+// Validate inspects the fields of the type to determine if they are valid.
+func (s *DeleteClusterParameterGroupInput) Validate() error {
+	invalidParams := request.ErrInvalidParams{Context: "DeleteClusterParameterGroupInput"}
+	if s.ParameterGroupName == nil {
+		invalidParams.Add(request.NewErrParamRequired("ParameterGroupName"))
+	}
+
+	if invalidParams.Len() > 0 {
+		return invalidParams
+	}
+	return nil
+}
+
 type DeleteClusterParameterGroupOutput struct {
 	_ struct{} `type:"structure"`
 }
@@ -3815,6 +4064,19 @@ func (s DeleteClusterSecurityGroupInput) String() string {
 // GoString returns the string representation
 func (s DeleteClusterSecurityGroupInput) GoString() string {
 	return s.String()
+}
+
+// Validate inspects the fields of the type to determine if they are valid.
+func (s *DeleteClusterSecurityGroupInput) Validate() error {
+	invalidParams := request.ErrInvalidParams{Context: "DeleteClusterSecurityGroupInput"}
+	if s.ClusterSecurityGroupName == nil {
+		invalidParams.Add(request.NewErrParamRequired("ClusterSecurityGroupName"))
+	}
+
+	if invalidParams.Len() > 0 {
+		return invalidParams
+	}
+	return nil
 }
 
 type DeleteClusterSecurityGroupOutput struct {
@@ -3858,6 +4120,19 @@ func (s DeleteClusterSnapshotInput) GoString() string {
 	return s.String()
 }
 
+// Validate inspects the fields of the type to determine if they are valid.
+func (s *DeleteClusterSnapshotInput) Validate() error {
+	invalidParams := request.ErrInvalidParams{Context: "DeleteClusterSnapshotInput"}
+	if s.SnapshotIdentifier == nil {
+		invalidParams.Add(request.NewErrParamRequired("SnapshotIdentifier"))
+	}
+
+	if invalidParams.Len() > 0 {
+		return invalidParams
+	}
+	return nil
+}
+
 type DeleteClusterSnapshotOutput struct {
 	_ struct{} `type:"structure"`
 
@@ -3892,6 +4167,19 @@ func (s DeleteClusterSubnetGroupInput) GoString() string {
 	return s.String()
 }
 
+// Validate inspects the fields of the type to determine if they are valid.
+func (s *DeleteClusterSubnetGroupInput) Validate() error {
+	invalidParams := request.ErrInvalidParams{Context: "DeleteClusterSubnetGroupInput"}
+	if s.ClusterSubnetGroupName == nil {
+		invalidParams.Add(request.NewErrParamRequired("ClusterSubnetGroupName"))
+	}
+
+	if invalidParams.Len() > 0 {
+		return invalidParams
+	}
+	return nil
+}
+
 type DeleteClusterSubnetGroupOutput struct {
 	_ struct{} `type:"structure"`
 }
@@ -3921,6 +4209,19 @@ func (s DeleteEventSubscriptionInput) String() string {
 // GoString returns the string representation
 func (s DeleteEventSubscriptionInput) GoString() string {
 	return s.String()
+}
+
+// Validate inspects the fields of the type to determine if they are valid.
+func (s *DeleteEventSubscriptionInput) Validate() error {
+	invalidParams := request.ErrInvalidParams{Context: "DeleteEventSubscriptionInput"}
+	if s.SubscriptionName == nil {
+		invalidParams.Add(request.NewErrParamRequired("SubscriptionName"))
+	}
+
+	if invalidParams.Len() > 0 {
+		return invalidParams
+	}
+	return nil
 }
 
 type DeleteEventSubscriptionOutput struct {
@@ -3954,6 +4255,19 @@ func (s DeleteHsmClientCertificateInput) GoString() string {
 	return s.String()
 }
 
+// Validate inspects the fields of the type to determine if they are valid.
+func (s *DeleteHsmClientCertificateInput) Validate() error {
+	invalidParams := request.ErrInvalidParams{Context: "DeleteHsmClientCertificateInput"}
+	if s.HsmClientCertificateIdentifier == nil {
+		invalidParams.Add(request.NewErrParamRequired("HsmClientCertificateIdentifier"))
+	}
+
+	if invalidParams.Len() > 0 {
+		return invalidParams
+	}
+	return nil
+}
+
 type DeleteHsmClientCertificateOutput struct {
 	_ struct{} `type:"structure"`
 }
@@ -3983,6 +4297,19 @@ func (s DeleteHsmConfigurationInput) String() string {
 // GoString returns the string representation
 func (s DeleteHsmConfigurationInput) GoString() string {
 	return s.String()
+}
+
+// Validate inspects the fields of the type to determine if they are valid.
+func (s *DeleteHsmConfigurationInput) Validate() error {
+	invalidParams := request.ErrInvalidParams{Context: "DeleteHsmConfigurationInput"}
+	if s.HsmConfigurationIdentifier == nil {
+		invalidParams.Add(request.NewErrParamRequired("HsmConfigurationIdentifier"))
+	}
+
+	if invalidParams.Len() > 0 {
+		return invalidParams
+	}
+	return nil
 }
 
 type DeleteHsmConfigurationOutput struct {
@@ -4015,6 +4342,19 @@ func (s DeleteSnapshotCopyGrantInput) String() string {
 // GoString returns the string representation
 func (s DeleteSnapshotCopyGrantInput) GoString() string {
 	return s.String()
+}
+
+// Validate inspects the fields of the type to determine if they are valid.
+func (s *DeleteSnapshotCopyGrantInput) Validate() error {
+	invalidParams := request.ErrInvalidParams{Context: "DeleteSnapshotCopyGrantInput"}
+	if s.SnapshotCopyGrantName == nil {
+		invalidParams.Add(request.NewErrParamRequired("SnapshotCopyGrantName"))
+	}
+
+	if invalidParams.Len() > 0 {
+		return invalidParams
+	}
+	return nil
 }
 
 type DeleteSnapshotCopyGrantOutput struct {
@@ -4051,6 +4391,22 @@ func (s DeleteTagsInput) String() string {
 // GoString returns the string representation
 func (s DeleteTagsInput) GoString() string {
 	return s.String()
+}
+
+// Validate inspects the fields of the type to determine if they are valid.
+func (s *DeleteTagsInput) Validate() error {
+	invalidParams := request.ErrInvalidParams{Context: "DeleteTagsInput"}
+	if s.ResourceName == nil {
+		invalidParams.Add(request.NewErrParamRequired("ResourceName"))
+	}
+	if s.TagKeys == nil {
+		invalidParams.Add(request.NewErrParamRequired("TagKeys"))
+	}
+
+	if invalidParams.Len() > 0 {
+		return invalidParams
+	}
+	return nil
 }
 
 type DeleteTagsOutput struct {
@@ -4187,6 +4543,19 @@ func (s DescribeClusterParametersInput) String() string {
 // GoString returns the string representation
 func (s DescribeClusterParametersInput) GoString() string {
 	return s.String()
+}
+
+// Validate inspects the fields of the type to determine if they are valid.
+func (s *DescribeClusterParametersInput) Validate() error {
+	invalidParams := request.ErrInvalidParams{Context: "DescribeClusterParametersInput"}
+	if s.ParameterGroupName == nil {
+		invalidParams.Add(request.NewErrParamRequired("ParameterGroupName"))
+	}
+
+	if invalidParams.Len() > 0 {
+		return invalidParams
+	}
+	return nil
 }
 
 // Contains the output from the DescribeClusterParameters action.
@@ -4663,6 +5032,19 @@ func (s DescribeDefaultClusterParametersInput) GoString() string {
 	return s.String()
 }
 
+// Validate inspects the fields of the type to determine if they are valid.
+func (s *DescribeDefaultClusterParametersInput) Validate() error {
+	invalidParams := request.ErrInvalidParams{Context: "DescribeDefaultClusterParametersInput"}
+	if s.ParameterGroupFamily == nil {
+		invalidParams.Add(request.NewErrParamRequired("ParameterGroupFamily"))
+	}
+
+	if invalidParams.Len() > 0 {
+		return invalidParams
+	}
+	return nil
+}
+
 type DescribeDefaultClusterParametersOutput struct {
 	_ struct{} `type:"structure"`
 
@@ -5054,6 +5436,19 @@ func (s DescribeLoggingStatusInput) GoString() string {
 	return s.String()
 }
 
+// Validate inspects the fields of the type to determine if they are valid.
+func (s *DescribeLoggingStatusInput) Validate() error {
+	invalidParams := request.ErrInvalidParams{Context: "DescribeLoggingStatusInput"}
+	if s.ClusterIdentifier == nil {
+		invalidParams.Add(request.NewErrParamRequired("ClusterIdentifier"))
+	}
+
+	if invalidParams.Len() > 0 {
+		return invalidParams
+	}
+	return nil
+}
+
 type DescribeOrderableClusterOptionsInput struct {
 	_ struct{} `type:"structure"`
 
@@ -5260,6 +5655,19 @@ func (s DescribeResizeInput) String() string {
 // GoString returns the string representation
 func (s DescribeResizeInput) GoString() string {
 	return s.String()
+}
+
+// Validate inspects the fields of the type to determine if they are valid.
+func (s *DescribeResizeInput) Validate() error {
+	invalidParams := request.ErrInvalidParams{Context: "DescribeResizeInput"}
+	if s.ClusterIdentifier == nil {
+		invalidParams.Add(request.NewErrParamRequired("ClusterIdentifier"))
+	}
+
+	if invalidParams.Len() > 0 {
+		return invalidParams
+	}
+	return nil
 }
 
 // Describes the result of a cluster resize operation.
@@ -5572,6 +5980,19 @@ func (s DisableLoggingInput) GoString() string {
 	return s.String()
 }
 
+// Validate inspects the fields of the type to determine if they are valid.
+func (s *DisableLoggingInput) Validate() error {
+	invalidParams := request.ErrInvalidParams{Context: "DisableLoggingInput"}
+	if s.ClusterIdentifier == nil {
+		invalidParams.Add(request.NewErrParamRequired("ClusterIdentifier"))
+	}
+
+	if invalidParams.Len() > 0 {
+		return invalidParams
+	}
+	return nil
+}
+
 type DisableSnapshotCopyInput struct {
 	_ struct{} `type:"structure"`
 
@@ -5591,6 +6012,19 @@ func (s DisableSnapshotCopyInput) String() string {
 // GoString returns the string representation
 func (s DisableSnapshotCopyInput) GoString() string {
 	return s.String()
+}
+
+// Validate inspects the fields of the type to determine if they are valid.
+func (s *DisableSnapshotCopyInput) Validate() error {
+	invalidParams := request.ErrInvalidParams{Context: "DisableSnapshotCopyInput"}
+	if s.ClusterIdentifier == nil {
+		invalidParams.Add(request.NewErrParamRequired("ClusterIdentifier"))
+	}
+
+	if invalidParams.Len() > 0 {
+		return invalidParams
+	}
+	return nil
 }
 
 type DisableSnapshotCopyOutput struct {
@@ -5695,6 +6129,22 @@ func (s EnableLoggingInput) GoString() string {
 	return s.String()
 }
 
+// Validate inspects the fields of the type to determine if they are valid.
+func (s *EnableLoggingInput) Validate() error {
+	invalidParams := request.ErrInvalidParams{Context: "EnableLoggingInput"}
+	if s.BucketName == nil {
+		invalidParams.Add(request.NewErrParamRequired("BucketName"))
+	}
+	if s.ClusterIdentifier == nil {
+		invalidParams.Add(request.NewErrParamRequired("ClusterIdentifier"))
+	}
+
+	if invalidParams.Len() > 0 {
+		return invalidParams
+	}
+	return nil
+}
+
 type EnableSnapshotCopyInput struct {
 	_ struct{} `type:"structure"`
 
@@ -5732,6 +6182,22 @@ func (s EnableSnapshotCopyInput) String() string {
 // GoString returns the string representation
 func (s EnableSnapshotCopyInput) GoString() string {
 	return s.String()
+}
+
+// Validate inspects the fields of the type to determine if they are valid.
+func (s *EnableSnapshotCopyInput) Validate() error {
+	invalidParams := request.ErrInvalidParams{Context: "EnableSnapshotCopyInput"}
+	if s.ClusterIdentifier == nil {
+		invalidParams.Add(request.NewErrParamRequired("ClusterIdentifier"))
+	}
+	if s.DestinationRegion == nil {
+		invalidParams.Add(request.NewErrParamRequired("DestinationRegion"))
+	}
+
+	if invalidParams.Len() > 0 {
+		return invalidParams
+	}
+	return nil
 }
 
 type EnableSnapshotCopyOutput struct {
@@ -6102,6 +6568,19 @@ func (s ModifyClusterIamRolesInput) GoString() string {
 	return s.String()
 }
 
+// Validate inspects the fields of the type to determine if they are valid.
+func (s *ModifyClusterIamRolesInput) Validate() error {
+	invalidParams := request.ErrInvalidParams{Context: "ModifyClusterIamRolesInput"}
+	if s.ClusterIdentifier == nil {
+		invalidParams.Add(request.NewErrParamRequired("ClusterIdentifier"))
+	}
+
+	if invalidParams.Len() > 0 {
+		return invalidParams
+	}
+	return nil
+}
+
 type ModifyClusterIamRolesOutput struct {
 	_ struct{} `type:"structure"`
 
@@ -6300,6 +6779,19 @@ func (s ModifyClusterInput) GoString() string {
 	return s.String()
 }
 
+// Validate inspects the fields of the type to determine if they are valid.
+func (s *ModifyClusterInput) Validate() error {
+	invalidParams := request.ErrInvalidParams{Context: "ModifyClusterInput"}
+	if s.ClusterIdentifier == nil {
+		invalidParams.Add(request.NewErrParamRequired("ClusterIdentifier"))
+	}
+
+	if invalidParams.Len() > 0 {
+		return invalidParams
+	}
+	return nil
+}
+
 type ModifyClusterOutput struct {
 	_ struct{} `type:"structure"`
 
@@ -6344,6 +6836,22 @@ func (s ModifyClusterParameterGroupInput) GoString() string {
 	return s.String()
 }
 
+// Validate inspects the fields of the type to determine if they are valid.
+func (s *ModifyClusterParameterGroupInput) Validate() error {
+	invalidParams := request.ErrInvalidParams{Context: "ModifyClusterParameterGroupInput"}
+	if s.ParameterGroupName == nil {
+		invalidParams.Add(request.NewErrParamRequired("ParameterGroupName"))
+	}
+	if s.Parameters == nil {
+		invalidParams.Add(request.NewErrParamRequired("Parameters"))
+	}
+
+	if invalidParams.Len() > 0 {
+		return invalidParams
+	}
+	return nil
+}
+
 type ModifyClusterSubnetGroupInput struct {
 	_ struct{} `type:"structure"`
 
@@ -6366,6 +6874,22 @@ func (s ModifyClusterSubnetGroupInput) String() string {
 // GoString returns the string representation
 func (s ModifyClusterSubnetGroupInput) GoString() string {
 	return s.String()
+}
+
+// Validate inspects the fields of the type to determine if they are valid.
+func (s *ModifyClusterSubnetGroupInput) Validate() error {
+	invalidParams := request.ErrInvalidParams{Context: "ModifyClusterSubnetGroupInput"}
+	if s.ClusterSubnetGroupName == nil {
+		invalidParams.Add(request.NewErrParamRequired("ClusterSubnetGroupName"))
+	}
+	if s.SubnetIds == nil {
+		invalidParams.Add(request.NewErrParamRequired("SubnetIds"))
+	}
+
+	if invalidParams.Len() > 0 {
+		return invalidParams
+	}
+	return nil
 }
 
 type ModifyClusterSubnetGroupOutput struct {
@@ -6443,6 +6967,19 @@ func (s ModifyEventSubscriptionInput) GoString() string {
 	return s.String()
 }
 
+// Validate inspects the fields of the type to determine if they are valid.
+func (s *ModifyEventSubscriptionInput) Validate() error {
+	invalidParams := request.ErrInvalidParams{Context: "ModifyEventSubscriptionInput"}
+	if s.SubscriptionName == nil {
+		invalidParams.Add(request.NewErrParamRequired("SubscriptionName"))
+	}
+
+	if invalidParams.Len() > 0 {
+		return invalidParams
+	}
+	return nil
+}
+
 type ModifyEventSubscriptionOutput struct {
 	_ struct{} `type:"structure"`
 
@@ -6490,6 +7027,22 @@ func (s ModifySnapshotCopyRetentionPeriodInput) String() string {
 // GoString returns the string representation
 func (s ModifySnapshotCopyRetentionPeriodInput) GoString() string {
 	return s.String()
+}
+
+// Validate inspects the fields of the type to determine if they are valid.
+func (s *ModifySnapshotCopyRetentionPeriodInput) Validate() error {
+	invalidParams := request.ErrInvalidParams{Context: "ModifySnapshotCopyRetentionPeriodInput"}
+	if s.ClusterIdentifier == nil {
+		invalidParams.Add(request.NewErrParamRequired("ClusterIdentifier"))
+	}
+	if s.RetentionPeriod == nil {
+		invalidParams.Add(request.NewErrParamRequired("RetentionPeriod"))
+	}
+
+	if invalidParams.Len() > 0 {
+		return invalidParams
+	}
+	return nil
 }
 
 type ModifySnapshotCopyRetentionPeriodOutput struct {
@@ -6647,6 +7200,19 @@ func (s PurchaseReservedNodeOfferingInput) GoString() string {
 	return s.String()
 }
 
+// Validate inspects the fields of the type to determine if they are valid.
+func (s *PurchaseReservedNodeOfferingInput) Validate() error {
+	invalidParams := request.ErrInvalidParams{Context: "PurchaseReservedNodeOfferingInput"}
+	if s.ReservedNodeOfferingId == nil {
+		invalidParams.Add(request.NewErrParamRequired("ReservedNodeOfferingId"))
+	}
+
+	if invalidParams.Len() > 0 {
+		return invalidParams
+	}
+	return nil
+}
+
 type PurchaseReservedNodeOfferingOutput struct {
 	_ struct{} `type:"structure"`
 
@@ -6680,6 +7246,19 @@ func (s RebootClusterInput) String() string {
 // GoString returns the string representation
 func (s RebootClusterInput) GoString() string {
 	return s.String()
+}
+
+// Validate inspects the fields of the type to determine if they are valid.
+func (s *RebootClusterInput) Validate() error {
+	invalidParams := request.ErrInvalidParams{Context: "RebootClusterInput"}
+	if s.ClusterIdentifier == nil {
+		invalidParams.Add(request.NewErrParamRequired("ClusterIdentifier"))
+	}
+
+	if invalidParams.Len() > 0 {
+		return invalidParams
+	}
+	return nil
 }
 
 type RebootClusterOutput struct {
@@ -6855,6 +7434,19 @@ func (s ResetClusterParameterGroupInput) GoString() string {
 	return s.String()
 }
 
+// Validate inspects the fields of the type to determine if they are valid.
+func (s *ResetClusterParameterGroupInput) Validate() error {
+	invalidParams := request.ErrInvalidParams{Context: "ResetClusterParameterGroupInput"}
+	if s.ParameterGroupName == nil {
+		invalidParams.Add(request.NewErrParamRequired("ParameterGroupName"))
+	}
+
+	if invalidParams.Len() > 0 {
+		return invalidParams
+	}
+	return nil
+}
+
 type RestoreFromClusterSnapshotInput struct {
 	_ struct{} `type:"structure"`
 
@@ -7015,6 +7607,22 @@ func (s RestoreFromClusterSnapshotInput) GoString() string {
 	return s.String()
 }
 
+// Validate inspects the fields of the type to determine if they are valid.
+func (s *RestoreFromClusterSnapshotInput) Validate() error {
+	invalidParams := request.ErrInvalidParams{Context: "RestoreFromClusterSnapshotInput"}
+	if s.ClusterIdentifier == nil {
+		invalidParams.Add(request.NewErrParamRequired("ClusterIdentifier"))
+	}
+	if s.SnapshotIdentifier == nil {
+		invalidParams.Add(request.NewErrParamRequired("SnapshotIdentifier"))
+	}
+
+	if invalidParams.Len() > 0 {
+		return invalidParams
+	}
+	return nil
+}
+
 type RestoreFromClusterSnapshotOutput struct {
 	_ struct{} `type:"structure"`
 
@@ -7111,6 +7719,31 @@ func (s RestoreTableFromClusterSnapshotInput) GoString() string {
 	return s.String()
 }
 
+// Validate inspects the fields of the type to determine if they are valid.
+func (s *RestoreTableFromClusterSnapshotInput) Validate() error {
+	invalidParams := request.ErrInvalidParams{Context: "RestoreTableFromClusterSnapshotInput"}
+	if s.ClusterIdentifier == nil {
+		invalidParams.Add(request.NewErrParamRequired("ClusterIdentifier"))
+	}
+	if s.NewTableName == nil {
+		invalidParams.Add(request.NewErrParamRequired("NewTableName"))
+	}
+	if s.SnapshotIdentifier == nil {
+		invalidParams.Add(request.NewErrParamRequired("SnapshotIdentifier"))
+	}
+	if s.SourceDatabaseName == nil {
+		invalidParams.Add(request.NewErrParamRequired("SourceDatabaseName"))
+	}
+	if s.SourceTableName == nil {
+		invalidParams.Add(request.NewErrParamRequired("SourceTableName"))
+	}
+
+	if invalidParams.Len() > 0 {
+		return invalidParams
+	}
+	return nil
+}
+
 type RestoreTableFromClusterSnapshotOutput struct {
 	_ struct{} `type:"structure"`
 
@@ -7163,6 +7796,19 @@ func (s RevokeClusterSecurityGroupIngressInput) GoString() string {
 	return s.String()
 }
 
+// Validate inspects the fields of the type to determine if they are valid.
+func (s *RevokeClusterSecurityGroupIngressInput) Validate() error {
+	invalidParams := request.ErrInvalidParams{Context: "RevokeClusterSecurityGroupIngressInput"}
+	if s.ClusterSecurityGroupName == nil {
+		invalidParams.Add(request.NewErrParamRequired("ClusterSecurityGroupName"))
+	}
+
+	if invalidParams.Len() > 0 {
+		return invalidParams
+	}
+	return nil
+}
+
 type RevokeClusterSecurityGroupIngressOutput struct {
 	_ struct{} `type:"structure"`
 
@@ -7206,6 +7852,22 @@ func (s RevokeSnapshotAccessInput) GoString() string {
 	return s.String()
 }
 
+// Validate inspects the fields of the type to determine if they are valid.
+func (s *RevokeSnapshotAccessInput) Validate() error {
+	invalidParams := request.ErrInvalidParams{Context: "RevokeSnapshotAccessInput"}
+	if s.AccountWithRestoreAccess == nil {
+		invalidParams.Add(request.NewErrParamRequired("AccountWithRestoreAccess"))
+	}
+	if s.SnapshotIdentifier == nil {
+		invalidParams.Add(request.NewErrParamRequired("SnapshotIdentifier"))
+	}
+
+	if invalidParams.Len() > 0 {
+		return invalidParams
+	}
+	return nil
+}
+
 type RevokeSnapshotAccessOutput struct {
 	_ struct{} `type:"structure"`
 
@@ -7241,6 +7903,19 @@ func (s RotateEncryptionKeyInput) String() string {
 // GoString returns the string representation
 func (s RotateEncryptionKeyInput) GoString() string {
 	return s.String()
+}
+
+// Validate inspects the fields of the type to determine if they are valid.
+func (s *RotateEncryptionKeyInput) Validate() error {
+	invalidParams := request.ErrInvalidParams{Context: "RotateEncryptionKeyInput"}
+	if s.ClusterIdentifier == nil {
+		invalidParams.Add(request.NewErrParamRequired("ClusterIdentifier"))
+	}
+
+	if invalidParams.Len() > 0 {
+		return invalidParams
+	}
+	return nil
 }
 
 type RotateEncryptionKeyOutput struct {

--- a/service/route53/api.go
+++ b/service/route53/api.go
@@ -4,6 +4,7 @@
 package route53
 
 import (
+	"fmt"
 	"time"
 
 	"github.com/aws/aws-sdk-go/aws/awsutil"
@@ -1831,6 +1832,28 @@ func (s AlarmIdentifier) GoString() string {
 	return s.String()
 }
 
+// Validate inspects the fields of the type to determine if they are valid.
+func (s *AlarmIdentifier) Validate() error {
+	invalidParams := request.ErrInvalidParams{Context: "AlarmIdentifier"}
+	if s.Name == nil {
+		invalidParams.Add(request.NewErrParamRequired("Name"))
+	}
+	if s.Name != nil && len(*s.Name) < 1 {
+		invalidParams.Add(request.NewErrParamMinLen("Name", 1))
+	}
+	if s.Region == nil {
+		invalidParams.Add(request.NewErrParamRequired("Region"))
+	}
+	if s.Region != nil && len(*s.Region) < 1 {
+		invalidParams.Add(request.NewErrParamMinLen("Region", 1))
+	}
+
+	if invalidParams.Len() > 0 {
+		return invalidParams
+	}
+	return nil
+}
+
 // Alias resource record sets only: Information about the CloudFront distribution,
 // ELB load balancer, Amazon S3 bucket, or Amazon Route 53 resource record set
 // to which you are routing traffic.
@@ -1966,6 +1989,25 @@ func (s AliasTarget) GoString() string {
 	return s.String()
 }
 
+// Validate inspects the fields of the type to determine if they are valid.
+func (s *AliasTarget) Validate() error {
+	invalidParams := request.ErrInvalidParams{Context: "AliasTarget"}
+	if s.DNSName == nil {
+		invalidParams.Add(request.NewErrParamRequired("DNSName"))
+	}
+	if s.EvaluateTargetHealth == nil {
+		invalidParams.Add(request.NewErrParamRequired("EvaluateTargetHealth"))
+	}
+	if s.HostedZoneId == nil {
+		invalidParams.Add(request.NewErrParamRequired("HostedZoneId"))
+	}
+
+	if invalidParams.Len() > 0 {
+		return invalidParams
+	}
+	return nil
+}
+
 // A complex type that contains information about the request to associate a
 // VPC with an hosted zone.
 type AssociateVPCWithHostedZoneInput struct {
@@ -1992,6 +2034,27 @@ func (s AssociateVPCWithHostedZoneInput) String() string {
 // GoString returns the string representation
 func (s AssociateVPCWithHostedZoneInput) GoString() string {
 	return s.String()
+}
+
+// Validate inspects the fields of the type to determine if they are valid.
+func (s *AssociateVPCWithHostedZoneInput) Validate() error {
+	invalidParams := request.ErrInvalidParams{Context: "AssociateVPCWithHostedZoneInput"}
+	if s.HostedZoneId == nil {
+		invalidParams.Add(request.NewErrParamRequired("HostedZoneId"))
+	}
+	if s.VPC == nil {
+		invalidParams.Add(request.NewErrParamRequired("VPC"))
+	}
+	if s.VPC != nil {
+		if err := s.VPC.Validate(); err != nil {
+			invalidParams.AddNested("VPC", err.(request.ErrInvalidParams))
+		}
+	}
+
+	if invalidParams.Len() > 0 {
+		return invalidParams
+	}
+	return nil
 }
 
 // A complex type containing the response information for the request.
@@ -2047,6 +2110,27 @@ func (s Change) GoString() string {
 	return s.String()
 }
 
+// Validate inspects the fields of the type to determine if they are valid.
+func (s *Change) Validate() error {
+	invalidParams := request.ErrInvalidParams{Context: "Change"}
+	if s.Action == nil {
+		invalidParams.Add(request.NewErrParamRequired("Action"))
+	}
+	if s.ResourceRecordSet == nil {
+		invalidParams.Add(request.NewErrParamRequired("ResourceRecordSet"))
+	}
+	if s.ResourceRecordSet != nil {
+		if err := s.ResourceRecordSet.Validate(); err != nil {
+			invalidParams.AddNested("ResourceRecordSet", err.(request.ErrInvalidParams))
+		}
+	}
+
+	if invalidParams.Len() > 0 {
+		return invalidParams
+	}
+	return nil
+}
+
 // A complex type that contains an optional comment and the changes that you
 // want to make with a change batch request.
 type ChangeBatch struct {
@@ -2068,6 +2152,32 @@ func (s ChangeBatch) String() string {
 // GoString returns the string representation
 func (s ChangeBatch) GoString() string {
 	return s.String()
+}
+
+// Validate inspects the fields of the type to determine if they are valid.
+func (s *ChangeBatch) Validate() error {
+	invalidParams := request.ErrInvalidParams{Context: "ChangeBatch"}
+	if s.Changes == nil {
+		invalidParams.Add(request.NewErrParamRequired("Changes"))
+	}
+	if s.Changes != nil && len(s.Changes) < 1 {
+		invalidParams.Add(request.NewErrParamMinLen("Changes", 1))
+	}
+	if s.Changes != nil {
+		for i, v := range s.Changes {
+			if v == nil {
+				continue
+			}
+			if err := v.Validate(); err != nil {
+				invalidParams.AddNested(fmt.Sprintf("%s[%v]", "Changes", i), err.(request.ErrInvalidParams))
+			}
+		}
+	}
+
+	if invalidParams.Len() > 0 {
+		return invalidParams
+	}
+	return nil
 }
 
 // A complex type that lists the changes and information for a ChangeBatch.
@@ -2178,6 +2288,27 @@ func (s ChangeResourceRecordSetsInput) GoString() string {
 	return s.String()
 }
 
+// Validate inspects the fields of the type to determine if they are valid.
+func (s *ChangeResourceRecordSetsInput) Validate() error {
+	invalidParams := request.ErrInvalidParams{Context: "ChangeResourceRecordSetsInput"}
+	if s.ChangeBatch == nil {
+		invalidParams.Add(request.NewErrParamRequired("ChangeBatch"))
+	}
+	if s.HostedZoneId == nil {
+		invalidParams.Add(request.NewErrParamRequired("HostedZoneId"))
+	}
+	if s.ChangeBatch != nil {
+		if err := s.ChangeBatch.Validate(); err != nil {
+			invalidParams.AddNested("ChangeBatch", err.(request.ErrInvalidParams))
+		}
+	}
+
+	if invalidParams.Len() > 0 {
+		return invalidParams
+	}
+	return nil
+}
+
 // A complex type containing the response for the request.
 type ChangeResourceRecordSetsOutput struct {
 	_ struct{} `type:"structure"`
@@ -2231,6 +2362,28 @@ func (s ChangeTagsForResourceInput) String() string {
 // GoString returns the string representation
 func (s ChangeTagsForResourceInput) GoString() string {
 	return s.String()
+}
+
+// Validate inspects the fields of the type to determine if they are valid.
+func (s *ChangeTagsForResourceInput) Validate() error {
+	invalidParams := request.ErrInvalidParams{Context: "ChangeTagsForResourceInput"}
+	if s.AddTags != nil && len(s.AddTags) < 1 {
+		invalidParams.Add(request.NewErrParamMinLen("AddTags", 1))
+	}
+	if s.RemoveTagKeys != nil && len(s.RemoveTagKeys) < 1 {
+		invalidParams.Add(request.NewErrParamMinLen("RemoveTagKeys", 1))
+	}
+	if s.ResourceId == nil {
+		invalidParams.Add(request.NewErrParamRequired("ResourceId"))
+	}
+	if s.ResourceType == nil {
+		invalidParams.Add(request.NewErrParamRequired("ResourceType"))
+	}
+
+	if invalidParams.Len() > 0 {
+		return invalidParams
+	}
+	return nil
 }
 
 // Empty response for the request.
@@ -2333,6 +2486,30 @@ func (s CreateHealthCheckInput) GoString() string {
 	return s.String()
 }
 
+// Validate inspects the fields of the type to determine if they are valid.
+func (s *CreateHealthCheckInput) Validate() error {
+	invalidParams := request.ErrInvalidParams{Context: "CreateHealthCheckInput"}
+	if s.CallerReference == nil {
+		invalidParams.Add(request.NewErrParamRequired("CallerReference"))
+	}
+	if s.CallerReference != nil && len(*s.CallerReference) < 1 {
+		invalidParams.Add(request.NewErrParamMinLen("CallerReference", 1))
+	}
+	if s.HealthCheckConfig == nil {
+		invalidParams.Add(request.NewErrParamRequired("HealthCheckConfig"))
+	}
+	if s.HealthCheckConfig != nil {
+		if err := s.HealthCheckConfig.Validate(); err != nil {
+			invalidParams.AddNested("HealthCheckConfig", err.(request.ErrInvalidParams))
+		}
+	}
+
+	if invalidParams.Len() > 0 {
+		return invalidParams
+	}
+	return nil
+}
+
 // A complex type containing the response information for the new health check.
 type CreateHealthCheckOutput struct {
 	_ struct{} `type:"structure"`
@@ -2403,6 +2580,30 @@ func (s CreateHostedZoneInput) GoString() string {
 	return s.String()
 }
 
+// Validate inspects the fields of the type to determine if they are valid.
+func (s *CreateHostedZoneInput) Validate() error {
+	invalidParams := request.ErrInvalidParams{Context: "CreateHostedZoneInput"}
+	if s.CallerReference == nil {
+		invalidParams.Add(request.NewErrParamRequired("CallerReference"))
+	}
+	if s.CallerReference != nil && len(*s.CallerReference) < 1 {
+		invalidParams.Add(request.NewErrParamMinLen("CallerReference", 1))
+	}
+	if s.Name == nil {
+		invalidParams.Add(request.NewErrParamRequired("Name"))
+	}
+	if s.VPC != nil {
+		if err := s.VPC.Validate(); err != nil {
+			invalidParams.AddNested("VPC", err.(request.ErrInvalidParams))
+		}
+	}
+
+	if invalidParams.Len() > 0 {
+		return invalidParams
+	}
+	return nil
+}
+
 // A complex type containing the response information for the new hosted zone.
 type CreateHostedZoneOutput struct {
 	_ struct{} `type:"structure"`
@@ -2462,6 +2663,22 @@ func (s CreateReusableDelegationSetInput) GoString() string {
 	return s.String()
 }
 
+// Validate inspects the fields of the type to determine if they are valid.
+func (s *CreateReusableDelegationSetInput) Validate() error {
+	invalidParams := request.ErrInvalidParams{Context: "CreateReusableDelegationSetInput"}
+	if s.CallerReference == nil {
+		invalidParams.Add(request.NewErrParamRequired("CallerReference"))
+	}
+	if s.CallerReference != nil && len(*s.CallerReference) < 1 {
+		invalidParams.Add(request.NewErrParamMinLen("CallerReference", 1))
+	}
+
+	if invalidParams.Len() > 0 {
+		return invalidParams
+	}
+	return nil
+}
+
 type CreateReusableDelegationSetOutput struct {
 	_ struct{} `type:"structure"`
 
@@ -2507,6 +2724,22 @@ func (s CreateTrafficPolicyInput) GoString() string {
 	return s.String()
 }
 
+// Validate inspects the fields of the type to determine if they are valid.
+func (s *CreateTrafficPolicyInput) Validate() error {
+	invalidParams := request.ErrInvalidParams{Context: "CreateTrafficPolicyInput"}
+	if s.Document == nil {
+		invalidParams.Add(request.NewErrParamRequired("Document"))
+	}
+	if s.Name == nil {
+		invalidParams.Add(request.NewErrParamRequired("Name"))
+	}
+
+	if invalidParams.Len() > 0 {
+		return invalidParams
+	}
+	return nil
+}
+
 // A complex type that contains information about the resource record sets that
 // you want to create based on a specified traffic policy.
 type CreateTrafficPolicyInstanceInput struct {
@@ -2542,6 +2775,34 @@ func (s CreateTrafficPolicyInstanceInput) String() string {
 // GoString returns the string representation
 func (s CreateTrafficPolicyInstanceInput) GoString() string {
 	return s.String()
+}
+
+// Validate inspects the fields of the type to determine if they are valid.
+func (s *CreateTrafficPolicyInstanceInput) Validate() error {
+	invalidParams := request.ErrInvalidParams{Context: "CreateTrafficPolicyInstanceInput"}
+	if s.HostedZoneId == nil {
+		invalidParams.Add(request.NewErrParamRequired("HostedZoneId"))
+	}
+	if s.Name == nil {
+		invalidParams.Add(request.NewErrParamRequired("Name"))
+	}
+	if s.TTL == nil {
+		invalidParams.Add(request.NewErrParamRequired("TTL"))
+	}
+	if s.TrafficPolicyId == nil {
+		invalidParams.Add(request.NewErrParamRequired("TrafficPolicyId"))
+	}
+	if s.TrafficPolicyVersion == nil {
+		invalidParams.Add(request.NewErrParamRequired("TrafficPolicyVersion"))
+	}
+	if s.TrafficPolicyVersion != nil && *s.TrafficPolicyVersion < 1 {
+		invalidParams.Add(request.NewErrParamMinValue("TrafficPolicyVersion", 1))
+	}
+
+	if invalidParams.Len() > 0 {
+		return invalidParams
+	}
+	return nil
 }
 
 // A complex type that contains the response information for the CreateTrafficPolicyInstance
@@ -2614,6 +2875,22 @@ func (s CreateTrafficPolicyVersionInput) GoString() string {
 	return s.String()
 }
 
+// Validate inspects the fields of the type to determine if they are valid.
+func (s *CreateTrafficPolicyVersionInput) Validate() error {
+	invalidParams := request.ErrInvalidParams{Context: "CreateTrafficPolicyVersionInput"}
+	if s.Document == nil {
+		invalidParams.Add(request.NewErrParamRequired("Document"))
+	}
+	if s.Id == nil {
+		invalidParams.Add(request.NewErrParamRequired("Id"))
+	}
+
+	if invalidParams.Len() > 0 {
+		return invalidParams
+	}
+	return nil
+}
+
 // A complex type that contains the response information for the CreateTrafficPolicyVersion
 // request.
 type CreateTrafficPolicyVersionOutput struct {
@@ -2678,6 +2955,19 @@ func (s DeleteHealthCheckInput) GoString() string {
 	return s.String()
 }
 
+// Validate inspects the fields of the type to determine if they are valid.
+func (s *DeleteHealthCheckInput) Validate() error {
+	invalidParams := request.ErrInvalidParams{Context: "DeleteHealthCheckInput"}
+	if s.HealthCheckId == nil {
+		invalidParams.Add(request.NewErrParamRequired("HealthCheckId"))
+	}
+
+	if invalidParams.Len() > 0 {
+		return invalidParams
+	}
+	return nil
+}
+
 // Empty response for the request.
 type DeleteHealthCheckOutput struct {
 	_ struct{} `type:"structure"`
@@ -2710,6 +3000,19 @@ func (s DeleteHostedZoneInput) String() string {
 // GoString returns the string representation
 func (s DeleteHostedZoneInput) GoString() string {
 	return s.String()
+}
+
+// Validate inspects the fields of the type to determine if they are valid.
+func (s *DeleteHostedZoneInput) Validate() error {
+	invalidParams := request.ErrInvalidParams{Context: "DeleteHostedZoneInput"}
+	if s.Id == nil {
+		invalidParams.Add(request.NewErrParamRequired("Id"))
+	}
+
+	if invalidParams.Len() > 0 {
+		return invalidParams
+	}
+	return nil
 }
 
 // A complex type containing the response information for the request.
@@ -2749,6 +3052,19 @@ func (s DeleteReusableDelegationSetInput) GoString() string {
 	return s.String()
 }
 
+// Validate inspects the fields of the type to determine if they are valid.
+func (s *DeleteReusableDelegationSetInput) Validate() error {
+	invalidParams := request.ErrInvalidParams{Context: "DeleteReusableDelegationSetInput"}
+	if s.Id == nil {
+		invalidParams.Add(request.NewErrParamRequired("Id"))
+	}
+
+	if invalidParams.Len() > 0 {
+		return invalidParams
+	}
+	return nil
+}
+
 // Empty response for the request.
 type DeleteReusableDelegationSetOutput struct {
 	_ struct{} `type:"structure"`
@@ -2785,6 +3101,25 @@ func (s DeleteTrafficPolicyInput) GoString() string {
 	return s.String()
 }
 
+// Validate inspects the fields of the type to determine if they are valid.
+func (s *DeleteTrafficPolicyInput) Validate() error {
+	invalidParams := request.ErrInvalidParams{Context: "DeleteTrafficPolicyInput"}
+	if s.Id == nil {
+		invalidParams.Add(request.NewErrParamRequired("Id"))
+	}
+	if s.Version == nil {
+		invalidParams.Add(request.NewErrParamRequired("Version"))
+	}
+	if s.Version != nil && *s.Version < 1 {
+		invalidParams.Add(request.NewErrParamMinValue("Version", 1))
+	}
+
+	if invalidParams.Len() > 0 {
+		return invalidParams
+	}
+	return nil
+}
+
 // A complex type that contains information about the traffic policy instance
 // that you want to delete.
 type DeleteTrafficPolicyInstanceInput struct {
@@ -2806,6 +3141,19 @@ func (s DeleteTrafficPolicyInstanceInput) String() string {
 // GoString returns the string representation
 func (s DeleteTrafficPolicyInstanceInput) GoString() string {
 	return s.String()
+}
+
+// Validate inspects the fields of the type to determine if they are valid.
+func (s *DeleteTrafficPolicyInstanceInput) Validate() error {
+	invalidParams := request.ErrInvalidParams{Context: "DeleteTrafficPolicyInstanceInput"}
+	if s.Id == nil {
+		invalidParams.Add(request.NewErrParamRequired("Id"))
+	}
+
+	if invalidParams.Len() > 0 {
+		return invalidParams
+	}
+	return nil
 }
 
 // An empty element.
@@ -2886,6 +3234,27 @@ func (s DisassociateVPCFromHostedZoneInput) GoString() string {
 	return s.String()
 }
 
+// Validate inspects the fields of the type to determine if they are valid.
+func (s *DisassociateVPCFromHostedZoneInput) Validate() error {
+	invalidParams := request.ErrInvalidParams{Context: "DisassociateVPCFromHostedZoneInput"}
+	if s.HostedZoneId == nil {
+		invalidParams.Add(request.NewErrParamRequired("HostedZoneId"))
+	}
+	if s.VPC == nil {
+		invalidParams.Add(request.NewErrParamRequired("VPC"))
+	}
+	if s.VPC != nil {
+		if err := s.VPC.Validate(); err != nil {
+			invalidParams.AddNested("VPC", err.(request.ErrInvalidParams))
+		}
+	}
+
+	if invalidParams.Len() > 0 {
+		return invalidParams
+	}
+	return nil
+}
+
 // A complex type containing the response information for the request.
 type DisassociateVPCFromHostedZoneOutput struct {
 	_ struct{} `type:"structure"`
@@ -2941,6 +3310,25 @@ func (s GeoLocation) String() string {
 // GoString returns the string representation
 func (s GeoLocation) GoString() string {
 	return s.String()
+}
+
+// Validate inspects the fields of the type to determine if they are valid.
+func (s *GeoLocation) Validate() error {
+	invalidParams := request.ErrInvalidParams{Context: "GeoLocation"}
+	if s.ContinentCode != nil && len(*s.ContinentCode) < 2 {
+		invalidParams.Add(request.NewErrParamMinLen("ContinentCode", 2))
+	}
+	if s.CountryCode != nil && len(*s.CountryCode) < 1 {
+		invalidParams.Add(request.NewErrParamMinLen("CountryCode", 1))
+	}
+	if s.SubdivisionCode != nil && len(*s.SubdivisionCode) < 1 {
+		invalidParams.Add(request.NewErrParamMinLen("SubdivisionCode", 1))
+	}
+
+	if invalidParams.Len() > 0 {
+		return invalidParams
+	}
+	return nil
 }
 
 // A complex type that contains information about a GeoLocation.
@@ -3005,6 +3393,19 @@ func (s GetChangeDetailsInput) GoString() string {
 	return s.String()
 }
 
+// Validate inspects the fields of the type to determine if they are valid.
+func (s *GetChangeDetailsInput) Validate() error {
+	invalidParams := request.ErrInvalidParams{Context: "GetChangeDetailsInput"}
+	if s.Id == nil {
+		invalidParams.Add(request.NewErrParamRequired("Id"))
+	}
+
+	if invalidParams.Len() > 0 {
+		return invalidParams
+	}
+	return nil
+}
+
 // A complex type that contains the ChangeBatchRecord element.
 type GetChangeDetailsOutput struct {
 	_ struct{} `deprecated:"true" type:"structure"`
@@ -3043,6 +3444,19 @@ func (s GetChangeInput) String() string {
 // GoString returns the string representation
 func (s GetChangeInput) GoString() string {
 	return s.String()
+}
+
+// Validate inspects the fields of the type to determine if they are valid.
+func (s *GetChangeInput) Validate() error {
+	invalidParams := request.ErrInvalidParams{Context: "GetChangeInput"}
+	if s.Id == nil {
+		invalidParams.Add(request.NewErrParamRequired("Id"))
+	}
+
+	if invalidParams.Len() > 0 {
+		return invalidParams
+	}
+	return nil
 }
 
 // A complex type that contains the ChangeInfo element.
@@ -3137,6 +3551,25 @@ func (s GetGeoLocationInput) GoString() string {
 	return s.String()
 }
 
+// Validate inspects the fields of the type to determine if they are valid.
+func (s *GetGeoLocationInput) Validate() error {
+	invalidParams := request.ErrInvalidParams{Context: "GetGeoLocationInput"}
+	if s.ContinentCode != nil && len(*s.ContinentCode) < 2 {
+		invalidParams.Add(request.NewErrParamMinLen("ContinentCode", 2))
+	}
+	if s.CountryCode != nil && len(*s.CountryCode) < 1 {
+		invalidParams.Add(request.NewErrParamMinLen("CountryCode", 1))
+	}
+	if s.SubdivisionCode != nil && len(*s.SubdivisionCode) < 1 {
+		invalidParams.Add(request.NewErrParamMinLen("SubdivisionCode", 1))
+	}
+
+	if invalidParams.Len() > 0 {
+		return invalidParams
+	}
+	return nil
+}
+
 // A complex type containing information about the specified geo location.
 type GetGeoLocationOutput struct {
 	_ struct{} `type:"structure"`
@@ -3209,6 +3642,19 @@ func (s GetHealthCheckInput) GoString() string {
 	return s.String()
 }
 
+// Validate inspects the fields of the type to determine if they are valid.
+func (s *GetHealthCheckInput) Validate() error {
+	invalidParams := request.ErrInvalidParams{Context: "GetHealthCheckInput"}
+	if s.HealthCheckId == nil {
+		invalidParams.Add(request.NewErrParamRequired("HealthCheckId"))
+	}
+
+	if invalidParams.Len() > 0 {
+		return invalidParams
+	}
+	return nil
+}
+
 // A complex type that contains information about the request to get the most
 // recent failure reason for a health check.
 type GetHealthCheckLastFailureReasonInput struct {
@@ -3227,6 +3673,19 @@ func (s GetHealthCheckLastFailureReasonInput) String() string {
 // GoString returns the string representation
 func (s GetHealthCheckLastFailureReasonInput) GoString() string {
 	return s.String()
+}
+
+// Validate inspects the fields of the type to determine if they are valid.
+func (s *GetHealthCheckLastFailureReasonInput) Validate() error {
+	invalidParams := request.ErrInvalidParams{Context: "GetHealthCheckLastFailureReasonInput"}
+	if s.HealthCheckId == nil {
+		invalidParams.Add(request.NewErrParamRequired("HealthCheckId"))
+	}
+
+	if invalidParams.Len() > 0 {
+		return invalidParams
+	}
+	return nil
 }
 
 // A complex type that contains information about the most recent failure for
@@ -3340,6 +3799,19 @@ func (s GetHealthCheckStatusInput) GoString() string {
 	return s.String()
 }
 
+// Validate inspects the fields of the type to determine if they are valid.
+func (s *GetHealthCheckStatusInput) Validate() error {
+	invalidParams := request.ErrInvalidParams{Context: "GetHealthCheckStatusInput"}
+	if s.HealthCheckId == nil {
+		invalidParams.Add(request.NewErrParamRequired("HealthCheckId"))
+	}
+
+	if invalidParams.Len() > 0 {
+		return invalidParams
+	}
+	return nil
+}
+
 // A complex type that contains information about the status of the specified
 // health check.
 type GetHealthCheckStatusOutput struct {
@@ -3414,6 +3886,19 @@ func (s GetHostedZoneInput) GoString() string {
 	return s.String()
 }
 
+// Validate inspects the fields of the type to determine if they are valid.
+func (s *GetHostedZoneInput) Validate() error {
+	invalidParams := request.ErrInvalidParams{Context: "GetHostedZoneInput"}
+	if s.Id == nil {
+		invalidParams.Add(request.NewErrParamRequired("Id"))
+	}
+
+	if invalidParams.Len() > 0 {
+		return invalidParams
+	}
+	return nil
+}
+
 // A complex type containing information about the specified hosted zone.
 type GetHostedZoneOutput struct {
 	_ struct{} `type:"structure"`
@@ -3459,6 +3944,19 @@ func (s GetReusableDelegationSetInput) GoString() string {
 	return s.String()
 }
 
+// Validate inspects the fields of the type to determine if they are valid.
+func (s *GetReusableDelegationSetInput) Validate() error {
+	invalidParams := request.ErrInvalidParams{Context: "GetReusableDelegationSetInput"}
+	if s.Id == nil {
+		invalidParams.Add(request.NewErrParamRequired("Id"))
+	}
+
+	if invalidParams.Len() > 0 {
+		return invalidParams
+	}
+	return nil
+}
+
 // A complex type containing information about the specified reusable delegation
 // set.
 type GetReusableDelegationSetOutput struct {
@@ -3501,6 +3999,25 @@ func (s GetTrafficPolicyInput) String() string {
 // GoString returns the string representation
 func (s GetTrafficPolicyInput) GoString() string {
 	return s.String()
+}
+
+// Validate inspects the fields of the type to determine if they are valid.
+func (s *GetTrafficPolicyInput) Validate() error {
+	invalidParams := request.ErrInvalidParams{Context: "GetTrafficPolicyInput"}
+	if s.Id == nil {
+		invalidParams.Add(request.NewErrParamRequired("Id"))
+	}
+	if s.Version == nil {
+		invalidParams.Add(request.NewErrParamRequired("Version"))
+	}
+	if s.Version != nil && *s.Version < 1 {
+		invalidParams.Add(request.NewErrParamMinValue("Version", 1))
+	}
+
+	if invalidParams.Len() > 0 {
+		return invalidParams
+	}
+	return nil
 }
 
 // To retrieve a count of all your traffic policy instances, send a GET request
@@ -3558,6 +4075,19 @@ func (s GetTrafficPolicyInstanceInput) String() string {
 // GoString returns the string representation
 func (s GetTrafficPolicyInstanceInput) GoString() string {
 	return s.String()
+}
+
+// Validate inspects the fields of the type to determine if they are valid.
+func (s *GetTrafficPolicyInstanceInput) Validate() error {
+	invalidParams := request.ErrInvalidParams{Context: "GetTrafficPolicyInstanceInput"}
+	if s.Id == nil {
+		invalidParams.Add(request.NewErrParamRequired("Id"))
+	}
+
+	if invalidParams.Len() > 0 {
+		return invalidParams
+	}
+	return nil
 }
 
 // A complex type that contains information about the resource record sets that
@@ -3725,6 +4255,36 @@ func (s HealthCheckConfig) GoString() string {
 	return s.String()
 }
 
+// Validate inspects the fields of the type to determine if they are valid.
+func (s *HealthCheckConfig) Validate() error {
+	invalidParams := request.ErrInvalidParams{Context: "HealthCheckConfig"}
+	if s.FailureThreshold != nil && *s.FailureThreshold < 1 {
+		invalidParams.Add(request.NewErrParamMinValue("FailureThreshold", 1))
+	}
+	if s.Port != nil && *s.Port < 1 {
+		invalidParams.Add(request.NewErrParamMinValue("Port", 1))
+	}
+	if s.Regions != nil && len(s.Regions) < 1 {
+		invalidParams.Add(request.NewErrParamMinLen("Regions", 1))
+	}
+	if s.RequestInterval != nil && *s.RequestInterval < 10 {
+		invalidParams.Add(request.NewErrParamMinValue("RequestInterval", 10))
+	}
+	if s.Type == nil {
+		invalidParams.Add(request.NewErrParamRequired("Type"))
+	}
+	if s.AlarmIdentifier != nil {
+		if err := s.AlarmIdentifier.Validate(); err != nil {
+			invalidParams.AddNested("AlarmIdentifier", err.(request.ErrInvalidParams))
+		}
+	}
+
+	if invalidParams.Len() > 0 {
+		return invalidParams
+	}
+	return nil
+}
+
 // A complex type that contains the IP address of a Amazon Route 53 health checker
 // and the reason for the health check status.
 type HealthCheckObservation struct {
@@ -3845,6 +4405,25 @@ func (s ListChangeBatchesByHostedZoneInput) GoString() string {
 	return s.String()
 }
 
+// Validate inspects the fields of the type to determine if they are valid.
+func (s *ListChangeBatchesByHostedZoneInput) Validate() error {
+	invalidParams := request.ErrInvalidParams{Context: "ListChangeBatchesByHostedZoneInput"}
+	if s.EndDate == nil {
+		invalidParams.Add(request.NewErrParamRequired("EndDate"))
+	}
+	if s.HostedZoneId == nil {
+		invalidParams.Add(request.NewErrParamRequired("HostedZoneId"))
+	}
+	if s.StartDate == nil {
+		invalidParams.Add(request.NewErrParamRequired("StartDate"))
+	}
+
+	if invalidParams.Len() > 0 {
+		return invalidParams
+	}
+	return nil
+}
+
 // The input for a ListChangeBatchesByHostedZone request.
 type ListChangeBatchesByHostedZoneOutput struct {
 	_ struct{} `deprecated:"true" type:"structure"`
@@ -3912,6 +4491,34 @@ func (s ListChangeBatchesByRRSetInput) String() string {
 // GoString returns the string representation
 func (s ListChangeBatchesByRRSetInput) GoString() string {
 	return s.String()
+}
+
+// Validate inspects the fields of the type to determine if they are valid.
+func (s *ListChangeBatchesByRRSetInput) Validate() error {
+	invalidParams := request.ErrInvalidParams{Context: "ListChangeBatchesByRRSetInput"}
+	if s.EndDate == nil {
+		invalidParams.Add(request.NewErrParamRequired("EndDate"))
+	}
+	if s.HostedZoneId == nil {
+		invalidParams.Add(request.NewErrParamRequired("HostedZoneId"))
+	}
+	if s.Name == nil {
+		invalidParams.Add(request.NewErrParamRequired("Name"))
+	}
+	if s.SetIdentifier != nil && len(*s.SetIdentifier) < 1 {
+		invalidParams.Add(request.NewErrParamMinLen("SetIdentifier", 1))
+	}
+	if s.StartDate == nil {
+		invalidParams.Add(request.NewErrParamRequired("StartDate"))
+	}
+	if s.Type == nil {
+		invalidParams.Add(request.NewErrParamRequired("Type"))
+	}
+
+	if invalidParams.Len() > 0 {
+		return invalidParams
+	}
+	return nil
 }
 
 // The input for a ListChangeBatchesByRRSet request.
@@ -3984,6 +4591,25 @@ func (s ListGeoLocationsInput) String() string {
 // GoString returns the string representation
 func (s ListGeoLocationsInput) GoString() string {
 	return s.String()
+}
+
+// Validate inspects the fields of the type to determine if they are valid.
+func (s *ListGeoLocationsInput) Validate() error {
+	invalidParams := request.ErrInvalidParams{Context: "ListGeoLocationsInput"}
+	if s.StartContinentCode != nil && len(*s.StartContinentCode) < 2 {
+		invalidParams.Add(request.NewErrParamMinLen("StartContinentCode", 2))
+	}
+	if s.StartCountryCode != nil && len(*s.StartCountryCode) < 1 {
+		invalidParams.Add(request.NewErrParamMinLen("StartCountryCode", 1))
+	}
+	if s.StartSubdivisionCode != nil && len(*s.StartSubdivisionCode) < 1 {
+		invalidParams.Add(request.NewErrParamMinLen("StartSubdivisionCode", 1))
+	}
+
+	if invalidParams.Len() > 0 {
+		return invalidParams
+	}
+	return nil
 }
 
 // A complex type that contains information about the geo locations that are
@@ -4330,6 +4956,22 @@ func (s ListResourceRecordSetsInput) GoString() string {
 	return s.String()
 }
 
+// Validate inspects the fields of the type to determine if they are valid.
+func (s *ListResourceRecordSetsInput) Validate() error {
+	invalidParams := request.ErrInvalidParams{Context: "ListResourceRecordSetsInput"}
+	if s.HostedZoneId == nil {
+		invalidParams.Add(request.NewErrParamRequired("HostedZoneId"))
+	}
+	if s.StartRecordIdentifier != nil && len(*s.StartRecordIdentifier) < 1 {
+		invalidParams.Add(request.NewErrParamMinLen("StartRecordIdentifier", 1))
+	}
+
+	if invalidParams.Len() > 0 {
+		return invalidParams
+	}
+	return nil
+}
+
 // A complex type that contains information about the resource record sets that
 // are returned by the request and information about the response.
 type ListResourceRecordSetsOutput struct {
@@ -4481,6 +5123,22 @@ func (s ListTagsForResourceInput) GoString() string {
 	return s.String()
 }
 
+// Validate inspects the fields of the type to determine if they are valid.
+func (s *ListTagsForResourceInput) Validate() error {
+	invalidParams := request.ErrInvalidParams{Context: "ListTagsForResourceInput"}
+	if s.ResourceId == nil {
+		invalidParams.Add(request.NewErrParamRequired("ResourceId"))
+	}
+	if s.ResourceType == nil {
+		invalidParams.Add(request.NewErrParamRequired("ResourceType"))
+	}
+
+	if invalidParams.Len() > 0 {
+		return invalidParams
+	}
+	return nil
+}
+
 // A complex type containing tags for the specified resource.
 type ListTagsForResourceOutput struct {
 	_ struct{} `type:"structure"`
@@ -4524,6 +5182,25 @@ func (s ListTagsForResourcesInput) String() string {
 // GoString returns the string representation
 func (s ListTagsForResourcesInput) GoString() string {
 	return s.String()
+}
+
+// Validate inspects the fields of the type to determine if they are valid.
+func (s *ListTagsForResourcesInput) Validate() error {
+	invalidParams := request.ErrInvalidParams{Context: "ListTagsForResourcesInput"}
+	if s.ResourceIds == nil {
+		invalidParams.Add(request.NewErrParamRequired("ResourceIds"))
+	}
+	if s.ResourceIds != nil && len(s.ResourceIds) < 1 {
+		invalidParams.Add(request.NewErrParamMinLen("ResourceIds", 1))
+	}
+	if s.ResourceType == nil {
+		invalidParams.Add(request.NewErrParamRequired("ResourceType"))
+	}
+
+	if invalidParams.Len() > 0 {
+		return invalidParams
+	}
+	return nil
 }
 
 // A complex type containing tags for the specified resources.
@@ -4666,6 +5343,19 @@ func (s ListTrafficPolicyInstancesByHostedZoneInput) GoString() string {
 	return s.String()
 }
 
+// Validate inspects the fields of the type to determine if they are valid.
+func (s *ListTrafficPolicyInstancesByHostedZoneInput) Validate() error {
+	invalidParams := request.ErrInvalidParams{Context: "ListTrafficPolicyInstancesByHostedZoneInput"}
+	if s.HostedZoneId == nil {
+		invalidParams.Add(request.NewErrParamRequired("HostedZoneId"))
+	}
+
+	if invalidParams.Len() > 0 {
+		return invalidParams
+	}
+	return nil
+}
+
 // A complex type that contains the response information for the request.
 type ListTrafficPolicyInstancesByHostedZoneOutput struct {
 	_ struct{} `type:"structure"`
@@ -4775,6 +5465,25 @@ func (s ListTrafficPolicyInstancesByPolicyInput) String() string {
 // GoString returns the string representation
 func (s ListTrafficPolicyInstancesByPolicyInput) GoString() string {
 	return s.String()
+}
+
+// Validate inspects the fields of the type to determine if they are valid.
+func (s *ListTrafficPolicyInstancesByPolicyInput) Validate() error {
+	invalidParams := request.ErrInvalidParams{Context: "ListTrafficPolicyInstancesByPolicyInput"}
+	if s.TrafficPolicyId == nil {
+		invalidParams.Add(request.NewErrParamRequired("TrafficPolicyId"))
+	}
+	if s.TrafficPolicyVersion == nil {
+		invalidParams.Add(request.NewErrParamRequired("TrafficPolicyVersion"))
+	}
+	if s.TrafficPolicyVersion != nil && *s.TrafficPolicyVersion < 1 {
+		invalidParams.Add(request.NewErrParamMinValue("TrafficPolicyVersion", 1))
+	}
+
+	if invalidParams.Len() > 0 {
+		return invalidParams
+	}
+	return nil
 }
 
 // A complex type that contains the response information for the request.
@@ -4970,6 +5679,19 @@ func (s ListTrafficPolicyVersionsInput) GoString() string {
 	return s.String()
 }
 
+// Validate inspects the fields of the type to determine if they are valid.
+func (s *ListTrafficPolicyVersionsInput) Validate() error {
+	invalidParams := request.ErrInvalidParams{Context: "ListTrafficPolicyVersionsInput"}
+	if s.Id == nil {
+		invalidParams.Add(request.NewErrParamRequired("Id"))
+	}
+
+	if invalidParams.Len() > 0 {
+		return invalidParams
+	}
+	return nil
+}
+
 // A complex type that contains the response information for the request.
 type ListTrafficPolicyVersionsOutput struct {
 	_ struct{} `type:"structure"`
@@ -5033,6 +5755,19 @@ func (s ResourceRecord) String() string {
 // GoString returns the string representation
 func (s ResourceRecord) GoString() string {
 	return s.String()
+}
+
+// Validate inspects the fields of the type to determine if they are valid.
+func (s *ResourceRecord) Validate() error {
+	invalidParams := request.ErrInvalidParams{Context: "ResourceRecord"}
+	if s.Value == nil {
+		invalidParams.Add(request.NewErrParamRequired("Value"))
+	}
+
+	if invalidParams.Len() > 0 {
+		return invalidParams
+	}
+	return nil
 }
 
 // A complex type that contains information about the current resource record
@@ -5262,6 +5997,51 @@ func (s ResourceRecordSet) String() string {
 // GoString returns the string representation
 func (s ResourceRecordSet) GoString() string {
 	return s.String()
+}
+
+// Validate inspects the fields of the type to determine if they are valid.
+func (s *ResourceRecordSet) Validate() error {
+	invalidParams := request.ErrInvalidParams{Context: "ResourceRecordSet"}
+	if s.Name == nil {
+		invalidParams.Add(request.NewErrParamRequired("Name"))
+	}
+	if s.Region != nil && len(*s.Region) < 1 {
+		invalidParams.Add(request.NewErrParamMinLen("Region", 1))
+	}
+	if s.ResourceRecords != nil && len(s.ResourceRecords) < 1 {
+		invalidParams.Add(request.NewErrParamMinLen("ResourceRecords", 1))
+	}
+	if s.SetIdentifier != nil && len(*s.SetIdentifier) < 1 {
+		invalidParams.Add(request.NewErrParamMinLen("SetIdentifier", 1))
+	}
+	if s.Type == nil {
+		invalidParams.Add(request.NewErrParamRequired("Type"))
+	}
+	if s.AliasTarget != nil {
+		if err := s.AliasTarget.Validate(); err != nil {
+			invalidParams.AddNested("AliasTarget", err.(request.ErrInvalidParams))
+		}
+	}
+	if s.GeoLocation != nil {
+		if err := s.GeoLocation.Validate(); err != nil {
+			invalidParams.AddNested("GeoLocation", err.(request.ErrInvalidParams))
+		}
+	}
+	if s.ResourceRecords != nil {
+		for i, v := range s.ResourceRecords {
+			if v == nil {
+				continue
+			}
+			if err := v.Validate(); err != nil {
+				invalidParams.AddNested(fmt.Sprintf("%s[%v]", "ResourceRecords", i), err.(request.ErrInvalidParams))
+			}
+		}
+	}
+
+	if invalidParams.Len() > 0 {
+		return invalidParams
+	}
+	return nil
 }
 
 // A complex type containing a resource and its associated tags.
@@ -5533,6 +6313,36 @@ func (s UpdateHealthCheckInput) GoString() string {
 	return s.String()
 }
 
+// Validate inspects the fields of the type to determine if they are valid.
+func (s *UpdateHealthCheckInput) Validate() error {
+	invalidParams := request.ErrInvalidParams{Context: "UpdateHealthCheckInput"}
+	if s.FailureThreshold != nil && *s.FailureThreshold < 1 {
+		invalidParams.Add(request.NewErrParamMinValue("FailureThreshold", 1))
+	}
+	if s.HealthCheckId == nil {
+		invalidParams.Add(request.NewErrParamRequired("HealthCheckId"))
+	}
+	if s.HealthCheckVersion != nil && *s.HealthCheckVersion < 1 {
+		invalidParams.Add(request.NewErrParamMinValue("HealthCheckVersion", 1))
+	}
+	if s.Port != nil && *s.Port < 1 {
+		invalidParams.Add(request.NewErrParamMinValue("Port", 1))
+	}
+	if s.Regions != nil && len(s.Regions) < 1 {
+		invalidParams.Add(request.NewErrParamMinLen("Regions", 1))
+	}
+	if s.AlarmIdentifier != nil {
+		if err := s.AlarmIdentifier.Validate(); err != nil {
+			invalidParams.AddNested("AlarmIdentifier", err.(request.ErrInvalidParams))
+		}
+	}
+
+	if invalidParams.Len() > 0 {
+		return invalidParams
+	}
+	return nil
+}
+
 type UpdateHealthCheckOutput struct {
 	_ struct{} `type:"structure"`
 
@@ -5570,6 +6380,19 @@ func (s UpdateHostedZoneCommentInput) String() string {
 // GoString returns the string representation
 func (s UpdateHostedZoneCommentInput) GoString() string {
 	return s.String()
+}
+
+// Validate inspects the fields of the type to determine if they are valid.
+func (s *UpdateHostedZoneCommentInput) Validate() error {
+	invalidParams := request.ErrInvalidParams{Context: "UpdateHostedZoneCommentInput"}
+	if s.Id == nil {
+		invalidParams.Add(request.NewErrParamRequired("Id"))
+	}
+
+	if invalidParams.Len() > 0 {
+		return invalidParams
+	}
+	return nil
 }
 
 // A complex type containing information about the specified hosted zone after
@@ -5615,6 +6438,28 @@ func (s UpdateTrafficPolicyCommentInput) String() string {
 // GoString returns the string representation
 func (s UpdateTrafficPolicyCommentInput) GoString() string {
 	return s.String()
+}
+
+// Validate inspects the fields of the type to determine if they are valid.
+func (s *UpdateTrafficPolicyCommentInput) Validate() error {
+	invalidParams := request.ErrInvalidParams{Context: "UpdateTrafficPolicyCommentInput"}
+	if s.Comment == nil {
+		invalidParams.Add(request.NewErrParamRequired("Comment"))
+	}
+	if s.Id == nil {
+		invalidParams.Add(request.NewErrParamRequired("Id"))
+	}
+	if s.Version == nil {
+		invalidParams.Add(request.NewErrParamRequired("Version"))
+	}
+	if s.Version != nil && *s.Version < 1 {
+		invalidParams.Add(request.NewErrParamMinValue("Version", 1))
+	}
+
+	if invalidParams.Len() > 0 {
+		return invalidParams
+	}
+	return nil
 }
 
 // A complex type that contains the response information for the traffic policy.
@@ -5666,6 +6511,31 @@ func (s UpdateTrafficPolicyInstanceInput) GoString() string {
 	return s.String()
 }
 
+// Validate inspects the fields of the type to determine if they are valid.
+func (s *UpdateTrafficPolicyInstanceInput) Validate() error {
+	invalidParams := request.ErrInvalidParams{Context: "UpdateTrafficPolicyInstanceInput"}
+	if s.Id == nil {
+		invalidParams.Add(request.NewErrParamRequired("Id"))
+	}
+	if s.TTL == nil {
+		invalidParams.Add(request.NewErrParamRequired("TTL"))
+	}
+	if s.TrafficPolicyId == nil {
+		invalidParams.Add(request.NewErrParamRequired("TrafficPolicyId"))
+	}
+	if s.TrafficPolicyVersion == nil {
+		invalidParams.Add(request.NewErrParamRequired("TrafficPolicyVersion"))
+	}
+	if s.TrafficPolicyVersion != nil && *s.TrafficPolicyVersion < 1 {
+		invalidParams.Add(request.NewErrParamMinValue("TrafficPolicyVersion", 1))
+	}
+
+	if invalidParams.Len() > 0 {
+		return invalidParams
+	}
+	return nil
+}
+
 // A complex type that contains information about the resource record sets that
 // Amazon Route 53 created based on a specified traffic policy.
 type UpdateTrafficPolicyInstanceOutput struct {
@@ -5702,6 +6572,19 @@ func (s VPC) String() string {
 // GoString returns the string representation
 func (s VPC) GoString() string {
 	return s.String()
+}
+
+// Validate inspects the fields of the type to determine if they are valid.
+func (s *VPC) Validate() error {
+	invalidParams := request.ErrInvalidParams{Context: "VPC"}
+	if s.VPCRegion != nil && len(*s.VPCRegion) < 1 {
+		invalidParams.Add(request.NewErrParamMinLen("VPCRegion", 1))
+	}
+
+	if invalidParams.Len() > 0 {
+		return invalidParams
+	}
+	return nil
 }
 
 const (

--- a/service/route53domains/api.go
+++ b/service/route53domains/api.go
@@ -4,6 +4,7 @@
 package route53domains
 
 import (
+	"fmt"
 	"time"
 
 	"github.com/aws/aws-sdk-go/aws/awsutil"
@@ -661,6 +662,19 @@ func (s CheckDomainAvailabilityInput) GoString() string {
 	return s.String()
 }
 
+// Validate inspects the fields of the type to determine if they are valid.
+func (s *CheckDomainAvailabilityInput) Validate() error {
+	invalidParams := request.ErrInvalidParams{Context: "CheckDomainAvailabilityInput"}
+	if s.DomainName == nil {
+		invalidParams.Add(request.NewErrParamRequired("DomainName"))
+	}
+
+	if invalidParams.Len() > 0 {
+		return invalidParams
+	}
+	return nil
+}
+
 // The CheckDomainAvailability response includes the following elements.
 type CheckDomainAvailabilityOutput struct {
 	_ struct{} `type:"structure"`
@@ -901,6 +915,26 @@ func (s ContactDetail) GoString() string {
 	return s.String()
 }
 
+// Validate inspects the fields of the type to determine if they are valid.
+func (s *ContactDetail) Validate() error {
+	invalidParams := request.ErrInvalidParams{Context: "ContactDetail"}
+	if s.ExtraParams != nil {
+		for i, v := range s.ExtraParams {
+			if v == nil {
+				continue
+			}
+			if err := v.Validate(); err != nil {
+				invalidParams.AddNested(fmt.Sprintf("%s[%v]", "ExtraParams", i), err.(request.ErrInvalidParams))
+			}
+		}
+	}
+
+	if invalidParams.Len() > 0 {
+		return invalidParams
+	}
+	return nil
+}
+
 // The DeleteTagsForDomainRequest includes the following elements.
 type DeleteTagsForDomainInput struct {
 	_ struct{} `type:"structure"`
@@ -944,6 +978,22 @@ func (s DeleteTagsForDomainInput) GoString() string {
 	return s.String()
 }
 
+// Validate inspects the fields of the type to determine if they are valid.
+func (s *DeleteTagsForDomainInput) Validate() error {
+	invalidParams := request.ErrInvalidParams{Context: "DeleteTagsForDomainInput"}
+	if s.DomainName == nil {
+		invalidParams.Add(request.NewErrParamRequired("DomainName"))
+	}
+	if s.TagsToDelete == nil {
+		invalidParams.Add(request.NewErrParamRequired("TagsToDelete"))
+	}
+
+	if invalidParams.Len() > 0 {
+		return invalidParams
+	}
+	return nil
+}
+
 type DeleteTagsForDomainOutput struct {
 	_ struct{} `type:"structure"`
 }
@@ -972,6 +1022,19 @@ func (s DisableDomainAutoRenewInput) String() string {
 // GoString returns the string representation
 func (s DisableDomainAutoRenewInput) GoString() string {
 	return s.String()
+}
+
+// Validate inspects the fields of the type to determine if they are valid.
+func (s *DisableDomainAutoRenewInput) Validate() error {
+	invalidParams := request.ErrInvalidParams{Context: "DisableDomainAutoRenewInput"}
+	if s.DomainName == nil {
+		invalidParams.Add(request.NewErrParamRequired("DomainName"))
+	}
+
+	if invalidParams.Len() > 0 {
+		return invalidParams
+	}
+	return nil
 }
 
 type DisableDomainAutoRenewOutput struct {
@@ -1014,6 +1077,19 @@ func (s DisableDomainTransferLockInput) String() string {
 // GoString returns the string representation
 func (s DisableDomainTransferLockInput) GoString() string {
 	return s.String()
+}
+
+// Validate inspects the fields of the type to determine if they are valid.
+func (s *DisableDomainTransferLockInput) Validate() error {
+	invalidParams := request.ErrInvalidParams{Context: "DisableDomainTransferLockInput"}
+	if s.DomainName == nil {
+		invalidParams.Add(request.NewErrParamRequired("DomainName"))
+	}
+
+	if invalidParams.Len() > 0 {
+		return invalidParams
+	}
+	return nil
 }
 
 // The DisableDomainTransferLock response includes the following element.
@@ -1096,6 +1172,19 @@ func (s EnableDomainAutoRenewInput) GoString() string {
 	return s.String()
 }
 
+// Validate inspects the fields of the type to determine if they are valid.
+func (s *EnableDomainAutoRenewInput) Validate() error {
+	invalidParams := request.ErrInvalidParams{Context: "EnableDomainAutoRenewInput"}
+	if s.DomainName == nil {
+		invalidParams.Add(request.NewErrParamRequired("DomainName"))
+	}
+
+	if invalidParams.Len() > 0 {
+		return invalidParams
+	}
+	return nil
+}
+
 type EnableDomainAutoRenewOutput struct {
 	_ struct{} `type:"structure"`
 }
@@ -1136,6 +1225,19 @@ func (s EnableDomainTransferLockInput) String() string {
 // GoString returns the string representation
 func (s EnableDomainTransferLockInput) GoString() string {
 	return s.String()
+}
+
+// Validate inspects the fields of the type to determine if they are valid.
+func (s *EnableDomainTransferLockInput) Validate() error {
+	invalidParams := request.ErrInvalidParams{Context: "EnableDomainTransferLockInput"}
+	if s.DomainName == nil {
+		invalidParams.Add(request.NewErrParamRequired("DomainName"))
+	}
+
+	if invalidParams.Len() > 0 {
+		return invalidParams
+	}
+	return nil
 }
 
 // The EnableDomainTransferLock response includes the following elements.
@@ -1209,6 +1311,22 @@ func (s ExtraParam) GoString() string {
 	return s.String()
 }
 
+// Validate inspects the fields of the type to determine if they are valid.
+func (s *ExtraParam) Validate() error {
+	invalidParams := request.ErrInvalidParams{Context: "ExtraParam"}
+	if s.Name == nil {
+		invalidParams.Add(request.NewErrParamRequired("Name"))
+	}
+	if s.Value == nil {
+		invalidParams.Add(request.NewErrParamRequired("Value"))
+	}
+
+	if invalidParams.Len() > 0 {
+		return invalidParams
+	}
+	return nil
+}
+
 // The GetDomainDetail request includes the following element.
 type GetDomainDetailInput struct {
 	_ struct{} `type:"structure"`
@@ -1235,6 +1353,19 @@ func (s GetDomainDetailInput) String() string {
 // GoString returns the string representation
 func (s GetDomainDetailInput) GoString() string {
 	return s.String()
+}
+
+// Validate inspects the fields of the type to determine if they are valid.
+func (s *GetDomainDetailInput) Validate() error {
+	invalidParams := request.ErrInvalidParams{Context: "GetDomainDetailInput"}
+	if s.DomainName == nil {
+		invalidParams.Add(request.NewErrParamRequired("DomainName"))
+	}
+
+	if invalidParams.Len() > 0 {
+		return invalidParams
+	}
+	return nil
 }
 
 // The GetDomainDetail response includes the following elements.
@@ -1412,6 +1543,19 @@ func (s GetOperationDetailInput) String() string {
 // GoString returns the string representation
 func (s GetOperationDetailInput) GoString() string {
 	return s.String()
+}
+
+// Validate inspects the fields of the type to determine if they are valid.
+func (s *GetOperationDetailInput) Validate() error {
+	invalidParams := request.ErrInvalidParams{Context: "GetOperationDetailInput"}
+	if s.OperationId == nil {
+		invalidParams.Add(request.NewErrParamRequired("OperationId"))
+	}
+
+	if invalidParams.Len() > 0 {
+		return invalidParams
+	}
+	return nil
 }
 
 // The GetOperationDetail response includes the following elements.
@@ -1619,6 +1763,19 @@ func (s ListTagsForDomainInput) GoString() string {
 	return s.String()
 }
 
+// Validate inspects the fields of the type to determine if they are valid.
+func (s *ListTagsForDomainInput) Validate() error {
+	invalidParams := request.ErrInvalidParams{Context: "ListTagsForDomainInput"}
+	if s.DomainName == nil {
+		invalidParams.Add(request.NewErrParamRequired("DomainName"))
+	}
+
+	if invalidParams.Len() > 0 {
+		return invalidParams
+	}
+	return nil
+}
+
 // The ListTagsForDomain response includes the following elements.
 type ListTagsForDomainOutput struct {
 	_ struct{} `type:"structure"`
@@ -1687,6 +1844,19 @@ func (s Nameserver) String() string {
 // GoString returns the string representation
 func (s Nameserver) GoString() string {
 	return s.String()
+}
+
+// Validate inspects the fields of the type to determine if they are valid.
+func (s *Nameserver) Validate() error {
+	invalidParams := request.ErrInvalidParams{Context: "Nameserver"}
+	if s.Name == nil {
+		invalidParams.Add(request.NewErrParamRequired("Name"))
+	}
+
+	if invalidParams.Len() > 0 {
+		return invalidParams
+	}
+	return nil
 }
 
 // OperationSummary includes the following elements.
@@ -1855,6 +2025,49 @@ func (s RegisterDomainInput) GoString() string {
 	return s.String()
 }
 
+// Validate inspects the fields of the type to determine if they are valid.
+func (s *RegisterDomainInput) Validate() error {
+	invalidParams := request.ErrInvalidParams{Context: "RegisterDomainInput"}
+	if s.AdminContact == nil {
+		invalidParams.Add(request.NewErrParamRequired("AdminContact"))
+	}
+	if s.DomainName == nil {
+		invalidParams.Add(request.NewErrParamRequired("DomainName"))
+	}
+	if s.DurationInYears == nil {
+		invalidParams.Add(request.NewErrParamRequired("DurationInYears"))
+	}
+	if s.DurationInYears != nil && *s.DurationInYears < 1 {
+		invalidParams.Add(request.NewErrParamMinValue("DurationInYears", 1))
+	}
+	if s.RegistrantContact == nil {
+		invalidParams.Add(request.NewErrParamRequired("RegistrantContact"))
+	}
+	if s.TechContact == nil {
+		invalidParams.Add(request.NewErrParamRequired("TechContact"))
+	}
+	if s.AdminContact != nil {
+		if err := s.AdminContact.Validate(); err != nil {
+			invalidParams.AddNested("AdminContact", err.(request.ErrInvalidParams))
+		}
+	}
+	if s.RegistrantContact != nil {
+		if err := s.RegistrantContact.Validate(); err != nil {
+			invalidParams.AddNested("RegistrantContact", err.(request.ErrInvalidParams))
+		}
+	}
+	if s.TechContact != nil {
+		if err := s.TechContact.Validate(); err != nil {
+			invalidParams.AddNested("TechContact", err.(request.ErrInvalidParams))
+		}
+	}
+
+	if invalidParams.Len() > 0 {
+		return invalidParams
+	}
+	return nil
+}
+
 // The RegisterDomain response includes the following element.
 type RegisterDomainOutput struct {
 	_ struct{} `type:"structure"`
@@ -1906,6 +2119,19 @@ func (s RetrieveDomainAuthCodeInput) String() string {
 // GoString returns the string representation
 func (s RetrieveDomainAuthCodeInput) GoString() string {
 	return s.String()
+}
+
+// Validate inspects the fields of the type to determine if they are valid.
+func (s *RetrieveDomainAuthCodeInput) Validate() error {
+	invalidParams := request.ErrInvalidParams{Context: "RetrieveDomainAuthCodeInput"}
+	if s.DomainName == nil {
+		invalidParams.Add(request.NewErrParamRequired("DomainName"))
+	}
+
+	if invalidParams.Len() > 0 {
+		return invalidParams
+	}
+	return nil
 }
 
 // The RetrieveDomainAuthCode response includes the following element.
@@ -2116,6 +2342,59 @@ func (s TransferDomainInput) GoString() string {
 	return s.String()
 }
 
+// Validate inspects the fields of the type to determine if they are valid.
+func (s *TransferDomainInput) Validate() error {
+	invalidParams := request.ErrInvalidParams{Context: "TransferDomainInput"}
+	if s.AdminContact == nil {
+		invalidParams.Add(request.NewErrParamRequired("AdminContact"))
+	}
+	if s.DomainName == nil {
+		invalidParams.Add(request.NewErrParamRequired("DomainName"))
+	}
+	if s.DurationInYears == nil {
+		invalidParams.Add(request.NewErrParamRequired("DurationInYears"))
+	}
+	if s.DurationInYears != nil && *s.DurationInYears < 1 {
+		invalidParams.Add(request.NewErrParamMinValue("DurationInYears", 1))
+	}
+	if s.RegistrantContact == nil {
+		invalidParams.Add(request.NewErrParamRequired("RegistrantContact"))
+	}
+	if s.TechContact == nil {
+		invalidParams.Add(request.NewErrParamRequired("TechContact"))
+	}
+	if s.AdminContact != nil {
+		if err := s.AdminContact.Validate(); err != nil {
+			invalidParams.AddNested("AdminContact", err.(request.ErrInvalidParams))
+		}
+	}
+	if s.Nameservers != nil {
+		for i, v := range s.Nameservers {
+			if v == nil {
+				continue
+			}
+			if err := v.Validate(); err != nil {
+				invalidParams.AddNested(fmt.Sprintf("%s[%v]", "Nameservers", i), err.(request.ErrInvalidParams))
+			}
+		}
+	}
+	if s.RegistrantContact != nil {
+		if err := s.RegistrantContact.Validate(); err != nil {
+			invalidParams.AddNested("RegistrantContact", err.(request.ErrInvalidParams))
+		}
+	}
+	if s.TechContact != nil {
+		if err := s.TechContact.Validate(); err != nil {
+			invalidParams.AddNested("TechContact", err.(request.ErrInvalidParams))
+		}
+	}
+
+	if invalidParams.Len() > 0 {
+		return invalidParams
+	}
+	return nil
+}
+
 // The TranserDomain response includes the following element.
 type TransferDomainOutput struct {
 	_ struct{} `type:"structure"`
@@ -2200,6 +2479,34 @@ func (s UpdateDomainContactInput) String() string {
 // GoString returns the string representation
 func (s UpdateDomainContactInput) GoString() string {
 	return s.String()
+}
+
+// Validate inspects the fields of the type to determine if they are valid.
+func (s *UpdateDomainContactInput) Validate() error {
+	invalidParams := request.ErrInvalidParams{Context: "UpdateDomainContactInput"}
+	if s.DomainName == nil {
+		invalidParams.Add(request.NewErrParamRequired("DomainName"))
+	}
+	if s.AdminContact != nil {
+		if err := s.AdminContact.Validate(); err != nil {
+			invalidParams.AddNested("AdminContact", err.(request.ErrInvalidParams))
+		}
+	}
+	if s.RegistrantContact != nil {
+		if err := s.RegistrantContact.Validate(); err != nil {
+			invalidParams.AddNested("RegistrantContact", err.(request.ErrInvalidParams))
+		}
+	}
+	if s.TechContact != nil {
+		if err := s.TechContact.Validate(); err != nil {
+			invalidParams.AddNested("TechContact", err.(request.ErrInvalidParams))
+		}
+	}
+
+	if invalidParams.Len() > 0 {
+		return invalidParams
+	}
+	return nil
 }
 
 // The UpdateDomainContact response includes the following element.
@@ -2297,6 +2604,19 @@ func (s UpdateDomainContactPrivacyInput) GoString() string {
 	return s.String()
 }
 
+// Validate inspects the fields of the type to determine if they are valid.
+func (s *UpdateDomainContactPrivacyInput) Validate() error {
+	invalidParams := request.ErrInvalidParams{Context: "UpdateDomainContactPrivacyInput"}
+	if s.DomainName == nil {
+		invalidParams.Add(request.NewErrParamRequired("DomainName"))
+	}
+
+	if invalidParams.Len() > 0 {
+		return invalidParams
+	}
+	return nil
+}
+
 // The UpdateDomainContactPrivacy response includes the following element.
 type UpdateDomainContactPrivacyOutput struct {
 	_ struct{} `type:"structure"`
@@ -2360,6 +2680,32 @@ func (s UpdateDomainNameserversInput) String() string {
 // GoString returns the string representation
 func (s UpdateDomainNameserversInput) GoString() string {
 	return s.String()
+}
+
+// Validate inspects the fields of the type to determine if they are valid.
+func (s *UpdateDomainNameserversInput) Validate() error {
+	invalidParams := request.ErrInvalidParams{Context: "UpdateDomainNameserversInput"}
+	if s.DomainName == nil {
+		invalidParams.Add(request.NewErrParamRequired("DomainName"))
+	}
+	if s.Nameservers == nil {
+		invalidParams.Add(request.NewErrParamRequired("Nameservers"))
+	}
+	if s.Nameservers != nil {
+		for i, v := range s.Nameservers {
+			if v == nil {
+				continue
+			}
+			if err := v.Validate(); err != nil {
+				invalidParams.AddNested(fmt.Sprintf("%s[%v]", "Nameservers", i), err.(request.ErrInvalidParams))
+			}
+		}
+	}
+
+	if invalidParams.Len() > 0 {
+		return invalidParams
+	}
+	return nil
 }
 
 // The UpdateDomainNameservers response includes the following element.
@@ -2457,6 +2803,19 @@ func (s UpdateTagsForDomainInput) String() string {
 // GoString returns the string representation
 func (s UpdateTagsForDomainInput) GoString() string {
 	return s.String()
+}
+
+// Validate inspects the fields of the type to determine if they are valid.
+func (s *UpdateTagsForDomainInput) Validate() error {
+	invalidParams := request.ErrInvalidParams{Context: "UpdateTagsForDomainInput"}
+	if s.DomainName == nil {
+		invalidParams.Add(request.NewErrParamRequired("DomainName"))
+	}
+
+	if invalidParams.Len() > 0 {
+		return invalidParams
+	}
+	return nil
 }
 
 type UpdateTagsForDomainOutput struct {

--- a/service/s3/api.go
+++ b/service/s3/api.go
@@ -4,6 +4,7 @@
 package s3
 
 import (
+	"fmt"
 	"io"
 	"time"
 
@@ -1774,6 +1775,28 @@ func (s AbortMultipartUploadInput) GoString() string {
 	return s.String()
 }
 
+// Validate inspects the fields of the type to determine if they are valid.
+func (s *AbortMultipartUploadInput) Validate() error {
+	invalidParams := request.ErrInvalidParams{Context: "AbortMultipartUploadInput"}
+	if s.Bucket == nil {
+		invalidParams.Add(request.NewErrParamRequired("Bucket"))
+	}
+	if s.Key == nil {
+		invalidParams.Add(request.NewErrParamRequired("Key"))
+	}
+	if s.Key != nil && len(*s.Key) < 1 {
+		invalidParams.Add(request.NewErrParamMinLen("Key", 1))
+	}
+	if s.UploadId == nil {
+		invalidParams.Add(request.NewErrParamRequired("UploadId"))
+	}
+
+	if invalidParams.Len() > 0 {
+		return invalidParams
+	}
+	return nil
+}
+
 type AbortMultipartUploadOutput struct {
 	_ struct{} `type:"structure"`
 
@@ -1828,6 +1851,26 @@ func (s AccessControlPolicy) GoString() string {
 	return s.String()
 }
 
+// Validate inspects the fields of the type to determine if they are valid.
+func (s *AccessControlPolicy) Validate() error {
+	invalidParams := request.ErrInvalidParams{Context: "AccessControlPolicy"}
+	if s.Grants != nil {
+		for i, v := range s.Grants {
+			if v == nil {
+				continue
+			}
+			if err := v.Validate(); err != nil {
+				invalidParams.AddNested(fmt.Sprintf("%s[%v]", "Grants", i), err.(request.ErrInvalidParams))
+			}
+		}
+	}
+
+	if invalidParams.Len() > 0 {
+		return invalidParams
+	}
+	return nil
+}
+
 type Bucket struct {
 	_ struct{} `type:"structure"`
 
@@ -1864,6 +1907,29 @@ func (s BucketLifecycleConfiguration) GoString() string {
 	return s.String()
 }
 
+// Validate inspects the fields of the type to determine if they are valid.
+func (s *BucketLifecycleConfiguration) Validate() error {
+	invalidParams := request.ErrInvalidParams{Context: "BucketLifecycleConfiguration"}
+	if s.Rules == nil {
+		invalidParams.Add(request.NewErrParamRequired("Rules"))
+	}
+	if s.Rules != nil {
+		for i, v := range s.Rules {
+			if v == nil {
+				continue
+			}
+			if err := v.Validate(); err != nil {
+				invalidParams.AddNested(fmt.Sprintf("%s[%v]", "Rules", i), err.(request.ErrInvalidParams))
+			}
+		}
+	}
+
+	if invalidParams.Len() > 0 {
+		return invalidParams
+	}
+	return nil
+}
+
 type BucketLoggingStatus struct {
 	_ struct{} `type:"structure"`
 
@@ -1880,6 +1946,21 @@ func (s BucketLoggingStatus) GoString() string {
 	return s.String()
 }
 
+// Validate inspects the fields of the type to determine if they are valid.
+func (s *BucketLoggingStatus) Validate() error {
+	invalidParams := request.ErrInvalidParams{Context: "BucketLoggingStatus"}
+	if s.LoggingEnabled != nil {
+		if err := s.LoggingEnabled.Validate(); err != nil {
+			invalidParams.AddNested("LoggingEnabled", err.(request.ErrInvalidParams))
+		}
+	}
+
+	if invalidParams.Len() > 0 {
+		return invalidParams
+	}
+	return nil
+}
+
 type CORSConfiguration struct {
 	_ struct{} `type:"structure"`
 
@@ -1894,6 +1975,29 @@ func (s CORSConfiguration) String() string {
 // GoString returns the string representation
 func (s CORSConfiguration) GoString() string {
 	return s.String()
+}
+
+// Validate inspects the fields of the type to determine if they are valid.
+func (s *CORSConfiguration) Validate() error {
+	invalidParams := request.ErrInvalidParams{Context: "CORSConfiguration"}
+	if s.CORSRules == nil {
+		invalidParams.Add(request.NewErrParamRequired("CORSRules"))
+	}
+	if s.CORSRules != nil {
+		for i, v := range s.CORSRules {
+			if v == nil {
+				continue
+			}
+			if err := v.Validate(); err != nil {
+				invalidParams.AddNested(fmt.Sprintf("%s[%v]", "CORSRules", i), err.(request.ErrInvalidParams))
+			}
+		}
+	}
+
+	if invalidParams.Len() > 0 {
+		return invalidParams
+	}
+	return nil
 }
 
 type CORSRule struct {
@@ -1927,6 +2031,22 @@ func (s CORSRule) String() string {
 // GoString returns the string representation
 func (s CORSRule) GoString() string {
 	return s.String()
+}
+
+// Validate inspects the fields of the type to determine if they are valid.
+func (s *CORSRule) Validate() error {
+	invalidParams := request.ErrInvalidParams{Context: "CORSRule"}
+	if s.AllowedMethods == nil {
+		invalidParams.Add(request.NewErrParamRequired("AllowedMethods"))
+	}
+	if s.AllowedOrigins == nil {
+		invalidParams.Add(request.NewErrParamRequired("AllowedOrigins"))
+	}
+
+	if invalidParams.Len() > 0 {
+		return invalidParams
+	}
+	return nil
 }
 
 type CloudFunctionConfiguration struct {
@@ -1998,6 +2118,28 @@ func (s CompleteMultipartUploadInput) String() string {
 // GoString returns the string representation
 func (s CompleteMultipartUploadInput) GoString() string {
 	return s.String()
+}
+
+// Validate inspects the fields of the type to determine if they are valid.
+func (s *CompleteMultipartUploadInput) Validate() error {
+	invalidParams := request.ErrInvalidParams{Context: "CompleteMultipartUploadInput"}
+	if s.Bucket == nil {
+		invalidParams.Add(request.NewErrParamRequired("Bucket"))
+	}
+	if s.Key == nil {
+		invalidParams.Add(request.NewErrParamRequired("Key"))
+	}
+	if s.Key != nil && len(*s.Key) < 1 {
+		invalidParams.Add(request.NewErrParamMinLen("Key", 1))
+	}
+	if s.UploadId == nil {
+		invalidParams.Add(request.NewErrParamRequired("UploadId"))
+	}
+
+	if invalidParams.Len() > 0 {
+		return invalidParams
+	}
+	return nil
 }
 
 type CompleteMultipartUploadOutput struct {
@@ -2238,6 +2380,28 @@ func (s CopyObjectInput) GoString() string {
 	return s.String()
 }
 
+// Validate inspects the fields of the type to determine if they are valid.
+func (s *CopyObjectInput) Validate() error {
+	invalidParams := request.ErrInvalidParams{Context: "CopyObjectInput"}
+	if s.Bucket == nil {
+		invalidParams.Add(request.NewErrParamRequired("Bucket"))
+	}
+	if s.CopySource == nil {
+		invalidParams.Add(request.NewErrParamRequired("CopySource"))
+	}
+	if s.Key == nil {
+		invalidParams.Add(request.NewErrParamRequired("Key"))
+	}
+	if s.Key != nil && len(*s.Key) < 1 {
+		invalidParams.Add(request.NewErrParamMinLen("Key", 1))
+	}
+
+	if invalidParams.Len() > 0 {
+		return invalidParams
+	}
+	return nil
+}
+
 type CopyObjectOutput struct {
 	_ struct{} `type:"structure" payload:"CopyObjectResult"`
 
@@ -2377,6 +2541,19 @@ func (s CreateBucketInput) GoString() string {
 	return s.String()
 }
 
+// Validate inspects the fields of the type to determine if they are valid.
+func (s *CreateBucketInput) Validate() error {
+	invalidParams := request.ErrInvalidParams{Context: "CreateBucketInput"}
+	if s.Bucket == nil {
+		invalidParams.Add(request.NewErrParamRequired("Bucket"))
+	}
+
+	if invalidParams.Len() > 0 {
+		return invalidParams
+	}
+	return nil
+}
+
 type CreateBucketOutput struct {
 	_ struct{} `type:"structure"`
 
@@ -2488,6 +2665,25 @@ func (s CreateMultipartUploadInput) GoString() string {
 	return s.String()
 }
 
+// Validate inspects the fields of the type to determine if they are valid.
+func (s *CreateMultipartUploadInput) Validate() error {
+	invalidParams := request.ErrInvalidParams{Context: "CreateMultipartUploadInput"}
+	if s.Bucket == nil {
+		invalidParams.Add(request.NewErrParamRequired("Bucket"))
+	}
+	if s.Key == nil {
+		invalidParams.Add(request.NewErrParamRequired("Key"))
+	}
+	if s.Key != nil && len(*s.Key) < 1 {
+		invalidParams.Add(request.NewErrParamMinLen("Key", 1))
+	}
+
+	if invalidParams.Len() > 0 {
+		return invalidParams
+	}
+	return nil
+}
+
 type CreateMultipartUploadOutput struct {
 	_ struct{} `type:"structure"`
 
@@ -2560,6 +2756,29 @@ func (s Delete) GoString() string {
 	return s.String()
 }
 
+// Validate inspects the fields of the type to determine if they are valid.
+func (s *Delete) Validate() error {
+	invalidParams := request.ErrInvalidParams{Context: "Delete"}
+	if s.Objects == nil {
+		invalidParams.Add(request.NewErrParamRequired("Objects"))
+	}
+	if s.Objects != nil {
+		for i, v := range s.Objects {
+			if v == nil {
+				continue
+			}
+			if err := v.Validate(); err != nil {
+				invalidParams.AddNested(fmt.Sprintf("%s[%v]", "Objects", i), err.(request.ErrInvalidParams))
+			}
+		}
+	}
+
+	if invalidParams.Len() > 0 {
+		return invalidParams
+	}
+	return nil
+}
+
 type DeleteBucketCorsInput struct {
 	_ struct{} `type:"structure"`
 
@@ -2574,6 +2793,19 @@ func (s DeleteBucketCorsInput) String() string {
 // GoString returns the string representation
 func (s DeleteBucketCorsInput) GoString() string {
 	return s.String()
+}
+
+// Validate inspects the fields of the type to determine if they are valid.
+func (s *DeleteBucketCorsInput) Validate() error {
+	invalidParams := request.ErrInvalidParams{Context: "DeleteBucketCorsInput"}
+	if s.Bucket == nil {
+		invalidParams.Add(request.NewErrParamRequired("Bucket"))
+	}
+
+	if invalidParams.Len() > 0 {
+		return invalidParams
+	}
+	return nil
 }
 
 type DeleteBucketCorsOutput struct {
@@ -2606,6 +2838,19 @@ func (s DeleteBucketInput) GoString() string {
 	return s.String()
 }
 
+// Validate inspects the fields of the type to determine if they are valid.
+func (s *DeleteBucketInput) Validate() error {
+	invalidParams := request.ErrInvalidParams{Context: "DeleteBucketInput"}
+	if s.Bucket == nil {
+		invalidParams.Add(request.NewErrParamRequired("Bucket"))
+	}
+
+	if invalidParams.Len() > 0 {
+		return invalidParams
+	}
+	return nil
+}
+
 type DeleteBucketLifecycleInput struct {
 	_ struct{} `type:"structure"`
 
@@ -2620,6 +2865,19 @@ func (s DeleteBucketLifecycleInput) String() string {
 // GoString returns the string representation
 func (s DeleteBucketLifecycleInput) GoString() string {
 	return s.String()
+}
+
+// Validate inspects the fields of the type to determine if they are valid.
+func (s *DeleteBucketLifecycleInput) Validate() error {
+	invalidParams := request.ErrInvalidParams{Context: "DeleteBucketLifecycleInput"}
+	if s.Bucket == nil {
+		invalidParams.Add(request.NewErrParamRequired("Bucket"))
+	}
+
+	if invalidParams.Len() > 0 {
+		return invalidParams
+	}
+	return nil
 }
 
 type DeleteBucketLifecycleOutput struct {
@@ -2666,6 +2924,19 @@ func (s DeleteBucketPolicyInput) GoString() string {
 	return s.String()
 }
 
+// Validate inspects the fields of the type to determine if they are valid.
+func (s *DeleteBucketPolicyInput) Validate() error {
+	invalidParams := request.ErrInvalidParams{Context: "DeleteBucketPolicyInput"}
+	if s.Bucket == nil {
+		invalidParams.Add(request.NewErrParamRequired("Bucket"))
+	}
+
+	if invalidParams.Len() > 0 {
+		return invalidParams
+	}
+	return nil
+}
+
 type DeleteBucketPolicyOutput struct {
 	_ struct{} `type:"structure"`
 }
@@ -2694,6 +2965,19 @@ func (s DeleteBucketReplicationInput) String() string {
 // GoString returns the string representation
 func (s DeleteBucketReplicationInput) GoString() string {
 	return s.String()
+}
+
+// Validate inspects the fields of the type to determine if they are valid.
+func (s *DeleteBucketReplicationInput) Validate() error {
+	invalidParams := request.ErrInvalidParams{Context: "DeleteBucketReplicationInput"}
+	if s.Bucket == nil {
+		invalidParams.Add(request.NewErrParamRequired("Bucket"))
+	}
+
+	if invalidParams.Len() > 0 {
+		return invalidParams
+	}
+	return nil
 }
 
 type DeleteBucketReplicationOutput struct {
@@ -2726,6 +3010,19 @@ func (s DeleteBucketTaggingInput) GoString() string {
 	return s.String()
 }
 
+// Validate inspects the fields of the type to determine if they are valid.
+func (s *DeleteBucketTaggingInput) Validate() error {
+	invalidParams := request.ErrInvalidParams{Context: "DeleteBucketTaggingInput"}
+	if s.Bucket == nil {
+		invalidParams.Add(request.NewErrParamRequired("Bucket"))
+	}
+
+	if invalidParams.Len() > 0 {
+		return invalidParams
+	}
+	return nil
+}
+
 type DeleteBucketTaggingOutput struct {
 	_ struct{} `type:"structure"`
 }
@@ -2754,6 +3051,19 @@ func (s DeleteBucketWebsiteInput) String() string {
 // GoString returns the string representation
 func (s DeleteBucketWebsiteInput) GoString() string {
 	return s.String()
+}
+
+// Validate inspects the fields of the type to determine if they are valid.
+func (s *DeleteBucketWebsiteInput) Validate() error {
+	invalidParams := request.ErrInvalidParams{Context: "DeleteBucketWebsiteInput"}
+	if s.Bucket == nil {
+		invalidParams.Add(request.NewErrParamRequired("Bucket"))
+	}
+
+	if invalidParams.Len() > 0 {
+		return invalidParams
+	}
+	return nil
 }
 
 type DeleteBucketWebsiteOutput struct {
@@ -2830,6 +3140,25 @@ func (s DeleteObjectInput) GoString() string {
 	return s.String()
 }
 
+// Validate inspects the fields of the type to determine if they are valid.
+func (s *DeleteObjectInput) Validate() error {
+	invalidParams := request.ErrInvalidParams{Context: "DeleteObjectInput"}
+	if s.Bucket == nil {
+		invalidParams.Add(request.NewErrParamRequired("Bucket"))
+	}
+	if s.Key == nil {
+		invalidParams.Add(request.NewErrParamRequired("Key"))
+	}
+	if s.Key != nil && len(*s.Key) < 1 {
+		invalidParams.Add(request.NewErrParamMinLen("Key", 1))
+	}
+
+	if invalidParams.Len() > 0 {
+		return invalidParams
+	}
+	return nil
+}
+
 type DeleteObjectOutput struct {
 	_ struct{} `type:"structure"`
 
@@ -2882,6 +3211,27 @@ func (s DeleteObjectsInput) String() string {
 // GoString returns the string representation
 func (s DeleteObjectsInput) GoString() string {
 	return s.String()
+}
+
+// Validate inspects the fields of the type to determine if they are valid.
+func (s *DeleteObjectsInput) Validate() error {
+	invalidParams := request.ErrInvalidParams{Context: "DeleteObjectsInput"}
+	if s.Bucket == nil {
+		invalidParams.Add(request.NewErrParamRequired("Bucket"))
+	}
+	if s.Delete == nil {
+		invalidParams.Add(request.NewErrParamRequired("Delete"))
+	}
+	if s.Delete != nil {
+		if err := s.Delete.Validate(); err != nil {
+			invalidParams.AddNested("Delete", err.(request.ErrInvalidParams))
+		}
+	}
+
+	if invalidParams.Len() > 0 {
+		return invalidParams
+	}
+	return nil
 }
 
 type DeleteObjectsOutput struct {
@@ -2949,6 +3299,19 @@ func (s Destination) GoString() string {
 	return s.String()
 }
 
+// Validate inspects the fields of the type to determine if they are valid.
+func (s *Destination) Validate() error {
+	invalidParams := request.ErrInvalidParams{Context: "Destination"}
+	if s.Bucket == nil {
+		invalidParams.Add(request.NewErrParamRequired("Bucket"))
+	}
+
+	if invalidParams.Len() > 0 {
+		return invalidParams
+	}
+	return nil
+}
+
 type Error struct {
 	_ struct{} `type:"structure"`
 
@@ -2986,6 +3349,22 @@ func (s ErrorDocument) String() string {
 // GoString returns the string representation
 func (s ErrorDocument) GoString() string {
 	return s.String()
+}
+
+// Validate inspects the fields of the type to determine if they are valid.
+func (s *ErrorDocument) Validate() error {
+	invalidParams := request.ErrInvalidParams{Context: "ErrorDocument"}
+	if s.Key == nil {
+		invalidParams.Add(request.NewErrParamRequired("Key"))
+	}
+	if s.Key != nil && len(*s.Key) < 1 {
+		invalidParams.Add(request.NewErrParamMinLen("Key", 1))
+	}
+
+	if invalidParams.Len() > 0 {
+		return invalidParams
+	}
+	return nil
 }
 
 // Container for key value pair that defines the criteria for the filter rule.
@@ -3029,6 +3408,19 @@ func (s GetBucketAccelerateConfigurationInput) GoString() string {
 	return s.String()
 }
 
+// Validate inspects the fields of the type to determine if they are valid.
+func (s *GetBucketAccelerateConfigurationInput) Validate() error {
+	invalidParams := request.ErrInvalidParams{Context: "GetBucketAccelerateConfigurationInput"}
+	if s.Bucket == nil {
+		invalidParams.Add(request.NewErrParamRequired("Bucket"))
+	}
+
+	if invalidParams.Len() > 0 {
+		return invalidParams
+	}
+	return nil
+}
+
 type GetBucketAccelerateConfigurationOutput struct {
 	_ struct{} `type:"structure"`
 
@@ -3060,6 +3452,19 @@ func (s GetBucketAclInput) String() string {
 // GoString returns the string representation
 func (s GetBucketAclInput) GoString() string {
 	return s.String()
+}
+
+// Validate inspects the fields of the type to determine if they are valid.
+func (s *GetBucketAclInput) Validate() error {
+	invalidParams := request.ErrInvalidParams{Context: "GetBucketAclInput"}
+	if s.Bucket == nil {
+		invalidParams.Add(request.NewErrParamRequired("Bucket"))
+	}
+
+	if invalidParams.Len() > 0 {
+		return invalidParams
+	}
+	return nil
 }
 
 type GetBucketAclOutput struct {
@@ -3097,6 +3502,19 @@ func (s GetBucketCorsInput) GoString() string {
 	return s.String()
 }
 
+// Validate inspects the fields of the type to determine if they are valid.
+func (s *GetBucketCorsInput) Validate() error {
+	invalidParams := request.ErrInvalidParams{Context: "GetBucketCorsInput"}
+	if s.Bucket == nil {
+		invalidParams.Add(request.NewErrParamRequired("Bucket"))
+	}
+
+	if invalidParams.Len() > 0 {
+		return invalidParams
+	}
+	return nil
+}
+
 type GetBucketCorsOutput struct {
 	_ struct{} `type:"structure"`
 
@@ -3127,6 +3545,19 @@ func (s GetBucketLifecycleConfigurationInput) String() string {
 // GoString returns the string representation
 func (s GetBucketLifecycleConfigurationInput) GoString() string {
 	return s.String()
+}
+
+// Validate inspects the fields of the type to determine if they are valid.
+func (s *GetBucketLifecycleConfigurationInput) Validate() error {
+	invalidParams := request.ErrInvalidParams{Context: "GetBucketLifecycleConfigurationInput"}
+	if s.Bucket == nil {
+		invalidParams.Add(request.NewErrParamRequired("Bucket"))
+	}
+
+	if invalidParams.Len() > 0 {
+		return invalidParams
+	}
+	return nil
 }
 
 type GetBucketLifecycleConfigurationOutput struct {
@@ -3161,6 +3592,19 @@ func (s GetBucketLifecycleInput) GoString() string {
 	return s.String()
 }
 
+// Validate inspects the fields of the type to determine if they are valid.
+func (s *GetBucketLifecycleInput) Validate() error {
+	invalidParams := request.ErrInvalidParams{Context: "GetBucketLifecycleInput"}
+	if s.Bucket == nil {
+		invalidParams.Add(request.NewErrParamRequired("Bucket"))
+	}
+
+	if invalidParams.Len() > 0 {
+		return invalidParams
+	}
+	return nil
+}
+
 type GetBucketLifecycleOutput struct {
 	_ struct{} `type:"structure"`
 
@@ -3193,6 +3637,19 @@ func (s GetBucketLocationInput) GoString() string {
 	return s.String()
 }
 
+// Validate inspects the fields of the type to determine if they are valid.
+func (s *GetBucketLocationInput) Validate() error {
+	invalidParams := request.ErrInvalidParams{Context: "GetBucketLocationInput"}
+	if s.Bucket == nil {
+		invalidParams.Add(request.NewErrParamRequired("Bucket"))
+	}
+
+	if invalidParams.Len() > 0 {
+		return invalidParams
+	}
+	return nil
+}
+
 type GetBucketLocationOutput struct {
 	_ struct{} `type:"structure"`
 
@@ -3223,6 +3680,19 @@ func (s GetBucketLoggingInput) String() string {
 // GoString returns the string representation
 func (s GetBucketLoggingInput) GoString() string {
 	return s.String()
+}
+
+// Validate inspects the fields of the type to determine if they are valid.
+func (s *GetBucketLoggingInput) Validate() error {
+	invalidParams := request.ErrInvalidParams{Context: "GetBucketLoggingInput"}
+	if s.Bucket == nil {
+		invalidParams.Add(request.NewErrParamRequired("Bucket"))
+	}
+
+	if invalidParams.Len() > 0 {
+		return invalidParams
+	}
+	return nil
 }
 
 type GetBucketLoggingOutput struct {
@@ -3258,6 +3728,19 @@ func (s GetBucketNotificationConfigurationRequest) GoString() string {
 	return s.String()
 }
 
+// Validate inspects the fields of the type to determine if they are valid.
+func (s *GetBucketNotificationConfigurationRequest) Validate() error {
+	invalidParams := request.ErrInvalidParams{Context: "GetBucketNotificationConfigurationRequest"}
+	if s.Bucket == nil {
+		invalidParams.Add(request.NewErrParamRequired("Bucket"))
+	}
+
+	if invalidParams.Len() > 0 {
+		return invalidParams
+	}
+	return nil
+}
+
 type GetBucketPolicyInput struct {
 	_ struct{} `type:"structure"`
 
@@ -3272,6 +3755,19 @@ func (s GetBucketPolicyInput) String() string {
 // GoString returns the string representation
 func (s GetBucketPolicyInput) GoString() string {
 	return s.String()
+}
+
+// Validate inspects the fields of the type to determine if they are valid.
+func (s *GetBucketPolicyInput) Validate() error {
+	invalidParams := request.ErrInvalidParams{Context: "GetBucketPolicyInput"}
+	if s.Bucket == nil {
+		invalidParams.Add(request.NewErrParamRequired("Bucket"))
+	}
+
+	if invalidParams.Len() > 0 {
+		return invalidParams
+	}
+	return nil
 }
 
 type GetBucketPolicyOutput struct {
@@ -3305,6 +3801,19 @@ func (s GetBucketReplicationInput) String() string {
 // GoString returns the string representation
 func (s GetBucketReplicationInput) GoString() string {
 	return s.String()
+}
+
+// Validate inspects the fields of the type to determine if they are valid.
+func (s *GetBucketReplicationInput) Validate() error {
+	invalidParams := request.ErrInvalidParams{Context: "GetBucketReplicationInput"}
+	if s.Bucket == nil {
+		invalidParams.Add(request.NewErrParamRequired("Bucket"))
+	}
+
+	if invalidParams.Len() > 0 {
+		return invalidParams
+	}
+	return nil
 }
 
 type GetBucketReplicationOutput struct {
@@ -3341,6 +3850,19 @@ func (s GetBucketRequestPaymentInput) GoString() string {
 	return s.String()
 }
 
+// Validate inspects the fields of the type to determine if they are valid.
+func (s *GetBucketRequestPaymentInput) Validate() error {
+	invalidParams := request.ErrInvalidParams{Context: "GetBucketRequestPaymentInput"}
+	if s.Bucket == nil {
+		invalidParams.Add(request.NewErrParamRequired("Bucket"))
+	}
+
+	if invalidParams.Len() > 0 {
+		return invalidParams
+	}
+	return nil
+}
+
 type GetBucketRequestPaymentOutput struct {
 	_ struct{} `type:"structure"`
 
@@ -3374,6 +3896,19 @@ func (s GetBucketTaggingInput) GoString() string {
 	return s.String()
 }
 
+// Validate inspects the fields of the type to determine if they are valid.
+func (s *GetBucketTaggingInput) Validate() error {
+	invalidParams := request.ErrInvalidParams{Context: "GetBucketTaggingInput"}
+	if s.Bucket == nil {
+		invalidParams.Add(request.NewErrParamRequired("Bucket"))
+	}
+
+	if invalidParams.Len() > 0 {
+		return invalidParams
+	}
+	return nil
+}
+
 type GetBucketTaggingOutput struct {
 	_ struct{} `type:"structure"`
 
@@ -3404,6 +3939,19 @@ func (s GetBucketVersioningInput) String() string {
 // GoString returns the string representation
 func (s GetBucketVersioningInput) GoString() string {
 	return s.String()
+}
+
+// Validate inspects the fields of the type to determine if they are valid.
+func (s *GetBucketVersioningInput) Validate() error {
+	invalidParams := request.ErrInvalidParams{Context: "GetBucketVersioningInput"}
+	if s.Bucket == nil {
+		invalidParams.Add(request.NewErrParamRequired("Bucket"))
+	}
+
+	if invalidParams.Len() > 0 {
+		return invalidParams
+	}
+	return nil
 }
 
 type GetBucketVersioningOutput struct {
@@ -3442,6 +3990,19 @@ func (s GetBucketWebsiteInput) String() string {
 // GoString returns the string representation
 func (s GetBucketWebsiteInput) GoString() string {
 	return s.String()
+}
+
+// Validate inspects the fields of the type to determine if they are valid.
+func (s *GetBucketWebsiteInput) Validate() error {
+	invalidParams := request.ErrInvalidParams{Context: "GetBucketWebsiteInput"}
+	if s.Bucket == nil {
+		invalidParams.Add(request.NewErrParamRequired("Bucket"))
+	}
+
+	if invalidParams.Len() > 0 {
+		return invalidParams
+	}
+	return nil
 }
 
 type GetBucketWebsiteOutput struct {
@@ -3491,6 +4052,25 @@ func (s GetObjectAclInput) String() string {
 // GoString returns the string representation
 func (s GetObjectAclInput) GoString() string {
 	return s.String()
+}
+
+// Validate inspects the fields of the type to determine if they are valid.
+func (s *GetObjectAclInput) Validate() error {
+	invalidParams := request.ErrInvalidParams{Context: "GetObjectAclInput"}
+	if s.Bucket == nil {
+		invalidParams.Add(request.NewErrParamRequired("Bucket"))
+	}
+	if s.Key == nil {
+		invalidParams.Add(request.NewErrParamRequired("Key"))
+	}
+	if s.Key != nil && len(*s.Key) < 1 {
+		invalidParams.Add(request.NewErrParamMinLen("Key", 1))
+	}
+
+	if invalidParams.Len() > 0 {
+		return invalidParams
+	}
+	return nil
 }
 
 type GetObjectAclOutput struct {
@@ -3594,6 +4174,25 @@ func (s GetObjectInput) String() string {
 // GoString returns the string representation
 func (s GetObjectInput) GoString() string {
 	return s.String()
+}
+
+// Validate inspects the fields of the type to determine if they are valid.
+func (s *GetObjectInput) Validate() error {
+	invalidParams := request.ErrInvalidParams{Context: "GetObjectInput"}
+	if s.Bucket == nil {
+		invalidParams.Add(request.NewErrParamRequired("Bucket"))
+	}
+	if s.Key == nil {
+		invalidParams.Add(request.NewErrParamRequired("Key"))
+	}
+	if s.Key != nil && len(*s.Key) < 1 {
+		invalidParams.Add(request.NewErrParamMinLen("Key", 1))
+	}
+
+	if invalidParams.Len() > 0 {
+		return invalidParams
+	}
+	return nil
 }
 
 type GetObjectOutput struct {
@@ -3729,6 +4328,25 @@ func (s GetObjectTorrentInput) GoString() string {
 	return s.String()
 }
 
+// Validate inspects the fields of the type to determine if they are valid.
+func (s *GetObjectTorrentInput) Validate() error {
+	invalidParams := request.ErrInvalidParams{Context: "GetObjectTorrentInput"}
+	if s.Bucket == nil {
+		invalidParams.Add(request.NewErrParamRequired("Bucket"))
+	}
+	if s.Key == nil {
+		invalidParams.Add(request.NewErrParamRequired("Key"))
+	}
+	if s.Key != nil && len(*s.Key) < 1 {
+		invalidParams.Add(request.NewErrParamMinLen("Key", 1))
+	}
+
+	if invalidParams.Len() > 0 {
+		return invalidParams
+	}
+	return nil
+}
+
 type GetObjectTorrentOutput struct {
 	_ struct{} `type:"structure" payload:"Body"`
 
@@ -3768,6 +4386,21 @@ func (s Grant) GoString() string {
 	return s.String()
 }
 
+// Validate inspects the fields of the type to determine if they are valid.
+func (s *Grant) Validate() error {
+	invalidParams := request.ErrInvalidParams{Context: "Grant"}
+	if s.Grantee != nil {
+		if err := s.Grantee.Validate(); err != nil {
+			invalidParams.AddNested("Grantee", err.(request.ErrInvalidParams))
+		}
+	}
+
+	if invalidParams.Len() > 0 {
+		return invalidParams
+	}
+	return nil
+}
+
 type Grantee struct {
 	_ struct{} `type:"structure" xmlPrefix:"xsi" xmlURI:"http://www.w3.org/2001/XMLSchema-instance"`
 
@@ -3797,6 +4430,19 @@ func (s Grantee) GoString() string {
 	return s.String()
 }
 
+// Validate inspects the fields of the type to determine if they are valid.
+func (s *Grantee) Validate() error {
+	invalidParams := request.ErrInvalidParams{Context: "Grantee"}
+	if s.Type == nil {
+		invalidParams.Add(request.NewErrParamRequired("Type"))
+	}
+
+	if invalidParams.Len() > 0 {
+		return invalidParams
+	}
+	return nil
+}
+
 type HeadBucketInput struct {
 	_ struct{} `type:"structure"`
 
@@ -3811,6 +4457,19 @@ func (s HeadBucketInput) String() string {
 // GoString returns the string representation
 func (s HeadBucketInput) GoString() string {
 	return s.String()
+}
+
+// Validate inspects the fields of the type to determine if they are valid.
+func (s *HeadBucketInput) Validate() error {
+	invalidParams := request.ErrInvalidParams{Context: "HeadBucketInput"}
+	if s.Bucket == nil {
+		invalidParams.Add(request.NewErrParamRequired("Bucket"))
+	}
+
+	if invalidParams.Len() > 0 {
+		return invalidParams
+	}
+	return nil
 }
 
 type HeadBucketOutput struct {
@@ -3887,6 +4546,25 @@ func (s HeadObjectInput) String() string {
 // GoString returns the string representation
 func (s HeadObjectInput) GoString() string {
 	return s.String()
+}
+
+// Validate inspects the fields of the type to determine if they are valid.
+func (s *HeadObjectInput) Validate() error {
+	invalidParams := request.ErrInvalidParams{Context: "HeadObjectInput"}
+	if s.Bucket == nil {
+		invalidParams.Add(request.NewErrParamRequired("Bucket"))
+	}
+	if s.Key == nil {
+		invalidParams.Add(request.NewErrParamRequired("Key"))
+	}
+	if s.Key != nil && len(*s.Key) < 1 {
+		invalidParams.Add(request.NewErrParamMinLen("Key", 1))
+	}
+
+	if invalidParams.Len() > 0 {
+		return invalidParams
+	}
+	return nil
 }
 
 type HeadObjectOutput struct {
@@ -4012,6 +4690,19 @@ func (s IndexDocument) GoString() string {
 	return s.String()
 }
 
+// Validate inspects the fields of the type to determine if they are valid.
+func (s *IndexDocument) Validate() error {
+	invalidParams := request.ErrInvalidParams{Context: "IndexDocument"}
+	if s.Suffix == nil {
+		invalidParams.Add(request.NewErrParamRequired("Suffix"))
+	}
+
+	if invalidParams.Len() > 0 {
+		return invalidParams
+	}
+	return nil
+}
+
 type Initiator struct {
 	_ struct{} `type:"structure"`
 
@@ -4082,6 +4773,22 @@ func (s LambdaFunctionConfiguration) GoString() string {
 	return s.String()
 }
 
+// Validate inspects the fields of the type to determine if they are valid.
+func (s *LambdaFunctionConfiguration) Validate() error {
+	invalidParams := request.ErrInvalidParams{Context: "LambdaFunctionConfiguration"}
+	if s.Events == nil {
+		invalidParams.Add(request.NewErrParamRequired("Events"))
+	}
+	if s.LambdaFunctionArn == nil {
+		invalidParams.Add(request.NewErrParamRequired("LambdaFunctionArn"))
+	}
+
+	if invalidParams.Len() > 0 {
+		return invalidParams
+	}
+	return nil
+}
+
 type LifecycleConfiguration struct {
 	_ struct{} `type:"structure"`
 
@@ -4096,6 +4803,29 @@ func (s LifecycleConfiguration) String() string {
 // GoString returns the string representation
 func (s LifecycleConfiguration) GoString() string {
 	return s.String()
+}
+
+// Validate inspects the fields of the type to determine if they are valid.
+func (s *LifecycleConfiguration) Validate() error {
+	invalidParams := request.ErrInvalidParams{Context: "LifecycleConfiguration"}
+	if s.Rules == nil {
+		invalidParams.Add(request.NewErrParamRequired("Rules"))
+	}
+	if s.Rules != nil {
+		for i, v := range s.Rules {
+			if v == nil {
+				continue
+			}
+			if err := v.Validate(); err != nil {
+				invalidParams.AddNested(fmt.Sprintf("%s[%v]", "Rules", i), err.(request.ErrInvalidParams))
+			}
+		}
+	}
+
+	if invalidParams.Len() > 0 {
+		return invalidParams
+	}
+	return nil
 }
 
 type LifecycleExpiration struct {
@@ -4165,6 +4895,22 @@ func (s LifecycleRule) String() string {
 // GoString returns the string representation
 func (s LifecycleRule) GoString() string {
 	return s.String()
+}
+
+// Validate inspects the fields of the type to determine if they are valid.
+func (s *LifecycleRule) Validate() error {
+	invalidParams := request.ErrInvalidParams{Context: "LifecycleRule"}
+	if s.Prefix == nil {
+		invalidParams.Add(request.NewErrParamRequired("Prefix"))
+	}
+	if s.Status == nil {
+		invalidParams.Add(request.NewErrParamRequired("Status"))
+	}
+
+	if invalidParams.Len() > 0 {
+		return invalidParams
+	}
+	return nil
 }
 
 type ListBucketsInput struct {
@@ -4242,6 +4988,19 @@ func (s ListMultipartUploadsInput) String() string {
 // GoString returns the string representation
 func (s ListMultipartUploadsInput) GoString() string {
 	return s.String()
+}
+
+// Validate inspects the fields of the type to determine if they are valid.
+func (s *ListMultipartUploadsInput) Validate() error {
+	invalidParams := request.ErrInvalidParams{Context: "ListMultipartUploadsInput"}
+	if s.Bucket == nil {
+		invalidParams.Add(request.NewErrParamRequired("Bucket"))
+	}
+
+	if invalidParams.Len() > 0 {
+		return invalidParams
+	}
+	return nil
 }
 
 type ListMultipartUploadsOutput struct {
@@ -4338,6 +5097,19 @@ func (s ListObjectVersionsInput) GoString() string {
 	return s.String()
 }
 
+// Validate inspects the fields of the type to determine if they are valid.
+func (s *ListObjectVersionsInput) Validate() error {
+	invalidParams := request.ErrInvalidParams{Context: "ListObjectVersionsInput"}
+	if s.Bucket == nil {
+		invalidParams.Add(request.NewErrParamRequired("Bucket"))
+	}
+
+	if invalidParams.Len() > 0 {
+		return invalidParams
+	}
+	return nil
+}
+
 type ListObjectVersionsOutput struct {
 	_ struct{} `type:"structure"`
 
@@ -4424,6 +5196,19 @@ func (s ListObjectsInput) GoString() string {
 	return s.String()
 }
 
+// Validate inspects the fields of the type to determine if they are valid.
+func (s *ListObjectsInput) Validate() error {
+	invalidParams := request.ErrInvalidParams{Context: "ListObjectsInput"}
+	if s.Bucket == nil {
+		invalidParams.Add(request.NewErrParamRequired("Bucket"))
+	}
+
+	if invalidParams.Len() > 0 {
+		return invalidParams
+	}
+	return nil
+}
+
 type ListObjectsOutput struct {
 	_ struct{} `type:"structure"`
 
@@ -4500,6 +5285,28 @@ func (s ListPartsInput) String() string {
 // GoString returns the string representation
 func (s ListPartsInput) GoString() string {
 	return s.String()
+}
+
+// Validate inspects the fields of the type to determine if they are valid.
+func (s *ListPartsInput) Validate() error {
+	invalidParams := request.ErrInvalidParams{Context: "ListPartsInput"}
+	if s.Bucket == nil {
+		invalidParams.Add(request.NewErrParamRequired("Bucket"))
+	}
+	if s.Key == nil {
+		invalidParams.Add(request.NewErrParamRequired("Key"))
+	}
+	if s.Key != nil && len(*s.Key) < 1 {
+		invalidParams.Add(request.NewErrParamMinLen("Key", 1))
+	}
+	if s.UploadId == nil {
+		invalidParams.Add(request.NewErrParamRequired("UploadId"))
+	}
+
+	if invalidParams.Len() > 0 {
+		return invalidParams
+	}
+	return nil
 }
 
 type ListPartsOutput struct {
@@ -4586,6 +5393,26 @@ func (s LoggingEnabled) String() string {
 // GoString returns the string representation
 func (s LoggingEnabled) GoString() string {
 	return s.String()
+}
+
+// Validate inspects the fields of the type to determine if they are valid.
+func (s *LoggingEnabled) Validate() error {
+	invalidParams := request.ErrInvalidParams{Context: "LoggingEnabled"}
+	if s.TargetGrants != nil {
+		for i, v := range s.TargetGrants {
+			if v == nil {
+				continue
+			}
+			if err := v.Validate(); err != nil {
+				invalidParams.AddNested(fmt.Sprintf("%s[%v]", "TargetGrants", i), err.(request.ErrInvalidParams))
+			}
+		}
+	}
+
+	if invalidParams.Len() > 0 {
+		return invalidParams
+	}
+	return nil
 }
 
 type MultipartUpload struct {
@@ -4696,6 +5523,46 @@ func (s NotificationConfiguration) GoString() string {
 	return s.String()
 }
 
+// Validate inspects the fields of the type to determine if they are valid.
+func (s *NotificationConfiguration) Validate() error {
+	invalidParams := request.ErrInvalidParams{Context: "NotificationConfiguration"}
+	if s.LambdaFunctionConfigurations != nil {
+		for i, v := range s.LambdaFunctionConfigurations {
+			if v == nil {
+				continue
+			}
+			if err := v.Validate(); err != nil {
+				invalidParams.AddNested(fmt.Sprintf("%s[%v]", "LambdaFunctionConfigurations", i), err.(request.ErrInvalidParams))
+			}
+		}
+	}
+	if s.QueueConfigurations != nil {
+		for i, v := range s.QueueConfigurations {
+			if v == nil {
+				continue
+			}
+			if err := v.Validate(); err != nil {
+				invalidParams.AddNested(fmt.Sprintf("%s[%v]", "QueueConfigurations", i), err.(request.ErrInvalidParams))
+			}
+		}
+	}
+	if s.TopicConfigurations != nil {
+		for i, v := range s.TopicConfigurations {
+			if v == nil {
+				continue
+			}
+			if err := v.Validate(); err != nil {
+				invalidParams.AddNested(fmt.Sprintf("%s[%v]", "TopicConfigurations", i), err.(request.ErrInvalidParams))
+			}
+		}
+	}
+
+	if invalidParams.Len() > 0 {
+		return invalidParams
+	}
+	return nil
+}
+
 type NotificationConfigurationDeprecated struct {
 	_ struct{} `type:"structure"`
 
@@ -4781,6 +5648,22 @@ func (s ObjectIdentifier) String() string {
 // GoString returns the string representation
 func (s ObjectIdentifier) GoString() string {
 	return s.String()
+}
+
+// Validate inspects the fields of the type to determine if they are valid.
+func (s *ObjectIdentifier) Validate() error {
+	invalidParams := request.ErrInvalidParams{Context: "ObjectIdentifier"}
+	if s.Key == nil {
+		invalidParams.Add(request.NewErrParamRequired("Key"))
+	}
+	if s.Key != nil && len(*s.Key) < 1 {
+		invalidParams.Add(request.NewErrParamMinLen("Key", 1))
+	}
+
+	if invalidParams.Len() > 0 {
+		return invalidParams
+	}
+	return nil
 }
 
 type ObjectVersion struct {
@@ -4885,6 +5768,22 @@ func (s PutBucketAccelerateConfigurationInput) GoString() string {
 	return s.String()
 }
 
+// Validate inspects the fields of the type to determine if they are valid.
+func (s *PutBucketAccelerateConfigurationInput) Validate() error {
+	invalidParams := request.ErrInvalidParams{Context: "PutBucketAccelerateConfigurationInput"}
+	if s.AccelerateConfiguration == nil {
+		invalidParams.Add(request.NewErrParamRequired("AccelerateConfiguration"))
+	}
+	if s.Bucket == nil {
+		invalidParams.Add(request.NewErrParamRequired("Bucket"))
+	}
+
+	if invalidParams.Len() > 0 {
+		return invalidParams
+	}
+	return nil
+}
+
 type PutBucketAccelerateConfigurationOutput struct {
 	_ struct{} `type:"structure"`
 }
@@ -4936,6 +5835,24 @@ func (s PutBucketAclInput) GoString() string {
 	return s.String()
 }
 
+// Validate inspects the fields of the type to determine if they are valid.
+func (s *PutBucketAclInput) Validate() error {
+	invalidParams := request.ErrInvalidParams{Context: "PutBucketAclInput"}
+	if s.Bucket == nil {
+		invalidParams.Add(request.NewErrParamRequired("Bucket"))
+	}
+	if s.AccessControlPolicy != nil {
+		if err := s.AccessControlPolicy.Validate(); err != nil {
+			invalidParams.AddNested("AccessControlPolicy", err.(request.ErrInvalidParams))
+		}
+	}
+
+	if invalidParams.Len() > 0 {
+		return invalidParams
+	}
+	return nil
+}
+
 type PutBucketAclOutput struct {
 	_ struct{} `type:"structure"`
 }
@@ -4966,6 +5883,27 @@ func (s PutBucketCorsInput) String() string {
 // GoString returns the string representation
 func (s PutBucketCorsInput) GoString() string {
 	return s.String()
+}
+
+// Validate inspects the fields of the type to determine if they are valid.
+func (s *PutBucketCorsInput) Validate() error {
+	invalidParams := request.ErrInvalidParams{Context: "PutBucketCorsInput"}
+	if s.Bucket == nil {
+		invalidParams.Add(request.NewErrParamRequired("Bucket"))
+	}
+	if s.CORSConfiguration == nil {
+		invalidParams.Add(request.NewErrParamRequired("CORSConfiguration"))
+	}
+	if s.CORSConfiguration != nil {
+		if err := s.CORSConfiguration.Validate(); err != nil {
+			invalidParams.AddNested("CORSConfiguration", err.(request.ErrInvalidParams))
+		}
+	}
+
+	if invalidParams.Len() > 0 {
+		return invalidParams
+	}
+	return nil
 }
 
 type PutBucketCorsOutput struct {
@@ -5000,6 +5938,24 @@ func (s PutBucketLifecycleConfigurationInput) GoString() string {
 	return s.String()
 }
 
+// Validate inspects the fields of the type to determine if they are valid.
+func (s *PutBucketLifecycleConfigurationInput) Validate() error {
+	invalidParams := request.ErrInvalidParams{Context: "PutBucketLifecycleConfigurationInput"}
+	if s.Bucket == nil {
+		invalidParams.Add(request.NewErrParamRequired("Bucket"))
+	}
+	if s.LifecycleConfiguration != nil {
+		if err := s.LifecycleConfiguration.Validate(); err != nil {
+			invalidParams.AddNested("LifecycleConfiguration", err.(request.ErrInvalidParams))
+		}
+	}
+
+	if invalidParams.Len() > 0 {
+		return invalidParams
+	}
+	return nil
+}
+
 type PutBucketLifecycleConfigurationOutput struct {
 	_ struct{} `type:"structure"`
 }
@@ -5032,6 +5988,24 @@ func (s PutBucketLifecycleInput) GoString() string {
 	return s.String()
 }
 
+// Validate inspects the fields of the type to determine if they are valid.
+func (s *PutBucketLifecycleInput) Validate() error {
+	invalidParams := request.ErrInvalidParams{Context: "PutBucketLifecycleInput"}
+	if s.Bucket == nil {
+		invalidParams.Add(request.NewErrParamRequired("Bucket"))
+	}
+	if s.LifecycleConfiguration != nil {
+		if err := s.LifecycleConfiguration.Validate(); err != nil {
+			invalidParams.AddNested("LifecycleConfiguration", err.(request.ErrInvalidParams))
+		}
+	}
+
+	if invalidParams.Len() > 0 {
+		return invalidParams
+	}
+	return nil
+}
+
 type PutBucketLifecycleOutput struct {
 	_ struct{} `type:"structure"`
 }
@@ -5062,6 +6036,27 @@ func (s PutBucketLoggingInput) String() string {
 // GoString returns the string representation
 func (s PutBucketLoggingInput) GoString() string {
 	return s.String()
+}
+
+// Validate inspects the fields of the type to determine if they are valid.
+func (s *PutBucketLoggingInput) Validate() error {
+	invalidParams := request.ErrInvalidParams{Context: "PutBucketLoggingInput"}
+	if s.Bucket == nil {
+		invalidParams.Add(request.NewErrParamRequired("Bucket"))
+	}
+	if s.BucketLoggingStatus == nil {
+		invalidParams.Add(request.NewErrParamRequired("BucketLoggingStatus"))
+	}
+	if s.BucketLoggingStatus != nil {
+		if err := s.BucketLoggingStatus.Validate(); err != nil {
+			invalidParams.AddNested("BucketLoggingStatus", err.(request.ErrInvalidParams))
+		}
+	}
+
+	if invalidParams.Len() > 0 {
+		return invalidParams
+	}
+	return nil
 }
 
 type PutBucketLoggingOutput struct {
@@ -5098,6 +6093,27 @@ func (s PutBucketNotificationConfigurationInput) GoString() string {
 	return s.String()
 }
 
+// Validate inspects the fields of the type to determine if they are valid.
+func (s *PutBucketNotificationConfigurationInput) Validate() error {
+	invalidParams := request.ErrInvalidParams{Context: "PutBucketNotificationConfigurationInput"}
+	if s.Bucket == nil {
+		invalidParams.Add(request.NewErrParamRequired("Bucket"))
+	}
+	if s.NotificationConfiguration == nil {
+		invalidParams.Add(request.NewErrParamRequired("NotificationConfiguration"))
+	}
+	if s.NotificationConfiguration != nil {
+		if err := s.NotificationConfiguration.Validate(); err != nil {
+			invalidParams.AddNested("NotificationConfiguration", err.(request.ErrInvalidParams))
+		}
+	}
+
+	if invalidParams.Len() > 0 {
+		return invalidParams
+	}
+	return nil
+}
+
 type PutBucketNotificationConfigurationOutput struct {
 	_ struct{} `type:"structure"`
 }
@@ -5128,6 +6144,22 @@ func (s PutBucketNotificationInput) String() string {
 // GoString returns the string representation
 func (s PutBucketNotificationInput) GoString() string {
 	return s.String()
+}
+
+// Validate inspects the fields of the type to determine if they are valid.
+func (s *PutBucketNotificationInput) Validate() error {
+	invalidParams := request.ErrInvalidParams{Context: "PutBucketNotificationInput"}
+	if s.Bucket == nil {
+		invalidParams.Add(request.NewErrParamRequired("Bucket"))
+	}
+	if s.NotificationConfiguration == nil {
+		invalidParams.Add(request.NewErrParamRequired("NotificationConfiguration"))
+	}
+
+	if invalidParams.Len() > 0 {
+		return invalidParams
+	}
+	return nil
 }
 
 type PutBucketNotificationOutput struct {
@@ -5161,6 +6193,22 @@ func (s PutBucketPolicyInput) String() string {
 // GoString returns the string representation
 func (s PutBucketPolicyInput) GoString() string {
 	return s.String()
+}
+
+// Validate inspects the fields of the type to determine if they are valid.
+func (s *PutBucketPolicyInput) Validate() error {
+	invalidParams := request.ErrInvalidParams{Context: "PutBucketPolicyInput"}
+	if s.Bucket == nil {
+		invalidParams.Add(request.NewErrParamRequired("Bucket"))
+	}
+	if s.Policy == nil {
+		invalidParams.Add(request.NewErrParamRequired("Policy"))
+	}
+
+	if invalidParams.Len() > 0 {
+		return invalidParams
+	}
+	return nil
 }
 
 type PutBucketPolicyOutput struct {
@@ -5197,6 +6245,27 @@ func (s PutBucketReplicationInput) GoString() string {
 	return s.String()
 }
 
+// Validate inspects the fields of the type to determine if they are valid.
+func (s *PutBucketReplicationInput) Validate() error {
+	invalidParams := request.ErrInvalidParams{Context: "PutBucketReplicationInput"}
+	if s.Bucket == nil {
+		invalidParams.Add(request.NewErrParamRequired("Bucket"))
+	}
+	if s.ReplicationConfiguration == nil {
+		invalidParams.Add(request.NewErrParamRequired("ReplicationConfiguration"))
+	}
+	if s.ReplicationConfiguration != nil {
+		if err := s.ReplicationConfiguration.Validate(); err != nil {
+			invalidParams.AddNested("ReplicationConfiguration", err.(request.ErrInvalidParams))
+		}
+	}
+
+	if invalidParams.Len() > 0 {
+		return invalidParams
+	}
+	return nil
+}
+
 type PutBucketReplicationOutput struct {
 	_ struct{} `type:"structure"`
 }
@@ -5229,6 +6298,27 @@ func (s PutBucketRequestPaymentInput) GoString() string {
 	return s.String()
 }
 
+// Validate inspects the fields of the type to determine if they are valid.
+func (s *PutBucketRequestPaymentInput) Validate() error {
+	invalidParams := request.ErrInvalidParams{Context: "PutBucketRequestPaymentInput"}
+	if s.Bucket == nil {
+		invalidParams.Add(request.NewErrParamRequired("Bucket"))
+	}
+	if s.RequestPaymentConfiguration == nil {
+		invalidParams.Add(request.NewErrParamRequired("RequestPaymentConfiguration"))
+	}
+	if s.RequestPaymentConfiguration != nil {
+		if err := s.RequestPaymentConfiguration.Validate(); err != nil {
+			invalidParams.AddNested("RequestPaymentConfiguration", err.(request.ErrInvalidParams))
+		}
+	}
+
+	if invalidParams.Len() > 0 {
+		return invalidParams
+	}
+	return nil
+}
+
 type PutBucketRequestPaymentOutput struct {
 	_ struct{} `type:"structure"`
 }
@@ -5259,6 +6349,27 @@ func (s PutBucketTaggingInput) String() string {
 // GoString returns the string representation
 func (s PutBucketTaggingInput) GoString() string {
 	return s.String()
+}
+
+// Validate inspects the fields of the type to determine if they are valid.
+func (s *PutBucketTaggingInput) Validate() error {
+	invalidParams := request.ErrInvalidParams{Context: "PutBucketTaggingInput"}
+	if s.Bucket == nil {
+		invalidParams.Add(request.NewErrParamRequired("Bucket"))
+	}
+	if s.Tagging == nil {
+		invalidParams.Add(request.NewErrParamRequired("Tagging"))
+	}
+	if s.Tagging != nil {
+		if err := s.Tagging.Validate(); err != nil {
+			invalidParams.AddNested("Tagging", err.(request.ErrInvalidParams))
+		}
+	}
+
+	if invalidParams.Len() > 0 {
+		return invalidParams
+	}
+	return nil
 }
 
 type PutBucketTaggingOutput struct {
@@ -5297,6 +6408,22 @@ func (s PutBucketVersioningInput) GoString() string {
 	return s.String()
 }
 
+// Validate inspects the fields of the type to determine if they are valid.
+func (s *PutBucketVersioningInput) Validate() error {
+	invalidParams := request.ErrInvalidParams{Context: "PutBucketVersioningInput"}
+	if s.Bucket == nil {
+		invalidParams.Add(request.NewErrParamRequired("Bucket"))
+	}
+	if s.VersioningConfiguration == nil {
+		invalidParams.Add(request.NewErrParamRequired("VersioningConfiguration"))
+	}
+
+	if invalidParams.Len() > 0 {
+		return invalidParams
+	}
+	return nil
+}
+
 type PutBucketVersioningOutput struct {
 	_ struct{} `type:"structure"`
 }
@@ -5327,6 +6454,27 @@ func (s PutBucketWebsiteInput) String() string {
 // GoString returns the string representation
 func (s PutBucketWebsiteInput) GoString() string {
 	return s.String()
+}
+
+// Validate inspects the fields of the type to determine if they are valid.
+func (s *PutBucketWebsiteInput) Validate() error {
+	invalidParams := request.ErrInvalidParams{Context: "PutBucketWebsiteInput"}
+	if s.Bucket == nil {
+		invalidParams.Add(request.NewErrParamRequired("Bucket"))
+	}
+	if s.WebsiteConfiguration == nil {
+		invalidParams.Add(request.NewErrParamRequired("WebsiteConfiguration"))
+	}
+	if s.WebsiteConfiguration != nil {
+		if err := s.WebsiteConfiguration.Validate(); err != nil {
+			invalidParams.AddNested("WebsiteConfiguration", err.(request.ErrInvalidParams))
+		}
+	}
+
+	if invalidParams.Len() > 0 {
+		return invalidParams
+	}
+	return nil
 }
 
 type PutBucketWebsiteOutput struct {
@@ -5389,6 +6537,30 @@ func (s PutObjectAclInput) String() string {
 // GoString returns the string representation
 func (s PutObjectAclInput) GoString() string {
 	return s.String()
+}
+
+// Validate inspects the fields of the type to determine if they are valid.
+func (s *PutObjectAclInput) Validate() error {
+	invalidParams := request.ErrInvalidParams{Context: "PutObjectAclInput"}
+	if s.Bucket == nil {
+		invalidParams.Add(request.NewErrParamRequired("Bucket"))
+	}
+	if s.Key == nil {
+		invalidParams.Add(request.NewErrParamRequired("Key"))
+	}
+	if s.Key != nil && len(*s.Key) < 1 {
+		invalidParams.Add(request.NewErrParamMinLen("Key", 1))
+	}
+	if s.AccessControlPolicy != nil {
+		if err := s.AccessControlPolicy.Validate(); err != nil {
+			invalidParams.AddNested("AccessControlPolicy", err.(request.ErrInvalidParams))
+		}
+	}
+
+	if invalidParams.Len() > 0 {
+		return invalidParams
+	}
+	return nil
 }
 
 type PutObjectAclOutput struct {
@@ -5513,6 +6685,25 @@ func (s PutObjectInput) GoString() string {
 	return s.String()
 }
 
+// Validate inspects the fields of the type to determine if they are valid.
+func (s *PutObjectInput) Validate() error {
+	invalidParams := request.ErrInvalidParams{Context: "PutObjectInput"}
+	if s.Bucket == nil {
+		invalidParams.Add(request.NewErrParamRequired("Bucket"))
+	}
+	if s.Key == nil {
+		invalidParams.Add(request.NewErrParamRequired("Key"))
+	}
+	if s.Key != nil && len(*s.Key) < 1 {
+		invalidParams.Add(request.NewErrParamMinLen("Key", 1))
+	}
+
+	if invalidParams.Len() > 0 {
+		return invalidParams
+	}
+	return nil
+}
+
 type PutObjectOutput struct {
 	_ struct{} `type:"structure"`
 
@@ -5588,6 +6779,22 @@ func (s QueueConfiguration) String() string {
 // GoString returns the string representation
 func (s QueueConfiguration) GoString() string {
 	return s.String()
+}
+
+// Validate inspects the fields of the type to determine if they are valid.
+func (s *QueueConfiguration) Validate() error {
+	invalidParams := request.ErrInvalidParams{Context: "QueueConfiguration"}
+	if s.Events == nil {
+		invalidParams.Add(request.NewErrParamRequired("Events"))
+	}
+	if s.QueueArn == nil {
+		invalidParams.Add(request.NewErrParamRequired("QueueArn"))
+	}
+
+	if invalidParams.Len() > 0 {
+		return invalidParams
+	}
+	return nil
 }
 
 type QueueConfigurationDeprecated struct {
@@ -5674,6 +6881,19 @@ func (s RedirectAllRequestsTo) GoString() string {
 	return s.String()
 }
 
+// Validate inspects the fields of the type to determine if they are valid.
+func (s *RedirectAllRequestsTo) Validate() error {
+	invalidParams := request.ErrInvalidParams{Context: "RedirectAllRequestsTo"}
+	if s.HostName == nil {
+		invalidParams.Add(request.NewErrParamRequired("HostName"))
+	}
+
+	if invalidParams.Len() > 0 {
+		return invalidParams
+	}
+	return nil
+}
+
 // Container for replication rules. You can add as many as 1,000 rules. Total
 // replication configuration size can be up to 2 MB.
 type ReplicationConfiguration struct {
@@ -5696,6 +6916,32 @@ func (s ReplicationConfiguration) String() string {
 // GoString returns the string representation
 func (s ReplicationConfiguration) GoString() string {
 	return s.String()
+}
+
+// Validate inspects the fields of the type to determine if they are valid.
+func (s *ReplicationConfiguration) Validate() error {
+	invalidParams := request.ErrInvalidParams{Context: "ReplicationConfiguration"}
+	if s.Role == nil {
+		invalidParams.Add(request.NewErrParamRequired("Role"))
+	}
+	if s.Rules == nil {
+		invalidParams.Add(request.NewErrParamRequired("Rules"))
+	}
+	if s.Rules != nil {
+		for i, v := range s.Rules {
+			if v == nil {
+				continue
+			}
+			if err := v.Validate(); err != nil {
+				invalidParams.AddNested(fmt.Sprintf("%s[%v]", "Rules", i), err.(request.ErrInvalidParams))
+			}
+		}
+	}
+
+	if invalidParams.Len() > 0 {
+		return invalidParams
+	}
+	return nil
 }
 
 type ReplicationRule struct {
@@ -5725,6 +6971,30 @@ func (s ReplicationRule) GoString() string {
 	return s.String()
 }
 
+// Validate inspects the fields of the type to determine if they are valid.
+func (s *ReplicationRule) Validate() error {
+	invalidParams := request.ErrInvalidParams{Context: "ReplicationRule"}
+	if s.Destination == nil {
+		invalidParams.Add(request.NewErrParamRequired("Destination"))
+	}
+	if s.Prefix == nil {
+		invalidParams.Add(request.NewErrParamRequired("Prefix"))
+	}
+	if s.Status == nil {
+		invalidParams.Add(request.NewErrParamRequired("Status"))
+	}
+	if s.Destination != nil {
+		if err := s.Destination.Validate(); err != nil {
+			invalidParams.AddNested("Destination", err.(request.ErrInvalidParams))
+		}
+	}
+
+	if invalidParams.Len() > 0 {
+		return invalidParams
+	}
+	return nil
+}
+
 type RequestPaymentConfiguration struct {
 	_ struct{} `type:"structure"`
 
@@ -5740,6 +7010,19 @@ func (s RequestPaymentConfiguration) String() string {
 // GoString returns the string representation
 func (s RequestPaymentConfiguration) GoString() string {
 	return s.String()
+}
+
+// Validate inspects the fields of the type to determine if they are valid.
+func (s *RequestPaymentConfiguration) Validate() error {
+	invalidParams := request.ErrInvalidParams{Context: "RequestPaymentConfiguration"}
+	if s.Payer == nil {
+		invalidParams.Add(request.NewErrParamRequired("Payer"))
+	}
+
+	if invalidParams.Len() > 0 {
+		return invalidParams
+	}
+	return nil
 }
 
 type RestoreObjectInput struct {
@@ -5768,6 +7051,30 @@ func (s RestoreObjectInput) String() string {
 // GoString returns the string representation
 func (s RestoreObjectInput) GoString() string {
 	return s.String()
+}
+
+// Validate inspects the fields of the type to determine if they are valid.
+func (s *RestoreObjectInput) Validate() error {
+	invalidParams := request.ErrInvalidParams{Context: "RestoreObjectInput"}
+	if s.Bucket == nil {
+		invalidParams.Add(request.NewErrParamRequired("Bucket"))
+	}
+	if s.Key == nil {
+		invalidParams.Add(request.NewErrParamRequired("Key"))
+	}
+	if s.Key != nil && len(*s.Key) < 1 {
+		invalidParams.Add(request.NewErrParamMinLen("Key", 1))
+	}
+	if s.RestoreRequest != nil {
+		if err := s.RestoreRequest.Validate(); err != nil {
+			invalidParams.AddNested("RestoreRequest", err.(request.ErrInvalidParams))
+		}
+	}
+
+	if invalidParams.Len() > 0 {
+		return invalidParams
+	}
+	return nil
 }
 
 type RestoreObjectOutput struct {
@@ -5805,6 +7112,19 @@ func (s RestoreRequest) GoString() string {
 	return s.String()
 }
 
+// Validate inspects the fields of the type to determine if they are valid.
+func (s *RestoreRequest) Validate() error {
+	invalidParams := request.ErrInvalidParams{Context: "RestoreRequest"}
+	if s.Days == nil {
+		invalidParams.Add(request.NewErrParamRequired("Days"))
+	}
+
+	if invalidParams.Len() > 0 {
+		return invalidParams
+	}
+	return nil
+}
+
 type RoutingRule struct {
 	_ struct{} `type:"structure"`
 
@@ -5828,6 +7148,19 @@ func (s RoutingRule) String() string {
 // GoString returns the string representation
 func (s RoutingRule) GoString() string {
 	return s.String()
+}
+
+// Validate inspects the fields of the type to determine if they are valid.
+func (s *RoutingRule) Validate() error {
+	invalidParams := request.ErrInvalidParams{Context: "RoutingRule"}
+	if s.Redirect == nil {
+		invalidParams.Add(request.NewErrParamRequired("Redirect"))
+	}
+
+	if invalidParams.Len() > 0 {
+		return invalidParams
+	}
+	return nil
 }
 
 type Rule struct {
@@ -5876,6 +7209,22 @@ func (s Rule) GoString() string {
 	return s.String()
 }
 
+// Validate inspects the fields of the type to determine if they are valid.
+func (s *Rule) Validate() error {
+	invalidParams := request.ErrInvalidParams{Context: "Rule"}
+	if s.Prefix == nil {
+		invalidParams.Add(request.NewErrParamRequired("Prefix"))
+	}
+	if s.Status == nil {
+		invalidParams.Add(request.NewErrParamRequired("Status"))
+	}
+
+	if invalidParams.Len() > 0 {
+		return invalidParams
+	}
+	return nil
+}
+
 type Tag struct {
 	_ struct{} `type:"structure"`
 
@@ -5896,6 +7245,25 @@ func (s Tag) GoString() string {
 	return s.String()
 }
 
+// Validate inspects the fields of the type to determine if they are valid.
+func (s *Tag) Validate() error {
+	invalidParams := request.ErrInvalidParams{Context: "Tag"}
+	if s.Key == nil {
+		invalidParams.Add(request.NewErrParamRequired("Key"))
+	}
+	if s.Key != nil && len(*s.Key) < 1 {
+		invalidParams.Add(request.NewErrParamMinLen("Key", 1))
+	}
+	if s.Value == nil {
+		invalidParams.Add(request.NewErrParamRequired("Value"))
+	}
+
+	if invalidParams.Len() > 0 {
+		return invalidParams
+	}
+	return nil
+}
+
 type Tagging struct {
 	_ struct{} `type:"structure"`
 
@@ -5910,6 +7278,29 @@ func (s Tagging) String() string {
 // GoString returns the string representation
 func (s Tagging) GoString() string {
 	return s.String()
+}
+
+// Validate inspects the fields of the type to determine if they are valid.
+func (s *Tagging) Validate() error {
+	invalidParams := request.ErrInvalidParams{Context: "Tagging"}
+	if s.TagSet == nil {
+		invalidParams.Add(request.NewErrParamRequired("TagSet"))
+	}
+	if s.TagSet != nil {
+		for i, v := range s.TagSet {
+			if v == nil {
+				continue
+			}
+			if err := v.Validate(); err != nil {
+				invalidParams.AddNested(fmt.Sprintf("%s[%v]", "TagSet", i), err.(request.ErrInvalidParams))
+			}
+		}
+	}
+
+	if invalidParams.Len() > 0 {
+		return invalidParams
+	}
+	return nil
 }
 
 type TargetGrant struct {
@@ -5929,6 +7320,21 @@ func (s TargetGrant) String() string {
 // GoString returns the string representation
 func (s TargetGrant) GoString() string {
 	return s.String()
+}
+
+// Validate inspects the fields of the type to determine if they are valid.
+func (s *TargetGrant) Validate() error {
+	invalidParams := request.ErrInvalidParams{Context: "TargetGrant"}
+	if s.Grantee != nil {
+		if err := s.Grantee.Validate(); err != nil {
+			invalidParams.AddNested("Grantee", err.(request.ErrInvalidParams))
+		}
+	}
+
+	if invalidParams.Len() > 0 {
+		return invalidParams
+	}
+	return nil
 }
 
 // Container for specifying the configuration when you want Amazon S3 to publish
@@ -5960,6 +7366,22 @@ func (s TopicConfiguration) String() string {
 // GoString returns the string representation
 func (s TopicConfiguration) GoString() string {
 	return s.String()
+}
+
+// Validate inspects the fields of the type to determine if they are valid.
+func (s *TopicConfiguration) Validate() error {
+	invalidParams := request.ErrInvalidParams{Context: "TopicConfiguration"}
+	if s.Events == nil {
+		invalidParams.Add(request.NewErrParamRequired("Events"))
+	}
+	if s.TopicArn == nil {
+		invalidParams.Add(request.NewErrParamRequired("TopicArn"))
+	}
+
+	if invalidParams.Len() > 0 {
+		return invalidParams
+	}
+	return nil
 }
 
 type TopicConfigurationDeprecated struct {
@@ -6098,6 +7520,34 @@ func (s UploadPartCopyInput) GoString() string {
 	return s.String()
 }
 
+// Validate inspects the fields of the type to determine if they are valid.
+func (s *UploadPartCopyInput) Validate() error {
+	invalidParams := request.ErrInvalidParams{Context: "UploadPartCopyInput"}
+	if s.Bucket == nil {
+		invalidParams.Add(request.NewErrParamRequired("Bucket"))
+	}
+	if s.CopySource == nil {
+		invalidParams.Add(request.NewErrParamRequired("CopySource"))
+	}
+	if s.Key == nil {
+		invalidParams.Add(request.NewErrParamRequired("Key"))
+	}
+	if s.Key != nil && len(*s.Key) < 1 {
+		invalidParams.Add(request.NewErrParamMinLen("Key", 1))
+	}
+	if s.PartNumber == nil {
+		invalidParams.Add(request.NewErrParamRequired("PartNumber"))
+	}
+	if s.UploadId == nil {
+		invalidParams.Add(request.NewErrParamRequired("UploadId"))
+	}
+
+	if invalidParams.Len() > 0 {
+		return invalidParams
+	}
+	return nil
+}
+
 type UploadPartCopyOutput struct {
 	_ struct{} `type:"structure" payload:"CopyPartResult"`
 
@@ -6196,6 +7646,31 @@ func (s UploadPartInput) GoString() string {
 	return s.String()
 }
 
+// Validate inspects the fields of the type to determine if they are valid.
+func (s *UploadPartInput) Validate() error {
+	invalidParams := request.ErrInvalidParams{Context: "UploadPartInput"}
+	if s.Bucket == nil {
+		invalidParams.Add(request.NewErrParamRequired("Bucket"))
+	}
+	if s.Key == nil {
+		invalidParams.Add(request.NewErrParamRequired("Key"))
+	}
+	if s.Key != nil && len(*s.Key) < 1 {
+		invalidParams.Add(request.NewErrParamMinLen("Key", 1))
+	}
+	if s.PartNumber == nil {
+		invalidParams.Add(request.NewErrParamRequired("PartNumber"))
+	}
+	if s.UploadId == nil {
+		invalidParams.Add(request.NewErrParamRequired("UploadId"))
+	}
+
+	if invalidParams.Len() > 0 {
+		return invalidParams
+	}
+	return nil
+}
+
 type UploadPartOutput struct {
 	_ struct{} `type:"structure"`
 
@@ -6277,6 +7752,41 @@ func (s WebsiteConfiguration) String() string {
 // GoString returns the string representation
 func (s WebsiteConfiguration) GoString() string {
 	return s.String()
+}
+
+// Validate inspects the fields of the type to determine if they are valid.
+func (s *WebsiteConfiguration) Validate() error {
+	invalidParams := request.ErrInvalidParams{Context: "WebsiteConfiguration"}
+	if s.ErrorDocument != nil {
+		if err := s.ErrorDocument.Validate(); err != nil {
+			invalidParams.AddNested("ErrorDocument", err.(request.ErrInvalidParams))
+		}
+	}
+	if s.IndexDocument != nil {
+		if err := s.IndexDocument.Validate(); err != nil {
+			invalidParams.AddNested("IndexDocument", err.(request.ErrInvalidParams))
+		}
+	}
+	if s.RedirectAllRequestsTo != nil {
+		if err := s.RedirectAllRequestsTo.Validate(); err != nil {
+			invalidParams.AddNested("RedirectAllRequestsTo", err.(request.ErrInvalidParams))
+		}
+	}
+	if s.RoutingRules != nil {
+		for i, v := range s.RoutingRules {
+			if v == nil {
+				continue
+			}
+			if err := v.Validate(); err != nil {
+				invalidParams.AddNested(fmt.Sprintf("%s[%v]", "RoutingRules", i), err.(request.ErrInvalidParams))
+			}
+		}
+	}
+
+	if invalidParams.Len() > 0 {
+		return invalidParams
+	}
+	return nil
 }
 
 const (

--- a/service/ses/api.go
+++ b/service/ses/api.go
@@ -4,6 +4,7 @@
 package ses
 
 import (
+	"fmt"
 	"time"
 
 	"github.com/aws/aws-sdk-go/aws/awsutil"
@@ -1469,6 +1470,22 @@ func (s AddHeaderAction) GoString() string {
 	return s.String()
 }
 
+// Validate inspects the fields of the type to determine if they are valid.
+func (s *AddHeaderAction) Validate() error {
+	invalidParams := request.ErrInvalidParams{Context: "AddHeaderAction"}
+	if s.HeaderName == nil {
+		invalidParams.Add(request.NewErrParamRequired("HeaderName"))
+	}
+	if s.HeaderValue == nil {
+		invalidParams.Add(request.NewErrParamRequired("HeaderValue"))
+	}
+
+	if invalidParams.Len() > 0 {
+		return invalidParams
+	}
+	return nil
+}
+
 // Represents the body of the message. You can specify text, HTML, or both.
 // If you use both, then the message should display correctly in the widest
 // variety of email clients.
@@ -1493,6 +1510,26 @@ func (s Body) String() string {
 // GoString returns the string representation
 func (s Body) GoString() string {
 	return s.String()
+}
+
+// Validate inspects the fields of the type to determine if they are valid.
+func (s *Body) Validate() error {
+	invalidParams := request.ErrInvalidParams{Context: "Body"}
+	if s.Html != nil {
+		if err := s.Html.Validate(); err != nil {
+			invalidParams.AddNested("Html", err.(request.ErrInvalidParams))
+		}
+	}
+	if s.Text != nil {
+		if err := s.Text.Validate(); err != nil {
+			invalidParams.AddNested("Text", err.(request.ErrInvalidParams))
+		}
+	}
+
+	if invalidParams.Len() > 0 {
+		return invalidParams
+	}
+	return nil
 }
 
 // When included in a receipt rule, this action rejects the received email by
@@ -1534,6 +1571,25 @@ func (s BounceAction) GoString() string {
 	return s.String()
 }
 
+// Validate inspects the fields of the type to determine if they are valid.
+func (s *BounceAction) Validate() error {
+	invalidParams := request.ErrInvalidParams{Context: "BounceAction"}
+	if s.Message == nil {
+		invalidParams.Add(request.NewErrParamRequired("Message"))
+	}
+	if s.Sender == nil {
+		invalidParams.Add(request.NewErrParamRequired("Sender"))
+	}
+	if s.SmtpReplyCode == nil {
+		invalidParams.Add(request.NewErrParamRequired("SmtpReplyCode"))
+	}
+
+	if invalidParams.Len() > 0 {
+		return invalidParams
+	}
+	return nil
+}
+
 // Recipient-related information to include in the Delivery Status Notification
 // (DSN) when an email that Amazon SES receives on your behalf bounces.
 //
@@ -1570,6 +1626,24 @@ func (s BouncedRecipientInfo) GoString() string {
 	return s.String()
 }
 
+// Validate inspects the fields of the type to determine if they are valid.
+func (s *BouncedRecipientInfo) Validate() error {
+	invalidParams := request.ErrInvalidParams{Context: "BouncedRecipientInfo"}
+	if s.Recipient == nil {
+		invalidParams.Add(request.NewErrParamRequired("Recipient"))
+	}
+	if s.RecipientDsnFields != nil {
+		if err := s.RecipientDsnFields.Validate(); err != nil {
+			invalidParams.AddNested("RecipientDsnFields", err.(request.ErrInvalidParams))
+		}
+	}
+
+	if invalidParams.Len() > 0 {
+		return invalidParams
+	}
+	return nil
+}
+
 type CloneReceiptRuleSetInput struct {
 	_ struct{} `type:"structure"`
 
@@ -1592,6 +1666,22 @@ func (s CloneReceiptRuleSetInput) String() string {
 // GoString returns the string representation
 func (s CloneReceiptRuleSetInput) GoString() string {
 	return s.String()
+}
+
+// Validate inspects the fields of the type to determine if they are valid.
+func (s *CloneReceiptRuleSetInput) Validate() error {
+	invalidParams := request.ErrInvalidParams{Context: "CloneReceiptRuleSetInput"}
+	if s.OriginalRuleSetName == nil {
+		invalidParams.Add(request.NewErrParamRequired("OriginalRuleSetName"))
+	}
+	if s.RuleSetName == nil {
+		invalidParams.Add(request.NewErrParamRequired("RuleSetName"))
+	}
+
+	if invalidParams.Len() > 0 {
+		return invalidParams
+	}
+	return nil
 }
 
 type CloneReceiptRuleSetOutput struct {
@@ -1633,6 +1723,19 @@ func (s Content) GoString() string {
 	return s.String()
 }
 
+// Validate inspects the fields of the type to determine if they are valid.
+func (s *Content) Validate() error {
+	invalidParams := request.ErrInvalidParams{Context: "Content"}
+	if s.Data == nil {
+		invalidParams.Add(request.NewErrParamRequired("Data"))
+	}
+
+	if invalidParams.Len() > 0 {
+		return invalidParams
+	}
+	return nil
+}
+
 type CreateReceiptFilterInput struct {
 	_ struct{} `type:"structure"`
 
@@ -1649,6 +1752,24 @@ func (s CreateReceiptFilterInput) String() string {
 // GoString returns the string representation
 func (s CreateReceiptFilterInput) GoString() string {
 	return s.String()
+}
+
+// Validate inspects the fields of the type to determine if they are valid.
+func (s *CreateReceiptFilterInput) Validate() error {
+	invalidParams := request.ErrInvalidParams{Context: "CreateReceiptFilterInput"}
+	if s.Filter == nil {
+		invalidParams.Add(request.NewErrParamRequired("Filter"))
+	}
+	if s.Filter != nil {
+		if err := s.Filter.Validate(); err != nil {
+			invalidParams.AddNested("Filter", err.(request.ErrInvalidParams))
+		}
+	}
+
+	if invalidParams.Len() > 0 {
+		return invalidParams
+	}
+	return nil
 }
 
 type CreateReceiptFilterOutput struct {
@@ -1691,6 +1812,27 @@ func (s CreateReceiptRuleInput) GoString() string {
 	return s.String()
 }
 
+// Validate inspects the fields of the type to determine if they are valid.
+func (s *CreateReceiptRuleInput) Validate() error {
+	invalidParams := request.ErrInvalidParams{Context: "CreateReceiptRuleInput"}
+	if s.Rule == nil {
+		invalidParams.Add(request.NewErrParamRequired("Rule"))
+	}
+	if s.RuleSetName == nil {
+		invalidParams.Add(request.NewErrParamRequired("RuleSetName"))
+	}
+	if s.Rule != nil {
+		if err := s.Rule.Validate(); err != nil {
+			invalidParams.AddNested("Rule", err.(request.ErrInvalidParams))
+		}
+	}
+
+	if invalidParams.Len() > 0 {
+		return invalidParams
+	}
+	return nil
+}
+
 type CreateReceiptRuleOutput struct {
 	_ struct{} `type:"structure"`
 }
@@ -1726,6 +1868,19 @@ func (s CreateReceiptRuleSetInput) GoString() string {
 	return s.String()
 }
 
+// Validate inspects the fields of the type to determine if they are valid.
+func (s *CreateReceiptRuleSetInput) Validate() error {
+	invalidParams := request.ErrInvalidParams{Context: "CreateReceiptRuleSetInput"}
+	if s.RuleSetName == nil {
+		invalidParams.Add(request.NewErrParamRequired("RuleSetName"))
+	}
+
+	if invalidParams.Len() > 0 {
+		return invalidParams
+	}
+	return nil
+}
+
 type CreateReceiptRuleSetOutput struct {
 	_ struct{} `type:"structure"`
 }
@@ -1755,6 +1910,19 @@ func (s DeleteIdentityInput) String() string {
 // GoString returns the string representation
 func (s DeleteIdentityInput) GoString() string {
 	return s.String()
+}
+
+// Validate inspects the fields of the type to determine if they are valid.
+func (s *DeleteIdentityInput) Validate() error {
+	invalidParams := request.ErrInvalidParams{Context: "DeleteIdentityInput"}
+	if s.Identity == nil {
+		invalidParams.Add(request.NewErrParamRequired("Identity"))
+	}
+
+	if invalidParams.Len() > 0 {
+		return invalidParams
+	}
+	return nil
 }
 
 type DeleteIdentityOutput struct {
@@ -1795,6 +1963,25 @@ func (s DeleteIdentityPolicyInput) GoString() string {
 	return s.String()
 }
 
+// Validate inspects the fields of the type to determine if they are valid.
+func (s *DeleteIdentityPolicyInput) Validate() error {
+	invalidParams := request.ErrInvalidParams{Context: "DeleteIdentityPolicyInput"}
+	if s.Identity == nil {
+		invalidParams.Add(request.NewErrParamRequired("Identity"))
+	}
+	if s.PolicyName == nil {
+		invalidParams.Add(request.NewErrParamRequired("PolicyName"))
+	}
+	if s.PolicyName != nil && len(*s.PolicyName) < 1 {
+		invalidParams.Add(request.NewErrParamMinLen("PolicyName", 1))
+	}
+
+	if invalidParams.Len() > 0 {
+		return invalidParams
+	}
+	return nil
+}
+
 type DeleteIdentityPolicyOutput struct {
 	_ struct{} `type:"structure"`
 }
@@ -1824,6 +2011,19 @@ func (s DeleteReceiptFilterInput) String() string {
 // GoString returns the string representation
 func (s DeleteReceiptFilterInput) GoString() string {
 	return s.String()
+}
+
+// Validate inspects the fields of the type to determine if they are valid.
+func (s *DeleteReceiptFilterInput) Validate() error {
+	invalidParams := request.ErrInvalidParams{Context: "DeleteReceiptFilterInput"}
+	if s.FilterName == nil {
+		invalidParams.Add(request.NewErrParamRequired("FilterName"))
+	}
+
+	if invalidParams.Len() > 0 {
+		return invalidParams
+	}
+	return nil
 }
 
 type DeleteReceiptFilterOutput struct {
@@ -1860,6 +2060,22 @@ func (s DeleteReceiptRuleInput) GoString() string {
 	return s.String()
 }
 
+// Validate inspects the fields of the type to determine if they are valid.
+func (s *DeleteReceiptRuleInput) Validate() error {
+	invalidParams := request.ErrInvalidParams{Context: "DeleteReceiptRuleInput"}
+	if s.RuleName == nil {
+		invalidParams.Add(request.NewErrParamRequired("RuleName"))
+	}
+	if s.RuleSetName == nil {
+		invalidParams.Add(request.NewErrParamRequired("RuleSetName"))
+	}
+
+	if invalidParams.Len() > 0 {
+		return invalidParams
+	}
+	return nil
+}
+
 type DeleteReceiptRuleOutput struct {
 	_ struct{} `type:"structure"`
 }
@@ -1891,6 +2107,19 @@ func (s DeleteReceiptRuleSetInput) GoString() string {
 	return s.String()
 }
 
+// Validate inspects the fields of the type to determine if they are valid.
+func (s *DeleteReceiptRuleSetInput) Validate() error {
+	invalidParams := request.ErrInvalidParams{Context: "DeleteReceiptRuleSetInput"}
+	if s.RuleSetName == nil {
+		invalidParams.Add(request.NewErrParamRequired("RuleSetName"))
+	}
+
+	if invalidParams.Len() > 0 {
+		return invalidParams
+	}
+	return nil
+}
+
 type DeleteReceiptRuleSetOutput struct {
 	_ struct{} `type:"structure"`
 }
@@ -1920,6 +2149,19 @@ func (s DeleteVerifiedEmailAddressInput) String() string {
 // GoString returns the string representation
 func (s DeleteVerifiedEmailAddressInput) GoString() string {
 	return s.String()
+}
+
+// Validate inspects the fields of the type to determine if they are valid.
+func (s *DeleteVerifiedEmailAddressInput) Validate() error {
+	invalidParams := request.ErrInvalidParams{Context: "DeleteVerifiedEmailAddressInput"}
+	if s.EmailAddress == nil {
+		invalidParams.Add(request.NewErrParamRequired("EmailAddress"))
+	}
+
+	if invalidParams.Len() > 0 {
+		return invalidParams
+	}
+	return nil
 }
 
 type DeleteVerifiedEmailAddressOutput struct {
@@ -1991,6 +2233,22 @@ func (s DescribeReceiptRuleInput) GoString() string {
 	return s.String()
 }
 
+// Validate inspects the fields of the type to determine if they are valid.
+func (s *DescribeReceiptRuleInput) Validate() error {
+	invalidParams := request.ErrInvalidParams{Context: "DescribeReceiptRuleInput"}
+	if s.RuleName == nil {
+		invalidParams.Add(request.NewErrParamRequired("RuleName"))
+	}
+	if s.RuleSetName == nil {
+		invalidParams.Add(request.NewErrParamRequired("RuleSetName"))
+	}
+
+	if invalidParams.Len() > 0 {
+		return invalidParams
+	}
+	return nil
+}
+
 type DescribeReceiptRuleOutput struct {
 	_ struct{} `type:"structure"`
 
@@ -2025,6 +2283,19 @@ func (s DescribeReceiptRuleSetInput) String() string {
 // GoString returns the string representation
 func (s DescribeReceiptRuleSetInput) GoString() string {
 	return s.String()
+}
+
+// Validate inspects the fields of the type to determine if they are valid.
+func (s *DescribeReceiptRuleSetInput) Validate() error {
+	invalidParams := request.ErrInvalidParams{Context: "DescribeReceiptRuleSetInput"}
+	if s.RuleSetName == nil {
+		invalidParams.Add(request.NewErrParamRequired("RuleSetName"))
+	}
+
+	if invalidParams.Len() > 0 {
+		return invalidParams
+	}
+	return nil
 }
 
 type DescribeReceiptRuleSetOutput struct {
@@ -2105,6 +2376,22 @@ func (s ExtensionField) GoString() string {
 	return s.String()
 }
 
+// Validate inspects the fields of the type to determine if they are valid.
+func (s *ExtensionField) Validate() error {
+	invalidParams := request.ErrInvalidParams{Context: "ExtensionField"}
+	if s.Name == nil {
+		invalidParams.Add(request.NewErrParamRequired("Name"))
+	}
+	if s.Value == nil {
+		invalidParams.Add(request.NewErrParamRequired("Value"))
+	}
+
+	if invalidParams.Len() > 0 {
+		return invalidParams
+	}
+	return nil
+}
+
 type GetIdentityDkimAttributesInput struct {
 	_ struct{} `type:"structure"`
 
@@ -2121,6 +2408,19 @@ func (s GetIdentityDkimAttributesInput) String() string {
 // GoString returns the string representation
 func (s GetIdentityDkimAttributesInput) GoString() string {
 	return s.String()
+}
+
+// Validate inspects the fields of the type to determine if they are valid.
+func (s *GetIdentityDkimAttributesInput) Validate() error {
+	invalidParams := request.ErrInvalidParams{Context: "GetIdentityDkimAttributesInput"}
+	if s.Identities == nil {
+		invalidParams.Add(request.NewErrParamRequired("Identities"))
+	}
+
+	if invalidParams.Len() > 0 {
+		return invalidParams
+	}
+	return nil
 }
 
 type GetIdentityDkimAttributesOutput struct {
@@ -2157,6 +2457,19 @@ func (s GetIdentityMailFromDomainAttributesInput) GoString() string {
 	return s.String()
 }
 
+// Validate inspects the fields of the type to determine if they are valid.
+func (s *GetIdentityMailFromDomainAttributesInput) Validate() error {
+	invalidParams := request.ErrInvalidParams{Context: "GetIdentityMailFromDomainAttributesInput"}
+	if s.Identities == nil {
+		invalidParams.Add(request.NewErrParamRequired("Identities"))
+	}
+
+	if invalidParams.Len() > 0 {
+		return invalidParams
+	}
+	return nil
+}
+
 type GetIdentityMailFromDomainAttributesOutput struct {
 	_ struct{} `type:"structure"`
 
@@ -2191,6 +2504,19 @@ func (s GetIdentityNotificationAttributesInput) String() string {
 // GoString returns the string representation
 func (s GetIdentityNotificationAttributesInput) GoString() string {
 	return s.String()
+}
+
+// Validate inspects the fields of the type to determine if they are valid.
+func (s *GetIdentityNotificationAttributesInput) Validate() error {
+	invalidParams := request.ErrInvalidParams{Context: "GetIdentityNotificationAttributesInput"}
+	if s.Identities == nil {
+		invalidParams.Add(request.NewErrParamRequired("Identities"))
+	}
+
+	if invalidParams.Len() > 0 {
+		return invalidParams
+	}
+	return nil
 }
 
 type GetIdentityNotificationAttributesOutput struct {
@@ -2236,6 +2562,22 @@ func (s GetIdentityPoliciesInput) GoString() string {
 	return s.String()
 }
 
+// Validate inspects the fields of the type to determine if they are valid.
+func (s *GetIdentityPoliciesInput) Validate() error {
+	invalidParams := request.ErrInvalidParams{Context: "GetIdentityPoliciesInput"}
+	if s.Identity == nil {
+		invalidParams.Add(request.NewErrParamRequired("Identity"))
+	}
+	if s.PolicyNames == nil {
+		invalidParams.Add(request.NewErrParamRequired("PolicyNames"))
+	}
+
+	if invalidParams.Len() > 0 {
+		return invalidParams
+	}
+	return nil
+}
+
 type GetIdentityPoliciesOutput struct {
 	_ struct{} `type:"structure"`
 
@@ -2268,6 +2610,19 @@ func (s GetIdentityVerificationAttributesInput) String() string {
 // GoString returns the string representation
 func (s GetIdentityVerificationAttributesInput) GoString() string {
 	return s.String()
+}
+
+// Validate inspects the fields of the type to determine if they are valid.
+func (s *GetIdentityVerificationAttributesInput) Validate() error {
+	invalidParams := request.ErrInvalidParams{Context: "GetIdentityVerificationAttributesInput"}
+	if s.Identities == nil {
+		invalidParams.Add(request.NewErrParamRequired("Identities"))
+	}
+
+	if invalidParams.Len() > 0 {
+		return invalidParams
+	}
+	return nil
 }
 
 type GetIdentityVerificationAttributesOutput struct {
@@ -2539,6 +2894,19 @@ func (s LambdaAction) GoString() string {
 	return s.String()
 }
 
+// Validate inspects the fields of the type to determine if they are valid.
+func (s *LambdaAction) Validate() error {
+	invalidParams := request.ErrInvalidParams{Context: "LambdaAction"}
+	if s.FunctionArn == nil {
+		invalidParams.Add(request.NewErrParamRequired("FunctionArn"))
+	}
+
+	if invalidParams.Len() > 0 {
+		return invalidParams
+	}
+	return nil
+}
+
 type ListIdentitiesInput struct {
 	_ struct{} `type:"structure"`
 
@@ -2602,6 +2970,19 @@ func (s ListIdentityPoliciesInput) String() string {
 // GoString returns the string representation
 func (s ListIdentityPoliciesInput) GoString() string {
 	return s.String()
+}
+
+// Validate inspects the fields of the type to determine if they are valid.
+func (s *ListIdentityPoliciesInput) Validate() error {
+	invalidParams := request.ErrInvalidParams{Context: "ListIdentityPoliciesInput"}
+	if s.Identity == nil {
+		invalidParams.Add(request.NewErrParamRequired("Identity"))
+	}
+
+	if invalidParams.Len() > 0 {
+		return invalidParams
+	}
+	return nil
 }
 
 type ListIdentityPoliciesOutput struct {
@@ -2747,6 +3128,32 @@ func (s Message) GoString() string {
 	return s.String()
 }
 
+// Validate inspects the fields of the type to determine if they are valid.
+func (s *Message) Validate() error {
+	invalidParams := request.ErrInvalidParams{Context: "Message"}
+	if s.Body == nil {
+		invalidParams.Add(request.NewErrParamRequired("Body"))
+	}
+	if s.Subject == nil {
+		invalidParams.Add(request.NewErrParamRequired("Subject"))
+	}
+	if s.Body != nil {
+		if err := s.Body.Validate(); err != nil {
+			invalidParams.AddNested("Body", err.(request.ErrInvalidParams))
+		}
+	}
+	if s.Subject != nil {
+		if err := s.Subject.Validate(); err != nil {
+			invalidParams.AddNested("Subject", err.(request.ErrInvalidParams))
+		}
+	}
+
+	if invalidParams.Len() > 0 {
+		return invalidParams
+	}
+	return nil
+}
+
 // Message-related information to include in the Delivery Status Notification
 // (DSN) when an email that Amazon SES receives on your behalf bounces.
 //
@@ -2776,6 +3183,29 @@ func (s MessageDsn) String() string {
 // GoString returns the string representation
 func (s MessageDsn) GoString() string {
 	return s.String()
+}
+
+// Validate inspects the fields of the type to determine if they are valid.
+func (s *MessageDsn) Validate() error {
+	invalidParams := request.ErrInvalidParams{Context: "MessageDsn"}
+	if s.ReportingMta == nil {
+		invalidParams.Add(request.NewErrParamRequired("ReportingMta"))
+	}
+	if s.ExtensionFields != nil {
+		for i, v := range s.ExtensionFields {
+			if v == nil {
+				continue
+			}
+			if err := v.Validate(); err != nil {
+				invalidParams.AddNested(fmt.Sprintf("%s[%v]", "ExtensionFields", i), err.(request.ErrInvalidParams))
+			}
+		}
+	}
+
+	if invalidParams.Len() > 0 {
+		return invalidParams
+	}
+	return nil
 }
 
 type PutIdentityPolicyInput struct {
@@ -2809,6 +3239,31 @@ func (s PutIdentityPolicyInput) String() string {
 // GoString returns the string representation
 func (s PutIdentityPolicyInput) GoString() string {
 	return s.String()
+}
+
+// Validate inspects the fields of the type to determine if they are valid.
+func (s *PutIdentityPolicyInput) Validate() error {
+	invalidParams := request.ErrInvalidParams{Context: "PutIdentityPolicyInput"}
+	if s.Identity == nil {
+		invalidParams.Add(request.NewErrParamRequired("Identity"))
+	}
+	if s.Policy == nil {
+		invalidParams.Add(request.NewErrParamRequired("Policy"))
+	}
+	if s.Policy != nil && len(*s.Policy) < 1 {
+		invalidParams.Add(request.NewErrParamMinLen("Policy", 1))
+	}
+	if s.PolicyName == nil {
+		invalidParams.Add(request.NewErrParamRequired("PolicyName"))
+	}
+	if s.PolicyName != nil && len(*s.PolicyName) < 1 {
+		invalidParams.Add(request.NewErrParamMinLen("PolicyName", 1))
+	}
+
+	if invalidParams.Len() > 0 {
+		return invalidParams
+	}
+	return nil
 }
 
 type PutIdentityPolicyOutput struct {
@@ -2855,6 +3310,19 @@ func (s RawMessage) String() string {
 // GoString returns the string representation
 func (s RawMessage) GoString() string {
 	return s.String()
+}
+
+// Validate inspects the fields of the type to determine if they are valid.
+func (s *RawMessage) Validate() error {
+	invalidParams := request.ErrInvalidParams{Context: "RawMessage"}
+	if s.Data == nil {
+		invalidParams.Add(request.NewErrParamRequired("Data"))
+	}
+
+	if invalidParams.Len() > 0 {
+		return invalidParams
+	}
+	return nil
 }
 
 // An action that Amazon SES can take when it receives an email on behalf of
@@ -2904,6 +3372,51 @@ func (s ReceiptAction) GoString() string {
 	return s.String()
 }
 
+// Validate inspects the fields of the type to determine if they are valid.
+func (s *ReceiptAction) Validate() error {
+	invalidParams := request.ErrInvalidParams{Context: "ReceiptAction"}
+	if s.AddHeaderAction != nil {
+		if err := s.AddHeaderAction.Validate(); err != nil {
+			invalidParams.AddNested("AddHeaderAction", err.(request.ErrInvalidParams))
+		}
+	}
+	if s.BounceAction != nil {
+		if err := s.BounceAction.Validate(); err != nil {
+			invalidParams.AddNested("BounceAction", err.(request.ErrInvalidParams))
+		}
+	}
+	if s.LambdaAction != nil {
+		if err := s.LambdaAction.Validate(); err != nil {
+			invalidParams.AddNested("LambdaAction", err.(request.ErrInvalidParams))
+		}
+	}
+	if s.S3Action != nil {
+		if err := s.S3Action.Validate(); err != nil {
+			invalidParams.AddNested("S3Action", err.(request.ErrInvalidParams))
+		}
+	}
+	if s.SNSAction != nil {
+		if err := s.SNSAction.Validate(); err != nil {
+			invalidParams.AddNested("SNSAction", err.(request.ErrInvalidParams))
+		}
+	}
+	if s.StopAction != nil {
+		if err := s.StopAction.Validate(); err != nil {
+			invalidParams.AddNested("StopAction", err.(request.ErrInvalidParams))
+		}
+	}
+	if s.WorkmailAction != nil {
+		if err := s.WorkmailAction.Validate(); err != nil {
+			invalidParams.AddNested("WorkmailAction", err.(request.ErrInvalidParams))
+		}
+	}
+
+	if invalidParams.Len() > 0 {
+		return invalidParams
+	}
+	return nil
+}
+
 // A receipt IP address filter enables you to specify whether to accept or reject
 // mail originating from an IP address or range of IP addresses.
 //
@@ -2934,6 +3447,27 @@ func (s ReceiptFilter) GoString() string {
 	return s.String()
 }
 
+// Validate inspects the fields of the type to determine if they are valid.
+func (s *ReceiptFilter) Validate() error {
+	invalidParams := request.ErrInvalidParams{Context: "ReceiptFilter"}
+	if s.IpFilter == nil {
+		invalidParams.Add(request.NewErrParamRequired("IpFilter"))
+	}
+	if s.Name == nil {
+		invalidParams.Add(request.NewErrParamRequired("Name"))
+	}
+	if s.IpFilter != nil {
+		if err := s.IpFilter.Validate(); err != nil {
+			invalidParams.AddNested("IpFilter", err.(request.ErrInvalidParams))
+		}
+	}
+
+	if invalidParams.Len() > 0 {
+		return invalidParams
+	}
+	return nil
+}
+
 // A receipt IP address filter enables you to specify whether to accept or reject
 // mail originating from an IP address or range of IP addresses.
 //
@@ -2960,6 +3494,22 @@ func (s ReceiptIpFilter) String() string {
 // GoString returns the string representation
 func (s ReceiptIpFilter) GoString() string {
 	return s.String()
+}
+
+// Validate inspects the fields of the type to determine if they are valid.
+func (s *ReceiptIpFilter) Validate() error {
+	invalidParams := request.ErrInvalidParams{Context: "ReceiptIpFilter"}
+	if s.Cidr == nil {
+		invalidParams.Add(request.NewErrParamRequired("Cidr"))
+	}
+	if s.Policy == nil {
+		invalidParams.Add(request.NewErrParamRequired("Policy"))
+	}
+
+	if invalidParams.Len() > 0 {
+		return invalidParams
+	}
+	return nil
 }
 
 // Receipt rules enable you to specify which actions Amazon SES should take
@@ -3014,6 +3564,29 @@ func (s ReceiptRule) String() string {
 // GoString returns the string representation
 func (s ReceiptRule) GoString() string {
 	return s.String()
+}
+
+// Validate inspects the fields of the type to determine if they are valid.
+func (s *ReceiptRule) Validate() error {
+	invalidParams := request.ErrInvalidParams{Context: "ReceiptRule"}
+	if s.Name == nil {
+		invalidParams.Add(request.NewErrParamRequired("Name"))
+	}
+	if s.Actions != nil {
+		for i, v := range s.Actions {
+			if v == nil {
+				continue
+			}
+			if err := v.Validate(); err != nil {
+				invalidParams.AddNested(fmt.Sprintf("%s[%v]", "Actions", i), err.(request.ErrInvalidParams))
+			}
+		}
+	}
+
+	if invalidParams.Len() > 0 {
+		return invalidParams
+	}
+	return nil
 }
 
 // Information about a receipt rule set.
@@ -3103,6 +3676,32 @@ func (s RecipientDsnFields) GoString() string {
 	return s.String()
 }
 
+// Validate inspects the fields of the type to determine if they are valid.
+func (s *RecipientDsnFields) Validate() error {
+	invalidParams := request.ErrInvalidParams{Context: "RecipientDsnFields"}
+	if s.Action == nil {
+		invalidParams.Add(request.NewErrParamRequired("Action"))
+	}
+	if s.Status == nil {
+		invalidParams.Add(request.NewErrParamRequired("Status"))
+	}
+	if s.ExtensionFields != nil {
+		for i, v := range s.ExtensionFields {
+			if v == nil {
+				continue
+			}
+			if err := v.Validate(); err != nil {
+				invalidParams.AddNested(fmt.Sprintf("%s[%v]", "ExtensionFields", i), err.(request.ErrInvalidParams))
+			}
+		}
+	}
+
+	if invalidParams.Len() > 0 {
+		return invalidParams
+	}
+	return nil
+}
+
 type ReorderReceiptRuleSetInput struct {
 	_ struct{} `type:"structure"`
 
@@ -3122,6 +3721,22 @@ func (s ReorderReceiptRuleSetInput) String() string {
 // GoString returns the string representation
 func (s ReorderReceiptRuleSetInput) GoString() string {
 	return s.String()
+}
+
+// Validate inspects the fields of the type to determine if they are valid.
+func (s *ReorderReceiptRuleSetInput) Validate() error {
+	invalidParams := request.ErrInvalidParams{Context: "ReorderReceiptRuleSetInput"}
+	if s.RuleNames == nil {
+		invalidParams.Add(request.NewErrParamRequired("RuleNames"))
+	}
+	if s.RuleSetName == nil {
+		invalidParams.Add(request.NewErrParamRequired("RuleSetName"))
+	}
+
+	if invalidParams.Len() > 0 {
+		return invalidParams
+	}
+	return nil
 }
 
 type ReorderReceiptRuleSetOutput struct {
@@ -3208,6 +3823,19 @@ func (s S3Action) GoString() string {
 	return s.String()
 }
 
+// Validate inspects the fields of the type to determine if they are valid.
+func (s *S3Action) Validate() error {
+	invalidParams := request.ErrInvalidParams{Context: "S3Action"}
+	if s.BucketName == nil {
+		invalidParams.Add(request.NewErrParamRequired("BucketName"))
+	}
+
+	if invalidParams.Len() > 0 {
+		return invalidParams
+	}
+	return nil
+}
+
 // When included in a receipt rule, this action publishes a notification to
 // Amazon Simple Notification Service (Amazon SNS). This action includes a complete
 // copy of the email content in the Amazon SNS notifications. Amazon SNS notifications
@@ -3251,6 +3879,19 @@ func (s SNSAction) GoString() string {
 	return s.String()
 }
 
+// Validate inspects the fields of the type to determine if they are valid.
+func (s *SNSAction) Validate() error {
+	invalidParams := request.ErrInvalidParams{Context: "SNSAction"}
+	if s.TopicArn == nil {
+		invalidParams.Add(request.NewErrParamRequired("TopicArn"))
+	}
+
+	if invalidParams.Len() > 0 {
+		return invalidParams
+	}
+	return nil
+}
+
 type SendBounceInput struct {
 	_ struct{} `type:"structure"`
 
@@ -3290,6 +3931,40 @@ func (s SendBounceInput) String() string {
 // GoString returns the string representation
 func (s SendBounceInput) GoString() string {
 	return s.String()
+}
+
+// Validate inspects the fields of the type to determine if they are valid.
+func (s *SendBounceInput) Validate() error {
+	invalidParams := request.ErrInvalidParams{Context: "SendBounceInput"}
+	if s.BounceSender == nil {
+		invalidParams.Add(request.NewErrParamRequired("BounceSender"))
+	}
+	if s.BouncedRecipientInfoList == nil {
+		invalidParams.Add(request.NewErrParamRequired("BouncedRecipientInfoList"))
+	}
+	if s.OriginalMessageId == nil {
+		invalidParams.Add(request.NewErrParamRequired("OriginalMessageId"))
+	}
+	if s.BouncedRecipientInfoList != nil {
+		for i, v := range s.BouncedRecipientInfoList {
+			if v == nil {
+				continue
+			}
+			if err := v.Validate(); err != nil {
+				invalidParams.AddNested(fmt.Sprintf("%s[%v]", "BouncedRecipientInfoList", i), err.(request.ErrInvalidParams))
+			}
+		}
+	}
+	if s.MessageDsn != nil {
+		if err := s.MessageDsn.Validate(); err != nil {
+			invalidParams.AddNested("MessageDsn", err.(request.ErrInvalidParams))
+		}
+	}
+
+	if invalidParams.Len() > 0 {
+		return invalidParams
+	}
+	return nil
 }
 
 type SendBounceOutput struct {
@@ -3416,6 +4091,30 @@ func (s SendEmailInput) GoString() string {
 	return s.String()
 }
 
+// Validate inspects the fields of the type to determine if they are valid.
+func (s *SendEmailInput) Validate() error {
+	invalidParams := request.ErrInvalidParams{Context: "SendEmailInput"}
+	if s.Destination == nil {
+		invalidParams.Add(request.NewErrParamRequired("Destination"))
+	}
+	if s.Message == nil {
+		invalidParams.Add(request.NewErrParamRequired("Message"))
+	}
+	if s.Source == nil {
+		invalidParams.Add(request.NewErrParamRequired("Source"))
+	}
+	if s.Message != nil {
+		if err := s.Message.Validate(); err != nil {
+			invalidParams.AddNested("Message", err.(request.ErrInvalidParams))
+		}
+	}
+
+	if invalidParams.Len() > 0 {
+		return invalidParams
+	}
+	return nil
+}
+
 type SendEmailOutput struct {
 	_ struct{} `type:"structure"`
 
@@ -3524,6 +4223,24 @@ func (s SendRawEmailInput) GoString() string {
 	return s.String()
 }
 
+// Validate inspects the fields of the type to determine if they are valid.
+func (s *SendRawEmailInput) Validate() error {
+	invalidParams := request.ErrInvalidParams{Context: "SendRawEmailInput"}
+	if s.RawMessage == nil {
+		invalidParams.Add(request.NewErrParamRequired("RawMessage"))
+	}
+	if s.RawMessage != nil {
+		if err := s.RawMessage.Validate(); err != nil {
+			invalidParams.AddNested("RawMessage", err.(request.ErrInvalidParams))
+		}
+	}
+
+	if invalidParams.Len() > 0 {
+		return invalidParams
+	}
+	return nil
+}
+
 type SendRawEmailOutput struct {
 	_ struct{} `type:"structure"`
 
@@ -3594,6 +4311,22 @@ func (s SetIdentityDkimEnabledInput) GoString() string {
 	return s.String()
 }
 
+// Validate inspects the fields of the type to determine if they are valid.
+func (s *SetIdentityDkimEnabledInput) Validate() error {
+	invalidParams := request.ErrInvalidParams{Context: "SetIdentityDkimEnabledInput"}
+	if s.DkimEnabled == nil {
+		invalidParams.Add(request.NewErrParamRequired("DkimEnabled"))
+	}
+	if s.Identity == nil {
+		invalidParams.Add(request.NewErrParamRequired("Identity"))
+	}
+
+	if invalidParams.Len() > 0 {
+		return invalidParams
+	}
+	return nil
+}
+
 type SetIdentityDkimEnabledOutput struct {
 	_ struct{} `type:"structure"`
 }
@@ -3632,6 +4365,22 @@ func (s SetIdentityFeedbackForwardingEnabledInput) String() string {
 // GoString returns the string representation
 func (s SetIdentityFeedbackForwardingEnabledInput) GoString() string {
 	return s.String()
+}
+
+// Validate inspects the fields of the type to determine if they are valid.
+func (s *SetIdentityFeedbackForwardingEnabledInput) Validate() error {
+	invalidParams := request.ErrInvalidParams{Context: "SetIdentityFeedbackForwardingEnabledInput"}
+	if s.ForwardingEnabled == nil {
+		invalidParams.Add(request.NewErrParamRequired("ForwardingEnabled"))
+	}
+	if s.Identity == nil {
+		invalidParams.Add(request.NewErrParamRequired("Identity"))
+	}
+
+	if invalidParams.Len() > 0 {
+		return invalidParams
+	}
+	return nil
 }
 
 type SetIdentityFeedbackForwardingEnabledOutput struct {
@@ -3685,6 +4434,19 @@ func (s SetIdentityMailFromDomainInput) GoString() string {
 	return s.String()
 }
 
+// Validate inspects the fields of the type to determine if they are valid.
+func (s *SetIdentityMailFromDomainInput) Validate() error {
+	invalidParams := request.ErrInvalidParams{Context: "SetIdentityMailFromDomainInput"}
+	if s.Identity == nil {
+		invalidParams.Add(request.NewErrParamRequired("Identity"))
+	}
+
+	if invalidParams.Len() > 0 {
+		return invalidParams
+	}
+	return nil
+}
+
 type SetIdentityMailFromDomainOutput struct {
 	_ struct{} `type:"structure"`
 }
@@ -3727,6 +4489,22 @@ func (s SetIdentityNotificationTopicInput) GoString() string {
 	return s.String()
 }
 
+// Validate inspects the fields of the type to determine if they are valid.
+func (s *SetIdentityNotificationTopicInput) Validate() error {
+	invalidParams := request.ErrInvalidParams{Context: "SetIdentityNotificationTopicInput"}
+	if s.Identity == nil {
+		invalidParams.Add(request.NewErrParamRequired("Identity"))
+	}
+	if s.NotificationType == nil {
+		invalidParams.Add(request.NewErrParamRequired("NotificationType"))
+	}
+
+	if invalidParams.Len() > 0 {
+		return invalidParams
+	}
+	return nil
+}
+
 type SetIdentityNotificationTopicOutput struct {
 	_ struct{} `type:"structure"`
 }
@@ -3762,6 +4540,22 @@ func (s SetReceiptRulePositionInput) String() string {
 // GoString returns the string representation
 func (s SetReceiptRulePositionInput) GoString() string {
 	return s.String()
+}
+
+// Validate inspects the fields of the type to determine if they are valid.
+func (s *SetReceiptRulePositionInput) Validate() error {
+	invalidParams := request.ErrInvalidParams{Context: "SetReceiptRulePositionInput"}
+	if s.RuleName == nil {
+		invalidParams.Add(request.NewErrParamRequired("RuleName"))
+	}
+	if s.RuleSetName == nil {
+		invalidParams.Add(request.NewErrParamRequired("RuleSetName"))
+	}
+
+	if invalidParams.Len() > 0 {
+		return invalidParams
+	}
+	return nil
 }
 
 type SetReceiptRulePositionOutput struct {
@@ -3807,6 +4601,19 @@ func (s StopAction) GoString() string {
 	return s.String()
 }
 
+// Validate inspects the fields of the type to determine if they are valid.
+func (s *StopAction) Validate() error {
+	invalidParams := request.ErrInvalidParams{Context: "StopAction"}
+	if s.Scope == nil {
+		invalidParams.Add(request.NewErrParamRequired("Scope"))
+	}
+
+	if invalidParams.Len() > 0 {
+		return invalidParams
+	}
+	return nil
+}
+
 type UpdateReceiptRuleInput struct {
 	_ struct{} `type:"structure"`
 
@@ -3825,6 +4632,27 @@ func (s UpdateReceiptRuleInput) String() string {
 // GoString returns the string representation
 func (s UpdateReceiptRuleInput) GoString() string {
 	return s.String()
+}
+
+// Validate inspects the fields of the type to determine if they are valid.
+func (s *UpdateReceiptRuleInput) Validate() error {
+	invalidParams := request.ErrInvalidParams{Context: "UpdateReceiptRuleInput"}
+	if s.Rule == nil {
+		invalidParams.Add(request.NewErrParamRequired("Rule"))
+	}
+	if s.RuleSetName == nil {
+		invalidParams.Add(request.NewErrParamRequired("RuleSetName"))
+	}
+	if s.Rule != nil {
+		if err := s.Rule.Validate(); err != nil {
+			invalidParams.AddNested("Rule", err.(request.ErrInvalidParams))
+		}
+	}
+
+	if invalidParams.Len() > 0 {
+		return invalidParams
+	}
+	return nil
 }
 
 type UpdateReceiptRuleOutput struct {
@@ -3856,6 +4684,19 @@ func (s VerifyDomainDkimInput) String() string {
 // GoString returns the string representation
 func (s VerifyDomainDkimInput) GoString() string {
 	return s.String()
+}
+
+// Validate inspects the fields of the type to determine if they are valid.
+func (s *VerifyDomainDkimInput) Validate() error {
+	invalidParams := request.ErrInvalidParams{Context: "VerifyDomainDkimInput"}
+	if s.Domain == nil {
+		invalidParams.Add(request.NewErrParamRequired("Domain"))
+	}
+
+	if invalidParams.Len() > 0 {
+		return invalidParams
+	}
+	return nil
 }
 
 type VerifyDomainDkimOutput struct {
@@ -3902,6 +4743,19 @@ func (s VerifyDomainIdentityInput) GoString() string {
 	return s.String()
 }
 
+// Validate inspects the fields of the type to determine if they are valid.
+func (s *VerifyDomainIdentityInput) Validate() error {
+	invalidParams := request.ErrInvalidParams{Context: "VerifyDomainIdentityInput"}
+	if s.Domain == nil {
+		invalidParams.Add(request.NewErrParamRequired("Domain"))
+	}
+
+	if invalidParams.Len() > 0 {
+		return invalidParams
+	}
+	return nil
+}
+
 type VerifyDomainIdentityOutput struct {
 	_ struct{} `type:"structure"`
 
@@ -3937,6 +4791,19 @@ func (s VerifyEmailAddressInput) GoString() string {
 	return s.String()
 }
 
+// Validate inspects the fields of the type to determine if they are valid.
+func (s *VerifyEmailAddressInput) Validate() error {
+	invalidParams := request.ErrInvalidParams{Context: "VerifyEmailAddressInput"}
+	if s.EmailAddress == nil {
+		invalidParams.Add(request.NewErrParamRequired("EmailAddress"))
+	}
+
+	if invalidParams.Len() > 0 {
+		return invalidParams
+	}
+	return nil
+}
+
 type VerifyEmailAddressOutput struct {
 	_ struct{} `type:"structure"`
 }
@@ -3966,6 +4833,19 @@ func (s VerifyEmailIdentityInput) String() string {
 // GoString returns the string representation
 func (s VerifyEmailIdentityInput) GoString() string {
 	return s.String()
+}
+
+// Validate inspects the fields of the type to determine if they are valid.
+func (s *VerifyEmailIdentityInput) Validate() error {
+	invalidParams := request.ErrInvalidParams{Context: "VerifyEmailIdentityInput"}
+	if s.EmailAddress == nil {
+		invalidParams.Add(request.NewErrParamRequired("EmailAddress"))
+	}
+
+	if invalidParams.Len() > 0 {
+		return invalidParams
+	}
+	return nil
 }
 
 type VerifyEmailIdentityOutput struct {
@@ -4013,6 +4893,19 @@ func (s WorkmailAction) String() string {
 // GoString returns the string representation
 func (s WorkmailAction) GoString() string {
 	return s.String()
+}
+
+// Validate inspects the fields of the type to determine if they are valid.
+func (s *WorkmailAction) Validate() error {
+	invalidParams := request.ErrInvalidParams{Context: "WorkmailAction"}
+	if s.OrganizationArn == nil {
+		invalidParams.Add(request.NewErrParamRequired("OrganizationArn"))
+	}
+
+	if invalidParams.Len() > 0 {
+		return invalidParams
+	}
+	return nil
 }
 
 const (

--- a/service/simpledb/api.go
+++ b/service/simpledb/api.go
@@ -4,6 +4,8 @@
 package simpledb
 
 import (
+	"fmt"
+
 	"github.com/aws/aws-sdk-go/aws/awsutil"
 	"github.com/aws/aws-sdk-go/aws/request"
 	"github.com/aws/aws-sdk-go/private/protocol"
@@ -507,6 +509,32 @@ func (s BatchDeleteAttributesInput) GoString() string {
 	return s.String()
 }
 
+// Validate inspects the fields of the type to determine if they are valid.
+func (s *BatchDeleteAttributesInput) Validate() error {
+	invalidParams := request.ErrInvalidParams{Context: "BatchDeleteAttributesInput"}
+	if s.DomainName == nil {
+		invalidParams.Add(request.NewErrParamRequired("DomainName"))
+	}
+	if s.Items == nil {
+		invalidParams.Add(request.NewErrParamRequired("Items"))
+	}
+	if s.Items != nil {
+		for i, v := range s.Items {
+			if v == nil {
+				continue
+			}
+			if err := v.Validate(); err != nil {
+				invalidParams.AddNested(fmt.Sprintf("%s[%v]", "Items", i), err.(request.ErrInvalidParams))
+			}
+		}
+	}
+
+	if invalidParams.Len() > 0 {
+		return invalidParams
+	}
+	return nil
+}
+
 type BatchDeleteAttributesOutput struct {
 	_ struct{} `type:"structure"`
 }
@@ -541,6 +569,32 @@ func (s BatchPutAttributesInput) GoString() string {
 	return s.String()
 }
 
+// Validate inspects the fields of the type to determine if they are valid.
+func (s *BatchPutAttributesInput) Validate() error {
+	invalidParams := request.ErrInvalidParams{Context: "BatchPutAttributesInput"}
+	if s.DomainName == nil {
+		invalidParams.Add(request.NewErrParamRequired("DomainName"))
+	}
+	if s.Items == nil {
+		invalidParams.Add(request.NewErrParamRequired("Items"))
+	}
+	if s.Items != nil {
+		for i, v := range s.Items {
+			if v == nil {
+				continue
+			}
+			if err := v.Validate(); err != nil {
+				invalidParams.AddNested(fmt.Sprintf("%s[%v]", "Items", i), err.(request.ErrInvalidParams))
+			}
+		}
+	}
+
+	if invalidParams.Len() > 0 {
+		return invalidParams
+	}
+	return nil
+}
+
 type BatchPutAttributesOutput struct {
 	_ struct{} `type:"structure"`
 }
@@ -571,6 +625,19 @@ func (s CreateDomainInput) String() string {
 // GoString returns the string representation
 func (s CreateDomainInput) GoString() string {
 	return s.String()
+}
+
+// Validate inspects the fields of the type to determine if they are valid.
+func (s *CreateDomainInput) Validate() error {
+	invalidParams := request.ErrInvalidParams{Context: "CreateDomainInput"}
+	if s.DomainName == nil {
+		invalidParams.Add(request.NewErrParamRequired("DomainName"))
+	}
+
+	if invalidParams.Len() > 0 {
+		return invalidParams
+	}
+	return nil
 }
 
 type CreateDomainOutput struct {
@@ -607,6 +674,19 @@ func (s DeletableAttribute) GoString() string {
 	return s.String()
 }
 
+// Validate inspects the fields of the type to determine if they are valid.
+func (s *DeletableAttribute) Validate() error {
+	invalidParams := request.ErrInvalidParams{Context: "DeletableAttribute"}
+	if s.Name == nil {
+		invalidParams.Add(request.NewErrParamRequired("Name"))
+	}
+
+	if invalidParams.Len() > 0 {
+		return invalidParams
+	}
+	return nil
+}
+
 type DeletableItem struct {
 	_ struct{} `type:"structure"`
 
@@ -623,6 +703,29 @@ func (s DeletableItem) String() string {
 // GoString returns the string representation
 func (s DeletableItem) GoString() string {
 	return s.String()
+}
+
+// Validate inspects the fields of the type to determine if they are valid.
+func (s *DeletableItem) Validate() error {
+	invalidParams := request.ErrInvalidParams{Context: "DeletableItem"}
+	if s.Name == nil {
+		invalidParams.Add(request.NewErrParamRequired("Name"))
+	}
+	if s.Attributes != nil {
+		for i, v := range s.Attributes {
+			if v == nil {
+				continue
+			}
+			if err := v.Validate(); err != nil {
+				invalidParams.AddNested(fmt.Sprintf("%s[%v]", "Attributes", i), err.(request.ErrInvalidParams))
+			}
+		}
+	}
+
+	if invalidParams.Len() > 0 {
+		return invalidParams
+	}
+	return nil
 }
 
 type DeleteAttributesInput struct {
@@ -653,6 +756,32 @@ func (s DeleteAttributesInput) String() string {
 // GoString returns the string representation
 func (s DeleteAttributesInput) GoString() string {
 	return s.String()
+}
+
+// Validate inspects the fields of the type to determine if they are valid.
+func (s *DeleteAttributesInput) Validate() error {
+	invalidParams := request.ErrInvalidParams{Context: "DeleteAttributesInput"}
+	if s.DomainName == nil {
+		invalidParams.Add(request.NewErrParamRequired("DomainName"))
+	}
+	if s.ItemName == nil {
+		invalidParams.Add(request.NewErrParamRequired("ItemName"))
+	}
+	if s.Attributes != nil {
+		for i, v := range s.Attributes {
+			if v == nil {
+				continue
+			}
+			if err := v.Validate(); err != nil {
+				invalidParams.AddNested(fmt.Sprintf("%s[%v]", "Attributes", i), err.(request.ErrInvalidParams))
+			}
+		}
+	}
+
+	if invalidParams.Len() > 0 {
+		return invalidParams
+	}
+	return nil
 }
 
 type DeleteAttributesOutput struct {
@@ -686,6 +815,19 @@ func (s DeleteDomainInput) GoString() string {
 	return s.String()
 }
 
+// Validate inspects the fields of the type to determine if they are valid.
+func (s *DeleteDomainInput) Validate() error {
+	invalidParams := request.ErrInvalidParams{Context: "DeleteDomainInput"}
+	if s.DomainName == nil {
+		invalidParams.Add(request.NewErrParamRequired("DomainName"))
+	}
+
+	if invalidParams.Len() > 0 {
+		return invalidParams
+	}
+	return nil
+}
+
 type DeleteDomainOutput struct {
 	_ struct{} `type:"structure"`
 }
@@ -715,6 +857,19 @@ func (s DomainMetadataInput) String() string {
 // GoString returns the string representation
 func (s DomainMetadataInput) GoString() string {
 	return s.String()
+}
+
+// Validate inspects the fields of the type to determine if they are valid.
+func (s *DomainMetadataInput) Validate() error {
+	invalidParams := request.ErrInvalidParams{Context: "DomainMetadataInput"}
+	if s.DomainName == nil {
+		invalidParams.Add(request.NewErrParamRequired("DomainName"))
+	}
+
+	if invalidParams.Len() > 0 {
+		return invalidParams
+	}
+	return nil
 }
 
 type DomainMetadataOutput struct {
@@ -779,6 +934,22 @@ func (s GetAttributesInput) String() string {
 // GoString returns the string representation
 func (s GetAttributesInput) GoString() string {
 	return s.String()
+}
+
+// Validate inspects the fields of the type to determine if they are valid.
+func (s *GetAttributesInput) Validate() error {
+	invalidParams := request.ErrInvalidParams{Context: "GetAttributesInput"}
+	if s.DomainName == nil {
+		invalidParams.Add(request.NewErrParamRequired("DomainName"))
+	}
+	if s.ItemName == nil {
+		invalidParams.Add(request.NewErrParamRequired("ItemName"))
+	}
+
+	if invalidParams.Len() > 0 {
+		return invalidParams
+	}
+	return nil
 }
 
 type GetAttributesOutput struct {
@@ -891,6 +1062,35 @@ func (s PutAttributesInput) GoString() string {
 	return s.String()
 }
 
+// Validate inspects the fields of the type to determine if they are valid.
+func (s *PutAttributesInput) Validate() error {
+	invalidParams := request.ErrInvalidParams{Context: "PutAttributesInput"}
+	if s.Attributes == nil {
+		invalidParams.Add(request.NewErrParamRequired("Attributes"))
+	}
+	if s.DomainName == nil {
+		invalidParams.Add(request.NewErrParamRequired("DomainName"))
+	}
+	if s.ItemName == nil {
+		invalidParams.Add(request.NewErrParamRequired("ItemName"))
+	}
+	if s.Attributes != nil {
+		for i, v := range s.Attributes {
+			if v == nil {
+				continue
+			}
+			if err := v.Validate(); err != nil {
+				invalidParams.AddNested(fmt.Sprintf("%s[%v]", "Attributes", i), err.(request.ErrInvalidParams))
+			}
+		}
+	}
+
+	if invalidParams.Len() > 0 {
+		return invalidParams
+	}
+	return nil
+}
+
 type PutAttributesOutput struct {
 	_ struct{} `type:"structure"`
 }
@@ -929,6 +1129,22 @@ func (s ReplaceableAttribute) GoString() string {
 	return s.String()
 }
 
+// Validate inspects the fields of the type to determine if they are valid.
+func (s *ReplaceableAttribute) Validate() error {
+	invalidParams := request.ErrInvalidParams{Context: "ReplaceableAttribute"}
+	if s.Name == nil {
+		invalidParams.Add(request.NewErrParamRequired("Name"))
+	}
+	if s.Value == nil {
+		invalidParams.Add(request.NewErrParamRequired("Value"))
+	}
+
+	if invalidParams.Len() > 0 {
+		return invalidParams
+	}
+	return nil
+}
+
 type ReplaceableItem struct {
 	_ struct{} `type:"structure"`
 
@@ -947,6 +1163,32 @@ func (s ReplaceableItem) String() string {
 // GoString returns the string representation
 func (s ReplaceableItem) GoString() string {
 	return s.String()
+}
+
+// Validate inspects the fields of the type to determine if they are valid.
+func (s *ReplaceableItem) Validate() error {
+	invalidParams := request.ErrInvalidParams{Context: "ReplaceableItem"}
+	if s.Attributes == nil {
+		invalidParams.Add(request.NewErrParamRequired("Attributes"))
+	}
+	if s.Name == nil {
+		invalidParams.Add(request.NewErrParamRequired("Name"))
+	}
+	if s.Attributes != nil {
+		for i, v := range s.Attributes {
+			if v == nil {
+				continue
+			}
+			if err := v.Validate(); err != nil {
+				invalidParams.AddNested(fmt.Sprintf("%s[%v]", "Attributes", i), err.(request.ErrInvalidParams))
+			}
+		}
+	}
+
+	if invalidParams.Len() > 0 {
+		return invalidParams
+	}
+	return nil
 }
 
 type SelectInput struct {
@@ -973,6 +1215,19 @@ func (s SelectInput) String() string {
 // GoString returns the string representation
 func (s SelectInput) GoString() string {
 	return s.String()
+}
+
+// Validate inspects the fields of the type to determine if they are valid.
+func (s *SelectInput) Validate() error {
+	invalidParams := request.ErrInvalidParams{Context: "SelectInput"}
+	if s.SelectExpression == nil {
+		invalidParams.Add(request.NewErrParamRequired("SelectExpression"))
+	}
+
+	if invalidParams.Len() > 0 {
+		return invalidParams
+	}
+	return nil
 }
 
 type SelectOutput struct {

--- a/service/sns/api.go
+++ b/service/sns/api.go
@@ -4,6 +4,8 @@
 package sns
 
 import (
+	"fmt"
+
 	"github.com/aws/aws-sdk-go/aws/awsutil"
 	"github.com/aws/aws-sdk-go/aws/request"
 	"github.com/aws/aws-sdk-go/private/protocol"
@@ -893,6 +895,28 @@ func (s AddPermissionInput) GoString() string {
 	return s.String()
 }
 
+// Validate inspects the fields of the type to determine if they are valid.
+func (s *AddPermissionInput) Validate() error {
+	invalidParams := request.ErrInvalidParams{Context: "AddPermissionInput"}
+	if s.AWSAccountId == nil {
+		invalidParams.Add(request.NewErrParamRequired("AWSAccountId"))
+	}
+	if s.ActionName == nil {
+		invalidParams.Add(request.NewErrParamRequired("ActionName"))
+	}
+	if s.Label == nil {
+		invalidParams.Add(request.NewErrParamRequired("Label"))
+	}
+	if s.TopicArn == nil {
+		invalidParams.Add(request.NewErrParamRequired("TopicArn"))
+	}
+
+	if invalidParams.Len() > 0 {
+		return invalidParams
+	}
+	return nil
+}
+
 type AddPermissionOutput struct {
 	_ struct{} `type:"structure"`
 }
@@ -932,6 +956,22 @@ func (s ConfirmSubscriptionInput) String() string {
 // GoString returns the string representation
 func (s ConfirmSubscriptionInput) GoString() string {
 	return s.String()
+}
+
+// Validate inspects the fields of the type to determine if they are valid.
+func (s *ConfirmSubscriptionInput) Validate() error {
+	invalidParams := request.ErrInvalidParams{Context: "ConfirmSubscriptionInput"}
+	if s.Token == nil {
+		invalidParams.Add(request.NewErrParamRequired("Token"))
+	}
+	if s.TopicArn == nil {
+		invalidParams.Add(request.NewErrParamRequired("TopicArn"))
+	}
+
+	if invalidParams.Len() > 0 {
+		return invalidParams
+	}
+	return nil
 }
 
 // Response for ConfirmSubscriptions action.
@@ -977,6 +1017,25 @@ func (s CreatePlatformApplicationInput) String() string {
 // GoString returns the string representation
 func (s CreatePlatformApplicationInput) GoString() string {
 	return s.String()
+}
+
+// Validate inspects the fields of the type to determine if they are valid.
+func (s *CreatePlatformApplicationInput) Validate() error {
+	invalidParams := request.ErrInvalidParams{Context: "CreatePlatformApplicationInput"}
+	if s.Attributes == nil {
+		invalidParams.Add(request.NewErrParamRequired("Attributes"))
+	}
+	if s.Name == nil {
+		invalidParams.Add(request.NewErrParamRequired("Name"))
+	}
+	if s.Platform == nil {
+		invalidParams.Add(request.NewErrParamRequired("Platform"))
+	}
+
+	if invalidParams.Len() > 0 {
+		return invalidParams
+	}
+	return nil
 }
 
 // Response from CreatePlatformApplication action.
@@ -1030,6 +1089,22 @@ func (s CreatePlatformEndpointInput) GoString() string {
 	return s.String()
 }
 
+// Validate inspects the fields of the type to determine if they are valid.
+func (s *CreatePlatformEndpointInput) Validate() error {
+	invalidParams := request.ErrInvalidParams{Context: "CreatePlatformEndpointInput"}
+	if s.PlatformApplicationArn == nil {
+		invalidParams.Add(request.NewErrParamRequired("PlatformApplicationArn"))
+	}
+	if s.Token == nil {
+		invalidParams.Add(request.NewErrParamRequired("Token"))
+	}
+
+	if invalidParams.Len() > 0 {
+		return invalidParams
+	}
+	return nil
+}
+
 // Response from CreateEndpoint action.
 type CreatePlatformEndpointOutput struct {
 	_ struct{} `type:"structure"`
@@ -1070,6 +1145,19 @@ func (s CreateTopicInput) GoString() string {
 	return s.String()
 }
 
+// Validate inspects the fields of the type to determine if they are valid.
+func (s *CreateTopicInput) Validate() error {
+	invalidParams := request.ErrInvalidParams{Context: "CreateTopicInput"}
+	if s.Name == nil {
+		invalidParams.Add(request.NewErrParamRequired("Name"))
+	}
+
+	if invalidParams.Len() > 0 {
+		return invalidParams
+	}
+	return nil
+}
+
 // Response from CreateTopic action.
 type CreateTopicOutput struct {
 	_ struct{} `type:"structure"`
@@ -1106,6 +1194,19 @@ func (s DeleteEndpointInput) GoString() string {
 	return s.String()
 }
 
+// Validate inspects the fields of the type to determine if they are valid.
+func (s *DeleteEndpointInput) Validate() error {
+	invalidParams := request.ErrInvalidParams{Context: "DeleteEndpointInput"}
+	if s.EndpointArn == nil {
+		invalidParams.Add(request.NewErrParamRequired("EndpointArn"))
+	}
+
+	if invalidParams.Len() > 0 {
+		return invalidParams
+	}
+	return nil
+}
+
 type DeleteEndpointOutput struct {
 	_ struct{} `type:"structure"`
 }
@@ -1138,6 +1239,19 @@ func (s DeletePlatformApplicationInput) GoString() string {
 	return s.String()
 }
 
+// Validate inspects the fields of the type to determine if they are valid.
+func (s *DeletePlatformApplicationInput) Validate() error {
+	invalidParams := request.ErrInvalidParams{Context: "DeletePlatformApplicationInput"}
+	if s.PlatformApplicationArn == nil {
+		invalidParams.Add(request.NewErrParamRequired("PlatformApplicationArn"))
+	}
+
+	if invalidParams.Len() > 0 {
+		return invalidParams
+	}
+	return nil
+}
+
 type DeletePlatformApplicationOutput struct {
 	_ struct{} `type:"structure"`
 }
@@ -1167,6 +1281,19 @@ func (s DeleteTopicInput) String() string {
 // GoString returns the string representation
 func (s DeleteTopicInput) GoString() string {
 	return s.String()
+}
+
+// Validate inspects the fields of the type to determine if they are valid.
+func (s *DeleteTopicInput) Validate() error {
+	invalidParams := request.ErrInvalidParams{Context: "DeleteTopicInput"}
+	if s.TopicArn == nil {
+		invalidParams.Add(request.NewErrParamRequired("TopicArn"))
+	}
+
+	if invalidParams.Len() > 0 {
+		return invalidParams
+	}
+	return nil
 }
 
 type DeleteTopicOutput struct {
@@ -1222,6 +1349,19 @@ func (s GetEndpointAttributesInput) GoString() string {
 	return s.String()
 }
 
+// Validate inspects the fields of the type to determine if they are valid.
+func (s *GetEndpointAttributesInput) Validate() error {
+	invalidParams := request.ErrInvalidParams{Context: "GetEndpointAttributesInput"}
+	if s.EndpointArn == nil {
+		invalidParams.Add(request.NewErrParamRequired("EndpointArn"))
+	}
+
+	if invalidParams.Len() > 0 {
+		return invalidParams
+	}
+	return nil
+}
+
 // Response from GetEndpointAttributes of the EndpointArn.
 type GetEndpointAttributesOutput struct {
 	_ struct{} `type:"structure"`
@@ -1268,6 +1408,19 @@ func (s GetPlatformApplicationAttributesInput) GoString() string {
 	return s.String()
 }
 
+// Validate inspects the fields of the type to determine if they are valid.
+func (s *GetPlatformApplicationAttributesInput) Validate() error {
+	invalidParams := request.ErrInvalidParams{Context: "GetPlatformApplicationAttributesInput"}
+	if s.PlatformApplicationArn == nil {
+		invalidParams.Add(request.NewErrParamRequired("PlatformApplicationArn"))
+	}
+
+	if invalidParams.Len() > 0 {
+		return invalidParams
+	}
+	return nil
+}
+
 // Response for GetPlatformApplicationAttributes action.
 type GetPlatformApplicationAttributesOutput struct {
 	_ struct{} `type:"structure"`
@@ -1310,6 +1463,19 @@ func (s GetSubscriptionAttributesInput) String() string {
 // GoString returns the string representation
 func (s GetSubscriptionAttributesInput) GoString() string {
 	return s.String()
+}
+
+// Validate inspects the fields of the type to determine if they are valid.
+func (s *GetSubscriptionAttributesInput) Validate() error {
+	invalidParams := request.ErrInvalidParams{Context: "GetSubscriptionAttributesInput"}
+	if s.SubscriptionArn == nil {
+		invalidParams.Add(request.NewErrParamRequired("SubscriptionArn"))
+	}
+
+	if invalidParams.Len() > 0 {
+		return invalidParams
+	}
+	return nil
 }
 
 // Response for GetSubscriptionAttributes action.
@@ -1355,6 +1521,19 @@ func (s GetTopicAttributesInput) String() string {
 // GoString returns the string representation
 func (s GetTopicAttributesInput) GoString() string {
 	return s.String()
+}
+
+// Validate inspects the fields of the type to determine if they are valid.
+func (s *GetTopicAttributesInput) Validate() error {
+	invalidParams := request.ErrInvalidParams{Context: "GetTopicAttributesInput"}
+	if s.TopicArn == nil {
+		invalidParams.Add(request.NewErrParamRequired("TopicArn"))
+	}
+
+	if invalidParams.Len() > 0 {
+		return invalidParams
+	}
+	return nil
 }
 
 // Response for GetTopicAttributes action.
@@ -1407,6 +1586,19 @@ func (s ListEndpointsByPlatformApplicationInput) String() string {
 // GoString returns the string representation
 func (s ListEndpointsByPlatformApplicationInput) GoString() string {
 	return s.String()
+}
+
+// Validate inspects the fields of the type to determine if they are valid.
+func (s *ListEndpointsByPlatformApplicationInput) Validate() error {
+	invalidParams := request.ErrInvalidParams{Context: "ListEndpointsByPlatformApplicationInput"}
+	if s.PlatformApplicationArn == nil {
+		invalidParams.Add(request.NewErrParamRequired("PlatformApplicationArn"))
+	}
+
+	if invalidParams.Len() > 0 {
+		return invalidParams
+	}
+	return nil
 }
 
 // Response for ListEndpointsByPlatformApplication action.
@@ -1491,6 +1683,19 @@ func (s ListSubscriptionsByTopicInput) String() string {
 // GoString returns the string representation
 func (s ListSubscriptionsByTopicInput) GoString() string {
 	return s.String()
+}
+
+// Validate inspects the fields of the type to determine if they are valid.
+func (s *ListSubscriptionsByTopicInput) Validate() error {
+	invalidParams := request.ErrInvalidParams{Context: "ListSubscriptionsByTopicInput"}
+	if s.TopicArn == nil {
+		invalidParams.Add(request.NewErrParamRequired("TopicArn"))
+	}
+
+	if invalidParams.Len() > 0 {
+		return invalidParams
+	}
+	return nil
 }
 
 // Response for ListSubscriptionsByTopic action.
@@ -1631,6 +1836,19 @@ func (s MessageAttributeValue) GoString() string {
 	return s.String()
 }
 
+// Validate inspects the fields of the type to determine if they are valid.
+func (s *MessageAttributeValue) Validate() error {
+	invalidParams := request.ErrInvalidParams{Context: "MessageAttributeValue"}
+	if s.DataType == nil {
+		invalidParams.Add(request.NewErrParamRequired("DataType"))
+	}
+
+	if invalidParams.Len() > 0 {
+		return invalidParams
+	}
+	return nil
+}
+
 // Platform application object.
 type PlatformApplication struct {
 	_ struct{} `type:"structure"`
@@ -1729,6 +1947,29 @@ func (s PublishInput) GoString() string {
 	return s.String()
 }
 
+// Validate inspects the fields of the type to determine if they are valid.
+func (s *PublishInput) Validate() error {
+	invalidParams := request.ErrInvalidParams{Context: "PublishInput"}
+	if s.Message == nil {
+		invalidParams.Add(request.NewErrParamRequired("Message"))
+	}
+	if s.MessageAttributes != nil {
+		for i, v := range s.MessageAttributes {
+			if v == nil {
+				continue
+			}
+			if err := v.Validate(); err != nil {
+				invalidParams.AddNested(fmt.Sprintf("%s[%v]", "MessageAttributes", i), err.(request.ErrInvalidParams))
+			}
+		}
+	}
+
+	if invalidParams.Len() > 0 {
+		return invalidParams
+	}
+	return nil
+}
+
 // Response for Publish action.
 type PublishOutput struct {
 	_ struct{} `type:"structure"`
@@ -1768,6 +2009,22 @@ func (s RemovePermissionInput) String() string {
 // GoString returns the string representation
 func (s RemovePermissionInput) GoString() string {
 	return s.String()
+}
+
+// Validate inspects the fields of the type to determine if they are valid.
+func (s *RemovePermissionInput) Validate() error {
+	invalidParams := request.ErrInvalidParams{Context: "RemovePermissionInput"}
+	if s.Label == nil {
+		invalidParams.Add(request.NewErrParamRequired("Label"))
+	}
+	if s.TopicArn == nil {
+		invalidParams.Add(request.NewErrParamRequired("TopicArn"))
+	}
+
+	if invalidParams.Len() > 0 {
+		return invalidParams
+	}
+	return nil
 }
 
 type RemovePermissionOutput struct {
@@ -1813,6 +2070,22 @@ func (s SetEndpointAttributesInput) String() string {
 // GoString returns the string representation
 func (s SetEndpointAttributesInput) GoString() string {
 	return s.String()
+}
+
+// Validate inspects the fields of the type to determine if they are valid.
+func (s *SetEndpointAttributesInput) Validate() error {
+	invalidParams := request.ErrInvalidParams{Context: "SetEndpointAttributesInput"}
+	if s.Attributes == nil {
+		invalidParams.Add(request.NewErrParamRequired("Attributes"))
+	}
+	if s.EndpointArn == nil {
+		invalidParams.Add(request.NewErrParamRequired("EndpointArn"))
+	}
+
+	if invalidParams.Len() > 0 {
+		return invalidParams
+	}
+	return nil
 }
 
 type SetEndpointAttributesOutput struct {
@@ -1864,6 +2137,22 @@ func (s SetPlatformApplicationAttributesInput) GoString() string {
 	return s.String()
 }
 
+// Validate inspects the fields of the type to determine if they are valid.
+func (s *SetPlatformApplicationAttributesInput) Validate() error {
+	invalidParams := request.ErrInvalidParams{Context: "SetPlatformApplicationAttributesInput"}
+	if s.Attributes == nil {
+		invalidParams.Add(request.NewErrParamRequired("Attributes"))
+	}
+	if s.PlatformApplicationArn == nil {
+		invalidParams.Add(request.NewErrParamRequired("PlatformApplicationArn"))
+	}
+
+	if invalidParams.Len() > 0 {
+		return invalidParams
+	}
+	return nil
+}
+
 type SetPlatformApplicationAttributesOutput struct {
 	_ struct{} `type:"structure"`
 }
@@ -1905,6 +2194,22 @@ func (s SetSubscriptionAttributesInput) GoString() string {
 	return s.String()
 }
 
+// Validate inspects the fields of the type to determine if they are valid.
+func (s *SetSubscriptionAttributesInput) Validate() error {
+	invalidParams := request.ErrInvalidParams{Context: "SetSubscriptionAttributesInput"}
+	if s.AttributeName == nil {
+		invalidParams.Add(request.NewErrParamRequired("AttributeName"))
+	}
+	if s.SubscriptionArn == nil {
+		invalidParams.Add(request.NewErrParamRequired("SubscriptionArn"))
+	}
+
+	if invalidParams.Len() > 0 {
+		return invalidParams
+	}
+	return nil
+}
+
 type SetSubscriptionAttributesOutput struct {
 	_ struct{} `type:"structure"`
 }
@@ -1944,6 +2249,22 @@ func (s SetTopicAttributesInput) String() string {
 // GoString returns the string representation
 func (s SetTopicAttributesInput) GoString() string {
 	return s.String()
+}
+
+// Validate inspects the fields of the type to determine if they are valid.
+func (s *SetTopicAttributesInput) Validate() error {
+	invalidParams := request.ErrInvalidParams{Context: "SetTopicAttributesInput"}
+	if s.AttributeName == nil {
+		invalidParams.Add(request.NewErrParamRequired("AttributeName"))
+	}
+	if s.TopicArn == nil {
+		invalidParams.Add(request.NewErrParamRequired("TopicArn"))
+	}
+
+	if invalidParams.Len() > 0 {
+		return invalidParams
+	}
+	return nil
 }
 
 type SetTopicAttributesOutput struct {
@@ -1997,6 +2318,22 @@ func (s SubscribeInput) String() string {
 // GoString returns the string representation
 func (s SubscribeInput) GoString() string {
 	return s.String()
+}
+
+// Validate inspects the fields of the type to determine if they are valid.
+func (s *SubscribeInput) Validate() error {
+	invalidParams := request.ErrInvalidParams{Context: "SubscribeInput"}
+	if s.Protocol == nil {
+		invalidParams.Add(request.NewErrParamRequired("Protocol"))
+	}
+	if s.TopicArn == nil {
+		invalidParams.Add(request.NewErrParamRequired("TopicArn"))
+	}
+
+	if invalidParams.Len() > 0 {
+		return invalidParams
+	}
+	return nil
 }
 
 // Response for Subscribe action.
@@ -2083,6 +2420,19 @@ func (s UnsubscribeInput) String() string {
 // GoString returns the string representation
 func (s UnsubscribeInput) GoString() string {
 	return s.String()
+}
+
+// Validate inspects the fields of the type to determine if they are valid.
+func (s *UnsubscribeInput) Validate() error {
+	invalidParams := request.ErrInvalidParams{Context: "UnsubscribeInput"}
+	if s.SubscriptionArn == nil {
+		invalidParams.Add(request.NewErrParamRequired("SubscriptionArn"))
+	}
+
+	if invalidParams.Len() > 0 {
+		return invalidParams
+	}
+	return nil
 }
 
 type UnsubscribeOutput struct {

--- a/service/sqs/api.go
+++ b/service/sqs/api.go
@@ -4,6 +4,8 @@
 package sqs
 
 import (
+	"fmt"
+
 	"github.com/aws/aws-sdk-go/aws/awsutil"
 	"github.com/aws/aws-sdk-go/aws/request"
 	"github.com/aws/aws-sdk-go/private/protocol"
@@ -781,6 +783,28 @@ func (s AddPermissionInput) GoString() string {
 	return s.String()
 }
 
+// Validate inspects the fields of the type to determine if they are valid.
+func (s *AddPermissionInput) Validate() error {
+	invalidParams := request.ErrInvalidParams{Context: "AddPermissionInput"}
+	if s.AWSAccountIds == nil {
+		invalidParams.Add(request.NewErrParamRequired("AWSAccountIds"))
+	}
+	if s.Actions == nil {
+		invalidParams.Add(request.NewErrParamRequired("Actions"))
+	}
+	if s.Label == nil {
+		invalidParams.Add(request.NewErrParamRequired("Label"))
+	}
+	if s.QueueUrl == nil {
+		invalidParams.Add(request.NewErrParamRequired("QueueUrl"))
+	}
+
+	if invalidParams.Len() > 0 {
+		return invalidParams
+	}
+	return nil
+}
+
 type AddPermissionOutput struct {
 	_ struct{} `type:"structure"`
 }
@@ -844,6 +868,32 @@ func (s ChangeMessageVisibilityBatchInput) GoString() string {
 	return s.String()
 }
 
+// Validate inspects the fields of the type to determine if they are valid.
+func (s *ChangeMessageVisibilityBatchInput) Validate() error {
+	invalidParams := request.ErrInvalidParams{Context: "ChangeMessageVisibilityBatchInput"}
+	if s.Entries == nil {
+		invalidParams.Add(request.NewErrParamRequired("Entries"))
+	}
+	if s.QueueUrl == nil {
+		invalidParams.Add(request.NewErrParamRequired("QueueUrl"))
+	}
+	if s.Entries != nil {
+		for i, v := range s.Entries {
+			if v == nil {
+				continue
+			}
+			if err := v.Validate(); err != nil {
+				invalidParams.AddNested(fmt.Sprintf("%s[%v]", "Entries", i), err.(request.ErrInvalidParams))
+			}
+		}
+	}
+
+	if invalidParams.Len() > 0 {
+		return invalidParams
+	}
+	return nil
+}
+
 // For each message in the batch, the response contains a ChangeMessageVisibilityBatchResultEntry
 // tag if the message succeeds or a BatchResultErrorEntry tag if the message
 // fails.
@@ -902,6 +952,22 @@ func (s ChangeMessageVisibilityBatchRequestEntry) GoString() string {
 	return s.String()
 }
 
+// Validate inspects the fields of the type to determine if they are valid.
+func (s *ChangeMessageVisibilityBatchRequestEntry) Validate() error {
+	invalidParams := request.ErrInvalidParams{Context: "ChangeMessageVisibilityBatchRequestEntry"}
+	if s.Id == nil {
+		invalidParams.Add(request.NewErrParamRequired("Id"))
+	}
+	if s.ReceiptHandle == nil {
+		invalidParams.Add(request.NewErrParamRequired("ReceiptHandle"))
+	}
+
+	if invalidParams.Len() > 0 {
+		return invalidParams
+	}
+	return nil
+}
+
 // Encloses the id of an entry in ChangeMessageVisibilityBatch.
 type ChangeMessageVisibilityBatchResultEntry struct {
 	_ struct{} `type:"structure"`
@@ -943,6 +1009,25 @@ func (s ChangeMessageVisibilityInput) String() string {
 // GoString returns the string representation
 func (s ChangeMessageVisibilityInput) GoString() string {
 	return s.String()
+}
+
+// Validate inspects the fields of the type to determine if they are valid.
+func (s *ChangeMessageVisibilityInput) Validate() error {
+	invalidParams := request.ErrInvalidParams{Context: "ChangeMessageVisibilityInput"}
+	if s.QueueUrl == nil {
+		invalidParams.Add(request.NewErrParamRequired("QueueUrl"))
+	}
+	if s.ReceiptHandle == nil {
+		invalidParams.Add(request.NewErrParamRequired("ReceiptHandle"))
+	}
+	if s.VisibilityTimeout == nil {
+		invalidParams.Add(request.NewErrParamRequired("VisibilityTimeout"))
+	}
+
+	if invalidParams.Len() > 0 {
+		return invalidParams
+	}
+	return nil
 }
 
 type ChangeMessageVisibilityOutput struct {
@@ -1000,6 +1085,19 @@ func (s CreateQueueInput) GoString() string {
 	return s.String()
 }
 
+// Validate inspects the fields of the type to determine if they are valid.
+func (s *CreateQueueInput) Validate() error {
+	invalidParams := request.ErrInvalidParams{Context: "CreateQueueInput"}
+	if s.QueueName == nil {
+		invalidParams.Add(request.NewErrParamRequired("QueueName"))
+	}
+
+	if invalidParams.Len() > 0 {
+		return invalidParams
+	}
+	return nil
+}
+
 // Returns the QueueUrl element of the created queue.
 type CreateQueueOutput struct {
 	_ struct{} `type:"structure"`
@@ -1036,6 +1134,32 @@ func (s DeleteMessageBatchInput) String() string {
 // GoString returns the string representation
 func (s DeleteMessageBatchInput) GoString() string {
 	return s.String()
+}
+
+// Validate inspects the fields of the type to determine if they are valid.
+func (s *DeleteMessageBatchInput) Validate() error {
+	invalidParams := request.ErrInvalidParams{Context: "DeleteMessageBatchInput"}
+	if s.Entries == nil {
+		invalidParams.Add(request.NewErrParamRequired("Entries"))
+	}
+	if s.QueueUrl == nil {
+		invalidParams.Add(request.NewErrParamRequired("QueueUrl"))
+	}
+	if s.Entries != nil {
+		for i, v := range s.Entries {
+			if v == nil {
+				continue
+			}
+			if err := v.Validate(); err != nil {
+				invalidParams.AddNested(fmt.Sprintf("%s[%v]", "Entries", i), err.(request.ErrInvalidParams))
+			}
+		}
+	}
+
+	if invalidParams.Len() > 0 {
+		return invalidParams
+	}
+	return nil
 }
 
 // For each message in the batch, the response contains a DeleteMessageBatchResultEntry
@@ -1084,6 +1208,22 @@ func (s DeleteMessageBatchRequestEntry) GoString() string {
 	return s.String()
 }
 
+// Validate inspects the fields of the type to determine if they are valid.
+func (s *DeleteMessageBatchRequestEntry) Validate() error {
+	invalidParams := request.ErrInvalidParams{Context: "DeleteMessageBatchRequestEntry"}
+	if s.Id == nil {
+		invalidParams.Add(request.NewErrParamRequired("Id"))
+	}
+	if s.ReceiptHandle == nil {
+		invalidParams.Add(request.NewErrParamRequired("ReceiptHandle"))
+	}
+
+	if invalidParams.Len() > 0 {
+		return invalidParams
+	}
+	return nil
+}
+
 // Encloses the id an entry in DeleteMessageBatch.
 type DeleteMessageBatchResultEntry struct {
 	_ struct{} `type:"structure"`
@@ -1122,6 +1262,22 @@ func (s DeleteMessageInput) GoString() string {
 	return s.String()
 }
 
+// Validate inspects the fields of the type to determine if they are valid.
+func (s *DeleteMessageInput) Validate() error {
+	invalidParams := request.ErrInvalidParams{Context: "DeleteMessageInput"}
+	if s.QueueUrl == nil {
+		invalidParams.Add(request.NewErrParamRequired("QueueUrl"))
+	}
+	if s.ReceiptHandle == nil {
+		invalidParams.Add(request.NewErrParamRequired("ReceiptHandle"))
+	}
+
+	if invalidParams.Len() > 0 {
+		return invalidParams
+	}
+	return nil
+}
+
 type DeleteMessageOutput struct {
 	_ struct{} `type:"structure"`
 }
@@ -1151,6 +1307,19 @@ func (s DeleteQueueInput) String() string {
 // GoString returns the string representation
 func (s DeleteQueueInput) GoString() string {
 	return s.String()
+}
+
+// Validate inspects the fields of the type to determine if they are valid.
+func (s *DeleteQueueInput) Validate() error {
+	invalidParams := request.ErrInvalidParams{Context: "DeleteQueueInput"}
+	if s.QueueUrl == nil {
+		invalidParams.Add(request.NewErrParamRequired("QueueUrl"))
+	}
+
+	if invalidParams.Len() > 0 {
+		return invalidParams
+	}
+	return nil
 }
 
 type DeleteQueueOutput struct {
@@ -1185,6 +1354,19 @@ func (s GetQueueAttributesInput) String() string {
 // GoString returns the string representation
 func (s GetQueueAttributesInput) GoString() string {
 	return s.String()
+}
+
+// Validate inspects the fields of the type to determine if they are valid.
+func (s *GetQueueAttributesInput) Validate() error {
+	invalidParams := request.ErrInvalidParams{Context: "GetQueueAttributesInput"}
+	if s.QueueUrl == nil {
+		invalidParams.Add(request.NewErrParamRequired("QueueUrl"))
+	}
+
+	if invalidParams.Len() > 0 {
+		return invalidParams
+	}
+	return nil
 }
 
 // A list of returned queue attributes.
@@ -1226,6 +1408,19 @@ func (s GetQueueUrlInput) GoString() string {
 	return s.String()
 }
 
+// Validate inspects the fields of the type to determine if they are valid.
+func (s *GetQueueUrlInput) Validate() error {
+	invalidParams := request.ErrInvalidParams{Context: "GetQueueUrlInput"}
+	if s.QueueName == nil {
+		invalidParams.Add(request.NewErrParamRequired("QueueName"))
+	}
+
+	if invalidParams.Len() > 0 {
+		return invalidParams
+	}
+	return nil
+}
+
 // For more information, see Responses (http://docs.aws.amazon.com/AWSSimpleQueueService/latest/SQSDeveloperGuide/UnderstandingResponses.html)
 // in the Amazon SQS Developer Guide.
 type GetQueueUrlOutput struct {
@@ -1260,6 +1455,19 @@ func (s ListDeadLetterSourceQueuesInput) String() string {
 // GoString returns the string representation
 func (s ListDeadLetterSourceQueuesInput) GoString() string {
 	return s.String()
+}
+
+// Validate inspects the fields of the type to determine if they are valid.
+func (s *ListDeadLetterSourceQueuesInput) Validate() error {
+	invalidParams := request.ErrInvalidParams{Context: "ListDeadLetterSourceQueuesInput"}
+	if s.QueueUrl == nil {
+		invalidParams.Add(request.NewErrParamRequired("QueueUrl"))
+	}
+
+	if invalidParams.Len() > 0 {
+		return invalidParams
+	}
+	return nil
 }
 
 // A list of your dead letter source queues.
@@ -1406,6 +1614,19 @@ func (s MessageAttributeValue) GoString() string {
 	return s.String()
 }
 
+// Validate inspects the fields of the type to determine if they are valid.
+func (s *MessageAttributeValue) Validate() error {
+	invalidParams := request.ErrInvalidParams{Context: "MessageAttributeValue"}
+	if s.DataType == nil {
+		invalidParams.Add(request.NewErrParamRequired("DataType"))
+	}
+
+	if invalidParams.Len() > 0 {
+		return invalidParams
+	}
+	return nil
+}
+
 type PurgeQueueInput struct {
 	_ struct{} `type:"structure"`
 
@@ -1422,6 +1643,19 @@ func (s PurgeQueueInput) String() string {
 // GoString returns the string representation
 func (s PurgeQueueInput) GoString() string {
 	return s.String()
+}
+
+// Validate inspects the fields of the type to determine if they are valid.
+func (s *PurgeQueueInput) Validate() error {
+	invalidParams := request.ErrInvalidParams{Context: "PurgeQueueInput"}
+	if s.QueueUrl == nil {
+		invalidParams.Add(request.NewErrParamRequired("QueueUrl"))
+	}
+
+	if invalidParams.Len() > 0 {
+		return invalidParams
+	}
+	return nil
 }
 
 type PurgeQueueOutput struct {
@@ -1500,6 +1734,19 @@ func (s ReceiveMessageInput) GoString() string {
 	return s.String()
 }
 
+// Validate inspects the fields of the type to determine if they are valid.
+func (s *ReceiveMessageInput) Validate() error {
+	invalidParams := request.ErrInvalidParams{Context: "ReceiveMessageInput"}
+	if s.QueueUrl == nil {
+		invalidParams.Add(request.NewErrParamRequired("QueueUrl"))
+	}
+
+	if invalidParams.Len() > 0 {
+		return invalidParams
+	}
+	return nil
+}
+
 // A list of received messages.
 type ReceiveMessageOutput struct {
 	_ struct{} `type:"structure"`
@@ -1539,6 +1786,22 @@ func (s RemovePermissionInput) GoString() string {
 	return s.String()
 }
 
+// Validate inspects the fields of the type to determine if they are valid.
+func (s *RemovePermissionInput) Validate() error {
+	invalidParams := request.ErrInvalidParams{Context: "RemovePermissionInput"}
+	if s.Label == nil {
+		invalidParams.Add(request.NewErrParamRequired("Label"))
+	}
+	if s.QueueUrl == nil {
+		invalidParams.Add(request.NewErrParamRequired("QueueUrl"))
+	}
+
+	if invalidParams.Len() > 0 {
+		return invalidParams
+	}
+	return nil
+}
+
 type RemovePermissionOutput struct {
 	_ struct{} `type:"structure"`
 }
@@ -1571,6 +1834,32 @@ func (s SendMessageBatchInput) String() string {
 // GoString returns the string representation
 func (s SendMessageBatchInput) GoString() string {
 	return s.String()
+}
+
+// Validate inspects the fields of the type to determine if they are valid.
+func (s *SendMessageBatchInput) Validate() error {
+	invalidParams := request.ErrInvalidParams{Context: "SendMessageBatchInput"}
+	if s.Entries == nil {
+		invalidParams.Add(request.NewErrParamRequired("Entries"))
+	}
+	if s.QueueUrl == nil {
+		invalidParams.Add(request.NewErrParamRequired("QueueUrl"))
+	}
+	if s.Entries != nil {
+		for i, v := range s.Entries {
+			if v == nil {
+				continue
+			}
+			if err := v.Validate(); err != nil {
+				invalidParams.AddNested(fmt.Sprintf("%s[%v]", "Entries", i), err.(request.ErrInvalidParams))
+			}
+		}
+	}
+
+	if invalidParams.Len() > 0 {
+		return invalidParams
+	}
+	return nil
 }
 
 // For each message in the batch, the response contains a SendMessageBatchResultEntry
@@ -1625,6 +1914,32 @@ func (s SendMessageBatchRequestEntry) String() string {
 // GoString returns the string representation
 func (s SendMessageBatchRequestEntry) GoString() string {
 	return s.String()
+}
+
+// Validate inspects the fields of the type to determine if they are valid.
+func (s *SendMessageBatchRequestEntry) Validate() error {
+	invalidParams := request.ErrInvalidParams{Context: "SendMessageBatchRequestEntry"}
+	if s.Id == nil {
+		invalidParams.Add(request.NewErrParamRequired("Id"))
+	}
+	if s.MessageBody == nil {
+		invalidParams.Add(request.NewErrParamRequired("MessageBody"))
+	}
+	if s.MessageAttributes != nil {
+		for i, v := range s.MessageAttributes {
+			if v == nil {
+				continue
+			}
+			if err := v.Validate(); err != nil {
+				invalidParams.AddNested(fmt.Sprintf("%s[%v]", "MessageAttributes", i), err.(request.ErrInvalidParams))
+			}
+		}
+	}
+
+	if invalidParams.Len() > 0 {
+		return invalidParams
+	}
+	return nil
 }
 
 // Encloses a message ID for successfully enqueued message of a SendMessageBatch.
@@ -1689,6 +2004,32 @@ func (s SendMessageInput) String() string {
 // GoString returns the string representation
 func (s SendMessageInput) GoString() string {
 	return s.String()
+}
+
+// Validate inspects the fields of the type to determine if they are valid.
+func (s *SendMessageInput) Validate() error {
+	invalidParams := request.ErrInvalidParams{Context: "SendMessageInput"}
+	if s.MessageBody == nil {
+		invalidParams.Add(request.NewErrParamRequired("MessageBody"))
+	}
+	if s.QueueUrl == nil {
+		invalidParams.Add(request.NewErrParamRequired("QueueUrl"))
+	}
+	if s.MessageAttributes != nil {
+		for i, v := range s.MessageAttributes {
+			if v == nil {
+				continue
+			}
+			if err := v.Validate(); err != nil {
+				invalidParams.AddNested(fmt.Sprintf("%s[%v]", "MessageAttributes", i), err.(request.ErrInvalidParams))
+			}
+		}
+	}
+
+	if invalidParams.Len() > 0 {
+		return invalidParams
+	}
+	return nil
 }
 
 // The MD5OfMessageBody and MessageId elements.
@@ -1764,6 +2105,22 @@ func (s SetQueueAttributesInput) String() string {
 // GoString returns the string representation
 func (s SetQueueAttributesInput) GoString() string {
 	return s.String()
+}
+
+// Validate inspects the fields of the type to determine if they are valid.
+func (s *SetQueueAttributesInput) Validate() error {
+	invalidParams := request.ErrInvalidParams{Context: "SetQueueAttributesInput"}
+	if s.Attributes == nil {
+		invalidParams.Add(request.NewErrParamRequired("Attributes"))
+	}
+	if s.QueueUrl == nil {
+		invalidParams.Add(request.NewErrParamRequired("QueueUrl"))
+	}
+
+	if invalidParams.Len() > 0 {
+		return invalidParams
+	}
+	return nil
 }
 
 type SetQueueAttributesOutput struct {

--- a/service/ssm/api.go
+++ b/service/ssm/api.go
@@ -4,6 +4,7 @@
 package ssm
 
 import (
+	"fmt"
 	"time"
 
 	"github.com/aws/aws-sdk-go/aws/awsutil"
@@ -603,6 +604,25 @@ func (s AssociationFilter) GoString() string {
 	return s.String()
 }
 
+// Validate inspects the fields of the type to determine if they are valid.
+func (s *AssociationFilter) Validate() error {
+	invalidParams := request.ErrInvalidParams{Context: "AssociationFilter"}
+	if s.Key == nil {
+		invalidParams.Add(request.NewErrParamRequired("Key"))
+	}
+	if s.Value == nil {
+		invalidParams.Add(request.NewErrParamRequired("Value"))
+	}
+	if s.Value != nil && len(*s.Value) < 1 {
+		invalidParams.Add(request.NewErrParamMinLen("Value", 1))
+	}
+
+	if invalidParams.Len() > 0 {
+		return invalidParams
+	}
+	return nil
+}
+
 // Describes an association status.
 type AssociationStatus struct {
 	_ struct{} `type:"structure"`
@@ -630,6 +650,25 @@ func (s AssociationStatus) GoString() string {
 	return s.String()
 }
 
+// Validate inspects the fields of the type to determine if they are valid.
+func (s *AssociationStatus) Validate() error {
+	invalidParams := request.ErrInvalidParams{Context: "AssociationStatus"}
+	if s.Date == nil {
+		invalidParams.Add(request.NewErrParamRequired("Date"))
+	}
+	if s.Message == nil {
+		invalidParams.Add(request.NewErrParamRequired("Message"))
+	}
+	if s.Name == nil {
+		invalidParams.Add(request.NewErrParamRequired("Name"))
+	}
+
+	if invalidParams.Len() > 0 {
+		return invalidParams
+	}
+	return nil
+}
+
 type CancelCommandInput struct {
 	_ struct{} `type:"structure"`
 
@@ -650,6 +689,25 @@ func (s CancelCommandInput) String() string {
 // GoString returns the string representation
 func (s CancelCommandInput) GoString() string {
 	return s.String()
+}
+
+// Validate inspects the fields of the type to determine if they are valid.
+func (s *CancelCommandInput) Validate() error {
+	invalidParams := request.ErrInvalidParams{Context: "CancelCommandInput"}
+	if s.CommandId == nil {
+		invalidParams.Add(request.NewErrParamRequired("CommandId"))
+	}
+	if s.CommandId != nil && len(*s.CommandId) < 36 {
+		invalidParams.Add(request.NewErrParamMinLen("CommandId", 36))
+	}
+	if s.InstanceIds != nil && len(s.InstanceIds) < 1 {
+		invalidParams.Add(request.NewErrParamMinLen("InstanceIds", 1))
+	}
+
+	if invalidParams.Len() > 0 {
+		return invalidParams
+	}
+	return nil
 }
 
 // Whether or not the command was successfully canceled. There is no guarantee
@@ -738,6 +796,25 @@ func (s CommandFilter) String() string {
 // GoString returns the string representation
 func (s CommandFilter) GoString() string {
 	return s.String()
+}
+
+// Validate inspects the fields of the type to determine if they are valid.
+func (s *CommandFilter) Validate() error {
+	invalidParams := request.ErrInvalidParams{Context: "CommandFilter"}
+	if s.Key == nil {
+		invalidParams.Add(request.NewErrParamRequired("Key"))
+	}
+	if s.Value == nil {
+		invalidParams.Add(request.NewErrParamRequired("Value"))
+	}
+	if s.Value != nil && len(*s.Value) < 1 {
+		invalidParams.Add(request.NewErrParamMinLen("Value", 1))
+	}
+
+	if invalidParams.Len() > 0 {
+		return invalidParams
+	}
+	return nil
 }
 
 // An invocation is copy of a command sent to a specific instance. A command
@@ -844,6 +921,19 @@ func (s CreateAssociationBatchInput) GoString() string {
 	return s.String()
 }
 
+// Validate inspects the fields of the type to determine if they are valid.
+func (s *CreateAssociationBatchInput) Validate() error {
+	invalidParams := request.ErrInvalidParams{Context: "CreateAssociationBatchInput"}
+	if s.Entries == nil {
+		invalidParams.Add(request.NewErrParamRequired("Entries"))
+	}
+
+	if invalidParams.Len() > 0 {
+		return invalidParams
+	}
+	return nil
+}
+
 type CreateAssociationBatchOutput struct {
 	_ struct{} `type:"structure"`
 
@@ -911,6 +1001,22 @@ func (s CreateAssociationInput) GoString() string {
 	return s.String()
 }
 
+// Validate inspects the fields of the type to determine if they are valid.
+func (s *CreateAssociationInput) Validate() error {
+	invalidParams := request.ErrInvalidParams{Context: "CreateAssociationInput"}
+	if s.InstanceId == nil {
+		invalidParams.Add(request.NewErrParamRequired("InstanceId"))
+	}
+	if s.Name == nil {
+		invalidParams.Add(request.NewErrParamRequired("Name"))
+	}
+
+	if invalidParams.Len() > 0 {
+		return invalidParams
+	}
+	return nil
+}
+
 type CreateAssociationOutput struct {
 	_ struct{} `type:"structure"`
 
@@ -947,6 +1053,25 @@ func (s CreateDocumentInput) String() string {
 // GoString returns the string representation
 func (s CreateDocumentInput) GoString() string {
 	return s.String()
+}
+
+// Validate inspects the fields of the type to determine if they are valid.
+func (s *CreateDocumentInput) Validate() error {
+	invalidParams := request.ErrInvalidParams{Context: "CreateDocumentInput"}
+	if s.Content == nil {
+		invalidParams.Add(request.NewErrParamRequired("Content"))
+	}
+	if s.Content != nil && len(*s.Content) < 1 {
+		invalidParams.Add(request.NewErrParamMinLen("Content", 1))
+	}
+	if s.Name == nil {
+		invalidParams.Add(request.NewErrParamRequired("Name"))
+	}
+
+	if invalidParams.Len() > 0 {
+		return invalidParams
+	}
+	return nil
 }
 
 type CreateDocumentOutput struct {
@@ -986,6 +1111,22 @@ func (s DeleteAssociationInput) GoString() string {
 	return s.String()
 }
 
+// Validate inspects the fields of the type to determine if they are valid.
+func (s *DeleteAssociationInput) Validate() error {
+	invalidParams := request.ErrInvalidParams{Context: "DeleteAssociationInput"}
+	if s.InstanceId == nil {
+		invalidParams.Add(request.NewErrParamRequired("InstanceId"))
+	}
+	if s.Name == nil {
+		invalidParams.Add(request.NewErrParamRequired("Name"))
+	}
+
+	if invalidParams.Len() > 0 {
+		return invalidParams
+	}
+	return nil
+}
+
 type DeleteAssociationOutput struct {
 	_ struct{} `type:"structure"`
 }
@@ -1015,6 +1156,19 @@ func (s DeleteDocumentInput) String() string {
 // GoString returns the string representation
 func (s DeleteDocumentInput) GoString() string {
 	return s.String()
+}
+
+// Validate inspects the fields of the type to determine if they are valid.
+func (s *DeleteDocumentInput) Validate() error {
+	invalidParams := request.ErrInvalidParams{Context: "DeleteDocumentInput"}
+	if s.Name == nil {
+		invalidParams.Add(request.NewErrParamRequired("Name"))
+	}
+
+	if invalidParams.Len() > 0 {
+		return invalidParams
+	}
+	return nil
 }
 
 type DeleteDocumentOutput struct {
@@ -1051,6 +1205,22 @@ func (s DescribeAssociationInput) GoString() string {
 	return s.String()
 }
 
+// Validate inspects the fields of the type to determine if they are valid.
+func (s *DescribeAssociationInput) Validate() error {
+	invalidParams := request.ErrInvalidParams{Context: "DescribeAssociationInput"}
+	if s.InstanceId == nil {
+		invalidParams.Add(request.NewErrParamRequired("InstanceId"))
+	}
+	if s.Name == nil {
+		invalidParams.Add(request.NewErrParamRequired("Name"))
+	}
+
+	if invalidParams.Len() > 0 {
+		return invalidParams
+	}
+	return nil
+}
+
 type DescribeAssociationOutput struct {
 	_ struct{} `type:"structure"`
 
@@ -1083,6 +1253,19 @@ func (s DescribeDocumentInput) String() string {
 // GoString returns the string representation
 func (s DescribeDocumentInput) GoString() string {
 	return s.String()
+}
+
+// Validate inspects the fields of the type to determine if they are valid.
+func (s *DescribeDocumentInput) Validate() error {
+	invalidParams := request.ErrInvalidParams{Context: "DescribeDocumentInput"}
+	if s.Name == nil {
+		invalidParams.Add(request.NewErrParamRequired("Name"))
+	}
+
+	if invalidParams.Len() > 0 {
+		return invalidParams
+	}
+	return nil
 }
 
 type DescribeDocumentOutput struct {
@@ -1126,6 +1309,32 @@ func (s DescribeInstanceInformationInput) String() string {
 // GoString returns the string representation
 func (s DescribeInstanceInformationInput) GoString() string {
 	return s.String()
+}
+
+// Validate inspects the fields of the type to determine if they are valid.
+func (s *DescribeInstanceInformationInput) Validate() error {
+	invalidParams := request.ErrInvalidParams{Context: "DescribeInstanceInformationInput"}
+	if s.InstanceInformationFilterList != nil && len(s.InstanceInformationFilterList) < 1 {
+		invalidParams.Add(request.NewErrParamMinLen("InstanceInformationFilterList", 1))
+	}
+	if s.MaxResults != nil && *s.MaxResults < 5 {
+		invalidParams.Add(request.NewErrParamMinValue("MaxResults", 5))
+	}
+	if s.InstanceInformationFilterList != nil {
+		for i, v := range s.InstanceInformationFilterList {
+			if v == nil {
+				continue
+			}
+			if err := v.Validate(); err != nil {
+				invalidParams.AddNested(fmt.Sprintf("%s[%v]", "InstanceInformationFilterList", i), err.(request.ErrInvalidParams))
+			}
+		}
+	}
+
+	if invalidParams.Len() > 0 {
+		return invalidParams
+	}
+	return nil
 }
 
 type DescribeInstanceInformationOutput struct {
@@ -1204,6 +1413,25 @@ func (s DocumentFilter) String() string {
 // GoString returns the string representation
 func (s DocumentFilter) GoString() string {
 	return s.String()
+}
+
+// Validate inspects the fields of the type to determine if they are valid.
+func (s *DocumentFilter) Validate() error {
+	invalidParams := request.ErrInvalidParams{Context: "DocumentFilter"}
+	if s.Key == nil {
+		invalidParams.Add(request.NewErrParamRequired("Key"))
+	}
+	if s.Value == nil {
+		invalidParams.Add(request.NewErrParamRequired("Value"))
+	}
+	if s.Value != nil && len(*s.Value) < 1 {
+		invalidParams.Add(request.NewErrParamMinLen("Value", 1))
+	}
+
+	if invalidParams.Len() > 0 {
+		return invalidParams
+	}
+	return nil
 }
 
 // Describes the name of an SSM document.
@@ -1296,6 +1524,19 @@ func (s GetDocumentInput) GoString() string {
 	return s.String()
 }
 
+// Validate inspects the fields of the type to determine if they are valid.
+func (s *GetDocumentInput) Validate() error {
+	invalidParams := request.ErrInvalidParams{Context: "GetDocumentInput"}
+	if s.Name == nil {
+		invalidParams.Add(request.NewErrParamRequired("Name"))
+	}
+
+	if invalidParams.Len() > 0 {
+		return invalidParams
+	}
+	return nil
+}
+
 type GetDocumentOutput struct {
 	_ struct{} `type:"structure"`
 
@@ -1376,6 +1617,25 @@ func (s InstanceInformationFilter) GoString() string {
 	return s.String()
 }
 
+// Validate inspects the fields of the type to determine if they are valid.
+func (s *InstanceInformationFilter) Validate() error {
+	invalidParams := request.ErrInvalidParams{Context: "InstanceInformationFilter"}
+	if s.Key == nil {
+		invalidParams.Add(request.NewErrParamRequired("Key"))
+	}
+	if s.ValueSet == nil {
+		invalidParams.Add(request.NewErrParamRequired("ValueSet"))
+	}
+	if s.ValueSet != nil && len(s.ValueSet) < 1 {
+		invalidParams.Add(request.NewErrParamMinLen("ValueSet", 1))
+	}
+
+	if invalidParams.Len() > 0 {
+		return invalidParams
+	}
+	return nil
+}
+
 type ListAssociationsInput struct {
 	_ struct{} `type:"structure"`
 
@@ -1400,6 +1660,35 @@ func (s ListAssociationsInput) String() string {
 // GoString returns the string representation
 func (s ListAssociationsInput) GoString() string {
 	return s.String()
+}
+
+// Validate inspects the fields of the type to determine if they are valid.
+func (s *ListAssociationsInput) Validate() error {
+	invalidParams := request.ErrInvalidParams{Context: "ListAssociationsInput"}
+	if s.AssociationFilterList == nil {
+		invalidParams.Add(request.NewErrParamRequired("AssociationFilterList"))
+	}
+	if s.AssociationFilterList != nil && len(s.AssociationFilterList) < 1 {
+		invalidParams.Add(request.NewErrParamMinLen("AssociationFilterList", 1))
+	}
+	if s.MaxResults != nil && *s.MaxResults < 1 {
+		invalidParams.Add(request.NewErrParamMinValue("MaxResults", 1))
+	}
+	if s.AssociationFilterList != nil {
+		for i, v := range s.AssociationFilterList {
+			if v == nil {
+				continue
+			}
+			if err := v.Validate(); err != nil {
+				invalidParams.AddNested(fmt.Sprintf("%s[%v]", "AssociationFilterList", i), err.(request.ErrInvalidParams))
+			}
+		}
+	}
+
+	if invalidParams.Len() > 0 {
+		return invalidParams
+	}
+	return nil
 }
 
 type ListAssociationsOutput struct {
@@ -1460,6 +1749,35 @@ func (s ListCommandInvocationsInput) GoString() string {
 	return s.String()
 }
 
+// Validate inspects the fields of the type to determine if they are valid.
+func (s *ListCommandInvocationsInput) Validate() error {
+	invalidParams := request.ErrInvalidParams{Context: "ListCommandInvocationsInput"}
+	if s.CommandId != nil && len(*s.CommandId) < 36 {
+		invalidParams.Add(request.NewErrParamMinLen("CommandId", 36))
+	}
+	if s.Filters != nil && len(s.Filters) < 1 {
+		invalidParams.Add(request.NewErrParamMinLen("Filters", 1))
+	}
+	if s.MaxResults != nil && *s.MaxResults < 1 {
+		invalidParams.Add(request.NewErrParamMinValue("MaxResults", 1))
+	}
+	if s.Filters != nil {
+		for i, v := range s.Filters {
+			if v == nil {
+				continue
+			}
+			if err := v.Validate(); err != nil {
+				invalidParams.AddNested(fmt.Sprintf("%s[%v]", "Filters", i), err.(request.ErrInvalidParams))
+			}
+		}
+	}
+
+	if invalidParams.Len() > 0 {
+		return invalidParams
+	}
+	return nil
+}
+
 type ListCommandInvocationsOutput struct {
 	_ struct{} `type:"structure"`
 
@@ -1514,6 +1832,35 @@ func (s ListCommandsInput) GoString() string {
 	return s.String()
 }
 
+// Validate inspects the fields of the type to determine if they are valid.
+func (s *ListCommandsInput) Validate() error {
+	invalidParams := request.ErrInvalidParams{Context: "ListCommandsInput"}
+	if s.CommandId != nil && len(*s.CommandId) < 36 {
+		invalidParams.Add(request.NewErrParamMinLen("CommandId", 36))
+	}
+	if s.Filters != nil && len(s.Filters) < 1 {
+		invalidParams.Add(request.NewErrParamMinLen("Filters", 1))
+	}
+	if s.MaxResults != nil && *s.MaxResults < 1 {
+		invalidParams.Add(request.NewErrParamMinValue("MaxResults", 1))
+	}
+	if s.Filters != nil {
+		for i, v := range s.Filters {
+			if v == nil {
+				continue
+			}
+			if err := v.Validate(); err != nil {
+				invalidParams.AddNested(fmt.Sprintf("%s[%v]", "Filters", i), err.(request.ErrInvalidParams))
+			}
+		}
+	}
+
+	if invalidParams.Len() > 0 {
+		return invalidParams
+	}
+	return nil
+}
+
 type ListCommandsOutput struct {
 	_ struct{} `type:"structure"`
 
@@ -1559,6 +1906,32 @@ func (s ListDocumentsInput) String() string {
 // GoString returns the string representation
 func (s ListDocumentsInput) GoString() string {
 	return s.String()
+}
+
+// Validate inspects the fields of the type to determine if they are valid.
+func (s *ListDocumentsInput) Validate() error {
+	invalidParams := request.ErrInvalidParams{Context: "ListDocumentsInput"}
+	if s.DocumentFilterList != nil && len(s.DocumentFilterList) < 1 {
+		invalidParams.Add(request.NewErrParamMinLen("DocumentFilterList", 1))
+	}
+	if s.MaxResults != nil && *s.MaxResults < 1 {
+		invalidParams.Add(request.NewErrParamMinValue("MaxResults", 1))
+	}
+	if s.DocumentFilterList != nil {
+		for i, v := range s.DocumentFilterList {
+			if v == nil {
+				continue
+			}
+			if err := v.Validate(); err != nil {
+				invalidParams.AddNested(fmt.Sprintf("%s[%v]", "DocumentFilterList", i), err.(request.ErrInvalidParams))
+			}
+		}
+	}
+
+	if invalidParams.Len() > 0 {
+		return invalidParams
+	}
+	return nil
 }
 
 type ListDocumentsOutput struct {
@@ -1622,6 +1995,31 @@ func (s SendCommandInput) GoString() string {
 	return s.String()
 }
 
+// Validate inspects the fields of the type to determine if they are valid.
+func (s *SendCommandInput) Validate() error {
+	invalidParams := request.ErrInvalidParams{Context: "SendCommandInput"}
+	if s.DocumentName == nil {
+		invalidParams.Add(request.NewErrParamRequired("DocumentName"))
+	}
+	if s.InstanceIds == nil {
+		invalidParams.Add(request.NewErrParamRequired("InstanceIds"))
+	}
+	if s.InstanceIds != nil && len(s.InstanceIds) < 1 {
+		invalidParams.Add(request.NewErrParamMinLen("InstanceIds", 1))
+	}
+	if s.OutputS3BucketName != nil && len(*s.OutputS3BucketName) < 3 {
+		invalidParams.Add(request.NewErrParamMinLen("OutputS3BucketName", 3))
+	}
+	if s.TimeoutSeconds != nil && *s.TimeoutSeconds < 30 {
+		invalidParams.Add(request.NewErrParamMinValue("TimeoutSeconds", 30))
+	}
+
+	if invalidParams.Len() > 0 {
+		return invalidParams
+	}
+	return nil
+}
+
 type SendCommandOutput struct {
 	_ struct{} `type:"structure"`
 
@@ -1661,6 +2059,30 @@ func (s UpdateAssociationStatusInput) String() string {
 // GoString returns the string representation
 func (s UpdateAssociationStatusInput) GoString() string {
 	return s.String()
+}
+
+// Validate inspects the fields of the type to determine if they are valid.
+func (s *UpdateAssociationStatusInput) Validate() error {
+	invalidParams := request.ErrInvalidParams{Context: "UpdateAssociationStatusInput"}
+	if s.AssociationStatus == nil {
+		invalidParams.Add(request.NewErrParamRequired("AssociationStatus"))
+	}
+	if s.InstanceId == nil {
+		invalidParams.Add(request.NewErrParamRequired("InstanceId"))
+	}
+	if s.Name == nil {
+		invalidParams.Add(request.NewErrParamRequired("Name"))
+	}
+	if s.AssociationStatus != nil {
+		if err := s.AssociationStatus.Validate(); err != nil {
+			invalidParams.AddNested("AssociationStatus", err.(request.ErrInvalidParams))
+		}
+	}
+
+	if invalidParams.Len() > 0 {
+		return invalidParams
+	}
+	return nil
 }
 
 type UpdateAssociationStatusOutput struct {

--- a/service/storagegateway/api.go
+++ b/service/storagegateway/api.go
@@ -4,6 +4,7 @@
 package storagegateway
 
 import (
+	"fmt"
 	"time"
 
 	"github.com/aws/aws-sdk-go/aws/awsutil"
@@ -1990,6 +1991,49 @@ func (s ActivateGatewayInput) GoString() string {
 	return s.String()
 }
 
+// Validate inspects the fields of the type to determine if they are valid.
+func (s *ActivateGatewayInput) Validate() error {
+	invalidParams := request.ErrInvalidParams{Context: "ActivateGatewayInput"}
+	if s.ActivationKey == nil {
+		invalidParams.Add(request.NewErrParamRequired("ActivationKey"))
+	}
+	if s.ActivationKey != nil && len(*s.ActivationKey) < 1 {
+		invalidParams.Add(request.NewErrParamMinLen("ActivationKey", 1))
+	}
+	if s.GatewayName == nil {
+		invalidParams.Add(request.NewErrParamRequired("GatewayName"))
+	}
+	if s.GatewayName != nil && len(*s.GatewayName) < 2 {
+		invalidParams.Add(request.NewErrParamMinLen("GatewayName", 2))
+	}
+	if s.GatewayRegion == nil {
+		invalidParams.Add(request.NewErrParamRequired("GatewayRegion"))
+	}
+	if s.GatewayRegion != nil && len(*s.GatewayRegion) < 1 {
+		invalidParams.Add(request.NewErrParamMinLen("GatewayRegion", 1))
+	}
+	if s.GatewayTimezone == nil {
+		invalidParams.Add(request.NewErrParamRequired("GatewayTimezone"))
+	}
+	if s.GatewayTimezone != nil && len(*s.GatewayTimezone) < 3 {
+		invalidParams.Add(request.NewErrParamMinLen("GatewayTimezone", 3))
+	}
+	if s.GatewayType != nil && len(*s.GatewayType) < 2 {
+		invalidParams.Add(request.NewErrParamMinLen("GatewayType", 2))
+	}
+	if s.MediumChangerType != nil && len(*s.MediumChangerType) < 2 {
+		invalidParams.Add(request.NewErrParamMinLen("MediumChangerType", 2))
+	}
+	if s.TapeDriveType != nil && len(*s.TapeDriveType) < 2 {
+		invalidParams.Add(request.NewErrParamMinLen("TapeDriveType", 2))
+	}
+
+	if invalidParams.Len() > 0 {
+		return invalidParams
+	}
+	return nil
+}
+
 // AWS Storage Gateway returns the Amazon Resource Name (ARN) of the activated
 // gateway. It is a string made of information such as your account, gateway
 // name, and region. This ARN is used to reference the gateway in other API
@@ -2036,6 +2080,25 @@ func (s AddCacheInput) GoString() string {
 	return s.String()
 }
 
+// Validate inspects the fields of the type to determine if they are valid.
+func (s *AddCacheInput) Validate() error {
+	invalidParams := request.ErrInvalidParams{Context: "AddCacheInput"}
+	if s.DiskIds == nil {
+		invalidParams.Add(request.NewErrParamRequired("DiskIds"))
+	}
+	if s.GatewayARN == nil {
+		invalidParams.Add(request.NewErrParamRequired("GatewayARN"))
+	}
+	if s.GatewayARN != nil && len(*s.GatewayARN) < 50 {
+		invalidParams.Add(request.NewErrParamMinLen("GatewayARN", 50))
+	}
+
+	if invalidParams.Len() > 0 {
+		return invalidParams
+	}
+	return nil
+}
+
 type AddCacheOutput struct {
 	_ struct{} `type:"structure"`
 
@@ -2079,6 +2142,35 @@ func (s AddTagsToResourceInput) GoString() string {
 	return s.String()
 }
 
+// Validate inspects the fields of the type to determine if they are valid.
+func (s *AddTagsToResourceInput) Validate() error {
+	invalidParams := request.ErrInvalidParams{Context: "AddTagsToResourceInput"}
+	if s.ResourceARN == nil {
+		invalidParams.Add(request.NewErrParamRequired("ResourceARN"))
+	}
+	if s.ResourceARN != nil && len(*s.ResourceARN) < 50 {
+		invalidParams.Add(request.NewErrParamMinLen("ResourceARN", 50))
+	}
+	if s.Tags == nil {
+		invalidParams.Add(request.NewErrParamRequired("Tags"))
+	}
+	if s.Tags != nil {
+		for i, v := range s.Tags {
+			if v == nil {
+				continue
+			}
+			if err := v.Validate(); err != nil {
+				invalidParams.AddNested(fmt.Sprintf("%s[%v]", "Tags", i), err.(request.ErrInvalidParams))
+			}
+		}
+	}
+
+	if invalidParams.Len() > 0 {
+		return invalidParams
+	}
+	return nil
+}
+
 // AddTagsToResourceOutput
 type AddTagsToResourceOutput struct {
 	_ struct{} `type:"structure"`
@@ -2115,6 +2207,25 @@ func (s AddUploadBufferInput) String() string {
 // GoString returns the string representation
 func (s AddUploadBufferInput) GoString() string {
 	return s.String()
+}
+
+// Validate inspects the fields of the type to determine if they are valid.
+func (s *AddUploadBufferInput) Validate() error {
+	invalidParams := request.ErrInvalidParams{Context: "AddUploadBufferInput"}
+	if s.DiskIds == nil {
+		invalidParams.Add(request.NewErrParamRequired("DiskIds"))
+	}
+	if s.GatewayARN == nil {
+		invalidParams.Add(request.NewErrParamRequired("GatewayARN"))
+	}
+	if s.GatewayARN != nil && len(*s.GatewayARN) < 50 {
+		invalidParams.Add(request.NewErrParamMinLen("GatewayARN", 50))
+	}
+
+	if invalidParams.Len() > 0 {
+		return invalidParams
+	}
+	return nil
 }
 
 type AddUploadBufferOutput struct {
@@ -2159,6 +2270,25 @@ func (s AddWorkingStorageInput) String() string {
 // GoString returns the string representation
 func (s AddWorkingStorageInput) GoString() string {
 	return s.String()
+}
+
+// Validate inspects the fields of the type to determine if they are valid.
+func (s *AddWorkingStorageInput) Validate() error {
+	invalidParams := request.ErrInvalidParams{Context: "AddWorkingStorageInput"}
+	if s.DiskIds == nil {
+		invalidParams.Add(request.NewErrParamRequired("DiskIds"))
+	}
+	if s.GatewayARN == nil {
+		invalidParams.Add(request.NewErrParamRequired("GatewayARN"))
+	}
+	if s.GatewayARN != nil && len(*s.GatewayARN) < 50 {
+		invalidParams.Add(request.NewErrParamMinLen("GatewayARN", 50))
+	}
+
+	if invalidParams.Len() > 0 {
+		return invalidParams
+	}
+	return nil
 }
 
 // A JSON object containing the of the gateway for which working storage was
@@ -2235,6 +2365,28 @@ func (s CancelArchivalInput) GoString() string {
 	return s.String()
 }
 
+// Validate inspects the fields of the type to determine if they are valid.
+func (s *CancelArchivalInput) Validate() error {
+	invalidParams := request.ErrInvalidParams{Context: "CancelArchivalInput"}
+	if s.GatewayARN == nil {
+		invalidParams.Add(request.NewErrParamRequired("GatewayARN"))
+	}
+	if s.GatewayARN != nil && len(*s.GatewayARN) < 50 {
+		invalidParams.Add(request.NewErrParamMinLen("GatewayARN", 50))
+	}
+	if s.TapeARN == nil {
+		invalidParams.Add(request.NewErrParamRequired("TapeARN"))
+	}
+	if s.TapeARN != nil && len(*s.TapeARN) < 50 {
+		invalidParams.Add(request.NewErrParamMinLen("TapeARN", 50))
+	}
+
+	if invalidParams.Len() > 0 {
+		return invalidParams
+	}
+	return nil
+}
+
 // CancelArchivalOutput
 type CancelArchivalOutput struct {
 	_ struct{} `type:"structure"`
@@ -2275,6 +2427,28 @@ func (s CancelRetrievalInput) String() string {
 // GoString returns the string representation
 func (s CancelRetrievalInput) GoString() string {
 	return s.String()
+}
+
+// Validate inspects the fields of the type to determine if they are valid.
+func (s *CancelRetrievalInput) Validate() error {
+	invalidParams := request.ErrInvalidParams{Context: "CancelRetrievalInput"}
+	if s.GatewayARN == nil {
+		invalidParams.Add(request.NewErrParamRequired("GatewayARN"))
+	}
+	if s.GatewayARN != nil && len(*s.GatewayARN) < 50 {
+		invalidParams.Add(request.NewErrParamMinLen("GatewayARN", 50))
+	}
+	if s.TapeARN == nil {
+		invalidParams.Add(request.NewErrParamRequired("TapeARN"))
+	}
+	if s.TapeARN != nil && len(*s.TapeARN) < 50 {
+		invalidParams.Add(request.NewErrParamMinLen("TapeARN", 50))
+	}
+
+	if invalidParams.Len() > 0 {
+		return invalidParams
+	}
+	return nil
 }
 
 // CancelRetrievalOutput
@@ -2357,6 +2531,40 @@ func (s CreateCachediSCSIVolumeInput) GoString() string {
 	return s.String()
 }
 
+// Validate inspects the fields of the type to determine if they are valid.
+func (s *CreateCachediSCSIVolumeInput) Validate() error {
+	invalidParams := request.ErrInvalidParams{Context: "CreateCachediSCSIVolumeInput"}
+	if s.ClientToken == nil {
+		invalidParams.Add(request.NewErrParamRequired("ClientToken"))
+	}
+	if s.ClientToken != nil && len(*s.ClientToken) < 5 {
+		invalidParams.Add(request.NewErrParamMinLen("ClientToken", 5))
+	}
+	if s.GatewayARN == nil {
+		invalidParams.Add(request.NewErrParamRequired("GatewayARN"))
+	}
+	if s.GatewayARN != nil && len(*s.GatewayARN) < 50 {
+		invalidParams.Add(request.NewErrParamMinLen("GatewayARN", 50))
+	}
+	if s.NetworkInterfaceId == nil {
+		invalidParams.Add(request.NewErrParamRequired("NetworkInterfaceId"))
+	}
+	if s.TargetName == nil {
+		invalidParams.Add(request.NewErrParamRequired("TargetName"))
+	}
+	if s.TargetName != nil && len(*s.TargetName) < 1 {
+		invalidParams.Add(request.NewErrParamMinLen("TargetName", 1))
+	}
+	if s.VolumeSizeInBytes == nil {
+		invalidParams.Add(request.NewErrParamRequired("VolumeSizeInBytes"))
+	}
+
+	if invalidParams.Len() > 0 {
+		return invalidParams
+	}
+	return nil
+}
+
 type CreateCachediSCSIVolumeOutput struct {
 	_ struct{} `type:"structure"`
 
@@ -2391,6 +2599,28 @@ func (s CreateSnapshotFromVolumeRecoveryPointInput) String() string {
 // GoString returns the string representation
 func (s CreateSnapshotFromVolumeRecoveryPointInput) GoString() string {
 	return s.String()
+}
+
+// Validate inspects the fields of the type to determine if they are valid.
+func (s *CreateSnapshotFromVolumeRecoveryPointInput) Validate() error {
+	invalidParams := request.ErrInvalidParams{Context: "CreateSnapshotFromVolumeRecoveryPointInput"}
+	if s.SnapshotDescription == nil {
+		invalidParams.Add(request.NewErrParamRequired("SnapshotDescription"))
+	}
+	if s.SnapshotDescription != nil && len(*s.SnapshotDescription) < 1 {
+		invalidParams.Add(request.NewErrParamMinLen("SnapshotDescription", 1))
+	}
+	if s.VolumeARN == nil {
+		invalidParams.Add(request.NewErrParamRequired("VolumeARN"))
+	}
+	if s.VolumeARN != nil && len(*s.VolumeARN) < 50 {
+		invalidParams.Add(request.NewErrParamMinLen("VolumeARN", 50))
+	}
+
+	if invalidParams.Len() > 0 {
+		return invalidParams
+	}
+	return nil
 }
 
 type CreateSnapshotFromVolumeRecoveryPointOutput struct {
@@ -2437,6 +2667,28 @@ func (s CreateSnapshotInput) String() string {
 // GoString returns the string representation
 func (s CreateSnapshotInput) GoString() string {
 	return s.String()
+}
+
+// Validate inspects the fields of the type to determine if they are valid.
+func (s *CreateSnapshotInput) Validate() error {
+	invalidParams := request.ErrInvalidParams{Context: "CreateSnapshotInput"}
+	if s.SnapshotDescription == nil {
+		invalidParams.Add(request.NewErrParamRequired("SnapshotDescription"))
+	}
+	if s.SnapshotDescription != nil && len(*s.SnapshotDescription) < 1 {
+		invalidParams.Add(request.NewErrParamMinLen("SnapshotDescription", 1))
+	}
+	if s.VolumeARN == nil {
+		invalidParams.Add(request.NewErrParamRequired("VolumeARN"))
+	}
+	if s.VolumeARN != nil && len(*s.VolumeARN) < 50 {
+		invalidParams.Add(request.NewErrParamMinLen("VolumeARN", 50))
+	}
+
+	if invalidParams.Len() > 0 {
+		return invalidParams
+	}
+	return nil
 }
 
 // A JSON object containing the following fields:
@@ -2516,6 +2768,40 @@ func (s CreateStorediSCSIVolumeInput) GoString() string {
 	return s.String()
 }
 
+// Validate inspects the fields of the type to determine if they are valid.
+func (s *CreateStorediSCSIVolumeInput) Validate() error {
+	invalidParams := request.ErrInvalidParams{Context: "CreateStorediSCSIVolumeInput"}
+	if s.DiskId == nil {
+		invalidParams.Add(request.NewErrParamRequired("DiskId"))
+	}
+	if s.DiskId != nil && len(*s.DiskId) < 1 {
+		invalidParams.Add(request.NewErrParamMinLen("DiskId", 1))
+	}
+	if s.GatewayARN == nil {
+		invalidParams.Add(request.NewErrParamRequired("GatewayARN"))
+	}
+	if s.GatewayARN != nil && len(*s.GatewayARN) < 50 {
+		invalidParams.Add(request.NewErrParamMinLen("GatewayARN", 50))
+	}
+	if s.NetworkInterfaceId == nil {
+		invalidParams.Add(request.NewErrParamRequired("NetworkInterfaceId"))
+	}
+	if s.PreserveExistingData == nil {
+		invalidParams.Add(request.NewErrParamRequired("PreserveExistingData"))
+	}
+	if s.TargetName == nil {
+		invalidParams.Add(request.NewErrParamRequired("TargetName"))
+	}
+	if s.TargetName != nil && len(*s.TargetName) < 1 {
+		invalidParams.Add(request.NewErrParamMinLen("TargetName", 1))
+	}
+
+	if invalidParams.Len() > 0 {
+		return invalidParams
+	}
+	return nil
+}
+
 // A JSON object containing the following fields:
 type CreateStorediSCSIVolumeOutput struct {
 	_ struct{} `type:"structure"`
@@ -2567,6 +2853,31 @@ func (s CreateTapeWithBarcodeInput) String() string {
 // GoString returns the string representation
 func (s CreateTapeWithBarcodeInput) GoString() string {
 	return s.String()
+}
+
+// Validate inspects the fields of the type to determine if they are valid.
+func (s *CreateTapeWithBarcodeInput) Validate() error {
+	invalidParams := request.ErrInvalidParams{Context: "CreateTapeWithBarcodeInput"}
+	if s.GatewayARN == nil {
+		invalidParams.Add(request.NewErrParamRequired("GatewayARN"))
+	}
+	if s.GatewayARN != nil && len(*s.GatewayARN) < 50 {
+		invalidParams.Add(request.NewErrParamMinLen("GatewayARN", 50))
+	}
+	if s.TapeBarcode == nil {
+		invalidParams.Add(request.NewErrParamRequired("TapeBarcode"))
+	}
+	if s.TapeBarcode != nil && len(*s.TapeBarcode) < 7 {
+		invalidParams.Add(request.NewErrParamMinLen("TapeBarcode", 7))
+	}
+	if s.TapeSizeInBytes == nil {
+		invalidParams.Add(request.NewErrParamRequired("TapeSizeInBytes"))
+	}
+
+	if invalidParams.Len() > 0 {
+		return invalidParams
+	}
+	return nil
 }
 
 // CreateTapeOutput
@@ -2629,6 +2940,43 @@ func (s CreateTapesInput) GoString() string {
 	return s.String()
 }
 
+// Validate inspects the fields of the type to determine if they are valid.
+func (s *CreateTapesInput) Validate() error {
+	invalidParams := request.ErrInvalidParams{Context: "CreateTapesInput"}
+	if s.ClientToken == nil {
+		invalidParams.Add(request.NewErrParamRequired("ClientToken"))
+	}
+	if s.ClientToken != nil && len(*s.ClientToken) < 5 {
+		invalidParams.Add(request.NewErrParamMinLen("ClientToken", 5))
+	}
+	if s.GatewayARN == nil {
+		invalidParams.Add(request.NewErrParamRequired("GatewayARN"))
+	}
+	if s.GatewayARN != nil && len(*s.GatewayARN) < 50 {
+		invalidParams.Add(request.NewErrParamMinLen("GatewayARN", 50))
+	}
+	if s.NumTapesToCreate == nil {
+		invalidParams.Add(request.NewErrParamRequired("NumTapesToCreate"))
+	}
+	if s.NumTapesToCreate != nil && *s.NumTapesToCreate < 1 {
+		invalidParams.Add(request.NewErrParamMinValue("NumTapesToCreate", 1))
+	}
+	if s.TapeBarcodePrefix == nil {
+		invalidParams.Add(request.NewErrParamRequired("TapeBarcodePrefix"))
+	}
+	if s.TapeBarcodePrefix != nil && len(*s.TapeBarcodePrefix) < 1 {
+		invalidParams.Add(request.NewErrParamMinLen("TapeBarcodePrefix", 1))
+	}
+	if s.TapeSizeInBytes == nil {
+		invalidParams.Add(request.NewErrParamRequired("TapeSizeInBytes"))
+	}
+
+	if invalidParams.Len() > 0 {
+		return invalidParams
+	}
+	return nil
+}
+
 // CreateTapeOutput
 type CreateTapesOutput struct {
 	_ struct{} `type:"structure"`
@@ -2666,6 +3014,28 @@ func (s DeleteBandwidthRateLimitInput) String() string {
 // GoString returns the string representation
 func (s DeleteBandwidthRateLimitInput) GoString() string {
 	return s.String()
+}
+
+// Validate inspects the fields of the type to determine if they are valid.
+func (s *DeleteBandwidthRateLimitInput) Validate() error {
+	invalidParams := request.ErrInvalidParams{Context: "DeleteBandwidthRateLimitInput"}
+	if s.BandwidthType == nil {
+		invalidParams.Add(request.NewErrParamRequired("BandwidthType"))
+	}
+	if s.BandwidthType != nil && len(*s.BandwidthType) < 3 {
+		invalidParams.Add(request.NewErrParamMinLen("BandwidthType", 3))
+	}
+	if s.GatewayARN == nil {
+		invalidParams.Add(request.NewErrParamRequired("GatewayARN"))
+	}
+	if s.GatewayARN != nil && len(*s.GatewayARN) < 50 {
+		invalidParams.Add(request.NewErrParamMinLen("GatewayARN", 50))
+	}
+
+	if invalidParams.Len() > 0 {
+		return invalidParams
+	}
+	return nil
 }
 
 // A JSON object containing the of the gateway whose bandwidth rate information
@@ -2712,6 +3082,28 @@ func (s DeleteChapCredentialsInput) GoString() string {
 	return s.String()
 }
 
+// Validate inspects the fields of the type to determine if they are valid.
+func (s *DeleteChapCredentialsInput) Validate() error {
+	invalidParams := request.ErrInvalidParams{Context: "DeleteChapCredentialsInput"}
+	if s.InitiatorName == nil {
+		invalidParams.Add(request.NewErrParamRequired("InitiatorName"))
+	}
+	if s.InitiatorName != nil && len(*s.InitiatorName) < 1 {
+		invalidParams.Add(request.NewErrParamMinLen("InitiatorName", 1))
+	}
+	if s.TargetARN == nil {
+		invalidParams.Add(request.NewErrParamRequired("TargetARN"))
+	}
+	if s.TargetARN != nil && len(*s.TargetARN) < 50 {
+		invalidParams.Add(request.NewErrParamMinLen("TargetARN", 50))
+	}
+
+	if invalidParams.Len() > 0 {
+		return invalidParams
+	}
+	return nil
+}
+
 // A JSON object containing the following fields:
 type DeleteChapCredentialsOutput struct {
 	_ struct{} `type:"structure"`
@@ -2752,6 +3144,22 @@ func (s DeleteGatewayInput) GoString() string {
 	return s.String()
 }
 
+// Validate inspects the fields of the type to determine if they are valid.
+func (s *DeleteGatewayInput) Validate() error {
+	invalidParams := request.ErrInvalidParams{Context: "DeleteGatewayInput"}
+	if s.GatewayARN == nil {
+		invalidParams.Add(request.NewErrParamRequired("GatewayARN"))
+	}
+	if s.GatewayARN != nil && len(*s.GatewayARN) < 50 {
+		invalidParams.Add(request.NewErrParamMinLen("GatewayARN", 50))
+	}
+
+	if invalidParams.Len() > 0 {
+		return invalidParams
+	}
+	return nil
+}
+
 // A JSON object containing the id of the deleted gateway.
 type DeleteGatewayOutput struct {
 	_ struct{} `type:"structure"`
@@ -2787,6 +3195,22 @@ func (s DeleteSnapshotScheduleInput) GoString() string {
 	return s.String()
 }
 
+// Validate inspects the fields of the type to determine if they are valid.
+func (s *DeleteSnapshotScheduleInput) Validate() error {
+	invalidParams := request.ErrInvalidParams{Context: "DeleteSnapshotScheduleInput"}
+	if s.VolumeARN == nil {
+		invalidParams.Add(request.NewErrParamRequired("VolumeARN"))
+	}
+	if s.VolumeARN != nil && len(*s.VolumeARN) < 50 {
+		invalidParams.Add(request.NewErrParamMinLen("VolumeARN", 50))
+	}
+
+	if invalidParams.Len() > 0 {
+		return invalidParams
+	}
+	return nil
+}
+
 type DeleteSnapshotScheduleOutput struct {
 	_ struct{} `type:"structure"`
 
@@ -2820,6 +3244,22 @@ func (s DeleteTapeArchiveInput) String() string {
 // GoString returns the string representation
 func (s DeleteTapeArchiveInput) GoString() string {
 	return s.String()
+}
+
+// Validate inspects the fields of the type to determine if they are valid.
+func (s *DeleteTapeArchiveInput) Validate() error {
+	invalidParams := request.ErrInvalidParams{Context: "DeleteTapeArchiveInput"}
+	if s.TapeARN == nil {
+		invalidParams.Add(request.NewErrParamRequired("TapeARN"))
+	}
+	if s.TapeARN != nil && len(*s.TapeARN) < 50 {
+		invalidParams.Add(request.NewErrParamMinLen("TapeARN", 50))
+	}
+
+	if invalidParams.Len() > 0 {
+		return invalidParams
+	}
+	return nil
 }
 
 // DeleteTapeArchiveOutput
@@ -2864,6 +3304,28 @@ func (s DeleteTapeInput) GoString() string {
 	return s.String()
 }
 
+// Validate inspects the fields of the type to determine if they are valid.
+func (s *DeleteTapeInput) Validate() error {
+	invalidParams := request.ErrInvalidParams{Context: "DeleteTapeInput"}
+	if s.GatewayARN == nil {
+		invalidParams.Add(request.NewErrParamRequired("GatewayARN"))
+	}
+	if s.GatewayARN != nil && len(*s.GatewayARN) < 50 {
+		invalidParams.Add(request.NewErrParamMinLen("GatewayARN", 50))
+	}
+	if s.TapeARN == nil {
+		invalidParams.Add(request.NewErrParamRequired("TapeARN"))
+	}
+	if s.TapeARN != nil && len(*s.TapeARN) < 50 {
+		invalidParams.Add(request.NewErrParamMinLen("TapeARN", 50))
+	}
+
+	if invalidParams.Len() > 0 {
+		return invalidParams
+	}
+	return nil
+}
+
 // DeleteTapeOutput
 type DeleteTapeOutput struct {
 	_ struct{} `type:"structure"`
@@ -2899,6 +3361,22 @@ func (s DeleteVolumeInput) String() string {
 // GoString returns the string representation
 func (s DeleteVolumeInput) GoString() string {
 	return s.String()
+}
+
+// Validate inspects the fields of the type to determine if they are valid.
+func (s *DeleteVolumeInput) Validate() error {
+	invalidParams := request.ErrInvalidParams{Context: "DeleteVolumeInput"}
+	if s.VolumeARN == nil {
+		invalidParams.Add(request.NewErrParamRequired("VolumeARN"))
+	}
+	if s.VolumeARN != nil && len(*s.VolumeARN) < 50 {
+		invalidParams.Add(request.NewErrParamMinLen("VolumeARN", 50))
+	}
+
+	if invalidParams.Len() > 0 {
+		return invalidParams
+	}
+	return nil
 }
 
 // A JSON object containing the of the storage volume that was deleted
@@ -2937,6 +3415,22 @@ func (s DescribeBandwidthRateLimitInput) String() string {
 // GoString returns the string representation
 func (s DescribeBandwidthRateLimitInput) GoString() string {
 	return s.String()
+}
+
+// Validate inspects the fields of the type to determine if they are valid.
+func (s *DescribeBandwidthRateLimitInput) Validate() error {
+	invalidParams := request.ErrInvalidParams{Context: "DescribeBandwidthRateLimitInput"}
+	if s.GatewayARN == nil {
+		invalidParams.Add(request.NewErrParamRequired("GatewayARN"))
+	}
+	if s.GatewayARN != nil && len(*s.GatewayARN) < 50 {
+		invalidParams.Add(request.NewErrParamMinLen("GatewayARN", 50))
+	}
+
+	if invalidParams.Len() > 0 {
+		return invalidParams
+	}
+	return nil
 }
 
 // A JSON object containing the following fields:
@@ -2982,6 +3476,22 @@ func (s DescribeCacheInput) String() string {
 // GoString returns the string representation
 func (s DescribeCacheInput) GoString() string {
 	return s.String()
+}
+
+// Validate inspects the fields of the type to determine if they are valid.
+func (s *DescribeCacheInput) Validate() error {
+	invalidParams := request.ErrInvalidParams{Context: "DescribeCacheInput"}
+	if s.GatewayARN == nil {
+		invalidParams.Add(request.NewErrParamRequired("GatewayARN"))
+	}
+	if s.GatewayARN != nil && len(*s.GatewayARN) < 50 {
+		invalidParams.Add(request.NewErrParamMinLen("GatewayARN", 50))
+	}
+
+	if invalidParams.Len() > 0 {
+		return invalidParams
+	}
+	return nil
 }
 
 type DescribeCacheOutput struct {
@@ -3030,6 +3540,19 @@ func (s DescribeCachediSCSIVolumesInput) GoString() string {
 	return s.String()
 }
 
+// Validate inspects the fields of the type to determine if they are valid.
+func (s *DescribeCachediSCSIVolumesInput) Validate() error {
+	invalidParams := request.ErrInvalidParams{Context: "DescribeCachediSCSIVolumesInput"}
+	if s.VolumeARNs == nil {
+		invalidParams.Add(request.NewErrParamRequired("VolumeARNs"))
+	}
+
+	if invalidParams.Len() > 0 {
+		return invalidParams
+	}
+	return nil
+}
+
 // A JSON object containing the following fields:
 type DescribeCachediSCSIVolumesOutput struct {
 	_ struct{} `type:"structure"`
@@ -3067,6 +3590,22 @@ func (s DescribeChapCredentialsInput) String() string {
 // GoString returns the string representation
 func (s DescribeChapCredentialsInput) GoString() string {
 	return s.String()
+}
+
+// Validate inspects the fields of the type to determine if they are valid.
+func (s *DescribeChapCredentialsInput) Validate() error {
+	invalidParams := request.ErrInvalidParams{Context: "DescribeChapCredentialsInput"}
+	if s.TargetARN == nil {
+		invalidParams.Add(request.NewErrParamRequired("TargetARN"))
+	}
+	if s.TargetARN != nil && len(*s.TargetARN) < 50 {
+		invalidParams.Add(request.NewErrParamMinLen("TargetARN", 50))
+	}
+
+	if invalidParams.Len() > 0 {
+		return invalidParams
+	}
+	return nil
 }
 
 // A JSON object containing a .
@@ -3118,6 +3657,22 @@ func (s DescribeGatewayInformationInput) String() string {
 // GoString returns the string representation
 func (s DescribeGatewayInformationInput) GoString() string {
 	return s.String()
+}
+
+// Validate inspects the fields of the type to determine if they are valid.
+func (s *DescribeGatewayInformationInput) Validate() error {
+	invalidParams := request.ErrInvalidParams{Context: "DescribeGatewayInformationInput"}
+	if s.GatewayARN == nil {
+		invalidParams.Add(request.NewErrParamRequired("GatewayARN"))
+	}
+	if s.GatewayARN != nil && len(*s.GatewayARN) < 50 {
+		invalidParams.Add(request.NewErrParamMinLen("GatewayARN", 50))
+	}
+
+	if invalidParams.Len() > 0 {
+		return invalidParams
+	}
+	return nil
 }
 
 // A JSON object containing the following fields:
@@ -3189,6 +3744,22 @@ func (s DescribeMaintenanceStartTimeInput) GoString() string {
 	return s.String()
 }
 
+// Validate inspects the fields of the type to determine if they are valid.
+func (s *DescribeMaintenanceStartTimeInput) Validate() error {
+	invalidParams := request.ErrInvalidParams{Context: "DescribeMaintenanceStartTimeInput"}
+	if s.GatewayARN == nil {
+		invalidParams.Add(request.NewErrParamRequired("GatewayARN"))
+	}
+	if s.GatewayARN != nil && len(*s.GatewayARN) < 50 {
+		invalidParams.Add(request.NewErrParamMinLen("GatewayARN", 50))
+	}
+
+	if invalidParams.Len() > 0 {
+		return invalidParams
+	}
+	return nil
+}
+
 type DescribeMaintenanceStartTimeOutput struct {
 	_ struct{} `type:"structure"`
 
@@ -3235,6 +3806,22 @@ func (s DescribeSnapshotScheduleInput) GoString() string {
 	return s.String()
 }
 
+// Validate inspects the fields of the type to determine if they are valid.
+func (s *DescribeSnapshotScheduleInput) Validate() error {
+	invalidParams := request.ErrInvalidParams{Context: "DescribeSnapshotScheduleInput"}
+	if s.VolumeARN == nil {
+		invalidParams.Add(request.NewErrParamRequired("VolumeARN"))
+	}
+	if s.VolumeARN != nil && len(*s.VolumeARN) < 50 {
+		invalidParams.Add(request.NewErrParamMinLen("VolumeARN", 50))
+	}
+
+	if invalidParams.Len() > 0 {
+		return invalidParams
+	}
+	return nil
+}
+
 type DescribeSnapshotScheduleOutput struct {
 	_ struct{} `type:"structure"`
 
@@ -3279,6 +3866,19 @@ func (s DescribeStorediSCSIVolumesInput) GoString() string {
 	return s.String()
 }
 
+// Validate inspects the fields of the type to determine if they are valid.
+func (s *DescribeStorediSCSIVolumesInput) Validate() error {
+	invalidParams := request.ErrInvalidParams{Context: "DescribeStorediSCSIVolumesInput"}
+	if s.VolumeARNs == nil {
+		invalidParams.Add(request.NewErrParamRequired("VolumeARNs"))
+	}
+
+	if invalidParams.Len() > 0 {
+		return invalidParams
+	}
+	return nil
+}
+
 type DescribeStorediSCSIVolumesOutput struct {
 	_ struct{} `type:"structure"`
 
@@ -3320,6 +3920,22 @@ func (s DescribeTapeArchivesInput) String() string {
 // GoString returns the string representation
 func (s DescribeTapeArchivesInput) GoString() string {
 	return s.String()
+}
+
+// Validate inspects the fields of the type to determine if they are valid.
+func (s *DescribeTapeArchivesInput) Validate() error {
+	invalidParams := request.ErrInvalidParams{Context: "DescribeTapeArchivesInput"}
+	if s.Limit != nil && *s.Limit < 1 {
+		invalidParams.Add(request.NewErrParamMinValue("Limit", 1))
+	}
+	if s.Marker != nil && len(*s.Marker) < 1 {
+		invalidParams.Add(request.NewErrParamMinLen("Marker", 1))
+	}
+
+	if invalidParams.Len() > 0 {
+		return invalidParams
+	}
+	return nil
 }
 
 // DescribeTapeArchivesOutput
@@ -3375,6 +3991,28 @@ func (s DescribeTapeRecoveryPointsInput) String() string {
 // GoString returns the string representation
 func (s DescribeTapeRecoveryPointsInput) GoString() string {
 	return s.String()
+}
+
+// Validate inspects the fields of the type to determine if they are valid.
+func (s *DescribeTapeRecoveryPointsInput) Validate() error {
+	invalidParams := request.ErrInvalidParams{Context: "DescribeTapeRecoveryPointsInput"}
+	if s.GatewayARN == nil {
+		invalidParams.Add(request.NewErrParamRequired("GatewayARN"))
+	}
+	if s.GatewayARN != nil && len(*s.GatewayARN) < 50 {
+		invalidParams.Add(request.NewErrParamMinLen("GatewayARN", 50))
+	}
+	if s.Limit != nil && *s.Limit < 1 {
+		invalidParams.Add(request.NewErrParamMinValue("Limit", 1))
+	}
+	if s.Marker != nil && len(*s.Marker) < 1 {
+		invalidParams.Add(request.NewErrParamMinLen("Marker", 1))
+	}
+
+	if invalidParams.Len() > 0 {
+		return invalidParams
+	}
+	return nil
 }
 
 // DescribeTapeRecoveryPointsOutput
@@ -3444,6 +4082,28 @@ func (s DescribeTapesInput) GoString() string {
 	return s.String()
 }
 
+// Validate inspects the fields of the type to determine if they are valid.
+func (s *DescribeTapesInput) Validate() error {
+	invalidParams := request.ErrInvalidParams{Context: "DescribeTapesInput"}
+	if s.GatewayARN == nil {
+		invalidParams.Add(request.NewErrParamRequired("GatewayARN"))
+	}
+	if s.GatewayARN != nil && len(*s.GatewayARN) < 50 {
+		invalidParams.Add(request.NewErrParamMinLen("GatewayARN", 50))
+	}
+	if s.Limit != nil && *s.Limit < 1 {
+		invalidParams.Add(request.NewErrParamMinValue("Limit", 1))
+	}
+	if s.Marker != nil && len(*s.Marker) < 1 {
+		invalidParams.Add(request.NewErrParamMinLen("Marker", 1))
+	}
+
+	if invalidParams.Len() > 0 {
+		return invalidParams
+	}
+	return nil
+}
+
 // DescribeTapesOutput
 type DescribeTapesOutput struct {
 	_ struct{} `type:"structure"`
@@ -3485,6 +4145,22 @@ func (s DescribeUploadBufferInput) String() string {
 // GoString returns the string representation
 func (s DescribeUploadBufferInput) GoString() string {
 	return s.String()
+}
+
+// Validate inspects the fields of the type to determine if they are valid.
+func (s *DescribeUploadBufferInput) Validate() error {
+	invalidParams := request.ErrInvalidParams{Context: "DescribeUploadBufferInput"}
+	if s.GatewayARN == nil {
+		invalidParams.Add(request.NewErrParamRequired("GatewayARN"))
+	}
+	if s.GatewayARN != nil && len(*s.GatewayARN) < 50 {
+		invalidParams.Add(request.NewErrParamMinLen("GatewayARN", 50))
+	}
+
+	if invalidParams.Len() > 0 {
+		return invalidParams
+	}
+	return nil
 }
 
 type DescribeUploadBufferOutput struct {
@@ -3546,6 +4222,28 @@ func (s DescribeVTLDevicesInput) GoString() string {
 	return s.String()
 }
 
+// Validate inspects the fields of the type to determine if they are valid.
+func (s *DescribeVTLDevicesInput) Validate() error {
+	invalidParams := request.ErrInvalidParams{Context: "DescribeVTLDevicesInput"}
+	if s.GatewayARN == nil {
+		invalidParams.Add(request.NewErrParamRequired("GatewayARN"))
+	}
+	if s.GatewayARN != nil && len(*s.GatewayARN) < 50 {
+		invalidParams.Add(request.NewErrParamMinLen("GatewayARN", 50))
+	}
+	if s.Limit != nil && *s.Limit < 1 {
+		invalidParams.Add(request.NewErrParamMinValue("Limit", 1))
+	}
+	if s.Marker != nil && len(*s.Marker) < 1 {
+		invalidParams.Add(request.NewErrParamMinLen("Marker", 1))
+	}
+
+	if invalidParams.Len() > 0 {
+		return invalidParams
+	}
+	return nil
+}
+
 // DescribeVTLDevicesOutput
 type DescribeVTLDevicesOutput struct {
 	_ struct{} `type:"structure"`
@@ -3592,6 +4290,22 @@ func (s DescribeWorkingStorageInput) String() string {
 // GoString returns the string representation
 func (s DescribeWorkingStorageInput) GoString() string {
 	return s.String()
+}
+
+// Validate inspects the fields of the type to determine if they are valid.
+func (s *DescribeWorkingStorageInput) Validate() error {
+	invalidParams := request.ErrInvalidParams{Context: "DescribeWorkingStorageInput"}
+	if s.GatewayARN == nil {
+		invalidParams.Add(request.NewErrParamRequired("GatewayARN"))
+	}
+	if s.GatewayARN != nil && len(*s.GatewayARN) < 50 {
+		invalidParams.Add(request.NewErrParamMinLen("GatewayARN", 50))
+	}
+
+	if invalidParams.Len() > 0 {
+		return invalidParams
+	}
+	return nil
 }
 
 // A JSON object containing the following fields:
@@ -3672,6 +4386,22 @@ func (s DisableGatewayInput) String() string {
 // GoString returns the string representation
 func (s DisableGatewayInput) GoString() string {
 	return s.String()
+}
+
+// Validate inspects the fields of the type to determine if they are valid.
+func (s *DisableGatewayInput) Validate() error {
+	invalidParams := request.ErrInvalidParams{Context: "DisableGatewayInput"}
+	if s.GatewayARN == nil {
+		invalidParams.Add(request.NewErrParamRequired("GatewayARN"))
+	}
+	if s.GatewayARN != nil && len(*s.GatewayARN) < 50 {
+		invalidParams.Add(request.NewErrParamMinLen("GatewayARN", 50))
+	}
+
+	if invalidParams.Len() > 0 {
+		return invalidParams
+	}
+	return nil
 }
 
 // DisableGatewayOutput
@@ -3792,6 +4522,22 @@ func (s ListGatewaysInput) GoString() string {
 	return s.String()
 }
 
+// Validate inspects the fields of the type to determine if they are valid.
+func (s *ListGatewaysInput) Validate() error {
+	invalidParams := request.ErrInvalidParams{Context: "ListGatewaysInput"}
+	if s.Limit != nil && *s.Limit < 1 {
+		invalidParams.Add(request.NewErrParamMinValue("Limit", 1))
+	}
+	if s.Marker != nil && len(*s.Marker) < 1 {
+		invalidParams.Add(request.NewErrParamMinLen("Marker", 1))
+	}
+
+	if invalidParams.Len() > 0 {
+		return invalidParams
+	}
+	return nil
+}
+
 type ListGatewaysOutput struct {
 	_ struct{} `type:"structure"`
 
@@ -3827,6 +4573,22 @@ func (s ListLocalDisksInput) String() string {
 // GoString returns the string representation
 func (s ListLocalDisksInput) GoString() string {
 	return s.String()
+}
+
+// Validate inspects the fields of the type to determine if they are valid.
+func (s *ListLocalDisksInput) Validate() error {
+	invalidParams := request.ErrInvalidParams{Context: "ListLocalDisksInput"}
+	if s.GatewayARN == nil {
+		invalidParams.Add(request.NewErrParamRequired("GatewayARN"))
+	}
+	if s.GatewayARN != nil && len(*s.GatewayARN) < 50 {
+		invalidParams.Add(request.NewErrParamMinLen("GatewayARN", 50))
+	}
+
+	if invalidParams.Len() > 0 {
+		return invalidParams
+	}
+	return nil
 }
 
 type ListLocalDisksOutput struct {
@@ -3876,6 +4638,28 @@ func (s ListTagsForResourceInput) GoString() string {
 	return s.String()
 }
 
+// Validate inspects the fields of the type to determine if they are valid.
+func (s *ListTagsForResourceInput) Validate() error {
+	invalidParams := request.ErrInvalidParams{Context: "ListTagsForResourceInput"}
+	if s.Limit != nil && *s.Limit < 1 {
+		invalidParams.Add(request.NewErrParamMinValue("Limit", 1))
+	}
+	if s.Marker != nil && len(*s.Marker) < 1 {
+		invalidParams.Add(request.NewErrParamMinLen("Marker", 1))
+	}
+	if s.ResourceARN == nil {
+		invalidParams.Add(request.NewErrParamRequired("ResourceARN"))
+	}
+	if s.ResourceARN != nil && len(*s.ResourceARN) < 50 {
+		invalidParams.Add(request.NewErrParamMinLen("ResourceARN", 50))
+	}
+
+	if invalidParams.Len() > 0 {
+		return invalidParams
+	}
+	return nil
+}
+
 // ListTagsForResourceOutput
 type ListTagsForResourceOutput struct {
 	_ struct{} `type:"structure"`
@@ -3921,6 +4705,22 @@ func (s ListVolumeInitiatorsInput) GoString() string {
 	return s.String()
 }
 
+// Validate inspects the fields of the type to determine if they are valid.
+func (s *ListVolumeInitiatorsInput) Validate() error {
+	invalidParams := request.ErrInvalidParams{Context: "ListVolumeInitiatorsInput"}
+	if s.VolumeARN == nil {
+		invalidParams.Add(request.NewErrParamRequired("VolumeARN"))
+	}
+	if s.VolumeARN != nil && len(*s.VolumeARN) < 50 {
+		invalidParams.Add(request.NewErrParamMinLen("VolumeARN", 50))
+	}
+
+	if invalidParams.Len() > 0 {
+		return invalidParams
+	}
+	return nil
+}
+
 // ListVolumeInitiatorsOutput
 type ListVolumeInitiatorsOutput struct {
 	_ struct{} `type:"structure"`
@@ -3956,6 +4756,22 @@ func (s ListVolumeRecoveryPointsInput) String() string {
 // GoString returns the string representation
 func (s ListVolumeRecoveryPointsInput) GoString() string {
 	return s.String()
+}
+
+// Validate inspects the fields of the type to determine if they are valid.
+func (s *ListVolumeRecoveryPointsInput) Validate() error {
+	invalidParams := request.ErrInvalidParams{Context: "ListVolumeRecoveryPointsInput"}
+	if s.GatewayARN == nil {
+		invalidParams.Add(request.NewErrParamRequired("GatewayARN"))
+	}
+	if s.GatewayARN != nil && len(*s.GatewayARN) < 50 {
+		invalidParams.Add(request.NewErrParamMinLen("GatewayARN", 50))
+	}
+
+	if invalidParams.Len() > 0 {
+		return invalidParams
+	}
+	return nil
 }
 
 type ListVolumeRecoveryPointsOutput struct {
@@ -4006,6 +4822,28 @@ func (s ListVolumesInput) String() string {
 // GoString returns the string representation
 func (s ListVolumesInput) GoString() string {
 	return s.String()
+}
+
+// Validate inspects the fields of the type to determine if they are valid.
+func (s *ListVolumesInput) Validate() error {
+	invalidParams := request.ErrInvalidParams{Context: "ListVolumesInput"}
+	if s.GatewayARN == nil {
+		invalidParams.Add(request.NewErrParamRequired("GatewayARN"))
+	}
+	if s.GatewayARN != nil && len(*s.GatewayARN) < 50 {
+		invalidParams.Add(request.NewErrParamMinLen("GatewayARN", 50))
+	}
+	if s.Limit != nil && *s.Limit < 1 {
+		invalidParams.Add(request.NewErrParamMinValue("Limit", 1))
+	}
+	if s.Marker != nil && len(*s.Marker) < 1 {
+		invalidParams.Add(request.NewErrParamMinLen("Marker", 1))
+	}
+
+	if invalidParams.Len() > 0 {
+		return invalidParams
+	}
+	return nil
 }
 
 type ListVolumesOutput struct {
@@ -4080,6 +4918,25 @@ func (s RemoveTagsFromResourceInput) GoString() string {
 	return s.String()
 }
 
+// Validate inspects the fields of the type to determine if they are valid.
+func (s *RemoveTagsFromResourceInput) Validate() error {
+	invalidParams := request.ErrInvalidParams{Context: "RemoveTagsFromResourceInput"}
+	if s.ResourceARN == nil {
+		invalidParams.Add(request.NewErrParamRequired("ResourceARN"))
+	}
+	if s.ResourceARN != nil && len(*s.ResourceARN) < 50 {
+		invalidParams.Add(request.NewErrParamMinLen("ResourceARN", 50))
+	}
+	if s.TagKeys == nil {
+		invalidParams.Add(request.NewErrParamRequired("TagKeys"))
+	}
+
+	if invalidParams.Len() > 0 {
+		return invalidParams
+	}
+	return nil
+}
+
 // RemoveTagsFromResourceOutput
 type RemoveTagsFromResourceOutput struct {
 	_ struct{} `type:"structure"`
@@ -4115,6 +4972,22 @@ func (s ResetCacheInput) String() string {
 // GoString returns the string representation
 func (s ResetCacheInput) GoString() string {
 	return s.String()
+}
+
+// Validate inspects the fields of the type to determine if they are valid.
+func (s *ResetCacheInput) Validate() error {
+	invalidParams := request.ErrInvalidParams{Context: "ResetCacheInput"}
+	if s.GatewayARN == nil {
+		invalidParams.Add(request.NewErrParamRequired("GatewayARN"))
+	}
+	if s.GatewayARN != nil && len(*s.GatewayARN) < 50 {
+		invalidParams.Add(request.NewErrParamMinLen("GatewayARN", 50))
+	}
+
+	if invalidParams.Len() > 0 {
+		return invalidParams
+	}
+	return nil
 }
 
 type ResetCacheOutput struct {
@@ -4162,6 +5035,28 @@ func (s RetrieveTapeArchiveInput) GoString() string {
 	return s.String()
 }
 
+// Validate inspects the fields of the type to determine if they are valid.
+func (s *RetrieveTapeArchiveInput) Validate() error {
+	invalidParams := request.ErrInvalidParams{Context: "RetrieveTapeArchiveInput"}
+	if s.GatewayARN == nil {
+		invalidParams.Add(request.NewErrParamRequired("GatewayARN"))
+	}
+	if s.GatewayARN != nil && len(*s.GatewayARN) < 50 {
+		invalidParams.Add(request.NewErrParamMinLen("GatewayARN", 50))
+	}
+	if s.TapeARN == nil {
+		invalidParams.Add(request.NewErrParamRequired("TapeARN"))
+	}
+	if s.TapeARN != nil && len(*s.TapeARN) < 50 {
+		invalidParams.Add(request.NewErrParamMinLen("TapeARN", 50))
+	}
+
+	if invalidParams.Len() > 0 {
+		return invalidParams
+	}
+	return nil
+}
+
 // RetrieveTapeArchiveOutput
 type RetrieveTapeArchiveOutput struct {
 	_ struct{} `type:"structure"`
@@ -4201,6 +5096,28 @@ func (s RetrieveTapeRecoveryPointInput) String() string {
 // GoString returns the string representation
 func (s RetrieveTapeRecoveryPointInput) GoString() string {
 	return s.String()
+}
+
+// Validate inspects the fields of the type to determine if they are valid.
+func (s *RetrieveTapeRecoveryPointInput) Validate() error {
+	invalidParams := request.ErrInvalidParams{Context: "RetrieveTapeRecoveryPointInput"}
+	if s.GatewayARN == nil {
+		invalidParams.Add(request.NewErrParamRequired("GatewayARN"))
+	}
+	if s.GatewayARN != nil && len(*s.GatewayARN) < 50 {
+		invalidParams.Add(request.NewErrParamMinLen("GatewayARN", 50))
+	}
+	if s.TapeARN == nil {
+		invalidParams.Add(request.NewErrParamRequired("TapeARN"))
+	}
+	if s.TapeARN != nil && len(*s.TapeARN) < 50 {
+		invalidParams.Add(request.NewErrParamMinLen("TapeARN", 50))
+	}
+
+	if invalidParams.Len() > 0 {
+		return invalidParams
+	}
+	return nil
 }
 
 // RetrieveTapeRecoveryPointOutput
@@ -4244,6 +5161,28 @@ func (s SetLocalConsolePasswordInput) GoString() string {
 	return s.String()
 }
 
+// Validate inspects the fields of the type to determine if they are valid.
+func (s *SetLocalConsolePasswordInput) Validate() error {
+	invalidParams := request.ErrInvalidParams{Context: "SetLocalConsolePasswordInput"}
+	if s.GatewayARN == nil {
+		invalidParams.Add(request.NewErrParamRequired("GatewayARN"))
+	}
+	if s.GatewayARN != nil && len(*s.GatewayARN) < 50 {
+		invalidParams.Add(request.NewErrParamMinLen("GatewayARN", 50))
+	}
+	if s.LocalConsolePassword == nil {
+		invalidParams.Add(request.NewErrParamRequired("LocalConsolePassword"))
+	}
+	if s.LocalConsolePassword != nil && len(*s.LocalConsolePassword) < 6 {
+		invalidParams.Add(request.NewErrParamMinLen("LocalConsolePassword", 6))
+	}
+
+	if invalidParams.Len() > 0 {
+		return invalidParams
+	}
+	return nil
+}
+
 type SetLocalConsolePasswordOutput struct {
 	_ struct{} `type:"structure"`
 
@@ -4279,6 +5218,22 @@ func (s ShutdownGatewayInput) String() string {
 // GoString returns the string representation
 func (s ShutdownGatewayInput) GoString() string {
 	return s.String()
+}
+
+// Validate inspects the fields of the type to determine if they are valid.
+func (s *ShutdownGatewayInput) Validate() error {
+	invalidParams := request.ErrInvalidParams{Context: "ShutdownGatewayInput"}
+	if s.GatewayARN == nil {
+		invalidParams.Add(request.NewErrParamRequired("GatewayARN"))
+	}
+	if s.GatewayARN != nil && len(*s.GatewayARN) < 50 {
+		invalidParams.Add(request.NewErrParamMinLen("GatewayARN", 50))
+	}
+
+	if invalidParams.Len() > 0 {
+		return invalidParams
+	}
+	return nil
 }
 
 // A JSON object containing the of the gateway that was shut down.
@@ -4317,6 +5272,22 @@ func (s StartGatewayInput) String() string {
 // GoString returns the string representation
 func (s StartGatewayInput) GoString() string {
 	return s.String()
+}
+
+// Validate inspects the fields of the type to determine if they are valid.
+func (s *StartGatewayInput) Validate() error {
+	invalidParams := request.ErrInvalidParams{Context: "StartGatewayInput"}
+	if s.GatewayARN == nil {
+		invalidParams.Add(request.NewErrParamRequired("GatewayARN"))
+	}
+	if s.GatewayARN != nil && len(*s.GatewayARN) < 50 {
+		invalidParams.Add(request.NewErrParamMinLen("GatewayARN", 50))
+	}
+
+	if invalidParams.Len() > 0 {
+		return invalidParams
+	}
+	return nil
 }
 
 // A JSON object containing the of the gateway that was restarted.
@@ -4389,6 +5360,25 @@ func (s Tag) String() string {
 // GoString returns the string representation
 func (s Tag) GoString() string {
 	return s.String()
+}
+
+// Validate inspects the fields of the type to determine if they are valid.
+func (s *Tag) Validate() error {
+	invalidParams := request.ErrInvalidParams{Context: "Tag"}
+	if s.Key == nil {
+		invalidParams.Add(request.NewErrParamRequired("Key"))
+	}
+	if s.Key != nil && len(*s.Key) < 1 {
+		invalidParams.Add(request.NewErrParamMinLen("Key", 1))
+	}
+	if s.Value == nil {
+		invalidParams.Add(request.NewErrParamRequired("Value"))
+	}
+
+	if invalidParams.Len() > 0 {
+		return invalidParams
+	}
+	return nil
 }
 
 // Describes a virtual tape object.
@@ -4524,6 +5514,28 @@ func (s UpdateBandwidthRateLimitInput) GoString() string {
 	return s.String()
 }
 
+// Validate inspects the fields of the type to determine if they are valid.
+func (s *UpdateBandwidthRateLimitInput) Validate() error {
+	invalidParams := request.ErrInvalidParams{Context: "UpdateBandwidthRateLimitInput"}
+	if s.AverageDownloadRateLimitInBitsPerSec != nil && *s.AverageDownloadRateLimitInBitsPerSec < 102400 {
+		invalidParams.Add(request.NewErrParamMinValue("AverageDownloadRateLimitInBitsPerSec", 102400))
+	}
+	if s.AverageUploadRateLimitInBitsPerSec != nil && *s.AverageUploadRateLimitInBitsPerSec < 51200 {
+		invalidParams.Add(request.NewErrParamMinValue("AverageUploadRateLimitInBitsPerSec", 51200))
+	}
+	if s.GatewayARN == nil {
+		invalidParams.Add(request.NewErrParamRequired("GatewayARN"))
+	}
+	if s.GatewayARN != nil && len(*s.GatewayARN) < 50 {
+		invalidParams.Add(request.NewErrParamMinLen("GatewayARN", 50))
+	}
+
+	if invalidParams.Len() > 0 {
+		return invalidParams
+	}
+	return nil
+}
+
 // A JSON object containing the of the gateway whose throttle information was
 // updated.
 type UpdateBandwidthRateLimitOutput struct {
@@ -4583,6 +5595,37 @@ func (s UpdateChapCredentialsInput) GoString() string {
 	return s.String()
 }
 
+// Validate inspects the fields of the type to determine if they are valid.
+func (s *UpdateChapCredentialsInput) Validate() error {
+	invalidParams := request.ErrInvalidParams{Context: "UpdateChapCredentialsInput"}
+	if s.InitiatorName == nil {
+		invalidParams.Add(request.NewErrParamRequired("InitiatorName"))
+	}
+	if s.InitiatorName != nil && len(*s.InitiatorName) < 1 {
+		invalidParams.Add(request.NewErrParamMinLen("InitiatorName", 1))
+	}
+	if s.SecretToAuthenticateInitiator == nil {
+		invalidParams.Add(request.NewErrParamRequired("SecretToAuthenticateInitiator"))
+	}
+	if s.SecretToAuthenticateInitiator != nil && len(*s.SecretToAuthenticateInitiator) < 1 {
+		invalidParams.Add(request.NewErrParamMinLen("SecretToAuthenticateInitiator", 1))
+	}
+	if s.SecretToAuthenticateTarget != nil && len(*s.SecretToAuthenticateTarget) < 1 {
+		invalidParams.Add(request.NewErrParamMinLen("SecretToAuthenticateTarget", 1))
+	}
+	if s.TargetARN == nil {
+		invalidParams.Add(request.NewErrParamRequired("TargetARN"))
+	}
+	if s.TargetARN != nil && len(*s.TargetARN) < 50 {
+		invalidParams.Add(request.NewErrParamMinLen("TargetARN", 50))
+	}
+
+	if invalidParams.Len() > 0 {
+		return invalidParams
+	}
+	return nil
+}
+
 // A JSON object containing the following fields:
 type UpdateChapCredentialsOutput struct {
 	_ struct{} `type:"structure"`
@@ -4629,6 +5672,28 @@ func (s UpdateGatewayInformationInput) GoString() string {
 	return s.String()
 }
 
+// Validate inspects the fields of the type to determine if they are valid.
+func (s *UpdateGatewayInformationInput) Validate() error {
+	invalidParams := request.ErrInvalidParams{Context: "UpdateGatewayInformationInput"}
+	if s.GatewayARN == nil {
+		invalidParams.Add(request.NewErrParamRequired("GatewayARN"))
+	}
+	if s.GatewayARN != nil && len(*s.GatewayARN) < 50 {
+		invalidParams.Add(request.NewErrParamMinLen("GatewayARN", 50))
+	}
+	if s.GatewayName != nil && len(*s.GatewayName) < 2 {
+		invalidParams.Add(request.NewErrParamMinLen("GatewayName", 2))
+	}
+	if s.GatewayTimezone != nil && len(*s.GatewayTimezone) < 3 {
+		invalidParams.Add(request.NewErrParamMinLen("GatewayTimezone", 3))
+	}
+
+	if invalidParams.Len() > 0 {
+		return invalidParams
+	}
+	return nil
+}
+
 // A JSON object containing the ARN of the gateway that was updated.
 type UpdateGatewayInformationOutput struct {
 	_ struct{} `type:"structure"`
@@ -4667,6 +5732,22 @@ func (s UpdateGatewaySoftwareNowInput) String() string {
 // GoString returns the string representation
 func (s UpdateGatewaySoftwareNowInput) GoString() string {
 	return s.String()
+}
+
+// Validate inspects the fields of the type to determine if they are valid.
+func (s *UpdateGatewaySoftwareNowInput) Validate() error {
+	invalidParams := request.ErrInvalidParams{Context: "UpdateGatewaySoftwareNowInput"}
+	if s.GatewayARN == nil {
+		invalidParams.Add(request.NewErrParamRequired("GatewayARN"))
+	}
+	if s.GatewayARN != nil && len(*s.GatewayARN) < 50 {
+		invalidParams.Add(request.NewErrParamMinLen("GatewayARN", 50))
+	}
+
+	if invalidParams.Len() > 0 {
+		return invalidParams
+	}
+	return nil
 }
 
 // A JSON object containing the of the gateway that was updated.
@@ -4723,6 +5804,31 @@ func (s UpdateMaintenanceStartTimeInput) GoString() string {
 	return s.String()
 }
 
+// Validate inspects the fields of the type to determine if they are valid.
+func (s *UpdateMaintenanceStartTimeInput) Validate() error {
+	invalidParams := request.ErrInvalidParams{Context: "UpdateMaintenanceStartTimeInput"}
+	if s.DayOfWeek == nil {
+		invalidParams.Add(request.NewErrParamRequired("DayOfWeek"))
+	}
+	if s.GatewayARN == nil {
+		invalidParams.Add(request.NewErrParamRequired("GatewayARN"))
+	}
+	if s.GatewayARN != nil && len(*s.GatewayARN) < 50 {
+		invalidParams.Add(request.NewErrParamMinLen("GatewayARN", 50))
+	}
+	if s.HourOfDay == nil {
+		invalidParams.Add(request.NewErrParamRequired("HourOfDay"))
+	}
+	if s.MinuteOfHour == nil {
+		invalidParams.Add(request.NewErrParamRequired("MinuteOfHour"))
+	}
+
+	if invalidParams.Len() > 0 {
+		return invalidParams
+	}
+	return nil
+}
+
 // A JSON object containing the of the gateway whose maintenance start time
 // is updated.
 type UpdateMaintenanceStartTimeOutput struct {
@@ -4776,6 +5882,34 @@ func (s UpdateSnapshotScheduleInput) GoString() string {
 	return s.String()
 }
 
+// Validate inspects the fields of the type to determine if they are valid.
+func (s *UpdateSnapshotScheduleInput) Validate() error {
+	invalidParams := request.ErrInvalidParams{Context: "UpdateSnapshotScheduleInput"}
+	if s.Description != nil && len(*s.Description) < 1 {
+		invalidParams.Add(request.NewErrParamMinLen("Description", 1))
+	}
+	if s.RecurrenceInHours == nil {
+		invalidParams.Add(request.NewErrParamRequired("RecurrenceInHours"))
+	}
+	if s.RecurrenceInHours != nil && *s.RecurrenceInHours < 1 {
+		invalidParams.Add(request.NewErrParamMinValue("RecurrenceInHours", 1))
+	}
+	if s.StartAt == nil {
+		invalidParams.Add(request.NewErrParamRequired("StartAt"))
+	}
+	if s.VolumeARN == nil {
+		invalidParams.Add(request.NewErrParamRequired("VolumeARN"))
+	}
+	if s.VolumeARN != nil && len(*s.VolumeARN) < 50 {
+		invalidParams.Add(request.NewErrParamMinLen("VolumeARN", 50))
+	}
+
+	if invalidParams.Len() > 0 {
+		return invalidParams
+	}
+	return nil
+}
+
 // A JSON object containing the of the updated storage volume.
 type UpdateSnapshotScheduleOutput struct {
 	_ struct{} `type:"structure"`
@@ -4813,6 +5947,28 @@ func (s UpdateVTLDeviceTypeInput) String() string {
 // GoString returns the string representation
 func (s UpdateVTLDeviceTypeInput) GoString() string {
 	return s.String()
+}
+
+// Validate inspects the fields of the type to determine if they are valid.
+func (s *UpdateVTLDeviceTypeInput) Validate() error {
+	invalidParams := request.ErrInvalidParams{Context: "UpdateVTLDeviceTypeInput"}
+	if s.DeviceType == nil {
+		invalidParams.Add(request.NewErrParamRequired("DeviceType"))
+	}
+	if s.DeviceType != nil && len(*s.DeviceType) < 2 {
+		invalidParams.Add(request.NewErrParamMinLen("DeviceType", 2))
+	}
+	if s.VTLDeviceARN == nil {
+		invalidParams.Add(request.NewErrParamRequired("VTLDeviceARN"))
+	}
+	if s.VTLDeviceARN != nil && len(*s.VTLDeviceARN) < 50 {
+		invalidParams.Add(request.NewErrParamMinLen("VTLDeviceARN", 50))
+	}
+
+	if invalidParams.Len() > 0 {
+		return invalidParams
+	}
+	return nil
 }
 
 // UpdateVTLDeviceTypeOutput

--- a/service/sts/api.go
+++ b/service/sts/api.go
@@ -633,6 +633,43 @@ func (s AssumeRoleInput) GoString() string {
 	return s.String()
 }
 
+// Validate inspects the fields of the type to determine if they are valid.
+func (s *AssumeRoleInput) Validate() error {
+	invalidParams := request.ErrInvalidParams{Context: "AssumeRoleInput"}
+	if s.DurationSeconds != nil && *s.DurationSeconds < 900 {
+		invalidParams.Add(request.NewErrParamMinValue("DurationSeconds", 900))
+	}
+	if s.ExternalId != nil && len(*s.ExternalId) < 2 {
+		invalidParams.Add(request.NewErrParamMinLen("ExternalId", 2))
+	}
+	if s.Policy != nil && len(*s.Policy) < 1 {
+		invalidParams.Add(request.NewErrParamMinLen("Policy", 1))
+	}
+	if s.RoleArn == nil {
+		invalidParams.Add(request.NewErrParamRequired("RoleArn"))
+	}
+	if s.RoleArn != nil && len(*s.RoleArn) < 20 {
+		invalidParams.Add(request.NewErrParamMinLen("RoleArn", 20))
+	}
+	if s.RoleSessionName == nil {
+		invalidParams.Add(request.NewErrParamRequired("RoleSessionName"))
+	}
+	if s.RoleSessionName != nil && len(*s.RoleSessionName) < 2 {
+		invalidParams.Add(request.NewErrParamMinLen("RoleSessionName", 2))
+	}
+	if s.SerialNumber != nil && len(*s.SerialNumber) < 9 {
+		invalidParams.Add(request.NewErrParamMinLen("SerialNumber", 9))
+	}
+	if s.TokenCode != nil && len(*s.TokenCode) < 6 {
+		invalidParams.Add(request.NewErrParamMinLen("TokenCode", 6))
+	}
+
+	if invalidParams.Len() > 0 {
+		return invalidParams
+	}
+	return nil
+}
+
 // Contains the response to a successful AssumeRole request, including temporary
 // AWS credentials that can be used to make AWS requests.
 type AssumeRoleOutput struct {
@@ -726,6 +763,40 @@ func (s AssumeRoleWithSAMLInput) String() string {
 // GoString returns the string representation
 func (s AssumeRoleWithSAMLInput) GoString() string {
 	return s.String()
+}
+
+// Validate inspects the fields of the type to determine if they are valid.
+func (s *AssumeRoleWithSAMLInput) Validate() error {
+	invalidParams := request.ErrInvalidParams{Context: "AssumeRoleWithSAMLInput"}
+	if s.DurationSeconds != nil && *s.DurationSeconds < 900 {
+		invalidParams.Add(request.NewErrParamMinValue("DurationSeconds", 900))
+	}
+	if s.Policy != nil && len(*s.Policy) < 1 {
+		invalidParams.Add(request.NewErrParamMinLen("Policy", 1))
+	}
+	if s.PrincipalArn == nil {
+		invalidParams.Add(request.NewErrParamRequired("PrincipalArn"))
+	}
+	if s.PrincipalArn != nil && len(*s.PrincipalArn) < 20 {
+		invalidParams.Add(request.NewErrParamMinLen("PrincipalArn", 20))
+	}
+	if s.RoleArn == nil {
+		invalidParams.Add(request.NewErrParamRequired("RoleArn"))
+	}
+	if s.RoleArn != nil && len(*s.RoleArn) < 20 {
+		invalidParams.Add(request.NewErrParamMinLen("RoleArn", 20))
+	}
+	if s.SAMLAssertion == nil {
+		invalidParams.Add(request.NewErrParamRequired("SAMLAssertion"))
+	}
+	if s.SAMLAssertion != nil && len(*s.SAMLAssertion) < 4 {
+		invalidParams.Add(request.NewErrParamMinLen("SAMLAssertion", 4))
+	}
+
+	if invalidParams.Len() > 0 {
+		return invalidParams
+	}
+	return nil
 }
 
 // Contains the response to a successful AssumeRoleWithSAML request, including
@@ -856,6 +927,43 @@ func (s AssumeRoleWithWebIdentityInput) GoString() string {
 	return s.String()
 }
 
+// Validate inspects the fields of the type to determine if they are valid.
+func (s *AssumeRoleWithWebIdentityInput) Validate() error {
+	invalidParams := request.ErrInvalidParams{Context: "AssumeRoleWithWebIdentityInput"}
+	if s.DurationSeconds != nil && *s.DurationSeconds < 900 {
+		invalidParams.Add(request.NewErrParamMinValue("DurationSeconds", 900))
+	}
+	if s.Policy != nil && len(*s.Policy) < 1 {
+		invalidParams.Add(request.NewErrParamMinLen("Policy", 1))
+	}
+	if s.ProviderId != nil && len(*s.ProviderId) < 4 {
+		invalidParams.Add(request.NewErrParamMinLen("ProviderId", 4))
+	}
+	if s.RoleArn == nil {
+		invalidParams.Add(request.NewErrParamRequired("RoleArn"))
+	}
+	if s.RoleArn != nil && len(*s.RoleArn) < 20 {
+		invalidParams.Add(request.NewErrParamMinLen("RoleArn", 20))
+	}
+	if s.RoleSessionName == nil {
+		invalidParams.Add(request.NewErrParamRequired("RoleSessionName"))
+	}
+	if s.RoleSessionName != nil && len(*s.RoleSessionName) < 2 {
+		invalidParams.Add(request.NewErrParamMinLen("RoleSessionName", 2))
+	}
+	if s.WebIdentityToken == nil {
+		invalidParams.Add(request.NewErrParamRequired("WebIdentityToken"))
+	}
+	if s.WebIdentityToken != nil && len(*s.WebIdentityToken) < 4 {
+		invalidParams.Add(request.NewErrParamMinLen("WebIdentityToken", 4))
+	}
+
+	if invalidParams.Len() > 0 {
+		return invalidParams
+	}
+	return nil
+}
+
 // Contains the response to a successful AssumeRoleWithWebIdentity request,
 // including temporary AWS credentials that can be used to make AWS requests.
 type AssumeRoleWithWebIdentityOutput struct {
@@ -981,6 +1089,22 @@ func (s DecodeAuthorizationMessageInput) String() string {
 // GoString returns the string representation
 func (s DecodeAuthorizationMessageInput) GoString() string {
 	return s.String()
+}
+
+// Validate inspects the fields of the type to determine if they are valid.
+func (s *DecodeAuthorizationMessageInput) Validate() error {
+	invalidParams := request.ErrInvalidParams{Context: "DecodeAuthorizationMessageInput"}
+	if s.EncodedMessage == nil {
+		invalidParams.Add(request.NewErrParamRequired("EncodedMessage"))
+	}
+	if s.EncodedMessage != nil && len(*s.EncodedMessage) < 1 {
+		invalidParams.Add(request.NewErrParamMinLen("EncodedMessage", 1))
+	}
+
+	if invalidParams.Len() > 0 {
+		return invalidParams
+	}
+	return nil
 }
 
 // A document that contains additional information about the authorization status
@@ -1124,6 +1248,28 @@ func (s GetFederationTokenInput) GoString() string {
 	return s.String()
 }
 
+// Validate inspects the fields of the type to determine if they are valid.
+func (s *GetFederationTokenInput) Validate() error {
+	invalidParams := request.ErrInvalidParams{Context: "GetFederationTokenInput"}
+	if s.DurationSeconds != nil && *s.DurationSeconds < 900 {
+		invalidParams.Add(request.NewErrParamMinValue("DurationSeconds", 900))
+	}
+	if s.Name == nil {
+		invalidParams.Add(request.NewErrParamRequired("Name"))
+	}
+	if s.Name != nil && len(*s.Name) < 2 {
+		invalidParams.Add(request.NewErrParamMinLen("Name", 2))
+	}
+	if s.Policy != nil && len(*s.Policy) < 1 {
+		invalidParams.Add(request.NewErrParamMinLen("Policy", 1))
+	}
+
+	if invalidParams.Len() > 0 {
+		return invalidParams
+	}
+	return nil
+}
+
 // Contains the response to a successful GetFederationToken request, including
 // temporary AWS credentials that can be used to make AWS requests.
 type GetFederationTokenOutput struct {
@@ -1196,6 +1342,25 @@ func (s GetSessionTokenInput) String() string {
 // GoString returns the string representation
 func (s GetSessionTokenInput) GoString() string {
 	return s.String()
+}
+
+// Validate inspects the fields of the type to determine if they are valid.
+func (s *GetSessionTokenInput) Validate() error {
+	invalidParams := request.ErrInvalidParams{Context: "GetSessionTokenInput"}
+	if s.DurationSeconds != nil && *s.DurationSeconds < 900 {
+		invalidParams.Add(request.NewErrParamMinValue("DurationSeconds", 900))
+	}
+	if s.SerialNumber != nil && len(*s.SerialNumber) < 9 {
+		invalidParams.Add(request.NewErrParamMinLen("SerialNumber", 9))
+	}
+	if s.TokenCode != nil && len(*s.TokenCode) < 6 {
+		invalidParams.Add(request.NewErrParamMinLen("TokenCode", 6))
+	}
+
+	if invalidParams.Len() > 0 {
+		return invalidParams
+	}
+	return nil
 }
 
 // Contains the response to a successful GetSessionToken request, including

--- a/service/support/api.go
+++ b/service/support/api.go
@@ -548,6 +548,19 @@ func (s AddAttachmentsToSetInput) GoString() string {
 	return s.String()
 }
 
+// Validate inspects the fields of the type to determine if they are valid.
+func (s *AddAttachmentsToSetInput) Validate() error {
+	invalidParams := request.ErrInvalidParams{Context: "AddAttachmentsToSetInput"}
+	if s.Attachments == nil {
+		invalidParams.Add(request.NewErrParamRequired("Attachments"))
+	}
+
+	if invalidParams.Len() > 0 {
+		return invalidParams
+	}
+	return nil
+}
+
 // The ID and expiry time of the attachment set returned by the AddAttachmentsToSet
 // operation.
 type AddAttachmentsToSetOutput struct {
@@ -601,6 +614,19 @@ func (s AddCommunicationToCaseInput) String() string {
 // GoString returns the string representation
 func (s AddCommunicationToCaseInput) GoString() string {
 	return s.String()
+}
+
+// Validate inspects the fields of the type to determine if they are valid.
+func (s *AddCommunicationToCaseInput) Validate() error {
+	invalidParams := request.ErrInvalidParams{Context: "AddCommunicationToCaseInput"}
+	if s.CommunicationBody == nil {
+		invalidParams.Add(request.NewErrParamRequired("CommunicationBody"))
+	}
+
+	if invalidParams.Len() > 0 {
+		return invalidParams
+	}
+	return nil
 }
 
 // The result of the AddCommunicationToCase operation.
@@ -850,6 +876,22 @@ func (s CreateCaseInput) GoString() string {
 	return s.String()
 }
 
+// Validate inspects the fields of the type to determine if they are valid.
+func (s *CreateCaseInput) Validate() error {
+	invalidParams := request.ErrInvalidParams{Context: "CreateCaseInput"}
+	if s.CommunicationBody == nil {
+		invalidParams.Add(request.NewErrParamRequired("CommunicationBody"))
+	}
+	if s.Subject == nil {
+		invalidParams.Add(request.NewErrParamRequired("Subject"))
+	}
+
+	if invalidParams.Len() > 0 {
+		return invalidParams
+	}
+	return nil
+}
+
 // The AWS Support case ID returned by a successful completion of the CreateCase
 // operation.
 type CreateCaseOutput struct {
@@ -886,6 +928,19 @@ func (s DescribeAttachmentInput) String() string {
 // GoString returns the string representation
 func (s DescribeAttachmentInput) GoString() string {
 	return s.String()
+}
+
+// Validate inspects the fields of the type to determine if they are valid.
+func (s *DescribeAttachmentInput) Validate() error {
+	invalidParams := request.ErrInvalidParams{Context: "DescribeAttachmentInput"}
+	if s.AttachmentId == nil {
+		invalidParams.Add(request.NewErrParamRequired("AttachmentId"))
+	}
+
+	if invalidParams.Len() > 0 {
+		return invalidParams
+	}
+	return nil
 }
 
 // The content and file name of the attachment returned by the DescribeAttachment
@@ -955,6 +1010,19 @@ func (s DescribeCasesInput) GoString() string {
 	return s.String()
 }
 
+// Validate inspects the fields of the type to determine if they are valid.
+func (s *DescribeCasesInput) Validate() error {
+	invalidParams := request.ErrInvalidParams{Context: "DescribeCasesInput"}
+	if s.MaxResults != nil && *s.MaxResults < 10 {
+		invalidParams.Add(request.NewErrParamMinValue("MaxResults", 10))
+	}
+
+	if invalidParams.Len() > 0 {
+		return invalidParams
+	}
+	return nil
+}
+
 // Returns an array of CaseDetails objects and a NextToken that defines a point
 // for pagination in the result set.
 type DescribeCasesOutput struct {
@@ -1007,6 +1075,22 @@ func (s DescribeCommunicationsInput) String() string {
 // GoString returns the string representation
 func (s DescribeCommunicationsInput) GoString() string {
 	return s.String()
+}
+
+// Validate inspects the fields of the type to determine if they are valid.
+func (s *DescribeCommunicationsInput) Validate() error {
+	invalidParams := request.ErrInvalidParams{Context: "DescribeCommunicationsInput"}
+	if s.CaseId == nil {
+		invalidParams.Add(request.NewErrParamRequired("CaseId"))
+	}
+	if s.MaxResults != nil && *s.MaxResults < 10 {
+		invalidParams.Add(request.NewErrParamMinValue("MaxResults", 10))
+	}
+
+	if invalidParams.Len() > 0 {
+		return invalidParams
+	}
+	return nil
 }
 
 // The communications returned by the DescribeCommunications operation.
@@ -1125,6 +1209,19 @@ func (s DescribeTrustedAdvisorCheckRefreshStatusesInput) GoString() string {
 	return s.String()
 }
 
+// Validate inspects the fields of the type to determine if they are valid.
+func (s *DescribeTrustedAdvisorCheckRefreshStatusesInput) Validate() error {
+	invalidParams := request.ErrInvalidParams{Context: "DescribeTrustedAdvisorCheckRefreshStatusesInput"}
+	if s.CheckIds == nil {
+		invalidParams.Add(request.NewErrParamRequired("CheckIds"))
+	}
+
+	if invalidParams.Len() > 0 {
+		return invalidParams
+	}
+	return nil
+}
+
 // The statuses of the Trusted Advisor checks returned by the DescribeTrustedAdvisorCheckRefreshStatuses
 // operation.
 type DescribeTrustedAdvisorCheckRefreshStatusesOutput struct {
@@ -1166,6 +1263,19 @@ func (s DescribeTrustedAdvisorCheckResultInput) GoString() string {
 	return s.String()
 }
 
+// Validate inspects the fields of the type to determine if they are valid.
+func (s *DescribeTrustedAdvisorCheckResultInput) Validate() error {
+	invalidParams := request.ErrInvalidParams{Context: "DescribeTrustedAdvisorCheckResultInput"}
+	if s.CheckId == nil {
+		invalidParams.Add(request.NewErrParamRequired("CheckId"))
+	}
+
+	if invalidParams.Len() > 0 {
+		return invalidParams
+	}
+	return nil
+}
+
 // The result of the Trusted Advisor check returned by the DescribeTrustedAdvisorCheckResult
 // operation.
 type DescribeTrustedAdvisorCheckResultOutput struct {
@@ -1200,6 +1310,19 @@ func (s DescribeTrustedAdvisorCheckSummariesInput) String() string {
 // GoString returns the string representation
 func (s DescribeTrustedAdvisorCheckSummariesInput) GoString() string {
 	return s.String()
+}
+
+// Validate inspects the fields of the type to determine if they are valid.
+func (s *DescribeTrustedAdvisorCheckSummariesInput) Validate() error {
+	invalidParams := request.ErrInvalidParams{Context: "DescribeTrustedAdvisorCheckSummariesInput"}
+	if s.CheckIds == nil {
+		invalidParams.Add(request.NewErrParamRequired("CheckIds"))
+	}
+
+	if invalidParams.Len() > 0 {
+		return invalidParams
+	}
+	return nil
 }
 
 // The summaries of the Trusted Advisor checks returned by the DescribeTrustedAdvisorCheckSummaries
@@ -1238,6 +1361,19 @@ func (s DescribeTrustedAdvisorChecksInput) String() string {
 // GoString returns the string representation
 func (s DescribeTrustedAdvisorChecksInput) GoString() string {
 	return s.String()
+}
+
+// Validate inspects the fields of the type to determine if they are valid.
+func (s *DescribeTrustedAdvisorChecksInput) Validate() error {
+	invalidParams := request.ErrInvalidParams{Context: "DescribeTrustedAdvisorChecksInput"}
+	if s.Language == nil {
+		invalidParams.Add(request.NewErrParamRequired("Language"))
+	}
+
+	if invalidParams.Len() > 0 {
+		return invalidParams
+	}
+	return nil
 }
 
 // Information about the Trusted Advisor checks returned by the DescribeTrustedAdvisorChecks
@@ -1295,6 +1431,19 @@ func (s RefreshTrustedAdvisorCheckInput) String() string {
 // GoString returns the string representation
 func (s RefreshTrustedAdvisorCheckInput) GoString() string {
 	return s.String()
+}
+
+// Validate inspects the fields of the type to determine if they are valid.
+func (s *RefreshTrustedAdvisorCheckInput) Validate() error {
+	invalidParams := request.ErrInvalidParams{Context: "RefreshTrustedAdvisorCheckInput"}
+	if s.CheckId == nil {
+		invalidParams.Add(request.NewErrParamRequired("CheckId"))
+	}
+
+	if invalidParams.Len() > 0 {
+		return invalidParams
+	}
+	return nil
 }
 
 // The current refresh status of a Trusted Advisor check.

--- a/service/swf/api.go
+++ b/service/swf/api.go
@@ -4,6 +4,7 @@
 package swf
 
 import (
+	"fmt"
 	"time"
 
 	"github.com/aws/aws-sdk-go/aws/awsutil"
@@ -1874,6 +1875,28 @@ func (s ActivityType) GoString() string {
 	return s.String()
 }
 
+// Validate inspects the fields of the type to determine if they are valid.
+func (s *ActivityType) Validate() error {
+	invalidParams := request.ErrInvalidParams{Context: "ActivityType"}
+	if s.Name == nil {
+		invalidParams.Add(request.NewErrParamRequired("Name"))
+	}
+	if s.Name != nil && len(*s.Name) < 1 {
+		invalidParams.Add(request.NewErrParamMinLen("Name", 1))
+	}
+	if s.Version == nil {
+		invalidParams.Add(request.NewErrParamRequired("Version"))
+	}
+	if s.Version != nil && len(*s.Version) < 1 {
+		invalidParams.Add(request.NewErrParamMinLen("Version", 1))
+	}
+
+	if invalidParams.Len() > 0 {
+		return invalidParams
+	}
+	return nil
+}
+
 // Configuration settings registered with the activity type.
 type ActivityTypeConfiguration struct {
 	_ struct{} `type:"structure"`
@@ -2006,6 +2029,22 @@ func (s CancelTimerDecisionAttributes) String() string {
 // GoString returns the string representation
 func (s CancelTimerDecisionAttributes) GoString() string {
 	return s.String()
+}
+
+// Validate inspects the fields of the type to determine if they are valid.
+func (s *CancelTimerDecisionAttributes) Validate() error {
+	invalidParams := request.ErrInvalidParams{Context: "CancelTimerDecisionAttributes"}
+	if s.TimerId == nil {
+		invalidParams.Add(request.NewErrParamRequired("TimerId"))
+	}
+	if s.TimerId != nil && len(*s.TimerId) < 1 {
+		invalidParams.Add(request.NewErrParamMinLen("TimerId", 1))
+	}
+
+	if invalidParams.Len() > 0 {
+		return invalidParams
+	}
+	return nil
 }
 
 // Provides details of the CancelTimerFailed event.
@@ -2324,6 +2363,19 @@ func (s CloseStatusFilter) GoString() string {
 	return s.String()
 }
 
+// Validate inspects the fields of the type to determine if they are valid.
+func (s *CloseStatusFilter) Validate() error {
+	invalidParams := request.ErrInvalidParams{Context: "CloseStatusFilter"}
+	if s.Status == nil {
+		invalidParams.Add(request.NewErrParamRequired("Status"))
+	}
+
+	if invalidParams.Len() > 0 {
+		return invalidParams
+	}
+	return nil
+}
+
 // Provides details of the CompleteWorkflowExecution decision.
 //
 // Access Control
@@ -2494,6 +2546,27 @@ func (s ContinueAsNewWorkflowExecutionDecisionAttributes) GoString() string {
 	return s.String()
 }
 
+// Validate inspects the fields of the type to determine if they are valid.
+func (s *ContinueAsNewWorkflowExecutionDecisionAttributes) Validate() error {
+	invalidParams := request.ErrInvalidParams{Context: "ContinueAsNewWorkflowExecutionDecisionAttributes"}
+	if s.LambdaRole != nil && len(*s.LambdaRole) < 1 {
+		invalidParams.Add(request.NewErrParamMinLen("LambdaRole", 1))
+	}
+	if s.WorkflowTypeVersion != nil && len(*s.WorkflowTypeVersion) < 1 {
+		invalidParams.Add(request.NewErrParamMinLen("WorkflowTypeVersion", 1))
+	}
+	if s.TaskList != nil {
+		if err := s.TaskList.Validate(); err != nil {
+			invalidParams.AddNested("TaskList", err.(request.ErrInvalidParams))
+		}
+	}
+
+	if invalidParams.Len() > 0 {
+		return invalidParams
+	}
+	return nil
+}
+
 // Provides details of the ContinueAsNewWorkflowExecutionFailed event.
 type ContinueAsNewWorkflowExecutionFailedEventAttributes struct {
 	_ struct{} `type:"structure"`
@@ -2581,6 +2654,52 @@ func (s CountClosedWorkflowExecutionsInput) GoString() string {
 	return s.String()
 }
 
+// Validate inspects the fields of the type to determine if they are valid.
+func (s *CountClosedWorkflowExecutionsInput) Validate() error {
+	invalidParams := request.ErrInvalidParams{Context: "CountClosedWorkflowExecutionsInput"}
+	if s.Domain == nil {
+		invalidParams.Add(request.NewErrParamRequired("Domain"))
+	}
+	if s.Domain != nil && len(*s.Domain) < 1 {
+		invalidParams.Add(request.NewErrParamMinLen("Domain", 1))
+	}
+	if s.CloseStatusFilter != nil {
+		if err := s.CloseStatusFilter.Validate(); err != nil {
+			invalidParams.AddNested("CloseStatusFilter", err.(request.ErrInvalidParams))
+		}
+	}
+	if s.CloseTimeFilter != nil {
+		if err := s.CloseTimeFilter.Validate(); err != nil {
+			invalidParams.AddNested("CloseTimeFilter", err.(request.ErrInvalidParams))
+		}
+	}
+	if s.ExecutionFilter != nil {
+		if err := s.ExecutionFilter.Validate(); err != nil {
+			invalidParams.AddNested("ExecutionFilter", err.(request.ErrInvalidParams))
+		}
+	}
+	if s.StartTimeFilter != nil {
+		if err := s.StartTimeFilter.Validate(); err != nil {
+			invalidParams.AddNested("StartTimeFilter", err.(request.ErrInvalidParams))
+		}
+	}
+	if s.TagFilter != nil {
+		if err := s.TagFilter.Validate(); err != nil {
+			invalidParams.AddNested("TagFilter", err.(request.ErrInvalidParams))
+		}
+	}
+	if s.TypeFilter != nil {
+		if err := s.TypeFilter.Validate(); err != nil {
+			invalidParams.AddNested("TypeFilter", err.(request.ErrInvalidParams))
+		}
+	}
+
+	if invalidParams.Len() > 0 {
+		return invalidParams
+	}
+	return nil
+}
+
 type CountOpenWorkflowExecutionsInput struct {
 	_ struct{} `type:"structure"`
 
@@ -2622,6 +2741,45 @@ func (s CountOpenWorkflowExecutionsInput) GoString() string {
 	return s.String()
 }
 
+// Validate inspects the fields of the type to determine if they are valid.
+func (s *CountOpenWorkflowExecutionsInput) Validate() error {
+	invalidParams := request.ErrInvalidParams{Context: "CountOpenWorkflowExecutionsInput"}
+	if s.Domain == nil {
+		invalidParams.Add(request.NewErrParamRequired("Domain"))
+	}
+	if s.Domain != nil && len(*s.Domain) < 1 {
+		invalidParams.Add(request.NewErrParamMinLen("Domain", 1))
+	}
+	if s.StartTimeFilter == nil {
+		invalidParams.Add(request.NewErrParamRequired("StartTimeFilter"))
+	}
+	if s.ExecutionFilter != nil {
+		if err := s.ExecutionFilter.Validate(); err != nil {
+			invalidParams.AddNested("ExecutionFilter", err.(request.ErrInvalidParams))
+		}
+	}
+	if s.StartTimeFilter != nil {
+		if err := s.StartTimeFilter.Validate(); err != nil {
+			invalidParams.AddNested("StartTimeFilter", err.(request.ErrInvalidParams))
+		}
+	}
+	if s.TagFilter != nil {
+		if err := s.TagFilter.Validate(); err != nil {
+			invalidParams.AddNested("TagFilter", err.(request.ErrInvalidParams))
+		}
+	}
+	if s.TypeFilter != nil {
+		if err := s.TypeFilter.Validate(); err != nil {
+			invalidParams.AddNested("TypeFilter", err.(request.ErrInvalidParams))
+		}
+	}
+
+	if invalidParams.Len() > 0 {
+		return invalidParams
+	}
+	return nil
+}
+
 type CountPendingActivityTasksInput struct {
 	_ struct{} `type:"structure"`
 
@@ -2642,6 +2800,30 @@ func (s CountPendingActivityTasksInput) GoString() string {
 	return s.String()
 }
 
+// Validate inspects the fields of the type to determine if they are valid.
+func (s *CountPendingActivityTasksInput) Validate() error {
+	invalidParams := request.ErrInvalidParams{Context: "CountPendingActivityTasksInput"}
+	if s.Domain == nil {
+		invalidParams.Add(request.NewErrParamRequired("Domain"))
+	}
+	if s.Domain != nil && len(*s.Domain) < 1 {
+		invalidParams.Add(request.NewErrParamMinLen("Domain", 1))
+	}
+	if s.TaskList == nil {
+		invalidParams.Add(request.NewErrParamRequired("TaskList"))
+	}
+	if s.TaskList != nil {
+		if err := s.TaskList.Validate(); err != nil {
+			invalidParams.AddNested("TaskList", err.(request.ErrInvalidParams))
+		}
+	}
+
+	if invalidParams.Len() > 0 {
+		return invalidParams
+	}
+	return nil
+}
+
 type CountPendingDecisionTasksInput struct {
 	_ struct{} `type:"structure"`
 
@@ -2660,6 +2842,30 @@ func (s CountPendingDecisionTasksInput) String() string {
 // GoString returns the string representation
 func (s CountPendingDecisionTasksInput) GoString() string {
 	return s.String()
+}
+
+// Validate inspects the fields of the type to determine if they are valid.
+func (s *CountPendingDecisionTasksInput) Validate() error {
+	invalidParams := request.ErrInvalidParams{Context: "CountPendingDecisionTasksInput"}
+	if s.Domain == nil {
+		invalidParams.Add(request.NewErrParamRequired("Domain"))
+	}
+	if s.Domain != nil && len(*s.Domain) < 1 {
+		invalidParams.Add(request.NewErrParamMinLen("Domain", 1))
+	}
+	if s.TaskList == nil {
+		invalidParams.Add(request.NewErrParamRequired("TaskList"))
+	}
+	if s.TaskList != nil {
+		if err := s.TaskList.Validate(); err != nil {
+			invalidParams.AddNested("TaskList", err.(request.ErrInvalidParams))
+		}
+	}
+
+	if invalidParams.Len() > 0 {
+		return invalidParams
+	}
+	return nil
 }
 
 // Specifies a decision made by the decider. A decision can be one of these
@@ -2854,6 +3060,69 @@ func (s Decision) GoString() string {
 	return s.String()
 }
 
+// Validate inspects the fields of the type to determine if they are valid.
+func (s *Decision) Validate() error {
+	invalidParams := request.ErrInvalidParams{Context: "Decision"}
+	if s.DecisionType == nil {
+		invalidParams.Add(request.NewErrParamRequired("DecisionType"))
+	}
+	if s.CancelTimerDecisionAttributes != nil {
+		if err := s.CancelTimerDecisionAttributes.Validate(); err != nil {
+			invalidParams.AddNested("CancelTimerDecisionAttributes", err.(request.ErrInvalidParams))
+		}
+	}
+	if s.ContinueAsNewWorkflowExecutionDecisionAttributes != nil {
+		if err := s.ContinueAsNewWorkflowExecutionDecisionAttributes.Validate(); err != nil {
+			invalidParams.AddNested("ContinueAsNewWorkflowExecutionDecisionAttributes", err.(request.ErrInvalidParams))
+		}
+	}
+	if s.RecordMarkerDecisionAttributes != nil {
+		if err := s.RecordMarkerDecisionAttributes.Validate(); err != nil {
+			invalidParams.AddNested("RecordMarkerDecisionAttributes", err.(request.ErrInvalidParams))
+		}
+	}
+	if s.RequestCancelActivityTaskDecisionAttributes != nil {
+		if err := s.RequestCancelActivityTaskDecisionAttributes.Validate(); err != nil {
+			invalidParams.AddNested("RequestCancelActivityTaskDecisionAttributes", err.(request.ErrInvalidParams))
+		}
+	}
+	if s.RequestCancelExternalWorkflowExecutionDecisionAttributes != nil {
+		if err := s.RequestCancelExternalWorkflowExecutionDecisionAttributes.Validate(); err != nil {
+			invalidParams.AddNested("RequestCancelExternalWorkflowExecutionDecisionAttributes", err.(request.ErrInvalidParams))
+		}
+	}
+	if s.ScheduleActivityTaskDecisionAttributes != nil {
+		if err := s.ScheduleActivityTaskDecisionAttributes.Validate(); err != nil {
+			invalidParams.AddNested("ScheduleActivityTaskDecisionAttributes", err.(request.ErrInvalidParams))
+		}
+	}
+	if s.ScheduleLambdaFunctionDecisionAttributes != nil {
+		if err := s.ScheduleLambdaFunctionDecisionAttributes.Validate(); err != nil {
+			invalidParams.AddNested("ScheduleLambdaFunctionDecisionAttributes", err.(request.ErrInvalidParams))
+		}
+	}
+	if s.SignalExternalWorkflowExecutionDecisionAttributes != nil {
+		if err := s.SignalExternalWorkflowExecutionDecisionAttributes.Validate(); err != nil {
+			invalidParams.AddNested("SignalExternalWorkflowExecutionDecisionAttributes", err.(request.ErrInvalidParams))
+		}
+	}
+	if s.StartChildWorkflowExecutionDecisionAttributes != nil {
+		if err := s.StartChildWorkflowExecutionDecisionAttributes.Validate(); err != nil {
+			invalidParams.AddNested("StartChildWorkflowExecutionDecisionAttributes", err.(request.ErrInvalidParams))
+		}
+	}
+	if s.StartTimerDecisionAttributes != nil {
+		if err := s.StartTimerDecisionAttributes.Validate(); err != nil {
+			invalidParams.AddNested("StartTimerDecisionAttributes", err.(request.ErrInvalidParams))
+		}
+	}
+
+	if invalidParams.Len() > 0 {
+		return invalidParams
+	}
+	return nil
+}
+
 // Provides details of the DecisionTaskCompleted event.
 type DecisionTaskCompletedEventAttributes struct {
 	_ struct{} `type:"structure"`
@@ -2989,6 +3258,30 @@ func (s DeprecateActivityTypeInput) GoString() string {
 	return s.String()
 }
 
+// Validate inspects the fields of the type to determine if they are valid.
+func (s *DeprecateActivityTypeInput) Validate() error {
+	invalidParams := request.ErrInvalidParams{Context: "DeprecateActivityTypeInput"}
+	if s.ActivityType == nil {
+		invalidParams.Add(request.NewErrParamRequired("ActivityType"))
+	}
+	if s.Domain == nil {
+		invalidParams.Add(request.NewErrParamRequired("Domain"))
+	}
+	if s.Domain != nil && len(*s.Domain) < 1 {
+		invalidParams.Add(request.NewErrParamMinLen("Domain", 1))
+	}
+	if s.ActivityType != nil {
+		if err := s.ActivityType.Validate(); err != nil {
+			invalidParams.AddNested("ActivityType", err.(request.ErrInvalidParams))
+		}
+	}
+
+	if invalidParams.Len() > 0 {
+		return invalidParams
+	}
+	return nil
+}
+
 type DeprecateActivityTypeOutput struct {
 	_ struct{} `type:"structure"`
 }
@@ -3018,6 +3311,22 @@ func (s DeprecateDomainInput) String() string {
 // GoString returns the string representation
 func (s DeprecateDomainInput) GoString() string {
 	return s.String()
+}
+
+// Validate inspects the fields of the type to determine if they are valid.
+func (s *DeprecateDomainInput) Validate() error {
+	invalidParams := request.ErrInvalidParams{Context: "DeprecateDomainInput"}
+	if s.Name == nil {
+		invalidParams.Add(request.NewErrParamRequired("Name"))
+	}
+	if s.Name != nil && len(*s.Name) < 1 {
+		invalidParams.Add(request.NewErrParamMinLen("Name", 1))
+	}
+
+	if invalidParams.Len() > 0 {
+		return invalidParams
+	}
+	return nil
 }
 
 type DeprecateDomainOutput struct {
@@ -3054,6 +3363,30 @@ func (s DeprecateWorkflowTypeInput) GoString() string {
 	return s.String()
 }
 
+// Validate inspects the fields of the type to determine if they are valid.
+func (s *DeprecateWorkflowTypeInput) Validate() error {
+	invalidParams := request.ErrInvalidParams{Context: "DeprecateWorkflowTypeInput"}
+	if s.Domain == nil {
+		invalidParams.Add(request.NewErrParamRequired("Domain"))
+	}
+	if s.Domain != nil && len(*s.Domain) < 1 {
+		invalidParams.Add(request.NewErrParamMinLen("Domain", 1))
+	}
+	if s.WorkflowType == nil {
+		invalidParams.Add(request.NewErrParamRequired("WorkflowType"))
+	}
+	if s.WorkflowType != nil {
+		if err := s.WorkflowType.Validate(); err != nil {
+			invalidParams.AddNested("WorkflowType", err.(request.ErrInvalidParams))
+		}
+	}
+
+	if invalidParams.Len() > 0 {
+		return invalidParams
+	}
+	return nil
+}
+
 type DeprecateWorkflowTypeOutput struct {
 	_ struct{} `type:"structure"`
 }
@@ -3087,6 +3420,30 @@ func (s DescribeActivityTypeInput) String() string {
 // GoString returns the string representation
 func (s DescribeActivityTypeInput) GoString() string {
 	return s.String()
+}
+
+// Validate inspects the fields of the type to determine if they are valid.
+func (s *DescribeActivityTypeInput) Validate() error {
+	invalidParams := request.ErrInvalidParams{Context: "DescribeActivityTypeInput"}
+	if s.ActivityType == nil {
+		invalidParams.Add(request.NewErrParamRequired("ActivityType"))
+	}
+	if s.Domain == nil {
+		invalidParams.Add(request.NewErrParamRequired("Domain"))
+	}
+	if s.Domain != nil && len(*s.Domain) < 1 {
+		invalidParams.Add(request.NewErrParamMinLen("Domain", 1))
+	}
+	if s.ActivityType != nil {
+		if err := s.ActivityType.Validate(); err != nil {
+			invalidParams.AddNested("ActivityType", err.(request.ErrInvalidParams))
+		}
+	}
+
+	if invalidParams.Len() > 0 {
+		return invalidParams
+	}
+	return nil
 }
 
 // Detailed information about an activity type.
@@ -3135,6 +3492,22 @@ func (s DescribeDomainInput) GoString() string {
 	return s.String()
 }
 
+// Validate inspects the fields of the type to determine if they are valid.
+func (s *DescribeDomainInput) Validate() error {
+	invalidParams := request.ErrInvalidParams{Context: "DescribeDomainInput"}
+	if s.Name == nil {
+		invalidParams.Add(request.NewErrParamRequired("Name"))
+	}
+	if s.Name != nil && len(*s.Name) < 1 {
+		invalidParams.Add(request.NewErrParamMinLen("Name", 1))
+	}
+
+	if invalidParams.Len() > 0 {
+		return invalidParams
+	}
+	return nil
+}
+
 // Contains details of a domain.
 type DescribeDomainOutput struct {
 	_ struct{} `type:"structure"`
@@ -3174,6 +3547,30 @@ func (s DescribeWorkflowExecutionInput) String() string {
 // GoString returns the string representation
 func (s DescribeWorkflowExecutionInput) GoString() string {
 	return s.String()
+}
+
+// Validate inspects the fields of the type to determine if they are valid.
+func (s *DescribeWorkflowExecutionInput) Validate() error {
+	invalidParams := request.ErrInvalidParams{Context: "DescribeWorkflowExecutionInput"}
+	if s.Domain == nil {
+		invalidParams.Add(request.NewErrParamRequired("Domain"))
+	}
+	if s.Domain != nil && len(*s.Domain) < 1 {
+		invalidParams.Add(request.NewErrParamMinLen("Domain", 1))
+	}
+	if s.Execution == nil {
+		invalidParams.Add(request.NewErrParamRequired("Execution"))
+	}
+	if s.Execution != nil {
+		if err := s.Execution.Validate(); err != nil {
+			invalidParams.AddNested("Execution", err.(request.ErrInvalidParams))
+		}
+	}
+
+	if invalidParams.Len() > 0 {
+		return invalidParams
+	}
+	return nil
 }
 
 // Contains details about a workflow execution.
@@ -3230,6 +3627,30 @@ func (s DescribeWorkflowTypeInput) String() string {
 // GoString returns the string representation
 func (s DescribeWorkflowTypeInput) GoString() string {
 	return s.String()
+}
+
+// Validate inspects the fields of the type to determine if they are valid.
+func (s *DescribeWorkflowTypeInput) Validate() error {
+	invalidParams := request.ErrInvalidParams{Context: "DescribeWorkflowTypeInput"}
+	if s.Domain == nil {
+		invalidParams.Add(request.NewErrParamRequired("Domain"))
+	}
+	if s.Domain != nil && len(*s.Domain) < 1 {
+		invalidParams.Add(request.NewErrParamMinLen("Domain", 1))
+	}
+	if s.WorkflowType == nil {
+		invalidParams.Add(request.NewErrParamRequired("WorkflowType"))
+	}
+	if s.WorkflowType != nil {
+		if err := s.WorkflowType.Validate(); err != nil {
+			invalidParams.AddNested("WorkflowType", err.(request.ErrInvalidParams))
+		}
+	}
+
+	if invalidParams.Len() > 0 {
+		return invalidParams
+	}
+	return nil
 }
 
 // Contains details about a workflow type.
@@ -3331,6 +3752,19 @@ func (s ExecutionTimeFilter) String() string {
 // GoString returns the string representation
 func (s ExecutionTimeFilter) GoString() string {
 	return s.String()
+}
+
+// Validate inspects the fields of the type to determine if they are valid.
+func (s *ExecutionTimeFilter) Validate() error {
+	invalidParams := request.ErrInvalidParams{Context: "ExecutionTimeFilter"}
+	if s.OldestDate == nil {
+		invalidParams.Add(request.NewErrParamRequired("OldestDate"))
+	}
+
+	if invalidParams.Len() > 0 {
+		return invalidParams
+	}
+	return nil
 }
 
 // Provides details of the ExternalWorkflowExecutionCancelRequested event.
@@ -3484,6 +3918,30 @@ func (s GetWorkflowExecutionHistoryInput) String() string {
 // GoString returns the string representation
 func (s GetWorkflowExecutionHistoryInput) GoString() string {
 	return s.String()
+}
+
+// Validate inspects the fields of the type to determine if they are valid.
+func (s *GetWorkflowExecutionHistoryInput) Validate() error {
+	invalidParams := request.ErrInvalidParams{Context: "GetWorkflowExecutionHistoryInput"}
+	if s.Domain == nil {
+		invalidParams.Add(request.NewErrParamRequired("Domain"))
+	}
+	if s.Domain != nil && len(*s.Domain) < 1 {
+		invalidParams.Add(request.NewErrParamMinLen("Domain", 1))
+	}
+	if s.Execution == nil {
+		invalidParams.Add(request.NewErrParamRequired("Execution"))
+	}
+	if s.Execution != nil {
+		if err := s.Execution.Validate(); err != nil {
+			invalidParams.AddNested("Execution", err.(request.ErrInvalidParams))
+		}
+	}
+
+	if invalidParams.Len() > 0 {
+		return invalidParams
+	}
+	return nil
 }
 
 // Paginated representation of a workflow history for a workflow execution.
@@ -4032,6 +4490,28 @@ func (s ListActivityTypesInput) GoString() string {
 	return s.String()
 }
 
+// Validate inspects the fields of the type to determine if they are valid.
+func (s *ListActivityTypesInput) Validate() error {
+	invalidParams := request.ErrInvalidParams{Context: "ListActivityTypesInput"}
+	if s.Domain == nil {
+		invalidParams.Add(request.NewErrParamRequired("Domain"))
+	}
+	if s.Domain != nil && len(*s.Domain) < 1 {
+		invalidParams.Add(request.NewErrParamMinLen("Domain", 1))
+	}
+	if s.Name != nil && len(*s.Name) < 1 {
+		invalidParams.Add(request.NewErrParamMinLen("Name", 1))
+	}
+	if s.RegistrationStatus == nil {
+		invalidParams.Add(request.NewErrParamRequired("RegistrationStatus"))
+	}
+
+	if invalidParams.Len() > 0 {
+		return invalidParams
+	}
+	return nil
+}
+
 // Contains a paginated list of activity type information structures.
 type ListActivityTypesOutput struct {
 	_ struct{} `type:"structure"`
@@ -4141,6 +4621,52 @@ func (s ListClosedWorkflowExecutionsInput) GoString() string {
 	return s.String()
 }
 
+// Validate inspects the fields of the type to determine if they are valid.
+func (s *ListClosedWorkflowExecutionsInput) Validate() error {
+	invalidParams := request.ErrInvalidParams{Context: "ListClosedWorkflowExecutionsInput"}
+	if s.Domain == nil {
+		invalidParams.Add(request.NewErrParamRequired("Domain"))
+	}
+	if s.Domain != nil && len(*s.Domain) < 1 {
+		invalidParams.Add(request.NewErrParamMinLen("Domain", 1))
+	}
+	if s.CloseStatusFilter != nil {
+		if err := s.CloseStatusFilter.Validate(); err != nil {
+			invalidParams.AddNested("CloseStatusFilter", err.(request.ErrInvalidParams))
+		}
+	}
+	if s.CloseTimeFilter != nil {
+		if err := s.CloseTimeFilter.Validate(); err != nil {
+			invalidParams.AddNested("CloseTimeFilter", err.(request.ErrInvalidParams))
+		}
+	}
+	if s.ExecutionFilter != nil {
+		if err := s.ExecutionFilter.Validate(); err != nil {
+			invalidParams.AddNested("ExecutionFilter", err.(request.ErrInvalidParams))
+		}
+	}
+	if s.StartTimeFilter != nil {
+		if err := s.StartTimeFilter.Validate(); err != nil {
+			invalidParams.AddNested("StartTimeFilter", err.(request.ErrInvalidParams))
+		}
+	}
+	if s.TagFilter != nil {
+		if err := s.TagFilter.Validate(); err != nil {
+			invalidParams.AddNested("TagFilter", err.(request.ErrInvalidParams))
+		}
+	}
+	if s.TypeFilter != nil {
+		if err := s.TypeFilter.Validate(); err != nil {
+			invalidParams.AddNested("TypeFilter", err.(request.ErrInvalidParams))
+		}
+	}
+
+	if invalidParams.Len() > 0 {
+		return invalidParams
+	}
+	return nil
+}
+
 type ListDomainsInput struct {
 	_ struct{} `type:"structure"`
 
@@ -4177,6 +4703,19 @@ func (s ListDomainsInput) String() string {
 // GoString returns the string representation
 func (s ListDomainsInput) GoString() string {
 	return s.String()
+}
+
+// Validate inspects the fields of the type to determine if they are valid.
+func (s *ListDomainsInput) Validate() error {
+	invalidParams := request.ErrInvalidParams{Context: "ListDomainsInput"}
+	if s.RegistrationStatus == nil {
+		invalidParams.Add(request.NewErrParamRequired("RegistrationStatus"))
+	}
+
+	if invalidParams.Len() > 0 {
+		return invalidParams
+	}
+	return nil
 }
 
 // Contains a paginated collection of DomainInfo structures.
@@ -4266,6 +4805,45 @@ func (s ListOpenWorkflowExecutionsInput) GoString() string {
 	return s.String()
 }
 
+// Validate inspects the fields of the type to determine if they are valid.
+func (s *ListOpenWorkflowExecutionsInput) Validate() error {
+	invalidParams := request.ErrInvalidParams{Context: "ListOpenWorkflowExecutionsInput"}
+	if s.Domain == nil {
+		invalidParams.Add(request.NewErrParamRequired("Domain"))
+	}
+	if s.Domain != nil && len(*s.Domain) < 1 {
+		invalidParams.Add(request.NewErrParamMinLen("Domain", 1))
+	}
+	if s.StartTimeFilter == nil {
+		invalidParams.Add(request.NewErrParamRequired("StartTimeFilter"))
+	}
+	if s.ExecutionFilter != nil {
+		if err := s.ExecutionFilter.Validate(); err != nil {
+			invalidParams.AddNested("ExecutionFilter", err.(request.ErrInvalidParams))
+		}
+	}
+	if s.StartTimeFilter != nil {
+		if err := s.StartTimeFilter.Validate(); err != nil {
+			invalidParams.AddNested("StartTimeFilter", err.(request.ErrInvalidParams))
+		}
+	}
+	if s.TagFilter != nil {
+		if err := s.TagFilter.Validate(); err != nil {
+			invalidParams.AddNested("TagFilter", err.(request.ErrInvalidParams))
+		}
+	}
+	if s.TypeFilter != nil {
+		if err := s.TypeFilter.Validate(); err != nil {
+			invalidParams.AddNested("TypeFilter", err.(request.ErrInvalidParams))
+		}
+	}
+
+	if invalidParams.Len() > 0 {
+		return invalidParams
+	}
+	return nil
+}
+
 type ListWorkflowTypesInput struct {
 	_ struct{} `type:"structure"`
 
@@ -4309,6 +4887,28 @@ func (s ListWorkflowTypesInput) String() string {
 // GoString returns the string representation
 func (s ListWorkflowTypesInput) GoString() string {
 	return s.String()
+}
+
+// Validate inspects the fields of the type to determine if they are valid.
+func (s *ListWorkflowTypesInput) Validate() error {
+	invalidParams := request.ErrInvalidParams{Context: "ListWorkflowTypesInput"}
+	if s.Domain == nil {
+		invalidParams.Add(request.NewErrParamRequired("Domain"))
+	}
+	if s.Domain != nil && len(*s.Domain) < 1 {
+		invalidParams.Add(request.NewErrParamMinLen("Domain", 1))
+	}
+	if s.Name != nil && len(*s.Name) < 1 {
+		invalidParams.Add(request.NewErrParamMinLen("Name", 1))
+	}
+	if s.RegistrationStatus == nil {
+		invalidParams.Add(request.NewErrParamRequired("RegistrationStatus"))
+	}
+
+	if invalidParams.Len() > 0 {
+		return invalidParams
+	}
+	return nil
 }
 
 // Contains a paginated list of information structures about workflow types.
@@ -4416,6 +5016,30 @@ func (s PollForActivityTaskInput) GoString() string {
 	return s.String()
 }
 
+// Validate inspects the fields of the type to determine if they are valid.
+func (s *PollForActivityTaskInput) Validate() error {
+	invalidParams := request.ErrInvalidParams{Context: "PollForActivityTaskInput"}
+	if s.Domain == nil {
+		invalidParams.Add(request.NewErrParamRequired("Domain"))
+	}
+	if s.Domain != nil && len(*s.Domain) < 1 {
+		invalidParams.Add(request.NewErrParamMinLen("Domain", 1))
+	}
+	if s.TaskList == nil {
+		invalidParams.Add(request.NewErrParamRequired("TaskList"))
+	}
+	if s.TaskList != nil {
+		if err := s.TaskList.Validate(); err != nil {
+			invalidParams.AddNested("TaskList", err.(request.ErrInvalidParams))
+		}
+	}
+
+	if invalidParams.Len() > 0 {
+		return invalidParams
+	}
+	return nil
+}
+
 // Unit of work sent to an activity worker.
 type PollForActivityTaskOutput struct {
 	_ struct{} `type:"structure"`
@@ -4508,6 +5132,30 @@ func (s PollForDecisionTaskInput) GoString() string {
 	return s.String()
 }
 
+// Validate inspects the fields of the type to determine if they are valid.
+func (s *PollForDecisionTaskInput) Validate() error {
+	invalidParams := request.ErrInvalidParams{Context: "PollForDecisionTaskInput"}
+	if s.Domain == nil {
+		invalidParams.Add(request.NewErrParamRequired("Domain"))
+	}
+	if s.Domain != nil && len(*s.Domain) < 1 {
+		invalidParams.Add(request.NewErrParamMinLen("Domain", 1))
+	}
+	if s.TaskList == nil {
+		invalidParams.Add(request.NewErrParamRequired("TaskList"))
+	}
+	if s.TaskList != nil {
+		if err := s.TaskList.Validate(); err != nil {
+			invalidParams.AddNested("TaskList", err.(request.ErrInvalidParams))
+		}
+	}
+
+	if invalidParams.Len() > 0 {
+		return invalidParams
+	}
+	return nil
+}
+
 // A structure that represents a decision task. Decision tasks are sent to deciders
 // in order for them to make decisions.
 type PollForDecisionTaskOutput struct {
@@ -4580,6 +5228,22 @@ func (s RecordActivityTaskHeartbeatInput) GoString() string {
 	return s.String()
 }
 
+// Validate inspects the fields of the type to determine if they are valid.
+func (s *RecordActivityTaskHeartbeatInput) Validate() error {
+	invalidParams := request.ErrInvalidParams{Context: "RecordActivityTaskHeartbeatInput"}
+	if s.TaskToken == nil {
+		invalidParams.Add(request.NewErrParamRequired("TaskToken"))
+	}
+	if s.TaskToken != nil && len(*s.TaskToken) < 1 {
+		invalidParams.Add(request.NewErrParamMinLen("TaskToken", 1))
+	}
+
+	if invalidParams.Len() > 0 {
+		return invalidParams
+	}
+	return nil
+}
+
 // Status information about an activity task.
 type RecordActivityTaskHeartbeatOutput struct {
 	_ struct{} `type:"structure"`
@@ -4631,6 +5295,22 @@ func (s RecordMarkerDecisionAttributes) String() string {
 // GoString returns the string representation
 func (s RecordMarkerDecisionAttributes) GoString() string {
 	return s.String()
+}
+
+// Validate inspects the fields of the type to determine if they are valid.
+func (s *RecordMarkerDecisionAttributes) Validate() error {
+	invalidParams := request.ErrInvalidParams{Context: "RecordMarkerDecisionAttributes"}
+	if s.MarkerName == nil {
+		invalidParams.Add(request.NewErrParamRequired("MarkerName"))
+	}
+	if s.MarkerName != nil && len(*s.MarkerName) < 1 {
+		invalidParams.Add(request.NewErrParamMinLen("MarkerName", 1))
+	}
+
+	if invalidParams.Len() > 0 {
+		return invalidParams
+	}
+	return nil
 }
 
 // Provides details of the RecordMarkerFailed event.
@@ -4754,6 +5434,39 @@ func (s RegisterActivityTypeInput) GoString() string {
 	return s.String()
 }
 
+// Validate inspects the fields of the type to determine if they are valid.
+func (s *RegisterActivityTypeInput) Validate() error {
+	invalidParams := request.ErrInvalidParams{Context: "RegisterActivityTypeInput"}
+	if s.Domain == nil {
+		invalidParams.Add(request.NewErrParamRequired("Domain"))
+	}
+	if s.Domain != nil && len(*s.Domain) < 1 {
+		invalidParams.Add(request.NewErrParamMinLen("Domain", 1))
+	}
+	if s.Name == nil {
+		invalidParams.Add(request.NewErrParamRequired("Name"))
+	}
+	if s.Name != nil && len(*s.Name) < 1 {
+		invalidParams.Add(request.NewErrParamMinLen("Name", 1))
+	}
+	if s.Version == nil {
+		invalidParams.Add(request.NewErrParamRequired("Version"))
+	}
+	if s.Version != nil && len(*s.Version) < 1 {
+		invalidParams.Add(request.NewErrParamMinLen("Version", 1))
+	}
+	if s.DefaultTaskList != nil {
+		if err := s.DefaultTaskList.Validate(); err != nil {
+			invalidParams.AddNested("DefaultTaskList", err.(request.ErrInvalidParams))
+		}
+	}
+
+	if invalidParams.Len() > 0 {
+		return invalidParams
+	}
+	return nil
+}
+
 type RegisterActivityTypeOutput struct {
 	_ struct{} `type:"structure"`
 }
@@ -4805,6 +5518,28 @@ func (s RegisterDomainInput) String() string {
 // GoString returns the string representation
 func (s RegisterDomainInput) GoString() string {
 	return s.String()
+}
+
+// Validate inspects the fields of the type to determine if they are valid.
+func (s *RegisterDomainInput) Validate() error {
+	invalidParams := request.ErrInvalidParams{Context: "RegisterDomainInput"}
+	if s.Name == nil {
+		invalidParams.Add(request.NewErrParamRequired("Name"))
+	}
+	if s.Name != nil && len(*s.Name) < 1 {
+		invalidParams.Add(request.NewErrParamMinLen("Name", 1))
+	}
+	if s.WorkflowExecutionRetentionPeriodInDays == nil {
+		invalidParams.Add(request.NewErrParamRequired("WorkflowExecutionRetentionPeriodInDays"))
+	}
+	if s.WorkflowExecutionRetentionPeriodInDays != nil && len(*s.WorkflowExecutionRetentionPeriodInDays) < 1 {
+		invalidParams.Add(request.NewErrParamMinLen("WorkflowExecutionRetentionPeriodInDays", 1))
+	}
+
+	if invalidParams.Len() > 0 {
+		return invalidParams
+	}
+	return nil
 }
 
 type RegisterDomainOutput struct {
@@ -4918,6 +5653,42 @@ func (s RegisterWorkflowTypeInput) GoString() string {
 	return s.String()
 }
 
+// Validate inspects the fields of the type to determine if they are valid.
+func (s *RegisterWorkflowTypeInput) Validate() error {
+	invalidParams := request.ErrInvalidParams{Context: "RegisterWorkflowTypeInput"}
+	if s.DefaultLambdaRole != nil && len(*s.DefaultLambdaRole) < 1 {
+		invalidParams.Add(request.NewErrParamMinLen("DefaultLambdaRole", 1))
+	}
+	if s.Domain == nil {
+		invalidParams.Add(request.NewErrParamRequired("Domain"))
+	}
+	if s.Domain != nil && len(*s.Domain) < 1 {
+		invalidParams.Add(request.NewErrParamMinLen("Domain", 1))
+	}
+	if s.Name == nil {
+		invalidParams.Add(request.NewErrParamRequired("Name"))
+	}
+	if s.Name != nil && len(*s.Name) < 1 {
+		invalidParams.Add(request.NewErrParamMinLen("Name", 1))
+	}
+	if s.Version == nil {
+		invalidParams.Add(request.NewErrParamRequired("Version"))
+	}
+	if s.Version != nil && len(*s.Version) < 1 {
+		invalidParams.Add(request.NewErrParamMinLen("Version", 1))
+	}
+	if s.DefaultTaskList != nil {
+		if err := s.DefaultTaskList.Validate(); err != nil {
+			invalidParams.AddNested("DefaultTaskList", err.(request.ErrInvalidParams))
+		}
+	}
+
+	if invalidParams.Len() > 0 {
+		return invalidParams
+	}
+	return nil
+}
+
 type RegisterWorkflowTypeOutput struct {
 	_ struct{} `type:"structure"`
 }
@@ -4962,6 +5733,22 @@ func (s RequestCancelActivityTaskDecisionAttributes) String() string {
 // GoString returns the string representation
 func (s RequestCancelActivityTaskDecisionAttributes) GoString() string {
 	return s.String()
+}
+
+// Validate inspects the fields of the type to determine if they are valid.
+func (s *RequestCancelActivityTaskDecisionAttributes) Validate() error {
+	invalidParams := request.ErrInvalidParams{Context: "RequestCancelActivityTaskDecisionAttributes"}
+	if s.ActivityId == nil {
+		invalidParams.Add(request.NewErrParamRequired("ActivityId"))
+	}
+	if s.ActivityId != nil && len(*s.ActivityId) < 1 {
+		invalidParams.Add(request.NewErrParamMinLen("ActivityId", 1))
+	}
+
+	if invalidParams.Len() > 0 {
+		return invalidParams
+	}
+	return nil
 }
 
 // Provides details of the RequestCancelActivityTaskFailed event.
@@ -5033,6 +5820,22 @@ func (s RequestCancelExternalWorkflowExecutionDecisionAttributes) String() strin
 // GoString returns the string representation
 func (s RequestCancelExternalWorkflowExecutionDecisionAttributes) GoString() string {
 	return s.String()
+}
+
+// Validate inspects the fields of the type to determine if they are valid.
+func (s *RequestCancelExternalWorkflowExecutionDecisionAttributes) Validate() error {
+	invalidParams := request.ErrInvalidParams{Context: "RequestCancelExternalWorkflowExecutionDecisionAttributes"}
+	if s.WorkflowId == nil {
+		invalidParams.Add(request.NewErrParamRequired("WorkflowId"))
+	}
+	if s.WorkflowId != nil && len(*s.WorkflowId) < 1 {
+		invalidParams.Add(request.NewErrParamMinLen("WorkflowId", 1))
+	}
+
+	if invalidParams.Len() > 0 {
+		return invalidParams
+	}
+	return nil
 }
 
 // Provides details of the RequestCancelExternalWorkflowExecutionFailed event.
@@ -5133,6 +5936,28 @@ func (s RequestCancelWorkflowExecutionInput) GoString() string {
 	return s.String()
 }
 
+// Validate inspects the fields of the type to determine if they are valid.
+func (s *RequestCancelWorkflowExecutionInput) Validate() error {
+	invalidParams := request.ErrInvalidParams{Context: "RequestCancelWorkflowExecutionInput"}
+	if s.Domain == nil {
+		invalidParams.Add(request.NewErrParamRequired("Domain"))
+	}
+	if s.Domain != nil && len(*s.Domain) < 1 {
+		invalidParams.Add(request.NewErrParamMinLen("Domain", 1))
+	}
+	if s.WorkflowId == nil {
+		invalidParams.Add(request.NewErrParamRequired("WorkflowId"))
+	}
+	if s.WorkflowId != nil && len(*s.WorkflowId) < 1 {
+		invalidParams.Add(request.NewErrParamMinLen("WorkflowId", 1))
+	}
+
+	if invalidParams.Len() > 0 {
+		return invalidParams
+	}
+	return nil
+}
+
 type RequestCancelWorkflowExecutionOutput struct {
 	_ struct{} `type:"structure"`
 }
@@ -5169,6 +5994,22 @@ func (s RespondActivityTaskCanceledInput) String() string {
 // GoString returns the string representation
 func (s RespondActivityTaskCanceledInput) GoString() string {
 	return s.String()
+}
+
+// Validate inspects the fields of the type to determine if they are valid.
+func (s *RespondActivityTaskCanceledInput) Validate() error {
+	invalidParams := request.ErrInvalidParams{Context: "RespondActivityTaskCanceledInput"}
+	if s.TaskToken == nil {
+		invalidParams.Add(request.NewErrParamRequired("TaskToken"))
+	}
+	if s.TaskToken != nil && len(*s.TaskToken) < 1 {
+		invalidParams.Add(request.NewErrParamMinLen("TaskToken", 1))
+	}
+
+	if invalidParams.Len() > 0 {
+		return invalidParams
+	}
+	return nil
 }
 
 type RespondActivityTaskCanceledOutput struct {
@@ -5208,6 +6049,22 @@ func (s RespondActivityTaskCompletedInput) String() string {
 // GoString returns the string representation
 func (s RespondActivityTaskCompletedInput) GoString() string {
 	return s.String()
+}
+
+// Validate inspects the fields of the type to determine if they are valid.
+func (s *RespondActivityTaskCompletedInput) Validate() error {
+	invalidParams := request.ErrInvalidParams{Context: "RespondActivityTaskCompletedInput"}
+	if s.TaskToken == nil {
+		invalidParams.Add(request.NewErrParamRequired("TaskToken"))
+	}
+	if s.TaskToken != nil && len(*s.TaskToken) < 1 {
+		invalidParams.Add(request.NewErrParamMinLen("TaskToken", 1))
+	}
+
+	if invalidParams.Len() > 0 {
+		return invalidParams
+	}
+	return nil
 }
 
 type RespondActivityTaskCompletedOutput struct {
@@ -5251,6 +6108,22 @@ func (s RespondActivityTaskFailedInput) GoString() string {
 	return s.String()
 }
 
+// Validate inspects the fields of the type to determine if they are valid.
+func (s *RespondActivityTaskFailedInput) Validate() error {
+	invalidParams := request.ErrInvalidParams{Context: "RespondActivityTaskFailedInput"}
+	if s.TaskToken == nil {
+		invalidParams.Add(request.NewErrParamRequired("TaskToken"))
+	}
+	if s.TaskToken != nil && len(*s.TaskToken) < 1 {
+		invalidParams.Add(request.NewErrParamMinLen("TaskToken", 1))
+	}
+
+	if invalidParams.Len() > 0 {
+		return invalidParams
+	}
+	return nil
+}
+
 type RespondActivityTaskFailedOutput struct {
 	_ struct{} `type:"structure"`
 }
@@ -5291,6 +6164,32 @@ func (s RespondDecisionTaskCompletedInput) String() string {
 // GoString returns the string representation
 func (s RespondDecisionTaskCompletedInput) GoString() string {
 	return s.String()
+}
+
+// Validate inspects the fields of the type to determine if they are valid.
+func (s *RespondDecisionTaskCompletedInput) Validate() error {
+	invalidParams := request.ErrInvalidParams{Context: "RespondDecisionTaskCompletedInput"}
+	if s.TaskToken == nil {
+		invalidParams.Add(request.NewErrParamRequired("TaskToken"))
+	}
+	if s.TaskToken != nil && len(*s.TaskToken) < 1 {
+		invalidParams.Add(request.NewErrParamMinLen("TaskToken", 1))
+	}
+	if s.Decisions != nil {
+		for i, v := range s.Decisions {
+			if v == nil {
+				continue
+			}
+			if err := v.Validate(); err != nil {
+				invalidParams.AddNested(fmt.Sprintf("%s[%v]", "Decisions", i), err.(request.ErrInvalidParams))
+			}
+		}
+	}
+
+	if invalidParams.Len() > 0 {
+		return invalidParams
+	}
+	return nil
 }
 
 type RespondDecisionTaskCompletedOutput struct {
@@ -5429,6 +6328,35 @@ func (s ScheduleActivityTaskDecisionAttributes) GoString() string {
 	return s.String()
 }
 
+// Validate inspects the fields of the type to determine if they are valid.
+func (s *ScheduleActivityTaskDecisionAttributes) Validate() error {
+	invalidParams := request.ErrInvalidParams{Context: "ScheduleActivityTaskDecisionAttributes"}
+	if s.ActivityId == nil {
+		invalidParams.Add(request.NewErrParamRequired("ActivityId"))
+	}
+	if s.ActivityId != nil && len(*s.ActivityId) < 1 {
+		invalidParams.Add(request.NewErrParamMinLen("ActivityId", 1))
+	}
+	if s.ActivityType == nil {
+		invalidParams.Add(request.NewErrParamRequired("ActivityType"))
+	}
+	if s.ActivityType != nil {
+		if err := s.ActivityType.Validate(); err != nil {
+			invalidParams.AddNested("ActivityType", err.(request.ErrInvalidParams))
+		}
+	}
+	if s.TaskList != nil {
+		if err := s.TaskList.Validate(); err != nil {
+			invalidParams.AddNested("TaskList", err.(request.ErrInvalidParams))
+		}
+	}
+
+	if invalidParams.Len() > 0 {
+		return invalidParams
+	}
+	return nil
+}
+
 // Provides details of the ScheduleActivityTaskFailed event.
 type ScheduleActivityTaskFailedEventAttributes struct {
 	_ struct{} `type:"structure"`
@@ -5513,6 +6441,31 @@ func (s ScheduleLambdaFunctionDecisionAttributes) GoString() string {
 	return s.String()
 }
 
+// Validate inspects the fields of the type to determine if they are valid.
+func (s *ScheduleLambdaFunctionDecisionAttributes) Validate() error {
+	invalidParams := request.ErrInvalidParams{Context: "ScheduleLambdaFunctionDecisionAttributes"}
+	if s.Id == nil {
+		invalidParams.Add(request.NewErrParamRequired("Id"))
+	}
+	if s.Id != nil && len(*s.Id) < 1 {
+		invalidParams.Add(request.NewErrParamMinLen("Id", 1))
+	}
+	if s.Input != nil && len(*s.Input) < 1 {
+		invalidParams.Add(request.NewErrParamMinLen("Input", 1))
+	}
+	if s.Name == nil {
+		invalidParams.Add(request.NewErrParamRequired("Name"))
+	}
+	if s.Name != nil && len(*s.Name) < 1 {
+		invalidParams.Add(request.NewErrParamMinLen("Name", 1))
+	}
+
+	if invalidParams.Len() > 0 {
+		return invalidParams
+	}
+	return nil
+}
+
 // Provides details for the ScheduleLambdaFunctionFailed event.
 type ScheduleLambdaFunctionFailedEventAttributes struct {
 	_ struct{} `type:"structure"`
@@ -5593,6 +6546,28 @@ func (s SignalExternalWorkflowExecutionDecisionAttributes) String() string {
 // GoString returns the string representation
 func (s SignalExternalWorkflowExecutionDecisionAttributes) GoString() string {
 	return s.String()
+}
+
+// Validate inspects the fields of the type to determine if they are valid.
+func (s *SignalExternalWorkflowExecutionDecisionAttributes) Validate() error {
+	invalidParams := request.ErrInvalidParams{Context: "SignalExternalWorkflowExecutionDecisionAttributes"}
+	if s.SignalName == nil {
+		invalidParams.Add(request.NewErrParamRequired("SignalName"))
+	}
+	if s.SignalName != nil && len(*s.SignalName) < 1 {
+		invalidParams.Add(request.NewErrParamMinLen("SignalName", 1))
+	}
+	if s.WorkflowId == nil {
+		invalidParams.Add(request.NewErrParamRequired("WorkflowId"))
+	}
+	if s.WorkflowId != nil && len(*s.WorkflowId) < 1 {
+		invalidParams.Add(request.NewErrParamMinLen("WorkflowId", 1))
+	}
+
+	if invalidParams.Len() > 0 {
+		return invalidParams
+	}
+	return nil
 }
 
 // Provides details of the SignalExternalWorkflowExecutionFailed event.
@@ -5705,6 +6680,34 @@ func (s SignalWorkflowExecutionInput) String() string {
 // GoString returns the string representation
 func (s SignalWorkflowExecutionInput) GoString() string {
 	return s.String()
+}
+
+// Validate inspects the fields of the type to determine if they are valid.
+func (s *SignalWorkflowExecutionInput) Validate() error {
+	invalidParams := request.ErrInvalidParams{Context: "SignalWorkflowExecutionInput"}
+	if s.Domain == nil {
+		invalidParams.Add(request.NewErrParamRequired("Domain"))
+	}
+	if s.Domain != nil && len(*s.Domain) < 1 {
+		invalidParams.Add(request.NewErrParamMinLen("Domain", 1))
+	}
+	if s.SignalName == nil {
+		invalidParams.Add(request.NewErrParamRequired("SignalName"))
+	}
+	if s.SignalName != nil && len(*s.SignalName) < 1 {
+		invalidParams.Add(request.NewErrParamMinLen("SignalName", 1))
+	}
+	if s.WorkflowId == nil {
+		invalidParams.Add(request.NewErrParamRequired("WorkflowId"))
+	}
+	if s.WorkflowId != nil && len(*s.WorkflowId) < 1 {
+		invalidParams.Add(request.NewErrParamMinLen("WorkflowId", 1))
+	}
+
+	if invalidParams.Len() > 0 {
+		return invalidParams
+	}
+	return nil
 }
 
 type SignalWorkflowExecutionOutput struct {
@@ -5849,6 +6852,38 @@ func (s StartChildWorkflowExecutionDecisionAttributes) String() string {
 // GoString returns the string representation
 func (s StartChildWorkflowExecutionDecisionAttributes) GoString() string {
 	return s.String()
+}
+
+// Validate inspects the fields of the type to determine if they are valid.
+func (s *StartChildWorkflowExecutionDecisionAttributes) Validate() error {
+	invalidParams := request.ErrInvalidParams{Context: "StartChildWorkflowExecutionDecisionAttributes"}
+	if s.LambdaRole != nil && len(*s.LambdaRole) < 1 {
+		invalidParams.Add(request.NewErrParamMinLen("LambdaRole", 1))
+	}
+	if s.WorkflowId == nil {
+		invalidParams.Add(request.NewErrParamRequired("WorkflowId"))
+	}
+	if s.WorkflowId != nil && len(*s.WorkflowId) < 1 {
+		invalidParams.Add(request.NewErrParamMinLen("WorkflowId", 1))
+	}
+	if s.WorkflowType == nil {
+		invalidParams.Add(request.NewErrParamRequired("WorkflowType"))
+	}
+	if s.TaskList != nil {
+		if err := s.TaskList.Validate(); err != nil {
+			invalidParams.AddNested("TaskList", err.(request.ErrInvalidParams))
+		}
+	}
+	if s.WorkflowType != nil {
+		if err := s.WorkflowType.Validate(); err != nil {
+			invalidParams.AddNested("WorkflowType", err.(request.ErrInvalidParams))
+		}
+	}
+
+	if invalidParams.Len() > 0 {
+		return invalidParams
+	}
+	return nil
 }
 
 // Provides details of the StartChildWorkflowExecutionFailed event.
@@ -6054,6 +7089,28 @@ func (s StartTimerDecisionAttributes) GoString() string {
 	return s.String()
 }
 
+// Validate inspects the fields of the type to determine if they are valid.
+func (s *StartTimerDecisionAttributes) Validate() error {
+	invalidParams := request.ErrInvalidParams{Context: "StartTimerDecisionAttributes"}
+	if s.StartToFireTimeout == nil {
+		invalidParams.Add(request.NewErrParamRequired("StartToFireTimeout"))
+	}
+	if s.StartToFireTimeout != nil && len(*s.StartToFireTimeout) < 1 {
+		invalidParams.Add(request.NewErrParamMinLen("StartToFireTimeout", 1))
+	}
+	if s.TimerId == nil {
+		invalidParams.Add(request.NewErrParamRequired("TimerId"))
+	}
+	if s.TimerId != nil && len(*s.TimerId) < 1 {
+		invalidParams.Add(request.NewErrParamMinLen("TimerId", 1))
+	}
+
+	if invalidParams.Len() > 0 {
+		return invalidParams
+	}
+	return nil
+}
+
 // Provides details of the StartTimerFailed event.
 type StartTimerFailedEventAttributes struct {
 	_ struct{} `type:"structure"`
@@ -6207,6 +7264,44 @@ func (s StartWorkflowExecutionInput) GoString() string {
 	return s.String()
 }
 
+// Validate inspects the fields of the type to determine if they are valid.
+func (s *StartWorkflowExecutionInput) Validate() error {
+	invalidParams := request.ErrInvalidParams{Context: "StartWorkflowExecutionInput"}
+	if s.Domain == nil {
+		invalidParams.Add(request.NewErrParamRequired("Domain"))
+	}
+	if s.Domain != nil && len(*s.Domain) < 1 {
+		invalidParams.Add(request.NewErrParamMinLen("Domain", 1))
+	}
+	if s.LambdaRole != nil && len(*s.LambdaRole) < 1 {
+		invalidParams.Add(request.NewErrParamMinLen("LambdaRole", 1))
+	}
+	if s.WorkflowId == nil {
+		invalidParams.Add(request.NewErrParamRequired("WorkflowId"))
+	}
+	if s.WorkflowId != nil && len(*s.WorkflowId) < 1 {
+		invalidParams.Add(request.NewErrParamMinLen("WorkflowId", 1))
+	}
+	if s.WorkflowType == nil {
+		invalidParams.Add(request.NewErrParamRequired("WorkflowType"))
+	}
+	if s.TaskList != nil {
+		if err := s.TaskList.Validate(); err != nil {
+			invalidParams.AddNested("TaskList", err.(request.ErrInvalidParams))
+		}
+	}
+	if s.WorkflowType != nil {
+		if err := s.WorkflowType.Validate(); err != nil {
+			invalidParams.AddNested("WorkflowType", err.(request.ErrInvalidParams))
+		}
+	}
+
+	if invalidParams.Len() > 0 {
+		return invalidParams
+	}
+	return nil
+}
+
 // Specifies the runId of a workflow execution.
 type StartWorkflowExecutionOutput struct {
 	_ struct{} `type:"structure"`
@@ -6245,6 +7340,22 @@ func (s TagFilter) GoString() string {
 	return s.String()
 }
 
+// Validate inspects the fields of the type to determine if they are valid.
+func (s *TagFilter) Validate() error {
+	invalidParams := request.ErrInvalidParams{Context: "TagFilter"}
+	if s.Tag == nil {
+		invalidParams.Add(request.NewErrParamRequired("Tag"))
+	}
+	if s.Tag != nil && len(*s.Tag) < 1 {
+		invalidParams.Add(request.NewErrParamMinLen("Tag", 1))
+	}
+
+	if invalidParams.Len() > 0 {
+		return invalidParams
+	}
+	return nil
+}
+
 // Represents a task list.
 type TaskList struct {
 	_ struct{} `type:"structure"`
@@ -6261,6 +7372,22 @@ func (s TaskList) String() string {
 // GoString returns the string representation
 func (s TaskList) GoString() string {
 	return s.String()
+}
+
+// Validate inspects the fields of the type to determine if they are valid.
+func (s *TaskList) Validate() error {
+	invalidParams := request.ErrInvalidParams{Context: "TaskList"}
+	if s.Name == nil {
+		invalidParams.Add(request.NewErrParamRequired("Name"))
+	}
+	if s.Name != nil && len(*s.Name) < 1 {
+		invalidParams.Add(request.NewErrParamMinLen("Name", 1))
+	}
+
+	if invalidParams.Len() > 0 {
+		return invalidParams
+	}
+	return nil
 }
 
 type TerminateWorkflowExecutionInput struct {
@@ -6308,6 +7435,28 @@ func (s TerminateWorkflowExecutionInput) String() string {
 // GoString returns the string representation
 func (s TerminateWorkflowExecutionInput) GoString() string {
 	return s.String()
+}
+
+// Validate inspects the fields of the type to determine if they are valid.
+func (s *TerminateWorkflowExecutionInput) Validate() error {
+	invalidParams := request.ErrInvalidParams{Context: "TerminateWorkflowExecutionInput"}
+	if s.Domain == nil {
+		invalidParams.Add(request.NewErrParamRequired("Domain"))
+	}
+	if s.Domain != nil && len(*s.Domain) < 1 {
+		invalidParams.Add(request.NewErrParamMinLen("Domain", 1))
+	}
+	if s.WorkflowId == nil {
+		invalidParams.Add(request.NewErrParamRequired("WorkflowId"))
+	}
+	if s.WorkflowId != nil && len(*s.WorkflowId) < 1 {
+		invalidParams.Add(request.NewErrParamMinLen("WorkflowId", 1))
+	}
+
+	if invalidParams.Len() > 0 {
+		return invalidParams
+	}
+	return nil
 }
 
 type TerminateWorkflowExecutionOutput struct {
@@ -6429,6 +7578,28 @@ func (s WorkflowExecution) String() string {
 // GoString returns the string representation
 func (s WorkflowExecution) GoString() string {
 	return s.String()
+}
+
+// Validate inspects the fields of the type to determine if they are valid.
+func (s *WorkflowExecution) Validate() error {
+	invalidParams := request.ErrInvalidParams{Context: "WorkflowExecution"}
+	if s.RunId == nil {
+		invalidParams.Add(request.NewErrParamRequired("RunId"))
+	}
+	if s.RunId != nil && len(*s.RunId) < 1 {
+		invalidParams.Add(request.NewErrParamMinLen("RunId", 1))
+	}
+	if s.WorkflowId == nil {
+		invalidParams.Add(request.NewErrParamRequired("WorkflowId"))
+	}
+	if s.WorkflowId != nil && len(*s.WorkflowId) < 1 {
+		invalidParams.Add(request.NewErrParamMinLen("WorkflowId", 1))
+	}
+
+	if invalidParams.Len() > 0 {
+		return invalidParams
+	}
+	return nil
 }
 
 // Provides details of the WorkflowExecutionCancelRequested event.
@@ -6700,6 +7871,22 @@ func (s WorkflowExecutionFilter) String() string {
 // GoString returns the string representation
 func (s WorkflowExecutionFilter) GoString() string {
 	return s.String()
+}
+
+// Validate inspects the fields of the type to determine if they are valid.
+func (s *WorkflowExecutionFilter) Validate() error {
+	invalidParams := request.ErrInvalidParams{Context: "WorkflowExecutionFilter"}
+	if s.WorkflowId == nil {
+		invalidParams.Add(request.NewErrParamRequired("WorkflowId"))
+	}
+	if s.WorkflowId != nil && len(*s.WorkflowId) < 1 {
+		invalidParams.Add(request.NewErrParamMinLen("WorkflowId", 1))
+	}
+
+	if invalidParams.Len() > 0 {
+		return invalidParams
+	}
+	return nil
 }
 
 // Contains information about a workflow execution.
@@ -7020,6 +8207,28 @@ func (s WorkflowType) GoString() string {
 	return s.String()
 }
 
+// Validate inspects the fields of the type to determine if they are valid.
+func (s *WorkflowType) Validate() error {
+	invalidParams := request.ErrInvalidParams{Context: "WorkflowType"}
+	if s.Name == nil {
+		invalidParams.Add(request.NewErrParamRequired("Name"))
+	}
+	if s.Name != nil && len(*s.Name) < 1 {
+		invalidParams.Add(request.NewErrParamMinLen("Name", 1))
+	}
+	if s.Version == nil {
+		invalidParams.Add(request.NewErrParamRequired("Version"))
+	}
+	if s.Version != nil && len(*s.Version) < 1 {
+		invalidParams.Add(request.NewErrParamMinLen("Version", 1))
+	}
+
+	if invalidParams.Len() > 0 {
+		return invalidParams
+	}
+	return nil
+}
+
 // The configuration settings of a workflow type.
 type WorkflowTypeConfiguration struct {
 	_ struct{} `type:"structure"`
@@ -7114,6 +8323,22 @@ func (s WorkflowTypeFilter) String() string {
 // GoString returns the string representation
 func (s WorkflowTypeFilter) GoString() string {
 	return s.String()
+}
+
+// Validate inspects the fields of the type to determine if they are valid.
+func (s *WorkflowTypeFilter) Validate() error {
+	invalidParams := request.ErrInvalidParams{Context: "WorkflowTypeFilter"}
+	if s.Name == nil {
+		invalidParams.Add(request.NewErrParamRequired("Name"))
+	}
+	if s.Name != nil && len(*s.Name) < 1 {
+		invalidParams.Add(request.NewErrParamMinLen("Name", 1))
+	}
+
+	if invalidParams.Len() > 0 {
+		return invalidParams
+	}
+	return nil
 }
 
 // Contains information about a workflow type.

--- a/service/waf/api.go
+++ b/service/waf/api.go
@@ -4,6 +4,7 @@
 package waf
 
 import (
+	"fmt"
 	"time"
 
 	"github.com/aws/aws-sdk-go/aws/awsutil"
@@ -1477,6 +1478,33 @@ func (s ActivatedRule) GoString() string {
 	return s.String()
 }
 
+// Validate inspects the fields of the type to determine if they are valid.
+func (s *ActivatedRule) Validate() error {
+	invalidParams := request.ErrInvalidParams{Context: "ActivatedRule"}
+	if s.Action == nil {
+		invalidParams.Add(request.NewErrParamRequired("Action"))
+	}
+	if s.Priority == nil {
+		invalidParams.Add(request.NewErrParamRequired("Priority"))
+	}
+	if s.RuleId == nil {
+		invalidParams.Add(request.NewErrParamRequired("RuleId"))
+	}
+	if s.RuleId != nil && len(*s.RuleId) < 1 {
+		invalidParams.Add(request.NewErrParamMinLen("RuleId", 1))
+	}
+	if s.Action != nil {
+		if err := s.Action.Validate(); err != nil {
+			invalidParams.AddNested("Action", err.(request.ErrInvalidParams))
+		}
+	}
+
+	if invalidParams.Len() > 0 {
+		return invalidParams
+	}
+	return nil
+}
+
 // In a GetByteMatchSet request, ByteMatchSet is a complex type that contains
 // the ByteMatchSetId and Name of a ByteMatchSet, and the values that you specified
 // when you updated the ByteMatchSet.
@@ -1567,6 +1595,27 @@ func (s ByteMatchSetUpdate) String() string {
 // GoString returns the string representation
 func (s ByteMatchSetUpdate) GoString() string {
 	return s.String()
+}
+
+// Validate inspects the fields of the type to determine if they are valid.
+func (s *ByteMatchSetUpdate) Validate() error {
+	invalidParams := request.ErrInvalidParams{Context: "ByteMatchSetUpdate"}
+	if s.Action == nil {
+		invalidParams.Add(request.NewErrParamRequired("Action"))
+	}
+	if s.ByteMatchTuple == nil {
+		invalidParams.Add(request.NewErrParamRequired("ByteMatchTuple"))
+	}
+	if s.ByteMatchTuple != nil {
+		if err := s.ByteMatchTuple.Validate(); err != nil {
+			invalidParams.AddNested("ByteMatchTuple", err.(request.ErrInvalidParams))
+		}
+	}
+
+	if invalidParams.Len() > 0 {
+		return invalidParams
+	}
+	return nil
 }
 
 // The bytes (typically a string that corresponds with ASCII characters) that
@@ -1718,6 +1767,33 @@ func (s ByteMatchTuple) GoString() string {
 	return s.String()
 }
 
+// Validate inspects the fields of the type to determine if they are valid.
+func (s *ByteMatchTuple) Validate() error {
+	invalidParams := request.ErrInvalidParams{Context: "ByteMatchTuple"}
+	if s.FieldToMatch == nil {
+		invalidParams.Add(request.NewErrParamRequired("FieldToMatch"))
+	}
+	if s.PositionalConstraint == nil {
+		invalidParams.Add(request.NewErrParamRequired("PositionalConstraint"))
+	}
+	if s.TargetString == nil {
+		invalidParams.Add(request.NewErrParamRequired("TargetString"))
+	}
+	if s.TextTransformation == nil {
+		invalidParams.Add(request.NewErrParamRequired("TextTransformation"))
+	}
+	if s.FieldToMatch != nil {
+		if err := s.FieldToMatch.Validate(); err != nil {
+			invalidParams.AddNested("FieldToMatch", err.(request.ErrInvalidParams))
+		}
+	}
+
+	if invalidParams.Len() > 0 {
+		return invalidParams
+	}
+	return nil
+}
+
 type CreateByteMatchSetInput struct {
 	_ struct{} `type:"structure"`
 
@@ -1737,6 +1813,25 @@ func (s CreateByteMatchSetInput) String() string {
 // GoString returns the string representation
 func (s CreateByteMatchSetInput) GoString() string {
 	return s.String()
+}
+
+// Validate inspects the fields of the type to determine if they are valid.
+func (s *CreateByteMatchSetInput) Validate() error {
+	invalidParams := request.ErrInvalidParams{Context: "CreateByteMatchSetInput"}
+	if s.ChangeToken == nil {
+		invalidParams.Add(request.NewErrParamRequired("ChangeToken"))
+	}
+	if s.Name == nil {
+		invalidParams.Add(request.NewErrParamRequired("Name"))
+	}
+	if s.Name != nil && len(*s.Name) < 1 {
+		invalidParams.Add(request.NewErrParamMinLen("Name", 1))
+	}
+
+	if invalidParams.Len() > 0 {
+		return invalidParams
+	}
+	return nil
 }
 
 type CreateByteMatchSetOutput struct {
@@ -1780,6 +1875,25 @@ func (s CreateIPSetInput) String() string {
 // GoString returns the string representation
 func (s CreateIPSetInput) GoString() string {
 	return s.String()
+}
+
+// Validate inspects the fields of the type to determine if they are valid.
+func (s *CreateIPSetInput) Validate() error {
+	invalidParams := request.ErrInvalidParams{Context: "CreateIPSetInput"}
+	if s.ChangeToken == nil {
+		invalidParams.Add(request.NewErrParamRequired("ChangeToken"))
+	}
+	if s.Name == nil {
+		invalidParams.Add(request.NewErrParamRequired("Name"))
+	}
+	if s.Name != nil && len(*s.Name) < 1 {
+		invalidParams.Add(request.NewErrParamMinLen("Name", 1))
+	}
+
+	if invalidParams.Len() > 0 {
+		return invalidParams
+	}
+	return nil
 }
 
 type CreateIPSetOutput struct {
@@ -1831,6 +1945,28 @@ func (s CreateRuleInput) GoString() string {
 	return s.String()
 }
 
+// Validate inspects the fields of the type to determine if they are valid.
+func (s *CreateRuleInput) Validate() error {
+	invalidParams := request.ErrInvalidParams{Context: "CreateRuleInput"}
+	if s.ChangeToken == nil {
+		invalidParams.Add(request.NewErrParamRequired("ChangeToken"))
+	}
+	if s.MetricName == nil {
+		invalidParams.Add(request.NewErrParamRequired("MetricName"))
+	}
+	if s.Name == nil {
+		invalidParams.Add(request.NewErrParamRequired("Name"))
+	}
+	if s.Name != nil && len(*s.Name) < 1 {
+		invalidParams.Add(request.NewErrParamMinLen("Name", 1))
+	}
+
+	if invalidParams.Len() > 0 {
+		return invalidParams
+	}
+	return nil
+}
+
 type CreateRuleOutput struct {
 	_ struct{} `type:"structure"`
 
@@ -1872,6 +2008,25 @@ func (s CreateSizeConstraintSetInput) String() string {
 // GoString returns the string representation
 func (s CreateSizeConstraintSetInput) GoString() string {
 	return s.String()
+}
+
+// Validate inspects the fields of the type to determine if they are valid.
+func (s *CreateSizeConstraintSetInput) Validate() error {
+	invalidParams := request.ErrInvalidParams{Context: "CreateSizeConstraintSetInput"}
+	if s.ChangeToken == nil {
+		invalidParams.Add(request.NewErrParamRequired("ChangeToken"))
+	}
+	if s.Name == nil {
+		invalidParams.Add(request.NewErrParamRequired("Name"))
+	}
+	if s.Name != nil && len(*s.Name) < 1 {
+		invalidParams.Add(request.NewErrParamMinLen("Name", 1))
+	}
+
+	if invalidParams.Len() > 0 {
+		return invalidParams
+	}
+	return nil
 }
 
 type CreateSizeConstraintSetOutput struct {
@@ -1916,6 +2071,25 @@ func (s CreateSqlInjectionMatchSetInput) String() string {
 // GoString returns the string representation
 func (s CreateSqlInjectionMatchSetInput) GoString() string {
 	return s.String()
+}
+
+// Validate inspects the fields of the type to determine if they are valid.
+func (s *CreateSqlInjectionMatchSetInput) Validate() error {
+	invalidParams := request.ErrInvalidParams{Context: "CreateSqlInjectionMatchSetInput"}
+	if s.ChangeToken == nil {
+		invalidParams.Add(request.NewErrParamRequired("ChangeToken"))
+	}
+	if s.Name == nil {
+		invalidParams.Add(request.NewErrParamRequired("Name"))
+	}
+	if s.Name != nil && len(*s.Name) < 1 {
+		invalidParams.Add(request.NewErrParamMinLen("Name", 1))
+	}
+
+	if invalidParams.Len() > 0 {
+		return invalidParams
+	}
+	return nil
 }
 
 // The response to a CreateSqlInjectionMatchSet request.
@@ -1972,6 +2146,36 @@ func (s CreateWebACLInput) GoString() string {
 	return s.String()
 }
 
+// Validate inspects the fields of the type to determine if they are valid.
+func (s *CreateWebACLInput) Validate() error {
+	invalidParams := request.ErrInvalidParams{Context: "CreateWebACLInput"}
+	if s.ChangeToken == nil {
+		invalidParams.Add(request.NewErrParamRequired("ChangeToken"))
+	}
+	if s.DefaultAction == nil {
+		invalidParams.Add(request.NewErrParamRequired("DefaultAction"))
+	}
+	if s.MetricName == nil {
+		invalidParams.Add(request.NewErrParamRequired("MetricName"))
+	}
+	if s.Name == nil {
+		invalidParams.Add(request.NewErrParamRequired("Name"))
+	}
+	if s.Name != nil && len(*s.Name) < 1 {
+		invalidParams.Add(request.NewErrParamMinLen("Name", 1))
+	}
+	if s.DefaultAction != nil {
+		if err := s.DefaultAction.Validate(); err != nil {
+			invalidParams.AddNested("DefaultAction", err.(request.ErrInvalidParams))
+		}
+	}
+
+	if invalidParams.Len() > 0 {
+		return invalidParams
+	}
+	return nil
+}
+
 type CreateWebACLOutput struct {
 	_ struct{} `type:"structure"`
 
@@ -2014,6 +2218,25 @@ func (s CreateXssMatchSetInput) String() string {
 // GoString returns the string representation
 func (s CreateXssMatchSetInput) GoString() string {
 	return s.String()
+}
+
+// Validate inspects the fields of the type to determine if they are valid.
+func (s *CreateXssMatchSetInput) Validate() error {
+	invalidParams := request.ErrInvalidParams{Context: "CreateXssMatchSetInput"}
+	if s.ChangeToken == nil {
+		invalidParams.Add(request.NewErrParamRequired("ChangeToken"))
+	}
+	if s.Name == nil {
+		invalidParams.Add(request.NewErrParamRequired("Name"))
+	}
+	if s.Name != nil && len(*s.Name) < 1 {
+		invalidParams.Add(request.NewErrParamMinLen("Name", 1))
+	}
+
+	if invalidParams.Len() > 0 {
+		return invalidParams
+	}
+	return nil
 }
 
 // The response to a CreateXssMatchSet request.
@@ -2060,6 +2283,25 @@ func (s DeleteByteMatchSetInput) GoString() string {
 	return s.String()
 }
 
+// Validate inspects the fields of the type to determine if they are valid.
+func (s *DeleteByteMatchSetInput) Validate() error {
+	invalidParams := request.ErrInvalidParams{Context: "DeleteByteMatchSetInput"}
+	if s.ByteMatchSetId == nil {
+		invalidParams.Add(request.NewErrParamRequired("ByteMatchSetId"))
+	}
+	if s.ByteMatchSetId != nil && len(*s.ByteMatchSetId) < 1 {
+		invalidParams.Add(request.NewErrParamMinLen("ByteMatchSetId", 1))
+	}
+	if s.ChangeToken == nil {
+		invalidParams.Add(request.NewErrParamRequired("ChangeToken"))
+	}
+
+	if invalidParams.Len() > 0 {
+		return invalidParams
+	}
+	return nil
+}
+
 type DeleteByteMatchSetOutput struct {
 	_ struct{} `type:"structure"`
 
@@ -2098,6 +2340,25 @@ func (s DeleteIPSetInput) String() string {
 // GoString returns the string representation
 func (s DeleteIPSetInput) GoString() string {
 	return s.String()
+}
+
+// Validate inspects the fields of the type to determine if they are valid.
+func (s *DeleteIPSetInput) Validate() error {
+	invalidParams := request.ErrInvalidParams{Context: "DeleteIPSetInput"}
+	if s.ChangeToken == nil {
+		invalidParams.Add(request.NewErrParamRequired("ChangeToken"))
+	}
+	if s.IPSetId == nil {
+		invalidParams.Add(request.NewErrParamRequired("IPSetId"))
+	}
+	if s.IPSetId != nil && len(*s.IPSetId) < 1 {
+		invalidParams.Add(request.NewErrParamMinLen("IPSetId", 1))
+	}
+
+	if invalidParams.Len() > 0 {
+		return invalidParams
+	}
+	return nil
 }
 
 type DeleteIPSetOutput struct {
@@ -2140,6 +2401,25 @@ func (s DeleteRuleInput) GoString() string {
 	return s.String()
 }
 
+// Validate inspects the fields of the type to determine if they are valid.
+func (s *DeleteRuleInput) Validate() error {
+	invalidParams := request.ErrInvalidParams{Context: "DeleteRuleInput"}
+	if s.ChangeToken == nil {
+		invalidParams.Add(request.NewErrParamRequired("ChangeToken"))
+	}
+	if s.RuleId == nil {
+		invalidParams.Add(request.NewErrParamRequired("RuleId"))
+	}
+	if s.RuleId != nil && len(*s.RuleId) < 1 {
+		invalidParams.Add(request.NewErrParamMinLen("RuleId", 1))
+	}
+
+	if invalidParams.Len() > 0 {
+		return invalidParams
+	}
+	return nil
+}
+
 type DeleteRuleOutput struct {
 	_ struct{} `type:"structure"`
 
@@ -2178,6 +2458,25 @@ func (s DeleteSizeConstraintSetInput) String() string {
 // GoString returns the string representation
 func (s DeleteSizeConstraintSetInput) GoString() string {
 	return s.String()
+}
+
+// Validate inspects the fields of the type to determine if they are valid.
+func (s *DeleteSizeConstraintSetInput) Validate() error {
+	invalidParams := request.ErrInvalidParams{Context: "DeleteSizeConstraintSetInput"}
+	if s.ChangeToken == nil {
+		invalidParams.Add(request.NewErrParamRequired("ChangeToken"))
+	}
+	if s.SizeConstraintSetId == nil {
+		invalidParams.Add(request.NewErrParamRequired("SizeConstraintSetId"))
+	}
+	if s.SizeConstraintSetId != nil && len(*s.SizeConstraintSetId) < 1 {
+		invalidParams.Add(request.NewErrParamMinLen("SizeConstraintSetId", 1))
+	}
+
+	if invalidParams.Len() > 0 {
+		return invalidParams
+	}
+	return nil
 }
 
 type DeleteSizeConstraintSetOutput struct {
@@ -2221,6 +2520,25 @@ func (s DeleteSqlInjectionMatchSetInput) GoString() string {
 	return s.String()
 }
 
+// Validate inspects the fields of the type to determine if they are valid.
+func (s *DeleteSqlInjectionMatchSetInput) Validate() error {
+	invalidParams := request.ErrInvalidParams{Context: "DeleteSqlInjectionMatchSetInput"}
+	if s.ChangeToken == nil {
+		invalidParams.Add(request.NewErrParamRequired("ChangeToken"))
+	}
+	if s.SqlInjectionMatchSetId == nil {
+		invalidParams.Add(request.NewErrParamRequired("SqlInjectionMatchSetId"))
+	}
+	if s.SqlInjectionMatchSetId != nil && len(*s.SqlInjectionMatchSetId) < 1 {
+		invalidParams.Add(request.NewErrParamMinLen("SqlInjectionMatchSetId", 1))
+	}
+
+	if invalidParams.Len() > 0 {
+		return invalidParams
+	}
+	return nil
+}
+
 // The response to a request to delete a SqlInjectionMatchSet from AWS WAF.
 type DeleteSqlInjectionMatchSetOutput struct {
 	_ struct{} `type:"structure"`
@@ -2262,6 +2580,25 @@ func (s DeleteWebACLInput) GoString() string {
 	return s.String()
 }
 
+// Validate inspects the fields of the type to determine if they are valid.
+func (s *DeleteWebACLInput) Validate() error {
+	invalidParams := request.ErrInvalidParams{Context: "DeleteWebACLInput"}
+	if s.ChangeToken == nil {
+		invalidParams.Add(request.NewErrParamRequired("ChangeToken"))
+	}
+	if s.WebACLId == nil {
+		invalidParams.Add(request.NewErrParamRequired("WebACLId"))
+	}
+	if s.WebACLId != nil && len(*s.WebACLId) < 1 {
+		invalidParams.Add(request.NewErrParamMinLen("WebACLId", 1))
+	}
+
+	if invalidParams.Len() > 0 {
+		return invalidParams
+	}
+	return nil
+}
+
 type DeleteWebACLOutput struct {
 	_ struct{} `type:"structure"`
 
@@ -2301,6 +2638,25 @@ func (s DeleteXssMatchSetInput) String() string {
 // GoString returns the string representation
 func (s DeleteXssMatchSetInput) GoString() string {
 	return s.String()
+}
+
+// Validate inspects the fields of the type to determine if they are valid.
+func (s *DeleteXssMatchSetInput) Validate() error {
+	invalidParams := request.ErrInvalidParams{Context: "DeleteXssMatchSetInput"}
+	if s.ChangeToken == nil {
+		invalidParams.Add(request.NewErrParamRequired("ChangeToken"))
+	}
+	if s.XssMatchSetId == nil {
+		invalidParams.Add(request.NewErrParamRequired("XssMatchSetId"))
+	}
+	if s.XssMatchSetId != nil && len(*s.XssMatchSetId) < 1 {
+		invalidParams.Add(request.NewErrParamMinLen("XssMatchSetId", 1))
+	}
+
+	if invalidParams.Len() > 0 {
+		return invalidParams
+	}
+	return nil
 }
 
 // The response to a request to delete an XssMatchSet from AWS WAF.
@@ -2364,6 +2720,19 @@ func (s FieldToMatch) GoString() string {
 	return s.String()
 }
 
+// Validate inspects the fields of the type to determine if they are valid.
+func (s *FieldToMatch) Validate() error {
+	invalidParams := request.ErrInvalidParams{Context: "FieldToMatch"}
+	if s.Type == nil {
+		invalidParams.Add(request.NewErrParamRequired("Type"))
+	}
+
+	if invalidParams.Len() > 0 {
+		return invalidParams
+	}
+	return nil
+}
+
 type GetByteMatchSetInput struct {
 	_ struct{} `type:"structure"`
 
@@ -2380,6 +2749,22 @@ func (s GetByteMatchSetInput) String() string {
 // GoString returns the string representation
 func (s GetByteMatchSetInput) GoString() string {
 	return s.String()
+}
+
+// Validate inspects the fields of the type to determine if they are valid.
+func (s *GetByteMatchSetInput) Validate() error {
+	invalidParams := request.ErrInvalidParams{Context: "GetByteMatchSetInput"}
+	if s.ByteMatchSetId == nil {
+		invalidParams.Add(request.NewErrParamRequired("ByteMatchSetId"))
+	}
+	if s.ByteMatchSetId != nil && len(*s.ByteMatchSetId) < 1 {
+		invalidParams.Add(request.NewErrParamMinLen("ByteMatchSetId", 1))
+	}
+
+	if invalidParams.Len() > 0 {
+		return invalidParams
+	}
+	return nil
 }
 
 type GetByteMatchSetOutput struct {
@@ -2455,6 +2840,19 @@ func (s GetChangeTokenStatusInput) GoString() string {
 	return s.String()
 }
 
+// Validate inspects the fields of the type to determine if they are valid.
+func (s *GetChangeTokenStatusInput) Validate() error {
+	invalidParams := request.ErrInvalidParams{Context: "GetChangeTokenStatusInput"}
+	if s.ChangeToken == nil {
+		invalidParams.Add(request.NewErrParamRequired("ChangeToken"))
+	}
+
+	if invalidParams.Len() > 0 {
+		return invalidParams
+	}
+	return nil
+}
+
 type GetChangeTokenStatusOutput struct {
 	_ struct{} `type:"structure"`
 
@@ -2488,6 +2886,22 @@ func (s GetIPSetInput) String() string {
 // GoString returns the string representation
 func (s GetIPSetInput) GoString() string {
 	return s.String()
+}
+
+// Validate inspects the fields of the type to determine if they are valid.
+func (s *GetIPSetInput) Validate() error {
+	invalidParams := request.ErrInvalidParams{Context: "GetIPSetInput"}
+	if s.IPSetId == nil {
+		invalidParams.Add(request.NewErrParamRequired("IPSetId"))
+	}
+	if s.IPSetId != nil && len(*s.IPSetId) < 1 {
+		invalidParams.Add(request.NewErrParamMinLen("IPSetId", 1))
+	}
+
+	if invalidParams.Len() > 0 {
+		return invalidParams
+	}
+	return nil
 }
 
 type GetIPSetOutput struct {
@@ -2528,6 +2942,22 @@ func (s GetRuleInput) String() string {
 // GoString returns the string representation
 func (s GetRuleInput) GoString() string {
 	return s.String()
+}
+
+// Validate inspects the fields of the type to determine if they are valid.
+func (s *GetRuleInput) Validate() error {
+	invalidParams := request.ErrInvalidParams{Context: "GetRuleInput"}
+	if s.RuleId == nil {
+		invalidParams.Add(request.NewErrParamRequired("RuleId"))
+	}
+	if s.RuleId != nil && len(*s.RuleId) < 1 {
+		invalidParams.Add(request.NewErrParamMinLen("RuleId", 1))
+	}
+
+	if invalidParams.Len() > 0 {
+		return invalidParams
+	}
+	return nil
 }
 
 type GetRuleOutput struct {
@@ -2589,6 +3019,42 @@ func (s GetSampledRequestsInput) GoString() string {
 	return s.String()
 }
 
+// Validate inspects the fields of the type to determine if they are valid.
+func (s *GetSampledRequestsInput) Validate() error {
+	invalidParams := request.ErrInvalidParams{Context: "GetSampledRequestsInput"}
+	if s.MaxItems == nil {
+		invalidParams.Add(request.NewErrParamRequired("MaxItems"))
+	}
+	if s.MaxItems != nil && *s.MaxItems < 1 {
+		invalidParams.Add(request.NewErrParamMinValue("MaxItems", 1))
+	}
+	if s.RuleId == nil {
+		invalidParams.Add(request.NewErrParamRequired("RuleId"))
+	}
+	if s.RuleId != nil && len(*s.RuleId) < 1 {
+		invalidParams.Add(request.NewErrParamMinLen("RuleId", 1))
+	}
+	if s.TimeWindow == nil {
+		invalidParams.Add(request.NewErrParamRequired("TimeWindow"))
+	}
+	if s.WebAclId == nil {
+		invalidParams.Add(request.NewErrParamRequired("WebAclId"))
+	}
+	if s.WebAclId != nil && len(*s.WebAclId) < 1 {
+		invalidParams.Add(request.NewErrParamMinLen("WebAclId", 1))
+	}
+	if s.TimeWindow != nil {
+		if err := s.TimeWindow.Validate(); err != nil {
+			invalidParams.AddNested("TimeWindow", err.(request.ErrInvalidParams))
+		}
+	}
+
+	if invalidParams.Len() > 0 {
+		return invalidParams
+	}
+	return nil
+}
+
 type GetSampledRequestsOutput struct {
 	_ struct{} `type:"structure"`
 
@@ -2636,6 +3102,22 @@ func (s GetSizeConstraintSetInput) GoString() string {
 	return s.String()
 }
 
+// Validate inspects the fields of the type to determine if they are valid.
+func (s *GetSizeConstraintSetInput) Validate() error {
+	invalidParams := request.ErrInvalidParams{Context: "GetSizeConstraintSetInput"}
+	if s.SizeConstraintSetId == nil {
+		invalidParams.Add(request.NewErrParamRequired("SizeConstraintSetId"))
+	}
+	if s.SizeConstraintSetId != nil && len(*s.SizeConstraintSetId) < 1 {
+		invalidParams.Add(request.NewErrParamMinLen("SizeConstraintSetId", 1))
+	}
+
+	if invalidParams.Len() > 0 {
+		return invalidParams
+	}
+	return nil
+}
+
 type GetSizeConstraintSetOutput struct {
 	_ struct{} `type:"structure"`
 
@@ -2676,6 +3158,22 @@ func (s GetSqlInjectionMatchSetInput) String() string {
 // GoString returns the string representation
 func (s GetSqlInjectionMatchSetInput) GoString() string {
 	return s.String()
+}
+
+// Validate inspects the fields of the type to determine if they are valid.
+func (s *GetSqlInjectionMatchSetInput) Validate() error {
+	invalidParams := request.ErrInvalidParams{Context: "GetSqlInjectionMatchSetInput"}
+	if s.SqlInjectionMatchSetId == nil {
+		invalidParams.Add(request.NewErrParamRequired("SqlInjectionMatchSetId"))
+	}
+	if s.SqlInjectionMatchSetId != nil && len(*s.SqlInjectionMatchSetId) < 1 {
+		invalidParams.Add(request.NewErrParamMinLen("SqlInjectionMatchSetId", 1))
+	}
+
+	if invalidParams.Len() > 0 {
+		return invalidParams
+	}
+	return nil
 }
 
 // The response to a GetSqlInjectionMatchSet request.
@@ -2720,6 +3218,22 @@ func (s GetWebACLInput) GoString() string {
 	return s.String()
 }
 
+// Validate inspects the fields of the type to determine if they are valid.
+func (s *GetWebACLInput) Validate() error {
+	invalidParams := request.ErrInvalidParams{Context: "GetWebACLInput"}
+	if s.WebACLId == nil {
+		invalidParams.Add(request.NewErrParamRequired("WebACLId"))
+	}
+	if s.WebACLId != nil && len(*s.WebACLId) < 1 {
+		invalidParams.Add(request.NewErrParamMinLen("WebACLId", 1))
+	}
+
+	if invalidParams.Len() > 0 {
+		return invalidParams
+	}
+	return nil
+}
+
 type GetWebACLOutput struct {
 	_ struct{} `type:"structure"`
 
@@ -2760,6 +3274,22 @@ func (s GetXssMatchSetInput) String() string {
 // GoString returns the string representation
 func (s GetXssMatchSetInput) GoString() string {
 	return s.String()
+}
+
+// Validate inspects the fields of the type to determine if they are valid.
+func (s *GetXssMatchSetInput) Validate() error {
+	invalidParams := request.ErrInvalidParams{Context: "GetXssMatchSetInput"}
+	if s.XssMatchSetId == nil {
+		invalidParams.Add(request.NewErrParamRequired("XssMatchSetId"))
+	}
+	if s.XssMatchSetId != nil && len(*s.XssMatchSetId) < 1 {
+		invalidParams.Add(request.NewErrParamMinLen("XssMatchSetId", 1))
+	}
+
+	if invalidParams.Len() > 0 {
+		return invalidParams
+	}
+	return nil
 }
 
 // The response to a GetXssMatchSet request.
@@ -2927,6 +3457,22 @@ func (s IPSetDescriptor) GoString() string {
 	return s.String()
 }
 
+// Validate inspects the fields of the type to determine if they are valid.
+func (s *IPSetDescriptor) Validate() error {
+	invalidParams := request.ErrInvalidParams{Context: "IPSetDescriptor"}
+	if s.Type == nil {
+		invalidParams.Add(request.NewErrParamRequired("Type"))
+	}
+	if s.Value == nil {
+		invalidParams.Add(request.NewErrParamRequired("Value"))
+	}
+
+	if invalidParams.Len() > 0 {
+		return invalidParams
+	}
+	return nil
+}
+
 // Contains the identifier and the name of the IPSet.
 type IPSetSummary struct {
 	_ struct{} `type:"structure"`
@@ -2972,6 +3518,27 @@ func (s IPSetUpdate) GoString() string {
 	return s.String()
 }
 
+// Validate inspects the fields of the type to determine if they are valid.
+func (s *IPSetUpdate) Validate() error {
+	invalidParams := request.ErrInvalidParams{Context: "IPSetUpdate"}
+	if s.Action == nil {
+		invalidParams.Add(request.NewErrParamRequired("Action"))
+	}
+	if s.IPSetDescriptor == nil {
+		invalidParams.Add(request.NewErrParamRequired("IPSetDescriptor"))
+	}
+	if s.IPSetDescriptor != nil {
+		if err := s.IPSetDescriptor.Validate(); err != nil {
+			invalidParams.AddNested("IPSetDescriptor", err.(request.ErrInvalidParams))
+		}
+	}
+
+	if invalidParams.Len() > 0 {
+		return invalidParams
+	}
+	return nil
+}
+
 type ListByteMatchSetsInput struct {
 	_ struct{} `type:"structure"`
 
@@ -2997,6 +3564,25 @@ func (s ListByteMatchSetsInput) String() string {
 // GoString returns the string representation
 func (s ListByteMatchSetsInput) GoString() string {
 	return s.String()
+}
+
+// Validate inspects the fields of the type to determine if they are valid.
+func (s *ListByteMatchSetsInput) Validate() error {
+	invalidParams := request.ErrInvalidParams{Context: "ListByteMatchSetsInput"}
+	if s.Limit == nil {
+		invalidParams.Add(request.NewErrParamRequired("Limit"))
+	}
+	if s.Limit != nil && *s.Limit < 1 {
+		invalidParams.Add(request.NewErrParamMinValue("Limit", 1))
+	}
+	if s.NextMarker != nil && len(*s.NextMarker) < 1 {
+		invalidParams.Add(request.NewErrParamMinLen("NextMarker", 1))
+	}
+
+	if invalidParams.Len() > 0 {
+		return invalidParams
+	}
+	return nil
 }
 
 type ListByteMatchSetsOutput struct {
@@ -3050,6 +3636,25 @@ func (s ListIPSetsInput) GoString() string {
 	return s.String()
 }
 
+// Validate inspects the fields of the type to determine if they are valid.
+func (s *ListIPSetsInput) Validate() error {
+	invalidParams := request.ErrInvalidParams{Context: "ListIPSetsInput"}
+	if s.Limit == nil {
+		invalidParams.Add(request.NewErrParamRequired("Limit"))
+	}
+	if s.Limit != nil && *s.Limit < 1 {
+		invalidParams.Add(request.NewErrParamMinValue("Limit", 1))
+	}
+	if s.NextMarker != nil && len(*s.NextMarker) < 1 {
+		invalidParams.Add(request.NewErrParamMinLen("NextMarker", 1))
+	}
+
+	if invalidParams.Len() > 0 {
+		return invalidParams
+	}
+	return nil
+}
+
 type ListIPSetsOutput struct {
 	_ struct{} `type:"structure"`
 
@@ -3097,6 +3702,25 @@ func (s ListRulesInput) String() string {
 // GoString returns the string representation
 func (s ListRulesInput) GoString() string {
 	return s.String()
+}
+
+// Validate inspects the fields of the type to determine if they are valid.
+func (s *ListRulesInput) Validate() error {
+	invalidParams := request.ErrInvalidParams{Context: "ListRulesInput"}
+	if s.Limit == nil {
+		invalidParams.Add(request.NewErrParamRequired("Limit"))
+	}
+	if s.Limit != nil && *s.Limit < 1 {
+		invalidParams.Add(request.NewErrParamMinValue("Limit", 1))
+	}
+	if s.NextMarker != nil && len(*s.NextMarker) < 1 {
+		invalidParams.Add(request.NewErrParamMinLen("NextMarker", 1))
+	}
+
+	if invalidParams.Len() > 0 {
+		return invalidParams
+	}
+	return nil
 }
 
 type ListRulesOutput struct {
@@ -3147,6 +3771,25 @@ func (s ListSizeConstraintSetsInput) String() string {
 // GoString returns the string representation
 func (s ListSizeConstraintSetsInput) GoString() string {
 	return s.String()
+}
+
+// Validate inspects the fields of the type to determine if they are valid.
+func (s *ListSizeConstraintSetsInput) Validate() error {
+	invalidParams := request.ErrInvalidParams{Context: "ListSizeConstraintSetsInput"}
+	if s.Limit == nil {
+		invalidParams.Add(request.NewErrParamRequired("Limit"))
+	}
+	if s.Limit != nil && *s.Limit < 1 {
+		invalidParams.Add(request.NewErrParamMinValue("Limit", 1))
+	}
+	if s.NextMarker != nil && len(*s.NextMarker) < 1 {
+		invalidParams.Add(request.NewErrParamMinLen("NextMarker", 1))
+	}
+
+	if invalidParams.Len() > 0 {
+		return invalidParams
+	}
+	return nil
 }
 
 type ListSizeConstraintSetsOutput struct {
@@ -3202,6 +3845,25 @@ func (s ListSqlInjectionMatchSetsInput) GoString() string {
 	return s.String()
 }
 
+// Validate inspects the fields of the type to determine if they are valid.
+func (s *ListSqlInjectionMatchSetsInput) Validate() error {
+	invalidParams := request.ErrInvalidParams{Context: "ListSqlInjectionMatchSetsInput"}
+	if s.Limit == nil {
+		invalidParams.Add(request.NewErrParamRequired("Limit"))
+	}
+	if s.Limit != nil && *s.Limit < 1 {
+		invalidParams.Add(request.NewErrParamMinValue("Limit", 1))
+	}
+	if s.NextMarker != nil && len(*s.NextMarker) < 1 {
+		invalidParams.Add(request.NewErrParamMinLen("NextMarker", 1))
+	}
+
+	if invalidParams.Len() > 0 {
+		return invalidParams
+	}
+	return nil
+}
+
 // The response to a ListSqlInjectionMatchSets request.
 type ListSqlInjectionMatchSetsOutput struct {
 	_ struct{} `type:"structure"`
@@ -3255,6 +3917,25 @@ func (s ListWebACLsInput) GoString() string {
 	return s.String()
 }
 
+// Validate inspects the fields of the type to determine if they are valid.
+func (s *ListWebACLsInput) Validate() error {
+	invalidParams := request.ErrInvalidParams{Context: "ListWebACLsInput"}
+	if s.Limit == nil {
+		invalidParams.Add(request.NewErrParamRequired("Limit"))
+	}
+	if s.Limit != nil && *s.Limit < 1 {
+		invalidParams.Add(request.NewErrParamMinValue("Limit", 1))
+	}
+	if s.NextMarker != nil && len(*s.NextMarker) < 1 {
+		invalidParams.Add(request.NewErrParamMinLen("NextMarker", 1))
+	}
+
+	if invalidParams.Len() > 0 {
+		return invalidParams
+	}
+	return nil
+}
+
 type ListWebACLsOutput struct {
 	_ struct{} `type:"structure"`
 
@@ -3304,6 +3985,25 @@ func (s ListXssMatchSetsInput) String() string {
 // GoString returns the string representation
 func (s ListXssMatchSetsInput) GoString() string {
 	return s.String()
+}
+
+// Validate inspects the fields of the type to determine if they are valid.
+func (s *ListXssMatchSetsInput) Validate() error {
+	invalidParams := request.ErrInvalidParams{Context: "ListXssMatchSetsInput"}
+	if s.Limit == nil {
+		invalidParams.Add(request.NewErrParamRequired("Limit"))
+	}
+	if s.Limit != nil && *s.Limit < 1 {
+		invalidParams.Add(request.NewErrParamMinValue("Limit", 1))
+	}
+	if s.NextMarker != nil && len(*s.NextMarker) < 1 {
+		invalidParams.Add(request.NewErrParamMinLen("NextMarker", 1))
+	}
+
+	if invalidParams.Len() > 0 {
+		return invalidParams
+	}
+	return nil
 }
 
 // The response to a ListXssMatchSets request.
@@ -3367,6 +4067,28 @@ func (s Predicate) String() string {
 // GoString returns the string representation
 func (s Predicate) GoString() string {
 	return s.String()
+}
+
+// Validate inspects the fields of the type to determine if they are valid.
+func (s *Predicate) Validate() error {
+	invalidParams := request.ErrInvalidParams{Context: "Predicate"}
+	if s.DataId == nil {
+		invalidParams.Add(request.NewErrParamRequired("DataId"))
+	}
+	if s.DataId != nil && len(*s.DataId) < 1 {
+		invalidParams.Add(request.NewErrParamMinLen("DataId", 1))
+	}
+	if s.Negated == nil {
+		invalidParams.Add(request.NewErrParamRequired("Negated"))
+	}
+	if s.Type == nil {
+		invalidParams.Add(request.NewErrParamRequired("Type"))
+	}
+
+	if invalidParams.Len() > 0 {
+		return invalidParams
+	}
+	return nil
 }
 
 // A combination of ByteMatchSet, IPSet, and/or SqlInjectionMatchSet objects
@@ -3458,6 +4180,27 @@ func (s RuleUpdate) String() string {
 // GoString returns the string representation
 func (s RuleUpdate) GoString() string {
 	return s.String()
+}
+
+// Validate inspects the fields of the type to determine if they are valid.
+func (s *RuleUpdate) Validate() error {
+	invalidParams := request.ErrInvalidParams{Context: "RuleUpdate"}
+	if s.Action == nil {
+		invalidParams.Add(request.NewErrParamRequired("Action"))
+	}
+	if s.Predicate == nil {
+		invalidParams.Add(request.NewErrParamRequired("Predicate"))
+	}
+	if s.Predicate != nil {
+		if err := s.Predicate.Validate(); err != nil {
+			invalidParams.AddNested("Predicate", err.(request.ErrInvalidParams))
+		}
+	}
+
+	if invalidParams.Len() > 0 {
+		return invalidParams
+	}
+	return nil
 }
 
 // The response from a GetSampledRequests request includes a SampledHTTPRequests
@@ -3597,6 +4340,33 @@ func (s SizeConstraint) GoString() string {
 	return s.String()
 }
 
+// Validate inspects the fields of the type to determine if they are valid.
+func (s *SizeConstraint) Validate() error {
+	invalidParams := request.ErrInvalidParams{Context: "SizeConstraint"}
+	if s.ComparisonOperator == nil {
+		invalidParams.Add(request.NewErrParamRequired("ComparisonOperator"))
+	}
+	if s.FieldToMatch == nil {
+		invalidParams.Add(request.NewErrParamRequired("FieldToMatch"))
+	}
+	if s.Size == nil {
+		invalidParams.Add(request.NewErrParamRequired("Size"))
+	}
+	if s.TextTransformation == nil {
+		invalidParams.Add(request.NewErrParamRequired("TextTransformation"))
+	}
+	if s.FieldToMatch != nil {
+		if err := s.FieldToMatch.Validate(); err != nil {
+			invalidParams.AddNested("FieldToMatch", err.(request.ErrInvalidParams))
+		}
+	}
+
+	if invalidParams.Len() > 0 {
+		return invalidParams
+	}
+	return nil
+}
+
 // A complex type that contains SizeConstraint objects, which specify the parts
 // of web requests that you want AWS WAF to inspect the size of. If a SizeConstraintSet
 // contains more than one SizeConstraint object, a request only needs to match
@@ -3682,6 +4452,27 @@ func (s SizeConstraintSetUpdate) String() string {
 // GoString returns the string representation
 func (s SizeConstraintSetUpdate) GoString() string {
 	return s.String()
+}
+
+// Validate inspects the fields of the type to determine if they are valid.
+func (s *SizeConstraintSetUpdate) Validate() error {
+	invalidParams := request.ErrInvalidParams{Context: "SizeConstraintSetUpdate"}
+	if s.Action == nil {
+		invalidParams.Add(request.NewErrParamRequired("Action"))
+	}
+	if s.SizeConstraint == nil {
+		invalidParams.Add(request.NewErrParamRequired("SizeConstraint"))
+	}
+	if s.SizeConstraint != nil {
+		if err := s.SizeConstraint.Validate(); err != nil {
+			invalidParams.AddNested("SizeConstraint", err.(request.ErrInvalidParams))
+		}
+	}
+
+	if invalidParams.Len() > 0 {
+		return invalidParams
+	}
+	return nil
 }
 
 // A complex type that contains SqlInjectionMatchTuple objects, which specify
@@ -3775,6 +4566,27 @@ func (s SqlInjectionMatchSetUpdate) GoString() string {
 	return s.String()
 }
 
+// Validate inspects the fields of the type to determine if they are valid.
+func (s *SqlInjectionMatchSetUpdate) Validate() error {
+	invalidParams := request.ErrInvalidParams{Context: "SqlInjectionMatchSetUpdate"}
+	if s.Action == nil {
+		invalidParams.Add(request.NewErrParamRequired("Action"))
+	}
+	if s.SqlInjectionMatchTuple == nil {
+		invalidParams.Add(request.NewErrParamRequired("SqlInjectionMatchTuple"))
+	}
+	if s.SqlInjectionMatchTuple != nil {
+		if err := s.SqlInjectionMatchTuple.Validate(); err != nil {
+			invalidParams.AddNested("SqlInjectionMatchTuple", err.(request.ErrInvalidParams))
+		}
+	}
+
+	if invalidParams.Len() > 0 {
+		return invalidParams
+	}
+	return nil
+}
+
 // Specifies the part of a web request that you want AWS WAF to inspect for
 // snippets of malicious SQL code and, if you want AWS WAF to inspect a header,
 // the name of the header.
@@ -3842,6 +4654,27 @@ func (s SqlInjectionMatchTuple) GoString() string {
 	return s.String()
 }
 
+// Validate inspects the fields of the type to determine if they are valid.
+func (s *SqlInjectionMatchTuple) Validate() error {
+	invalidParams := request.ErrInvalidParams{Context: "SqlInjectionMatchTuple"}
+	if s.FieldToMatch == nil {
+		invalidParams.Add(request.NewErrParamRequired("FieldToMatch"))
+	}
+	if s.TextTransformation == nil {
+		invalidParams.Add(request.NewErrParamRequired("TextTransformation"))
+	}
+	if s.FieldToMatch != nil {
+		if err := s.FieldToMatch.Validate(); err != nil {
+			invalidParams.AddNested("FieldToMatch", err.(request.ErrInvalidParams))
+		}
+	}
+
+	if invalidParams.Len() > 0 {
+		return invalidParams
+	}
+	return nil
+}
+
 // In a GetSampledRequests request, the StartTime and EndTime objects specify
 // the time range for which you want AWS WAF to return a sample of web requests.
 //
@@ -3876,6 +4709,22 @@ func (s TimeWindow) GoString() string {
 	return s.String()
 }
 
+// Validate inspects the fields of the type to determine if they are valid.
+func (s *TimeWindow) Validate() error {
+	invalidParams := request.ErrInvalidParams{Context: "TimeWindow"}
+	if s.EndTime == nil {
+		invalidParams.Add(request.NewErrParamRequired("EndTime"))
+	}
+	if s.StartTime == nil {
+		invalidParams.Add(request.NewErrParamRequired("StartTime"))
+	}
+
+	if invalidParams.Len() > 0 {
+		return invalidParams
+	}
+	return nil
+}
+
 type UpdateByteMatchSetInput struct {
 	_ struct{} `type:"structure"`
 
@@ -3903,6 +4752,38 @@ func (s UpdateByteMatchSetInput) String() string {
 // GoString returns the string representation
 func (s UpdateByteMatchSetInput) GoString() string {
 	return s.String()
+}
+
+// Validate inspects the fields of the type to determine if they are valid.
+func (s *UpdateByteMatchSetInput) Validate() error {
+	invalidParams := request.ErrInvalidParams{Context: "UpdateByteMatchSetInput"}
+	if s.ByteMatchSetId == nil {
+		invalidParams.Add(request.NewErrParamRequired("ByteMatchSetId"))
+	}
+	if s.ByteMatchSetId != nil && len(*s.ByteMatchSetId) < 1 {
+		invalidParams.Add(request.NewErrParamMinLen("ByteMatchSetId", 1))
+	}
+	if s.ChangeToken == nil {
+		invalidParams.Add(request.NewErrParamRequired("ChangeToken"))
+	}
+	if s.Updates == nil {
+		invalidParams.Add(request.NewErrParamRequired("Updates"))
+	}
+	if s.Updates != nil {
+		for i, v := range s.Updates {
+			if v == nil {
+				continue
+			}
+			if err := v.Validate(); err != nil {
+				invalidParams.AddNested(fmt.Sprintf("%s[%v]", "Updates", i), err.(request.ErrInvalidParams))
+			}
+		}
+	}
+
+	if invalidParams.Len() > 0 {
+		return invalidParams
+	}
+	return nil
 }
 
 type UpdateByteMatchSetOutput struct {
@@ -3952,6 +4833,38 @@ func (s UpdateIPSetInput) GoString() string {
 	return s.String()
 }
 
+// Validate inspects the fields of the type to determine if they are valid.
+func (s *UpdateIPSetInput) Validate() error {
+	invalidParams := request.ErrInvalidParams{Context: "UpdateIPSetInput"}
+	if s.ChangeToken == nil {
+		invalidParams.Add(request.NewErrParamRequired("ChangeToken"))
+	}
+	if s.IPSetId == nil {
+		invalidParams.Add(request.NewErrParamRequired("IPSetId"))
+	}
+	if s.IPSetId != nil && len(*s.IPSetId) < 1 {
+		invalidParams.Add(request.NewErrParamMinLen("IPSetId", 1))
+	}
+	if s.Updates == nil {
+		invalidParams.Add(request.NewErrParamRequired("Updates"))
+	}
+	if s.Updates != nil {
+		for i, v := range s.Updates {
+			if v == nil {
+				continue
+			}
+			if err := v.Validate(); err != nil {
+				invalidParams.AddNested(fmt.Sprintf("%s[%v]", "Updates", i), err.(request.ErrInvalidParams))
+			}
+		}
+	}
+
+	if invalidParams.Len() > 0 {
+		return invalidParams
+	}
+	return nil
+}
+
 type UpdateIPSetOutput struct {
 	_ struct{} `type:"structure"`
 
@@ -3997,6 +4910,38 @@ func (s UpdateRuleInput) String() string {
 // GoString returns the string representation
 func (s UpdateRuleInput) GoString() string {
 	return s.String()
+}
+
+// Validate inspects the fields of the type to determine if they are valid.
+func (s *UpdateRuleInput) Validate() error {
+	invalidParams := request.ErrInvalidParams{Context: "UpdateRuleInput"}
+	if s.ChangeToken == nil {
+		invalidParams.Add(request.NewErrParamRequired("ChangeToken"))
+	}
+	if s.RuleId == nil {
+		invalidParams.Add(request.NewErrParamRequired("RuleId"))
+	}
+	if s.RuleId != nil && len(*s.RuleId) < 1 {
+		invalidParams.Add(request.NewErrParamMinLen("RuleId", 1))
+	}
+	if s.Updates == nil {
+		invalidParams.Add(request.NewErrParamRequired("Updates"))
+	}
+	if s.Updates != nil {
+		for i, v := range s.Updates {
+			if v == nil {
+				continue
+			}
+			if err := v.Validate(); err != nil {
+				invalidParams.AddNested(fmt.Sprintf("%s[%v]", "Updates", i), err.(request.ErrInvalidParams))
+			}
+		}
+	}
+
+	if invalidParams.Len() > 0 {
+		return invalidParams
+	}
+	return nil
 }
 
 type UpdateRuleOutput struct {
@@ -4048,6 +4993,38 @@ func (s UpdateSizeConstraintSetInput) GoString() string {
 	return s.String()
 }
 
+// Validate inspects the fields of the type to determine if they are valid.
+func (s *UpdateSizeConstraintSetInput) Validate() error {
+	invalidParams := request.ErrInvalidParams{Context: "UpdateSizeConstraintSetInput"}
+	if s.ChangeToken == nil {
+		invalidParams.Add(request.NewErrParamRequired("ChangeToken"))
+	}
+	if s.SizeConstraintSetId == nil {
+		invalidParams.Add(request.NewErrParamRequired("SizeConstraintSetId"))
+	}
+	if s.SizeConstraintSetId != nil && len(*s.SizeConstraintSetId) < 1 {
+		invalidParams.Add(request.NewErrParamMinLen("SizeConstraintSetId", 1))
+	}
+	if s.Updates == nil {
+		invalidParams.Add(request.NewErrParamRequired("Updates"))
+	}
+	if s.Updates != nil {
+		for i, v := range s.Updates {
+			if v == nil {
+				continue
+			}
+			if err := v.Validate(); err != nil {
+				invalidParams.AddNested(fmt.Sprintf("%s[%v]", "Updates", i), err.(request.ErrInvalidParams))
+			}
+		}
+	}
+
+	if invalidParams.Len() > 0 {
+		return invalidParams
+	}
+	return nil
+}
+
 type UpdateSizeConstraintSetOutput struct {
 	_ struct{} `type:"structure"`
 
@@ -4096,6 +5073,38 @@ func (s UpdateSqlInjectionMatchSetInput) String() string {
 // GoString returns the string representation
 func (s UpdateSqlInjectionMatchSetInput) GoString() string {
 	return s.String()
+}
+
+// Validate inspects the fields of the type to determine if they are valid.
+func (s *UpdateSqlInjectionMatchSetInput) Validate() error {
+	invalidParams := request.ErrInvalidParams{Context: "UpdateSqlInjectionMatchSetInput"}
+	if s.ChangeToken == nil {
+		invalidParams.Add(request.NewErrParamRequired("ChangeToken"))
+	}
+	if s.SqlInjectionMatchSetId == nil {
+		invalidParams.Add(request.NewErrParamRequired("SqlInjectionMatchSetId"))
+	}
+	if s.SqlInjectionMatchSetId != nil && len(*s.SqlInjectionMatchSetId) < 1 {
+		invalidParams.Add(request.NewErrParamMinLen("SqlInjectionMatchSetId", 1))
+	}
+	if s.Updates == nil {
+		invalidParams.Add(request.NewErrParamRequired("Updates"))
+	}
+	if s.Updates != nil {
+		for i, v := range s.Updates {
+			if v == nil {
+				continue
+			}
+			if err := v.Validate(); err != nil {
+				invalidParams.AddNested(fmt.Sprintf("%s[%v]", "Updates", i), err.(request.ErrInvalidParams))
+			}
+		}
+	}
+
+	if invalidParams.Len() > 0 {
+		return invalidParams
+	}
+	return nil
 }
 
 // The response to an UpdateSqlInjectionMatchSets request.
@@ -4155,6 +5164,40 @@ func (s UpdateWebACLInput) GoString() string {
 	return s.String()
 }
 
+// Validate inspects the fields of the type to determine if they are valid.
+func (s *UpdateWebACLInput) Validate() error {
+	invalidParams := request.ErrInvalidParams{Context: "UpdateWebACLInput"}
+	if s.ChangeToken == nil {
+		invalidParams.Add(request.NewErrParamRequired("ChangeToken"))
+	}
+	if s.WebACLId == nil {
+		invalidParams.Add(request.NewErrParamRequired("WebACLId"))
+	}
+	if s.WebACLId != nil && len(*s.WebACLId) < 1 {
+		invalidParams.Add(request.NewErrParamMinLen("WebACLId", 1))
+	}
+	if s.DefaultAction != nil {
+		if err := s.DefaultAction.Validate(); err != nil {
+			invalidParams.AddNested("DefaultAction", err.(request.ErrInvalidParams))
+		}
+	}
+	if s.Updates != nil {
+		for i, v := range s.Updates {
+			if v == nil {
+				continue
+			}
+			if err := v.Validate(); err != nil {
+				invalidParams.AddNested(fmt.Sprintf("%s[%v]", "Updates", i), err.(request.ErrInvalidParams))
+			}
+		}
+	}
+
+	if invalidParams.Len() > 0 {
+		return invalidParams
+	}
+	return nil
+}
+
 type UpdateWebACLOutput struct {
 	_ struct{} `type:"structure"`
 
@@ -4201,6 +5244,38 @@ func (s UpdateXssMatchSetInput) String() string {
 // GoString returns the string representation
 func (s UpdateXssMatchSetInput) GoString() string {
 	return s.String()
+}
+
+// Validate inspects the fields of the type to determine if they are valid.
+func (s *UpdateXssMatchSetInput) Validate() error {
+	invalidParams := request.ErrInvalidParams{Context: "UpdateXssMatchSetInput"}
+	if s.ChangeToken == nil {
+		invalidParams.Add(request.NewErrParamRequired("ChangeToken"))
+	}
+	if s.Updates == nil {
+		invalidParams.Add(request.NewErrParamRequired("Updates"))
+	}
+	if s.XssMatchSetId == nil {
+		invalidParams.Add(request.NewErrParamRequired("XssMatchSetId"))
+	}
+	if s.XssMatchSetId != nil && len(*s.XssMatchSetId) < 1 {
+		invalidParams.Add(request.NewErrParamMinLen("XssMatchSetId", 1))
+	}
+	if s.Updates != nil {
+		for i, v := range s.Updates {
+			if v == nil {
+				continue
+			}
+			if err := v.Validate(); err != nil {
+				invalidParams.AddNested(fmt.Sprintf("%s[%v]", "Updates", i), err.(request.ErrInvalidParams))
+			}
+		}
+	}
+
+	if invalidParams.Len() > 0 {
+		return invalidParams
+	}
+	return nil
 }
 
 // The response to an UpdateXssMatchSets request.
@@ -4250,6 +5325,19 @@ func (s WafAction) String() string {
 // GoString returns the string representation
 func (s WafAction) GoString() string {
 	return s.String()
+}
+
+// Validate inspects the fields of the type to determine if they are valid.
+func (s *WafAction) Validate() error {
+	invalidParams := request.ErrInvalidParams{Context: "WafAction"}
+	if s.Type == nil {
+		invalidParams.Add(request.NewErrParamRequired("Type"))
+	}
+
+	if invalidParams.Len() > 0 {
+		return invalidParams
+	}
+	return nil
 }
 
 // Contains the Rules that identify the requests that you want to allow, block,
@@ -4348,6 +5436,27 @@ func (s WebACLUpdate) GoString() string {
 	return s.String()
 }
 
+// Validate inspects the fields of the type to determine if they are valid.
+func (s *WebACLUpdate) Validate() error {
+	invalidParams := request.ErrInvalidParams{Context: "WebACLUpdate"}
+	if s.Action == nil {
+		invalidParams.Add(request.NewErrParamRequired("Action"))
+	}
+	if s.ActivatedRule == nil {
+		invalidParams.Add(request.NewErrParamRequired("ActivatedRule"))
+	}
+	if s.ActivatedRule != nil {
+		if err := s.ActivatedRule.Validate(); err != nil {
+			invalidParams.AddNested("ActivatedRule", err.(request.ErrInvalidParams))
+		}
+	}
+
+	if invalidParams.Len() > 0 {
+		return invalidParams
+	}
+	return nil
+}
+
 // A complex type that contains XssMatchTuple objects, which specify the parts
 // of web requests that you want AWS WAF to inspect for cross-site scripting
 // attacks and, if you want AWS WAF to inspect a header, the name of the header.
@@ -4435,6 +5544,27 @@ func (s XssMatchSetUpdate) GoString() string {
 	return s.String()
 }
 
+// Validate inspects the fields of the type to determine if they are valid.
+func (s *XssMatchSetUpdate) Validate() error {
+	invalidParams := request.ErrInvalidParams{Context: "XssMatchSetUpdate"}
+	if s.Action == nil {
+		invalidParams.Add(request.NewErrParamRequired("Action"))
+	}
+	if s.XssMatchTuple == nil {
+		invalidParams.Add(request.NewErrParamRequired("XssMatchTuple"))
+	}
+	if s.XssMatchTuple != nil {
+		if err := s.XssMatchTuple.Validate(); err != nil {
+			invalidParams.AddNested("XssMatchTuple", err.(request.ErrInvalidParams))
+		}
+	}
+
+	if invalidParams.Len() > 0 {
+		return invalidParams
+	}
+	return nil
+}
+
 // Specifies the part of a web request that you want AWS WAF to inspect for
 // cross-site scripting attacks and, if you want AWS WAF to inspect a header,
 // the name of the header.
@@ -4500,6 +5630,27 @@ func (s XssMatchTuple) String() string {
 // GoString returns the string representation
 func (s XssMatchTuple) GoString() string {
 	return s.String()
+}
+
+// Validate inspects the fields of the type to determine if they are valid.
+func (s *XssMatchTuple) Validate() error {
+	invalidParams := request.ErrInvalidParams{Context: "XssMatchTuple"}
+	if s.FieldToMatch == nil {
+		invalidParams.Add(request.NewErrParamRequired("FieldToMatch"))
+	}
+	if s.TextTransformation == nil {
+		invalidParams.Add(request.NewErrParamRequired("TextTransformation"))
+	}
+	if s.FieldToMatch != nil {
+		if err := s.FieldToMatch.Validate(); err != nil {
+			invalidParams.AddNested("FieldToMatch", err.(request.ErrInvalidParams))
+		}
+	}
+
+	if invalidParams.Len() > 0 {
+		return invalidParams
+	}
+	return nil
 }
 
 const (

--- a/service/workspaces/api.go
+++ b/service/workspaces/api.go
@@ -4,6 +4,8 @@
 package workspaces
 
 import (
+	"fmt"
+
 	"github.com/aws/aws-sdk-go/aws/awsutil"
 	"github.com/aws/aws-sdk-go/aws/request"
 )
@@ -331,6 +333,32 @@ func (s CreateWorkspacesInput) GoString() string {
 	return s.String()
 }
 
+// Validate inspects the fields of the type to determine if they are valid.
+func (s *CreateWorkspacesInput) Validate() error {
+	invalidParams := request.ErrInvalidParams{Context: "CreateWorkspacesInput"}
+	if s.Workspaces == nil {
+		invalidParams.Add(request.NewErrParamRequired("Workspaces"))
+	}
+	if s.Workspaces != nil && len(s.Workspaces) < 1 {
+		invalidParams.Add(request.NewErrParamMinLen("Workspaces", 1))
+	}
+	if s.Workspaces != nil {
+		for i, v := range s.Workspaces {
+			if v == nil {
+				continue
+			}
+			if err := v.Validate(); err != nil {
+				invalidParams.AddNested(fmt.Sprintf("%s[%v]", "Workspaces", i), err.(request.ErrInvalidParams))
+			}
+		}
+	}
+
+	if invalidParams.Len() > 0 {
+		return invalidParams
+	}
+	return nil
+}
+
 // Contains the result of the CreateWorkspaces operation.
 type CreateWorkspacesOutput struct {
 	_ struct{} `type:"structure"`
@@ -421,6 +449,22 @@ func (s DescribeWorkspaceBundlesInput) GoString() string {
 	return s.String()
 }
 
+// Validate inspects the fields of the type to determine if they are valid.
+func (s *DescribeWorkspaceBundlesInput) Validate() error {
+	invalidParams := request.ErrInvalidParams{Context: "DescribeWorkspaceBundlesInput"}
+	if s.BundleIds != nil && len(s.BundleIds) < 1 {
+		invalidParams.Add(request.NewErrParamMinLen("BundleIds", 1))
+	}
+	if s.NextToken != nil && len(*s.NextToken) < 1 {
+		invalidParams.Add(request.NewErrParamMinLen("NextToken", 1))
+	}
+
+	if invalidParams.Len() > 0 {
+		return invalidParams
+	}
+	return nil
+}
+
 // Contains the results of the DescribeWorkspaceBundles operation.
 type DescribeWorkspaceBundlesOutput struct {
 	_ struct{} `type:"structure"`
@@ -465,6 +509,22 @@ func (s DescribeWorkspaceDirectoriesInput) String() string {
 // GoString returns the string representation
 func (s DescribeWorkspaceDirectoriesInput) GoString() string {
 	return s.String()
+}
+
+// Validate inspects the fields of the type to determine if they are valid.
+func (s *DescribeWorkspaceDirectoriesInput) Validate() error {
+	invalidParams := request.ErrInvalidParams{Context: "DescribeWorkspaceDirectoriesInput"}
+	if s.DirectoryIds != nil && len(s.DirectoryIds) < 1 {
+		invalidParams.Add(request.NewErrParamMinLen("DirectoryIds", 1))
+	}
+	if s.NextToken != nil && len(*s.NextToken) < 1 {
+		invalidParams.Add(request.NewErrParamMinLen("NextToken", 1))
+	}
+
+	if invalidParams.Len() > 0 {
+		return invalidParams
+	}
+	return nil
 }
 
 // Contains the results of the DescribeWorkspaceDirectories operation.
@@ -533,6 +593,28 @@ func (s DescribeWorkspacesInput) String() string {
 // GoString returns the string representation
 func (s DescribeWorkspacesInput) GoString() string {
 	return s.String()
+}
+
+// Validate inspects the fields of the type to determine if they are valid.
+func (s *DescribeWorkspacesInput) Validate() error {
+	invalidParams := request.ErrInvalidParams{Context: "DescribeWorkspacesInput"}
+	if s.Limit != nil && *s.Limit < 1 {
+		invalidParams.Add(request.NewErrParamMinValue("Limit", 1))
+	}
+	if s.NextToken != nil && len(*s.NextToken) < 1 {
+		invalidParams.Add(request.NewErrParamMinLen("NextToken", 1))
+	}
+	if s.UserName != nil && len(*s.UserName) < 1 {
+		invalidParams.Add(request.NewErrParamMinLen("UserName", 1))
+	}
+	if s.WorkspaceIds != nil && len(s.WorkspaceIds) < 1 {
+		invalidParams.Add(request.NewErrParamMinLen("WorkspaceIds", 1))
+	}
+
+	if invalidParams.Len() > 0 {
+		return invalidParams
+	}
+	return nil
 }
 
 // Contains the results for the DescribeWorkspaces operation.
@@ -630,6 +712,19 @@ func (s RebootRequest) GoString() string {
 	return s.String()
 }
 
+// Validate inspects the fields of the type to determine if they are valid.
+func (s *RebootRequest) Validate() error {
+	invalidParams := request.ErrInvalidParams{Context: "RebootRequest"}
+	if s.WorkspaceId == nil {
+		invalidParams.Add(request.NewErrParamRequired("WorkspaceId"))
+	}
+
+	if invalidParams.Len() > 0 {
+		return invalidParams
+	}
+	return nil
+}
+
 // Contains the inputs for the RebootWorkspaces operation.
 type RebootWorkspacesInput struct {
 	_ struct{} `type:"structure"`
@@ -646,6 +741,32 @@ func (s RebootWorkspacesInput) String() string {
 // GoString returns the string representation
 func (s RebootWorkspacesInput) GoString() string {
 	return s.String()
+}
+
+// Validate inspects the fields of the type to determine if they are valid.
+func (s *RebootWorkspacesInput) Validate() error {
+	invalidParams := request.ErrInvalidParams{Context: "RebootWorkspacesInput"}
+	if s.RebootWorkspaceRequests == nil {
+		invalidParams.Add(request.NewErrParamRequired("RebootWorkspaceRequests"))
+	}
+	if s.RebootWorkspaceRequests != nil && len(s.RebootWorkspaceRequests) < 1 {
+		invalidParams.Add(request.NewErrParamMinLen("RebootWorkspaceRequests", 1))
+	}
+	if s.RebootWorkspaceRequests != nil {
+		for i, v := range s.RebootWorkspaceRequests {
+			if v == nil {
+				continue
+			}
+			if err := v.Validate(); err != nil {
+				invalidParams.AddNested(fmt.Sprintf("%s[%v]", "RebootWorkspaceRequests", i), err.(request.ErrInvalidParams))
+			}
+		}
+	}
+
+	if invalidParams.Len() > 0 {
+		return invalidParams
+	}
+	return nil
 }
 
 // Contains the results of the RebootWorkspaces operation.
@@ -685,6 +806,19 @@ func (s RebuildRequest) GoString() string {
 	return s.String()
 }
 
+// Validate inspects the fields of the type to determine if they are valid.
+func (s *RebuildRequest) Validate() error {
+	invalidParams := request.ErrInvalidParams{Context: "RebuildRequest"}
+	if s.WorkspaceId == nil {
+		invalidParams.Add(request.NewErrParamRequired("WorkspaceId"))
+	}
+
+	if invalidParams.Len() > 0 {
+		return invalidParams
+	}
+	return nil
+}
+
 // Contains the inputs for the RebuildWorkspaces operation.
 type RebuildWorkspacesInput struct {
 	_ struct{} `type:"structure"`
@@ -701,6 +835,32 @@ func (s RebuildWorkspacesInput) String() string {
 // GoString returns the string representation
 func (s RebuildWorkspacesInput) GoString() string {
 	return s.String()
+}
+
+// Validate inspects the fields of the type to determine if they are valid.
+func (s *RebuildWorkspacesInput) Validate() error {
+	invalidParams := request.ErrInvalidParams{Context: "RebuildWorkspacesInput"}
+	if s.RebuildWorkspaceRequests == nil {
+		invalidParams.Add(request.NewErrParamRequired("RebuildWorkspaceRequests"))
+	}
+	if s.RebuildWorkspaceRequests != nil && len(s.RebuildWorkspaceRequests) < 1 {
+		invalidParams.Add(request.NewErrParamMinLen("RebuildWorkspaceRequests", 1))
+	}
+	if s.RebuildWorkspaceRequests != nil {
+		for i, v := range s.RebuildWorkspaceRequests {
+			if v == nil {
+				continue
+			}
+			if err := v.Validate(); err != nil {
+				invalidParams.AddNested(fmt.Sprintf("%s[%v]", "RebuildWorkspaceRequests", i), err.(request.ErrInvalidParams))
+			}
+		}
+	}
+
+	if invalidParams.Len() > 0 {
+		return invalidParams
+	}
+	return nil
 }
 
 // Contains the results of the RebuildWorkspaces operation.
@@ -740,6 +900,19 @@ func (s TerminateRequest) GoString() string {
 	return s.String()
 }
 
+// Validate inspects the fields of the type to determine if they are valid.
+func (s *TerminateRequest) Validate() error {
+	invalidParams := request.ErrInvalidParams{Context: "TerminateRequest"}
+	if s.WorkspaceId == nil {
+		invalidParams.Add(request.NewErrParamRequired("WorkspaceId"))
+	}
+
+	if invalidParams.Len() > 0 {
+		return invalidParams
+	}
+	return nil
+}
+
 // Contains the inputs for the TerminateWorkspaces operation.
 type TerminateWorkspacesInput struct {
 	_ struct{} `type:"structure"`
@@ -756,6 +929,32 @@ func (s TerminateWorkspacesInput) String() string {
 // GoString returns the string representation
 func (s TerminateWorkspacesInput) GoString() string {
 	return s.String()
+}
+
+// Validate inspects the fields of the type to determine if they are valid.
+func (s *TerminateWorkspacesInput) Validate() error {
+	invalidParams := request.ErrInvalidParams{Context: "TerminateWorkspacesInput"}
+	if s.TerminateWorkspaceRequests == nil {
+		invalidParams.Add(request.NewErrParamRequired("TerminateWorkspaceRequests"))
+	}
+	if s.TerminateWorkspaceRequests != nil && len(s.TerminateWorkspaceRequests) < 1 {
+		invalidParams.Add(request.NewErrParamMinLen("TerminateWorkspaceRequests", 1))
+	}
+	if s.TerminateWorkspaceRequests != nil {
+		for i, v := range s.TerminateWorkspaceRequests {
+			if v == nil {
+				continue
+			}
+			if err := v.Validate(); err != nil {
+				invalidParams.AddNested(fmt.Sprintf("%s[%v]", "TerminateWorkspaceRequests", i), err.(request.ErrInvalidParams))
+			}
+		}
+	}
+
+	if invalidParams.Len() > 0 {
+		return invalidParams
+	}
+	return nil
 }
 
 // Contains the results of the TerminateWorkspaces operation.
@@ -978,6 +1177,28 @@ func (s WorkspaceRequest) String() string {
 // GoString returns the string representation
 func (s WorkspaceRequest) GoString() string {
 	return s.String()
+}
+
+// Validate inspects the fields of the type to determine if they are valid.
+func (s *WorkspaceRequest) Validate() error {
+	invalidParams := request.ErrInvalidParams{Context: "WorkspaceRequest"}
+	if s.BundleId == nil {
+		invalidParams.Add(request.NewErrParamRequired("BundleId"))
+	}
+	if s.DirectoryId == nil {
+		invalidParams.Add(request.NewErrParamRequired("DirectoryId"))
+	}
+	if s.UserName == nil {
+		invalidParams.Add(request.NewErrParamRequired("UserName"))
+	}
+	if s.UserName != nil && len(*s.UserName) < 1 {
+		invalidParams.Add(request.NewErrParamMinLen("UserName", 1))
+	}
+
+	if invalidParams.Len() > 0 {
+		return invalidParams
+	}
+	return nil
 }
 
 const (


### PR DESCRIPTION
Updates the SDK to generate its input parameter validation logic instead
of using reflection. This improves the performance (cpu/memory) of
building requests by about 15-20%.

This change should be transparent to users of the SDK, other than reduction of memory usage, and delay caused by param validation. This change does also refactor the SDK's internal API generator's templates to require go1.6. This will not impact usage of the SDK, just its code generation, which is covered by the [private pkg pact](https://github.com/aws/aws-sdk-go/blob/master/private/README.md).
   
Fix #537

Suggested to not review the diff as a whole at once since the generated services/protocol commit is pretty large.

This PR greatly improves the performance of validating API operation params. At the micro level the impact of validation now is extremely little. In the context of marshaling and signing a request this improves validation by about 15%-20%. 

`go test -bench . -benchmem -run NONE ./aws/corehandlers/`
```
benchmark                  old ns/op     new ns/op     delta
BenchmarkValidateAny-4     203116        790           -99.61%

benchmark                  old allocs     new allocs     delta
BenchmarkValidateAny-4     1909           0              -100.00%

benchmark                  old bytes     new bytes     delta
BenchmarkValidateAny-4     19363         0             -100.00%
```

Benchmark results with a simpler operation, and additional isolated bench of validation by its self.

[`go test -bench . -run NONE -benchmem bench_test.go`](https://gist.github.com/jasdel/ca7e97be2ee3e3e7f616efa04d445f64)
```
benchmark                old ns/op     new ns/op     delta
BenchmarkOperation-4     77574         66292         -14.54%
BenchmarkValidate-4      12554         36.4          -99.71%

benchmark                old allocs     new allocs     delta
BenchmarkOperation-4     494            421            -14.78%
BenchmarkValidate-4      73             0              -100.00%

benchmark                old bytes     new bytes     delta
BenchmarkOperation-4     24571         24135         -1.77%
BenchmarkValidate-4      440           0             -100.00%