### PR TITLE
Update V4 signer to sign Sha256 header for S3 requests

### DIFF
--- a/aws/config.go
+++ b/aws/config.go
@@ -139,6 +139,11 @@ type Config struct {
 	//
 	EC2MetadataDisableTimeoutOverride *bool
 
+	// SleepDelay is an override for the func the SDK will call when sleeping
+	// during the lifecycle of a request. Specifically this will be used for
+	// request delays. This value should only be used for testing. To adjust
+	// the delay of a request see the aws/client.DefaultRetryer and
+	// aws/request.Retryer.
 	SleepDelay func(time.Duration)
 }
 

--- a/aws/request/request.go
+++ b/aws/request/request.go
@@ -39,6 +39,7 @@ type Request struct {
 	RetryDelay       time.Duration
 	NotHoist         bool
 	SignedHeaderVals http.Header
+	LastSignedAt     time.Time
 
 	built bool
 }

--- a/aws/signer/v4/functional_test.go
+++ b/aws/signer/v4/functional_test.go
@@ -55,12 +55,13 @@ func TestPresignRequest(t *testing.T) {
 	assert.NoError(t, err)
 
 	expectedDate := "19700101T000000Z"
-	expectedHeaders := "content-disposition;host;x-amz-acl"
-	expectedSig := "b2754ba8ffeb74a40b94767017e24c4672107d6d5a894648d5d332ca61f5ffe4"
+	expectedHeaders := "content-disposition;host;x-amz-acl;x-amz-content-sha256"
+	expectedSig := "0d200ba61501d752acd06f39ef4dbe7d83ffd5ea15978dc3476dfc00b8eb574e"
 	expectedCred := "AKID/19700101/mock-region/s3/aws4_request"
 	expectedHeaderMap := http.Header{
-		"x-amz-acl":           []string{"public-read"},
-		"content-disposition": []string{"a+b c$d"},
+		"x-amz-acl":            []string{"public-read"},
+		"content-disposition":  []string{"a+b c$d"},
+		"x-amz-content-sha256": []string{"UNSIGNED-PAYLOAD"},
 	}
 
 	u, _ := url.Parse(urlstr)

--- a/aws/signer/v4/v4_test.go
+++ b/aws/signer/v4/v4_test.go
@@ -112,9 +112,9 @@ func TestSignRequest(t *testing.T) {
 }
 
 func TestSignBody(t *testing.T) {
-	req, body := buildRequest("dynamodb", "us-east-1", "hello")
+	req, body := buildRequest("s3", "us-east-1", "hello")
 	signer := buildSigner()
-	signer.Sign(req, body, "dynamodb", "us-east-1", time.Now())
+	signer.Sign(req, body, "s3", "us-east-1", time.Now())
 	hash := req.Header.Get("X-Amz-Content-Sha256")
 	assert.Equal(t, "2cf24dba5fb0a30e26e83b2ac5b9e29e1b161e5c1fa7425e73043362938b9824", hash)
 }


### PR DESCRIPTION
The X-Amz-Content-Sha256 header was not being signed for S3 requests.
This header is required to be signed, per the S3 V4 signature spec.

Fix #743