### PR TITLE
Remove max width from generated docs

### DIFF
--- a/doc-src/aws-godoc/templates/style.css
+++ b/doc-src/aws-godoc/templates/style.css
@@ -226,13 +226,10 @@ div#page {
 	box-sizing: border-box;
 	height:calc(100% - 64px);
 	overflow:auto;
-	max-width:1600px;
 }
 div#page > .container,
 div#topbar > .container {
 	text-align: left;
-	margin-left: auto;
-	margin-right: auto;
 	padding: 0 20px;
 }
 div#topbar > .container,


### PR DESCRIPTION
Updates the style sheet for the generated docs to not have a max width.