### PR TITLE
aws/session: Add support for shared config (~/.aws/config) file

### DIFF
--- a/aws/credentials/static_provider.go
+++ b/aws/credentials/static_provider.go
@@ -30,6 +30,13 @@ func NewStaticCredentials(id, secret, token string) *Credentials {
 	}})
 }
 
+// NewStaticCredentialsFromCreds returns a pointer to a new Credentials object
+// wrapping the static credentials value provide. Same as NewStaticCredentials
+// but takes the creds Value instead of individual fields
+func NewStaticCredentialsFromCreds(creds Value) *Credentials {
+	return NewCredentials(&StaticProvider{Value: creds})
+}
+
 // Retrieve returns the credentials or error if the credentials are invalid.
 func (s *StaticProvider) Retrieve() (Value, error) {
 	if s.AccessKeyID == "" || s.SecretAccessKey == "" {

--- a/aws/credentials/static_provider.go
+++ b/aws/credentials/static_provider.go
@@ -36,7 +36,9 @@ func (s *StaticProvider) Retrieve() (Value, error) {
 		return Value{ProviderName: StaticProviderName}, ErrStaticCredentialsEmpty
 	}
 
-	s.Value.ProviderName = StaticProviderName
+	if len(s.Value.ProviderName) == 0 {
+		s.Value.ProviderName = StaticProviderName
+	}
 	return s.Value, nil
 }
 

--- a/aws/defaults/defaults.go
+++ b/aws/defaults/defaults.go
@@ -90,12 +90,14 @@ func CredChain(cfg *aws.Config, handlers request.Handlers) *credentials.Credenti
 		Providers: []credentials.Provider{
 			&credentials.EnvProvider{},
 			&credentials.SharedCredentialsProvider{Filename: "", Profile: ""},
-			remoteCredProvider(*cfg, handlers),
+			RemoteCredProvider(*cfg, handlers),
 		},
 	})
 }
 
