### PR TITLE
aws/session: Correct credentials error messages, if no creds founds

### DIFF
--- a/aws/session/session.go
+++ b/aws/session/session.go
@@ -1,7 +1,10 @@
 package session
 
 import (
+	"fmt"
+
 	"github.com/aws/aws-sdk-go/aws"
+	"github.com/aws/aws-sdk-go/aws/awserr"
 	"github.com/aws/aws-sdk-go/aws/client"
 	"github.com/aws/aws-sdk-go/aws/corehandlers"
 	"github.com/aws/aws-sdk-go/aws/credentials"
@@ -310,12 +313,32 @@ func mergeConfigSrcs(cfg, userCfg *aws.Config, envCfg envConfig, sharedCfg share
 				sharedCfg.Creds,
 			)
 		} else {
-			// Fallback to default credentials provider
-			cfg.Credentials = credentials.NewCredentials(
-				defaults.RemoteCredProvider(*cfg, handlers),
-			)
+			// Fallback to default credentials provider, include mock errors
+			// for the credential chain so user can identify why credentials
+			// failed to be retrieved.
+			cfg.Credentials = credentials.NewCredentials(&credentials.ChainProvider{
+				VerboseErrors: aws.BoolValue(cfg.CredentialsChainVerboseErrors),
+				Providers: []credentials.Provider{
+					&credProviderError{Err: awserr.New("EnvAccessKeyNotFound", "failed to find credentials in the environment.", nil)},
+					&credProviderError{Err: awserr.New("SharedCredsLoad", fmt.Sprintf("failed to load profile, %s.", envCfg.Profile), nil)},
+					defaults.RemoteCredProvider(*cfg, handlers),
+				},
+			})
 		}
 	}
+}
+
+type credProviderError struct {
+	Err error
+}
+
+var emptyCreds = credentials.Value{}
+
+func (c credProviderError) Retrieve() (credentials.Value, error) {
+	return credentials.Value{}, c.Err
+}
+func (c credProviderError) IsExpired() bool {
+	return true
 }
 
 func initHandlers(s *Session) {


### PR DESCRIPTION
The Shared Config update expanded how the SDK can be configured to load
credentials, but the error message returned when no credentials were
found was not updated to be consistent with current chain provider
message.