### PR TITLE
awstesting: Add integration build tag to awstesting

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -50,22 +50,22 @@ build:
 
 unit: get-deps-tests build verify
 	@echo "go test SDK and vendor packages"
-	@go test $(SDK_ONLY_PKGS)
+	@go test -tags $(SDK_ONLY_PKGS)
 
 unit-with-race-cover: get-deps-tests build verify
 	@echo "go test SDK and vendor packages"
-	@go test -race -cpu=1,2,4 $(SDK_ONLY_PKGS)
+	@go test -tags -race -cpu=1,2,4 $(SDK_ONLY_PKGS)
 
 integration: get-deps-tests integ-custom smoke-tests performance
 
 integ-custom:
-	go test -tags=integration ./awstesting/integration/customizations/...
+	go test -tags "integration" ./awstesting/integration/customizations/...
 
 smoke-tests: get-deps-tests
-	gucumber ./awstesting/integration/smoke
+	gucumber -go-tags "integration" ./awstesting/integration/smoke
 
 performance: get-deps-tests
-	AWS_TESTING_LOG_RESULTS=${log-detailed} AWS_TESTING_REGION=$(region) AWS_TESTING_DB_TABLE=$(table) gucumber ./awstesting/performance
+	AWS_TESTING_LOG_RESULTS=${log-detailed} AWS_TESTING_REGION=$(region) AWS_TESTING_DB_TABLE=$(table) gucumber -go-tags "integration" ./awstesting/performance
 
 sandbox-tests: sandbox-test-go14 sandbox-test-go15 sandbox-test-go15-novendorexp sandbox-test-go16 sandbox-test-go17 sandbox-test-gotip
 

--- a/awstesting/integration/integration.go
+++ b/awstesting/integration/integration.go
@@ -1,3 +1,5 @@
+// +build integration
+
 // Package integration performs initialization and validation for integration
 // tests.
 package integration

--- a/awstesting/integration/smoke/acm/client.go
+++ b/awstesting/integration/smoke/acm/client.go
@@ -1,3 +1,5 @@
+// +build integration
+
 //Package acm provides gucumber integration tests support.
 package acm
 

--- a/awstesting/integration/smoke/apigateway/client.go
+++ b/awstesting/integration/smoke/apigateway/client.go
@@ -1,3 +1,5 @@
+// +build integration
+
 //Package apigateway provides gucumber integration tests support.
 package apigateway
 

--- a/awstesting/integration/smoke/applicationdiscoveryservice/client.go
+++ b/awstesting/integration/smoke/applicationdiscoveryservice/client.go
@@ -1,3 +1,5 @@
+// +build integration
+
 //Package applicationdiscoveryservice provides gucumber integration tests support.
 package applicationdiscoveryservice
 

--- a/awstesting/integration/smoke/autoscaling/client.go
+++ b/awstesting/integration/smoke/autoscaling/client.go
@@ -1,3 +1,5 @@
+// +build integration
+
 //Package autoscaling provides gucumber integration tests support.
 package autoscaling
 

--- a/awstesting/integration/smoke/cloudformation/client.go
+++ b/awstesting/integration/smoke/cloudformation/client.go
@@ -1,3 +1,5 @@
+// +build integration
+
 //Package cloudformation provides gucumber integration tests support.
 package cloudformation
 

--- a/awstesting/integration/smoke/cloudfront/client.go
+++ b/awstesting/integration/smoke/cloudfront/client.go
@@ -1,3 +1,5 @@
+// +build integration
+
 //Package cloudfront provides gucumber integration tests support.
 package cloudfront
 

--- a/awstesting/integration/smoke/cloudhsm/client.go
+++ b/awstesting/integration/smoke/cloudhsm/client.go
@@ -1,3 +1,5 @@
+// +build integration
+
 //Package cloudhsm provides gucumber integration tests support.
 package cloudhsm
 

--- a/awstesting/integration/smoke/cloudsearch/client.go
+++ b/awstesting/integration/smoke/cloudsearch/client.go
@@ -1,3 +1,5 @@
+// +build integration
+
 //Package cloudsearch provides gucumber integration tests support.
 package cloudsearch
 

--- a/awstesting/integration/smoke/cloudtrail/client.go
+++ b/awstesting/integration/smoke/cloudtrail/client.go
@@ -1,3 +1,5 @@
+// +build integration
+
 //Package cloudtrail provides gucumber integration tests support.
 package cloudtrail
 

--- a/awstesting/integration/smoke/cloudwatch/client.go
+++ b/awstesting/integration/smoke/cloudwatch/client.go
@@ -1,3 +1,5 @@
+// +build integration
+
 //Package cloudwatch provides gucumber integration tests support.
 package cloudwatch
 

