### PR TITLE
Fix crashes when embedded pointer to struct is being decoded/encoded to dynamodbattribute.

### DIFF
--- a/service/dynamodb/dynamodbattribute/decode.go
+++ b/service/dynamodb/dynamodbattribute/decode.go
@@ -449,20 +449,10 @@ func (d *Decoder) decodeMap(avMap map[string]*dynamodb.AttributeValue, v reflect
 		fields := unionStructFields(v.Type(), d.MarshalOptions)
 		for k, av := range avMap {
 			if f, ok := fieldByName(fields, k); ok {
-				fv := v
-				for i, x := range f.Index {
-					if i > 0 {
-						if fv.Kind() == reflect.Ptr && fv.Type().Elem().Kind() == reflect.Struct {
-							if fv.IsNil() {
-								// Create a struct object for embedded pointer
-								// fields, before accessing it.
-								fv.Set(reflect.New(fv.Type().Elem()))
-							}
-							fv = fv.Elem()
-						}
-					}
-					fv = fv.Field(x)
-				}
+				fv := fieldByIndex(v, f.Index, func(v *reflect.Value) bool {
+					v.Set(reflect.New(v.Type().Elem()))
+					return true // to continue the loop.
+				})
 				if err := d.decode(av, fv, f.tag); err != nil {
 					return err
 				}

--- a/service/dynamodb/dynamodbattribute/decode_test.go
+++ b/service/dynamodb/dynamodbattribute/decode_test.go
@@ -392,3 +392,36 @@ func TestDecodeUseNumberNumberSet(t *testing.T) {
 	assert.Equal(t, "123", ns[0].String())
 	assert.Equal(t, "321", ns[1].String())
 }
+
+func TestDecodeEmbeddedPointerStruct(t *testing.T) {
+	type B struct {
+		Bint int
+	}
+	type C struct {
+		Cint int
+	}
+	type A struct {
+		Aint int
+		*B
+		*C
+	}
+	av := &dynamodb.AttributeValue{
+		M: map[string]*dynamodb.AttributeValue{
+			"Aint": {
+				N: aws.String("321"),
+			},
+			"Bint": {
+				N: aws.String("123"),
+			},
+		},
+	}
+	decoder := NewDecoder()
+	a := A{}
+	err := decoder.Decode(av, &a)
+	assert.NoError(t, err)
+	assert.Equal(t, 321, a.Aint)
+	// Embedded pointer struct can be created automatically.
+	assert.Equal(t, 123, a.Bint)
+	// But not for absent fields.
+	assert.Nil(t, a.C)
+}

--- a/service/dynamodb/dynamodbattribute/encode.go
+++ b/service/dynamodb/dynamodbattribute/encode.go
@@ -182,6 +182,23 @@ func (e *Encoder) Encode(in interface{}) (*dynamodb.AttributeValue, error) {
 	return av, nil
 }
 
+func fieldByIndex(v reflect.Value, index []int,
+	OnEmbeddedNilStruct func(*reflect.Value) bool) reflect.Value {
+	fv := v
+	for i, x := range index {
+		if i > 0 {
+			if fv.Kind() == reflect.Ptr && fv.Type().Elem().Kind() == reflect.Struct {
+				if fv.IsNil() && !OnEmbeddedNilStruct(&fv) {
+					break
+				}
+				fv = fv.Elem()
+			}
+		}
+		fv = fv.Field(x)
+	}
+	return fv
+}
+
 func (e *Encoder) encode(av *dynamodb.AttributeValue, v reflect.Value, fieldTag tag) error {
 	// We should check for omitted values first before dereferencing.
 	if fieldTag.OmitEmpty && emptyValue(v) {
@@ -233,25 +250,14 @@ func (e *Encoder) encodeStruct(av *dynamodb.AttributeValue, v reflect.Value) err
 			return &InvalidMarshalError{msg: "map key cannot be empty"}
 		}
 
-		fv := v
 		found := true
-		for i, x := range f.Index {
-			if i > 0 {
-				if fv.Kind() == reflect.Ptr && fv.Type().Elem().Kind() == reflect.Struct {
-					if fv.IsNil() {
-						// Skip embedded pointer fields.
-						found = false
-						break
-					}
-					fv = fv.Elem()
-				}
-			}
-			fv = fv.Field(x)
-		}
+		fv := fieldByIndex(v, f.Index, func(v *reflect.Value) bool {
+			found = false
+			return false // to break the loop.
+		})
 		if !found {
 			continue
 		}
-		// fv := v.FieldByIndex(f.Index)
 		elem := &dynamodb.AttributeValue{}
 		err := e.encode(elem, fv, f.tag)
 		if err != nil {

--- a/service/dynamodb/dynamodbattribute/encode_test.go
+++ b/service/dynamodb/dynamodbattribute/encode_test.go
@@ -144,3 +144,35 @@ func TestMarshalOmitEmpty(t *testing.T) {
 	assert.NoError(t, err)
 	assert.Equal(t, expect, actual)
 }
+
+func TestEncodeEmbeddedPointerStruct(t *testing.T) {
+	type B struct {
+		Bint int
+	}
+	type C struct {
+		Cint int
+	}
+	type A struct {
+		Aint int
+		*B
+		*C
+	}
+	a := A{Aint: 321, B: &B{123}}
+	assert.Equal(t, 321, a.Aint)
+	assert.Equal(t, 123, a.Bint)
+	assert.Nil(t, a.C)
+
+	actual, err := Marshal(a)
+	assert.NoError(t, err)
+	expect := &dynamodb.AttributeValue{
+		M: map[string]*dynamodb.AttributeValue{
+			"Aint": {
+				N: aws.String("321"),
+			},
+			"Bint": {
+				N: aws.String("123"),
+			},
+		},
+	}
+	assert.Equal(t, expect, actual)
+}


### PR DESCRIPTION
If a struct pointer type is embedded as a field, the current implementation will crash when decoding a dynamodbattribute into it. Such as the c object in this following example:
```
	type B struct {
		Bint int
 	}
	type C struct {
		*B
	}
	c := C{}  // c.B is nil and we didn't create a B explicitly.
```
I think this is a bug because encoding/json could handle it correctly: https://play.golang.org/p/vg3PJJwrw6

The root cause of the bug is the abuse of reflect.Value.FieldByIndex which crashes on nil pointers.

The encoding procedure cannot handle embedded pointer struct field either, for the same reason. 

The fix is trivial, i.e., creating a object on nil embedded pointer when decoding and skipping nil embedded pointer when encoding.