### PR TITLE
Add build tags to internal SDK tools

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -48,14 +48,15 @@ gen-endpoints:
 build:
 	@echo "go build SDK and vendor packages"
 	@go build ${SDK_ONLY_PKGS}
+	@go build -tags example ./example/...
 
 unit: get-deps-tests build verify
 	@echo "go test SDK and vendor packages"
-	@go test -tags $(SDK_ONLY_PKGS)
+	@go test $(SDK_ONLY_PKGS)
 
 unit-with-race-cover: get-deps-tests build verify
 	@echo "go test SDK and vendor packages"
-	@go test -tags -race -cpu=1,2,4 $(SDK_ONLY_PKGS)
+	@go test -race -cpu=1,2,4 $(SDK_ONLY_PKGS)
 
 integration: get-deps-tests integ-custom smoke-tests performance
 

--- a/awsmigrate/awsmigrate-renamer/gen/gen.go
+++ b/awsmigrate/awsmigrate-renamer/gen/gen.go
@@ -1,4 +1,4 @@
-// +build go1.5
+// +build go1.5,deprecated
 
 package main
 

--- a/awsmigrate/awsmigrate-renamer/rename/rename.go
+++ b/awsmigrate/awsmigrate-renamer/rename/rename.go
@@ -1,4 +1,4 @@
-// +build go1.5
+// +build go1.5,deprecated
 
 package rename
 

--- a/awsmigrate/awsmigrate-renamer/rename/renames.go
+++ b/awsmigrate/awsmigrate-renamer/rename/renames.go
@@ -1,4 +1,4 @@
-// +build go1.5
+// +build go1.5,deprecated
 
 package rename
 

--- a/awsmigrate/awsmigrate-renamer/renamer.go
+++ b/awsmigrate/awsmigrate-renamer/renamer.go
@@ -1,4 +1,4 @@
-// +build go1.5
+// +build go1.5,deprecated
 
 package main
 

--- a/example/aws/request/handleServiceErrorCodes/README.md
+++ b/example/aws/request/handleServiceErrorCodes/README.md
@@ -13,5 +13,5 @@ If the object's bucket or key does not exist a specific error message will be pr
 Any other error will be printed as an unknown error.
 
 ```sh
-go run handleServiceErrorCodes.go mybucket mykey
+go run -tags example handleServiceErrorCodes.go mybucket mykey
 ```

