### PR TITLE
service/s3/s3crypto: Fixing unit test

### DIFF
--- a/service/s3/s3crypto/helper_test.go
+++ b/service/s3/s3crypto/helper_test.go
@@ -6,10 +6,10 @@ import (
 	"github.com/stretchr/testify/assert"
 )
 
-func TestbytesReadWriteSeeker_Read(t *testing.T) {
+func TestBytesReadWriteSeeker_Read(t *testing.T) {
 	b := &bytesReadWriteSeeker{[]byte{1, 2, 3}, 0}
 	expected := []byte{1, 2, 3}
-	buf := []byte{}
+	buf := make([]byte, 3)
 	n, err := b.Read(buf)
 
 	assert.NoError(t, err)
@@ -17,27 +17,31 @@ func TestbytesReadWriteSeeker_Read(t *testing.T) {
 	assert.Equal(t, expected, buf)
 }
 
-func TestbytesReadWriteSeeker_Write(t *testing.T) {
+func TestBytesReadWriteSeeker_Write(t *testing.T) {
 	b := &bytesReadWriteSeeker{}
 	expected := []byte{1, 2, 3}
-	buf := []byte{}
+	buf := make([]byte, 3)
 	n, err := b.Write([]byte{1, 2, 3})
 
 	assert.NoError(t, err)
 	assert.Equal(t, 3, n)
+
+	n, err = b.Read(buf)
+	assert.NoError(t, err)
+	assert.Equal(t, 3, n)
 	assert.Equal(t, expected, buf)
 }
 
-func TestbytesReadWriteSeeker_Seek(t *testing.T) {
+func TestBytesReadWriteSeeker_Seek(t *testing.T) {
 	b := &bytesReadWriteSeeker{[]byte{1, 2, 3}, 0}
 	expected := []byte{2, 3}
 	m, err := b.Seek(1, 0)
 	assert.NoError(t, err)
-	assert.Equal(t, 1, m)
-	buf := []byte{}
+	assert.Equal(t, 1, int(m))
+	buf := make([]byte, 3)
 	n, err := b.Read(buf)
 
 	assert.NoError(t, err)
-	assert.Equal(t, 3, n)
-	assert.Equal(t, expected, buf)
+	assert.Equal(t, 2, n)
+	assert.Equal(t, expected, buf[:n])
 }


### PR DESCRIPTION
This was never updated when the code was changed.

Basically was passing an empty buffer, but this wasn't suppose to be passed. The methods that calls `Read` will always provide a buffer of at least length 1.