### PR TITLE
Fixed a typo in session documentation (Optons vs Options)

### DIFF
--- a/aws/session/doc.go
+++ b/aws/session/doc.go
@@ -67,10 +67,10 @@ Use NewSessionWithOptions when you want to provide the config profile, or
 override the shared config state (AWS_SDK_LOAD_CONFIG).
 
 	// Equivalent to session.New
-	sess, err := session.NewSessionWithOptions(session.Optons{})
+	sess, err := session.NewSessionWithOptions(session.Options{})
 
 	// Specify profile to load for the session's config
-	sess, err := session.NewSessionWithOptions(session.Optons{
+	sess, err := session.NewSessionWithOptions(session.Options{
 		 Profile: "profile_name",
 	})
 
@@ -81,7 +81,7 @@ override the shared config state (AWS_SDK_LOAD_CONFIG).
 	})
 
 	// Force enable Shared Config support
-	sess, err := session.NewSessionWithOptions(session.Optons{
+	sess, err := session.NewSessionWithOptions(session.Options{
 		SharedConfigState: SharedConfigEnable,
 	})
 

--- a/aws/session/session.go
+++ b/aws/session/session.go
@@ -158,10 +158,10 @@ type Options struct {
 // to be built with retrieving credentials with AssumeRole set in the config.
 //
 //     // Equivalent to session.New
-//     sess, err := session.NewSessionWithOptions(session.Optons{})
+//     sess, err := session.NewSessionWithOptions(session.Options{})
 //
 //     // Specify profile to load for the session's config
-//     sess, err := session.NewSessionWithOptions(session.Optons{
+//     sess, err := session.NewSessionWithOptions(session.Options{
 //          Profile: "profile_name",
 //     })
 //
@@ -172,7 +172,7 @@ type Options struct {
 //     })
 //
 //     // Force enable Shared Config support
-//     sess, err := session.NewSessionWithOptions(session.Optons{
+//     sess, err := session.NewSessionWithOptions(session.Options{
 //         SharedConfigState: SharedConfigEnable,
 //     })
 func NewSessionWithOptions(opts Options) (*Session, error) {


### PR DESCRIPTION
Notice this typo while reading your doc, might as well contribute a fix :)