### PR TITLE
aws/signer/v4: Add support for URL.EscapedPath to signer

### DIFF
--- a/aws/signer/v4/functional_1_4_test.go
+++ b/aws/signer/v4/functional_1_4_test.go
@@ -1,0 +1,40 @@
+// +build !go1.5
+
+package v4_test
+
+import (
+	"fmt"
+	"net/http"
+	"testing"
+	"time"
+
+	"github.com/aws/aws-sdk-go/aws/signer/v4"
+	"github.com/aws/aws-sdk-go/awstesting/unit"
+	"github.com/stretchr/testify/assert"
+)
+
+func TestStandaloneSign(t *testing.T) {
+	creds := unit.Session.Config.Credentials
+	signer := v4.NewSigner(creds)
+
+	for _, c := range standaloneSignCases {
+		host := fmt.Sprintf("%s.%s.%s.amazonaws.com",
+			c.SubDomain, c.Region, c.Service)
+
+		req, err := http.NewRequest("GET", fmt.Sprintf("https://%s", host), nil)
+		assert.NoError(t, err)
+
+		req.URL.Path = c.OrigURI
+		req.URL.RawQuery = c.OrigQuery
+		req.URL.Opaque = fmt.Sprintf("//%s%s", host, c.EscapedURI)
+		opaqueURI := req.URL.Opaque
+
+		_, err = signer.Sign(req, nil, c.Service, c.Region, time.Unix(0, 0))
+		assert.NoError(t, err)
+
+		actual := req.Header.Get("Authorization")
+		assert.Equal(t, c.ExpSig, actual)
+		assert.Equal(t, c.OrigURI, req.URL.Path)
+		assert.Equal(t, opaqueURI, req.URL.Opaque)
+	}
+}

--- a/aws/signer/v4/functional_1_5_test.go
+++ b/aws/signer/v4/functional_1_5_test.go
@@ -1,0 +1,40 @@
+// +build go1.5
+
+package v4_test
+
+import (
+	"fmt"
+	"net/http"
+	"testing"
+	"time"
+
+	"github.com/aws/aws-sdk-go/aws/signer/v4"
+	"github.com/aws/aws-sdk-go/awstesting/unit"
+	"github.com/stretchr/testify/assert"
+)
+
+func TestStandaloneSign(t *testing.T) {
+	creds := unit.Session.Config.Credentials
+	signer := v4.NewSigner(creds)
+
+	for _, c := range standaloneSignCases {
+		host := fmt.Sprintf("https://%s.%s.%s.amazonaws.com",
+			c.SubDomain, c.Region, c.Service)
+
+		req, err := http.NewRequest("GET", host, nil)
+		assert.NoError(t, err)
+
+		// URL.EscapedPath() will be used by the signer to get the
+		// escaped form of the request's URI path.
+		req.URL.Path = c.OrigURI
+		req.URL.RawQuery = c.OrigQuery
+
+		_, err = signer.Sign(req, nil, c.Service, c.Region, time.Unix(0, 0))
+		assert.NoError(t, err)
+
+		actual := req.Header.Get("Authorization")
+		assert.Equal(t, c.ExpSig, actual)
+		assert.Equal(t, c.OrigURI, req.URL.Path)
+		assert.Equal(t, c.EscapedURI, req.URL.EscapedPath())
+	}
+}

--- a/aws/signer/v4/uri_path.go
+++ b/aws/signer/v4/uri_path.go
@@ -1,0 +1,24 @@
+// +build go1.5
+
+package v4
+
+import (
+	"net/url"
+	"strings"
+)
+
+func getURIPath(u *url.URL) string {
+	var uri string
+
+	if len(u.Opaque) > 0 {
+		uri = "/" + strings.Join(strings.Split(u.Opaque, "/")[3:], "/")
+	} else {
+		uri = u.EscapedPath()
+	}
+
+	if len(uri) == 0 {
+		uri = "/"
+	}
+
+	return uri
+}

