### PR TITLE
service/s3: Ensure error code is always set

### DIFF
--- a/service/s3/unmarshal_error.go
+++ b/service/s3/unmarshal_error.go
@@ -23,6 +23,8 @@ func unmarshalError(r *request.Request) {
 	defer r.HTTPResponse.Body.Close()
 	defer io.Copy(ioutil.Discard, r.HTTPResponse.Body)
 
+	// Bucket exists in a differnt region, and request needs
+	// to be made to the correct region.
 	if r.HTTPResponse.StatusCode == http.StatusMovedPermanently {
 		r.Error = awserr.NewRequestFailure(
 			awserr.New("BucketRegionError",
@@ -35,25 +37,29 @@ func unmarshalError(r *request.Request) {
 		return
 	}
 
-	if r.HTTPResponse.ContentLength == 0 {
-		// No body, use status code to generate an awserr.Error
-		r.Error = awserr.NewRequestFailure(
-			awserr.New(strings.Replace(r.HTTPResponse.Status, " ", "", -1), r.HTTPResponse.Status, nil),
-			r.HTTPResponse.StatusCode,
-			r.RequestID,
-		)
-		return
-	}
+	var errCode, errMsg string
 
+	// Attempt to parse error from body if it is known
 	resp := &xmlErrorResponse{}
 	err := xml.NewDecoder(r.HTTPResponse.Body).Decode(resp)
 	if err != nil && err != io.EOF {
-		r.Error = awserr.New("SerializationError", "failed to decode S3 XML error response", nil)
+		errCode = "SerializationError"
+		errMsg = "failed to decode S3 XML error response"
 	} else {
-		r.Error = awserr.NewRequestFailure(
-			awserr.New(resp.Code, resp.Message, nil),
-			r.HTTPResponse.StatusCode,
-			r.RequestID,
-		)
+		errCode = resp.Code
+		errMsg = resp.Message
 	}
+
+	// Fallback to status code converted to message if still no error code
+	if len(errCode) == 0 {
+		statusText := http.StatusText(r.HTTPResponse.StatusCode)
+		errCode = strings.Replace(statusText, " ", "", -1)
+		errMsg = statusText
+	}
+
+	r.Error = awserr.NewRequestFailure(
+		awserr.New(errCode, errMsg, nil),
+		r.HTTPResponse.StatusCode,
+		r.RequestID,
+	)
 }


### PR DESCRIPTION
Updates the S3 error unmarshaler to ensure the error code and message is
always provided. The logic was expecting ContentLength to be 0 if not
set, but this is incorrect. Removed the dependency on checking the
ContentLength and switch to fallback if the body parse fails.

Fix #765