### PR TITLE
Guard against nil panic

### DIFF
--- a/service/sqs/checksums.go
+++ b/service/sqs/checksums.go
@@ -74,7 +74,9 @@ func verifyReceiveMessage(r *request.Request) {
 		for _, msg := range out.Messages {
 			err := checksumsMatch(msg.Body, msg.MD5OfBody)
 			if err != nil {
-				ids = append(ids, *msg.MessageId)
+				if msg.MessageId != nil {
+					ids = append(ids, *msg.MessageId)
+				}
 			}
 		}
 		if len(ids) > 0 {


### PR DESCRIPTION
Our production app paniced because a message id was nil is a response