### PR TITLE
Read awscli/botocore credentials cache if available

### DIFF
--- a/aws/credentials/stscreds/assume_role_provider.go
+++ b/aws/credentials/stscreds/assume_role_provider.go
@@ -5,7 +5,11 @@
 package stscreds
 
 import (
+	"encoding/json"
 	"fmt"
+	"os"
+	"path/filepath"
+	"strings"
 	"time"
 
 	"github.com/aws/aws-sdk-go/aws"
@@ -34,6 +38,9 @@ type AssumeRoleProvider struct {
 
 	// STS client to make assume role request with.
 	Client AssumeRoler
+
+	// Profile name where the configuration came from.
+	Profile string
 
 	// Role to be assumed.
 	RoleARN string
@@ -77,6 +84,10 @@ type AssumeRoleProvider struct {
 	//
 	// If ExpiryWindow is 0 or less it will be ignored.
 	ExpiryWindow time.Duration
+
+	// CLICredentialsCacheDir specifies the location of the awscli/botocore
+	// credentials cache. At the moment aws-sdk-go only reads this cache.
+	CLICredentialsCacheDir string
 }
 
 // NewCredentials returns a pointer to a new Credentials object wrapping the
@@ -118,8 +129,52 @@ func NewCredentialsWithClient(svc AssumeRoler, roleARN string, options ...func(*
 	return credentials.NewCredentials(p)
 }
 
+// readCache uses credentials cached by awscli/botocore, if available.
+// At the moment, aws-sdk-go does not write into this cache.
+func (p *AssumeRoleProvider) readCache() (credentials.Value, bool) {
+	role := strings.Replace(p.RoleARN, ":", "_", -1)
+	var keyName string
+	if p.RoleSessionName != "" {
+		keyName = fmt.Sprintf("%s--%s--%s.json", p.Profile, role, p.RoleSessionName)
+	} else {
+		keyName = fmt.Sprintf("%s--%s.json", p.Profile, role)
+	}
+	keyName = strings.Replace(keyName, "/", "-", -1)
+	fileName := filepath.Join(p.CLICredentialsCacheDir, keyName)
+
+	fd, err := os.Open(fileName)
+	if err != nil {
+		return credentials.Value{}, false
+	}
+	defer fd.Close()
+	dec := json.NewDecoder(fd)
+
+	var m struct {
+		Credentials struct {
+			Expiration time.Time
+			credentials.Value
+		}
+	}
+	err = dec.Decode(&m)
+	if err != nil {
+		return credentials.Value{}, false
+	}
+
+	remaining := -time.Since(m.Credentials.Expiration)
+	if remaining < p.ExpiryWindow {
+		return credentials.Value{}, false
+	}
+
+	p.SetExpiration(m.Credentials.Expiration, p.ExpiryWindow)
+
+	return m.Credentials.Value, true
+}
+
 // Retrieve generates a new set of temporary credentials using STS.
 func (p *AssumeRoleProvider) Retrieve() (credentials.Value, error) {
+	if creds, ok := p.readCache(); ok {
+		return creds, nil
+	}
 
 	// Apply defaults where parameters are not set.
 	if p.RoleSessionName == "" {

--- a/aws/session/env_config.go
+++ b/aws/session/env_config.go
@@ -75,6 +75,13 @@ type envConfig struct {
 	//
 	//	AWS_CONFIG_FILE=$HOME/my_shared_config
 	SharedConfigFile string
+
+	// Location of credentials cache, $HOME/.aws/cli/cache, used for caching
+	// credentials obtained via sts:AssumeRole.
+	// Currently writing into the cache is not implemented, only reading.
+	//
+	//	AWS_CLI_CREDENTIALS_CACHE=$HOME/.aws/cli/cache
+	CLICredentialsCacheDir string
 }
 
 var (
@@ -149,6 +156,7 @@ func envConfigLoad(enableSharedConfig bool) envConfig {
 
 	cfg.SharedCredentialsFile = sharedCredentialsFilename()
 	cfg.SharedConfigFile = sharedConfigFilename()
+	cfg.CLICredentialsCacheDir = cliCredentialsCacheDir()
 
 	return cfg
 }
@@ -168,6 +176,14 @@ func sharedCredentialsFilename() string {
 	}
 
 	return filepath.Join(userHomeDir(), ".aws", "credentials")
+}
+
+func cliCredentialsCacheDir() string {
+	if name := os.Getenv("AWS_CLI_CREDENTIALS_CACHE"); len(name) > 0 {
+		return name
+	}
+
+	return filepath.Join(userHomeDir(), ".aws", "cli", "cache")
 }
 
 func sharedConfigFilename() string {

--- a/aws/session/session.go
+++ b/aws/session/session.go
@@ -299,6 +299,8 @@ func mergeConfigSrcs(cfg, userCfg *aws.Config, envCfg envConfig, sharedCfg share
 				},
 				sharedCfg.AssumeRole.RoleARN,
 				func(opt *stscreds.AssumeRoleProvider) {
+					opt.CLICredentialsCacheDir = envCfg.CLICredentialsCacheDir
+					opt.Profile = sharedCfg.AssumeRole.Profile
 					opt.RoleSessionName = sharedCfg.AssumeRole.RoleSessionName
 
 					if len(sharedCfg.AssumeRole.ExternalID) > 0 {

--- a/aws/session/shared_config.go
+++ b/aws/session/shared_config.go
@@ -32,6 +32,7 @@ const (
 )
 
 type assumeRoleConfig struct {
+	Profile         string
 	RoleARN         string
 	SourceProfile   string
 	ExternalID      string
@@ -196,6 +197,7 @@ func (cfg *sharedConfig) setFromIniFile(profile string, file sharedConfigFile) e
 	srcProfile := section.Key(sourceProfileKey).String()
 	if len(roleArn) > 0 && len(srcProfile) > 0 {
 		cfg.AssumeRole = assumeRoleConfig{
+			Profile:         profile,
 			RoleARN:         roleArn,
 			SourceProfile:   srcProfile,
 			ExternalID:      section.Key(externalIDKey).String(),

--- a/aws/session/shared_config_test.go
+++ b/aws/session/shared_config_test.go
@@ -61,6 +61,7 @@ func TestLoadSharedConfig(t *testing.T) {
 			Profile:   "assume_role",
 			Expected: sharedConfig{
 				AssumeRole: assumeRoleConfig{
+					Profile:       "assume_role",
 					RoleARN:       "assume_role_role_arn",
 					SourceProfile: "complete_creds",
 				},
@@ -94,6 +95,7 @@ func TestLoadSharedConfig(t *testing.T) {
 					ProviderName:    fmt.Sprintf("SharedConfigCredentials: %s", testConfigFilename),
 				},
 				AssumeRole: assumeRoleConfig{
+					Profile:         "assume_role_w_creds",
 					RoleARN:         "assume_role_w_creds_role_arn",
 					SourceProfile:   "assume_role_w_creds",
 					ExternalID:      "1234",
@@ -207,6 +209,7 @@ func TestLoadSharedConfigFromFile(t *testing.T) {
 			Profile: "assume_role",
 			Expected: sharedConfig{
 				AssumeRole: assumeRoleConfig{
+					Profile:       "assume_role",
 					RoleARN:       "assume_role_role_arn",
 					SourceProfile: "complete_creds",
 				},


### PR DESCRIPTION
Before this PR, it is not possible to use profiles which assume roles requiring MFA.

After this PR, it is possible so long as you first populate the AWS cli
credential cache, by running an awscli command which asks for the MFA token.

Given a profile of the form:

```
[default]
aws_access_key_id=FOO
aws_secret_access_key=BAR

[profile other-role]
role_arn = arn:aws:iam::000000000001:role/other-role
source_profile = default
mfa_serial = GAHP01234567
external_id = 123456789012
```

`aws-sdk-go` currently cannot function with `AWS_PROFILE=other-role`.

This PR enables this functionality without implementing MFA,
by taking advantage of the credentials cache maintained by awscli.

I submit this as a proof of concept to test the waters. Feedback welcome.

The next step would be to implement a method to request a MFA token from
the user, but this minimal implementation allows me to start being
productive using the aws-sdk-go toolkit.

It feels ugly to refer to the `~/.aws/cli/cache` directory, but I don't
know what else you might do, it seems desirable to share these
credentials with awscli/botocore.