### PR TITLE
Make DefaultRetryer more efficient in dealing with throttling errors

### DIFF
--- a/aws/client/default_retryer.go
+++ b/aws/client/default_retryer.go
@@ -2,6 +2,7 @@ package client
 
 import (
 	"math/rand"
+	"sync"
 	"time"
 
 	"github.com/aws/aws-sdk-go/aws/request"
@@ -29,13 +30,15 @@ func (d DefaultRetryer) MaxRetries() int {
 	return d.NumMaxRetries
 }
 
+var seededRand = rand.New(&lockedSource{src: rand.NewSource(time.Now().UnixNano())})
+
 // RetryRules returns the delay duration before retrying this request again
 func (d DefaultRetryer) RetryRules(r *request.Request) time.Duration {
 	// Set the upper limit of delay in retrying at ~five minutes
 	minTime := 30
 	throttle := d.shouldThrottle(r)
 	if throttle {
-		minTime = 1000
+		minTime = 500
 	}
 
 	retryCount := r.RetryCount
@@ -45,7 +48,7 @@ func (d DefaultRetryer) RetryRules(r *request.Request) time.Duration {
 		retryCount = 8
 	}
 
-	delay := (1 << uint(retryCount)) * (rand.Intn(30) + minTime)
+	delay := (1 << uint(retryCount)) * (seededRand.Intn(minTime) + minTime)
 	return time.Duration(delay) * time.Millisecond
 }
 
@@ -65,4 +68,23 @@ func (d DefaultRetryer) shouldThrottle(r *request.Request) bool {
 		return true
 	}
 	return r.IsErrorThrottle()
+}
+
+// lockedSource is a thread-safe implementation of rand.Source
+type lockedSource struct {
+	lk  sync.Mutex
+	src rand.Source
+}
+
+func (r *lockedSource) Int63() (n int64) {
+	r.lk.Lock()
+	n = r.src.Int63()
+	r.lk.Unlock()
+	return
+}
+
+func (r *lockedSource) Seed(seed int64) {
+	r.lk.Lock()
+	r.src.Seed(seed)
+	r.lk.Unlock()
 }

--- a/aws/request/request_test.go
+++ b/aws/request/request_test.go
@@ -296,7 +296,7 @@ func TestRequestThrottleRetries(t *testing.T) {
 	assert.Equal(t, "An error occurred.", err.(awserr.Error).Message())
 	assert.Equal(t, 3, int(r.RetryCount))
 
-	expectDelays := []struct{ min, max time.Duration }{{1000, 1030}, {2000, 2060}, {4000, 4120}}
+	expectDelays := []struct{ min, max time.Duration }{{500, 999}, {1000, 1998}, {2000, 3996}}
 	for i, v := range delays {
 		min := expectDelays[i].min * time.Millisecond
 		max := expectDelays[i].max * time.Millisecond


### PR DESCRIPTION
Implements #669 

* Use a seeded PRNG source in order to yield random backoff sequences
* Apply effective jitter to backoff durations for throttling errors