### PR TITLE
Fix nil pointer deref if Location is nil in CompleteMultipartUploadOutput

### DIFF
--- a/service/s3/s3manager/upload.go
+++ b/service/s3/s3manager/upload.go
@@ -8,6 +8,7 @@ import (
 	"sync"
 	"time"
 
+	"github.com/aws/aws-sdk-go/aws"
 	"github.com/aws/aws-sdk-go/aws/awserr"
 	"github.com/aws/aws-sdk-go/aws/awsutil"
 	"github.com/aws/aws-sdk-go/aws/client"
@@ -556,7 +557,7 @@ func (u *multiuploader) upload(firstBuf io.ReadSeeker) (*UploadOutput, error) {
 		}
 	}
 	return &UploadOutput{
-		Location:  *complete.Location,
+		Location:  aws.StringValue(complete.Location),
 		VersionID: complete.VersionId,
 		UploadID:  u.uploadID,
 	}, nil


### PR DESCRIPTION
This has been observed in testing with Ceph Infernalis. Strictly speaking the bug is in Ceph for sending malformed data, but crashing here with a nil pointer deref isn't good practice.

See ncw/rclone#459 for background