### PR TITLE
load shared environment if SharedConfigState Enable

### DIFF
--- a/aws/session/session.go
+++ b/aws/session/session.go
@@ -179,7 +179,12 @@ type Options struct {
 //         SharedConfigState: SharedConfigEnable,
 //     })
 func NewSessionWithOptions(opts Options) (*Session, error) {
-	envCfg := loadEnvConfig()
+	var envCfg envConfig
+	if opts.SharedConfigState == SharedConfigEnable {
+		envCfg = loadSharedEnvConfig()
+	} else {
+		envCfg = loadEnvConfig()
+	}
 
 	if len(opts.Profile) > 0 {
 		envCfg.Profile = opts.Profile


### PR DESCRIPTION
`AWS_DEFAULT_PROFILE` is not loaded, if `SharedConfigState = SharedConfigEnable`