### PR TITLE
Remove second API Reference badge from README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -5,7 +5,6 @@
 [![Join the chat at https://gitter.im/aws/aws-sdk-go](https://badges.gitter.im/Join%20Chat.svg)](https://gitter.im/aws/aws-sdk-go?utm_source=badge&utm_medium=badge&utm_campaign=pr-badge&utm_content=badge)
 [![Build Status](https://img.shields.io/travis/aws/aws-sdk-go.svg)](https://travis-ci.org/aws/aws-sdk-go)
 [![Apache V2 License](http://img.shields.io/badge/license-Apache%20V2-blue.svg)](https://github.com/aws/aws-sdk-go/blob/master/LICENSE.txt)
-[![API Reference](http://img.shields.io/badge/api-reference-blue.svg)](http://docs.aws.amazon.com/sdk-for-go/api)
 </span>
 
 aws-sdk-go is the official AWS SDK for the Go programming language.


### PR DESCRIPTION
There were two API Reference badges in the same line of badges.

They link to the same content. This PR removes one.