-func remoteCredProvider(cfg aws.Config, handlers request.Handlers) credentials.Provider {
+// RemoteCredProvider returns a credenitials provider for the default remote
+// endpoints such as EC2 or ECS Roles.
+func RemoteCredProvider(cfg aws.Config, handlers request.Handlers) credentials.Provider {
 	ecsCredURI := os.Getenv("AWS_CONTAINER_CREDENTIALS_RELATIVE_URI")
 
 	if len(ecsCredURI) > 0 {

--- a/aws/defaults/defaults_test.go
+++ b/aws/defaults/defaults_test.go
@@ -16,7 +16,7 @@ func TestECSCredProvider(t *testing.T) {
 	defer os.Clearenv()
 	os.Setenv("AWS_CONTAINER_CREDENTIALS_RELATIVE_URI", "/abc/123")
 
-	provider := remoteCredProvider(aws.Config{}, request.Handlers{})
+	provider := RemoteCredProvider(aws.Config{}, request.Handlers{})
 
 	assert.NotNil(t, provider)
 
@@ -29,7 +29,7 @@ func TestECSCredProvider(t *testing.T) {
 }
 
 func TestDefaultEC2RoleProvider(t *testing.T) {
-	provider := remoteCredProvider(aws.Config{}, request.Handlers{})
+	provider := RemoteCredProvider(aws.Config{}, request.Handlers{})
 
 	assert.NotNil(t, provider)
 

--- a/aws/session/doc.go
+++ b/aws/session/doc.go
@@ -1,0 +1,158 @@
+/*
+Package session provides configuration for the SDK's service clients.
+
+Sessions can be shared across all service clients that share the same base
+configuration.  The Session is built from the SDK's default configuration and
+request handlers.
+
+Sessions should be cached when possible, because creating a new Session will
+load all configuration values from the environment, and shared config files
+each time the Session is created. Sharing the Session value across all of your
+service clients will ensure the configuration is loaded the fewest number of
+times possible.
+
+Concurrency
+
+Sessions are safe to use concurrently as long as the Session is not being
+modified. The SDK will not modify the Session once the Session has been created.
+Creating service clients concurrently from a shared Session is safe.
+
+Creating Sessions
+
+When creating Sessions optional aws.Config values can be provided that will
+override the default, or loaded shared config, values the Session is being
+created with. This allows you to provide additional configuration, or use case
+based values as needed.
+
+By default the Session will only load credentials from the shared credentials
+file (~/.aws/credentials). If the AWS_SDK_LOAD_CONFIG environment variable is
+set to a truthy value. Sessions will also load the configuration values from
+the shared config (~/.aws/config) and shared credentials (~/.aws/credentials)
+files. See the Sessions with Shared Config section for more information.
+
+	// Create a Session with the default config and request handlers.
+	sess := session.New()
+
+	// Create a Session with a custom region
+	sess := session.New(&aws.Config{Region: aws.String("us-east-1")})
+
+	// Create a session, and add additional handlers for all service
+	// clients created with the Session to inherit. Adds logging handler.
+	sess := session.New()
+	sess.Handlers.Send.PushFront(func(r *request.Request) {
+		// Log every request made and its payload
+		logger.Println("Request: %s/%s, Payload: %s",
+			r.ClientInfo.ServiceName, r.Operation, r.Params)
+	})
+
+	// Create a S3 client instance from a session
+	sess := session.New()
+	svc := s3.New(sess)
+
+Sessions with Shared Config
+
+Sessions can be created using the method above that will only load the
+additional shared config if the AWS_SDK_LOAD_CONFIG environment variable is set.
+Alternatively you can explicitly create a Session with the shared config enabled.
+To do this you can call NewFromSharedConfig or NewFromSharedConfigProfile. Both
+of these functions operate as if the AWS_SDK_LOAD_CONFIG environment variable
+is set.
+
+Environment Variables
+
+When a Session is created several environment variables can be set to adjust
+how the SDK functions, and what configuration data it loads when creating
+Sessions. All environment values are optional, but some values like credentials
+require multiple of the values to set or the partial values will be ignored.
+All environment variable values are strings unless otherwise noted.
+
+Environment configuration values. If set both Access Key ID and Secret Access
+Key must be provided. Session Token and optionally also be provided, but is
+not required.
+
+	# Access Key ID
+	AWS_ACCESS_KEY_ID=AKID
+	AWS_ACCESS_KEY=AKID # only read if AWS_ACCESS_KEY_ID is not set.
+
+	# Secret Access Key
+	AWS_SECRET_ACCESS_KEY=SECRET
+	AWS_SECRET_KEY=SECRET=SECRET # only read if AWS_SECRET_ACCESS_KEY is not set.
+
+	# Session Token
+	AWS_SESSION_TOKEN=TOKEN
+
+Region value will instruct the SDK where to make service API requests to. If is
+not provided in the environment the region must be provided before a service
+client request is made.
+
+	AWS_REGION=us-east-1
+
+	# AWS_DEFAULT_REGION is only read if AWS_SDK_LOAD_CONFIG is also set,
+	# and AWS_REGION is not also set.
+	AWS_DEFAULT_REGION=us-east-1
+
+Profile name the SDK should load use when loading shared configuration from the
+shared configuration files. If not provided "default" will be used as the
+profile name.
+
+	AWS_PROFILE=my_profile
+
+	# AWS_DEFAULT_PROFILE is only read if AWS_SDK_LOAD_CONFIG is also set,
+	# and AWS_PROFILE is not also set.
+	AWS_DEFAULT_PROFILE=my_profile
+
+SDK load config instructs the SDK to load the shared config in addition to
+shared credentials. This also expands the configuration loaded from the shared
+credentials to have parity with the shared config file. This also enables
+Region and Profile support for the AWS_DEFAULT_REGION and AWS_DEFAULT_PROFILE
+env values as well.
+
+	AWS_SDK_LOAD_CONFIG=1
+
+Shared credentials file path can be set to instruct the SDK to use an alternate
+file for the shared credentials. If not set the file will be loaded from
+$HOME/.aws/credentials on Linux/Unix based systems, and
+%USERPROFILE%\.aws\credentials on Windows.
+
+	AWS_SHARED_CREDENTIALS_FILE=$HOME/my_shared_credentials
+
+Shared config file path can be set to instruct the SDK to use an alternate
+file for the shared config. If not set the file will be loaded from
+$HOME/.aws/config on Linux/Unix based systems, and
+%USERPROFILE%\.aws\config on Windows.
+
+	AWS_SHARED_CONFIG_FILE=$HOME/my_shared_config
+
+Shared Config Fields
+
+By default the SDK will only load the shared credentials file's (~/.aws/credentials)
+credentials values, and all other config is provided by the environment variables,
+SDK defaults, and user provided aws.Config values.
+
+If the AWS_SDK_LOAD_CONFIG environment variable is set, or NewFromSharedConfig
+methods are used to create the Session the full shared config values will be
+loaded. These include credentials and region. In addition the Session will
+load its configuration from both the shared config file (~/.aws/config) and
+shared credentials file (~/.aws/credentials). Both files share the same format.
+
+If both config files are present the configuration from both files will be
+loaded. The Session will take configuration values from the shared credentials
+file (~/.aws/credentials) over those in the shared credentials file (~/.aws/config).
+
+Credentials are the values the SDK should use for authenticating requests with
+AWS Services. They arfrom a configuration file will need to include both
+aws_access_key_id and aws_secret_access_key must be provided together in the
+same file to be considered valid. The values will be ignored if not a complete
+group. aws_session_token is an optional field that can be provided if both of
+the other two fields are also provided.
+
+	aws_access_key_id = AKID
+	aws_secret_access_key = SECRET
+	aws_session_token = TOKEN
+
+Region is the region the SDK should use for looking up AWS service endpoints
+and signing requests.
+
+	region = us-east-1
+*/
+package session

--- a/aws/session/doc.go
+++ b/aws/session/doc.go
@@ -6,10 +6,9 @@ configuration.  The Session is built from the SDK's default configuration and
 request handlers.
 
 Sessions should be cached when possible, because creating a new Session will
-load all configuration values from the environment, and shared config files
-each time the Session is created. Sharing the Session value across all of your
-service clients will ensure the configuration is loaded the fewest number of
-times possible.
+load all configuration values from the environment, and config files each time
+the Session is created. Sharing the Session value across all of your service
+clients will ensure the configuration is loaded the fewest number of times possible.
 
 Concurrency
 
@@ -17,46 +16,149 @@ Sessions are safe to use concurrently as long as the Session is not being
 modified. The SDK will not modify the Session once the Session has been created.
 Creating service clients concurrently from a shared Session is safe.
 
+Sessions from Shared Config
+
+Sessions can be created using the method above that will only load the
+additional config if the AWS_SDK_LOAD_CONFIG environment variable is set.
+Alternatively you can explicitly create a Session with shared config enabled.
+To do this you can use NewSessionWithOptions to configure how the Session will
+be created. Using the NewSessionWithOptions with SharedConfigState set to
+SharedConfigEnabled will create the session as if the AWS_SDK_LOAD_CONFIG
+environment variable was set.
+
 Creating Sessions
 
-When creating Sessions optional aws.Config values can be provided that will
-override the default, or loaded shared config, values the Session is being
-created with. This allows you to provide additional configuration, or use case
-based values as needed.
+When creating Sessions optional aws.Config values can be passed in that will
+override the default, or loaded config values the Session is being created
+with. This allows you to provide additional, or case based, configuration
+as needed.
 
-By default the Session will only load credentials from the shared credentials
+By default NewSession will only load credentials from the shared credentials
 file (~/.aws/credentials). If the AWS_SDK_LOAD_CONFIG environment variable is
-set to a truthy value. Sessions will also load the configuration values from
-the shared config (~/.aws/config) and shared credentials (~/.aws/credentials)
-files. See the Sessions with Shared Config section for more information.
+set to a truthy value the Session will be created from the configuration
+values from the shared config (~/.aws/config) and shared credentials
+(~/.aws/credentials) files. See the section Sessions from Shared Config for
+more information.
 
-	// Create a Session with the default config and request handlers.
-	sess := session.New()
+Create a Session with the default config and request handlers. With credentials
+region, and profile loaded from the environment and shared config automatically.
+Requires the AWS_PROFILE to be set, or "default" is used.
+
+	// Create Session
+	sess, err := session.NewSession()
 
 	// Create a Session with a custom region
-	sess := session.New(&aws.Config{Region: aws.String("us-east-1")})
+	sess, err := session.NewSession(&aws.Config{Region: aws.String("us-east-1")})
+
+	// Create a S3 client instance from a session
+	sess, err := session.NewSession()
+	if err != nil {
+		// Handle Session creation error
+	}
+	svc := s3.New(sess)
+
+Create Session With Option Overrides
+
+In addition to NewSession, Sessions can be created using NewSessionWithOptions.
+This func allows you to control and override how the Session will be created
+through code instead of being driven by environment variables only.
+
+Use NewSessionWithOptions when you want to provide the config profile, or
+override the shared config state (AWS_SDK_LOAD_CONFIG).
+
+	// Equivalent to session.New
+	sess, err := session.NewSessionWithOptions(session.Optons{})
+
+	// Specify profile to load for the session's config
+	sess, err := session.NewSessionWithOptions(session.Optons{
+		 Profile: "profile_name",
+	})
+
+	// Specify profile for config and region for requests
+	sess, err := session.NewSessionWithOptions(session.Options{
+		 Config: aws.Config{Region: aws.String("us-east-1")},
+		 Profile: "profile_name",
+	})
+
+	// Force enable Shared Config support
+	sess, err := session.NewSessionWithOptions(session.Optons{
+		SharedConfigState: SharedConfigEnable,
+	})
+
+Deprecated "New" function
+
+The New session function has been deprecated because it does not provide good
+way to return errors that occur when loading the configuration files and values.
+Because of this, the NewWithError
+
+Adding Handlers
+
+You can add handlers to a session for processing HTTP requests. All service
+clients that use the session inherit the handlers. For example, the following
+handler logs every request and its payload made by a service client:
 
 	// Create a session, and add additional handlers for all service
 	// clients created with the Session to inherit. Adds logging handler.
-	sess := session.New()
+	sess, err := session.NewSession()
 	sess.Handlers.Send.PushFront(func(r *request.Request) {
 		// Log every request made and its payload
 		logger.Println("Request: %s/%s, Payload: %s",
 			r.ClientInfo.ServiceName, r.Operation, r.Params)
 	})
 
-	// Create a S3 client instance from a session
-	sess := session.New()
-	svc := s3.New(sess)
+Deprecated "New" function
 
-Sessions with Shared Config
+The New session function has been deprecated because it does not provide good
+way to return errors that occur when loading the configuration files and values.
+Because of this, NewSession was created so errors can be retrieved when
+creating a session fails.
 
-Sessions can be created using the method above that will only load the
-additional shared config if the AWS_SDK_LOAD_CONFIG environment variable is set.
-Alternatively you can explicitly create a Session with the shared config enabled.
-To do this you can call NewFromSharedConfig or NewFromSharedConfigProfile. Both
-of these functions operate as if the AWS_SDK_LOAD_CONFIG environment variable
-is set.
+Shared Config Fields
+
+By default the SDK will only load the shared credentials file's (~/.aws/credentials)
+credentials values, and all other config is provided by the environment variables,
+SDK defaults, and user provided aws.Config values.
+
+If the AWS_SDK_LOAD_CONFIG environment variable is set, or SharedConfigEnable
+option is used to create the Session the full shared config values will be
+loaded. This includes credentials, region, and support for assume role. In
+addition the Session will load its configuration from both the shared config
+file (~/.aws/config) and shared credentials file (~/.aws/credentials). Both
+files have the same format.
+
+If both config files are present the configuration from both files will be
+read. The Session will be created from  configuration values from the shared
+credentials file (~/.aws/credentials) over those in the shared credentials
+file (~/.aws/config).
+
+Credentials are the values the SDK should use for authenticating requests with
+AWS Services. They arfrom a configuration file will need to include both
+aws_access_key_id and aws_secret_access_key must be provided together in the
+same file to be considered valid. The values will be ignored if not a complete
+group. aws_session_token is an optional field that can be provided if both of
+the other two fields are also provided.
+
+	aws_access_key_id = AKID
+	aws_secret_access_key = SECRET
+	aws_session_token = TOKEN
+
+Assume Role values allow you to configure the SDK to assume an IAM role using
+a set of credentials provided in a config file via the source_profile field.
+Both "role_arn" and "source_profile" are required. The SDK does not support
+assuming a role with MFA token Via the Session's constructor. You can use the
+stscreds.AssumeRoleProvider credentials provider to specify custom
+configuration and support for MFA.
+
+	role_arn = arn:aws:iam::<account_number>:role/<role_name>
+	source_profile = profile_with_creds
+	external_id = 1234
+	mfa_serial = not supported!
+	role_session_name = session_name
+
+Region is the region the SDK should use for looking up AWS service endpoints
+and signing requests.
+
+	region = us-east-1
 
 Environment Variables
 
@@ -91,9 +193,8 @@ client request is made.
 	# and AWS_REGION is not also set.
 	AWS_DEFAULT_REGION=us-east-1
 
-Profile name the SDK should load use when loading shared configuration from the
-shared configuration files. If not provided "default" will be used as the
-profile name.
+Profile name the SDK should load use when loading shared config from the
+configuration files. If not provided "default" will be used as the profile name.
 
 	AWS_PROFILE=my_profile
 
@@ -102,57 +203,27 @@ profile name.
 	AWS_DEFAULT_PROFILE=my_profile
 
 SDK load config instructs the SDK to load the shared config in addition to
-shared credentials. This also expands the configuration loaded from the shared
-credentials to have parity with the shared config file. This also enables
+shared credentials. This also expands the configuration loaded so the shared
+credentials will have parity with the shared config file. This also enables
 Region and Profile support for the AWS_DEFAULT_REGION and AWS_DEFAULT_PROFILE
 env values as well.
 
 	AWS_SDK_LOAD_CONFIG=1
 
-Shared credentials file path can be set to instruct the SDK to use an alternate
+Shared credentials file path can be set to instruct the SDK to use an alternative
 file for the shared credentials. If not set the file will be loaded from
 $HOME/.aws/credentials on Linux/Unix based systems, and
 %USERPROFILE%\.aws\credentials on Windows.
 
 	AWS_SHARED_CREDENTIALS_FILE=$HOME/my_shared_credentials
 
-Shared config file path can be set to instruct the SDK to use an alternate
+Shared config file path can be set to instruct the SDK to use an alternative
 file for the shared config. If not set the file will be loaded from
 $HOME/.aws/config on Linux/Unix based systems, and
 %USERPROFILE%\.aws\config on Windows.
 
-	AWS_SHARED_CONFIG_FILE=$HOME/my_shared_config
+	AWS_CONFIG_FILE=$HOME/my_shared_config
 
-Shared Config Fields
 
-By default the SDK will only load the shared credentials file's (~/.aws/credentials)
-credentials values, and all other config is provided by the environment variables,
-SDK defaults, and user provided aws.Config values.
-
-If the AWS_SDK_LOAD_CONFIG environment variable is set, or NewFromSharedConfig
-methods are used to create the Session the full shared config values will be
-loaded. These include credentials and region. In addition the Session will
-load its configuration from both the shared config file (~/.aws/config) and
-shared credentials file (~/.aws/credentials). Both files share the same format.
-
-If both config files are present the configuration from both files will be
-loaded. The Session will take configuration values from the shared credentials
-file (~/.aws/credentials) over those in the shared credentials file (~/.aws/config).
-
-Credentials are the values the SDK should use for authenticating requests with
-AWS Services. They arfrom a configuration file will need to include both
-aws_access_key_id and aws_secret_access_key must be provided together in the
-same file to be considered valid. The values will be ignored if not a complete
-group. aws_session_token is an optional field that can be provided if both of
-the other two fields are also provided.
-
-	aws_access_key_id = AKID
-	aws_secret_access_key = SECRET
-	aws_session_token = TOKEN
-
-Region is the region the SDK should use for looking up AWS service endpoints
-and signing requests.
-
-	region = us-east-1
 */
 package session

--- a/aws/session/env_config.go
+++ b/aws/session/env_config.go
@@ -1,0 +1,188 @@
+package session
+
+import (
+	"os"
+	"path/filepath"
+	"strconv"
+
+	"github.com/aws/aws-sdk-go/aws/credentials"
+)
+
+// envConfig is a collection of environment values the SDK will read
+// setup config from. All environment values are optional. But some values
+// such as credentials require multiple values to be complete or the values
+// will be ignored.
+type envConfig struct {
+	// Environment configuration values. If set both Access Key ID and Secret Access
+	// Key must be provided. Session Token and optionally also be provided, but is
+	// not required.
+	//
+	//	# Access Key ID
+	//	AWS_ACCESS_KEY_ID=AKID
+	//	AWS_ACCESS_KEY=AKID # only read if AWS_ACCESS_KEY_ID is not set.
+	//
+	//	# Secret Access Key
+	//	AWS_SECRET_ACCESS_KEY=SECRET
+	//	AWS_SECRET_KEY=SECRET=SECRET # only read if AWS_SECRET_ACCESS_KEY is not set.
+	//
+	//	# Session Token
+	//	AWS_SESSION_TOKEN=TOKEN
+	Creds credentials.Value
+
+	// Region value will instruct the SDK where to make service API requests to. If is
+	// not provided in the environment the region must be provided before a service
+	// client request is made.
+	//
+	//	AWS_REGION=us-east-1
+	//
+	//	# AWS_DEFAULT_REGION is only read if AWS_SDK_LOAD_CONFIG is also set,
+	//	# and AWS_REGION is not also set.
+	//	AWS_DEFAULT_REGION=us-east-1
+	Region string
+
+	// Profile name the SDK should load use when loading shared configuration from the
+	// shared configuration files. If not provided "default" will be used as the
+	// profile name.
+	//
+	//	AWS_PROFILE=my_profile
+	//
+	//	# AWS_DEFAULT_PROFILE is only read if AWS_SDK_LOAD_CONFIG is also set,
+	//	# and AWS_PROFILE is not also set.
+	//	AWS_DEFAULT_PROFILE=my_profile
+	Profile string
+
+	// SDK load config instructs the SDK to load the shared config in addition to
+	// shared credentials. This also expands the configuration loaded from the shared
+	// credentials to have parity with the shared config file. This also enables
+	// Region and Profile support for the AWS_DEFAULT_REGION and AWS_DEFAULT_PROFILE
+	// env values as well.
+	//
+	//	AWS_SDK_LOAD_CONFIG=1
+	EnableSharedConfig bool
+
+	// Shared credentials file path can be set to instruct the SDK to use an alternate
+	// file for the shared credentials. If not set the file will be loaded from
+	// $HOME/.aws/credentials on Linux/Unix based systems, and
+	// %USERPROFILE%\.aws\credentials on Windows.
+	//
+	//	AWS_SHARED_CREDENTIALS_FILE=$HOME/my_shared_credentials
+	SharedCredentialsFile string
+
+	// Shared config file path can be set to instruct the SDK to use an alternate
+	// file for the shared config. If not set the file will be loaded from
+	// $HOME/.aws/config on Linux/Unix based systems, and
+	// %USERPROFILE%\.aws\config on Windows.
+	//
+	//	AWS_SHARED_CONFIG_FILE=$HOME/my_shared_config
+	SharedConfigFile string
+}
+
+var (
+	credAccessEnvKey = []string{
+		"AWS_ACCESS_KEY_ID",
+		"AWS_ACCESS_KEY",
+	}
+	credSecretEnvKey = []string{
+		"AWS_SECRET_ACCESS_KEY",
+		"AWS_SECRET_KEY",
+	}
+	credSessionEnvKey = []string{
+		"AWS_SESSION_TOKEN",
+	}
+
+	regionEnvKeys = []string{
+		"AWS_REGION",
+		"AWS_DEFAULT_REGION", // Only read if AWS_SDK_LOAD_CONFIG is also set
+	}
+	profileEnvKeys = []string{
+		"AWS_PROFILE",
+		"AWS_DEFAULT_PROFILE", // Only read if AWS_SDK_LOAD_CONFIG is also set
+	}
+)
+
+// loadEnvConfig retrieves the SDK's environment configuration.
+// See `envConfig` for the values that will be retrieved.
+//
+// If the environment variable `AWS_SDK_LOAD_CONFIG` is set to a truthy value
+// the shared SDK config will be loaded in addition to the SDK's specific
+// configuration values.
+func loadEnvConfig() envConfig {
+	enableSharedConfig, _ := strconv.ParseBool(os.Getenv("AWS_SDK_LOAD_CONFIG"))
+	return envConfigLoad(enableSharedConfig)
+}
+
+// loadEnvSharedConfig retrieves the SDK's environment configuration, and the
+// SDK shared config. See `envConfig` for the values that will be retrieved.
+//
+// Loads the shared configuration in addition to the SDK's specific configuration.
+// This will load the same values as `loadEnvConfig` if the `AWS_SDK_LOAD_CONFIG`
+// environment variable is set.
+func loadSharedEnvConfig() envConfig {
+	return envConfigLoad(true)
+}
+
+func envConfigLoad(enableSharedConfig bool) envConfig {
+	cfg := envConfig{}
+
+	cfg.EnableSharedConfig = enableSharedConfig
+
+	setFromEnvVal(&cfg.Creds.AccessKeyID, credAccessEnvKey)
+	setFromEnvVal(&cfg.Creds.SecretAccessKey, credSecretEnvKey)
+	setFromEnvVal(&cfg.Creds.SessionToken, credSessionEnvKey)
+
+	// Require logical grouping of credentials
+	if len(cfg.Creds.AccessKeyID) == 0 || len(cfg.Creds.SecretAccessKey) == 0 {
+		cfg.Creds = credentials.Value{}
+	} else {
+		cfg.Creds.ProviderName = "EnvConfigCredentials"
+	}
+
+	regionKeys := regionEnvKeys
+	profileKeys := profileEnvKeys
+	if !cfg.EnableSharedConfig {
+		regionKeys = regionKeys[:1]
+		profileKeys = profileKeys[:1]
+	}
+
+	setFromEnvVal(&cfg.Region, regionKeys)
+	setFromEnvVal(&cfg.Profile, profileKeys)
+
+	cfg.SharedCredentialsFile = sharedCredentialsFilename()
+	cfg.SharedConfigFile = sharedConfigFilename()
+
+	return cfg
+}
+
+func setFromEnvVal(dst *string, keys []string) {
+	for _, k := range keys {
+		if v := os.Getenv(k); len(v) > 0 {
+			*dst = v
+			break
+		}
+	}
+}
+
+func sharedCredentialsFilename() string {
+	if name := os.Getenv("AWS_SHARED_CREDENTIALS_FILE"); len(name) > 0 {
+		return name
+	}
+
+	return filepath.Join(userHomeDir(), ".aws", "credentials")
+}
+
+func sharedConfigFilename() string {
+	if name := os.Getenv("AWS_CONFIG_FILE"); len(name) > 0 {
+		return name
+	}
+
+	return filepath.Join(userHomeDir(), ".aws", "config")
+}
+
+func userHomeDir() string {
+	homeDir := os.Getenv("HOME") // *nix
+	if len(homeDir) == 0 {       // windows
+		homeDir = os.Getenv("USERPROFILE")
+	}
+
+	return homeDir
+}

--- a/aws/session/env_config.go
+++ b/aws/session/env_config.go
@@ -73,7 +73,7 @@ type envConfig struct {
 	// $HOME/.aws/config on Linux/Unix based systems, and
 	// %USERPROFILE%\.aws\config on Windows.
 	//
-	//	AWS_SHARED_CONFIG_FILE=$HOME/my_shared_config
+	//	AWS_CONFIG_FILE=$HOME/my_shared_config
 	SharedConfigFile string
 }
 

--- a/aws/session/env_config_test.go
+++ b/aws/session/env_config_test.go
@@ -1,0 +1,276 @@
+package session
+
+import (
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+
+	"github.com/aws/aws-sdk-go/aws/credentials"
+	"github.com/stretchr/testify/assert"
+)
+
+func TestLoadEnvConfig_Creds(t *testing.T) {
+	env := stashEnv()
+	defer popEnv(env)
+
+	cases := []struct {
+		Env map[string]string
+		Val credentials.Value
+	}{
+		{
+			Env: map[string]string{
+				"AWS_ACCESS_KEY": "AKID",
+			},
+			Val: credentials.Value{},
+		},
+		{
+			Env: map[string]string{
+				"AWS_ACCESS_KEY_ID": "AKID",
+			},
+			Val: credentials.Value{},
+		},
+		{
+			Env: map[string]string{
+				"AWS_SECRET_KEY": "SECRET",
+			},
+			Val: credentials.Value{},
+		},
+		{
+			Env: map[string]string{
+				"AWS_SECRET_ACCESS_KEY": "SECRET",
+			},
+			Val: credentials.Value{},
+		},
+		{
+			Env: map[string]string{
+				"AWS_ACCESS_KEY_ID":     "AKID",
+				"AWS_SECRET_ACCESS_KEY": "SECRET",
+			},
+			Val: credentials.Value{
+				AccessKeyID: "AKID", SecretAccessKey: "SECRET",
+				ProviderName: "EnvConfigCredentials",
+			},
+		},
+		{
+			Env: map[string]string{
+				"AWS_ACCESS_KEY": "AKID",
+				"AWS_SECRET_KEY": "SECRET",
+			},
+			Val: credentials.Value{
+				AccessKeyID: "AKID", SecretAccessKey: "SECRET",
+				ProviderName: "EnvConfigCredentials",
+			},
+		},
+		{
+			Env: map[string]string{
+				"AWS_ACCESS_KEY":    "AKID",
+				"AWS_SECRET_KEY":    "SECRET",
+				"AWS_SESSION_TOKEN": "TOKEN",
+			},
+			Val: credentials.Value{
+				AccessKeyID: "AKID", SecretAccessKey: "SECRET", SessionToken: "TOKEN",
+				ProviderName: "EnvConfigCredentials",
+			},
+		},
+	}
+
+	for _, c := range cases {
+		os.Clearenv()
+
+		for k, v := range c.Env {
+			os.Setenv(k, v)
+		}
+
+		cfg := loadEnvConfig()
+		assert.Equal(t, c.Val, cfg.Creds)
+	}
+}
+
+func TestLoadEnvConfig(t *testing.T) {
+	env := stashEnv()
+	defer popEnv(env)
+
+	cases := []struct {
+		Env                 map[string]string
+		Region, Profile     string
+		UseSharedConfigCall bool
+	}{
+		{
+			Env: map[string]string{
+				"AWS_REGION":  "region",
+				"AWS_PROFILE": "profile",
+			},
+			Region: "region", Profile: "profile",
+		},
+		{
+			Env: map[string]string{
+				"AWS_REGION":          "region",
+				"AWS_DEFAULT_REGION":  "default_region",
+				"AWS_PROFILE":         "profile",
+				"AWS_DEFAULT_PROFILE": "default_profile",
+			},
+			Region: "region", Profile: "profile",
+		},
+		{
+			Env: map[string]string{
+				"AWS_REGION":          "region",
+				"AWS_DEFAULT_REGION":  "default_region",
+				"AWS_PROFILE":         "profile",
+				"AWS_DEFAULT_PROFILE": "default_profile",
+				"AWS_SDK_LOAD_CONFIG": "1",
+			},
+			Region: "region", Profile: "profile",
+		},
+		{
+			Env: map[string]string{
+				"AWS_DEFAULT_REGION":  "default_region",
+				"AWS_DEFAULT_PROFILE": "default_profile",
+			},
+		},
+		{
+			Env: map[string]string{
+				"AWS_DEFAULT_REGION":  "default_region",
+				"AWS_DEFAULT_PROFILE": "default_profile",
+				"AWS_SDK_LOAD_CONFIG": "1",
+			},
+			Region: "default_region", Profile: "default_profile",
+		},
+		{
+			Env: map[string]string{
+				"AWS_REGION":  "region",
+				"AWS_PROFILE": "profile",
+			},
+			Region: "region", Profile: "profile",
+			UseSharedConfigCall: true,
+		},
+		{
+			Env: map[string]string{
+				"AWS_REGION":          "region",
+				"AWS_DEFAULT_REGION":  "default_region",
+				"AWS_PROFILE":         "profile",
+				"AWS_DEFAULT_PROFILE": "default_profile",
+			},
+			Region: "region", Profile: "profile",
+			UseSharedConfigCall: true,
+		},
+		{
+			Env: map[string]string{
+				"AWS_REGION":          "region",
+				"AWS_DEFAULT_REGION":  "default_region",
+				"AWS_PROFILE":         "profile",
+				"AWS_DEFAULT_PROFILE": "default_profile",
+				"AWS_SDK_LOAD_CONFIG": "1",
+			},
+			Region: "region", Profile: "profile",
+			UseSharedConfigCall: true,
+		},
+		{
+			Env: map[string]string{
+				"AWS_DEFAULT_REGION":  "default_region",
+				"AWS_DEFAULT_PROFILE": "default_profile",
+			},
+			Region: "default_region", Profile: "default_profile",
+			UseSharedConfigCall: true,
+		},
+		{
+			Env: map[string]string{
+				"AWS_DEFAULT_REGION":  "default_region",
+				"AWS_DEFAULT_PROFILE": "default_profile",
+				"AWS_SDK_LOAD_CONFIG": "1",
+			},
+			Region: "default_region", Profile: "default_profile",
+			UseSharedConfigCall: true,
+		},
+	}
+
+	for _, c := range cases {
+		os.Clearenv()
+
+		for k, v := range c.Env {
+			os.Setenv(k, v)
+		}
+
+		var cfg envConfig
+		if c.UseSharedConfigCall {
+			cfg = loadSharedEnvConfig()
+		} else {
+			cfg = loadEnvConfig()
+		}
+
+		assert.Equal(t, c.Region, cfg.Region)
+		assert.Equal(t, c.Profile, cfg.Profile)
+	}
+}
+
+func TestSharedCredsFilename(t *testing.T) {
+	env := stashEnv()
+	defer popEnv(env)
+
+	os.Setenv("USERPROFILE", "profile_dir")
+	expect := filepath.Join("profile_dir", ".aws", "credentials")
+	name := sharedCredentialsFilename()
+	assert.Equal(t, expect, name)
+
+	os.Setenv("HOME", "home_dir")
+	expect = filepath.Join("home_dir", ".aws", "credentials")
+	name = sharedCredentialsFilename()
+	assert.Equal(t, expect, name)
+
+	expect = filepath.Join("path/to/credentials/file")
+	os.Setenv("AWS_SHARED_CREDENTIALS_FILE", expect)
+	name = sharedCredentialsFilename()
+	assert.Equal(t, expect, name)
+}
+
+func TestSharedConfigFilename(t *testing.T) {
+	env := stashEnv()
+	defer popEnv(env)
+
+	os.Setenv("USERPROFILE", "profile_dir")
+	expect := filepath.Join("profile_dir", ".aws", "config")
+	name := sharedConfigFilename()
+	assert.Equal(t, expect, name)
+
+	os.Setenv("HOME", "home_dir")
+	expect = filepath.Join("home_dir", ".aws", "config")
+	name = sharedConfigFilename()
+	assert.Equal(t, expect, name)
+
+	expect = filepath.Join("path/to/config/file")
+	os.Setenv("AWS_CONFIG_FILE", expect)
+	name = sharedConfigFilename()
+	assert.Equal(t, expect, name)
+}
+
+func TestSetEnvValue(t *testing.T) {
+	env := stashEnv()
+	defer popEnv(env)
+
+	os.Setenv("empty_key", "")
+	os.Setenv("second_key", "2")
+	os.Setenv("third_key", "3")
+
+	var dst string
+	setFromEnvVal(&dst, []string{
+		"empty_key", "first_key", "second_key", "third_key",
+	})
+
+	assert.Equal(t, "2", dst)
+}
+
+func stashEnv() []string {
+	env := os.Environ()
+	os.Clearenv()
+
+	return env
+}
+
+func popEnv(env []string) {
+	os.Clearenv()
+
+	for _, e := range env {
+		p := strings.SplitN(e, "=", 2)
+		os.Setenv(p[0], p[1])
+	}
+}

--- a/aws/session/session.go
+++ b/aws/session/session.go
@@ -5,6 +5,7 @@ import (
 	"github.com/aws/aws-sdk-go/aws/client"
 	"github.com/aws/aws-sdk-go/aws/corehandlers"
 	"github.com/aws/aws-sdk-go/aws/credentials"
+	"github.com/aws/aws-sdk-go/aws/credentials/stscreds"
 	"github.com/aws/aws-sdk-go/aws/defaults"
 	"github.com/aws/aws-sdk-go/aws/request"
 	"github.com/aws/aws-sdk-go/private/endpoints"
@@ -24,116 +25,199 @@ type Session struct {
 
 // New creates a new instance of the handlers merging in the provided configs
 // on top of the SDK's default configurations. Once the Session is created it
-// can be mutated to modify Config or Handlers. The Session is safe to be read
-// concurrently, but it should not be written to concurrently.
+// can be mutated to modify the Config or Handlers. The Session is safe to be
+// read concurrently, but it should not be written to concurrently.
+//
+// If the AWS_SDK_LOAD_CONFIG environment is set to a truthy value, the New
+// method could now encounter an error when loading the configuration. When
+// The environment variable is set, and an error occurs, New will return a
+// session that will fail all requests reporting the error that occured while
+// loading the session. Use NewSession to get the error when creating the
+// session.
 //
 // If the AWS_SDK_LOAD_CONFIG environment variable is set to a truthy value
-// the shared config (~/.aws/config) will also be loaded. Values from the shared
-// credentials file will have taken over those in the shared config.
+// the shared config file (~/.aws/config) will also be loaded, in addition to
+// the shared credentials file (~/.aws/config). Values set in both the
+// shared config, and shared credentials will be taken from the shared
+// credentials file.
 //
-// Example:
-//     // Create a Session with the default config and request handlers.
-//     sess := session.New()
+// Deprecated: Use NewSession functiions to create sessions instead. NewSession
+// has the same functionality as New except an error can be returned when the
+// func is called instead of waiting to receive an error until a request is made.
+func New(cfgs ...*aws.Config) *Session {
+	// load initial config from environment
+	envCfg := loadEnvConfig()
+
+	if envCfg.EnableSharedConfig {
+		s, err := newSession(envCfg, cfgs...)
+		if err != nil {
+			// Old session.New expected all errors to be discovered when
+			// a request is made, and would report the errors then. This
+			// needs to be replicated if an error occurs while creating
+			// the session.
+			msg := "failed to create session with AWS_SDK_LOAD_CONFIG enabled. " +
+				"Use session.NewSession to handle errors occuring during session creation."
+
+			// Session creation failed, need to report the error and prevent
+			// any requests from succeeding.
+			s = &Session{Config: defaults.Config()}
+			s.Config.MergeIn(cfgs...)
+			s.Config.Logger.Log("ERROR:", msg, "Error:", err)
+			s.Handlers.Validate.PushBack(func(r *request.Request) {
+				r.Error = err
+			})
+		}
+		return s
+	}
+
+	return oldNewSession(cfgs...)
+}
+
+// NewSession returns a new Session created from SDK defaults, config files,
+// environment, and user provided config files. Once the Session is created
+// it can be mutated to modify the Config or Handlers. The Session is safe to
+// be read concurrently, but it should not be written to concurrently.
 //
-//     // Create a Session with a custom region
-//     sess := session.New(&aws.Config{Region: aws.String("us-east-1")})
+// If the AWS_SDK_LOAD_CONFIG environment variable is set to a truthy value
+// the shared config file (~/.aws/config) will also be loaded in addition to
+// the shared credentials file (~/.aws/config). Values set in both the
+// shared config, and shared credentials will be taken from the shared
+// credentials file. Enabling the Shared Config will also allow the Session
+// to be built with retrieving credentials with AssumeRole set in the config.
 //
-//     // Create a Session, and add additional handlers for all service
-//     // clients created with the Session to inherit. Adds logging handler.
-//     sess := session.New()
-//     sess.Handlers.Send.PushFront(func(r *request.Request) {
-//          // Log every request made and its payload
-//          logger.Println("Request: %s/%s, Payload: %s", r.ClientInfo.ServiceName, r.Operation, r.Params)
+// See the NewSessionWithOptions func for information on how to override or
+// control through code how the Session will be created. Such as specifing the
+// config profile, and controlling if shared config is enabled or not.
+func NewSession(cfgs ...*aws.Config) (*Session, error) {
+	envCfg := loadEnvConfig()
+
+	return newSession(envCfg, cfgs...)
+}
+
+// SharedConfigState provides the ability to optionally override the state
+// of the session's creation based on the shared config being enabled or
+// disabled.
+type SharedConfigState int
+
+const (
+	// SharedConfigStateFromEnv does not override any state of the
+	// AWS_SDK_LOAD_CONFIG env var. It is the default value of the
+	// SharedConfigState type.
+	SharedConfigStateFromEnv SharedConfigState = iota
+
+	// SharedConfigDisable overrides the AWS_SDK_LOAD_CONFIG env var value
+	// and disables the shared config functionality.
+	SharedConfigDisable
+
+	// SharedConfigEnable overrides the AWS_SDK_LOAD_CONFIG env var value
+	// and enables the shared config functionality.
+	SharedConfigEnable
+)
+
+// Options provides the means to control how a Session is created and what
+// configuration values will be loaded.
+//
+type Options struct {
+	// Provides config values for the SDK to use when creating service clients
+	// and making API requests to services. Any value set in with this field
+	// will override the associated value provided by the SDK defaults,
+	// environment or config files where relevent.
+	//
+	// If not set, configuration values from from SDK defaults, environment,
+	// config will be used.
+	Config aws.Config
+
+	// Overrides the config profile the Session should be created from. If not
+	// set the value of the environment variable will be loaded (AWS_PROFILE,
+	// or AWS_DEFAULT_PROFILE if the Shared Config is enabled).
+	//
+	// If not set and environment variables are not set the "default"
+	// (DefaultSharedConfigProfile) will be used as the profile to load the
+	// session config from.
+	Profile string
+
+	// Instructs how the Session will be created based on the AWS_SDK_LOAD_CONFIG
+	// environment variable. By default a Session will be created using the
+	// value provided by the AWS_SDK_LOAD_CONFIG environment variable.
+	//
+	// Setting this value to SharedConfigEnable or SharedConfigDisable
+	// will allow you to override the AWS_SDK_LOAD_CONFIG environment variable
+	// and enable or disable the shared config functionality.
+	SharedConfigState SharedConfigState
+}
+
+// NewSessionWithOptions returns a new Session created from SDK defaults, config files,
+// environment, and user provided config files. This func uses the Options
+// values to configure how the Session is created.
+//
+// If the AWS_SDK_LOAD_CONFIG environment variable is set to a truthy value
+// the shared config file (~/.aws/config) will also be loaded in addition to
+// the shared credentials file (~/.aws/config). Values set in both the
+// shared config, and shared credentials will be taken from the shared
+// credentials file. Enabling the Shared Config will also allow the Session
+// to be built with retrieving credentials with AssumeRole set in the config.
+//
+//     // Equivalent to session.New
+//     sess, err := session.NewSessionWithOptions(session.Optons{})
+//
+//     // Specify profile to load for the session's config
+//     sess, err := session.NewSessionWithOptions(session.Optons{
+//          Profile: "profile_name",
 //     })
 //
-//     // Create a S3 client instance from a Session
-//     sess := session.New()
-//     svc := s3.New(sess)
-func New(cfgs ...*aws.Config) *Session {
-	// Load initial config from environment
+//     // Specify profile for config and region for requests
+//     sess, err := session.NewSessionWithOptions(session.Options{
+//          Config: aws.Config{Region: aws.String("us-east-1")},
+//          Profile: "profile_name",
+//     })
+//
+//     // Force enable Shared Config support
+//     sess, err := session.NewSessionWithOptions(session.Optons{
+//         SharedConfigState: SharedConfigEnable,
+//     })
+func NewSessionWithOptions(opts Options) (*Session, error) {
 	envCfg := loadEnvConfig()
 
-	// Load user's shared config, and passed in config
-	return newSession(envCfg, cfgs...)
+	if len(opts.Profile) > 0 {
+		envCfg.Profile = opts.Profile
+	}
+
+	switch opts.SharedConfigState {
+	case SharedConfigDisable:
+		envCfg.EnableSharedConfig = false
+	case SharedConfigEnable:
+		envCfg.EnableSharedConfig = true
+	}
+
+	return newSession(envCfg, &opts.Config)
 }
 
-// NewFromProfile creates a new Session loading configuration from the SDKs
-// defaults, and credentials from the shared credentials file.
+// Must is a helper function to ensure the Session is valid and there was no
+// error when calling a NewSession function.
 //
-// Uses the profile to configure which profile to load the shared configuration
-// from. This will override the profile specififed in the environment.
+// This helper is intended to be used in variable initialization to load the
+// Session and configuration at startup. Such as:
 //
-// Same as New, but specifies the profile that will be loaded from the shared
-// configuration files. This function also uses the AWS_SDK_LOAD_CONFIG the
-// same as the New function.
-func NewFromProfile(profile string, cfgs ...*aws.Config) *Session {
-	// Load initial config from environment
-	envCfg := loadEnvConfig()
-	envCfg.Profile = profile
+//     var sess = session.Must(session.NewSession())
+func Must(sess *Session, err error) *Session {
+	if err != nil {
+		panic(err)
+	}
 
-	// Load user's shared config, and passed in config
-	return newSession(envCfg, cfgs...)
+	return sess
 }
 
-// NewFromSharedConfig creates a new Session loading configuration from the
-// shared configuration, as a base which the passed in configurations will
-// be merged on top off.
-//
-// Same as New, but loads the configuration as if the AWS_SDK_LOAD_CONFIG
-// environment variable is set.
-func NewFromSharedConfig(cfgs ...*aws.Config) *Session {
-	// Load initial config from environment
-	envCfg := loadSharedEnvConfig()
-
-	// Load user's shared config, and passed in config
-	return newSession(envCfg, cfgs...)
-}
-
-// NewFromSharedConfigProfile creates a new Session loading configuration from
-// the shared configuration, as a base which the passed in configurations will
-// be merged on top off.
-//
-// Uses the profile to configure which profile to load the shared configuration
-// from. This will override the profile specififed in the environment.
-//
-// Same as New, but loads the configuration as if the AWS_SDK_LOAD_CONFIG
-// environment variable is set.
-func NewFromSharedConfigProfile(profile string, cfgs ...*aws.Config) *Session {
-	// Load initial config from environment
-	envCfg := loadSharedEnvConfig()
-	envCfg.Profile = profile
-
-	// Load user's shared config, and passed in config
-	return newSession(envCfg, cfgs...)
-}
-
-func newSession(envCfg envConfig, cfgs ...*aws.Config) *Session {
+func oldNewSession(cfgs ...*aws.Config) *Session {
 	cfg := defaults.Config()
 	handlers := defaults.Handlers()
 
-	// Load user shared config
-	err := loadConfig(envCfg, cfg)
+	// Apply the passed in configs so the configuration can be applied to the
+	// default credential chain
+	cfg.MergeIn(cfgs...)
+	cfg.Credentials = defaults.CredChain(cfg, handlers)
 
-	// Get a merged version of the user provided config to determine if
-	// credentials were.
-	userCfg := aws.Config{}
-	userCfg.MergeIn(cfgs...)
-
-	// Merge in user provided configuration
-	cfg.MergeIn(&userCfg)
-
-	// Need to wait until after the user, shared, and default configs are merged,
-	// so any log options are set to report the error to.
-	if err != nil && cfg.Logger != nil && cfg.LogLevel.Matches(aws.LogDebug) {
-		cfg.Logger.Log("DEBUG: failed to load shared config, error", err)
-	}
-
-	// Set default credential chain if none found in env/shared config, and
-	// not set by the user.
-	if cfg.Credentials == credentials.AnonymousCredentials && userCfg.Credentials == nil {
-		// Use default credentials chain if none in env/shared config
-		cfg.Credentials = defaults.CredChain(cfg, handlers)
-	}
+	// Reapply any passed in configs to override credentials if set
+	cfg.MergeIn(cfgs...)
 
 	s := &Session{
 		Config:   cfg,
@@ -145,7 +229,15 @@ func newSession(envCfg envConfig, cfgs ...*aws.Config) *Session {
 	return s
 }
 
-func loadConfig(envCfg envConfig, cfg *aws.Config) error {
+func newSession(envCfg envConfig, cfgs ...*aws.Config) (*Session, error) {
+	cfg := defaults.Config()
+	handlers := defaults.Handlers()
+
+	// Get a merged version of the user provided config to determine if
+	// credentials were.
+	userCfg := &aws.Config{}
+	userCfg.MergeIn(cfgs...)
+
 	// Order config files will be loaded in with later files overwriting
 	// previous config file values.
 	cfgFiles := []string{envCfg.SharedConfigFile, envCfg.SharedCredentialsFile}
@@ -156,30 +248,74 @@ func loadConfig(envCfg envConfig, cfg *aws.Config) error {
 	}
 
 	// Load additional config from file(s)
-	sharedCfg, err := loadSharedConfig(envCfg.Profile, cfgFiles...)
+	sharedCfg, err := loadSharedConfig(envCfg.Profile, cfgFiles)
 	if err != nil {
-		return err
+		return nil, err
 	}
 
-	// Region
-	if len(envCfg.Region) > 0 {
-		cfg.WithRegion(envCfg.Region)
-	} else if envCfg.EnableSharedConfig && len(sharedCfg.Region) > 0 {
-		cfg.WithRegion(sharedCfg.Region)
+	mergeConfigSrcs(cfg, userCfg, envCfg, sharedCfg, handlers)
+
+	s := &Session{
+		Config:   cfg,
+		Handlers: handlers,
 	}
 
-	// Configure credentials if known
-	if len(envCfg.Creds.AccessKeyID) > 0 {
-		cfg.Credentials = credentials.NewCredentials(
-			&credentials.StaticProvider{Value: envCfg.Creds},
-		)
-	} else if len(sharedCfg.Creds.AccessKeyID) > 0 {
-		cfg.Credentials = credentials.NewCredentials(
-			&credentials.StaticProvider{Value: sharedCfg.Creds},
-		)
+	initHandlers(s)
+
+	return s, nil
+}
+
+func mergeConfigSrcs(cfg, userCfg *aws.Config, envCfg envConfig, sharedCfg sharedConfig, handlers request.Handlers) {
+	// Merge in user provided configuration
+	cfg.MergeIn(userCfg)
+
+	// Region if not already set by user
+	if len(aws.StringValue(cfg.Region)) == 0 {
+		if len(envCfg.Region) > 0 {
+			cfg.WithRegion(envCfg.Region)
+		} else if envCfg.EnableSharedConfig && len(sharedCfg.Region) > 0 {
+			cfg.WithRegion(sharedCfg.Region)
+		}
 	}
 
-	return nil
+	// Configure credentials if not already set
+	if cfg.Credentials == credentials.AnonymousCredentials && userCfg.Credentials == nil {
+		if len(envCfg.Creds.AccessKeyID) > 0 {
+			cfg.Credentials = credentials.NewStaticCredentialsFromCreds(
+				envCfg.Creds,
+			)
+		} else if envCfg.EnableSharedConfig && len(sharedCfg.AssumeRole.RoleARN) > 0 && sharedCfg.AssumeRoleSource != nil {
+			cfgCp := *cfg
+			cfgCp.Credentials = credentials.NewStaticCredentialsFromCreds(
+				sharedCfg.AssumeRoleSource.Creds,
+			)
+			cfg.Credentials = stscreds.NewCredentials(
+				&Session{
+					Config:   &cfgCp,
+					Handlers: handlers.Copy(),
+				},
+				sharedCfg.AssumeRole.RoleARN,
+				func(opt *stscreds.AssumeRoleProvider) {
+					opt.RoleSessionName = sharedCfg.AssumeRole.RoleSessionName
+
+					if len(sharedCfg.AssumeRole.ExternalID) > 0 {
+						opt.ExternalID = aws.String(sharedCfg.AssumeRole.ExternalID)
+					}
+
+					// MFA not supported
+				},
+			)
+		} else if len(sharedCfg.Creds.AccessKeyID) > 0 {
+			cfg.Credentials = credentials.NewStaticCredentialsFromCreds(
+				sharedCfg.Creds,
+			)
+		} else {
+			// Fallback to default credentials provider
+			cfg.Credentials = credentials.NewCredentials(
+				defaults.RemoteCredProvider(*cfg, handlers),
+			)
+		}
+	}
 }
 
 func initHandlers(s *Session) {
@@ -194,7 +330,6 @@ func initHandlers(s *Session) {
 // and handlers. If any additional configs are provided they will be merged
 // on top of the Session's copied config.
 //
-// Example:
 //     // Create a copy of the current Session, configured for the us-west-2 region.
 //     sess.Copy(&aws.Config{Region: aws.String("us-west-2")})
 func (s *Session) Copy(cfgs ...*aws.Config) *Session {
@@ -211,10 +346,6 @@ func (s *Session) Copy(cfgs ...*aws.Config) *Session {
 // ClientConfig satisfies the client.ConfigProvider interface and is used to
 // configure the service client instances. Passing the Session to the service
 // client's constructor (New) will use this method to configure the client.
-//
-// Example:
-//     sess := session.New()
-//     s3.New(sess)
 func (s *Session) ClientConfig(serviceName string, cfgs ...*aws.Config) client.Config {
 	s = s.Copy(cfgs...)
 	endpoint, signingRegion := endpoints.NormalizeEndpoint(

--- a/aws/session/session.go
+++ b/aws/session/session.go
@@ -1,17 +1,10 @@
-// Package session provides a way to create service clients with shared configuration
-// and handlers.
-//
-// Generally this package should be used instead of the `defaults` package.
-//
-// A session should be used to share configurations and request handlers between multiple
-// service clients. When service clients need specific configuration aws.Config can be
-// used to provide additional configuration directly to the service client.
 package session
 
 import (
 	"github.com/aws/aws-sdk-go/aws"
 	"github.com/aws/aws-sdk-go/aws/client"
 	"github.com/aws/aws-sdk-go/aws/corehandlers"
+	"github.com/aws/aws-sdk-go/aws/credentials"
 	"github.com/aws/aws-sdk-go/aws/defaults"
 	"github.com/aws/aws-sdk-go/aws/request"
 	"github.com/aws/aws-sdk-go/private/endpoints"
@@ -21,46 +14,126 @@ import (
 // store configurations and request handlers for those services.
 //
 // Sessions are safe to create service clients concurrently, but it is not safe
-// to mutate the session concurrently.
+// to mutate the Session concurrently.
+//
+// The Session satisfies the service client's client.ClientConfigProvider.
 type Session struct {
 	Config   *aws.Config
 	Handlers request.Handlers
 }
 
-// New creates a new instance of the handlers merging in the provided Configs
-// on top of the SDK's default configurations. Once the session is created it
-// can be mutated to modify Configs or Handlers. The session is safe to be read
+// New creates a new instance of the handlers merging in the provided configs
+// on top of the SDK's default configurations. Once the Session is created it
+// can be mutated to modify Config or Handlers. The Session is safe to be read
 // concurrently, but it should not be written to concurrently.
 //
+// If the AWS_SDK_LOAD_CONFIG environment variable is set to a truthy value
+// the shared config (~/.aws/config) will also be loaded. Values from the shared
+// credentials file will have taken over those in the shared config.
+//
 // Example:
-//     // Create a session with the default config and request handlers.
+//     // Create a Session with the default config and request handlers.
 //     sess := session.New()
 //
-//     // Create a session with a custom region
+//     // Create a Session with a custom region
 //     sess := session.New(&aws.Config{Region: aws.String("us-east-1")})
 //
-//     // Create a session, and add additional handlers for all service
-//     // clients created with the session to inherit. Adds logging handler.
+//     // Create a Session, and add additional handlers for all service
+//     // clients created with the Session to inherit. Adds logging handler.
 //     sess := session.New()
 //     sess.Handlers.Send.PushFront(func(r *request.Request) {
 //          // Log every request made and its payload
 //          logger.Println("Request: %s/%s, Payload: %s", r.ClientInfo.ServiceName, r.Operation, r.Params)
 //     })
 //
-//     // Create a S3 client instance from a session
+//     // Create a S3 client instance from a Session
 //     sess := session.New()
 //     svc := s3.New(sess)
 func New(cfgs ...*aws.Config) *Session {
+	// Load initial config from environment
+	envCfg := loadEnvConfig()
+
+	// Load user's shared config, and passed in config
+	return newSession(envCfg, cfgs...)
+}
+
+// NewFromProfile creates a new Session loading configuration from the SDKs
+// defaults, and credentials from the shared credentials file.
+//
+// Uses the profile to configure which profile to load the shared configuration
+// from. This will override the profile specififed in the environment.
+//
+// Same as New, but specifies the profile that will be loaded from the shared
+// configuration files. This function also uses the AWS_SDK_LOAD_CONFIG the
+// same as the New function.
+func NewFromProfile(profile string, cfgs ...*aws.Config) *Session {
+	// Load initial config from environment
+	envCfg := loadEnvConfig()
+	envCfg.Profile = profile
+
+	// Load user's shared config, and passed in config
+	return newSession(envCfg, cfgs...)
+}
+
+// NewFromSharedConfig creates a new Session loading configuration from the
+// shared configuration, as a base which the passed in configurations will
+// be merged on top off.
+//
+// Same as New, but loads the configuration as if the AWS_SDK_LOAD_CONFIG
+// environment variable is set.
+func NewFromSharedConfig(cfgs ...*aws.Config) *Session {
+	// Load initial config from environment
+	envCfg := loadSharedEnvConfig()
+
+	// Load user's shared config, and passed in config
+	return newSession(envCfg, cfgs...)
+}
+
+// NewFromSharedConfigProfile creates a new Session loading configuration from
+// the shared configuration, as a base which the passed in configurations will
+// be merged on top off.
+//
+// Uses the profile to configure which profile to load the shared configuration
+// from. This will override the profile specififed in the environment.
+//
+// Same as New, but loads the configuration as if the AWS_SDK_LOAD_CONFIG
+// environment variable is set.
+func NewFromSharedConfigProfile(profile string, cfgs ...*aws.Config) *Session {
+	// Load initial config from environment
+	envCfg := loadSharedEnvConfig()
+	envCfg.Profile = profile
+
+	// Load user's shared config, and passed in config
+	return newSession(envCfg, cfgs...)
+}
+
+func newSession(envCfg envConfig, cfgs ...*aws.Config) *Session {
 	cfg := defaults.Config()
 	handlers := defaults.Handlers()
 
-	// Apply the passed in configs so the configuration can be applied to the
-	// default credential chain
-	cfg.MergeIn(cfgs...)
-	cfg.Credentials = defaults.CredChain(cfg, handlers)
+	// Load user shared config
+	err := loadConfig(envCfg, cfg)
 
-	// Reapply any passed in configs to override credentials if set
-	cfg.MergeIn(cfgs...)
+	// Get a merged version of the user provided config to determine if
+	// credentials were.
+	userCfg := aws.Config{}
+	userCfg.MergeIn(cfgs...)
+
+	// Merge in user provided configuration
+	cfg.MergeIn(&userCfg)
+
+	// Need to wait until after the user, shared, and default configs are merged,
+	// so any log options are set to report the error to.
+	if err != nil && cfg.Logger != nil && cfg.LogLevel.Matches(aws.LogDebug) {
+		cfg.Logger.Log("DEBUG: failed to load shared config, error", err)
+	}
+
+	// Set default credential chain if none found in env/shared config, and
+	// not set by the user.
+	if cfg.Credentials == credentials.AnonymousCredentials && userCfg.Credentials == nil {
+		// Use default credentials chain if none in env/shared config
+		cfg.Credentials = defaults.CredChain(cfg, handlers)
+	}
 
 	s := &Session{
 		Config:   cfg,
@@ -72,6 +145,43 @@ func New(cfgs ...*aws.Config) *Session {
 	return s
 }
 
+func loadConfig(envCfg envConfig, cfg *aws.Config) error {
+	// Order config files will be loaded in with later files overwriting
+	// previous config file values.
+	cfgFiles := []string{envCfg.SharedConfigFile, envCfg.SharedCredentialsFile}
+	if !envCfg.EnableSharedConfig {
+		// The shared config file (~/.aws/config) is only loaded if instructed
+		// to load via the envConfig.EnableSharedConfig (AWS_SDK_LOAD_CONFIG).
+		cfgFiles = cfgFiles[1:]
+	}
+
+	// Load additional config from file(s)
+	sharedCfg, err := loadSharedConfig(envCfg.Profile, cfgFiles...)
+	if err != nil {
+		return err
+	}
+
+	// Region
+	if len(envCfg.Region) > 0 {
+		cfg.WithRegion(envCfg.Region)
+	} else if envCfg.EnableSharedConfig && len(sharedCfg.Region) > 0 {
+		cfg.WithRegion(sharedCfg.Region)
+	}
+
+	// Configure credentials if known
+	if len(envCfg.Creds.AccessKeyID) > 0 {
+		cfg.Credentials = credentials.NewCredentials(
+			&credentials.StaticProvider{Value: envCfg.Creds},
+		)
+	} else if len(sharedCfg.Creds.AccessKeyID) > 0 {
+		cfg.Credentials = credentials.NewCredentials(
+			&credentials.StaticProvider{Value: sharedCfg.Creds},
+		)
+	}
+
+	return nil
+}
+
 func initHandlers(s *Session) {
 	// Add the Validate parameter handler if it is not disabled.
 	s.Handlers.Validate.Remove(corehandlers.ValidateParametersHandler)
@@ -80,12 +190,12 @@ func initHandlers(s *Session) {
 	}
 }
 
-// Copy creates and returns a copy of the current session, coping the config
+// Copy creates and returns a copy of the current Session, coping the config
 // and handlers. If any additional configs are provided they will be merged
-// on top of the session's copied config.
+// on top of the Session's copied config.
 //
 // Example:
-//     // Create a copy of the current session, configured for the us-west-2 region.
+//     // Create a copy of the current Session, configured for the us-west-2 region.
 //     sess.Copy(&aws.Config{Region: aws.String("us-west-2")})
 func (s *Session) Copy(cfgs ...*aws.Config) *Session {
 	newSession := &Session{

--- a/aws/session/session_test.go
+++ b/aws/session/session_test.go
@@ -1,20 +1,25 @@
 package session
 
 import (
+	"bytes"
+	"fmt"
 	"net/http"
+	"net/http/httptest"
 	"os"
 	"testing"
+	"time"
 
 	"github.com/stretchr/testify/assert"
 
 	"github.com/aws/aws-sdk-go/aws"
 	"github.com/aws/aws-sdk-go/aws/credentials"
 	"github.com/aws/aws-sdk-go/aws/defaults"
+	"github.com/aws/aws-sdk-go/service/s3"
 )
 
 func TestNewDefaultSession(t *testing.T) {
-	env := stashEnv()
-	defer popEnv(env)
+	oldEnv := initSessionTestEnv()
+	defer popEnv(oldEnv)
 
 	s := New(&aws.Config{Region: aws.String("region")})
 
@@ -25,8 +30,8 @@ func TestNewDefaultSession(t *testing.T) {
 }
 
 func TestNew_WithCustomCreds(t *testing.T) {
-	env := stashEnv()
-	defer popEnv(env)
+	oldEnv := initSessionTestEnv()
+	defer popEnv(oldEnv)
 
 	customCreds := credentials.NewStaticCredentials("AKID", "SECRET", "TOKEN")
 	s := New(&aws.Config{Credentials: customCreds})
@@ -34,9 +39,40 @@ func TestNew_WithCustomCreds(t *testing.T) {
 	assert.Equal(t, customCreds, s.Config.Credentials)
 }
 
+type mockLogger struct {
+	*bytes.Buffer
+}
+
+func (w mockLogger) Log(args ...interface{}) {
+	fmt.Fprintln(w, args...)
+}
+
+func TestNew_WithSessionLoadError(t *testing.T) {
+	oldEnv := initSessionTestEnv()
+	defer popEnv(oldEnv)
+
+	os.Setenv("AWS_SDK_LOAD_CONFIG", "1")
+	os.Setenv("AWS_CONFIG_FILE", testConfigFilename)
+	os.Setenv("AWS_PROFILE", "assume_role_invalid_source_profile")
+
+	logger := bytes.Buffer{}
+	s := New(&aws.Config{Logger: &mockLogger{&logger}})
+
+	assert.NotNil(t, s)
+
+	svc := s3.New(s)
+	_, err := svc.ListBuckets(&s3.ListBucketsInput{})
+
+	assert.Error(t, err)
+	assert.Contains(t, logger.String(), "ERROR: failed to create session with AWS_SDK_LOAD_CONFIG enabled")
+	assert.Contains(t, err.Error(), SharedConfigAssumeRoleError{
+		RoleARN: "assume_role_invalid_source_profile_role_arn",
+	}.Error())
+}
+
 func TestSessionCopy(t *testing.T) {
-	env := stashEnv()
-	defer popEnv(env)
+	oldEnv := initSessionTestEnv()
+	defer popEnv(oldEnv)
 
 	os.Setenv("AWS_REGION", "orig_region")
 
@@ -52,7 +88,8 @@ func TestSessionCopy(t *testing.T) {
 }
 
 func TestSessionClientConfig(t *testing.T) {
-	s := New(&aws.Config{Region: aws.String("orig_region")})
+	s, err := NewSession(&aws.Config{Region: aws.String("orig_region")})
+	assert.NoError(t, err)
 
 	cfg := s.ClientConfig("s3", &aws.Config{Region: aws.String("us-west-2")})
 
@@ -61,14 +98,75 @@ func TestSessionClientConfig(t *testing.T) {
 	assert.Equal(t, "us-west-2", *cfg.Config.Region)
 }
 
-func TestNewFromProfile(t *testing.T) {
-	env := stashEnv()
-	defer popEnv(env)
+func TestNewSession_NoCredentials(t *testing.T) {
+	oldEnv := initSessionTestEnv()
+	defer popEnv(oldEnv)
 
+	s, err := NewSession()
+	assert.NoError(t, err)
+
+	assert.NotNil(t, s.Config.Credentials)
+	assert.NotEqual(t, credentials.AnonymousCredentials, s.Config.Credentials)
+}
+
+func TestNewSessionWithOptions_OverrideProfile(t *testing.T) {
+	oldEnv := initSessionTestEnv()
+	defer popEnv(oldEnv)
+
+	os.Setenv("AWS_SDK_LOAD_CONFIG", "1")
 	os.Setenv("AWS_SHARED_CREDENTIALS_FILE", testConfigFilename)
 	os.Setenv("AWS_PROFILE", "other_profile")
 
-	s := NewFromProfile("full_profile")
+	s, err := NewSessionWithOptions(Options{
+		Profile: "full_profile",
+	})
+	assert.NoError(t, err)
+
+	assert.Equal(t, "full_profile_region", *s.Config.Region)
+
+	creds, err := s.Config.Credentials.Get()
+	assert.NoError(t, err)
+	assert.Equal(t, "full_profile_akid", creds.AccessKeyID)
+	assert.Equal(t, "full_profile_secret", creds.SecretAccessKey)
+	assert.Empty(t, creds.SessionToken)
+	assert.Contains(t, creds.ProviderName, "SharedConfigCredentials")
+}
+
+func TestNewSessionWithOptions_OverrideSharedConfigEnable(t *testing.T) {
+	oldEnv := initSessionTestEnv()
+	defer popEnv(oldEnv)
+
+	os.Setenv("AWS_SDK_LOAD_CONFIG", "0")
+	os.Setenv("AWS_SHARED_CREDENTIALS_FILE", testConfigFilename)
+	os.Setenv("AWS_PROFILE", "full_profile")
+
+	s, err := NewSessionWithOptions(Options{
+		SharedConfigState: SharedConfigEnable,
+	})
+	assert.NoError(t, err)
+
+	assert.Equal(t, "full_profile_region", *s.Config.Region)
+
+	creds, err := s.Config.Credentials.Get()
+	assert.NoError(t, err)
+	assert.Equal(t, "full_profile_akid", creds.AccessKeyID)
+	assert.Equal(t, "full_profile_secret", creds.SecretAccessKey)
+	assert.Empty(t, creds.SessionToken)
+	assert.Contains(t, creds.ProviderName, "SharedConfigCredentials")
+}
+
+func TestNewSessionWithOptions_OverrideSharedConfigDisable(t *testing.T) {
+	oldEnv := initSessionTestEnv()
+	defer popEnv(oldEnv)
+
+	os.Setenv("AWS_SDK_LOAD_CONFIG", "1")
+	os.Setenv("AWS_SHARED_CREDENTIALS_FILE", testConfigFilename)
+	os.Setenv("AWS_PROFILE", "full_profile")
+
+	s, err := NewSessionWithOptions(Options{
+		SharedConfigState: SharedConfigDisable,
+	})
+	assert.NoError(t, err)
 
 	assert.Empty(t, *s.Config.Region)
 
@@ -80,47 +178,7 @@ func TestNewFromProfile(t *testing.T) {
 	assert.Contains(t, creds.ProviderName, "SharedConfigCredentials")
 }
 
-func TestNewFromProfile_WithSharedConfig(t *testing.T) {
-	env := stashEnv()
-	defer popEnv(env)
-
-	os.Setenv("AWS_SDK_LOAD_CONFIG", "1")
-	os.Setenv("AWS_SHARED_CREDENTIALS_FILE", testConfigFilename)
-	os.Setenv("AWS_PROFILE", "other_profile")
-
-	s := NewFromProfile("full_profile")
-
-	assert.Equal(t, "full_profile_region", *s.Config.Region)
-
-	creds, err := s.Config.Credentials.Get()
-	assert.NoError(t, err)
-	assert.Equal(t, "full_profile_akid", creds.AccessKeyID)
-	assert.Equal(t, "full_profile_secret", creds.SecretAccessKey)
-	assert.Empty(t, creds.SessionToken)
-	assert.Contains(t, creds.ProviderName, "SharedConfigCredentials")
-}
-
-func TestNewFromSharedConfig(t *testing.T) {
-	env := stashEnv()
-	defer popEnv(env)
-
-	os.Setenv("AWS_SDK_LOAD_CONFIG", "0")
-	os.Setenv("AWS_SHARED_CREDENTIALS_FILE", testConfigFilename)
-	os.Setenv("AWS_PROFILE", "full_profile")
-
-	s := NewFromSharedConfig()
-
-	assert.Equal(t, "full_profile_region", *s.Config.Region)
-
-	creds, err := s.Config.Credentials.Get()
-	assert.NoError(t, err)
-	assert.Equal(t, "full_profile_akid", creds.AccessKeyID)
-	assert.Equal(t, "full_profile_secret", creds.SecretAccessKey)
-	assert.Empty(t, creds.SessionToken)
-	assert.Contains(t, creds.ProviderName, "SharedConfigCredentials")
-}
-
-func TestNewFromSharedConfigProfile(t *testing.T) {
+func TestNewSessionWithOptions_Overrides(t *testing.T) {
 	cases := []struct {
 		InEnvs    map[string]string
 		InProfile string
@@ -162,7 +220,7 @@ func TestNewFromSharedConfigProfile(t *testing.T) {
 			InEnvs: map[string]string{
 				"AWS_SDK_LOAD_CONFIG":         "0",
 				"AWS_SHARED_CREDENTIALS_FILE": testConfigFilename,
-				"AWS_SHARED_CONFIG_FILE":      testConfigOtherFilename,
+				"AWS_CONFIG_FILE":             testConfigOtherFilename,
 				"AWS_PROFILE":                 "shared_profile",
 			},
 			InProfile: "config_file_load_order",
@@ -176,14 +234,18 @@ func TestNewFromSharedConfigProfile(t *testing.T) {
 	}
 
 	for _, c := range cases {
-		env := stashEnv()
-		defer popEnv(env)
+		oldEnv := initSessionTestEnv()
+		defer popEnv(oldEnv)
 
 		for k, v := range c.InEnvs {
 			os.Setenv(k, v)
 		}
 
-		s := NewFromSharedConfigProfile(c.InProfile)
+		s, err := NewSessionWithOptions(Options{
+			Profile:           c.InProfile,
+			SharedConfigState: SharedConfigEnable,
+		})
+		assert.NoError(t, err)
 
 		creds, err := s.Config.Credentials.Get()
 		assert.NoError(t, err)
@@ -193,4 +255,90 @@ func TestNewFromSharedConfigProfile(t *testing.T) {
 		assert.Equal(t, c.OutCreds.SessionToken, creds.SessionToken)
 		assert.Contains(t, creds.ProviderName, c.OutCreds.ProviderName)
 	}
+}
+
+func TestSesisonAssumeRole(t *testing.T) {
+	oldEnv := initSessionTestEnv()
+	defer popEnv(oldEnv)
+
+	os.Setenv("AWS_REGION", "us-east-1")
+	os.Setenv("AWS_SDK_LOAD_CONFIG", "1")
+	os.Setenv("AWS_SHARED_CREDENTIALS_FILE", testConfigFilename)
+	os.Setenv("AWS_PROFILE", "assume_role_w_creds")
+
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		const respMsg = `
+<AssumeRoleResponse xmlns="https://sts.amazonaws.com/doc/2011-06-15/">
+  <AssumeRoleResult>
+    <AssumedRoleUser>
+      <Arn>arn:aws:sts::account_id:assumed-role/role/session_name</Arn>
+      <AssumedRoleId>AKID:session_name</AssumedRoleId>
+    </AssumedRoleUser>
+    <Credentials>
+      <AccessKeyId>AKID</AccessKeyId>
+      <SecretAccessKey>SECRET</SecretAccessKey>
+      <SessionToken>SESSION_TOKEN</SessionToken>
+      <Expiration>%s</Expiration>
+    </Credentials>
+  </AssumeRoleResult>
+  <ResponseMetadata>
+    <RequestId>request-id</RequestId>
+  </ResponseMetadata>
+</AssumeRoleResponse>
+`
+		w.Write([]byte(fmt.Sprintf(respMsg, time.Now().Add(15*time.Minute).Format("2006-01-02T15:04:05Z"))))
+	}))
+
+	s, err := NewSession(&aws.Config{Endpoint: aws.String(server.URL), DisableSSL: aws.Bool(true)})
+
+	creds, err := s.Config.Credentials.Get()
+	assert.NoError(t, err)
+	assert.Equal(t, "AKID", creds.AccessKeyID)
+	assert.Equal(t, "SECRET", creds.SecretAccessKey)
+	assert.Equal(t, "SESSION_TOKEN", creds.SessionToken)
+	assert.Contains(t, creds.ProviderName, "AssumeRoleProvider")
+}
+
+func TestSessionAssumeRole_DisableSharedConfig(t *testing.T) {
+	// Backwards compatibility with Shared config disabled
+	// assume role should not be built into the config.
+	oldEnv := initSessionTestEnv()
+	defer popEnv(oldEnv)
+
+	os.Setenv("AWS_SDK_LOAD_CONFIG", "0")
+	os.Setenv("AWS_SHARED_CREDENTIALS_FILE", testConfigFilename)
+	os.Setenv("AWS_PROFILE", "assume_role_w_creds")
+
+	s, err := NewSession()
+	assert.NoError(t, err)
+
+	creds, err := s.Config.Credentials.Get()
+	assert.NoError(t, err)
+	assert.Equal(t, "assume_role_w_creds_akid", creds.AccessKeyID)
+	assert.Equal(t, "assume_role_w_creds_secret", creds.SecretAccessKey)
+	assert.Contains(t, creds.ProviderName, "SharedConfigCredentials")
+}
+
+func TestSessionAssumeRole_InvalidSourceProfile(t *testing.T) {
+	// Backwards compatibility with Shared config disabled
+	// assume role should not be built into the config.
+	oldEnv := initSessionTestEnv()
+	defer popEnv(oldEnv)
+
+	os.Setenv("AWS_SDK_LOAD_CONFIG", "1")
+	os.Setenv("AWS_SHARED_CREDENTIALS_FILE", testConfigFilename)
+	os.Setenv("AWS_PROFILE", "assume_role_invalid_source_profile")
+
+	s, err := NewSession()
+	assert.Error(t, err)
+	assert.Contains(t, err.Error(), "SharedConfigAssumeRoleError: failed to load assume role")
+	assert.Nil(t, s)
+}
+
+func initSessionTestEnv() (oldEnv []string) {
+	oldEnv = stashEnv()
+	os.Setenv("AWS_CONFIG_FILE", "file_not_exists")
+	os.Setenv("AWS_SHARED_CREDENTIALS_FILE", "file_not_exists")
+
+	return oldEnv
 }

--- a/aws/session/session_test.go
+++ b/aws/session/session_test.go
@@ -1,20 +1,196 @@
-package session_test
+package session
 
 import (
 	"net/http"
+	"os"
 	"testing"
 
 	"github.com/stretchr/testify/assert"
 
 	"github.com/aws/aws-sdk-go/aws"
-	"github.com/aws/aws-sdk-go/aws/session"
+	"github.com/aws/aws-sdk-go/aws/credentials"
+	"github.com/aws/aws-sdk-go/aws/defaults"
 )
 
 func TestNewDefaultSession(t *testing.T) {
-	s := session.New(&aws.Config{Region: aws.String("region")})
+	env := stashEnv()
+	defer popEnv(env)
+
+	s := New(&aws.Config{Region: aws.String("region")})
 
 	assert.Equal(t, "region", *s.Config.Region)
 	assert.Equal(t, http.DefaultClient, s.Config.HTTPClient)
 	assert.NotNil(t, s.Config.Logger)
 	assert.Equal(t, aws.LogOff, *s.Config.LogLevel)
+}
+
+func TestNew_WithCustomCreds(t *testing.T) {
+	env := stashEnv()
+	defer popEnv(env)
+
+	customCreds := credentials.NewStaticCredentials("AKID", "SECRET", "TOKEN")
+	s := New(&aws.Config{Credentials: customCreds})
+
+	assert.Equal(t, customCreds, s.Config.Credentials)
+}
+
+func TestSessionCopy(t *testing.T) {
+	env := stashEnv()
+	defer popEnv(env)
+
+	os.Setenv("AWS_REGION", "orig_region")
+
+	s := Session{
+		Config:   defaults.Config(),
+		Handlers: defaults.Handlers(),
+	}
+
+	newSess := s.Copy(&aws.Config{Region: aws.String("new_region")})
+
+	assert.Equal(t, "orig_region", *s.Config.Region)
+	assert.Equal(t, "new_region", *newSess.Config.Region)
+}
+
+func TestSessionClientConfig(t *testing.T) {
+	s := New(&aws.Config{Region: aws.String("orig_region")})
+
+	cfg := s.ClientConfig("s3", &aws.Config{Region: aws.String("us-west-2")})
+
+	assert.Equal(t, "https://s3-us-west-2.amazonaws.com", cfg.Endpoint)
+	assert.Empty(t, cfg.SigningRegion)
+	assert.Equal(t, "us-west-2", *cfg.Config.Region)
+}
+
+func TestNewFromProfile(t *testing.T) {
+	env := stashEnv()
+	defer popEnv(env)
+
+	os.Setenv("AWS_SHARED_CREDENTIALS_FILE", testConfigFilename)
+	os.Setenv("AWS_PROFILE", "other_profile")
+
+	s := NewFromProfile("full_profile")
+
+	assert.Empty(t, *s.Config.Region)
+
+	creds, err := s.Config.Credentials.Get()
+	assert.NoError(t, err)
+	assert.Equal(t, "full_profile_akid", creds.AccessKeyID)
+	assert.Equal(t, "full_profile_secret", creds.SecretAccessKey)
+	assert.Empty(t, creds.SessionToken)
+	assert.Contains(t, creds.ProviderName, "SharedConfigCredentials")
+}
+
+func TestNewFromProfile_WithSharedConfig(t *testing.T) {
+	env := stashEnv()
+	defer popEnv(env)
+
+	os.Setenv("AWS_SDK_LOAD_CONFIG", "1")
+	os.Setenv("AWS_SHARED_CREDENTIALS_FILE", testConfigFilename)
+	os.Setenv("AWS_PROFILE", "other_profile")
+
+	s := NewFromProfile("full_profile")
+
+	assert.Equal(t, "full_profile_region", *s.Config.Region)
+
+	creds, err := s.Config.Credentials.Get()
+	assert.NoError(t, err)
+	assert.Equal(t, "full_profile_akid", creds.AccessKeyID)
+	assert.Equal(t, "full_profile_secret", creds.SecretAccessKey)
+	assert.Empty(t, creds.SessionToken)
+	assert.Contains(t, creds.ProviderName, "SharedConfigCredentials")
+}
+
+func TestNewFromSharedConfig(t *testing.T) {
+	env := stashEnv()
+	defer popEnv(env)
+
+	os.Setenv("AWS_SDK_LOAD_CONFIG", "0")
+	os.Setenv("AWS_SHARED_CREDENTIALS_FILE", testConfigFilename)
+	os.Setenv("AWS_PROFILE", "full_profile")
+
+	s := NewFromSharedConfig()
+
+	assert.Equal(t, "full_profile_region", *s.Config.Region)
+
+	creds, err := s.Config.Credentials.Get()
+	assert.NoError(t, err)
+	assert.Equal(t, "full_profile_akid", creds.AccessKeyID)
+	assert.Equal(t, "full_profile_secret", creds.SecretAccessKey)
+	assert.Empty(t, creds.SessionToken)
+	assert.Contains(t, creds.ProviderName, "SharedConfigCredentials")
+}
+
+func TestNewFromSharedConfigProfile(t *testing.T) {
+	cases := []struct {
+		InEnvs    map[string]string
+		InProfile string
+		OutRegion string
+		OutCreds  credentials.Value
+	}{
+		{
+			InEnvs: map[string]string{
+				"AWS_SDK_LOAD_CONFIG":         "0",
+				"AWS_SHARED_CREDENTIALS_FILE": testConfigFilename,
+				"AWS_PROFILE":                 "other_profile",
+			},
+			InProfile: "full_profile",
+			OutRegion: "full_profile_region",
+			OutCreds: credentials.Value{
+				AccessKeyID:     "full_profile_akid",
+				SecretAccessKey: "full_profile_secret",
+				ProviderName:    "SharedConfigCredentials",
+			},
+		},
+		{
+			InEnvs: map[string]string{
+				"AWS_SDK_LOAD_CONFIG":         "0",
+				"AWS_SHARED_CREDENTIALS_FILE": testConfigFilename,
+				"AWS_REGION":                  "env_region",
+				"AWS_ACCESS_KEY":              "env_akid",
+				"AWS_SECRET_ACCESS_KEY":       "env_secret",
+				"AWS_PROFILE":                 "other_profile",
+			},
+			InProfile: "full_profile",
+			OutRegion: "env_region",
+			OutCreds: credentials.Value{
+				AccessKeyID:     "env_akid",
+				SecretAccessKey: "env_secret",
+				ProviderName:    "EnvConfigCredentials",
+			},
+		},
+		{
+			InEnvs: map[string]string{
+				"AWS_SDK_LOAD_CONFIG":         "0",
+				"AWS_SHARED_CREDENTIALS_FILE": testConfigFilename,
+				"AWS_SHARED_CONFIG_FILE":      testConfigOtherFilename,
+				"AWS_PROFILE":                 "shared_profile",
+			},
+			InProfile: "config_file_load_order",
+			OutRegion: "shared_config_region",
+			OutCreds: credentials.Value{
+				AccessKeyID:     "shared_config_akid",
+				SecretAccessKey: "shared_config_secret",
+				ProviderName:    "SharedConfigCredentials",
+			},
+		},
+	}
+
+	for _, c := range cases {
+		env := stashEnv()
+		defer popEnv(env)
+
+		for k, v := range c.InEnvs {
+			os.Setenv(k, v)
+		}
+
+		s := NewFromSharedConfigProfile(c.InProfile)
+
+		creds, err := s.Config.Credentials.Get()
+		assert.NoError(t, err)
+		assert.Equal(t, c.OutRegion, *s.Config.Region)
+		assert.Equal(t, c.OutCreds.AccessKeyID, creds.AccessKeyID)
+		assert.Equal(t, c.OutCreds.SecretAccessKey, creds.SecretAccessKey)
+		assert.Equal(t, c.OutCreds.SessionToken, creds.SessionToken)
+		assert.Contains(t, creds.ProviderName, c.OutCreds.ProviderName)
+	}
 }

--- a/aws/session/shared_config.go
+++ b/aws/session/shared_config.go
@@ -1,0 +1,120 @@
+package session
+
+import (
+	"fmt"
+	"os"
+
+	"github.com/aws/aws-sdk-go/aws/awserr"
+	"github.com/aws/aws-sdk-go/aws/credentials"
+	"github.com/go-ini/ini"
+)
+
+const (
+	accessKeyIDKey  = `aws_access_key_id`
+	secretAccessKey = `aws_secret_access_key`
+	sessionTokenKey = `aws_session_token`
+
+	regionKey = `region`
+
+	// DefaultSharedConfigProfile is the default profile to be used when
+	// loading configuration from the shared configuration files if another
+	// profile name is not provided.
+	DefaultSharedConfigProfile = `default`
+)
+
+// sharedConfig represents the configuration fields of the shared configuration
+// files.
+type sharedConfig struct {
+	// Credentials values from the shared configuration file. Both aws_access_key_id
+	// and aws_secret_access_key must be provided together in the same file
+	// to be considered valid. The values will be ignored if not a complete group.
+	// aws_session_token is an optional field that can be provided if both of the
+	// other two fields are also provided.
+	//
+	//	aws_access_key_id
+	//	aws_secret_access_key
+	//	aws_session_token
+	Creds credentials.Value
+
+	// Region is the region the SDK should use for looking up AWS service endpoints
+	// and signing requests.
+	//
+	//	region
+	Region string
+}
+
+// loadSharedConfig retrieves the shared configuration from the list of files
+// using the profile provided. The order the files are listed will determine
+// precedence. Values in subsequent files will overwrite values defined in
+// earlier files.
+//
+// For example, given two files A and B. Both define credentials. If the order
+// of the files are A then B, B's credential values will be used instead of A's.
+//
+// See sharedConfig.setFromFile for information how the shared config files
+// will be loaded.
+func loadSharedConfig(profile string, configFiles ...string) (sharedConfig, error) {
+	if len(profile) == 0 {
+		profile = DefaultSharedConfigProfile
+	}
+
+	cfg := sharedConfig{}
+	for _, filename := range configFiles {
+		if _, err := os.Stat(filename); os.IsNotExist(err) {
+			// Ignore config files that don't exist.
+			continue
+		}
+
+		if err := cfg.setFromFile(profile, filename); err != nil {
+			return sharedConfig{}, err
+		}
+	}
+
+	return cfg, nil
+}
+
+// setFromFile loads the shared configuration from the file using
+// the profile provided. A sharedConfig pointer type value is used so that
+// multiple shared config file loadings can be chained.
+//
+// Only loads complete logically grouped values, and will not set fields in cfg
+// for incomplete grouped values in the config. Such as credentials. For example
+// if a config file only includes aws_access_key_id but no aws_secret_access_key
+// the aws_access_key_id will be ignored.
+func (cfg *sharedConfig) setFromFile(profile, filename string) error {
+	file, err := ini.Load(filename)
+	if err != nil {
+		return awserr.New("LoadSharedConfigError",
+			"failed to load shared config file.", err)
+	}
+
+	section, err := file.GetSection(profile)
+	if err != nil {
+		// Fallback to to alternate profile name: profile %s
+		section, err = file.GetSection(fmt.Sprintf("profile %s", profile))
+		if err != nil {
+			return awserr.New("LoadSharedConfigError",
+				fmt.Sprintf("failed to get profile %s.", profile), err)
+		}
+	}
+
+	// Credentials
+	creds := credentials.Value{
+		AccessKeyID:     section.Key(accessKeyIDKey).String(),
+		SecretAccessKey: section.Key(secretAccessKey).String(),
+		SessionToken:    section.Key(sessionTokenKey).String(),
+		ProviderName:    fmt.Sprintf("SharedConfigCredentials: %s", filename),
+	}
+
+	// Require logical grouping of credentials
+	if len(creds.AccessKeyID) > 0 && len(creds.SecretAccessKey) > 0 {
+		cfg.Creds = creds
+	}
+
+	// Region
+	if v := section.Key(regionKey).String(); len(v) > 0 {
+		cfg.Region = v
+	}
+
+	return nil
+}

--- a/aws/session/shared_config_test.go
+++ b/aws/session/shared_config_test.go
@@ -1,0 +1,146 @@
+package session
+
+import (
+	"fmt"
+	"path/filepath"
+	"testing"
+
+	"github.com/aws/aws-sdk-go/aws/credentials"
+	"github.com/stretchr/testify/assert"
+)
+
+var (
+	testConfigFilename      = filepath.Join("testdata", "shared_config")
+	testConfigOtherFilename = filepath.Join("testdata", "shared_config_other")
+)
+
+func TestLoadSharedConfigFromFile(t *testing.T) {
+	cases := []struct {
+		Filename    string
+		Profile     string
+		Expected    sharedConfig
+		ErrContains string
+	}{
+		{
+			Filename: testConfigFilename, Profile: "default",
+			Expected: sharedConfig{Region: "default_region"},
+		},
+		{
+			Filename: testConfigFilename, Profile: "alt_profile_name",
+			Expected: sharedConfig{Region: "alt_profile_name_region"},
+		},
+		{
+			Filename: testConfigFilename, Profile: "short_profile_name_first",
+			Expected: sharedConfig{Region: "short_profile_name_first_short"},
+		},
+		{
+			Filename: testConfigFilename, Profile: "partial_creds",
+			Expected: sharedConfig{},
+		},
+		{
+			Filename: testConfigFilename, Profile: "complete_creds",
+			Expected: sharedConfig{
+				Creds: credentials.Value{
+					AccessKeyID:     "complete_creds_akid",
+					SecretAccessKey: "complete_creds_secret",
+					ProviderName:    fmt.Sprintf("SharedConfigCredentials: %s", testConfigFilename),
+				},
+			},
+		},
+		{
+			Filename: testConfigFilename, Profile: "complete_creds_with_token",
+			Expected: sharedConfig{
+				Creds: credentials.Value{
+					AccessKeyID:     "complete_creds_with_token_akid",
+					SecretAccessKey: "complete_creds_with_token_secret",
+					SessionToken:    "complete_creds_with_token_token",
+					ProviderName:    fmt.Sprintf("SharedConfigCredentials: %s", testConfigFilename),
+				},
+			},
+		},
+		{
+			Filename: testConfigFilename, Profile: "full_profile",
+			Expected: sharedConfig{
+				Creds: credentials.Value{
+					AccessKeyID:     "full_profile_akid",
+					SecretAccessKey: "full_profile_secret",
+					ProviderName:    fmt.Sprintf("SharedConfigCredentials: %s", testConfigFilename),
+				},
+				Region: "full_profile_region",
+			},
+		},
+	}
+
+	for _, c := range cases {
+		cfg := sharedConfig{}
+
+		err := cfg.setFromFile(c.Profile, c.Filename)
+		if len(c.ErrContains) > 0 {
+			assert.Error(t, err)
+			assert.Contains(t, err, c.ErrContains)
+			continue
+		}
+
+		assert.NoError(t, err)
+	}
+}
+
+func TestLoadSharedConfig(t *testing.T) {
+	cases := []struct {
+		Filenames   []string
+		Profile     string
+		Expected    sharedConfig
+		ErrContains string
+	}{
+		{
+			Filenames: []string{"file_not_exists"},
+			Profile:   "default",
+		},
+		{
+			Filenames: []string{testConfigFilename},
+			Expected: sharedConfig{
+				Region: "default_region",
+			},
+		},
+		{
+			Filenames: []string{testConfigOtherFilename, testConfigFilename},
+			Profile:   "config_file_load_order",
+			Expected: sharedConfig{
+				Region: "shared_config_region",
+				Creds: credentials.Value{
+					AccessKeyID:     "shared_config_akid",
+					SecretAccessKey: "shared_config_secret",
+					ProviderName:    "SharedConfigCredentials",
+				},
+			},
+		},
+		{
+			Filenames: []string{testConfigFilename, testConfigOtherFilename},
+			Profile:   "config_file_load_order",
+			Expected: sharedConfig{
+				Region: "shared_config_other_region",
+				Creds: credentials.Value{
+					AccessKeyID:     "shared_config_other_akid",
+					SecretAccessKey: "shared_config_other_secret",
+					ProviderName:    "SharedConfigCredentials",
+				},
+			},
+		},
+	}
+
+	for _, c := range cases {
+		cfg, err := loadSharedConfig(c.Profile, c.Filenames...)
+		if len(c.ErrContains) > 0 {
+			assert.Error(t, err)
+			assert.Contains(t, err, c.ErrContains)
+			continue
+		}
+
+		assert.NoError(t, err)
+
+		assert.Contains(t, cfg.Creds.ProviderName, c.Expected.Creds.ProviderName)
+		cfg.Creds.ProviderName = c.Expected.Creds.ProviderName
+
+		assert.Equal(t, c.Expected, cfg)
+	}
+}

--- a/aws/session/shared_config_test.go
+++ b/aws/session/shared_config_test.go
@@ -6,6 +6,7 @@ import (
 	"testing"
 
 	"github.com/aws/aws-sdk-go/aws/credentials"
+	"github.com/go-ini/ini"
 	"github.com/stretchr/testify/assert"
 )
 
@@ -14,83 +15,12 @@ var (
 	testConfigOtherFilename = filepath.Join("testdata", "shared_config_other")
 )
 
-func TestLoadSharedConfigFromFile(t *testing.T) {
-	cases := []struct {
-		Filename    string
-		Profile     string
-		Expected    sharedConfig
-		ErrContains string
-	}{
-		{
-			Filename: testConfigFilename, Profile: "default",
-			Expected: sharedConfig{Region: "default_region"},
-		},
-		{
-			Filename: testConfigFilename, Profile: "alt_profile_name",
-			Expected: sharedConfig{Region: "alt_profile_name_region"},
-		},
-		{
-			Filename: testConfigFilename, Profile: "short_profile_name_first",
-			Expected: sharedConfig{Region: "short_profile_name_first_short"},
-		},
-		{
-			Filename: testConfigFilename, Profile: "partial_creds",
-			Expected: sharedConfig{},
-		},
-		{
-			Filename: testConfigFilename, Profile: "complete_creds",
-			Expected: sharedConfig{
-				Creds: credentials.Value{
-					AccessKeyID:     "complete_creds_akid",
-					SecretAccessKey: "complete_creds_secret",
-					ProviderName:    fmt.Sprintf("SharedConfigCredentials: %s", testConfigFilename),
-				},
-			},
-		},
-		{
-			Filename: testConfigFilename, Profile: "complete_creds_with_token",
-			Expected: sharedConfig{
-				Creds: credentials.Value{
-					AccessKeyID:     "complete_creds_with_token_akid",
-					SecretAccessKey: "complete_creds_with_token_secret",
-					SessionToken:    "complete_creds_with_token_token",
-					ProviderName:    fmt.Sprintf("SharedConfigCredentials: %s", testConfigFilename),
-				},
-			},
-		},
-		{
-			Filename: testConfigFilename, Profile: "full_profile",
-			Expected: sharedConfig{
-				Creds: credentials.Value{
-					AccessKeyID:     "full_profile_akid",
-					SecretAccessKey: "full_profile_secret",
-					ProviderName:    fmt.Sprintf("SharedConfigCredentials: %s", testConfigFilename),
-				},
-				Region: "full_profile_region",
-			},
-		},
-	}
-
-	for _, c := range cases {
-		cfg := sharedConfig{}
-
-		err := cfg.setFromFile(c.Profile, c.Filename)
-		if len(c.ErrContains) > 0 {
-			assert.Error(t, err)
-			assert.Contains(t, err, c.ErrContains)
-			continue
-		}
-
-		assert.NoError(t, err)
-	}
-}
-
 func TestLoadSharedConfig(t *testing.T) {
 	cases := []struct {
-		Filenames   []string
-		Profile     string
-		Expected    sharedConfig
-		ErrContains string
+		Filenames []string
+		Profile   string
+		Expected  sharedConfig
+		Err       error
 	}{
 		{
 			Filenames: []string{"file_not_exists"},
@@ -110,7 +40,7 @@ func TestLoadSharedConfig(t *testing.T) {
 				Creds: credentials.Value{
 					AccessKeyID:     "shared_config_akid",
 					SecretAccessKey: "shared_config_secret",
-					ProviderName:    "SharedConfigCredentials",
+					ProviderName:    fmt.Sprintf("SharedConfigCredentials: %s", testConfigFilename),
 				},
 			},
 		},
@@ -122,25 +52,213 @@ func TestLoadSharedConfig(t *testing.T) {
 				Creds: credentials.Value{
 					AccessKeyID:     "shared_config_other_akid",
 					SecretAccessKey: "shared_config_other_secret",
-					ProviderName:    "SharedConfigCredentials",
+					ProviderName:    fmt.Sprintf("SharedConfigCredentials: %s", testConfigOtherFilename),
 				},
+			},
+		},
+		{
+			Filenames: []string{testConfigOtherFilename, testConfigFilename},
+			Profile:   "assume_role",
+			Expected: sharedConfig{
+				AssumeRole: assumeRoleConfig{
+					RoleARN:       "assume_role_role_arn",
+					SourceProfile: "complete_creds",
+				},
+				AssumeRoleSource: &sharedConfig{
+					Creds: credentials.Value{
+						AccessKeyID:     "complete_creds_akid",
+						SecretAccessKey: "complete_creds_secret",
+						ProviderName:    fmt.Sprintf("SharedConfigCredentials: %s", testConfigFilename),
+					},
+				},
+			},
+		},
+		{
+			Filenames: []string{testConfigOtherFilename, testConfigFilename},
+			Profile:   "assume_role_invalid_source_profile",
+			Expected: sharedConfig{
+				AssumeRole: assumeRoleConfig{
+					RoleARN:       "assume_role_invalid_source_profile_role_arn",
+					SourceProfile: "profile_not_exists",
+				},
+			},
+			Err: SharedConfigAssumeRoleError{RoleARN: "assume_role_invalid_source_profile_role_arn"},
+		},
+		{
+			Filenames: []string{testConfigOtherFilename, testConfigFilename},
+			Profile:   "assume_role_w_creds",
+			Expected: sharedConfig{
+				Creds: credentials.Value{
+					AccessKeyID:     "assume_role_w_creds_akid",
+					SecretAccessKey: "assume_role_w_creds_secret",
+					ProviderName:    fmt.Sprintf("SharedConfigCredentials: %s", testConfigFilename),
+				},
+				AssumeRole: assumeRoleConfig{
+					RoleARN:         "assume_role_w_creds_role_arn",
+					SourceProfile:   "assume_role_w_creds",
+					ExternalID:      "1234",
+					RoleSessionName: "assume_role_w_creds_session_name",
+				},
+				AssumeRoleSource: &sharedConfig{
+					Creds: credentials.Value{
+						AccessKeyID:     "assume_role_w_creds_akid",
+						SecretAccessKey: "assume_role_w_creds_secret",
+						ProviderName:    fmt.Sprintf("SharedConfigCredentials: %s", testConfigFilename),
+					},
+				},
+			},
+		},
+		{
+			Filenames: []string{testConfigOtherFilename, testConfigFilename},
+			Profile:   "assume_role_wo_creds",
+			Expected: sharedConfig{
+				AssumeRole: assumeRoleConfig{
+					RoleARN:       "assume_role_wo_creds_role_arn",
+					SourceProfile: "assume_role_wo_creds",
+				},
+			},
+			Err: SharedConfigAssumeRoleError{RoleARN: "assume_role_wo_creds_role_arn"},
+		},
+		{
+			Filenames: []string{filepath.Join("testdata", "shared_config_invalid_ini")},
+			Profile:   "profile_name",
+			Err:       SharedConfigLoadError{Filename: filepath.Join("testdata", "shared_config_invalid_ini")},
+		},
+	}
+
+	for i, c := range cases {
+		cfg, err := loadSharedConfig(c.Profile, c.Filenames)
+		if c.Err != nil {
+			assert.Contains(t, err.Error(), c.Err.Error(), "expected error, %d", i)
+			continue
+		}
+
+		assert.NoError(t, err, "unexpected error, %d", i)
+		assert.Equal(t, c.Expected, cfg, "not equal, %d", i)
+	}
+}
+
+func TestLoadSharedConfigFromFile(t *testing.T) {
+	filename := testConfigFilename
+	f, err := ini.Load(filename)
+	if err != nil {
+		t.Fatalf("failed to load test config file, %s, %v", filename, err)
+	}
+	iniFile := sharedConfigFile{IniData: f, Filename: filename}
+
+	cases := []struct {
+		Profile  string
+		Expected sharedConfig
+		Err      error
+	}{
+		{
+			Profile:  "default",
+			Expected: sharedConfig{Region: "default_region"},
+		},
+		{
+			Profile:  "alt_profile_name",
+			Expected: sharedConfig{Region: "alt_profile_name_region"},
+		},
+		{
+			Profile:  "short_profile_name_first",
+			Expected: sharedConfig{Region: "short_profile_name_first_short"},
+		},
+		{
+			Profile:  "partial_creds",
+			Expected: sharedConfig{},
+		},
+		{
+			Profile: "complete_creds",
+			Expected: sharedConfig{
+				Creds: credentials.Value{
+					AccessKeyID:     "complete_creds_akid",
+					SecretAccessKey: "complete_creds_secret",
+					ProviderName:    fmt.Sprintf("SharedConfigCredentials: %s", testConfigFilename),
+				},
+			},
+		},
+		{
+			Profile: "complete_creds_with_token",
+			Expected: sharedConfig{
+				Creds: credentials.Value{
+					AccessKeyID:     "complete_creds_with_token_akid",
+					SecretAccessKey: "complete_creds_with_token_secret",
+					SessionToken:    "complete_creds_with_token_token",
+					ProviderName:    fmt.Sprintf("SharedConfigCredentials: %s", testConfigFilename),
+				},
+			},
+		},
+		{
+			Profile: "full_profile",
+			Expected: sharedConfig{
+				Creds: credentials.Value{
+					AccessKeyID:     "full_profile_akid",
+					SecretAccessKey: "full_profile_secret",
+					ProviderName:    fmt.Sprintf("SharedConfigCredentials: %s", testConfigFilename),
+				},
+				Region: "full_profile_region",
+			},
+		},
+		{
+			Profile:  "partial_assume_role",
+			Expected: sharedConfig{},
+		},
+		{
+			Profile: "assume_role",
+			Expected: sharedConfig{
+				AssumeRole: assumeRoleConfig{
+					RoleARN:       "assume_role_role_arn",
+					SourceProfile: "complete_creds",
+				},
+			},
+		},
+		{
+			Profile: "does_not_exists",
+			Err:     SharedConfigProfileNotExistsError{Profile: "does_not_exists"},
+		},
+	}
+
+	for i, c := range cases {
+		cfg := sharedConfig{}
+
+		err := cfg.setFromIniFile(c.Profile, iniFile)
+		if c.Err != nil {
+			assert.Contains(t, err.Error(), c.Err.Error(), "expected error, %d", i)
+			continue
+		}
+
+		assert.NoError(t, err, "unexpected error, %d", i)
+		assert.Equal(t, c.Expected, cfg, "not equal, %d", i)
+	}
+}
+
+func TestLoadSharedConfigIniFiles(t *testing.T) {
+	cases := []struct {
+		Filenames []string
+		Expected  []sharedConfigFile
+	}{
+		{
+			Filenames: []string{"not_exists", testConfigFilename},
+			Expected: []sharedConfigFile{
+				{Filename: testConfigFilename},
+			},
+		},
+		{
+			Filenames: []string{testConfigFilename, testConfigOtherFilename},
+			Expected: []sharedConfigFile{
+				{Filename: testConfigFilename},
+				{Filename: testConfigOtherFilename},
 			},
 		},
 	}
 
-	for _, c := range cases {
-		cfg, err := loadSharedConfig(c.Profile, c.Filenames...)
-		if len(c.ErrContains) > 0 {
-			assert.Error(t, err)
-			assert.Contains(t, err, c.ErrContains)
-			continue
+	for i, c := range cases {
+		files, err := loadSharedConfigIniFiles(c.Filenames)
+		assert.NoError(t, err, "unexpected error, %d", i)
+		assert.Equal(t, len(c.Expected), len(files), "expected num files, %d", i)
+
+		for i, expectedFile := range c.Expected {
+			assert.Equal(t, expectedFile.Filename, files[i].Filename)
 		}
-
-		assert.NoError(t, err)
-
-		assert.Contains(t, cfg.Creds.ProviderName, c.Expected.Creds.ProviderName)
-		cfg.Creds.ProviderName = c.Expected.Creds.ProviderName
-
-		assert.Equal(t, c.Expected, cfg)
 	}
 }

--- a/aws/session/testdata/shared_config
+++ b/aws/session/testdata/shared_config
@@ -1,4 +1,8 @@
 [default]
+s3 = 
+  unsupported_key=123
+  other_unsupported=abc
+
 region = default_region
 
 [profile alt_profile_name]
@@ -18,9 +22,9 @@ aws_access_key_id = complete_creds_akid
 aws_secret_access_key = complete_creds_secret
 
 [complete_creds_with_token]
-aws_access_key_id = complete_creds_akid_token_akid
-aws_secret_access_key = complete_creds_secret_token_secret
-aws_session_token = complete_creds_secret_token_token
+aws_access_key_id = complete_creds_with_token_akid
+aws_secret_access_key = complete_creds_with_token_secret
+aws_session_token = complete_creds_with_token_token
 
 [full_profile]
 aws_access_key_id = full_profile_akid
@@ -31,3 +35,26 @@ region = full_profile_region
 region = shared_config_region
 aws_access_key_id = shared_config_akid
 aws_secret_access_key = shared_config_secret
+
+[partial_assume_role]
+role_arn = partial_assume_role_role_arn
+
+[assume_role]
+role_arn = assume_role_role_arn
+source_profile = complete_creds
+
+[assume_role_invalid_source_profile]
+role_arn = assume_role_invalid_source_profile_role_arn
+source_profile = profile_not_exists
+
+[assume_role_w_creds]
+role_arn = assume_role_w_creds_role_arn
+source_profile = assume_role_w_creds
+external_id = 1234
+role_session_name = assume_role_w_creds_session_name
+aws_access_key_id = assume_role_w_creds_akid
+aws_secret_access_key = assume_role_w_creds_secret
+
+[assume_role_wo_creds]
+role_arn = assume_role_wo_creds_role_arn
+source_profile = assume_role_wo_creds

--- a/aws/session/testdata/shared_config
+++ b/aws/session/testdata/shared_config
@@ -1,0 +1,33 @@
+[default]
+region = default_region
+
+[profile alt_profile_name]
+region = alt_profile_name_region
+
+[short_profile_name_first]
+region = short_profile_name_first_short
+
+[profile short_profile_name_first]
+region = short_profile_name_first_alt
+
+[partial_creds]
+aws_access_key_id = partial_creds_akid
+
+[complete_creds]
+aws_access_key_id = complete_creds_akid
+aws_secret_access_key = complete_creds_secret
+
+[complete_creds_with_token]
+aws_access_key_id = complete_creds_akid_token_akid
+aws_secret_access_key = complete_creds_secret_token_secret
+aws_session_token = complete_creds_secret_token_token
+
+[full_profile]
+aws_access_key_id = full_profile_akid
+aws_secret_access_key = full_profile_secret
+region = full_profile_region
+
+[config_file_load_order]
+region = shared_config_region
+aws_access_key_id = shared_config_akid
+aws_secret_access_key = shared_config_secret

--- a/aws/session/testdata/shared_config_invalid_ini
+++ b/aws/session/testdata/shared_config_invalid_ini
@@ -1,0 +1,1 @@
+[profile_nam

--- a/aws/session/testdata/shared_config_other
+++ b/aws/session/testdata/shared_config_other
@@ -1,0 +1,17 @@
+[default]
+region = default_region
+
+[partial_creds]
+aws_access_key_id = AKID
+
+[profile alt_profile_name]
+region = alt_profile_name_region
+
+[creds_from_credentials]
+aws_access_key_id = creds_from_config_akid
+aws_secret_access_key = creds_from_config_secret
+
+[config_file_load_order]
+region = shared_config_other_region
+aws_access_key_id = shared_config_other_akid
+aws_secret_access_key = shared_config_other_secret

--- a/awstesting/integration/customizations/s3/s3manager/integration_test.go
+++ b/awstesting/integration/customizations/s3/s3manager/integration_test.go
@@ -58,7 +58,7 @@ func setup() {
 
 // Delete the bucket
 func teardown() {
-	svc := s3.New(session.New())
+	svc := s3.New(session.NewFromSharedConfig())
 
 	objs, _ := svc.ListObjects(&s3.ListObjectsInput{Bucket: bucketName})
 	for _, o := range objs.Contents {
@@ -128,7 +128,7 @@ func TestUploadConcurrently(t *testing.T) {
 }
 
 func TestUploadFailCleanup(t *testing.T) {
-	svc := s3.New(session.New())
+	svc := s3.New(session.NewFromSharedConfig())
 
 	// Break checksum on 2nd part so it fails
 	part := 0
@@ -151,6 +151,7 @@ func TestUploadFailCleanup(t *testing.T) {
 		Body:   bytes.NewReader(integBuf12MB),
 	})
 	assert.Error(t, err)
+	assert.NotContains(t, err.Error(), "MissingRegion")
 	uploadID := ""
 	if merr, ok := err.(s3manager.MultiUploadFailure); ok {
 		uploadID = merr.UploadID()

--- a/awstesting/integration/customizations/s3/s3manager/integration_test.go
+++ b/awstesting/integration/customizations/s3/s3manager/integration_test.go
@@ -16,7 +16,6 @@ import (
 
 	"github.com/aws/aws-sdk-go/aws"
 	"github.com/aws/aws-sdk-go/aws/request"
-	"github.com/aws/aws-sdk-go/aws/session"
 	"github.com/aws/aws-sdk-go/awstesting/integration"
 	"github.com/aws/aws-sdk-go/service/s3"
 	"github.com/aws/aws-sdk-go/service/s3/s3manager"
@@ -58,7 +57,7 @@ func setup() {
 
 // Delete the bucket
 func teardown() {
-	svc := s3.New(session.NewFromSharedConfig())
+	svc := s3.New(integration.Session)
 
 	objs, _ := svc.ListObjects(&s3.ListObjectsInput{Bucket: bucketName})
 	for _, o := range objs.Contents {
@@ -128,7 +127,7 @@ func TestUploadConcurrently(t *testing.T) {
 }
 
 func TestUploadFailCleanup(t *testing.T) {
-	svc := s3.New(session.NewFromSharedConfig())
+	svc := s3.New(integration.Session)
 
 	// Break checksum on 2nd part so it fails
 	part := 0

--- a/awstesting/integration/integration.go
+++ b/awstesting/integration/integration.go
@@ -15,7 +15,7 @@ import (
 )
 
 // Session is a shared session for all integration tests to use.
-var Session = session.NewFromSharedConfig()
+var Session = session.Must(session.NewSession())
 
 func init() {
 	logLevel := Session.Config.LogLevel

--- a/awstesting/integration/integration.go
+++ b/awstesting/integration/integration.go
@@ -15,7 +15,7 @@ import (
 )
 
 // Session is a shared session for all integration tests to use.
-var Session = session.New()
+var Session = session.NewFromSharedConfig()
 
 func init() {
 	logLevel := Session.Config.LogLevel

--- a/awstesting/integration/smoke/shared.go
+++ b/awstesting/integration/smoke/shared.go
@@ -22,7 +22,7 @@ import (
 )
 
 // Session is a shared session for all integration smoke tests to use.
-var Session = session.New()
+var Session = session.NewFromSharedConfig()
 
 func init() {
 	logLevel := Session.Config.LogLevel

--- a/awstesting/integration/smoke/shared.go
+++ b/awstesting/integration/smoke/shared.go
@@ -22,7 +22,7 @@ import (
 )
 
 // Session is a shared session for all integration smoke tests to use.
-var Session = session.NewFromSharedConfig()
+var Session = session.Must(session.NewSession())
 
 func init() {
 	logLevel := Session.Config.LogLevel


### PR DESCRIPTION
Updates the SDK to take advantage of the new `AWS_SDK_LOAD_CONFIG` environment variable. When set to a truthy value, as defined in strconv.ParseBool, the SDK will load both shared config file (~/.aws/config), and the shared credentials file (~/.aws/credentials). The shared credentials file has precedence over the shared config.

Both config files share the same format. Both `[name]` and `[profile name]` are accepted as section names. The first, `[name]` will be looked for first before falling back to `[profile name]` per config file.

See the [session](http://docs.aws.amazon.com/sdk-for-go/api/aws/session/) package docs for more information.

Deprecates the `session.New` method since it cannot return an error when the session fails to load until a request is made. `session.NewSession` corrects this by returning an error when creating the session.

Fix #384
