### PR TITLE
service/s3/s3manager: Add retry download object part body

### DIFF
--- a/service/s3/s3manager/download.go
+++ b/service/s3/s3manager/download.go
@@ -8,6 +8,7 @@ import (
 	"strings"
 	"sync"
 
+	"github.com/aws/aws-sdk-go/aws"
 	"github.com/aws/aws-sdk-go/aws/awserr"
 	"github.com/aws/aws-sdk-go/aws/awsutil"
 	"github.com/aws/aws-sdk-go/aws/client"
@@ -103,6 +104,10 @@ func NewDownloaderWithClient(svc s3iface.S3API, options ...func(*Downloader)) *D
 	return d
 }
 
+type maxRetrier interface {
+	MaxRetries() int
+}
+
 // Download downloads an object in S3 and writes the payload into w using
 // concurrent GET requests.
 //
@@ -119,6 +124,19 @@ func (d Downloader) Download(w io.WriterAt, input *s3.GetObjectInput, options ..
 
 	for _, option := range options {
 		option(&impl.ctx)
+	}
+
+	if s, ok := d.S3.(maxRetrier); ok {
+		impl.partBodyMaxRetries = s.MaxRetries()
+	}
+
+	impl.totalBytes = -1
+	if impl.ctx.Concurrency == 0 {
+		impl.ctx.Concurrency = DefaultDownloadConcurrency
+	}
+
+	if impl.ctx.PartSize == 0 {
+		impl.ctx.PartSize = DefaultDownloadPartSize
 	}
 
 	return impl.download()
@@ -138,26 +156,13 @@ type downloader struct {
 	totalBytes int64
 	written    int64
 	err        error
-}
 
-// init initializes the downloader with default options.
-func (d *downloader) init() {
-	d.totalBytes = -1
-
-	if d.ctx.Concurrency == 0 {
-		d.ctx.Concurrency = DefaultDownloadConcurrency
-	}
-
-	if d.ctx.PartSize == 0 {
-		d.ctx.PartSize = DefaultDownloadPartSize
-	}
+	partBodyMaxRetries int
 }
 
 // download performs the implementation of the object download across ranged
 // GETs.
 func (d *downloader) download() (n int64, err error) {
-	d.init()
-
 	// Spin off first worker to check additional header information
 	d.getChunk()
 
@@ -214,49 +219,82 @@ func (d *downloader) downloadPart(ch chan dlchunk) {
 	defer d.wg.Done()
 	for {
 		chunk, ok := <-ch
-		if !ok {
+		if !ok || d.getErr() != nil {
 			break
 		}
-		d.downloadChunk(chunk)
+
+		if err := d.downloadChunk(chunk); err != nil {
+			d.setErr(err)
+			break
+		}
 	}
 }
 
 // getChunk grabs a chunk of data from the body.
 // Not thread safe. Should only used when grabbing data on a single thread.
 func (d *downloader) getChunk() {
-	chunk := dlchunk{w: d.w, start: d.pos, size: d.ctx.PartSize}
-	d.pos += d.ctx.PartSize
-	d.downloadChunk(chunk)
-}
-
-// downloadChunk downloads the chunk froom s3
-func (d *downloader) downloadChunk(chunk dlchunk) {
 	if d.getErr() != nil {
 		return
 	}
-	// Get the next byte range of data
+
+	chunk := dlchunk{w: d.w, start: d.pos, size: d.ctx.PartSize}
+	d.pos += d.ctx.PartSize
+
+	if err := d.downloadChunk(chunk); err != nil {
+		d.setErr(err)
+	}
+}
+
+// downloadChunk downloads the chunk froom s3
+func (d *downloader) downloadChunk(chunk dlchunk) error {
 	in := &s3.GetObjectInput{}
 	awsutil.Copy(in, d.in)
-	rng := fmt.Sprintf("bytes=%d-%d",
-		chunk.start, chunk.start+chunk.size-1)
+
+	// Get the next byte range of data
+	rng := fmt.Sprintf("bytes=%d-%d", chunk.start, chunk.start+chunk.size-1)
 	in.Range = &rng
 
-	req, resp := d.ctx.S3.GetObjectRequest(in)
-	req.Handlers.Build.PushBack(request.MakeAddToUserAgentFreeFormHandler("S3Manager"))
-	err := req.Send()
+	var n int64
+	var err error
+	for retry := 0; retry <= d.partBodyMaxRetries; retry++ {
+		req, resp := d.ctx.S3.GetObjectRequest(in)
+		req.Handlers.Build.PushBack(request.MakeAddToUserAgentFreeFormHandler("S3Manager"))
 
-	if err != nil {
-		d.setErr(err)
-	} else {
+		err = req.Send()
+		if err != nil {
+			return err
+		}
 		d.setTotalBytes(resp) // Set total if not yet set.
 
-		n, err := io.Copy(&chunk, resp.Body)
+		n, err = io.Copy(&chunk, resp.Body)
 		resp.Body.Close()
-
-		if err != nil {
-			d.setErr(err)
+		if err == nil {
+			break
 		}
-		d.incrWritten(n)
+
+		chunk.cur = 0
+		logMessage(d.ctx.S3, aws.LogDebugWithRequestRetries,
+			fmt.Sprintf("DEBUG: object part body download interrupted %s, err, %v, retrying attempt %d",
+				aws.StringValue(in.Key), err, retry))
+	}
+
+	d.incrWritten(n)
+
+	return err
+}
+
+func logMessage(svc s3iface.S3API, level aws.LogLevelType, msg string) {
+	s, ok := svc.(*s3.S3)
+	if !ok {
+		return
+	}
+
+	if s.Config.Logger == nil {
+		return
+	}
+
+	if s.Config.LogLevel.Matches(level) {
+		s.Config.Logger.Log(msg)
 	}
 }
 


### PR DESCRIPTION
Adds the ability to automatically retried S3 object parts that fail
after the initial request response is provided. This includes scenarios
such as the network connection is terminated, or broken.

The body parts will be retried based on the S3 service clients Max
Retries configuration. For example setting the aws.Config.MaxRetries to
3 will allow the S3 Downloader to retry part body failures up to 3
times.

This feature is enabled automatically. No additional work is needed to
take advantage of it.

Fix #466