### PR TITLE
aws/request: Fix data race caused by resusing request header map value

### DIFF
--- a/aws/request/http_request.go
+++ b/aws/request/http_request.go
@@ -5,17 +5,15 @@ package request
 import (
 	"io"
 	"net/http"
+	"net/url"
 )
 
 func copyHTTPRequest(r *http.Request, body io.ReadCloser) *http.Request {
-	return &http.Request{
-		URL:           r.URL,
-		Header:        r.Header,
+	req := &http.Request{
+		URL:           &url.URL{},
+		Header:        http.Header{},
 		Close:         r.Close,
-		Form:          r.Form,
-		PostForm:      r.PostForm,
 		Body:          body,
-		MultipartForm: r.MultipartForm,
 		Host:          r.Host,
 		Method:        r.Method,
 		Proto:         r.Proto,
@@ -23,4 +21,13 @@ func copyHTTPRequest(r *http.Request, body io.ReadCloser) *http.Request {
 		// Cancel will be deprecated in 1.7 and will be replaced with Context
 		Cancel: r.Cancel,
 	}
+
+	*req.URL = *r.URL
+	for k, v := range r.Header {
+		for _, vv := range v {
+			req.Header.Add(k, vv)
+		}
+	}
+
+	return req
 }

--- a/aws/request/http_request_1_4.go
+++ b/aws/request/http_request_1_4.go
@@ -5,20 +5,27 @@ package request
 import (
 	"io"
 	"net/http"
+	"net/url"
 )
 
 func copyHTTPRequest(r *http.Request, body io.ReadCloser) *http.Request {
-	return &http.Request{
-		URL:           r.URL,
-		Header:        r.Header,
+	req := &http.Request{
+		URL:           &url.URL{},
+		Header:        http.Header{},
 		Close:         r.Close,
-		Form:          r.Form,
-		PostForm:      r.PostForm,
 		Body:          body,
-		MultipartForm: r.MultipartForm,
 		Host:          r.Host,
 		Method:        r.Method,
 		Proto:         r.Proto,
 		ContentLength: r.ContentLength,
 	}
+
+	*req.URL = *r.URL
+	for k, v := range r.Header {
+		for _, vv := range v {
+			req.Header.Add(k, vv)
+		}
+	}
+
+	return req
 }

--- a/aws/request/http_request_copy_test.go
+++ b/aws/request/http_request_copy_test.go
@@ -1,0 +1,34 @@
+package request
+
+import (
+	"bytes"
+	"io/ioutil"
+	"net/http"
+	"net/url"
+	"sync"
+	"testing"
+)
+
+func TestRequestCopyRace(t *testing.T) {
+	origReq := &http.Request{URL: &url.URL{}, Header: http.Header{}}
+	origReq.Header.Set("Header", "OrigValue")
+
+	var wg sync.WaitGroup
+	for i := 0; i < 100; i++ {
+		wg.Add(1)
+		go func() {
+			req := copyHTTPRequest(origReq, ioutil.NopCloser(&bytes.Buffer{}))
+			req.Header.Set("Header", "Value")
+			go func() {
+				req2 := copyHTTPRequest(req, ioutil.NopCloser(&bytes.Buffer{}))
+				req2.Header.Add("Header", "Value2")
+			}()
+			_ = req.Header.Get("Header")
+			wg.Done()
+		}()
+		_ = origReq.Header.Get("Header")
+	}
+	origReq.Header.Get("Header")
+
+	wg.Wait()
+}

--- a/aws/request/http_request_retry_test.go
+++ b/aws/request/http_request_retry_test.go
@@ -7,11 +7,10 @@ import (
 	"strings"
 	"testing"
 
-	"github.com/stretchr/testify/assert"
-
 	"github.com/aws/aws-sdk-go/aws"
 	"github.com/aws/aws-sdk-go/aws/request"
 	"github.com/aws/aws-sdk-go/awstesting"
+	"github.com/stretchr/testify/assert"
 )
 
 func TestRequestCancelRetry(t *testing.T) {


### PR DESCRIPTION
If the header map values are reused between retry attempts it is
possible for a race codition to occur where transporter is still
referencing the header values when the request is being retried and
resigned.

This change updates the request copy to do a deep copy for headers and
URL. In addition the request fields not used by the SDK are dropped.

Fix #679