### PR TITLE
service/dynamodb/dynamodbattribute: Update Marshalers for aliased types

### DIFF
--- a/service/dynamodb/dynamodbattribute/encode.go
+++ b/service/dynamodb/dynamodbattribute/encode.go
@@ -279,13 +279,14 @@ func (e *Encoder) encodeMap(av *dynamodb.AttributeValue, v reflect.Value, fieldT
 }
 
 func (e *Encoder) encodeSlice(av *dynamodb.AttributeValue, v reflect.Value, fieldTag tag) error {
-	switch typed := v.Interface().(type) {
-	case []byte:
-		if len(typed) == 0 {
+	switch v.Type().Elem().Kind() {
+	case reflect.Uint8:
+		b := v.Bytes()
+		if len(b) == 0 {
 			encodeNull(av)
 			return nil
 		}
-		av.B = append([]byte{}, typed...)
+		av.B = append([]byte{}, b...)
 	default:
 		var elemFn func(dynamodb.AttributeValue) error
 
@@ -356,20 +357,23 @@ func (e *Encoder) encodeList(v reflect.Value, fieldTag tag, elemFn func(dynamodb
 }
 
 func (e *Encoder) encodeScalar(av *dynamodb.AttributeValue, v reflect.Value, fieldTag tag) error {
-	switch typed := v.Interface().(type) {
-	case bool:
-		av.BOOL = new(bool)
-		*av.BOOL = typed
-	case string:
-		if err := e.encodeString(av, v); err != nil {
-			return err
-		}
-	case Number:
-		s := string(typed)
+	if v.Type() == numberType {
+		s := v.String()
 		if fieldTag.AsString {
 			av.S = &s
 		} else {
 			av.N = &s
+		}
+		return nil
+	}
+
+	switch v.Kind() {
+	case reflect.Bool:
+		av.BOOL = new(bool)
+		*av.BOOL = v.Bool()
+	case reflect.String:
+		if err := e.encodeString(av, v); err != nil {
+			return err
 		}
 	default:
 		// Fallback to encoding numbers, will return invalid type if not supported
@@ -391,31 +395,13 @@ func (e *Encoder) encodeNumber(av *dynamodb.AttributeValue, v reflect.Value) err
 	}
 
 	var out string
-	switch typed := v.Interface().(type) {
-	case int:
-		out = encodeInt(int64(typed))
-	case int8:
-		out = encodeInt(int64(typed))
-	case int16:
-		out = encodeInt(int64(typed))
-	case int32:
-		out = encodeInt(int64(typed))
-	case int64:
-		out = encodeInt(typed)
-	case uint:
-		out = encodeUint(uint64(typed))
-	case uint8:
-		out = encodeUint(uint64(typed))
-	case uint16:
-		out = encodeUint(uint64(typed))
-	case uint32:
-		out = encodeUint(uint64(typed))
-	case uint64:
-		out = encodeUint(typed)
-	case float32:
-		out = encodeFloat(float64(typed))
-	case float64:
-		out = encodeFloat(typed)
+	switch v.Kind() {
+	case reflect.Int, reflect.Int8, reflect.Int16, reflect.Int32, reflect.Int64:
+		out = encodeInt(v.Int())
+	case reflect.Uint, reflect.Uint8, reflect.Uint16, reflect.Uint32, reflect.Uint64:
+		out = encodeUint(v.Uint())
+	case reflect.Float32, reflect.Float64:
+		out = encodeFloat(v.Float())
 	default:
 		return &unsupportedMarshalTypeError{Type: v.Type()}
 	}
@@ -430,12 +416,13 @@ func (e *Encoder) encodeString(av *dynamodb.AttributeValue, v reflect.Value) err
 		return err
 	}
 
-	switch typed := v.Interface().(type) {
-	case string:
-		if len(typed) == 0 && e.NullEmptyString {
+	switch v.Kind() {
+	case reflect.String:
+		s := v.String()
+		if len(s) == 0 && e.NullEmptyString {
 			encodeNull(av)
 		} else {
-			av.S = &typed
+			av.S = &s
 		}
 	default:
 		return &unsupportedMarshalTypeError{Type: v.Type()}

--- a/service/dynamodb/dynamodbattribute/shared_test.go
+++ b/service/dynamodb/dynamodbattribute/shared_test.go
@@ -30,6 +30,32 @@ type testOmitEmptyStruct struct {
 	Value3 int
 }
 
+type testAliasedString string
+type testAliasedStringSlice []string
+type testAliasedInt int
+type testAliasedIntSlice []int
+type testAliasedMap map[string]int
+type testAliasedSlice []string
+type testAliasedByteSlice []byte
+
+type testAliasedStruct struct {
+	Value  testAliasedString
+	Value2 testAliasedInt
+	Value3 testAliasedMap
+	Value4 testAliasedSlice
+
+	Value5 testAliasedByteSlice
+	Value6 []testAliasedInt
+	Value7 []testAliasedString
+
+	Value8  []testAliasedByteSlice `dynamodbav:",binaryset"`
+	Value9  []testAliasedInt       `dynamodbav:",numberset"`
+	Value10 []testAliasedString    `dynamodbav:",stringset"`
+
+	Value11 testAliasedIntSlice
+	Value12 testAliasedStringSlice
+}
+
 type testNamedPointer *int
 
 var testDate, _ = time.Parse(time.RFC3339, "2016-05-03T17:06:26.209072Z")
@@ -172,6 +198,75 @@ var sharedTestCases = []struct {
 		},
 		actual:   &testOmitEmptyStruct{},
 		expected: testOmitEmptyStruct{Value: "", Value2: nil, Value3: 0},
+	},
+	{ // aliased type
+		in: &dynamodb.AttributeValue{
+			M: map[string]*dynamodb.AttributeValue{
+				"Value":  {S: aws.String("123")},
+				"Value2": {N: aws.String("123")},
+				"Value3": {M: map[string]*dynamodb.AttributeValue{
+					"Key": {N: aws.String("321")},
+				}},
+				"Value4": {L: []*dynamodb.AttributeValue{
+					{S: aws.String("1")},
+					{S: aws.String("2")},
+					{S: aws.String("3")},
+				}},
+				"Value5": {B: []byte{0, 1, 2}},
+				"Value6": {L: []*dynamodb.AttributeValue{
+					{N: aws.String("1")},
+					{N: aws.String("2")},
+					{N: aws.String("3")},
+				}},
+				"Value7": {L: []*dynamodb.AttributeValue{
+					{S: aws.String("1")},
+					{S: aws.String("2")},
+					{S: aws.String("3")},
+				}},
+				"Value8": {BS: [][]byte{
+					{0, 1, 2}, {3, 4, 5},
+				}},
+				"Value9": {NS: []*string{
+					aws.String("1"),
+					aws.String("2"),
+					aws.String("3"),
+				}},
+				"Value10": {SS: []*string{
+					aws.String("1"),
+					aws.String("2"),
+					aws.String("3"),
+				}},
+				"Value11": {L: []*dynamodb.AttributeValue{
+					{N: aws.String("1")},
+					{N: aws.String("2")},
+					{N: aws.String("3")},
+				}},
+				"Value12": {L: []*dynamodb.AttributeValue{
+					{S: aws.String("1")},
+					{S: aws.String("2")},
+					{S: aws.String("3")},
+				}},
+			},
+		},
+		actual: &testAliasedStruct{},
+		expected: testAliasedStruct{
+			Value: "123", Value2: 123,
+			Value3: testAliasedMap{
+				"Key": 321,
+			},
+			Value4: testAliasedSlice{"1", "2", "3"},
+			Value5: testAliasedByteSlice{0, 1, 2},
+			Value6: []testAliasedInt{1, 2, 3},
+			Value7: []testAliasedString{"1", "2", "3"},
+			Value8: []testAliasedByteSlice{
+				testAliasedByteSlice{0, 1, 2},
+				testAliasedByteSlice{3, 4, 5},
+			},
+			Value9:  []testAliasedInt{1, 2, 3},
+			Value10: []testAliasedString{"1", "2", "3"},
+			Value11: testAliasedIntSlice{1, 2, 3},
+			Value12: testAliasedStringSlice{"1", "2", "3"},
+		},
 	},
 	{
 		in:       &dynamodb.AttributeValue{N: aws.String("123")},


### PR DESCRIPTION
Previously the marshalers would not be able to assign or receive values
correctly from type aliased primitives because interface type switch
casing was used. These comparisons need to be done with reflect Kinds to
find the correct type matches.


Fix #724