### PR TITLE
Converted search requests for CloudSearch Domain from GET to POST

### DIFF
--- a/models/apis/cloudsearchdomain/2013-01-01/api-2.json
+++ b/models/apis/cloudsearchdomain/2013-01-01/api-2.json
@@ -13,8 +13,8 @@
     "Search":{
       "name":"Search",
       "http":{
-        "method":"GET",
-        "requestUri":"/2013-01-01/search?format=sdk&pretty=true"
+        "method":"POST",
+        "requestUri":"/2013-01-01/search"
       },
       "input":{"shape":"SearchRequest"},
       "output":{"shape":"SearchResponse"},

--- a/private/protocol/rest/build.go
+++ b/private/protocol/rest/build.go
@@ -91,7 +91,16 @@ func buildLocationElements(r *request.Request, v reflect.Value) {
 		}
 	}
 
-	r.HTTPRequest.URL.RawQuery = query.Encode()
+	if r.HTTPRequest.Method == "POST" {
+		query.Add("format", "sdk")
+		query.Add("pretty", "true")
+		body := []byte(query.Encode())
+		r.SetBufferBody(body)
+		r.HTTPRequest.Header.Add("Content-Length", strconv.Itoa(len(body)))
+		r.HTTPRequest.Header.Add("Content-Type", "application/x-www-form-urlencoded")
+	} else {
+		r.HTTPRequest.URL.RawQuery = query.Encode()
+	}
 	updatePath(r.HTTPRequest.URL, r.HTTPRequest.URL.Path)
 }
 

--- a/service/cloudsearchdomain/api.go
+++ b/service/cloudsearchdomain/api.go
@@ -37,8 +37,8 @@ const opSearch = "Search"
 func (c *CloudSearchDomain) SearchRequest(input *SearchInput) (req *request.Request, output *SearchOutput) {
 	op := &request.Operation{
 		Name:       opSearch,
-		HTTPMethod: "GET",
-		HTTPPath:   "/2013-01-01/search?format=sdk&pretty=true",
+		HTTPMethod: "POST",
+		HTTPPath:   "/2013-01-01/search",
 	}
 
 	if input == nil {


### PR DESCRIPTION
I had to convert the GET requests for CloudSearch to POST requests because of the limit on the GET request sizes.

I followed previous similar changes that were done with both the [Java SDK](https://github.com/aws/aws-sdk-java/pull/697/files#diff-943a471a06ce28c853295034aae44be5R47) and the [Javascript SDK](https://github.com/aws/aws-sdk-js/commit/6bac85eff6472fd7150d7c4aaf290ed27e29b05a).