--- a/aws/signer/v4/uri_path_1_4.go
+++ b/aws/signer/v4/uri_path_1_4.go
@@ -1,0 +1,24 @@
+// +build !go1.5
+
+package v4
+
+import (
+	"net/url"
+	"strings"
+)
+
+func getURIPath(u *url.URL) string {
+	var uri string
+
+	if len(u.Opaque) > 0 {
+		uri = "/" + strings.Join(strings.Split(u.Opaque, "/")[3:], "/")
+	} else {
+		uri = u.Path
+	}
+
+	if len(uri) == 0 {
+		uri = "/"
+	}
+
+	return uri
+}

--- a/aws/signer/v4/v4.go
+++ b/aws/signer/v4/v4.go
@@ -22,9 +22,10 @@
 // The leading "//" and hostname are required or the URL.Opaque escaping will
 // not work correctly.
 //
-// If URL.Opaque is not set the signer will vallback to the URL.EscapedPath()
+// If URL.Opaque is not set the signer will fallback to the URL.EscapedPath()
 // method and using the returned value. If you're using Go v1.4 you must set
-// URL.Opaque if the URI path needs escaping.
+// URL.Opaque if the URI path needs escaping. If URL.Opaque is not set with
+// Go v1.5 the signer will fallback to URL.Path.
 //
 // AWS v4 signature validation requires that the canonical string's URI path
 // element must be the URI escaped form of the HTTP request's path.

--- a/aws/signer/v4/v4.go
+++ b/aws/signer/v4/v4.go
@@ -7,7 +7,7 @@
 //
 // Generally using the signer outside of the SDK should not require any additional
 // logic when using Go v1.5 or higher. The signer does this by taking advantage
-// of the URL.EscapedURL method. If your request URI requires additional escaping
+// of the URL.EscapedPath method. If your request URI requires additional escaping
 // you many need to use the URL.Opaque to define what the raw URI should be sent
 // to the service as.
 //
@@ -162,41 +162,19 @@ type Signer struct {
 	// request's query string.
 	DisableHeaderHoisting bool
 
-	// The func to use for escaping URI paths. Default for AWS signed request
-	// is to escape all but [a-zA-Z0-9-_.~]. The escaping of '+' is not a part
-	// of this func and is done for all requests. If not set, DefaultURIPathEscape
-	// will be used.
+	// Disables the automatic escaping of the URI path of the request for the
+	// siganture's canonical string's path. For services that do not need additional
+	// escaping then use this to disable the signer escaping the path.
 	//
-	// Generally the escaping function does not need to be set. The only time
-	// this may be useful to set is if custom escaping logic is needed for the
-	// request's URI path escaping.
+	// S3 is an example of a service that does not need additional escaping.
 	//
 	// http://docs.aws.amazon.com/general/latest/gr/sigv4-create-canonical-request.html
-	URIPathEscapeFn URIPathEscapeFunc
+	DisableURIPathEscaping bool
 
 	// currentTimeFn returns the time value which represents the current time.
 	// This value should only be used for testing. If it is nil the default
 	// time.Now will be used.
 	currentTimeFn func() time.Time
-}
-
-// URIPathEscapeFunc is the type for strategies that can be used by the signer
-// for escaping URI path. This is not needed when signing requests generated with
-// the SDK's API operations.
-type URIPathEscapeFunc func(u string) string
-
-// DefaultURIPathEscape is the default escape URI path func the AWS signer
-// will use. Performs escaping based on the AWS Signature V4 rules.
-//
-// http://docs.aws.amazon.com/general/latest/gr/sigv4-create-canonical-request.html
-func DefaultURIPathEscape(u string) string {
-	return rest.EscapePath(u, false)
-}
-
-// noURIPathEscape performs no escaping. Used for services like S3 that do not
-// need double escaping for the signature validation to function properly.
-func noURIPathEscape(u string) string {
-	return u
 }
 
 // NewSigner returns a Signer pointer configured with the credentials and optional
