### PR TITLE
service/s3/s3manager: Fix UnexpectedEOF not being handled durign upload

### DIFF
--- a/service/s3/s3manager/upload.go
+++ b/service/s3/s3manager/upload.go
@@ -354,15 +354,15 @@ func (u *uploader) upload() (*UploadOutput, error) {
 	}
 
 	// Do one read to determine if we have more than one part
-	buf, err := u.nextReader()
-	if err == io.EOF || err == io.ErrUnexpectedEOF { // single part
-		return u.singlePart(buf)
+	reader, _, err := u.nextReader()
+	if err == io.EOF { // single part
+		return u.singlePart(reader)
 	} else if err != nil {
 		return nil, awserr.New("ReadRequestBody", "read upload data failed", err)
 	}
 
 	mu := multiuploader{uploader: u}
-	return mu.upload(buf)
+	return mu.upload(reader)
 }
 
 // init will initialize all default options.
@@ -408,7 +408,7 @@ func (u *uploader) initSize() {
 // This operation increases the shared u.readerPos counter, but note that it
 // does not need to be wrapped in a mutex because nextReader is only called
 // from the main thread.
-func (u *uploader) nextReader() (io.ReadSeeker, error) {
+func (u *uploader) nextReader() (io.ReadSeeker, int, error) {
 	switch r := u.in.Body.(type) {
 	case io.ReaderAt:
 		var err error
@@ -417,27 +417,34 @@ func (u *uploader) nextReader() (io.ReadSeeker, error) {
 		if u.totalSize >= 0 {
 			bytesLeft := u.totalSize - u.readerPos
 
-			if bytesLeft == 0 {
+			if bytesLeft <= u.ctx.PartSize {
 				err = io.EOF
-				n = bytesLeft
-			} else if bytesLeft <= u.ctx.PartSize {
-				err = io.ErrUnexpectedEOF
 				n = bytesLeft
 			}
 		}
 
-		buf := io.NewSectionReader(r, u.readerPos, n)
+		reader := io.NewSectionReader(r, u.readerPos, n)
 		u.readerPos += n
 
-		return buf, err
+		return reader, int(n), err
 
 	default:
-		packet := make([]byte, u.ctx.PartSize)
-		n, err := io.ReadFull(u.in.Body, packet)
+		part := make([]byte, u.ctx.PartSize)
+		n, err := readFillBuf(r, part)
 		u.readerPos += int64(n)
 
-		return bytes.NewReader(packet[0:n]), err
+		return bytes.NewReader(part[0:n]), n, err
 	}
+}
+
+func readFillBuf(r io.Reader, b []byte) (offset int, err error) {
+	for offset < len(b) && err == nil {
+		var n int
+		n, err = r.Read(b[offset:])
+		offset += n
+	}
+
+	return offset, err
 }
 
 // singlePart contains upload logic for uploading a single chunk via
@@ -511,8 +518,10 @@ func (u *multiuploader) upload(firstBuf io.ReadSeeker) (*UploadOutput, error) {
 	ch <- chunk{buf: firstBuf, num: num}
 
 	// Read and queue the rest of the parts
-	for u.geterr() == nil {
+	var err error
+	for u.geterr() == nil && err == nil {
 		num++
+		fmt.Println("upload num", num)
 		// This upload exceeded maximum number of supported parts, error now.
 		if num > int64(u.ctx.MaxUploadParts) || num > int64(MaxUploadParts) {
 			var msg string
@@ -527,22 +536,26 @@ func (u *multiuploader) upload(firstBuf io.ReadSeeker) (*UploadOutput, error) {
 			break
 		}
 
-		buf, err := u.nextReader()
-		if err == io.EOF {
-			break
-		}
+		var reader io.ReadSeeker
+		var nextChunkLen int
+		reader, nextChunkLen, err = u.nextReader()
 
-		ch <- chunk{buf: buf, num: num}
-
-		if err == io.ErrUnexpectedEOF {
-			break
-		} else if err != nil {
+		if err != nil && err != io.EOF {
 			u.seterr(awserr.New(
 				"ReadRequestBody",
 				"read multipart upload data failed",
 				err))
 			break
 		}
+
+		if nextChunkLen == 0 {
+			// No need to upload empty part, if file was empty to start
+			// with empty single part would of been created and never
+			// started multipart upload.
+			break
+		}
+
+		ch <- chunk{buf: reader, num: num}
 	}
 
 	// Close the channel, wait for workers, and complete upload

--- a/service/s3/s3manager/upload.go
+++ b/service/s3/s3manager/upload.go
@@ -521,7 +521,6 @@ func (u *multiuploader) upload(firstBuf io.ReadSeeker) (*UploadOutput, error) {
 	var err error
 	for u.geterr() == nil && err == nil {
 		num++
-		fmt.Println("upload num", num)
 		// This upload exceeded maximum number of supported parts, error now.
 		if num > int64(u.ctx.MaxUploadParts) || num > int64(MaxUploadParts) {
 			var msg string

--- a/service/s3/s3manager/upload_test.go
+++ b/service/s3/s3manager/upload_test.go
@@ -552,6 +552,44 @@ func TestUploadInputS3PutObjectInputPairity(t *testing.T) {
 	assert.Empty(t, aOnly, "s3.PutObjectInput")
 	assert.Empty(t, bOnly, "s3Manager.UploadInput")
 }
+
+type testIncompleteReader struct {
+	Buf   []byte
+	Count int
+}
+
+func (r *testIncompleteReader) Read(p []byte) (n int, err error) {
+	if r.Count < 0 {
+		return 0, io.ErrUnexpectedEOF
+	}
+
+	r.Count--
+	return copy(p, r.Buf), nil
+}
+
+func TestUploadUnexpectedEOF(t *testing.T) {
+	s, ops, args := loggingSvc(emptyList)
+	mgr := s3manager.NewUploaderWithClient(s, func(u *s3manager.Uploader) {
+		u.Concurrency = 1
+	})
+	_, err := mgr.Upload(&s3manager.UploadInput{
+		Bucket: aws.String("Bucket"),
+		Key:    aws.String("Key"),
+		Body: &testIncompleteReader{
+			Buf:   make([]byte, 1024*1024*5),
+			Count: 1,
+		},
+	})
+
+	assert.Error(t, err)
+	assert.Equal(t, "CreateMultipartUpload", (*ops)[0])
+	assert.Equal(t, "UploadPart", (*ops)[1])
+	assert.Equal(t, "AbortMultipartUpload", (*ops)[len(*ops)-1])
+
+	// Part lengths
+	assert.Equal(t, 1024*1024*5, buflen(val((*args)[1], "Body")))
+}
+
 func compareStructType(a, b reflect.Type) map[string]int {
 	if a.Kind() != reflect.Struct || b.Kind() != reflect.Struct {
 		panic(fmt.Sprintf("types must both be structs, got %v and %v", a.Kind(), b.Kind()))

--- a/service/s3/s3manager/upload_test.go
+++ b/service/s3/s3manager/upload_test.go
@@ -433,13 +433,13 @@ func TestUploadOrderMultiBufferedReader(t *testing.T) {
 	assert.Equal(t, []int{1024 * 1024 * 2, 1024 * 1024 * 5, 1024 * 1024 * 5}, parts)
 }
 
-func TestUploadOrderMultiBufferedReaderUnexpectedEOF(t *testing.T) {
+func TestUploadOrderMultiBufferedReaderPartial(t *testing.T) {
 	s, ops, args := loggingSvc(emptyList)
 	mgr := s3manager.NewUploaderWithClient(s)
 	_, err := mgr.Upload(&s3manager.UploadInput{
 		Bucket: aws.String("Bucket"),
 		Key:    aws.String("Key"),
-		Body:   &sizedReader{size: 1024 * 1024 * 12, err: io.ErrUnexpectedEOF},
+		Body:   &sizedReader{size: 1024 * 1024 * 12, err: io.EOF},
 	})
 
 	assert.NoError(t, err)
@@ -456,8 +456,7 @@ func TestUploadOrderMultiBufferedReaderUnexpectedEOF(t *testing.T) {
 }
 
 // TestUploadOrderMultiBufferedReaderEOF tests the edge case where the
-// file size is the same as part size, which means nextReader will
-// return io.EOF rather than io.ErrUnexpectedEOF
+// file size is the same as part size.
 func TestUploadOrderMultiBufferedReaderEOF(t *testing.T) {
 	s, ops, args := loggingSvc(emptyList)
 	mgr := s3manager.NewUploaderWithClient(s)


### PR DESCRIPTION
Fixes how the io.ErrUnexpectedEOF error was handled by the uploader received from io.Reader input.

Fix #780