### PR TITLE
Resign requests if they will expire within 1 min

### DIFF
--- a/aws/signer/v4/v4.go
+++ b/aws/signer/v4/v4.go
@@ -240,9 +240,10 @@ func (v4 Signer) signWithBody(r *http.Request, body io.ReadSeeker, service, regi
 	}
 
 	if ctx.isRequestSigned() {
-		if !v4.Credentials.IsExpired() && currentTimeFn().Before(ctx.Time.Add(10*time.Minute)) {
-			// If the request is already signed, and the credentials have not
-			// expired, and the request is not too old ignore the signing request.
+		if !v4.Credentials.IsExpired() && currentTimeFn().Before(ctx.Time.Add(9*time.Minute)) {
+			// If the request is already signed, and the credentials will not
+			// expire within one minute, and the request is not too old ignore
+			// the signing request.
 			return ctx.SignedHeaderVals, nil
 		}
 		ctx.Time = currentTimeFn()


### PR DESCRIPTION
I use Terraform, which uses this library. From time to time while running a `terraform plan` (asks AWS for the status of all my resources, takes a long time) I get this error:

```
Error refreshing state: 4 error(s) occurred:

* aws_route53_record.XXXXXX: SignatureDoesNotMatch: Signature expired: 20160831T170848Z is now earlier than 20160831T170921Z (20160831T171421Z - 5 min.)
	status code: 403, request id: XXXXXXXXXXXXXXX
```

I believe there is a race condition where the signature is checked for expiration, verified as not expired, then it expires, and the request is sent off. The expiration is being set in this same file here:

```go
ctx.Query.Set("X-Amz-Expires", strconv.FormatInt(duration, 10))
```

I'm also curious why 10 minutes was chosen as the expiration. Would it be possible to increase this value? Why not, say, one hour?