### PR TITLE
Fixes bug with Uploader

### DIFF
--- a/service/s3/s3manager/upload.go
+++ b/service/s3/s3manager/upload.go
@@ -409,8 +409,12 @@ func (u *uploader) initSize() {
 // does not need to be wrapped in a mutex because nextReader is only called
 // from the main thread.
 func (u *uploader) nextReader() (io.ReadSeeker, int, error) {
+	type readerAtSeeker interface {
+		io.ReaderAt
+		io.ReadSeeker
+	}
 	switch r := u.in.Body.(type) {
-	case io.ReaderAt:
+	case readerAtSeeker:
 		var err error
 
 		n := u.ctx.PartSize


### PR DESCRIPTION
Fixes #824 in regards to the `Body` being an `io.ReaderAt` and potentially not implementing a `Seek` method. If it doesn't implement a seek method, then the `Content-Length` will be the part size.