--- a/awstesting/integration/smoke/cloudwatchlogs/client.go
+++ b/awstesting/integration/smoke/cloudwatchlogs/client.go
@@ -1,3 +1,5 @@
+// +build integration
+
 //Package cloudwatchlogs provides gucumber integration tests support.
 package cloudwatchlogs
 

--- a/awstesting/integration/smoke/codecommit/client.go
+++ b/awstesting/integration/smoke/codecommit/client.go
@@ -1,3 +1,5 @@
+// +build integration
+
 //Package codecommit provides gucumber integration tests support.
 package codecommit
 

--- a/awstesting/integration/smoke/codedeploy/client.go
+++ b/awstesting/integration/smoke/codedeploy/client.go
@@ -1,3 +1,5 @@
+// +build integration
+
 //Package codedeploy provides gucumber integration tests support.
 package codedeploy
 

--- a/awstesting/integration/smoke/codepipeline/client.go
+++ b/awstesting/integration/smoke/codepipeline/client.go
@@ -1,3 +1,5 @@
+// +build integration
+
 //Package codepipeline provides gucumber integration tests support.
 package codepipeline
 

--- a/awstesting/integration/smoke/cognitoidentity/client.go
+++ b/awstesting/integration/smoke/cognitoidentity/client.go
@@ -1,3 +1,5 @@
+// +build integration
+
 //Package cognitoidentity provides gucumber integration tests support.
 package cognitoidentity
 

--- a/awstesting/integration/smoke/cognitosync/client.go
+++ b/awstesting/integration/smoke/cognitosync/client.go
@@ -1,3 +1,5 @@
+// +build integration
+
 //Package cognitosync provides gucumber integration tests support.
 package cognitosync
 

--- a/awstesting/integration/smoke/configservice/client.go
+++ b/awstesting/integration/smoke/configservice/client.go
@@ -1,3 +1,5 @@
+// +build integration
+
 //Package configservice provides gucumber integration tests support.
 package configservice
 

--- a/awstesting/integration/smoke/datapipeline/client.go
+++ b/awstesting/integration/smoke/datapipeline/client.go
@@ -1,3 +1,5 @@
+// +build integration
+
 //Package datapipeline provides gucumber integration tests support.
 package datapipeline
 

--- a/awstesting/integration/smoke/devicefarm/client.go
+++ b/awstesting/integration/smoke/devicefarm/client.go
@@ -1,3 +1,5 @@
+// +build integration
+
 //Package devicefarm provides gucumber integration tests support.
 package devicefarm
 

--- a/awstesting/integration/smoke/directconnect/client.go
+++ b/awstesting/integration/smoke/directconnect/client.go
@@ -1,3 +1,5 @@
+// +build integration
+
 //Package directconnect provides gucumber integration tests support.
 package directconnect
 

--- a/awstesting/integration/smoke/directoryservice/client.go
+++ b/awstesting/integration/smoke/directoryservice/client.go
@@ -1,3 +1,5 @@
+// +build integration
+
 //Package directoryservice provides gucumber integration tests support.
 package directoryservice
 

--- a/awstesting/integration/smoke/dynamodb/client.go
+++ b/awstesting/integration/smoke/dynamodb/client.go
@@ -1,3 +1,5 @@
+// +build integration
+
 //Package dynamodb provides gucumber integration tests support.
 package dynamodb
 

--- a/awstesting/integration/smoke/dynamodbstreams/client.go
+++ b/awstesting/integration/smoke/dynamodbstreams/client.go
@@ -1,3 +1,5 @@
+// +build integration
+
 //Package dynamodbstreams provides gucumber integration tests support.
 package dynamodbstreams
 

--- a/awstesting/integration/smoke/ec2/client.go
+++ b/awstesting/integration/smoke/ec2/client.go
@@ -1,3 +1,5 @@
+// +build integration
+
 //Package ec2 provides gucumber integration tests support.
 package ec2
 

--- a/awstesting/integration/smoke/ecs/client.go
+++ b/awstesting/integration/smoke/ecs/client.go
@@ -1,3 +1,5 @@
+// +build integration
+
 //Package ecs provides gucumber integration tests support.
 package ecs
 

--- a/awstesting/integration/smoke/efs/client.go
+++ b/awstesting/integration/smoke/efs/client.go
@@ -1,3 +1,5 @@
+// +build integration
+
 //Package efs provides gucumber integration tests support.
 package efs
 

