### PR TITLE
service/sqs: Guard against nil panic in ReceiveMessage

### DIFF
--- a/service/sqs/checksums.go
+++ b/service/sqs/checksums.go
@@ -71,9 +71,19 @@ func verifyReceiveMessage(r *request.Request) {
 	if r.DataFilled() && r.ParamsFilled() {
 		ids := []string{}
 		out := r.Data.(*ReceiveMessageOutput)
-		for _, msg := range out.Messages {
+		for i, msg := range out.Messages {
 			err := checksumsMatch(msg.Body, msg.MD5OfBody)
 			if err != nil {
+				if msg.MessageId == nil {
+					if r.Config.Logger != nil {
+						r.Config.Logger.Log(fmt.Sprintf(
+							"WARN: SQS.ReceiveMessage failed checksum request id: %s, message %d has no message ID.",
+							r.RequestID, i,
+						))
+					}
+					continue
+				}
+
 				ids = append(ids, *msg.MessageId)
 			}
 		}

--- a/service/sqs/checksums_test.go
+++ b/service/sqs/checksums_test.go
@@ -140,6 +140,7 @@ func TestRecieveMessageChecksumInvalid(t *testing.T) {
 				{Body: aws.String("test"), MD5OfBody: &md5},
 				{Body: aws.String("test"), MD5OfBody: aws.String("000"), MessageId: aws.String("123")},
 				{Body: aws.String("test"), MD5OfBody: aws.String("000"), MessageId: aws.String("456")},
+				{Body: aws.String("test"), MD5OfBody: aws.String("000")},
 				{Body: aws.String("test"), MD5OfBody: &md5},
 			},
 		}


### PR DESCRIPTION
In rare cases the message ID in the response could be nil, this update
guards against this, and logs the occurrence with request ID.

Fixup of #707