### PR TITLE
Log errors that happen while dumping requests/responses

### DIFF
--- a/aws/client/client.go
+++ b/aws/client/client.go
@@ -97,6 +97,7 @@ func logRequest(r *request.Request) {
 	dumpedBody, err := httputil.DumpRequestOut(r.HTTPRequest, logBody)
 	if err != nil {
 		r.Config.Logger.Log(fmt.Sprintf(logReqErrMsg, r.ClientInfo.ServiceName, r.Operation.Name, err))
+		return
 	}
 
 	if logBody {
@@ -127,6 +128,7 @@ func logResponse(r *request.Request) {
 		dumpedBody, err := httputil.DumpResponse(r.HTTPResponse, logBody)
 		if err != nil {
 			r.Config.Logger.Log(fmt.Sprintf(logRespErrMsg, r.ClientInfo.ServiceName, r.Operation.Name, err))
+			return
 		}
 
 		msg = string(dumpedBody)

--- a/aws/client/client.go
+++ b/aws/client/client.go
@@ -89,7 +89,10 @@ const logReqMsg = `DEBUG: Request %s/%s Details:
 
 func logRequest(r *request.Request) {
 	logBody := r.Config.LogLevel.Matches(aws.LogDebugWithHTTPBody)
-	dumpedBody, _ := httputil.DumpRequestOut(r.HTTPRequest, logBody)
+	dumpedBody, err := httputil.DumpRequestOut(r.HTTPRequest, logBody)
+	if err != nil {
+		r.Config.Logger.Log(fmt.Sprintf("Error dumping request: %s", err))
+	}
 
 	if logBody {
 		// Reset the request body because dumpRequest will re-wrap the r.HTTPRequest's
@@ -111,7 +114,11 @@ func logResponse(r *request.Request) {
 	var msg = "no response data"
 	if r.HTTPResponse != nil {
 		logBody := r.Config.LogLevel.Matches(aws.LogDebugWithHTTPBody)
-		dumpedBody, _ := httputil.DumpResponse(r.HTTPResponse, logBody)
+		dumpedBody, err := httputil.DumpResponse(r.HTTPResponse, logBody)
+		if err != nil {
+			r.Config.Logger.Log(fmt.Sprintf("Error dumping response: %s", err))
+		}
+
 		msg = string(dumpedBody)
 	} else if r.Error != nil {
 		msg = r.Error.Error()

--- a/aws/client/client.go
+++ b/aws/client/client.go
@@ -87,11 +87,16 @@ const logReqMsg = `DEBUG: Request %s/%s Details:
 %s
 -----------------------------------------------------`
 
+const logReqErrMsg = `DEBUG ERROR: Request %s/%s:
+---[ REQUEST DUMP ERROR ]-----------------------------
+%s
+-----------------------------------------------------`
+
 func logRequest(r *request.Request) {
 	logBody := r.Config.LogLevel.Matches(aws.LogDebugWithHTTPBody)
 	dumpedBody, err := httputil.DumpRequestOut(r.HTTPRequest, logBody)
 	if err != nil {
-		r.Config.Logger.Log(fmt.Sprintf("Error dumping request: %s", err))
+		r.Config.Logger.Log(fmt.Sprintf(logReqErrMsg, r.ClientInfo.ServiceName, r.Operation.Name, err))
 	}
 
 	if logBody {
@@ -110,13 +115,18 @@ const logRespMsg = `DEBUG: Response %s/%s Details:
 %s
 -----------------------------------------------------`
 
+const logRespErrMsg = `DEBUG ERROR: Response %s/%s:
+---[ RESPONSE DUMP ERROR ]-----------------------------
+%s
+-----------------------------------------------------`
+
 func logResponse(r *request.Request) {
 	var msg = "no response data"
 	if r.HTTPResponse != nil {
 		logBody := r.Config.LogLevel.Matches(aws.LogDebugWithHTTPBody)
 		dumpedBody, err := httputil.DumpResponse(r.HTTPResponse, logBody)
 		if err != nil {
-			r.Config.Logger.Log(fmt.Sprintf("Error dumping response: %s", err))
+			r.Config.Logger.Log(fmt.Sprintf(logRespErrMsg, r.ClientInfo.ServiceName, r.Operation.Name, err))
 		}
 
 		msg = string(dumpedBody)


### PR DESCRIPTION
fixes #805 (which also describes the scenario in which this is important).