### PR TITLE
aws/signer/v4: Use const SHA256 for empty request body hash

### DIFF
--- a/aws/signer/v4/v4.go
+++ b/aws/signer/v4/v4.go
@@ -27,6 +27,9 @@ const (
 	authHeaderPrefix = "AWS4-HMAC-SHA256"
 	timeFormat       = "20060102T150405Z"
 	shortTimeFormat  = "20060102"
+
+	// emptyStringSHA256 is a SHA256 of an empty string
+	emptyStringSHA256 = `e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855`
 )
 
 var ignoredHeaders = rules{
@@ -510,7 +513,7 @@ func (ctx *signingCtx) bodyDigest() string {
 		if ctx.isPresign && ctx.ServiceName == "s3" {
 			hash = "UNSIGNED-PAYLOAD"
 		} else if ctx.Body == nil {
-			hash = hex.EncodeToString(makeSha256([]byte{}))
+			hash = emptyStringSHA256
 		} else {
 			hash = hex.EncodeToString(makeSha256Reader(ctx.Body))
 		}


### PR DESCRIPTION
Updated to use a const instead of recomputing the SHA256 for each
request's empty body.

Minor fix up of #731