### PR TITLE
Fix spelling errors and remove dot imports

### DIFF
--- a/aws/awserr/error.go
+++ b/aws/awserr/error.go
@@ -44,7 +44,7 @@ type Error interface {
 
 // BatchError is a batch of errors which also wraps lower level errors with
 // code, message, and original errors. Calling Error() will include all errors
-// that occured in the batch.
+// that occurred in the batch.
 //
 // Deprecated: Replaced with BatchedErrors. Only defined for backwards
 // compatibility.
@@ -64,7 +64,7 @@ type BatchError interface {
 
 // BatchedErrors is a batch of errors which also wraps lower level errors with
 // code, message, and original errors. Calling Error() will include all errors
-// that occured in the batch.
+// that occurred in the batch.
 //
 // Replaces BatchError
 type BatchedErrors interface {

--- a/aws/awserr/types.go
+++ b/aws/awserr/types.go
@@ -98,7 +98,7 @@ func (b baseError) OrigErr() error {
 			return NewBatchError(err.Code(), err.Message(), b.errs[1:])
 		}
 		return NewBatchError("BatchedErrors",
-			"multiple errors occured", b.errs)
+			"multiple errors occurred", b.errs)
 	}
 }
 

--- a/aws/config.go
+++ b/aws/config.go
@@ -19,7 +19,7 @@ type RequestRetryer interface{}
 // all clients will use the {defaults.DefaultConfig} structure.
 type Config struct {
 	// Enables verbose error printing of all credential chain errors.
-	// Should be used when wanting to see all errors while attempting to retreive
+	// Should be used when wanting to see all errors while attempting to retrieve
 	// credentials.
 	CredentialsChainVerboseErrors *bool
 
@@ -112,8 +112,8 @@ type Config struct {
 	// `ExpectContinueTimeout` for information on adjusting the continue wait timeout.
 	// https://golang.org/pkg/net/http/#Transport
 	//
-	// You should use this flag to disble 100-Continue if you experiance issues
-	// with proxies or thrid party S3 compatible services.
+	// You should use this flag to disble 100-Continue if you experience issues
+	// with proxies or third party S3 compatible services.
 	S3Disable100Continue *bool
 
 	// Set this to `true` to enable S3 Accelerate feature. For all operations compatible

--- a/aws/request/handlers_test.go
+++ b/aws/request/handlers_test.go
@@ -79,7 +79,7 @@ func TestStopHandlers(t *testing.T) {
 		called++
 	}})
 	l.PushBackNamed(request.NamedHandler{Name: "name3", Fn: func(r *request.Request) {
-		assert.Fail(t, "thrid handler should not be called")
+		assert.Fail(t, "third handler should not be called")
 	}})
 	l.Run(&request.Request{})
 

