### PR TITLE
Move awstesting.SortedKeys to private/util package (fixes #721)

### DIFF
--- a/awstesting/util.go
+++ b/awstesting/util.go
@@ -2,6 +2,8 @@ package awstesting
 
 import (
 	"io"
+
+	"github.com/aws/aws-sdk-go/private/util"
 )
 
 // ZeroReader is a io.Reader which will always write zeros to the byte slice provided.
@@ -57,4 +59,9 @@ func (r *ReadCloser) Read(b []byte) (int, error) {
 func (r *ReadCloser) Close() error {
 	r.Closed = true
 	return nil
+}
+
+// SortedKeys returns a sorted slice of keys of a map.
+func SortedKeys(m map[string]interface{}) []string {
+	return util.SortedKeys(m)
 }

--- a/models/protocol_tests/generate.go
+++ b/models/protocol_tests/generate.go
@@ -14,7 +14,6 @@ import (
 	"strings"
 	"text/template"
 
-	"github.com/aws/aws-sdk-go/awstesting"
 	"github.com/aws/aws-sdk-go/private/model/api"
 	"github.com/aws/aws-sdk-go/private/util"
 )
@@ -359,7 +358,7 @@ func findMember(shape *api.Shape, key string) string {
 func GenerateAssertions(out interface{}, shape *api.Shape, prefix string) string {
 	switch t := out.(type) {
 	case map[string]interface{}:
-		keys := awstesting.SortedKeys(t)
+		keys := util.SortedKeys(t)
 
 		code := ""
 		if shape.Type == "map" {

--- a/private/model/api/param_filler.go
+++ b/private/model/api/param_filler.go
@@ -5,7 +5,6 @@ import (
 	"reflect"
 	"strings"
 
-	"github.com/aws/aws-sdk-go/awstesting"
 	"github.com/aws/aws-sdk-go/private/util"
 )
 
@@ -102,7 +101,7 @@ func (f paramFiller) paramsStructStruct(value map[string]interface{}, shape *Sha
 // paramsStructMap returns the string representation of a map of values
 func (f paramFiller) paramsStructMap(value map[string]interface{}, shape *Shape) string {
 	out := f.typeName(shape) + "{\n"
-	keys := awstesting.SortedKeys(value)
+	keys := util.SortedKeys(value)
 	for _, k := range keys {
 		v := value[k]
 		out += fmt.Sprintf("%q: %s,\n", k, f.paramsStructAny(v, shape.ValueRef.Shape))

--- a/private/util/sort_keys.go
+++ b/private/util/sort_keys.go
@@ -1,4 +1,4 @@
-package awstesting
+package util
 
 import "sort"
 


### PR DESCRIPTION
A single function from `awstesting` caused the main packages to import `awstesting` which in turn brought a lot of testing related dependencies with itself. By moving a single file we can get rid of this dependency and the library can be self-contained again with the already vendored dependencies.