### PR TITLE
Truly skip shared config on read errors

### DIFF
--- a/aws/session/shared_config.go
+++ b/aws/session/shared_config.go
@@ -2,7 +2,7 @@ package session
 
 import (
 	"fmt"
-	"os"
+	"io/ioutil"
 
 	"github.com/aws/aws-sdk-go/aws/awserr"
 	"github.com/aws/aws-sdk-go/aws/credentials"
@@ -105,12 +105,13 @@ func loadSharedConfigIniFiles(filenames []string) ([]sharedConfigFile, error) {
 	files := make([]sharedConfigFile, 0, len(filenames))
 
 	for _, filename := range filenames {
-		if _, err := os.Stat(filename); os.IsNotExist(err) {
-			// Trim files from the list that don't exist.
+		b, err := ioutil.ReadFile(filename)
+		if err != nil {
+			// Skip files which can't be opened and read for whatever reason
 			continue
 		}
 
-		f, err := ini.Load(filename)
+		f, err := ini.Load(b)
 		if err != nil {
 			return nil, SharedConfigLoadError{Filename: filename}
 		}


### PR DESCRIPTION
Make it skip shared config file if it can't be read for
whatever reason (not exist, permissions, IO error, etc).

Previously files were skipped only if they didn't exist,
but other conditions can prevent them from being read and
same logic should be applicable to them.