### PR TITLE
aws/session: Enables support for Shared Config by default

### DIFF
--- a/README.md
+++ b/README.md
@@ -62,7 +62,7 @@ AWS_SECRET_ACCESS_KEY=MY-SECRET-KEY
 ```
 
 ### AWS shared config file (`~/.aws/config`)
-The AWS SDK for Go added support the shared config file in release [v1.3.0](https://github.com/aws/aws-sdk-go/releases/tag/v1.3.0). You can opt into enabling support for the shared config by setting the environment variable `AWS_SDK_LOAD_CONFIG` to a truthy value. See the [Session](https://github.com/aws/aws-sdk-go/wiki/sessions) wiki for more information about this feature.
+The AWS SDK for Go added support the shared config file in release [v1.3.0](https://github.com/aws/aws-sdk-go/releases/tag/v1.3.0), and was changed to on by default with the option to opt out in [v1.4.0](https://github.com/aws/aws-sdk-go/releases/tag/v1.4.0). You can opt out of support for the shared config by setting the environment variable `AWS_SDK_CONFIG_OPT_OUT`. See the [Session](https://github.com/aws/aws-sdk-go/wiki/sessions) wiki for more information about this feature.
 
 ## Using the Go SDK
 

--- a/aws/session/doc.go
+++ b/aws/session/doc.go
@@ -171,6 +171,13 @@ Sessions. All environment values are optional, but some values like credentials
 require multiple of the values to set or the partial values will be ignored.
 All environment variable values are strings unless otherwise noted.
 
+Sessions can also be configured to enable fallback support for the CLI's
+AWS_DEFAULT_REGION and AWS_DEFAULT_PROFILE environment variables. If the
+AWS_SDK_ENABLE_CLI_ENV_VAR_FALLBACK environment variable is set the SDK will
+read the region and profile from those variables if it was not found using
+AWS_REGION or AWS_PROFILE. By default this functionality is disabled and must
+be enabled for sessions to use these additional environment variables.
+
 Environment configuration values. If set both Access Key ID and Secret Access
 Key must be provided. Session Token and optionally also be provided, but is
 not required.
@@ -192,8 +199,8 @@ client request is made.
 
 	AWS_REGION=us-east-1
 
-	# AWS_DEFAULT_REGION is only read if Shared Config is enabled.
-	# and AWS_REGION is not also set.
+	# AWS_DEFAULT_REGION is only read if AWS_SDK_ENABLE_CLI_ENV_VAR_FALLBACK.
+	# is also set, and AWS_REGION is not also set.
 	AWS_DEFAULT_REGION=us-east-1
 
 Profile name the SDK should load use when loading shared config from the
@@ -201,8 +208,8 @@ configuration files. If not provided "default" will be used as the profile name.
 
 	AWS_PROFILE=my_profile
 
-	# AWS_DEFAULT_PROFILE is only read if Shared Config is enabled.
-	# and AWS_PROFILE is not also set.
+	# AWS_DEFAULT_PROFILE is only read if AWS_SDK_ENABLE_CLI_ENV_VAR_FALLBACK.
+	# is also set, and AWS_PROFILE is not also set.
 	AWS_DEFAULT_PROFILE=my_profile
 
 SDK config opt out instructs the SDK to not load the shared config in addition

--- a/aws/session/env_config_test.go
+++ b/aws/session/env_config_test.go
@@ -92,9 +92,8 @@ func TestLoadEnvConfig(t *testing.T) {
 	defer popEnv(env)
 
 	cases := []struct {
-		Env                 map[string]string
-		Region, Profile     string
-		UseSharedConfigCall bool
+		Env             map[string]string
+		Region, Profile string
 	}{
 		{
 			Env: map[string]string{
@@ -114,56 +113,20 @@ func TestLoadEnvConfig(t *testing.T) {
 		},
 		{
 			Env: map[string]string{
-				"AWS_REGION":          "region",
-				"AWS_DEFAULT_REGION":  "default_region",
-				"AWS_PROFILE":         "profile",
-				"AWS_DEFAULT_PROFILE": "default_profile",
-				"AWS_SDK_LOAD_CONFIG": "1",
+				"AWS_REGION":            "region",
+				"AWS_DEFAULT_REGION":    "default_region",
+				"AWS_PROFILE":           "profile",
+				"AWS_DEFAULT_PROFILE":   "default_profile",
+				"AWS_SDK_CONFIG_OPT_OUT": "1",
 			},
 			Region: "region", Profile: "profile",
 		},
 		{
 			Env: map[string]string{
-				"AWS_DEFAULT_REGION":  "default_region",
-				"AWS_DEFAULT_PROFILE": "default_profile",
+				"AWS_DEFAULT_REGION":    "default_region",
+				"AWS_DEFAULT_PROFILE":   "default_profile",
+				"AWS_SDK_CONFIG_OPT_OUT": "1",
 			},
-		},
-		{
-			Env: map[string]string{
-				"AWS_DEFAULT_REGION":  "default_region",
-				"AWS_DEFAULT_PROFILE": "default_profile",
-				"AWS_SDK_LOAD_CONFIG": "1",
-			},
-			Region: "default_region", Profile: "default_profile",
-		},
-		{
-			Env: map[string]string{
-				"AWS_REGION":  "region",
-				"AWS_PROFILE": "profile",
-			},
-			Region: "region", Profile: "profile",
-			UseSharedConfigCall: true,
-		},
-		{
-			Env: map[string]string{
-				"AWS_REGION":          "region",
-				"AWS_DEFAULT_REGION":  "default_region",
-				"AWS_PROFILE":         "profile",
-				"AWS_DEFAULT_PROFILE": "default_profile",
-			},
-			Region: "region", Profile: "profile",
-			UseSharedConfigCall: true,
-		},
-		{
-			Env: map[string]string{
-				"AWS_REGION":          "region",
-				"AWS_DEFAULT_REGION":  "default_region",
-				"AWS_PROFILE":         "profile",
-				"AWS_DEFAULT_PROFILE": "default_profile",
-				"AWS_SDK_LOAD_CONFIG": "1",
-			},
-			Region: "region", Profile: "profile",
-			UseSharedConfigCall: true,
 		},
 		{
 			Env: map[string]string{
@@ -171,35 +134,20 @@ func TestLoadEnvConfig(t *testing.T) {
 				"AWS_DEFAULT_PROFILE": "default_profile",
 			},
 			Region: "default_region", Profile: "default_profile",
-			UseSharedConfigCall: true,
-		},
-		{
-			Env: map[string]string{
-				"AWS_DEFAULT_REGION":  "default_region",
-				"AWS_DEFAULT_PROFILE": "default_profile",
-				"AWS_SDK_LOAD_CONFIG": "1",
-			},
-			Region: "default_region", Profile: "default_profile",
-			UseSharedConfigCall: true,
 		},
 	}
 
-	for _, c := range cases {
+	for i, c := range cases {
 		os.Clearenv()
 
 		for k, v := range c.Env {
 			os.Setenv(k, v)
 		}
 
-		var cfg envConfig
-		if c.UseSharedConfigCall {
-			cfg = loadSharedEnvConfig()
-		} else {
-			cfg = loadEnvConfig()
-		}
+		cfg := loadEnvConfig()
 
-		assert.Equal(t, c.Region, cfg.Region)
-		assert.Equal(t, c.Profile, cfg.Profile)
+		assert.Equal(t, c.Region, cfg.Region, "case %d", i)
+		assert.Equal(t, c.Profile, cfg.Profile, "case %d", i)
 	}
 }
 

--- a/aws/session/env_config_test.go
+++ b/aws/session/env_config_test.go
@@ -113,18 +113,18 @@ func TestLoadEnvConfig(t *testing.T) {
 		},
 		{
 			Env: map[string]string{
-				"AWS_REGION":            "region",
-				"AWS_DEFAULT_REGION":    "default_region",
-				"AWS_PROFILE":           "profile",
-				"AWS_DEFAULT_PROFILE":   "default_profile",
+				"AWS_REGION":             "region",
+				"AWS_DEFAULT_REGION":     "default_region",
+				"AWS_PROFILE":            "profile",
+				"AWS_DEFAULT_PROFILE":    "default_profile",
 				"AWS_SDK_CONFIG_OPT_OUT": "1",
 			},
 			Region: "region", Profile: "profile",
 		},
 		{
 			Env: map[string]string{
-				"AWS_DEFAULT_REGION":    "default_region",
-				"AWS_DEFAULT_PROFILE":   "default_profile",
+				"AWS_DEFAULT_REGION":     "default_region",
+				"AWS_DEFAULT_PROFILE":    "default_profile",
 				"AWS_SDK_CONFIG_OPT_OUT": "1",
 			},
 		},
@@ -132,6 +132,21 @@ func TestLoadEnvConfig(t *testing.T) {
 			Env: map[string]string{
 				"AWS_DEFAULT_REGION":  "default_region",
 				"AWS_DEFAULT_PROFILE": "default_profile",
+			},
+		},
+		{
+			Env: map[string]string{
+				"AWS_DEFAULT_REGION":                  "default_region",
+				"AWS_DEFAULT_PROFILE":                 "default_profile",
+				"AWS_SDK_ENABLE_CLI_ENV_VAR_FALLBACK": "1",
+			},
+			Region: "default_region", Profile: "default_profile",
+		},
+		{
+			Env: map[string]string{
+				"AWS_DEFAULT_REGION":  "default_region",
+				"AWS_DEFAULT_PROFILE": "default_profile",
+				"AWS_SDK_LOAD_CONFIG": "1",
 			},
 			Region: "default_region", Profile: "default_profile",
 		},
@@ -199,12 +214,11 @@ func TestSetEnvValue(t *testing.T) {
 	os.Setenv("second_key", "2")
 	os.Setenv("third_key", "3")
 
-	var dst string
-	setFromEnvVal(&dst, []string{
+	val := stringFromEnv([]string{
 		"empty_key", "first_key", "second_key", "third_key",
 	})
 
-	assert.Equal(t, "2", dst)
+	assert.Equal(t, "2", val)
 }
 
 func stashEnv() []string {

--- a/aws/session/session.go
+++ b/aws/session/session.go
@@ -132,7 +132,7 @@ type Options struct {
 
 	// Overrides the config profile the Session should be created from. If not
 	// set the value of the environment variable will be loaded (AWS_PROFILE,
-	// or AWS_DEFAULT_PROFILE if the Shared Config is enabled).
+	// or AWS_DEFAULT_PROFILE if AWS_SDK_ENABLE_CLI_ENV_VAR_FALLBACK is set).
 	//
 	// If not set and environment variables are not set the "default"
 	// (DefaultSharedConfigProfile) will be used as the profile to load the

--- a/aws/session/session_test.go
+++ b/aws/session/session_test.go
@@ -51,7 +51,6 @@ func TestNew_WithSessionLoadError(t *testing.T) {
 	oldEnv := initSessionTestEnv()
 	defer popEnv(oldEnv)
 
-	os.Setenv("AWS_SDK_LOAD_CONFIG", "1")
 	os.Setenv("AWS_CONFIG_FILE", testConfigFilename)
 	os.Setenv("AWS_PROFILE", "assume_role_invalid_source_profile")
 
@@ -64,7 +63,7 @@ func TestNew_WithSessionLoadError(t *testing.T) {
 	_, err := svc.ListBuckets(&s3.ListBucketsInput{})
 
 	assert.Error(t, err)
-	assert.Contains(t, logger.String(), "ERROR: failed to create session with AWS_SDK_LOAD_CONFIG enabled")
+	assert.Contains(t, logger.String(), "ERROR: failed to create session with SDK Shared Config enabled")
 	assert.Contains(t, err.Error(), SharedConfigAssumeRoleError{
 		RoleARN: "assume_role_invalid_source_profile_role_arn",
 	}.Error())
@@ -113,7 +112,6 @@ func TestNewSessionWithOptions_OverrideProfile(t *testing.T) {
 	oldEnv := initSessionTestEnv()
 	defer popEnv(oldEnv)
 
-	os.Setenv("AWS_SDK_LOAD_CONFIG", "1")
 	os.Setenv("AWS_SHARED_CREDENTIALS_FILE", testConfigFilename)
 	os.Setenv("AWS_PROFILE", "other_profile")
 
@@ -136,7 +134,7 @@ func TestNewSessionWithOptions_OverrideSharedConfigEnable(t *testing.T) {
 	oldEnv := initSessionTestEnv()
 	defer popEnv(oldEnv)
 
-	os.Setenv("AWS_SDK_LOAD_CONFIG", "0")
+	os.Setenv("AWS_SDK_CONFIG_OPT_OUT", "1")
 	os.Setenv("AWS_SHARED_CREDENTIALS_FILE", testConfigFilename)
 	os.Setenv("AWS_PROFILE", "full_profile")
 
@@ -159,7 +157,6 @@ func TestNewSessionWithOptions_OverrideSharedConfigDisable(t *testing.T) {
 	oldEnv := initSessionTestEnv()
 	defer popEnv(oldEnv)
 
-	os.Setenv("AWS_SDK_LOAD_CONFIG", "1")
 	os.Setenv("AWS_SHARED_CREDENTIALS_FILE", testConfigFilename)
 	os.Setenv("AWS_PROFILE", "full_profile")
 
@@ -187,7 +184,7 @@ func TestNewSessionWithOptions_Overrides(t *testing.T) {
 	}{
 		{
 			InEnvs: map[string]string{
-				"AWS_SDK_LOAD_CONFIG":         "0",
+				"AWS_SDK_CONFIG_OPT_OUT":      "1",
 				"AWS_SHARED_CREDENTIALS_FILE": testConfigFilename,
 				"AWS_PROFILE":                 "other_profile",
 			},
@@ -201,7 +198,19 @@ func TestNewSessionWithOptions_Overrides(t *testing.T) {
 		},
 		{
 			InEnvs: map[string]string{
-				"AWS_SDK_LOAD_CONFIG":         "0",
+				"AWS_SHARED_CREDENTIALS_FILE": testConfigFilename,
+				"AWS_PROFILE":                 "other_profile",
+			},
+			InProfile: "full_profile",
+			OutRegion: "full_profile_region",
+			OutCreds: credentials.Value{
+				AccessKeyID:     "full_profile_akid",
+				SecretAccessKey: "full_profile_secret",
+				ProviderName:    "SharedConfigCredentials",
+			},
+		},
+		{
+			InEnvs: map[string]string{
 				"AWS_SHARED_CREDENTIALS_FILE": testConfigFilename,
 				"AWS_REGION":                  "env_region",
 				"AWS_ACCESS_KEY":              "env_akid",
@@ -218,7 +227,6 @@ func TestNewSessionWithOptions_Overrides(t *testing.T) {
 		},
 		{
 			InEnvs: map[string]string{
-				"AWS_SDK_LOAD_CONFIG":         "0",
 				"AWS_SHARED_CREDENTIALS_FILE": testConfigFilename,
 				"AWS_CONFIG_FILE":             testConfigOtherFilename,
 				"AWS_PROFILE":                 "shared_profile",
@@ -262,7 +270,6 @@ func TestSesisonAssumeRole(t *testing.T) {
 	defer popEnv(oldEnv)
 
 	os.Setenv("AWS_REGION", "us-east-1")
-	os.Setenv("AWS_SDK_LOAD_CONFIG", "1")
 	os.Setenv("AWS_SHARED_CREDENTIALS_FILE", testConfigFilename)
 	os.Setenv("AWS_PROFILE", "assume_role_w_creds")
 
@@ -305,7 +312,7 @@ func TestSessionAssumeRole_DisableSharedConfig(t *testing.T) {
 	oldEnv := initSessionTestEnv()
 	defer popEnv(oldEnv)
 
-	os.Setenv("AWS_SDK_LOAD_CONFIG", "0")
+	os.Setenv("AWS_SDK_CONFIG_OPT_OUT", "1")
 	os.Setenv("AWS_SHARED_CREDENTIALS_FILE", testConfigFilename)
 	os.Setenv("AWS_PROFILE", "assume_role_w_creds")
 
@@ -325,7 +332,6 @@ func TestSessionAssumeRole_InvalidSourceProfile(t *testing.T) {
 	oldEnv := initSessionTestEnv()
 	defer popEnv(oldEnv)
 
-	os.Setenv("AWS_SDK_LOAD_CONFIG", "1")
 	os.Setenv("AWS_SHARED_CREDENTIALS_FILE", testConfigFilename)
 	os.Setenv("AWS_PROFILE", "assume_role_invalid_source_profile")
 


### PR DESCRIPTION
Updates the SDK so by default the Session returned will be created with the
configuration loaded from the shared config file (~/.aws/config) will also be
loaded, in addition to the shared credentials file (~/.aws/config). Options
set in both the shared config, and shared credentials will be taken from the
shared credentials file. This functionality can be disabled by setting the
AWS_SDK_CONFIG_OPT_OUT environment variable.

This changes the behavior added in v1.3.0 to load the shared config by default instead of requiring an opt in flag. This also brings the SDK in like with the AWS SDK for Ruby to use an opt out flag with default support for the shared config.

In order to prevent introducing a breaking change with the opt out shared config update AWS_DEFAULT_x environment variables are gated behind the `AWS_SDK_ENABLE_CLI_ENV_VAR_FALLBACK` environment variable.

Set this value to enable the SDK to read the AWS_DEFAULT_x environment variables as fallback when AWS_REGION or AWS_PROFILE are not set.

`AWS_SDK_LOAD_CONFIG` is deprecated, but will still enable this fallback functionality. It is now an alias for AWS_SDK_ENABLE_CLI_ENV_VAR_FALLBACK.

Related: #472, aws/aws-sdk-ruby#1257