--- a/aws/signer/v4/v4_test.go
+++ b/aws/signer/v4/v4_test.go
@@ -280,7 +280,7 @@ func TestPreResignRequestExpiredCreds(t *testing.T) {
 	creds.Expire()
 
 	signSDKRequestWithCurrTime(r, func() time.Time {
-		// Simulate the request occured 15 minutes in the past
+		// Simulate the request occurred 15 minutes in the past
 		return time.Now().Add(-48 * time.Hour)
 	})
 	assert.NotEqual(t, querySig, r.HTTPRequest.URL.Query().Get("X-Amz-Signature"))
@@ -308,7 +308,7 @@ func TestResignRequestExpiredRequest(t *testing.T) {
 	origSignedAt := r.LastSignedAt
 
 	signSDKRequestWithCurrTime(r, func() time.Time {
-		// Simulate the request occured 15 minutes in the past
+		// Simulate the request occurred 15 minutes in the past
 		return time.Now().Add(15 * time.Minute)
 	})
 	assert.NotEqual(t, querySig, r.HTTPRequest.Header.Get("Authorization"))

--- a/awstesting/integration/smoke/acm/client.go
+++ b/awstesting/integration/smoke/acm/client.go
@@ -6,11 +6,11 @@ package acm
 import (
 	"github.com/aws/aws-sdk-go/awstesting/integration/smoke"
 	"github.com/aws/aws-sdk-go/service/acm"
-	. "github.com/gucumber/gucumber"
+	"github.com/gucumber/gucumber"
 )
 
 func init() {
-	Before("@acm", func() {
-		World["client"] = acm.New(smoke.Session)
+	gucumber.Before("@acm", func() {
+		gucumber.World["client"] = acm.New(smoke.Session)
 	})
 }

--- a/awstesting/integration/smoke/apigateway/client.go
+++ b/awstesting/integration/smoke/apigateway/client.go
@@ -6,11 +6,11 @@ package apigateway
 import (
 	"github.com/aws/aws-sdk-go/awstesting/integration/smoke"
 	"github.com/aws/aws-sdk-go/service/apigateway"
-	. "github.com/gucumber/gucumber"
+	"github.com/gucumber/gucumber"
 )
 
 func init() {
-	Before("@apigateway", func() {
-		World["client"] = apigateway.New(smoke.Session)
+	gucumber.Before("@apigateway", func() {
+		gucumber.World["client"] = apigateway.New(smoke.Session)
 	})
 }

--- a/awstesting/integration/smoke/applicationdiscoveryservice/client.go
+++ b/awstesting/integration/smoke/applicationdiscoveryservice/client.go
@@ -7,11 +7,13 @@ import (
 	"github.com/aws/aws-sdk-go/aws"
 	"github.com/aws/aws-sdk-go/awstesting/integration/smoke"
 	"github.com/aws/aws-sdk-go/service/applicationdiscoveryservice"
-	. "github.com/gucumber/gucumber"
+	"github.com/gucumber/gucumber"
 )
 
 func init() {
-	Before("@applicationdiscoveryservice", func() {
-		World["client"] = applicationdiscoveryservice.New(smoke.Session, &aws.Config{Region: aws.String("us-west-2")})
+	gucumber.Before("@applicationdiscoveryservice", func() {
+		gucumber.World["client"] = applicationdiscoveryservice.New(
+			smoke.Session, &aws.Config{Region: aws.String("us-west-2")},
+		)
 	})
 }

--- a/awstesting/integration/smoke/autoscaling/client.go
+++ b/awstesting/integration/smoke/autoscaling/client.go
@@ -6,11 +6,11 @@ package autoscaling
 import (
 	"github.com/aws/aws-sdk-go/awstesting/integration/smoke"
 	"github.com/aws/aws-sdk-go/service/autoscaling"
-	. "github.com/gucumber/gucumber"
+	"github.com/gucumber/gucumber"
 )
 
 func init() {
-	Before("@autoscaling", func() {
-		World["client"] = autoscaling.New(smoke.Session)
+	gucumber.Before("@autoscaling", func() {
+		gucumber.World["client"] = autoscaling.New(smoke.Session)
 	})
 }

--- a/awstesting/integration/smoke/cloudformation/client.go
+++ b/awstesting/integration/smoke/cloudformation/client.go
@@ -6,11 +6,11 @@ package cloudformation
 import (
 	"github.com/aws/aws-sdk-go/awstesting/integration/smoke"
 	"github.com/aws/aws-sdk-go/service/cloudformation"
-	. "github.com/gucumber/gucumber"
+	"github.com/gucumber/gucumber"
 )
 
 func init() {
-	Before("@cloudformation", func() {
-		World["client"] = cloudformation.New(smoke.Session)
+	gucumber.Before("@cloudformation", func() {
+		gucumber.World["client"] = cloudformation.New(smoke.Session)
 	})
 }

--- a/awstesting/integration/smoke/cloudfront/client.go
+++ b/awstesting/integration/smoke/cloudfront/client.go
@@ -6,11 +6,11 @@ package cloudfront
 import (
 	"github.com/aws/aws-sdk-go/awstesting/integration/smoke"
 	"github.com/aws/aws-sdk-go/service/cloudfront"
-	. "github.com/gucumber/gucumber"
+	"github.com/gucumber/gucumber"
 )
 
 func init() {
-	Before("@cloudfront", func() {
-		World["client"] = cloudfront.New(smoke.Session)
+	gucumber.Before("@cloudfront", func() {
+		gucumber.World["client"] = cloudfront.New(smoke.Session)
 	})
 }

--- a/awstesting/integration/smoke/cloudhsm/client.go
+++ b/awstesting/integration/smoke/cloudhsm/client.go
@@ -6,11 +6,11 @@ package cloudhsm
 import (
 	"github.com/aws/aws-sdk-go/awstesting/integration/smoke"
 	"github.com/aws/aws-sdk-go/service/cloudhsm"
-	. "github.com/gucumber/gucumber"
+	"github.com/gucumber/gucumber"
 )
 
 func init() {
-	Before("@cloudhsm", func() {
-		World["client"] = cloudhsm.New(smoke.Session)
+	gucumber.Before("@cloudhsm", func() {
+		gucumber.World["client"] = cloudhsm.New(smoke.Session)
 	})
 }

--- a/awstesting/integration/smoke/cloudsearch/client.go
+++ b/awstesting/integration/smoke/cloudsearch/client.go
@@ -6,11 +6,11 @@ package cloudsearch
 import (
 	"github.com/aws/aws-sdk-go/awstesting/integration/smoke"
 	"github.com/aws/aws-sdk-go/service/cloudsearch"
-	. "github.com/gucumber/gucumber"
+	"github.com/gucumber/gucumber"
 )
 
 func init() {
-	Before("@cloudsearch", func() {
-		World["client"] = cloudsearch.New(smoke.Session)
+	gucumber.Before("@cloudsearch", func() {
+		gucumber.World["client"] = cloudsearch.New(smoke.Session)
 	})
 }

--- a/awstesting/integration/smoke/cloudtrail/client.go
+++ b/awstesting/integration/smoke/cloudtrail/client.go
@@ -6,11 +6,11 @@ package cloudtrail
 import (
 	"github.com/aws/aws-sdk-go/awstesting/integration/smoke"
 	"github.com/aws/aws-sdk-go/service/cloudtrail"
-	. "github.com/gucumber/gucumber"
+	"github.com/gucumber/gucumber"
 )
 
 func init() {
-	Before("@cloudtrail", func() {
-		World["client"] = cloudtrail.New(smoke.Session)
+	gucumber.Before("@cloudtrail", func() {
+		gucumber.World["client"] = cloudtrail.New(smoke.Session)
 	})
 }

--- a/awstesting/integration/smoke/cloudwatch/client.go
+++ b/awstesting/integration/smoke/cloudwatch/client.go
@@ -6,11 +6,11 @@ package cloudwatch
 import (
 	"github.com/aws/aws-sdk-go/awstesting/integration/smoke"
 	"github.com/aws/aws-sdk-go/service/cloudwatch"
-	. "github.com/gucumber/gucumber"
+	"github.com/gucumber/gucumber"
 )
 
 func init() {
-	Before("@cloudwatch", func() {
-		World["client"] = cloudwatch.New(smoke.Session)
+	gucumber.Before("@cloudwatch", func() {
+		gucumber.World["client"] = cloudwatch.New(smoke.Session)
 	})
 }

--- a/awstesting/integration/smoke/cloudwatchlogs/client.go
+++ b/awstesting/integration/smoke/cloudwatchlogs/client.go
@@ -6,11 +6,11 @@ package cloudwatchlogs
 import (
 	"github.com/aws/aws-sdk-go/awstesting/integration/smoke"
 	"github.com/aws/aws-sdk-go/service/cloudwatchlogs"
-	. "github.com/gucumber/gucumber"
+	"github.com/gucumber/gucumber"
 )
 
 func init() {
-	Before("@cloudwatchlogs", func() {
-		World["client"] = cloudwatchlogs.New(smoke.Session)
+	gucumber.Before("@cloudwatchlogs", func() {
+		gucumber.World["client"] = cloudwatchlogs.New(smoke.Session)
 	})
 }

--- a/awstesting/integration/smoke/codecommit/client.go
+++ b/awstesting/integration/smoke/codecommit/client.go
@@ -6,11 +6,11 @@ package codecommit
 import (
 	"github.com/aws/aws-sdk-go/awstesting/integration/smoke"
 	"github.com/aws/aws-sdk-go/service/codecommit"
-	. "github.com/gucumber/gucumber"
+	"github.com/gucumber/gucumber"
 )
 
 func init() {
-	Before("@codecommit", func() {
-		World["client"] = codecommit.New(smoke.Session)
+	gucumber.Before("@codecommit", func() {
+		gucumber.World["client"] = codecommit.New(smoke.Session)
 	})
 }

--- a/awstesting/integration/smoke/codedeploy/client.go
+++ b/awstesting/integration/smoke/codedeploy/client.go
@@ -6,11 +6,11 @@ package codedeploy
 import (
 	"github.com/aws/aws-sdk-go/awstesting/integration/smoke"
 	"github.com/aws/aws-sdk-go/service/codedeploy"
-	. "github.com/gucumber/gucumber"
+	"github.com/gucumber/gucumber"
 )
 
 func init() {
-	Before("@codedeploy", func() {
-		World["client"] = codedeploy.New(smoke.Session)
+	gucumber.Before("@codedeploy", func() {
+		gucumber.World["client"] = codedeploy.New(smoke.Session)
 	})
 }

--- a/awstesting/integration/smoke/codepipeline/client.go
+++ b/awstesting/integration/smoke/codepipeline/client.go
@@ -6,11 +6,11 @@ package codepipeline
 import (
 	"github.com/aws/aws-sdk-go/awstesting/integration/smoke"
 	"github.com/aws/aws-sdk-go/service/codepipeline"
-	. "github.com/gucumber/gucumber"
+	"github.com/gucumber/gucumber"
 )
 
 func init() {
-	Before("@codepipeline", func() {
-		World["client"] = codepipeline.New(smoke.Session)
+	gucumber.Before("@codepipeline", func() {
+		gucumber.World["client"] = codepipeline.New(smoke.Session)
 	})
 }

--- a/awstesting/integration/smoke/cognitoidentity/client.go
+++ b/awstesting/integration/smoke/cognitoidentity/client.go
@@ -6,11 +6,11 @@ package cognitoidentity
 import (
 	"github.com/aws/aws-sdk-go/awstesting/integration/smoke"
 	"github.com/aws/aws-sdk-go/service/cognitoidentity"
-	. "github.com/gucumber/gucumber"
+	"github.com/gucumber/gucumber"
 )
 
 func init() {
-	Before("@cognitoidentity", func() {
-		World["client"] = cognitoidentity.New(smoke.Session)
+	gucumber.Before("@cognitoidentity", func() {
+		gucumber.World["client"] = cognitoidentity.New(smoke.Session)
 	})
 }

--- a/awstesting/integration/smoke/cognitosync/client.go
+++ b/awstesting/integration/smoke/cognitosync/client.go
@@ -6,11 +6,11 @@ package cognitosync
 import (
 	"github.com/aws/aws-sdk-go/awstesting/integration/smoke"
 	"github.com/aws/aws-sdk-go/service/cognitosync"
-	. "github.com/gucumber/gucumber"
+	"github.com/gucumber/gucumber"
 )
 
 func init() {
-	Before("@cognitosync", func() {
-		World["client"] = cognitosync.New(smoke.Session)
+	gucumber.Before("@cognitosync", func() {
+		gucumber.World["client"] = cognitosync.New(smoke.Session)
 	})
 }

--- a/awstesting/integration/smoke/configservice/client.go
+++ b/awstesting/integration/smoke/configservice/client.go
@@ -6,11 +6,11 @@ package configservice
 import (
 	"github.com/aws/aws-sdk-go/awstesting/integration/smoke"
 	"github.com/aws/aws-sdk-go/service/configservice"
-	. "github.com/gucumber/gucumber"
+	"github.com/gucumber/gucumber"
 )
 
 func init() {
-	Before("@configservice", func() {
-		World["client"] = configservice.New(smoke.Session)
+	gucumber.Before("@configservice", func() {
+		gucumber.World["client"] = configservice.New(smoke.Session)
 	})
 }

--- a/awstesting/integration/smoke/datapipeline/client.go
+++ b/awstesting/integration/smoke/datapipeline/client.go
@@ -6,11 +6,11 @@ package datapipeline
 import (
 	"github.com/aws/aws-sdk-go/awstesting/integration/smoke"
 	"github.com/aws/aws-sdk-go/service/datapipeline"
-	. "github.com/gucumber/gucumber"
+	"github.com/gucumber/gucumber"
 )
 
 func init() {
-	Before("@datapipeline", func() {
-		World["client"] = datapipeline.New(smoke.Session)
+	gucumber.Before("@datapipeline", func() {
+		gucumber.World["client"] = datapipeline.New(smoke.Session)
 	})
 }

--- a/awstesting/integration/smoke/devicefarm/client.go
+++ b/awstesting/integration/smoke/devicefarm/client.go
@@ -7,13 +7,13 @@ import (
 	"github.com/aws/aws-sdk-go/aws"
 	"github.com/aws/aws-sdk-go/awstesting/integration/smoke"
 	"github.com/aws/aws-sdk-go/service/devicefarm"
-	. "github.com/gucumber/gucumber"
+	"github.com/gucumber/gucumber"
 )
 
 func init() {
-	Before("@devicefarm", func() {
+	gucumber.Before("@devicefarm", func() {
 		// FIXME remove custom region
-		World["client"] = devicefarm.New(smoke.Session,
+		gucumber.World["client"] = devicefarm.New(smoke.Session,
 			aws.NewConfig().WithRegion("us-west-2"))
 	})
 }

--- a/awstesting/integration/smoke/directconnect/client.go
+++ b/awstesting/integration/smoke/directconnect/client.go
@@ -6,11 +6,11 @@ package directconnect
 import (
 	"github.com/aws/aws-sdk-go/awstesting/integration/smoke"
 	"github.com/aws/aws-sdk-go/service/directconnect"
-	. "github.com/gucumber/gucumber"
+	"github.com/gucumber/gucumber"
 )
 
 func init() {
-	Before("@directconnect", func() {
-		World["client"] = directconnect.New(smoke.Session)
+	gucumber.Before("@directconnect", func() {
+		gucumber.World["client"] = directconnect.New(smoke.Session)
 	})
 }

--- a/awstesting/integration/smoke/directoryservice/client.go
+++ b/awstesting/integration/smoke/directoryservice/client.go
@@ -6,11 +6,11 @@ package directoryservice
 import (
 	"github.com/aws/aws-sdk-go/awstesting/integration/smoke"
 	"github.com/aws/aws-sdk-go/service/directoryservice"
-	. "github.com/gucumber/gucumber"
+	"github.com/gucumber/gucumber"
 )
 
 func init() {
-	Before("@directoryservice", func() {
-		World["client"] = directoryservice.New(smoke.Session)
+	gucumber.Before("@directoryservice", func() {
+		gucumber.World["client"] = directoryservice.New(smoke.Session)
 	})
 }

--- a/awstesting/integration/smoke/dynamodb/client.go
+++ b/awstesting/integration/smoke/dynamodb/client.go
@@ -6,11 +6,11 @@ package dynamodb
 import (
 	"github.com/aws/aws-sdk-go/awstesting/integration/smoke"
 	"github.com/aws/aws-sdk-go/service/dynamodb"
-	. "github.com/gucumber/gucumber"
+	"github.com/gucumber/gucumber"
 )
 
 func init() {
-	Before("@dynamodb", func() {
-		World["client"] = dynamodb.New(smoke.Session)
+	gucumber.Before("@dynamodb", func() {
+		gucumber.World["client"] = dynamodb.New(smoke.Session)
 	})
 }

--- a/awstesting/integration/smoke/dynamodbstreams/client.go
+++ b/awstesting/integration/smoke/dynamodbstreams/client.go
@@ -6,11 +6,11 @@ package dynamodbstreams
 import (
 	"github.com/aws/aws-sdk-go/awstesting/integration/smoke"
 	"github.com/aws/aws-sdk-go/service/dynamodbstreams"
-	. "github.com/gucumber/gucumber"
+	"github.com/gucumber/gucumber"
 )
 
 func init() {
-	Before("@dynamodbstreams", func() {
-		World["client"] = dynamodbstreams.New(smoke.Session)
+	gucumber.Before("@dynamodbstreams", func() {
+		gucumber.World["client"] = dynamodbstreams.New(smoke.Session)
 	})
 }

--- a/awstesting/integration/smoke/ec2/client.go
+++ b/awstesting/integration/smoke/ec2/client.go
@@ -6,11 +6,11 @@ package ec2
 import (
 	"github.com/aws/aws-sdk-go/awstesting/integration/smoke"
 	"github.com/aws/aws-sdk-go/service/ec2"
-	. "github.com/gucumber/gucumber"
+	"github.com/gucumber/gucumber"
 )
 
 func init() {
-	Before("@ec2", func() {
-		World["client"] = ec2.New(smoke.Session)
+	gucumber.Before("@ec2", func() {
+		gucumber.World["client"] = ec2.New(smoke.Session)
 	})
 }

--- a/awstesting/integration/smoke/ecs/client.go
+++ b/awstesting/integration/smoke/ecs/client.go
@@ -7,13 +7,13 @@ import (
 	"github.com/aws/aws-sdk-go/aws"
 	"github.com/aws/aws-sdk-go/awstesting/integration/smoke"
 	"github.com/aws/aws-sdk-go/service/ecs"
-	. "github.com/gucumber/gucumber"
+	"github.com/gucumber/gucumber"
 )
 
 func init() {
-	Before("@ecs", func() {
+	gucumber.Before("@ecs", func() {
 		// FIXME remove custom region
-		World["client"] = ecs.New(smoke.Session,
+		gucumber.World["client"] = ecs.New(smoke.Session,
 			aws.NewConfig().WithRegion("us-west-2"))
 	})
 }

--- a/awstesting/integration/smoke/efs/client.go
+++ b/awstesting/integration/smoke/efs/client.go
@@ -7,13 +7,13 @@ import (
 	"github.com/aws/aws-sdk-go/aws"
 	"github.com/aws/aws-sdk-go/awstesting/integration/smoke"
 	"github.com/aws/aws-sdk-go/service/efs"
-	. "github.com/gucumber/gucumber"
+	"github.com/gucumber/gucumber"
 )
 
 func init() {
-	Before("@efs", func() {
+	gucumber.Before("@efs", func() {
 		// FIXME remove custom region
-		World["client"] = efs.New(smoke.Session,
+		gucumber.World["client"] = efs.New(smoke.Session,
 			aws.NewConfig().WithRegion("us-west-2"))
 	})
 }

--- a/awstesting/integration/smoke/elasticache/client.go
+++ b/awstesting/integration/smoke/elasticache/client.go
@@ -6,11 +6,11 @@ package elasticache
 import (
 	"github.com/aws/aws-sdk-go/awstesting/integration/smoke"
 	"github.com/aws/aws-sdk-go/service/elasticache"
-	. "github.com/gucumber/gucumber"
+	"github.com/gucumber/gucumber"
 )
 
 func init() {
-	Before("@elasticache", func() {
-		World["client"] = elasticache.New(smoke.Session)
+	gucumber.Before("@elasticache", func() {
+		gucumber.World["client"] = elasticache.New(smoke.Session)
 	})
 }

--- a/awstesting/integration/smoke/elasticbeanstalk/client.go
+++ b/awstesting/integration/smoke/elasticbeanstalk/client.go
@@ -6,11 +6,11 @@ package elasticbeanstalk
 import (
 	"github.com/aws/aws-sdk-go/awstesting/integration/smoke"
 	"github.com/aws/aws-sdk-go/service/elasticbeanstalk"
-	. "github.com/gucumber/gucumber"
+	"github.com/gucumber/gucumber"
 )
 
 func init() {
-	Before("@elasticbeanstalk", func() {
-		World["client"] = elasticbeanstalk.New(smoke.Session)
+	gucumber.Before("@elasticbeanstalk", func() {
+		gucumber.World["client"] = elasticbeanstalk.New(smoke.Session)
 	})
 }

--- a/awstesting/integration/smoke/elasticloadbalancing/client.go
+++ b/awstesting/integration/smoke/elasticloadbalancing/client.go
@@ -6,11 +6,11 @@ package elasticloadbalancing
 import (
 	"github.com/aws/aws-sdk-go/awstesting/integration/smoke"
 	"github.com/aws/aws-sdk-go/service/elb"
-	. "github.com/gucumber/gucumber"
+	"github.com/gucumber/gucumber"
 )
 
 func init() {
-	Before("@elasticloadbalancing", func() {
-		World["client"] = elb.New(smoke.Session)
+	gucumber.Before("@elasticloadbalancing", func() {
+		gucumber.World["client"] = elb.New(smoke.Session)
 	})
 }

--- a/awstesting/integration/smoke/elastictranscoder/client.go
+++ b/awstesting/integration/smoke/elastictranscoder/client.go
@@ -6,11 +6,11 @@ package elastictranscoder
 import (
 	"github.com/aws/aws-sdk-go/awstesting/integration/smoke"
 	"github.com/aws/aws-sdk-go/service/elastictranscoder"
-	. "github.com/gucumber/gucumber"
+	"github.com/gucumber/gucumber"
 )
 
 func init() {
-	Before("@elastictranscoder", func() {
-		World["client"] = elastictranscoder.New(smoke.Session)
+	gucumber.Before("@elastictranscoder", func() {
+		gucumber.World["client"] = elastictranscoder.New(smoke.Session)
 	})
 }

--- a/awstesting/integration/smoke/emr/client.go
+++ b/awstesting/integration/smoke/emr/client.go
@@ -6,11 +6,11 @@ package emr
 import (
 	"github.com/aws/aws-sdk-go/awstesting/integration/smoke"
 	"github.com/aws/aws-sdk-go/service/emr"
-	. "github.com/gucumber/gucumber"
+	"github.com/gucumber/gucumber"
 )
 
 func init() {
-	Before("@emr", func() {
-		World["client"] = emr.New(smoke.Session)
+	gucumber.Before("@emr", func() {
+		gucumber.World["client"] = emr.New(smoke.Session)
 	})
 }

--- a/awstesting/integration/smoke/es/client.go
+++ b/awstesting/integration/smoke/es/client.go
@@ -6,11 +6,11 @@ package es
 import (
 	"github.com/aws/aws-sdk-go/awstesting/integration/smoke"
 	"github.com/aws/aws-sdk-go/service/elasticsearchservice"
-	. "github.com/gucumber/gucumber"
+	"github.com/gucumber/gucumber"
 )
 
 func init() {
-	Before("@es", func() {
-		World["client"] = elasticsearchservice.New(smoke.Session)
+	gucumber.Before("@es", func() {
+		gucumber.World["client"] = elasticsearchservice.New(smoke.Session)
 	})
 }

--- a/awstesting/integration/smoke/glacier/client.go
+++ b/awstesting/integration/smoke/glacier/client.go
@@ -6,11 +6,11 @@ package glacier
 import (
 	"github.com/aws/aws-sdk-go/awstesting/integration/smoke"
 	"github.com/aws/aws-sdk-go/service/glacier"
-	. "github.com/gucumber/gucumber"
+	"github.com/gucumber/gucumber"
 )
 
 func init() {
-	Before("@glacier", func() {
-		World["client"] = glacier.New(smoke.Session)
+	gucumber.Before("@glacier", func() {
+		gucumber.World["client"] = glacier.New(smoke.Session)
 	})
 }

--- a/awstesting/integration/smoke/iam/client.go
+++ b/awstesting/integration/smoke/iam/client.go
@@ -6,11 +6,11 @@ package iam
 import (
 	"github.com/aws/aws-sdk-go/awstesting/integration/smoke"
 	"github.com/aws/aws-sdk-go/service/iam"
-	. "github.com/gucumber/gucumber"
+	"github.com/gucumber/gucumber"
 )
 
 func init() {
-	Before("@iam", func() {
-		World["client"] = iam.New(smoke.Session)
+	gucumber.Before("@iam", func() {
+		gucumber.World["client"] = iam.New(smoke.Session)
 	})
 }

--- a/awstesting/integration/smoke/iotdataplane/client.go
+++ b/awstesting/integration/smoke/iotdataplane/client.go
@@ -8,19 +8,19 @@ import (
 	"github.com/aws/aws-sdk-go/awstesting/integration/smoke"
 	"github.com/aws/aws-sdk-go/service/iot"
 	"github.com/aws/aws-sdk-go/service/iotdataplane"
-	. "github.com/gucumber/gucumber"
+	"github.com/gucumber/gucumber"
 )
 
 func init() {
-	Before("@iotdataplane", func() {
+	gucumber.Before("@iotdataplane", func() {
 		svc := iot.New(smoke.Session)
 		result, err := svc.DescribeEndpoint(&iot.DescribeEndpointInput{})
 		if err != nil {
-			World["error"] = err
+			gucumber.World["error"] = err
 			return
 		}
 
-		World["client"] = iotdataplane.New(smoke.Session, aws.NewConfig().
+		gucumber.World["client"] = iotdataplane.New(smoke.Session, aws.NewConfig().
 			WithEndpoint(*result.EndpointAddress))
 	})
 }

--- a/awstesting/integration/smoke/kinesis/client.go
+++ b/awstesting/integration/smoke/kinesis/client.go
@@ -6,11 +6,11 @@ package kinesis
 import (
 	"github.com/aws/aws-sdk-go/awstesting/integration/smoke"
 	"github.com/aws/aws-sdk-go/service/kinesis"
-	. "github.com/gucumber/gucumber"
+	"github.com/gucumber/gucumber"
 )
 
 func init() {
-	Before("@kinesis", func() {
-		World["client"] = kinesis.New(smoke.Session)
+	gucumber.Before("@kinesis", func() {
+		gucumber.World["client"] = kinesis.New(smoke.Session)
 	})
 }

--- a/awstesting/integration/smoke/kms/client.go
+++ b/awstesting/integration/smoke/kms/client.go
@@ -6,11 +6,11 @@ package kms
 import (
 	"github.com/aws/aws-sdk-go/awstesting/integration/smoke"
 	"github.com/aws/aws-sdk-go/service/kms"
-	. "github.com/gucumber/gucumber"
+	"github.com/gucumber/gucumber"
 )
 
 func init() {
-	Before("@kms", func() {
-		World["client"] = kms.New(smoke.Session)
+	gucumber.Before("@kms", func() {
+		gucumber.World["client"] = kms.New(smoke.Session)
 	})
 }

--- a/awstesting/integration/smoke/lambda/client.go
+++ b/awstesting/integration/smoke/lambda/client.go
@@ -6,11 +6,11 @@ package lambda
 import (
 	"github.com/aws/aws-sdk-go/awstesting/integration/smoke"
 	"github.com/aws/aws-sdk-go/service/lambda"
-	. "github.com/gucumber/gucumber"
+	"github.com/gucumber/gucumber"
 )
 
 func init() {
-	Before("@lambda", func() {
-		World["client"] = lambda.New(smoke.Session)
+	gucumber.Before("@lambda", func() {
+		gucumber.World["client"] = lambda.New(smoke.Session)
 	})
 }

--- a/awstesting/integration/smoke/machinelearning/client.go
+++ b/awstesting/integration/smoke/machinelearning/client.go
@@ -6,11 +6,11 @@ package machinelearning
 import (
 	"github.com/aws/aws-sdk-go/awstesting/integration/smoke"
 	"github.com/aws/aws-sdk-go/service/machinelearning"
-	. "github.com/gucumber/gucumber"
+	"github.com/gucumber/gucumber"
 )
 
 func init() {
-	Before("@machinelearning", func() {
-		World["client"] = machinelearning.New(smoke.Session)
+	gucumber.Before("@machinelearning", func() {
+		gucumber.World["client"] = machinelearning.New(smoke.Session)
 	})
 }

--- a/awstesting/integration/smoke/opsworks/client.go
+++ b/awstesting/integration/smoke/opsworks/client.go
@@ -6,11 +6,11 @@ package opsworks
 import (
 	"github.com/aws/aws-sdk-go/awstesting/integration/smoke"
 	"github.com/aws/aws-sdk-go/service/opsworks"
-	. "github.com/gucumber/gucumber"
+	"github.com/gucumber/gucumber"
 )
 
 func init() {
-	Before("@opsworks", func() {
-		World["client"] = opsworks.New(smoke.Session)
+	gucumber.Before("@opsworks", func() {
+		gucumber.World["client"] = opsworks.New(smoke.Session)
 	})
 }

--- a/awstesting/integration/smoke/rds/client.go
+++ b/awstesting/integration/smoke/rds/client.go
@@ -6,11 +6,11 @@ package rds
 import (
 	"github.com/aws/aws-sdk-go/awstesting/integration/smoke"
 	"github.com/aws/aws-sdk-go/service/rds"
-	. "github.com/gucumber/gucumber"
+	"github.com/gucumber/gucumber"
 )
 
 func init() {
-	Before("@rds", func() {
-		World["client"] = rds.New(smoke.Session)
+	gucumber.Before("@rds", func() {
+		gucumber.World["client"] = rds.New(smoke.Session)
 	})
 }

--- a/awstesting/integration/smoke/redshift/client.go
+++ b/awstesting/integration/smoke/redshift/client.go
@@ -6,11 +6,11 @@ package redshift
 import (
 	"github.com/aws/aws-sdk-go/awstesting/integration/smoke"
 	"github.com/aws/aws-sdk-go/service/redshift"
-	. "github.com/gucumber/gucumber"
+	"github.com/gucumber/gucumber"
 )
 
 func init() {
-	Before("@redshift", func() {
-		World["client"] = redshift.New(smoke.Session)
+	gucumber.Before("@redshift", func() {
+		gucumber.World["client"] = redshift.New(smoke.Session)
 	})
 }

--- a/awstesting/integration/smoke/route53/client.go
+++ b/awstesting/integration/smoke/route53/client.go
@@ -6,11 +6,11 @@ package route53
 import (
 	"github.com/aws/aws-sdk-go/awstesting/integration/smoke"
 	"github.com/aws/aws-sdk-go/service/route53"
-	. "github.com/gucumber/gucumber"
+	"github.com/gucumber/gucumber"
 )
 
 func init() {
-	Before("@route53", func() {
-		World["client"] = route53.New(smoke.Session)
+	gucumber.Before("@route53", func() {
+		gucumber.World["client"] = route53.New(smoke.Session)
 	})
 }

--- a/awstesting/integration/smoke/route53domains/client.go
+++ b/awstesting/integration/smoke/route53domains/client.go
@@ -6,11 +6,11 @@ package route53domains
 import (
 	"github.com/aws/aws-sdk-go/awstesting/integration/smoke"
 	"github.com/aws/aws-sdk-go/service/route53domains"
-	. "github.com/gucumber/gucumber"
+	"github.com/gucumber/gucumber"
 )
 
 func init() {
-	Before("@route53domains", func() {
-		World["client"] = route53domains.New(smoke.Session)
+	gucumber.Before("@route53domains", func() {
+		gucumber.World["client"] = route53domains.New(smoke.Session)
 	})
 }

--- a/awstesting/integration/smoke/ses/client.go
+++ b/awstesting/integration/smoke/ses/client.go
@@ -6,11 +6,11 @@ package ses
 import (
 	"github.com/aws/aws-sdk-go/awstesting/integration/smoke"
 	"github.com/aws/aws-sdk-go/service/ses"
-	. "github.com/gucumber/gucumber"
+	"github.com/gucumber/gucumber"
 )
 
 func init() {
-	Before("@ses", func() {
-		World["client"] = ses.New(smoke.Session)
+	gucumber.Before("@ses", func() {
+		gucumber.World["client"] = ses.New(smoke.Session)
 	})
 }

--- a/awstesting/integration/smoke/shared.go
+++ b/awstesting/integration/smoke/shared.go
@@ -12,7 +12,7 @@ import (
 	"strconv"
 	"strings"
 
-	. "github.com/gucumber/gucumber"
+	"github.com/gucumber/gucumber"
 	"github.com/stretchr/testify/assert"
 
 	"github.com/aws/aws-sdk-go/aws"
@@ -37,47 +37,47 @@ func init() {
 	}
 	Session.Config.LogLevel = logLevel
 
-	When(`^I call the "(.+?)" API$`, func(op string) {
+	gucumber.When(`^I call the "(.+?)" API$`, func(op string) {
 		call(op, nil, false)
 	})
 
-	When(`^I call the "(.+?)" API with:$`, func(op string, args [][]string) {
+	gucumber.When(`^I call the "(.+?)" API with:$`, func(op string, args [][]string) {
 		call(op, args, false)
 	})
 
-	Then(`^the value at "(.+?)" should be a list$`, func(member string) {
-		vals, _ := awsutil.ValuesAtPath(World["response"], member)
-		assert.NotNil(T, vals)
+	gucumber.Then(`^the value at "(.+?)" should be a list$`, func(member string) {
+		vals, _ := awsutil.ValuesAtPath(gucumber.World["response"], member)
+		assert.NotNil(gucumber.T, vals)
 	})
 
-	Then(`^the response should contain a "(.+?)"$`, func(member string) {
-		vals, _ := awsutil.ValuesAtPath(World["response"], member)
-		assert.NotEmpty(T, vals)
+	gucumber.Then(`^the response should contain a "(.+?)"$`, func(member string) {
+		vals, _ := awsutil.ValuesAtPath(gucumber.World["response"], member)
+		assert.NotEmpty(gucumber.T, vals)
 	})
 
-	When(`^I attempt to call the "(.+?)" API with:$`, func(op string, args [][]string) {
+	gucumber.When(`^I attempt to call the "(.+?)" API with:$`, func(op string, args [][]string) {
 		call(op, args, true)
 	})
 
-	Then(`^I expect the response error code to be "(.+?)"$`, func(code string) {
-		err, ok := World["error"].(awserr.Error)
-		assert.True(T, ok, "no error returned")
+	gucumber.Then(`^I expect the response error code to be "(.+?)"$`, func(code string) {
+		err, ok := gucumber.World["error"].(awserr.Error)
+		assert.True(gucumber.T, ok, "no error returned")
 		if ok {
-			assert.Equal(T, code, err.Code(), "Error: %v", err)
+			assert.Equal(gucumber.T, code, err.Code(), "Error: %v", err)
 		}
 	})
 
-	And(`^I expect the response error message to include:$`, func(data string) {
-		err, ok := World["error"].(awserr.Error)
-		assert.True(T, ok, "no error returned")
+	gucumber.And(`^I expect the response error message to include:$`, func(data string) {
+		err, ok := gucumber.World["error"].(awserr.Error)
+		assert.True(gucumber.T, ok, "no error returned")
 		if ok {
-			assert.Contains(T, err.Error(), data)
+			assert.Contains(gucumber.T, err.Error(), data)
 		}
 	})
 
-	And(`^I expect the response error message to include one of:$`, func(table [][]string) {
-		err, ok := World["error"].(awserr.Error)
-		assert.True(T, ok, "no error returned")
+	gucumber.And(`^I expect the response error message to include one of:$`, func(table [][]string) {
+		err, ok := gucumber.World["error"].(awserr.Error)
+		assert.True(gucumber.T, ok, "no error returned")
 		if ok {
 			found := false
 			for _, row := range table {
@@ -87,46 +87,46 @@ func init() {
 				}
 			}
 
-			assert.True(T, found, fmt.Sprintf("no error messages matched: \"%s\"", err.Error()))
+			assert.True(gucumber.T, found, fmt.Sprintf("no error messages matched: \"%s\"", err.Error()))
 		}
 	})
 
-	And(`^I expect the response error message not be empty$`, func() {
-		err, ok := World["error"].(awserr.Error)
-		assert.True(T, ok, "no error returned")
-		assert.NotEmpty(T, err.Message())
+	gucumber.And(`^I expect the response error message not be empty$`, func() {
+		err, ok := gucumber.World["error"].(awserr.Error)
+		assert.True(gucumber.T, ok, "no error returned")
+		assert.NotEmpty(gucumber.T, err.Message())
 	})
 
-	When(`^I call the "(.+?)" API with JSON:$`, func(s1 string, data string) {
+	gucumber.When(`^I call the "(.+?)" API with JSON:$`, func(s1 string, data string) {
 		callWithJSON(s1, data, false)
 	})
 
-	When(`^I attempt to call the "(.+?)" API with JSON:$`, func(s1 string, data string) {
+	gucumber.When(`^I attempt to call the "(.+?)" API with JSON:$`, func(s1 string, data string) {
 		callWithJSON(s1, data, true)
 	})
 
-	Then(`^the error code should be "(.+?)"$`, func(s1 string) {
-		err, ok := World["error"].(awserr.Error)
-		assert.True(T, ok, "no error returned")
-		assert.Equal(T, s1, err.Code())
+	gucumber.Then(`^the error code should be "(.+?)"$`, func(s1 string) {
+		err, ok := gucumber.World["error"].(awserr.Error)
+		assert.True(gucumber.T, ok, "no error returned")
+		assert.Equal(gucumber.T, s1, err.Code())
 	})
 
-	And(`^the error message should contain:$`, func(data string) {
-		err, ok := World["error"].(awserr.Error)
-		assert.True(T, ok, "no error returned")
-		assert.Contains(T, err.Error(), data)
+	gucumber.And(`^the error message should contain:$`, func(data string) {
+		err, ok := gucumber.World["error"].(awserr.Error)
+		assert.True(gucumber.T, ok, "no error returned")
+		assert.Contains(gucumber.T, err.Error(), data)
 	})
 
-	Then(`^the request should fail$`, func() {
-		err, ok := World["error"].(awserr.Error)
-		assert.True(T, ok, "no error returned")
-		assert.Error(T, err)
+	gucumber.Then(`^the request should fail$`, func() {
+		err, ok := gucumber.World["error"].(awserr.Error)
+		assert.True(gucumber.T, ok, "no error returned")
+		assert.Error(gucumber.T, err)
 	})
 
-	Then(`^the request should be successful$`, func() {
-		err, ok := World["error"].(awserr.Error)
-		assert.False(T, ok, "error returned")
-		assert.NoError(T, err)
+	gucumber.Then(`^the request should be successful$`, func() {
+		err, ok := gucumber.World["error"].(awserr.Error)
+		assert.False(gucumber.T, ok, "error returned")
+		assert.NoError(gucumber.T, err)
 	})
 }
 
@@ -145,25 +145,25 @@ func findMethod(v reflect.Value, op string) *reflect.Value {
 	return nil
 }
 
-// call calls an operation on World["client"] by the name op using the args
+// call calls an operation on gucumber.World["client"] by the name op using the args
 // table of arguments to set.
 func call(op string, args [][]string, allowError bool) {
-	v := reflect.ValueOf(World["client"])
+	v := reflect.ValueOf(gucumber.World["client"])
 	if m := findMethod(v, op); m != nil {
 		t := m.Type()
 		in := reflect.New(t.In(0).Elem())
 		fillArgs(in, args)
 
 		resps := m.Call([]reflect.Value{in})
-		World["response"] = resps[0].Interface()
-		World["error"] = resps[1].Interface()
+		gucumber.World["response"] = resps[0].Interface()
+		gucumber.World["error"] = resps[1].Interface()
 
 		if !allowError {
-			err, _ := World["error"].(error)
-			assert.NoError(T, err)
+			err, _ := gucumber.World["error"].(error)
+			assert.NoError(gucumber.T, err)
 		}
 	} else {
-		assert.Fail(T, "failed to find operation "+op)
+		assert.Fail(gucumber.T, "failed to find operation "+op)
 	}
 }
 
@@ -203,22 +203,22 @@ func fillArgs(in reflect.Value, args [][]string) {
 }
 
 func callWithJSON(op, j string, allowError bool) {
-	v := reflect.ValueOf(World["client"])
+	v := reflect.ValueOf(gucumber.World["client"])
 	if m := findMethod(v, op); m != nil {
 		t := m.Type()
 		in := reflect.New(t.In(0).Elem())
 		fillJSON(in, j)
 
 		resps := m.Call([]reflect.Value{in})
-		World["response"] = resps[0].Interface()
-		World["error"] = resps[1].Interface()
+		gucumber.World["response"] = resps[0].Interface()
+		gucumber.World["error"] = resps[1].Interface()
 
 		if !allowError {
-			err, _ := World["error"].(error)
-			assert.NoError(T, err)
+			err, _ := gucumber.World["error"].(error)
+			assert.NoError(gucumber.T, err)
 		}
 	} else {
-		assert.Fail(T, "failed to find operation "+op)
+		assert.Fail(gucumber.T, "failed to find operation "+op)
 	}
 }
 

--- a/awstesting/integration/smoke/simpledb/client.go
+++ b/awstesting/integration/smoke/simpledb/client.go
@@ -6,11 +6,11 @@ package simpledb
 import (
 	"github.com/aws/aws-sdk-go/awstesting/integration/smoke"
 	"github.com/aws/aws-sdk-go/service/simpledb"
-	. "github.com/gucumber/gucumber"
+	"github.com/gucumber/gucumber"
 )
 
 func init() {
-	Before("@simpledb", func() {
-		World["client"] = simpledb.New(smoke.Session)
+	gucumber.Before("@simpledb", func() {
+		gucumber.World["client"] = simpledb.New(smoke.Session)
 	})
 }

--- a/awstesting/integration/smoke/sns/client.go
+++ b/awstesting/integration/smoke/sns/client.go
@@ -6,11 +6,11 @@ package sns
 import (
 	"github.com/aws/aws-sdk-go/awstesting/integration/smoke"
 	"github.com/aws/aws-sdk-go/service/sns"
-	. "github.com/gucumber/gucumber"
+	"github.com/gucumber/gucumber"
 )
 
 func init() {
-	Before("@sns", func() {
-		World["client"] = sns.New(smoke.Session)
+	gucumber.Before("@sns", func() {
+		gucumber.World["client"] = sns.New(smoke.Session)
 	})
 }

--- a/awstesting/integration/smoke/sqs/client.go
+++ b/awstesting/integration/smoke/sqs/client.go
@@ -6,11 +6,11 @@ package sqs
 import (
 	"github.com/aws/aws-sdk-go/awstesting/integration/smoke"
 	"github.com/aws/aws-sdk-go/service/sqs"
-	. "github.com/gucumber/gucumber"
+	"github.com/gucumber/gucumber"
 )
 
 func init() {
-	Before("@sqs", func() {
-		World["client"] = sqs.New(smoke.Session)
+	gucumber.Before("@sqs", func() {
+		gucumber.World["client"] = sqs.New(smoke.Session)
 	})
 }

--- a/awstesting/integration/smoke/ssm/client.go
+++ b/awstesting/integration/smoke/ssm/client.go
@@ -6,11 +6,11 @@ package ssm
 import (
 	"github.com/aws/aws-sdk-go/awstesting/integration/smoke"
 	"github.com/aws/aws-sdk-go/service/ssm"
-	. "github.com/gucumber/gucumber"
+	"github.com/gucumber/gucumber"
 )
 
 func init() {
-	Before("@ssm", func() {
-		World["client"] = ssm.New(smoke.Session)
+	gucumber.Before("@ssm", func() {
+		gucumber.World["client"] = ssm.New(smoke.Session)
 	})
 }

--- a/awstesting/integration/smoke/storagegateway/client.go
+++ b/awstesting/integration/smoke/storagegateway/client.go
@@ -6,11 +6,11 @@ package storagegateway
 import (
 	"github.com/aws/aws-sdk-go/awstesting/integration/smoke"
 	"github.com/aws/aws-sdk-go/service/storagegateway"
-	. "github.com/gucumber/gucumber"
+	"github.com/gucumber/gucumber"
 )
 
 func init() {
-	Before("@storagegateway", func() {
-		World["client"] = storagegateway.New(smoke.Session)
+	gucumber.Before("@storagegateway", func() {
+		gucumber.World["client"] = storagegateway.New(smoke.Session)
 	})
 }

--- a/awstesting/integration/smoke/sts/client.go
+++ b/awstesting/integration/smoke/sts/client.go
@@ -6,11 +6,11 @@ package sts
 import (
 	"github.com/aws/aws-sdk-go/awstesting/integration/smoke"
 	"github.com/aws/aws-sdk-go/service/sts"
-	. "github.com/gucumber/gucumber"
+	"github.com/gucumber/gucumber"
 )
 
 func init() {
-	Before("@sts", func() {
-		World["client"] = sts.New(smoke.Session)
+	gucumber.Before("@sts", func() {
+		gucumber.World["client"] = sts.New(smoke.Session)
 	})
 }

--- a/awstesting/integration/smoke/support/client.go
+++ b/awstesting/integration/smoke/support/client.go
@@ -6,11 +6,11 @@ package support
 import (
 	"github.com/aws/aws-sdk-go/awstesting/integration/smoke"
 	"github.com/aws/aws-sdk-go/service/support"
-	. "github.com/gucumber/gucumber"
+	"github.com/gucumber/gucumber"
 )
 
 func init() {
-	Before("@support", func() {
-		World["client"] = support.New(smoke.Session)
+	gucumber.Before("@support", func() {
+		gucumber.World["client"] = support.New(smoke.Session)
 	})
 }

--- a/awstesting/integration/smoke/swf/client.go
+++ b/awstesting/integration/smoke/swf/client.go
@@ -6,11 +6,11 @@ package swf
 import (
 	"github.com/aws/aws-sdk-go/awstesting/integration/smoke"
 	"github.com/aws/aws-sdk-go/service/swf"
-	. "github.com/gucumber/gucumber"
+	"github.com/gucumber/gucumber"
 )
 
 func init() {
-	Before("@swf", func() {
-		World["client"] = swf.New(smoke.Session)
+	gucumber.Before("@swf", func() {
+		gucumber.World["client"] = swf.New(smoke.Session)
 	})
 }

--- a/awstesting/integration/smoke/waf/client.go
+++ b/awstesting/integration/smoke/waf/client.go
@@ -6,11 +6,11 @@ package waf
 import (
 	"github.com/aws/aws-sdk-go/awstesting/integration/smoke"
 	"github.com/aws/aws-sdk-go/service/waf"
-	. "github.com/gucumber/gucumber"
+	"github.com/gucumber/gucumber"
 )
 
 func init() {
-	Before("@waf", func() {
-		World["client"] = waf.New(smoke.Session)
+	gucumber.Before("@waf", func() {
+		gucumber.World["client"] = waf.New(smoke.Session)
 	})
 }

--- a/awstesting/integration/smoke/workspaces/client.go
+++ b/awstesting/integration/smoke/workspaces/client.go
@@ -6,11 +6,11 @@ package workspaces
 import (
 	"github.com/aws/aws-sdk-go/awstesting/integration/smoke"
 	"github.com/aws/aws-sdk-go/service/workspaces"
-	. "github.com/gucumber/gucumber"
+	"github.com/gucumber/gucumber"
 )
 
 func init() {
-	Before("@workspaces", func() {
-		World["client"] = workspaces.New(smoke.Session)
+	gucumber.Before("@workspaces", func() {
+		gucumber.World["client"] = workspaces.New(smoke.Session)
 	})
 }

--- a/awstesting/performance/logging.go
+++ b/awstesting/performance/logging.go
@@ -25,7 +25,7 @@ type logger interface {
 	log(key string, data map[string]interface{}) error
 }
 
-// init intializes the logger and uses dependecy injection for the
+// init initializes the logger and uses dependency injection for the
 // outputer
 func newBenchmarkLogger(output string) (*benchmarkLogger, error) {
 	b := &benchmarkLogger{}

--- a/example/service/cloudfront/signCookies/signCookies.go
+++ b/example/service/cloudfront/signCookies/signCookies.go
@@ -57,7 +57,7 @@ func main() {
 
 	// Send and handle the response. For a successful response the object's
 	// content will be written to stdout. The same process could be applied
-	// to a http service written cookies to the response but useing
+	// to a http service written cookies to the response but using
 	// http.SetCookie(w, c,) on the ResponseWriter.
 	resp, err := http.DefaultClient.Do(req)
 	if err != nil {

--- a/private/model/api/shape.go
+++ b/private/model/api/shape.go
@@ -226,7 +226,7 @@ func (s ShapeTag) String() string {
 type ShapeTags []ShapeTag
 
 // Join returns an ordered serialization of the shape tags with the provided
-// seperator.
+// separator.
 func (s ShapeTags) Join(sep string) string {
 	o := &bytes.Buffer{}
 	for i, t := range s {
@@ -239,7 +239,7 @@ func (s ShapeTags) Join(sep string) string {
 	return o.String()
 }
 
-// String is an alias for Join with the empty space seperator.
+// String is an alias for Join with the empty space separator.
 func (s ShapeTags) String() string {
 	return s.Join(" ")
 }

--- a/private/protocol/ec2query/build.go
+++ b/private/protocol/ec2query/build.go
@@ -1,4 +1,4 @@
-// Package ec2query provides serialisation of AWS EC2 requests and responses.
+// Package ec2query provides serialization of AWS EC2 requests and responses.
 package ec2query
 
 //go:generate go run ../../../models/protocol_tests/generate.go ../../../models/protocol_tests/input/ec2.json build_test.go

--- a/private/protocol/json/jsonutil/build.go
+++ b/private/protocol/json/jsonutil/build.go
@@ -1,4 +1,4 @@
-// Package jsonutil provides JSON serialisation of AWS requests and responses.
+// Package jsonutil provides JSON serialization of AWS requests and responses.
 package jsonutil
 
 import (

--- a/private/protocol/jsonrpc/jsonrpc.go
+++ b/private/protocol/jsonrpc/jsonrpc.go
@@ -1,4 +1,4 @@
-// Package jsonrpc provides JSON RPC utilities for serialisation of AWS
+// Package jsonrpc provides JSON RPC utilities for serialization of AWS
 // requests and responses.
 package jsonrpc
 

--- a/private/protocol/query/build.go
+++ b/private/protocol/query/build.go
@@ -1,4 +1,4 @@
-// Package query provides serialisation of AWS query requests, and responses.
+// Package query provides serialization of AWS query requests, and responses.
 package query
 
 //go:generate go run ../../../models/protocol_tests/generate.go ../../../models/protocol_tests/input/query.json build_test.go

--- a/private/protocol/restjson/restjson.go
+++ b/private/protocol/restjson/restjson.go
@@ -1,4 +1,4 @@
-// Package restjson provides RESTful JSON serialisation of AWS
+// Package restjson provides RESTful JSON serialization of AWS
 // requests and responses.
 package restjson
 

--- a/private/protocol/restxml/restxml.go
+++ b/private/protocol/restxml/restxml.go
@@ -1,4 +1,4 @@
-// Package restxml provides RESTful XML serialisation of AWS
+// Package restxml provides RESTful XML serialization of AWS
 // requests and responses.
 package restxml
 

--- a/private/protocol/xml/xmlutil/build.go
+++ b/private/protocol/xml/xmlutil/build.go
@@ -1,4 +1,4 @@
-// Package xmlutil provides XML serialisation of AWS requests and responses.
+// Package xmlutil provides XML serialization of AWS requests and responses.
 package xmlutil
 
 import (

--- a/service/cloudfront/sign/sign_cookie.go
+++ b/service/cloudfront/sign/sign_cookie.go
@@ -17,7 +17,7 @@ const (
 	CookieKeyIDName = "CloudFront-Key-Pair-Id"
 )
 
-// A CookieOptions optional additonal options that can be applied to the signed
+// A CookieOptions optional additional options that can be applied to the signed
 // cookies.
 type CookieOptions struct {
 	Path   string

--- a/service/cloudfront/sign/sign_cookie_example_test.go
+++ b/service/cloudfront/sign/sign_cookie_example_test.go
@@ -124,7 +124,7 @@ func ExampleCookieSigner_SignOptions() {
 	}
 
 	// Create the CookieSigner with options set. These options can be set
-	// directly with cookieSigner.Opts. These values can be overriden on
+	// directly with cookieSigner.Opts. These values can be overridden on
 	// individual Sign and SignWithProfile calls.
 	cookieSigner := NewCookieSigner("keyID", privKey, func(o *CookieOptions) {
 		//provide an optional struct fields to specify other options

--- a/service/dynamodb/dynamodbattribute/encode.go
+++ b/service/dynamodb/dynamodbattribute/encode.go
@@ -9,7 +9,7 @@ import (
 	"github.com/aws/aws-sdk-go/service/dynamodb"
 )
 
-// A Marshaler is an interface to provide custom marshalling of Go value types
+// A Marshaler is an interface to provide custom marshaling of Go value types
 // to AttributeValues. Use this to provide custom logic determining how a
 // Go Value type should be marshaled.
 //

--- a/service/route53/unmarshal_error.go
+++ b/service/route53/unmarshal_error.go
@@ -69,7 +69,7 @@ func unmarshalInvalidChangeBatchError(r *request.Request, requestBody []byte) {
 	}
 
 	r.Error = awserr.NewRequestFailure(
-		awserr.NewBatchError(errorCode, "ChangeBatch errors occured", errors),
+		awserr.NewBatchError(errorCode, "ChangeBatch errors occurred", errors),
 		r.HTTPResponse.StatusCode,
 		r.RequestID,
 	)

--- a/service/s3/s3manager/download.go
+++ b/service/s3/s3manager/download.go
@@ -170,7 +170,7 @@ func (d *downloader) download() (n int64, err error) {
 		// Assign work
 		for d.getErr() == nil {
 			if d.pos >= total {
-				break // We're finished queueing chunks
+				break // We're finished queuing chunks
 			}
 
 			// Queue the next range of bytes to read.

--- a/service/s3/s3manager/upload.go
+++ b/service/s3/s3manager/upload.go
@@ -318,7 +318,7 @@ func NewUploaderWithClient(svc s3iface.S3API, options ...func(*Uploader)) *Uploa
 //     // Perform upload with options different than the those in the Uploader.
 //     result, err := uploader.Upload(upParams, func(u *s3manager.Uploader) {
 //          u.PartSize = 10 * 1024 * 1024 // 10MB part size
-//          u.LeavePartsOnError = true    // Dont delete the parts if the upload fails.
+//          u.LeavePartsOnError = true    // Don't delete the parts if the upload fails.
 //     })
 func (u Uploader) Upload(input *UploadInput, options ...func(*Uploader)) (*UploadOutput, error) {
 	i := uploader{in: input, ctx: u}

--- a/service/s3/unmarshal_error.go
+++ b/service/s3/unmarshal_error.go
@@ -23,7 +23,7 @@ func unmarshalError(r *request.Request) {
 	defer r.HTTPResponse.Body.Close()
 	defer io.Copy(ioutil.Discard, r.HTTPResponse.Body)
 
-	// Bucket exists in a differnt region, and request needs
+	// Bucket exists in a different region, and request needs
 	// to be made to the correct region.
 	if r.HTTPResponse.StatusCode == http.StatusMovedPermanently {
 		r.Error = awserr.NewRequestFailure(


### PR DESCRIPTION
Fixes several spelling errors in the SDK (excluding service generated doc strings), and removed `.` imports from the integration tests.