--- a/example/aws/request/handleServiceErrorCodes/handleServiceErrorCodes.go
+++ b/example/aws/request/handleServiceErrorCodes/handleServiceErrorCodes.go
@@ -1,3 +1,5 @@
+// +build example
+
 package main
 
 import (

--- a/example/service/cloudfront/signCookies/README.md
+++ b/example/service/cloudfront/signCookies/README.md
@@ -6,7 +6,7 @@ This example shows how the CloudFront CookieSigner can be used to generate signe
 Makes a request for object using CloudFront cookie signing, and outputs the contents of the object to stdout.
 
 ```sh
-go run signCookies.go -file <privkey file>  -id <keyId> -r <resource pattern> -g <object to get>
+go run -tags example signCookies.go -file <privkey file>  -id <keyId> -r <resource pattern> -g <object to get>
 ```
 
 

--- a/example/service/cloudfront/signCookies/signCookies.go
+++ b/example/service/cloudfront/signCookies/signCookies.go
@@ -1,3 +1,5 @@
+// +build example
+
 package main
 
 import (

--- a/example/service/cloudfront/signCookies/signCookies.go
+++ b/example/service/cloudfront/signCookies/signCookies.go
@@ -16,7 +16,7 @@ import (
 // the contents of the object to stdout.
 //
 // Usage example:
-// go run signCookies.go -file <privkey file>  -id <keyId> -r <resource pattern> -g <object to get>
+// signCookies -file <privkey file>  -id <keyId> -r <resource pattern> -g <object to get>
 func main() {
 	var keyFile string  // Private key PEM file
 	var keyID string    // Key pair ID of CloudFront key pair

--- a/example/service/ec2/filterInstances/README.md
+++ b/example/service/ec2/filterInstances/README.md
@@ -8,7 +8,7 @@ filter_ec2_by_tag is an example using the AWS SDK for Go to list ec2 instaces th
 The example uses the the bucket name provided, and lists all object keys in a bucket.
 
 ```sh
-go run filter_ec2_by_tag.go <name_filter>
+go run -tags example filter_ec2_by_tag.go <name_filter>
 ```
 
 Output:

--- a/example/service/ec2/filterInstances/filter_ec2_by_tag.go
+++ b/example/service/ec2/filterInstances/filter_ec2_by_tag.go
@@ -1,3 +1,5 @@
+// +build example
+
 package main
 
 import (

--- a/example/service/ec2/filterInstances/filter_ec2_by_tag.go
+++ b/example/service/ec2/filterInstances/filter_ec2_by_tag.go
@@ -16,7 +16,7 @@ import (
 // This example will list instances with a filter
 //
 // Usage:
-// go run filter_ec2_by_tag.go <name_filter>
+// filter_ec2_by_tag <name_filter>
 func main() {
 	sess, err := session.NewSession()
 	if err != nil {

--- a/example/service/s3/concatObjects/README.md
+++ b/example/service/s3/concatObjects/README.md
@@ -10,5 +10,5 @@ two objects that we want to concatenate together.
 The example uses the the bucket name provided, two keys for each object, and lastly the output key.
 
 ```sh
-AWS_REGION=<region> go run concatenateObjects.go <bucket> <key for object 1> <key for object 2> <key for output>
+AWS_REGION=<region> go run -tags example concatenateObjects.go <bucket> <key for object 1> <key for object 2> <key for output>
 ```

--- a/example/service/s3/concatObjects/concatObjects.go
+++ b/example/service/s3/concatObjects/concatObjects.go
@@ -1,3 +1,5 @@
+// +build example
+
 package main
 
 import (

--- a/example/service/s3/listObjects/README.md
+++ b/example/service/s3/listObjects/README.md
@@ -8,7 +8,7 @@ listObjects is an example using the AWS SDK for Go to list objects' key in a S3 
 The example uses the the bucket name provided, and lists all object keys in a bucket.
 
 ```sh
-go run listObjects.go <bucket>
+go run -tags example listObjects.go <bucket>
 ```
 
 Output:

--- a/example/service/s3/listObjects/listObjects.go
+++ b/example/service/s3/listObjects/listObjects.go
@@ -1,3 +1,5 @@
+// +build example
+
 package main
 
 import (

--- a/example/service/s3/listObjects/listObjects.go
+++ b/example/service/s3/listObjects/listObjects.go
@@ -13,7 +13,7 @@ import (
 // Lists all objects in a bucket using pagination
 //
 // Usage:
-// go run listObjects.go <bucket>
+// listObjects <bucket>
 func main() {
 	if len(os.Args) < 2 {
 		fmt.Println("you must specify a bucket")

--- a/example/service/s3/listObjectsConcurrently/README.md
+++ b/example/service/s3/listObjectsConcurrently/README.md
@@ -1,13 +1,13 @@
 ## Example
 
-listS3EncryptedObjects is an example using the AWS SDK for Go concurrently to list the encrypted objects in the S3 buckets owned by an account.
+listObjectsConcurrentlv is an example using the AWS SDK for Go concurrently to list the encrypted objects in the S3 buckets owned by an account.
 
 ## Usage
 
 The example's `accounts` string slice contains a list of the SharedCredentials profiles which will be used to look up the buckets owned by each profile. Each bucket's objects will be queried.
 
 ```
-AWS_REGION=us-east-1 go run example/listS3EncryptedObjects/main.go
+AWS_REGION=us-east-1 go run -tags example listObjectsConcurrentlv.go
 ```
 
 

--- a/example/service/s3/listObjectsConcurrently/listObjectsConcurrently.go
+++ b/example/service/s3/listObjectsConcurrently/listObjectsConcurrently.go
@@ -1,3 +1,5 @@
+// +build example
+
 package main
 
 import (

--- a/example/service/s3/listObjectsConcurrently/listObjectsConcurrently.go
+++ b/example/service/s3/listObjectsConcurrently/listObjectsConcurrently.go
@@ -23,7 +23,7 @@ func exit(msg ...interface{}) {
 // contains a list of profiles to use.
 //
 // Usage:
-// go run listObjectsConcurrently.go
+// listObjectsConcurrentlv
 func main() {
 	accounts := []string{"default", "default2", "otherprofile"}
 

--- a/models/protocol_tests/generate.go
+++ b/models/protocol_tests/generate.go
@@ -1,3 +1,5 @@
+// +build codegen
+
 package main
 
 import (

--- a/private/model/cli/api-info/api-info.go
+++ b/private/model/cli/api-info/api-info.go
@@ -1,3 +1,5 @@
+// +build codegen
+
 package main
 
 import (

--- a/private/model/cli/gen-api/main.go
+++ b/private/model/cli/gen-api/main.go
@@ -1,3 +1,5 @@
+// +build codegen
+
 // Command aws-gen-gocli parses a JSON description of an AWS API and generates a
 // Go file containing a client for the API.
 //

--- a/private/model/cli/gen-endpoints/main.go
+++ b/private/model/cli/gen-endpoints/main.go
@@ -1,3 +1,5 @@
+// +build codegen
+
 // Command aws-gen-goendpoints parses a JSON description of the AWS endpoint
 // discovery logic and generates a Go file which returns an endpoint.
 //


### PR DESCRIPTION
Adds the `deprecated` build tags to the awsmigrate.
Adds the `example` build tag to all examples.
Adds the `codegen` build tags to the SDK's code generate commands.

This change prevents the SDK adding unintended executables to the user's `/bin`