### PR TITLE
Alter dynamodbattribute marshaling to handle time conversion

### DIFF
--- a/service/dynamodb/dynamodbattribute/decode.go
+++ b/service/dynamodb/dynamodbattribute/decode.go
@@ -457,9 +457,8 @@ func (d *Decoder) decodeString(s *string, v reflect.Value, fieldTag tag) error {
 
 	// To maintain backwards compatibility with ConvertFrom family of methods which
 	// converted strings to time.Time structs (using JSON encoding/decoding)
-	if t, ok := v.Interface().(time.Time); ok {
-		b := []byte(*s)
-		err := t.UnmarshalJSON(b)
+	if _, ok := v.Interface().(time.Time); ok {
+		t, err := time.Parse(time.RFC3339, *s)
 		if err != nil {
 			return err
 		}

--- a/service/dynamodb/dynamodbattribute/decode.go
+++ b/service/dynamodb/dynamodbattribute/decode.go
@@ -456,7 +456,7 @@ func (d *Decoder) decodeString(s *string, v reflect.Value, fieldTag tag) error {
 	}
 
 	// To maintain backwards compatibility with ConvertFrom family of methods which
-	// converted strings to time.Time structs (using JSON encoding/decoding)
+	// converted strings to time.Time structs
 	if _, ok := v.Interface().(time.Time); ok {
 		t, err := time.Parse(time.RFC3339, *s)
 		if err != nil {

--- a/service/dynamodb/dynamodbattribute/decode_test.go
+++ b/service/dynamodb/dynamodbattribute/decode_test.go
@@ -344,8 +344,6 @@ func (u *unmarshalUnmarshaler) UnmarshalDynamoDBAttributeValue(av *dynamodb.Attr
 		err := u.Value4.UnmarshalJSON(b)
 		return err
 	}
-
-	return nil
 }
 
 func TestUnmarshalUnmashaler(t *testing.T) {

--- a/service/dynamodb/dynamodbattribute/decode_test.go
+++ b/service/dynamodb/dynamodbattribute/decode_test.go
@@ -26,8 +26,6 @@ func TestUnmarshalShared(t *testing.T) {
 }
 
 func TestUnmarshal(t *testing.T) {
-	testDate, _ := time.Parse(time.RFC3339, "2016-05-03T17:06:26.209072Z")
-
 	cases := []struct {
 		in               *dynamodb.AttributeValue
 		actual, expected interface{}
@@ -172,29 +170,6 @@ func TestUnmarshal(t *testing.T) {
 				Value: fmt.Sprintf("number overflow, 512"),
 				Type:  reflect.TypeOf(uint8(0)),
 			},
-		},
-		//------------
-		// time.Time fields
-		//------------
-		{
-			in:       &dynamodb.AttributeValue{S: aws.String("2016-05-03T17:06:26.209072Z")},
-			actual:   new(time.Time),
-			expected: testDate,
-		},
-		{
-			in: &dynamodb.AttributeValue{SS: []*string{
-				aws.String("2016-05-03T17:06:26.209072Z"),
-				aws.String("2016-05-04T17:06:26.209072Z"),
-			}},
-			actual:   new([]time.Time),
-			expected: []time.Time{testDate, testDate.Add(24 * time.Hour)},
-		},
-		{
-			in: &dynamodb.AttributeValue{M: map[string]*dynamodb.AttributeValue{
-				"abc": {S: aws.String("2016-05-03T17:06:26.209072Z")},
-			}},
-			actual:   &struct{ Abc time.Time }{},
-			expected: struct{ Abc time.Time }{Abc: testDate},
 		},
 	}
 
@@ -351,8 +326,6 @@ func (u *unmarshalUnmarshaler) UnmarshalDynamoDBAttributeValue(av *dynamodb.Attr
 }
 
 func TestUnmarshalUnmashaler(t *testing.T) {
-	testDate, _ := time.Parse(time.RFC3339, "2016-05-03T17:06:26.209072Z")
-
 	u := &unmarshalUnmarshaler{}
 	av := &dynamodb.AttributeValue{
 		M: map[string]*dynamodb.AttributeValue{

--- a/service/dynamodb/dynamodbattribute/encode.go
+++ b/service/dynamodb/dynamodbattribute/encode.go
@@ -4,6 +4,7 @@ import (
 	"fmt"
 	"reflect"
 	"strconv"
+	"time"
 
 	"github.com/aws/aws-sdk-go/service/dynamodb"
 )
@@ -215,6 +216,19 @@ func (e *Encoder) encode(av *dynamodb.AttributeValue, v reflect.Value, fieldTag 
 }
 
 func (e *Encoder) encodeStruct(av *dynamodb.AttributeValue, v reflect.Value) error {
+
+	// To maintain backwards compatibility with ConvertTo family of methods which
+	// converted time.Time structs to strings (using JSON encoding/decoding)
+	if t, ok := v.Interface().(time.Time); ok {
+		b, err := t.MarshalJSON()
+		if err != nil {
+			return err
+		}
+		s := string(b)
+		av.S = &s
+		return nil
+	}
+
 	av.M = map[string]*dynamodb.AttributeValue{}
 	fields := unionStructFields(v.Type(), e.MarshalOptions)
 	for _, f := range fields {

--- a/service/dynamodb/dynamodbattribute/encode.go
+++ b/service/dynamodb/dynamodbattribute/encode.go
@@ -218,7 +218,7 @@ func (e *Encoder) encode(av *dynamodb.AttributeValue, v reflect.Value, fieldTag 
 func (e *Encoder) encodeStruct(av *dynamodb.AttributeValue, v reflect.Value) error {
 
 	// To maintain backwards compatibility with ConvertTo family of methods which
-	// converted time.Time structs to strings (using JSON encoding/decoding)
+	// converted time.Time structs to strings
 	if t, ok := v.Interface().(time.Time); ok {
 		s := t.Format(time.RFC3339Nano)
 		av.S = &s

--- a/service/dynamodb/dynamodbattribute/encode.go
+++ b/service/dynamodb/dynamodbattribute/encode.go
@@ -220,11 +220,7 @@ func (e *Encoder) encodeStruct(av *dynamodb.AttributeValue, v reflect.Value) err
 	// To maintain backwards compatibility with ConvertTo family of methods which
 	// converted time.Time structs to strings (using JSON encoding/decoding)
 	if t, ok := v.Interface().(time.Time); ok {
-		b, err := t.MarshalJSON()
-		if err != nil {
-			return err
-		}
-		s := string(b)
+		s := t.Format(time.RFC3339Nano)
 		av.S = &s
 		return nil
 	}

--- a/service/dynamodb/dynamodbattribute/encode_test.go
+++ b/service/dynamodb/dynamodbattribute/encode_test.go
@@ -56,8 +56,6 @@ func (m *marshalMarshaler) MarshalDynamoDBAttributeValue(av *dynamodb.AttributeV
 }
 
 func TestMarshalMashaler(t *testing.T) {
-	testDate, _ := time.Parse(time.RFC3339, "2016-05-03T17:06:26.209072Z")
-
 	m := &marshalMarshaler{
 		Value:  "value",
 		Value2: 123,

--- a/service/dynamodb/dynamodbattribute/encode_test.go
+++ b/service/dynamodb/dynamodbattribute/encode_test.go
@@ -45,16 +45,11 @@ type marshalMarshaler struct {
 }
 
 func (m *marshalMarshaler) MarshalDynamoDBAttributeValue(av *dynamodb.AttributeValue) error {
-	b, err := m.Value4.MarshalJSON()
-	if err != nil {
-		return err
-	}
-
 	av.M = map[string]*dynamodb.AttributeValue{
 		"abc": {S: &m.Value},
 		"def": {N: aws.String(fmt.Sprintf("%d", m.Value2))},
 		"ghi": {BOOL: &m.Value3},
-		"jkl": {S: aws.String(string(b))},
+		"jkl": {S: aws.String(m.Value4.Format(time.RFC3339Nano))},
 	}
 
 	return nil
@@ -75,7 +70,7 @@ func TestMarshalMashaler(t *testing.T) {
 			"abc": {S: aws.String("value")},
 			"def": {N: aws.String("123")},
 			"ghi": {BOOL: aws.Bool(true)},
-			"jkl": {S: aws.String("\"2016-05-03T17:06:26.209072Z\"")},
+			"jkl": {S: aws.String("2016-05-03T17:06:26.209072Z")},
 		},
 	}
 


### PR DESCRIPTION
@xibz - a PR in response to issue #671.

I started to enhance the tests in marshaler_test with time fields on the test structs, but received a sea of failures, since most (all?) of the tests seem to verify success using reflect.DeepEqual. Unfortunately, DeepEqual doesn't play very well with time, so I aborted the changes.

 