### PR TITLE
Update doc tool dependency pinning.

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -1,6 +1,6 @@
 source 'https://rubygems.org'
 
-gem 'yard', git: 'git://github.com/lsegal/yard'
-gem 'yard-go', git: 'git://github.com/lsegal/yard-go'
+gem 'yard', git: 'git://github.com/lsegal/yard', ref: '5025564a491e1b7c6192632cba2802202ca08449'
+gem 'yard-go', git: 'git://github.com/jasdel/yard-go', ref: 'e78e1ef7cdf5e0f3266845b26bb4fd64f1dd6f85'
 gem 'rdiscount'
 


### PR DESCRIPTION
Updates the doc tool temporarily to fix the unexpected inclusion of`Input` or validated shapes in package list root on http://docs.aws.amazon.com/sdk-for-go/api/.

Fix #658