@@ -224,7 +202,7 @@ type signingCtx struct {
 	ExpireTime       time.Duration
 	SignedHeaderVals http.Header
 
-	URIPathEscapeFn URIPathEscapeFunc
+	DisableURIPathEscaping bool
 
 	credValues         credentials.Value
 	isPresign          bool
@@ -311,15 +289,15 @@ func (v4 Signer) signWithBody(r *http.Request, body io.ReadSeeker, service, regi
 	}
 
 	ctx := &signingCtx{
-		Request:         r,
-		Body:            body,
-		Query:           r.URL.Query(),
-		Time:            signTime,
-		ExpireTime:      exp,
-		isPresign:       exp != 0,
-		ServiceName:     service,
-		Region:          region,
-		URIPathEscapeFn: v4.URIPathEscapeFn,
+		Request:                r,
+		Body:                   body,
+		Query:                  r.URL.Query(),
+		Time:                   signTime,
+		ExpireTime:             exp,
+		isPresign:              exp != 0,
+		ServiceName:            service,
+		Region:                 region,
+		DisableURIPathEscaping: v4.DisableURIPathEscaping,
 	}
 
 	if ctx.isRequestSigned() {
@@ -331,10 +309,6 @@ func (v4 Signer) signWithBody(r *http.Request, body io.ReadSeeker, service, regi
 	ctx.credValues, err = v4.Credentials.Get()
 	if err != nil {
 		return http.Header{}, err
-	}
-
-	if ctx.URIPathEscapeFn == nil {
-		ctx.URIPathEscapeFn = DefaultURIPathEscape
 	}
 
 	ctx.assignAmzQueryValues()
@@ -435,8 +409,8 @@ func signSDKRequestWithCurrTime(req *request.Request, curTimeFn func() time.Time
 		v4.DisableHeaderHoisting = req.NotHoist
 		v4.currentTimeFn = curTimeFn
 		if name == "s3" {
-			// S3 service should not have any escapting applied
-			v4.URIPathEscapeFn = noURIPathEscape
+			// S3 service should not have any escaping applied
+			v4.DisableURIPathEscaping = true
 		}
 	})
 
@@ -597,7 +571,9 @@ func (ctx *signingCtx) buildCanonicalString() {
 
 	uri := getURIPath(ctx.Request.URL)
 
-	uri = ctx.URIPathEscapeFn(uri)
+	if !ctx.DisableURIPathEscaping {
+		uri = rest.EscapePath(uri, false)
+	}
 
 	ctx.canonicalString = strings.Join([]string{
 		ctx.Request.Method,

--- a/aws/signer/v4/v4_test.go
+++ b/aws/signer/v4/v4_test.go
@@ -2,7 +2,6 @@ package v4
 
 import (
 	"bytes"
-	"fmt"
 	"io"
 	"io/ioutil"
 	"net/http"
@@ -217,7 +216,6 @@ func TestIgnorePreResignRequestWithValidCreds(t *testing.T) {
 	SignSDKRequest(r)
 	sig := r.HTTPRequest.URL.Query().Get("X-Amz-Signature")
 
-	fmt.Println(sig)
 	signSDKRequestWithCurrTime(r, func() time.Time {
 		// Simulate one second has passed so that signature's date changes
 		// when it is resigned.


### PR DESCRIPTION
aws/signer/v4: Add support for URL.EscapedPath to signer

Adds support for the URL.EscapedPath method added in Go1.5. This allows
you to hint to the signer and Go HTTP client what the escaped form of the
request's URI path will be. This is needed when using the AWS v4 Signer
outside of the context of the SDK on http.Requests you manage.

Also adds documentation to the signer that pre-escaping of the URI path
is needed, and suggestions how how to do this.

aws/signer/v4 TestStandaloneSign test function is an example
using the request signer outside of the SDK.

Fix #866
