### PR TITLE
fix for issue #783

### DIFF
--- a/aws/signer/v4/v4.go
+++ b/aws/signer/v4/v4.go
@@ -545,7 +545,7 @@ func (ctx *signingCtx) buildBodyDigest() {
 		} else {
 			hash = hex.EncodeToString(makeSha256Reader(ctx.Body))
 		}
-		if ctx.ServiceName == "s3" {
+		if ctx.ServiceName == "s3" || ctx.ServiceName == "glacier" {
 			ctx.Request.Header.Set("X-Amz-Content-Sha256", hash)
 		}
 	}

--- a/aws/signer/v4/v4_test.go
+++ b/aws/signer/v4/v4_test.go
@@ -111,10 +111,18 @@ func TestSignRequest(t *testing.T) {
 	assert.Equal(t, expectedDate, q.Get("X-Amz-Date"))
 }
 
-func TestSignBody(t *testing.T) {
+func TestSignBodyS3(t *testing.T) {
 	req, body := buildRequest("s3", "us-east-1", "hello")
 	signer := buildSigner()
 	signer.Sign(req, body, "s3", "us-east-1", time.Now())
+	hash := req.Header.Get("X-Amz-Content-Sha256")
+	assert.Equal(t, "2cf24dba5fb0a30e26e83b2ac5b9e29e1b161e5c1fa7425e73043362938b9824", hash)
+}
+
+func TestSignBodyGlacier(t *testing.T) {
+	req, body := buildRequest("glacier", "us-east-1", "hello")
+	signer := buildSigner()
+	signer.Sign(req, body, "glacier", "us-east-1", time.Now())
 	hash := req.Header.Get("X-Amz-Content-Sha256")
 	assert.Equal(t, "2cf24dba5fb0a30e26e83b2ac5b9e29e1b161e5c1fa7425e73043362938b9824", hash)
 }


### PR DESCRIPTION
A regression was introduced in commit bae4e5236e96d15b7d97d69b7d91550defa99741 (relating to issue #743) that broke glacier's UploadMultpartPart. I'm not 100% sure what's going on here, but it appears that glacier has the same signer-v4 exceptions as s3?

Fix #783