### PR TITLE
Fix DescribeReservedInstancesListings

### DIFF
--- a/service/ec2/api.go
+++ b/service/ec2/api.go
@@ -19524,7 +19524,7 @@ type DescribeReservedInstancesListingsInput struct {
 	// | cancelled | closed).
 	//
 	//    status-message - The reason for the status.
-	Filters []*Filter `locationName:"filters" locationNameList:"Filter" type:"list"`
+	Filters []*Filter `locationName:"filter" locationNameList:"Filter" type:"list"`
 
 	// One or more Reserved Instance IDs.
 	ReservedInstancesId *string `locationName:"reservedInstancesId" type:"string"`


### PR DESCRIPTION
The struct annotation for the Filter field should be "filter",
not "filters". Without this change we get a 400 error.