--- a/awstesting/integration/smoke/elasticache/client.go
+++ b/awstesting/integration/smoke/elasticache/client.go
@@ -1,3 +1,5 @@
+// +build integration
+
 //Package elasticache provides gucumber integration tests support.
 package elasticache
 

--- a/awstesting/integration/smoke/elasticbeanstalk/client.go
+++ b/awstesting/integration/smoke/elasticbeanstalk/client.go
@@ -1,3 +1,5 @@
+// +build integration
+
 //Package elasticbeanstalk provides gucumber integration tests support.
 package elasticbeanstalk
 

--- a/awstesting/integration/smoke/elasticloadbalancing/client.go
+++ b/awstesting/integration/smoke/elasticloadbalancing/client.go
@@ -1,3 +1,5 @@
+// +build integration
+
 //Package elasticloadbalancing provides gucumber integration tests support.
 package elasticloadbalancing
 

--- a/awstesting/integration/smoke/elastictranscoder/client.go
+++ b/awstesting/integration/smoke/elastictranscoder/client.go
@@ -1,3 +1,5 @@
+// +build integration
+
 //Package elastictranscoder provides gucumber integration tests support.
 package elastictranscoder
 

--- a/awstesting/integration/smoke/emr/client.go
+++ b/awstesting/integration/smoke/emr/client.go
@@ -1,3 +1,5 @@
+// +build integration
+
 //Package emr provides gucumber integration tests support.
 package emr
 

--- a/awstesting/integration/smoke/es/client.go
+++ b/awstesting/integration/smoke/es/client.go
@@ -1,3 +1,5 @@
+// +build integration
+
 //Package es provides gucumber integration tests support.
 package es
 

--- a/awstesting/integration/smoke/glacier/client.go
+++ b/awstesting/integration/smoke/glacier/client.go
@@ -1,3 +1,5 @@
+// +build integration
+
 //Package glacier provides gucumber integration tests support.
 package glacier
 

--- a/awstesting/integration/smoke/iam/client.go
+++ b/awstesting/integration/smoke/iam/client.go
@@ -1,3 +1,5 @@
+// +build integration
+
 //Package iam provides gucumber integration tests support.
 package iam
 

--- a/awstesting/integration/smoke/iotdataplane/client.go
+++ b/awstesting/integration/smoke/iotdataplane/client.go
@@ -1,3 +1,5 @@
+// +build integration
+
 //Package iotdataplane provides gucumber integration tests support.
 package iotdataplane
 

--- a/awstesting/integration/smoke/kinesis/client.go
+++ b/awstesting/integration/smoke/kinesis/client.go
@@ -1,3 +1,5 @@
+// +build integration
+
 //Package kinesis provides gucumber integration tests support.
 package kinesis
 

--- a/awstesting/integration/smoke/kms/client.go
+++ b/awstesting/integration/smoke/kms/client.go
@@ -1,3 +1,5 @@
+// +build integration
+
 //Package kms provides gucumber integration tests support.
 package kms
 

--- a/awstesting/integration/smoke/lambda/client.go
+++ b/awstesting/integration/smoke/lambda/client.go
@@ -1,3 +1,5 @@
+// +build integration
+
 //Package lambda provides gucumber integration tests support.
 package lambda
 

--- a/awstesting/integration/smoke/machinelearning/client.go
+++ b/awstesting/integration/smoke/machinelearning/client.go
@@ -1,3 +1,5 @@
+// +build integration
+
 //Package machinelearning provides gucumber integration tests support.
 package machinelearning
 

--- a/awstesting/integration/smoke/opsworks/client.go
+++ b/awstesting/integration/smoke/opsworks/client.go
@@ -1,3 +1,5 @@
+// +build integration
+
 //Package opsworks provides gucumber integration tests support.
 package opsworks
 

--- a/awstesting/integration/smoke/rds/client.go
+++ b/awstesting/integration/smoke/rds/client.go
@@ -1,3 +1,5 @@
+// +build integration
+
 //Package rds provides gucumber integration tests support.
 package rds
 

--- a/awstesting/integration/smoke/redshift/client.go
+++ b/awstesting/integration/smoke/redshift/client.go
@@ -1,3 +1,5 @@
+// +build integration
+
 //Package redshift provides gucumber integration tests support.
 package redshift
 

--- a/awstesting/integration/smoke/route53/client.go
+++ b/awstesting/integration/smoke/route53/client.go
@@ -1,3 +1,5 @@
+// +build integration
+
 //Package route53 provides gucumber integration tests support.
 package route53
 

