### PR TITLE
private/protocol/json/jsonutil: Fix JSON string encoding for unicode 

### DIFF
--- a/private/protocol/json/jsonutil/build.go
+++ b/private/protocol/json/jsonutil/build.go
@@ -120,7 +120,8 @@ func buildStruct(value reflect.Value, buf *bytes.Buffer, tag reflect.StructTag) 
 			name = locName
 		}
 
-		fmt.Fprintf(buf, "%q:", name)
+		writeString(name, buf)
+		buf.WriteString(`:`)
 
 		err := buildAny(member, buf, field.Tag)
 		if err != nil {
@@ -167,7 +168,9 @@ func buildMap(value reflect.Value, buf *bytes.Buffer, tag reflect.StructTag) err
 			buf.WriteByte(',')
 		}
 
-		fmt.Fprintf(buf, "%q:", k)
+		writeString(k.String(), buf)
+		buf.WriteString(`:`)
+
 		buildAny(value.MapIndex(k), buf, "")
 	}
 


### PR DESCRIPTION
Updates the `jsonutil` package to encode non printable characters as
`\u0000` instead of `\x00`.

Fix #654