### PR TITLE
awstesting: Remove non-testing dependancy on testify assert

### DIFF
--- a/awstesting/assert.go
+++ b/awstesting/assert.go
@@ -5,11 +5,10 @@ import (
 	"encoding/xml"
 	"fmt"
 	"net/url"
+	"reflect"
 	"regexp"
 	"sort"
 	"testing"
-
-	"github.com/stretchr/testify/assert"
 )
 
 // Match is a testing helper to test for testing error by comparing expected
@@ -33,9 +32,9 @@ func AssertURL(t *testing.T, expect, actual string, msgAndArgs ...interface{}) b
 		return false
 	}
 
-	assert.Equal(t, expectURL.Host, actualURL.Host, msgAndArgs...)
-	assert.Equal(t, expectURL.Scheme, actualURL.Scheme, msgAndArgs...)
-	assert.Equal(t, expectURL.Path, actualURL.Path, msgAndArgs...)
+	equal(t, expectURL.Host, actualURL.Host, msgAndArgs...)
+	equal(t, expectURL.Scheme, actualURL.Scheme, msgAndArgs...)
+	equal(t, expectURL.Path, actualURL.Path, msgAndArgs...)
 
 	return AssertQuery(t, expectURL.Query().Encode(), actualURL.Query().Encode(), msgAndArgs...)
 }
@@ -54,7 +53,7 @@ func AssertQuery(t *testing.T, expect, actual string, msgAndArgs ...interface{})
 	}
 
 	// Make sure the keys are the same
-	if !assert.Equal(t, queryValueKeys(expectQ), queryValueKeys(actualQ), msgAndArgs...) {
+	if !equal(t, queryValueKeys(expectQ), queryValueKeys(actualQ), msgAndArgs...) {
 		return false
 	}
 
@@ -62,7 +61,7 @@ func AssertQuery(t *testing.T, expect, actual string, msgAndArgs ...interface{})
 		sort.Strings(expectQVals)
 		actualQVals := actualQ[k]
 		sort.Strings(actualQVals)
-		assert.Equal(t, expectQVals, actualQVals, msgAndArgs...)
+		equal(t, expectQVals, actualQVals, msgAndArgs...)
 	}
 
 	return true
@@ -82,7 +81,7 @@ func AssertJSON(t *testing.T, expect, actual string, msgAndArgs ...interface{}) 
 		return false
 	}
 
-	return assert.Equal(t, expectVal, actualVal, msgAndArgs...)
+	return equal(t, expectVal, actualVal, msgAndArgs...)
 }
 
 // AssertXML verifies that the expect xml string matches the actual.
@@ -96,7 +95,39 @@ func AssertXML(t *testing.T, expect, actual string, container interface{}, msgAn
 	if err := xml.Unmarshal([]byte(actual), &actualVal); err != nil {
 		t.Errorf(errMsg("unable to parse actual XML", err, msgAndArgs...))
 	}
-	return assert.Equal(t, expectVal, actualVal, msgAndArgs...)
+	return equal(t, expectVal, actualVal, msgAndArgs...)
+}
+
+// objectsAreEqual determines if two objects are considered equal.
+//
+// This function does no assertion of any kind.
+//
+// Based on github.com/stretchr/testify/assert.ObjectsAreEqual
+// Copied locally to prevent non-test build dependencies on testify
+func objectsAreEqual(expected, actual interface{}) bool {
+	if expected == nil || actual == nil {
+		return expected == actual
+	}
+
+	return reflect.DeepEqual(expected, actual)
+}
+
+// Equal asserts that two objects are equal.
+//
+//    assert.Equal(t, 123, 123, "123 and 123 should be equal")
+//
+// Returns whether the assertion was successful (true) or not (false).
+//
+// Based on github.com/stretchr/testify/assert.Equal
+// Copied locally to prevent non-test build dependencies on testify
+func equal(t *testing.T, expected, actual interface{}, msgAndArgs ...interface{}) bool {
+	if !objectsAreEqual(expected, actual) {
+		t.Errorf("Not Equal:\n\t%#v (expected)\n\t%#v (actual), %s",
+			expected, actual, messageFromMsgAndArgs(msgAndArgs))
+		return false
+	}
+
+	return true
 }
 
 func errMsg(baseMsg string, err error, msgAndArgs ...interface{}) string {
@@ -107,6 +138,8 @@ func errMsg(baseMsg string, err error, msgAndArgs ...interface{}) string {
 	return fmt.Sprintf("%s%s, %v", message, baseMsg, err)
 }
 
+// Based on github.com/stretchr/testify/assert.messageFromMsgAndArgs
+// Copied locally to prevent non-test build dependencies on testify
 func messageFromMsgAndArgs(msgAndArgs []interface{}) string {
 	if len(msgAndArgs) == 0 || msgAndArgs == nil {
 		return ""


### PR DESCRIPTION
Removes the dependency on testify's assert in awstesting so the SDK will no longer require additional non-runtime related libraries when doing operations like `go build ./...` on a Go workspace with the SDK in it.

Related to #737 and #449