--- a/awstesting/integration/smoke/route53domains/client.go
+++ b/awstesting/integration/smoke/route53domains/client.go
@@ -1,3 +1,5 @@
+// +build integration
+
 //Package route53domains provides gucumber integration tests support.
 package route53domains
 

--- a/awstesting/integration/smoke/ses/client.go
+++ b/awstesting/integration/smoke/ses/client.go
@@ -1,3 +1,5 @@
+// +build integration
+
 //Package ses provides gucumber integration tests support.
 package ses
 

--- a/awstesting/integration/smoke/shared.go
+++ b/awstesting/integration/smoke/shared.go
@@ -1,3 +1,5 @@
+// +build integration
+
 // Package smoke contains shared step definitions that are used across integration tests
 package smoke
 

--- a/awstesting/integration/smoke/simpledb/client.go
+++ b/awstesting/integration/smoke/simpledb/client.go
@@ -1,3 +1,5 @@
+// +build integration
+
 //Package simpledb provides gucumber integration tests support.
 package simpledb
 

--- a/awstesting/integration/smoke/sns/client.go
+++ b/awstesting/integration/smoke/sns/client.go
@@ -1,3 +1,5 @@
+// +build integration
+
 //Package sns provides gucumber integration tests support.
 package sns
 

--- a/awstesting/integration/smoke/sqs/client.go
+++ b/awstesting/integration/smoke/sqs/client.go
@@ -1,3 +1,5 @@
+// +build integration
+
 //Package sqs provides gucumber integration tests support.
 package sqs
 

--- a/awstesting/integration/smoke/ssm/client.go
+++ b/awstesting/integration/smoke/ssm/client.go
@@ -1,3 +1,5 @@
+// +build integration
+
 //Package ssm provides gucumber integration tests support.
 package ssm
 

--- a/awstesting/integration/smoke/storagegateway/client.go
+++ b/awstesting/integration/smoke/storagegateway/client.go
@@ -1,3 +1,5 @@
+// +build integration
+
 //Package storagegateway provides gucumber integration tests support.
 package storagegateway
 

--- a/awstesting/integration/smoke/sts/client.go
+++ b/awstesting/integration/smoke/sts/client.go
@@ -1,3 +1,5 @@
+// +build integration
+
 //Package sts provides gucumber integration tests support.
 package sts
 

--- a/awstesting/integration/smoke/support/client.go
+++ b/awstesting/integration/smoke/support/client.go
@@ -1,3 +1,5 @@
+// +build integration
+
 //Package support provides gucumber integration tests support.
 package support
 

--- a/awstesting/integration/smoke/swf/client.go
+++ b/awstesting/integration/smoke/swf/client.go
@@ -1,3 +1,5 @@
+// +build integration
+
 //Package swf provides gucumber integration tests support.
 package swf
 

--- a/awstesting/integration/smoke/waf/client.go
+++ b/awstesting/integration/smoke/waf/client.go
@@ -1,3 +1,5 @@
+// +build integration
+
 //Package waf provides gucumber integration tests support.
 package waf
 

--- a/awstesting/integration/smoke/workspaces/client.go
+++ b/awstesting/integration/smoke/workspaces/client.go
@@ -1,3 +1,5 @@
+// +build integration
+
 //Package workspaces provides gucumber integration tests support.
 package workspaces
 

--- a/awstesting/performance/benchmarks.go
+++ b/awstesting/performance/benchmarks.go
@@ -1,3 +1,5 @@
+// +build integration
+
 package performance
 
 import (

--- a/awstesting/performance/client.go
+++ b/awstesting/performance/client.go
@@ -1,3 +1,5 @@
+// +build integration
+
 //Package performance provides gucumber integration tests support.
 package performance
 

--- a/awstesting/performance/clients.go
+++ b/awstesting/performance/clients.go
@@ -1,3 +1,5 @@
+// +build integration
+
 package performance
 
 import (

--- a/awstesting/performance/init.go
+++ b/awstesting/performance/init.go
@@ -1,3 +1,5 @@
+// +build integration
+
 package performance
 
 import (

--- a/awstesting/performance/logging.go
+++ b/awstesting/performance/logging.go
@@ -1,3 +1,5 @@
+// +build integration
+
 // Package performance contains shared step definitions that are used for performance testing
 package performance
 


### PR DESCRIPTION
Adds the `integration` Go build tags to all integration and performance
tests. This will help reduce the dependencies that are downloaded by users
when using the `go get github.com/aws/aws-sdk-go/...` pattern.

When updating to this commit will also need to pull the latest version
of github/lsegal/gucumber package which adds support for go build tags.

Author:    j7b <j7b@noreply.users.github.com>
Committer:    j7b <j7b@noreply.users.github.com>