### PR TITLE
Tag can be split into max 3

### DIFF
--- a/service/dynamodb/dynamodbattribute/tag.go
+++ b/service/dynamodb/dynamodbattribute/tag.go
@@ -33,7 +33,7 @@ func (t *tag) parseJSONTag(structTag reflect.StructTag) {
 }
 
 func (t *tag) parseTagStr(tagStr string) {
-	parts := strings.SplitN(tagStr, ",", 2)
+	parts := strings.SplitN(tagStr, ",", 3)
 	if len(parts) == 0 {
 		return
 	}

--- a/service/dynamodb/dynamodbattribute/tag.go
+++ b/service/dynamodb/dynamodbattribute/tag.go
@@ -33,7 +33,7 @@ func (t *tag) parseJSONTag(structTag reflect.StructTag) {
 }
 
 func (t *tag) parseTagStr(tagStr string) {
-	parts := strings.SplitN(tagStr, ",", 3)
+	parts := strings.Split(tagStr, ",")
 	if len(parts) == 0 {
 		return
 	}

--- a/service/dynamodb/dynamodbattribute/tag_test.go
+++ b/service/dynamodb/dynamodbattribute/tag_test.go
@@ -30,6 +30,7 @@ func TestTagParse(t *testing.T) {
 		{`dynamodbav:",binaryset"`, false, true, tag{AsBinSet: true}},
 		{`dynamodbav:",numberset"`, false, true, tag{AsNumSet: true}},
 		{`dynamodbav:",stringset"`, false, true, tag{AsStrSet: true}},
+		{`dynamodbav:",stringset,omitemptyelem"`, false, true, tag{AsStrSet: true,OmitEmptyElem:true}},
 	}
 
 	for i, c := range cases {

--- a/service/dynamodb/dynamodbattribute/tag_test.go
+++ b/service/dynamodb/dynamodbattribute/tag_test.go
@@ -31,6 +31,7 @@ func TestTagParse(t *testing.T) {
 		{`dynamodbav:",numberset"`, false, true, tag{AsNumSet: true}},
 		{`dynamodbav:",stringset"`, false, true, tag{AsStrSet: true}},
 		{`dynamodbav:",stringset,omitemptyelem"`, false, true, tag{AsStrSet: true,OmitEmptyElem:true}},
+		{`dynamodbav:"name,stringset,omitemptyelem"`, false, true, tag{Name: "name",AsStrSet: true,OmitEmptyElem: true}},
 	}
 
 	for i, c := range cases {


### PR DESCRIPTION
As a set can also have omitemptyelem tag.

https://github.com/aws/aws-sdk-go/blob/master/service/dynamodb/dynamodbattribute/encode.go#L108

@jasdel 