### PR TITLE
Update integration test for SNS error message

### DIFF
--- a/awstesting/integration/smoke/sns/sns.feature
+++ b/awstesting/integration/smoke/sns/sns.feature
@@ -11,7 +11,4 @@ Feature: Amazon Simple Notification Service
     | Message  | hello      |
     | TopicArn | fake_topic |
     Then I expect the response error code to be "InvalidParameter"
-    And I expect the response error message to include:
-    """
-    Invalid parameter: TopicArn Reason: fake_topic does not start with arn
-    """
+    And I expect the response error message not be empty


### PR DESCRIPTION
Error message changes should not cause integ tests to fail. Loosening the validation done on responses.