### PR TITLE
Release v1.4.16

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,25 @@
+Release v1.4.16
+===
+
+Service Model Updates
+---
+* `service/ecr`: Update Amazon EC2 Container Registry service model
+  * DescribeImages is a new api used to expose image metadata which today includes image size and image creation timestamp.
+* `service/elasticache`: Update Amazon ElastiCache service model
+  * Elasticache is launching a new major engine release of Redis, 3.2 (providing stability updates and new command sets over 2.8), as well as ElasticSupport for enabling Redis Cluster in 3.2, which provides support for multiple node groups to horizontally scale data, as well as superior engine failover capabilities 
+
+SDK Bug Fixes
+---
+* `aws/session`: Skip shared config on read errors [#883](https://github.com/aws/aws-sdk-go/issues/883)
+* `aws/signer/v4`: Add support for URL.EscapedPath to signer [#885](https://github.com/aws/aws-sdk-go/issues/885)
+
+SDK Features
+---
+* `private/model/api`: Add docs for errors to API operations [#881](https://github.com/aws/aws-sdk-go/issues/881)
+* `private/model/api`: Improve field and waiter doc strings [#879](https://github.com/aws/aws-sdk-go/issues/879)
+* `service/dynamodb/dynamodbattribute`: Allow multiple struct tag elements [#886](https://github.com/aws/aws-sdk-go/issues/886)
+* Add build tags to internal SDK tools [#880](https://github.com/aws/aws-sdk-go/issues/880)
+
 Release v1.4.15
 ===
 

--- a/aws/version.go
+++ b/aws/version.go
@@ -5,4 +5,4 @@ package aws
 const SDKName = "aws-sdk-go"
 
 // SDKVersion is the version of this SDK
-const SDKVersion = "1.4.14"
+const SDKVersion = "1.4.16"

--- a/models/apis/ecr/2015-09-21/api-2.json
+++ b/models/apis/ecr/2015-09-21/api-2.json
@@ -117,6 +117,21 @@
         {"shape":"RepositoryPolicyNotFoundException"}
       ]
     },
+    "DescribeImages":{
+      "name":"DescribeImages",
+      "http":{
+        "method":"POST",
+        "requestUri":"/"
+      },
+      "input":{"shape":"DescribeImagesRequest"},
+      "output":{"shape":"DescribeImagesResponse"},
+      "errors":[
+        {"shape":"ServerException"},
+        {"shape":"InvalidParameterException"},
+        {"shape":"RepositoryNotFoundException"},
+        {"shape":"ImageNotFoundException"}
+      ]
+    },
     "DescribeRepositories":{
       "name":"DescribeRepositories",
       "http":{
@@ -374,6 +389,7 @@
         "repository":{"shape":"Repository"}
       }
     },
+    "CreationTimestamp":{"type":"timestamp"},
     "DeleteRepositoryPolicyRequest":{
       "type":"structure",
       "required":["repositoryName"],
@@ -403,6 +419,31 @@
       "type":"structure",
       "members":{
         "repository":{"shape":"Repository"}
+      }
+    },
+    "DescribeImagesFilter":{
+      "type":"structure",
+      "members":{
+        "tagStatus":{"shape":"TagStatus"}
+      }
+    },
+    "DescribeImagesRequest":{
+      "type":"structure",
+      "required":["repositoryName"],
+      "members":{
+        "registryId":{"shape":"RegistryId"},
+        "repositoryName":{"shape":"RepositoryName"},
+        "imageIds":{"shape":"ImageIdentifierList"},
+        "nextToken":{"shape":"NextToken"},
+        "maxResults":{"shape":"MaxResults"},
+        "filter":{"shape":"DescribeImagesFilter"}
+      }
+    },
+    "DescribeImagesResponse":{
+      "type":"structure",
+      "members":{
+        "imageDetails":{"shape":"ImageDetailList"},
+        "nextToken":{"shape":"NextToken"}
       }
     },
     "DescribeRepositoriesRequest":{
@@ -500,6 +541,21 @@
       },
       "exception":true
     },
+    "ImageDetail":{
+      "type":"structure",
+      "members":{
+        "registryId":{"shape":"RegistryId"},
+        "repositoryName":{"shape":"RepositoryName"},
+        "imageDigest":{"shape":"ImageDigest"},
+        "imageTags":{"shape":"ImageTagList"},
+        "imageSizeInBytes":{"shape":"ImageSizeInBytes"},
+        "imagePushedAt":{"shape":"PushTimestamp"}
+      }
+    },
+    "ImageDetailList":{
+      "type":"list",
+      "member":{"shape":"ImageDetail"}
+    },
     "ImageDigest":{"type":"string"},
     "ImageFailure":{
       "type":"structure",
@@ -542,7 +598,19 @@
       "member":{"shape":"Image"}
     },
     "ImageManifest":{"type":"string"},
+    "ImageNotFoundException":{
+      "type":"structure",
+      "members":{
+        "message":{"shape":"ExceptionMessage"}
+      },
+      "exception":true
+    },
+    "ImageSizeInBytes":{"type":"long"},
     "ImageTag":{"type":"string"},
+    "ImageTagList":{
+      "type":"list",
+      "member":{"shape":"ImageTag"}
+    },
     "InitiateLayerUploadRequest":{
       "type":"structure",
       "required":["repositoryName"],
@@ -704,6 +772,7 @@
       "min":0
     },
     "ProxyEndpoint":{"type":"string"},
+    "PushTimestamp":{"type":"timestamp"},
     "PutImageRequest":{
       "type":"structure",
       "required":[
@@ -732,7 +801,8 @@
         "repositoryArn":{"shape":"Arn"},
         "registryId":{"shape":"RegistryId"},
         "repositoryName":{"shape":"RepositoryName"},
-        "repositoryUri":{"shape":"Url"}
+        "repositoryUri":{"shape":"Url"},
+        "createdAt":{"shape":"CreationTimestamp"}
       }
     },
     "RepositoryAlreadyExistsException":{

--- a/models/apis/ecr/2015-09-21/docs-2.json
+++ b/models/apis/ecr/2015-09-21/docs-2.json
@@ -9,6 +9,7 @@
     "CreateRepository": "<p>Creates an image repository.</p>",
     "DeleteRepository": "<p>Deletes an existing image repository. If a repository contains images, you must use the <code>force</code> option to delete it.</p>",
     "DeleteRepositoryPolicy": "<p>Deletes the repository policy from a specified repository.</p>",
+    "DescribeImages": "<p>Returns metadata about the images in a repository, including image size and creation date.</p> <note> <p>Beginning with Docker version 1.9, the Docker client compresses image layers before pushing them to a V2 Docker registry. The output of the <code>docker images</code> command shows the uncompressed image size, so it may return a larger image size than the image sizes returned by <a>DescribeImages</a>.</p> </note>",
     "DescribeRepositories": "<p>Describes image repositories in a registry.</p>",
     "GetAuthorizationToken": "<p>Retrieves a token that is valid for a specified registry for 12 hours. This command allows you to use the <code>docker</code> CLI to push and pull images with Amazon ECR. If you do not specify a registry, the default registry is assumed.</p> <p>The <code>authorizationToken</code> returned for each registry specified is a base64 encoded string that can be decoded and used in a <code>docker login</code> command to authenticate to a registry. The AWS CLI offers an <code>aws ecr get-login</code> command that simplifies the login process.</p>",
     "GetDownloadUrlForLayer": "<p>Retrieves the pre-signed Amazon S3 download URL corresponding to an image layer. You can only get URLs for image layers that are referenced in an image.</p> <note> <p>This operation is used by the Amazon ECR proxy, and it is not intended for general use by customers. Use the <code>docker</code> CLI to pull, tag, and push images.</p> </note>",
@@ -107,6 +108,12 @@
       "refs": {
       }
     },
+    "CreationTimestamp": {
+      "base": null,
+      "refs": {
+        "Repository$createdAt": "<p>The date and time, in JavaScript date/time format, when the repository was created.</p>"
+      }
+    },
     "DeleteRepositoryPolicyRequest": {
       "base": null,
       "refs": {
@@ -123,6 +130,22 @@
       }
     },
     "DeleteRepositoryResponse": {
+      "base": null,
+      "refs": {
+      }
+    },
+    "DescribeImagesFilter": {
+      "base": "<p>An object representing a filter on a <a>DescribeImages</a> operation.</p>",
+      "refs": {
+        "DescribeImagesRequest$filter": "<p>The filter key and value with which to filter your <code>DescribeImages</code> results.</p>"
+      }
+    },
+    "DescribeImagesRequest": {
+      "base": null,
+      "refs": {
+      }
+    },
+    "DescribeImagesResponse": {
       "base": null,
       "refs": {
       }
@@ -147,6 +170,7 @@
       "refs": {
         "EmptyUploadException$message": "<p>The error message associated with the exception.</p>",
         "ImageAlreadyExistsException$message": "<p>The error message associated with the exception.</p>",
+        "ImageNotFoundException$message": null,
         "InvalidLayerException$message": "<p>The error message associated with the exception.</p>",
         "InvalidLayerPartException$message": "<p>The error message associated with the exception.</p>",
         "InvalidParameterException$message": "<p>The error message associated with the exception.</p>",
@@ -224,9 +248,22 @@
       "refs": {
       }
     },
+    "ImageDetail": {
+      "base": "<p>An object that describes an image returned by a <a>DescribeImages</a> operation.</p>",
+      "refs": {
+        "ImageDetailList$member": null
+      }
+    },
+    "ImageDetailList": {
+      "base": null,
+      "refs": {
+        "DescribeImagesResponse$imageDetails": "<p>A list of <a>ImageDetail</a> objects that contain data about the image.</p>"
+      }
+    },
     "ImageDigest": {
       "base": null,
       "refs": {
+        "ImageDetail$imageDigest": "<p>The <code>sha256</code> digest of the image manifest.</p>",
         "ImageIdentifier$imageDigest": "<p>The <code>sha256</code> digest of the image manifest.</p>"
       }
     },
@@ -269,6 +306,7 @@
         "BatchDeleteImageRequest$imageIds": "<p>A list of image ID references that correspond to images to delete. The format of the <code>imageIds</code> reference is <code>imageTag=tag</code> or <code>imageDigest=digest</code>.</p>",
         "BatchDeleteImageResponse$imageIds": "<p>The image IDs of the deleted images.</p>",
         "BatchGetImageRequest$imageIds": "<p>A list of image ID references that correspond to images to describe. The format of the <code>imageIds</code> reference is <code>imageTag=tag</code> or <code>imageDigest=digest</code>.</p>",
+        "DescribeImagesRequest$imageIds": "<p>The list of image IDs for the requested repository.</p>",
         "ListImagesResponse$imageIds": "<p>The list of image IDs for the requested repository.</p>"
       }
     },
@@ -285,10 +323,28 @@
         "PutImageRequest$imageManifest": "<p>The image manifest corresponding to the image to be uploaded.</p>"
       }
     },
+    "ImageNotFoundException": {
+      "base": "<p>The image requested does not exist in the specified repository.</p>",
+      "refs": {
+      }
+    },
+    "ImageSizeInBytes": {
+      "base": null,
+      "refs": {
+        "ImageDetail$imageSizeInBytes": "<p>The size, in bytes, of the image in the repository.</p> <note> <p>Beginning with Docker version 1.9, the Docker client compresses image layers before pushing them to a V2 Docker registry. The output of the <code>docker images</code> command shows the uncompressed image size, so it may return a larger image size than the image sizes returned by <a>DescribeImages</a>.</p> </note>"
+      }
+    },
     "ImageTag": {
       "base": null,
       "refs": {
-        "ImageIdentifier$imageTag": "<p>The tag used for the image.</p>"
+        "ImageIdentifier$imageTag": "<p>The tag used for the image.</p>",
+        "ImageTagList$member": null
+      }
+    },
+    "ImageTagList": {
+      "base": null,
+      "refs": {
+        "ImageDetail$imageTags": "<p>The list of tags associated with this image.</p>"
       }
     },
     "InitiateLayerUploadRequest": {
@@ -430,6 +486,7 @@
     "MaxResults": {
       "base": null,
       "refs": {
+        "DescribeImagesRequest$maxResults": "<p>The maximum number of repository results returned by <code>DescribeImages</code> in paginated output. When this parameter is used, <code>DescribeImages</code> only returns <code>maxResults</code> results in a single page along with a <code>nextToken</code> response element. The remaining results of the initial request can be seen by sending another <code>DescribeImages</code> request with the returned <code>nextToken</code> value. This value can be between 1 and 100. If this parameter is not used, then <code>DescribeImages</code> returns up to 100 results and a <code>nextToken</code> value, if applicable.</p>",
         "DescribeRepositoriesRequest$maxResults": "<p>The maximum number of repository results returned by <code>DescribeRepositories</code> in paginated output. When this parameter is used, <code>DescribeRepositories</code> only returns <code>maxResults</code> results in a single page along with a <code>nextToken</code> response element. The remaining results of the initial request can be seen by sending another <code>DescribeRepositories</code> request with the returned <code>nextToken</code> value. This value can be between 1 and 100. If this parameter is not used, then <code>DescribeRepositories</code> returns up to 100 results and a <code>nextToken</code> value, if applicable.</p>",
         "ListImagesRequest$maxResults": "<p>The maximum number of image results returned by <code>ListImages</code> in paginated output. When this parameter is used, <code>ListImages</code> only returns <code>maxResults</code> results in a single page along with a <code>nextToken</code> response element. The remaining results of the initial request can be seen by sending another <code>ListImages</code> request with the returned <code>nextToken</code> value. This value can be between 1 and 100. If this parameter is not used, then <code>ListImages</code> returns up to 100 results and a <code>nextToken</code> value, if applicable.</p>"
       }
@@ -437,6 +494,8 @@
     "NextToken": {
       "base": null,
       "refs": {
+        "DescribeImagesRequest$nextToken": "<p>The <code>nextToken</code> value returned from a previous paginated <code>DescribeImages</code> request where <code>maxResults</code> was used and the results exceeded the value of that parameter. Pagination continues from the end of the previous results that returned the <code>nextToken</code> value. This value is <code>null</code> when there are no more results to return.</p>",
+        "DescribeImagesResponse$nextToken": "<p>The <code>nextToken</code> value to include in a future <code>DescribeImages</code> request. When the results of a <code>DescribeImages</code> request exceed <code>maxResults</code>, this value can be used to retrieve the next page of results. This value is <code>null</code> when there are no more results to return.</p>",
         "DescribeRepositoriesRequest$nextToken": "<p>The <code>nextToken</code> value returned from a previous paginated <code>DescribeRepositories</code> request where <code>maxResults</code> was used and the results exceeded the value of that parameter. Pagination continues from the end of the previous results that returned the <code>nextToken</code> value. This value is <code>null</code> when there are no more results to return.</p> <note> <p>This token should be treated as an opaque identifier that is only used to retrieve the next items in a list and not for other programmatic purposes.</p> </note>",
         "DescribeRepositoriesResponse$nextToken": "<p>The <code>nextToken</code> value to include in a future <code>DescribeRepositories</code> request. When the results of a <code>DescribeRepositories</code> request exceed <code>maxResults</code>, this value can be used to retrieve the next page of results. This value is <code>null</code> when there are no more results to return.</p>",
         "ListImagesRequest$nextToken": "<p>The <code>nextToken</code> value returned from a previous paginated <code>ListImages</code> request where <code>maxResults</code> was used and the results exceeded the value of that parameter. Pagination continues from the end of the previous results that returned the <code>nextToken</code> value. This value is <code>null</code> when there are no more results to return.</p> <note> <p>This token should be treated as an opaque identifier that is only used to retrieve the next items in a list and not for other programmatic purposes.</p> </note>",
@@ -457,6 +516,12 @@
       "base": null,
       "refs": {
         "AuthorizationData$proxyEndpoint": "<p>The registry URL to use for this authorization token in a <code>docker login</code> command. The Amazon ECR registry URL format is <code>https://aws_account_id.dkr.ecr.region.amazonaws.com</code>. For example, <code>https://012345678910.dkr.ecr.us-east-1.amazonaws.com</code>.. </p>"
+      }
+    },
+    "PushTimestamp": {
+      "base": null,
+      "refs": {
+        "ImageDetail$imagePushedAt": "<p>The date and time, expressed in standard JavaScript date format, at which the current image was pushed to the repository. </p>"
       }
     },
     "PutImageRequest": {
@@ -480,12 +545,14 @@
         "DeleteRepositoryPolicyRequest$registryId": "<p>The AWS account ID associated with the registry that contains the repository policy to delete. If you do not specify a registry, the default registry is assumed.</p>",
         "DeleteRepositoryPolicyResponse$registryId": "<p>The registry ID associated with the request.</p>",
         "DeleteRepositoryRequest$registryId": "<p>The AWS account ID associated with the registry that contains the repository to delete. If you do not specify a registry, the default registry is assumed.</p>",
+        "DescribeImagesRequest$registryId": "<p>The AWS account ID associated with the registry that contains the repository in which to list images. If you do not specify a registry, the default registry is assumed.</p>",
         "DescribeRepositoriesRequest$registryId": "<p>The AWS account ID associated with the registry that contains the repositories to be described. If you do not specify a registry, the default registry is assumed.</p>",
         "GetAuthorizationTokenRegistryIdList$member": null,
         "GetDownloadUrlForLayerRequest$registryId": "<p>The AWS account ID associated with the registry that contains the image layer to download. If you do not specify a registry, the default registry is assumed.</p>",
         "GetRepositoryPolicyRequest$registryId": "<p>The AWS account ID associated with the registry that contains the repository. If you do not specify a registry, the default registry is assumed.</p>",
         "GetRepositoryPolicyResponse$registryId": "<p>The registry ID associated with the request.</p>",
         "Image$registryId": "<p>The AWS account ID associated with the registry containing the image.</p>",
+        "ImageDetail$registryId": "<p>The AWS account ID associated with the registry to which this image belongs.</p>",
         "InitiateLayerUploadRequest$registryId": "<p>The AWS account ID associated with the registry that you intend to upload layers to. If you do not specify a registry, the default registry is assumed.</p>",
         "InvalidLayerPartException$registryId": "<p>The registry ID associated with the exception.</p>",
         "ListImagesRequest$registryId": "<p>The AWS account ID associated with the registry that contains the repository to list images in. If you do not specify a registry, the default registry is assumed.</p>",
@@ -500,8 +567,8 @@
     "Repository": {
       "base": "<p>An object representing a repository.</p>",
       "refs": {
-        "CreateRepositoryResponse$repository": null,
-        "DeleteRepositoryResponse$repository": null,
+        "CreateRepositoryResponse$repository": "<p>The repository that was created.</p>",
+        "DeleteRepositoryResponse$repository": "<p>The repository that was deleted.</p>",
         "RepositoryList$member": null
       }
     },
@@ -528,10 +595,12 @@
         "DeleteRepositoryPolicyRequest$repositoryName": "<p>The name of the repository that is associated with the repository policy to delete.</p>",
         "DeleteRepositoryPolicyResponse$repositoryName": "<p>The repository name associated with the request.</p>",
         "DeleteRepositoryRequest$repositoryName": "<p>The name of the repository to delete.</p>",
+        "DescribeImagesRequest$repositoryName": "<p>A list of repositories to describe. If this parameter is omitted, then all repositories in a registry are described.</p>",
         "GetDownloadUrlForLayerRequest$repositoryName": "<p>The name of the repository that is associated with the image layer to download.</p>",
         "GetRepositoryPolicyRequest$repositoryName": "<p>The name of the repository whose policy you want to retrieve.</p>",
         "GetRepositoryPolicyResponse$repositoryName": "<p>The repository name associated with the request.</p>",
         "Image$repositoryName": "<p>The name of the repository associated with the image.</p>",
+        "ImageDetail$repositoryName": "<p>The name of the repository to which this image belongs.</p>",
         "InitiateLayerUploadRequest$repositoryName": "<p>The name of the repository that you intend to upload layers to.</p>",
         "InvalidLayerPartException$repositoryName": "<p>The repository name associated with the exception.</p>",
         "ListImagesRequest$repositoryName": "<p>The repository whose image IDs are to be listed.</p>",
@@ -592,6 +661,7 @@
     "TagStatus": {
       "base": null,
       "refs": {
+        "DescribeImagesFilter$tagStatus": "<p>The tag status with which to filter your <a>DescribeImages</a> results. You can filter results based on whether they are <code>TAGGED</code> or <code>UNTAGGED</code>.</p>",
         "ListImagesFilter$tagStatus": "<p>The tag status with which to filter your <a>ListImages</a> results. You can filter results based on whether they are <code>TAGGED</code> or <code>UNTAGGED</code>.</p>"
       }
     },

--- a/models/apis/elasticache/2015-02-02/api-2.json
+++ b/models/apis/elasticache/2015-02-02/api-2.json
@@ -173,6 +173,7 @@
         {"shape":"CacheParameterGroupNotFoundFault"},
         {"shape":"InvalidVPCNetworkStateFault"},
         {"shape":"TagQuotaPerResourceExceeded"},
+        {"shape":"NodeGroupsPerReplicationGroupQuotaExceededFault"},
         {"shape":"InvalidParameterValueException"},
         {"shape":"InvalidParameterCombinationException"}
       ]
@@ -191,7 +192,9 @@
       "errors":[
         {"shape":"SnapshotAlreadyExistsFault"},
         {"shape":"CacheClusterNotFoundFault"},
+        {"shape":"ReplicationGroupNotFoundFault"},
         {"shape":"InvalidCacheClusterStateFault"},
+        {"shape":"InvalidReplicationGroupStateFault"},
         {"shape":"SnapshotQuotaExceededFault"},
         {"shape":"SnapshotFeatureNotSupportedFault"},
         {"shape":"InvalidParameterCombinationException"},
@@ -1329,6 +1332,9 @@
         "AutomaticFailoverEnabled":{"shape":"BooleanOptional"},
         "NumCacheClusters":{"shape":"IntegerOptional"},
         "PreferredCacheClusterAZs":{"shape":"AvailabilityZonesList"},
+        "NumNodeGroups":{"shape":"IntegerOptional"},
+        "ReplicasPerNodeGroup":{"shape":"IntegerOptional"},
+        "NodeGroupConfiguration":{"shape":"NodeGroupConfigurationList"},
         "CacheNodeType":{"shape":"String"},
         "Engine":{"shape":"String"},
         "EngineVersion":{"shape":"String"},
@@ -1355,11 +1361,9 @@
     },
     "CreateSnapshotMessage":{
       "type":"structure",
-      "required":[
-        "CacheClusterId",
-        "SnapshotName"
-      ],
+      "required":["SnapshotName"],
       "members":{
+        "ReplicationGroupId":{"shape":"String"},
         "CacheClusterId":{"shape":"String"},
         "SnapshotName":{"shape":"String"}
       }
@@ -1557,11 +1561,13 @@
     "DescribeSnapshotsMessage":{
       "type":"structure",
       "members":{
+        "ReplicationGroupId":{"shape":"String"},
         "CacheClusterId":{"shape":"String"},
         "SnapshotName":{"shape":"String"},
         "SnapshotSource":{"shape":"String"},
         "Marker":{"shape":"String"},
-        "MaxRecords":{"shape":"IntegerOptional"}
+        "MaxRecords":{"shape":"IntegerOptional"},
+        "ShowNodeGroupConfig":{"shape":"BooleanOptional"}
       }
     },
     "Double":{"type":"double"},
@@ -1853,7 +1859,24 @@
         "NodeGroupId":{"shape":"String"},
         "Status":{"shape":"String"},
         "PrimaryEndpoint":{"shape":"Endpoint"},
+        "Slots":{"shape":"String"},
         "NodeGroupMembers":{"shape":"NodeGroupMemberList"}
+      }
+    },
+    "NodeGroupConfiguration":{
+      "type":"structure",
+      "members":{
+        "Slots":{"shape":"String"},
+        "ReplicaCount":{"shape":"IntegerOptional"},
+        "PrimaryAvailabilityZone":{"shape":"String"},
+        "ReplicaAvailabilityZones":{"shape":"AvailabilityZonesList"}
+      }
+    },
+    "NodeGroupConfigurationList":{
+      "type":"list",
+      "member":{
+        "shape":"NodeGroupConfiguration",
+        "locationName":"NodeGroupConfiguration"
       }
     },
     "NodeGroupList":{
@@ -1880,6 +1903,17 @@
         "locationName":"NodeGroupMember"
       }
     },
+    "NodeGroupsPerReplicationGroupQuotaExceededFault":{
+      "type":"structure",
+      "members":{
+      },
+      "error":{
+        "code":"NodeGroupsPerReplicationGroupQuotaExceeded",
+        "httpStatusCode":400,
+        "senderFault":true
+      },
+      "exception":true
+    },
     "NodeQuotaForClusterExceededFault":{
       "type":"structure",
       "members":{
@@ -1905,7 +1939,10 @@
     "NodeSnapshot":{
       "type":"structure",
       "members":{
+        "CacheClusterId":{"shape":"String"},
+        "NodeGroupId":{"shape":"String"},
         "CacheNodeId":{"shape":"String"},
+        "NodeGroupConfiguration":{"shape":"NodeGroupConfiguration"},
         "CacheSize":{"shape":"String"},
         "CacheNodeCreateTime":{"shape":"TStamp"},
         "SnapshotCreateTime":{"shape":"TStamp"}
@@ -2056,7 +2093,10 @@
         "MemberClusters":{"shape":"ClusterIdList"},
         "NodeGroups":{"shape":"NodeGroupList"},
         "SnapshottingClusterId":{"shape":"String"},
-        "AutomaticFailover":{"shape":"AutomaticFailoverStatus"}
+        "AutomaticFailover":{"shape":"AutomaticFailoverStatus"},
+        "ConfigurationEndpoint":{"shape":"Endpoint"},
+        "SnapshotRetentionLimit":{"shape":"IntegerOptional"},
+        "SnapshotWindow":{"shape":"String"}
       },
       "wrapper":true
     },
@@ -2257,6 +2297,8 @@
       "type":"structure",
       "members":{
         "SnapshotName":{"shape":"String"},
+        "ReplicationGroupId":{"shape":"String"},
+        "ReplicationGroupDescription":{"shape":"String"},
         "CacheClusterId":{"shape":"String"},
         "SnapshotStatus":{"shape":"String"},
         "SnapshotSource":{"shape":"String"},
@@ -2275,6 +2317,8 @@
         "AutoMinorVersionUpgrade":{"shape":"Boolean"},
         "SnapshotRetentionLimit":{"shape":"IntegerOptional"},
         "SnapshotWindow":{"shape":"String"},
+        "NumNodeGroups":{"shape":"IntegerOptional"},
+        "AutomaticFailover":{"shape":"AutomaticFailoverStatus"},
         "NodeSnapshots":{"shape":"NodeSnapshotList"}
       },
       "wrapper":true
@@ -2343,7 +2387,8 @@
         "cache-cluster",
         "cache-parameter-group",
         "cache-security-group",
-        "cache-subnet-group"
+        "cache-subnet-group",
+        "replication-group"
       ]
     },
     "String":{"type":"string"},

--- a/models/apis/elasticache/2015-02-02/docs-2.json
+++ b/models/apis/elasticache/2015-02-02/docs-2.json
@@ -1,61 +1,61 @@
 {
   "version": "2.0",
-  "service": "<fullname>Amazon ElastiCache</fullname> <p>Amazon ElastiCache is a web service that makes it easier to set up, operate, and scale a distributed cache in the cloud.</p> <p>With ElastiCache, customers gain all of the benefits of a high-performance, in-memory cache with far less of the administrative burden of launching and managing a distributed cache. The service makes setup, scaling, and cluster failure handling much simpler than in a self-managed cache deployment.</p> <p>In addition, through integration with Amazon CloudWatch, customers get enhanced visibility into the key performance statistics associated with their cache and can receive alarms if a part of their cache runs hot.</p>",
+  "service": "<fullname>Amazon ElastiCache</fullname> <p>Amazon ElastiCache is a web service that makes it easier to set up, operate, and scale a distributed cache in the cloud.</p> <p>With ElastiCache, customers get all of the benefits of a high-performance, in-memory cache with less of the administrative burden involved in launching and managing a distributed cache. The service makes setup, scaling, and cluster failure handling much simpler than in a self-managed cache deployment.</p> <p>In addition, through integration with Amazon CloudWatch, customers get enhanced visibility into the key performance statistics associated with their cache and can receive alarms if a part of their cache runs hot.</p>",
   "operations": {
-    "AddTagsToResource": "<p>The <i>AddTagsToResource</i> action adds up to 10 cost allocation tags to the named resource. A <i>cost allocation tag</i> is a key-value pair where the key and value are case-sensitive. Cost allocation tags can be used to categorize and track your AWS costs.</p> <p> When you apply tags to your ElastiCache resources, AWS generates a cost allocation report as a comma-separated value (CSV) file with your usage and costs aggregated by your tags. You can apply tags that represent business categories (such as cost centers, application names, or owners) to organize your costs across multiple services. For more information, see <a href=\"http://docs.aws.amazon.com/AmazonElastiCache/latest/UserGuide/Tagging.html\">Using Cost Allocation Tags in Amazon ElastiCache</a> in the <i>ElastiCache User Guide</i>.</p>",
-    "AuthorizeCacheSecurityGroupIngress": "<p>The <i>AuthorizeCacheSecurityGroupIngress</i> action allows network ingress to a cache security group. Applications using ElastiCache must be running on Amazon EC2, and Amazon EC2 security groups are used as the authorization mechanism.</p> <note> <p>You cannot authorize ingress from an Amazon EC2 security group in one region to an ElastiCache cluster in another region.</p> </note>",
-    "CopySnapshot": "<p>The <i>CopySnapshot</i> action makes a copy of an existing snapshot.</p> <important> <p>Users or groups that have permissions to use the <i>CopySnapshot</i> API can create their own Amazon S3 buckets and copy snapshots to it. To control access to your snapshots, use an IAM policy to control who has the ability to use the <i>CopySnapshot</i> API. For more information about using IAM to control the use of ElastiCache APIs, see <a href=\"http://docs.aws.amazon.com/ElastiCache/latest/Snapshots.Exporting.html\">Exporting Snapshots</a> and <a href=\"http://docs.aws.amazon.com/ElastiCache/latest/IAM.html\">Authentication &amp; Access Control</a>.</p> </important> <p class=\"title\"> <b>Erorr Message:</b> </p> <ul> <li> <p> <b>Error Message:</b> The authenticated user does not have sufficient permissions to perform the desired activity.</p> <p> <b>Solution:</b> Contact your system administrator to get the needed permissions.</p> </li> </ul>",
-    "CreateCacheCluster": "<p>The <i>CreateCacheCluster</i> action creates a cache cluster. All nodes in the cache cluster run the same protocol-compliant cache engine software, either Memcached or Redis.</p>",
-    "CreateCacheParameterGroup": "<p>The <i>CreateCacheParameterGroup</i> action creates a new cache parameter group. A cache parameter group is a collection of parameters that you apply to all of the nodes in a cache cluster.</p>",
-    "CreateCacheSecurityGroup": "<p>The <i>CreateCacheSecurityGroup</i> action creates a new cache security group. Use a cache security group to control access to one or more cache clusters.</p> <p>Cache security groups are only used when you are creating a cache cluster outside of an Amazon Virtual Private Cloud (VPC). If you are creating a cache cluster inside of a VPC, use a cache subnet group instead. For more information, see <a href=\"http://docs.aws.amazon.com/AmazonElastiCache/latest/APIReference/API_CreateCacheSubnetGroup.html\">CreateCacheSubnetGroup</a>.</p>",
-    "CreateCacheSubnetGroup": "<p>The <i>CreateCacheSubnetGroup</i> action creates a new cache subnet group.</p> <p>Use this parameter only when you are creating a cluster in an Amazon Virtual Private Cloud (VPC).</p>",
-    "CreateReplicationGroup": "<p>The <i>CreateReplicationGroup</i> action creates a replication group. A replication group is a collection of cache clusters, where one of the cache clusters is a read/write primary and the others are read-only replicas. Writes to the primary are automatically propagated to the replicas.</p> <p>When you create a replication group, you must specify an existing cache cluster that is in the primary role. When the replication group has been successfully created, you can add one or more read replica replicas to it, up to a total of five read replicas.</p> <note> <p>This action is valid only for Redis.</p> </note>",
-    "CreateSnapshot": "<p>The <i>CreateSnapshot</i> action creates a copy of an entire cache cluster at a specific moment in time.</p>",
-    "DeleteCacheCluster": "<p>The <i>DeleteCacheCluster</i> action deletes a previously provisioned cache cluster. <i>DeleteCacheCluster</i> deletes all associated cache nodes, node endpoints and the cache cluster itself. When you receive a successful response from this action, Amazon ElastiCache immediately begins deleting the cache cluster; you cannot cancel or revert this action.</p> <p>This API cannot be used to delete a cache cluster that is the last read replica of a replication group that has Multi-AZ mode enabled.</p>",
-    "DeleteCacheParameterGroup": "<p>The <i>DeleteCacheParameterGroup</i> action deletes the specified cache parameter group. You cannot delete a cache parameter group if it is associated with any cache clusters.</p>",
-    "DeleteCacheSecurityGroup": "<p>The <i>DeleteCacheSecurityGroup</i> action deletes a cache security group.</p> <note> <p>You cannot delete a cache security group if it is associated with any cache clusters.</p> </note>",
-    "DeleteCacheSubnetGroup": "<p>The <i>DeleteCacheSubnetGroup</i> action deletes a cache subnet group.</p> <note> <p>You cannot delete a cache subnet group if it is associated with any cache clusters.</p> </note>",
-    "DeleteReplicationGroup": "<p>The <i>DeleteReplicationGroup</i> action deletes an existing replication group. By default, this action deletes the entire replication group, including the primary cluster and all of the read replicas. You can optionally delete only the read replicas, while retaining the primary cluster.</p> <p>When you receive a successful response from this action, Amazon ElastiCache immediately begins deleting the selected resources; you cannot cancel or revert this action.</p>",
-    "DeleteSnapshot": "<p>The <i>DeleteSnapshot</i> action deletes an existing snapshot. When you receive a successful response from this action, ElastiCache immediately begins deleting the snapshot; you cannot cancel or revert this action.</p>",
-    "DescribeCacheClusters": "<p>The <i>DescribeCacheClusters</i> action returns information about all provisioned cache clusters if no cache cluster identifier is specified, or about a specific cache cluster if a cache cluster identifier is supplied.</p> <p>By default, abbreviated information about the cache clusters(s) will be returned. You can use the optional <i>ShowDetails</i> flag to retrieve detailed information about the cache nodes associated with the cache clusters. These details include the DNS address and port for the cache node endpoint.</p> <p>If the cluster is in the CREATING state, only cluster level information will be displayed until all of the nodes are successfully provisioned.</p> <p>If the cluster is in the DELETING state, only cluster level information will be displayed.</p> <p>If cache nodes are currently being added to the cache cluster, node endpoint information and creation time for the additional nodes will not be displayed until they are completely provisioned. When the cache cluster state is <i>available</i>, the cluster is ready for use.</p> <p>If cache nodes are currently being removed from the cache cluster, no endpoint information for the removed nodes is displayed.</p>",
-    "DescribeCacheEngineVersions": "<p>The <i>DescribeCacheEngineVersions</i> action returns a list of the available cache engines and their versions.</p>",
-    "DescribeCacheParameterGroups": "<p>The <i>DescribeCacheParameterGroups</i> action returns a list of cache parameter group descriptions. If a cache parameter group name is specified, the list will contain only the descriptions for that group.</p>",
-    "DescribeCacheParameters": "<p>The <i>DescribeCacheParameters</i> action returns the detailed parameter list for a particular cache parameter group.</p>",
-    "DescribeCacheSecurityGroups": "<p>The <i>DescribeCacheSecurityGroups</i> action returns a list of cache security group descriptions. If a cache security group name is specified, the list will contain only the description of that group.</p>",
-    "DescribeCacheSubnetGroups": "<p>The <i>DescribeCacheSubnetGroups</i> action returns a list of cache subnet group descriptions. If a subnet group name is specified, the list will contain only the description of that group.</p>",
-    "DescribeEngineDefaultParameters": "<p>The <i>DescribeEngineDefaultParameters</i> action returns the default engine and system parameter information for the specified cache engine.</p>",
-    "DescribeEvents": "<p>The <i>DescribeEvents</i> action returns events related to cache clusters, cache security groups, and cache parameter groups. You can obtain events specific to a particular cache cluster, cache security group, or cache parameter group by providing the name as a parameter.</p> <p>By default, only the events occurring within the last hour are returned; however, you can retrieve up to 14 days' worth of events if necessary.</p>",
-    "DescribeReplicationGroups": "<p>The <i>DescribeReplicationGroups</i> action returns information about a particular replication group. If no identifier is specified, <i>DescribeReplicationGroups</i> returns information about all replication groups.</p>",
-    "DescribeReservedCacheNodes": "<p>The <i>DescribeReservedCacheNodes</i> action returns information about reserved cache nodes for this account, or about a specified reserved cache node.</p>",
-    "DescribeReservedCacheNodesOfferings": "<p>The <i>DescribeReservedCacheNodesOfferings</i> action lists available reserved cache node offerings.</p>",
-    "DescribeSnapshots": "<p>The <i>DescribeSnapshots</i> action returns information about cache cluster snapshots. By default, <i>DescribeSnapshots</i> lists all of your snapshots; it can optionally describe a single snapshot, or just the snapshots associated with a particular cache cluster.</p>",
-    "ListAllowedNodeTypeModifications": "<p>The <code>ListAllowedNodeTypeModifications</code> action lists all available node types that you can scale your Redis cluster's or replication group's current node type up to.</p> <p>When you use the <code>ModifyCacheCluster</code> or <code>ModifyReplicationGroup</code> APIs to scale up your cluster or replication group, the value of the <i>CacheNodeType</i> parameter must be one of the node types returned by this action.</p>",
-    "ListTagsForResource": "<p>The <i>ListTagsForResource</i> action lists all cost allocation tags currently on the named resource. A <i>cost allocation tag</i> is a key-value pair where the key is case-sensitive and the value is optional. Cost allocation tags can be used to categorize and track your AWS costs.</p> <p>You can have a maximum of 10 cost allocation tags on an ElastiCache resource. For more information, see <a href=\"http://docs.aws.amazon.com/AmazonElastiCache/latest/UserGuide/BestPractices.html\">Using Cost Allocation Tags in Amazon ElastiCache</a>.</p>",
-    "ModifyCacheCluster": "<p>The <i>ModifyCacheCluster</i> action modifies the settings for a cache cluster. You can use this action to change one or more cluster configuration parameters by specifying the parameters and the new values.</p>",
-    "ModifyCacheParameterGroup": "<p>The <i>ModifyCacheParameterGroup</i> action modifies the parameters of a cache parameter group. You can modify up to 20 parameters in a single request by submitting a list parameter name and value pairs.</p>",
-    "ModifyCacheSubnetGroup": "<p>The <i>ModifyCacheSubnetGroup</i> action modifies an existing cache subnet group.</p>",
-    "ModifyReplicationGroup": "<p>The <i>ModifyReplicationGroup</i> action modifies the settings for a replication group.</p>",
-    "PurchaseReservedCacheNodesOffering": "<p>The <i>PurchaseReservedCacheNodesOffering</i> action allows you to purchase a reserved cache node offering.</p>",
-    "RebootCacheCluster": "<p>The <i>RebootCacheCluster</i> action reboots some, or all, of the cache nodes within a provisioned cache cluster. This API will apply any modified cache parameter groups to the cache cluster. The reboot action takes place as soon as possible, and results in a momentary outage to the cache cluster. During the reboot, the cache cluster status is set to REBOOTING.</p> <p>The reboot causes the contents of the cache (for each cache node being rebooted) to be lost.</p> <p>When the reboot is complete, a cache cluster event is created.</p>",
-    "RemoveTagsFromResource": "<p>The <i>RemoveTagsFromResource</i> action removes the tags identified by the <code>TagKeys</code> list from the named resource.</p>",
-    "ResetCacheParameterGroup": "<p>The <i>ResetCacheParameterGroup</i> action modifies the parameters of a cache parameter group to the engine or system default value. You can reset specific parameters by submitting a list of parameter names. To reset the entire cache parameter group, specify the <i>ResetAllParameters</i> and <i>CacheParameterGroupName</i> parameters.</p>",
-    "RevokeCacheSecurityGroupIngress": "<p>The <i>RevokeCacheSecurityGroupIngress</i> action revokes ingress from a cache security group. Use this action to disallow access from an Amazon EC2 security group that had been previously authorized.</p>"
+    "AddTagsToResource": "<p>Adds up to 10 cost allocation tags to the named resource. A cost allocation tag is a key-value pair where the key and value are case-sensitive. You can use cost allocation tags to categorize and track your AWS costs.</p> <p> When you apply tags to your ElastiCache resources, AWS generates a cost allocation report as a comma-separated value (CSV) file with your usage and costs aggregated by your tags. You can apply tags that represent business categories (such as cost centers, application names, or owners) to organize your costs across multiple services. For more information, see <a href=\"http://docs.aws.amazon.com/AmazonElastiCache/latest/UserGuide/Tagging.html\">Using Cost Allocation Tags in Amazon ElastiCache</a> in the <i>ElastiCache User Guide</i>.</p>",
+    "AuthorizeCacheSecurityGroupIngress": "<p>Allows network ingress to a cache security group. Applications using ElastiCache must be running on Amazon EC2, and Amazon EC2 security groups are used as the authorization mechanism.</p> <note> <p>You cannot authorize ingress from an Amazon EC2 security group in one region to an ElastiCache cluster in another region.</p> </note>",
+    "CopySnapshot": "<p>Makes a copy of an existing snapshot.</p> <note> <p>This operation is valid for Redis only.</p> </note> <important> <p>Users or groups that have permissions to use the <code>CopySnapshot</code> operation can create their own Amazon S3 buckets and copy snapshots to it. To control access to your snapshots, use an IAM policy to control who has the ability to use the <code>CopySnapshot</code> operation. For more information about using IAM to control the use of ElastiCache operations, see <a href=\"http://docs.aws.amazon.com/AmazonElastiCache/latest/UserGuide/Snapshots.Exporting.html\">Exporting Snapshots</a> and <a href=\"http://docs.aws.amazon.com/AmazonElastiCache/latest/UserGuide/IAM.html\">Authentication &amp; Access Control</a>.</p> </important> <p>You could receive the following error messages.</p> <p class=\"title\"> <b>Error Messages</b> </p> <ul> <li> <p> <b>Error Message:</b> The S3 bucket %s is outside of the region.</p> <p> <b>Solution:</b> Create an Amazon S3 bucket in the same region as your snapshot. For more information, see <a href=\"http://docs.aws.amazon.com/AmazonElastiCache/latest/UserGuide/Snapshots.Exporting.html#Snapshots.Exporting.CreateBucket\">Step 1: Create an Amazon S3 Bucket</a> in the ElastiCache User Guide.</p> </li> <li> <p> <b>Error Message:</b> The S3 bucket %s does not exist.</p> <p> <b>Solution:</b> Create an Amazon S3 bucket in the same region as your snapshot. For more information, see <a href=\"http://docs.aws.amazon.com/AmazonElastiCache/latest/UserGuide/Snapshots.Exporting.html#Snapshots.Exporting.CreateBucket\">Step 1: Create an Amazon S3 Bucket</a> in the ElastiCache User Guide.</p> </li> <li> <p> <b>Error Message:</b> The S3 bucket %s is not owned by the authenticated user.</p> <p> <b>Solution:</b> Create an Amazon S3 bucket in the same region as your snapshot. For more information, see <a href=\"http://docs.aws.amazon.com/AmazonElastiCache/latest/UserGuide/Snapshots.Exporting.html#Snapshots.Exporting.CreateBucket\">Step 1: Create an Amazon S3 Bucket</a> in the ElastiCache User Guide.</p> </li> <li> <p> <b>Error Message:</b> The authenticated user does not have sufficient permissions to perform the desired activity.</p> <p> <b>Solution:</b> Contact your system administrator to get the needed permissions.</p> </li> <li> <p> <b>Error Message:</b> The S3 bucket %s already contains an object with key %s.</p> <p> <b>Solution:</b> Give the <code>TargetSnapshotName</code> a new and unique value. If exporting a snapshot, you could alternatively create a new Amazon S3 bucket and use this same value for <code>TargetSnapshotName</code>.</p> </li> <li> <p> <b>Error Message: </b> ElastiCache has not been granted READ permissions %s on the S3 Bucket.</p> <p> <b>Solution:</b> Add List and Read permissions on the bucket. For more information, see <a href=\"http://docs.aws.amazon.com/AmazonElastiCache/latest/UserGuide/Snapshots.Exporting.html#Snapshots.Exporting.GrantAccess\">Step 2: Grant ElastiCache Access to Your Amazon S3 Bucket</a> in the ElastiCache User Guide.</p> </li> <li> <p> <b>Error Message: </b> ElastiCache has not been granted WRITE permissions %s on the S3 Bucket.</p> <p> <b>Solution:</b> Add Upload/Delete permissions on the bucket. For more information, see <a href=\"http://docs.aws.amazon.com/AmazonElastiCache/latest/UserGuide/Snapshots.Exporting.html#Snapshots.Exporting.GrantAccess\">Step 2: Grant ElastiCache Access to Your Amazon S3 Bucket</a> in the ElastiCache User Guide.</p> </li> <li> <p> <b>Error Message: </b> ElastiCache has not been granted READ_ACP permissions %s on the S3 Bucket.</p> <p> <b>Solution:</b> Add View Permissions on the bucket. For more information, see <a href=\"http://docs.aws.amazon.com/AmazonElastiCache/latest/UserGuide/Snapshots.Exporting.html#Snapshots.Exporting.GrantAccess\">Step 2: Grant ElastiCache Access to Your Amazon S3 Bucket</a> in the ElastiCache User Guide.</p> </li> </ul>",
+    "CreateCacheCluster": "<p>Creates a cache cluster. All nodes in the cache cluster run the same protocol-compliant cache engine software, either Memcached or Redis.</p> <important> <p>Due to current limitations on Redis (cluster mode disabled), this operation or parameter is not supported on Redis (cluster mode enabled) replication groups.</p> </important>",
+    "CreateCacheParameterGroup": "<p>Creates a new cache parameter group. A cache parameter group is a collection of parameters that you apply to all of the nodes in a cache cluster.</p>",
+    "CreateCacheSecurityGroup": "<p>Creates a new cache security group. Use a cache security group to control access to one or more cache clusters.</p> <p>Cache security groups are only used when you are creating a cache cluster outside of an Amazon Virtual Private Cloud (Amazon VPC). If you are creating a cache cluster inside of a VPC, use a cache subnet group instead. For more information, see <a href=\"http://docs.aws.amazon.com/AmazonElastiCache/latest/APIReference/API_CreateCacheSubnetGroup.html\">CreateCacheSubnetGroup</a>.</p>",
+    "CreateCacheSubnetGroup": "<p>Creates a new cache subnet group.</p> <p>Use this parameter only when you are creating a cluster in an Amazon Virtual Private Cloud (Amazon VPC).</p>",
+    "CreateReplicationGroup": "<p>Creates a Redis (cluster mode disabled) or a Redis (cluster mode enabled) replication group.</p> <p>A Redis (cluster mode disabled) replication group is a collection of cache clusters, where one of the cache clusters is a read/write primary and the others are read-only replicas. Writes to the primary are asynchronously propagated to the replicas.</p> <p>A Redis (cluster mode enabled) replication group is a collection of 1 to 15 node groups (shards). Each node group (shard) has one read/write primary node and up to 5 read-only replica nodes. Writes to the primary are asynchronously propagated to the replicas. Redis (cluster mode enabled) replication groups partition the data across node groups (shards).</p> <p>When a Redis (cluster mode disabled) replication group has been successfully created, you can add one or more read replicas to it, up to a total of 5 read replicas. You cannot alter a Redis (cluster mode enabled) replication group once it has been created.</p> <note> <p>This operation is valid for Redis only.</p> </note>",
+    "CreateSnapshot": "<p>Creates a copy of an entire cache cluster or replication group at a specific moment in time.</p> <note> <p>This operation is valid for Redis only.</p> </note>",
+    "DeleteCacheCluster": "<p>Deletes a previously provisioned cache cluster. <code>DeleteCacheCluster</code> deletes all associated cache nodes, node endpoints and the cache cluster itself. When you receive a successful response from this operation, Amazon ElastiCache immediately begins deleting the cache cluster; you cannot cancel or revert this operation.</p> <p>This operation cannot be used to delete a cache cluster that is the last read replica of a replication group or node group (shard) that has Multi-AZ mode enabled or a cache cluster from a Redis (cluster mode enabled) replication group.</p> <important> <p>Due to current limitations on Redis (cluster mode disabled), this operation or parameter is not supported on Redis (cluster mode enabled) replication groups.</p> </important>",
+    "DeleteCacheParameterGroup": "<p>Deletes the specified cache parameter group. You cannot delete a cache parameter group if it is associated with any cache clusters.</p>",
+    "DeleteCacheSecurityGroup": "<p>Deletes a cache security group.</p> <note> <p>You cannot delete a cache security group if it is associated with any cache clusters.</p> </note>",
+    "DeleteCacheSubnetGroup": "<p>Deletes a cache subnet group.</p> <note> <p>You cannot delete a cache subnet group if it is associated with any cache clusters.</p> </note>",
+    "DeleteReplicationGroup": "<p>Deletes an existing replication group. By default, this operation deletes the entire replication group, including the primary/primaries and all of the read replicas. If the replication group has only one primary, you can optionally delete only the read replicas, while retaining the primary by setting <code>RetainPrimaryCluster=true</code>.</p> <p>When you receive a successful response from this operation, Amazon ElastiCache immediately begins deleting the selected resources; you cannot cancel or revert this operation.</p> <note> <p>This operation is valid for Redis only.</p> </note>",
+    "DeleteSnapshot": "<p>Deletes an existing snapshot. When you receive a successful response from this operation, ElastiCache immediately begins deleting the snapshot; you cannot cancel or revert this operation.</p> <note> <p>This operation is valid for Redis only.</p> </note>",
+    "DescribeCacheClusters": "<p>Returns information about all provisioned cache clusters if no cache cluster identifier is specified, or about a specific cache cluster if a cache cluster identifier is supplied.</p> <p>By default, abbreviated information about the cache clusters are returned. You can use the optional <code>ShowDetails</code> flag to retrieve detailed information about the cache nodes associated with the cache clusters. These details include the DNS address and port for the cache node endpoint.</p> <p>If the cluster is in the CREATING state, only cluster-level information is displayed until all of the nodes are successfully provisioned.</p> <p>If the cluster is in the DELETING state, only cluster-level information is displayed.</p> <p>If cache nodes are currently being added to the cache cluster, node endpoint information and creation time for the additional nodes are not displayed until they are completely provisioned. When the cache cluster state is <code>available</code>, the cluster is ready for use.</p> <p>If cache nodes are currently being removed from the cache cluster, no endpoint information for the removed nodes is displayed.</p>",
+    "DescribeCacheEngineVersions": "<p>Returns a list of the available cache engines and their versions.</p>",
+    "DescribeCacheParameterGroups": "<p>Returns a list of cache parameter group descriptions. If a cache parameter group name is specified, the list contains only the descriptions for that group.</p>",
+    "DescribeCacheParameters": "<p>Returns the detailed parameter list for a particular cache parameter group.</p>",
+    "DescribeCacheSecurityGroups": "<p>Returns a list of cache security group descriptions. If a cache security group name is specified, the list contains only the description of that group.</p>",
+    "DescribeCacheSubnetGroups": "<p>Returns a list of cache subnet group descriptions. If a subnet group name is specified, the list contains only the description of that group.</p>",
+    "DescribeEngineDefaultParameters": "<p>Returns the default engine and system parameter information for the specified cache engine.</p>",
+    "DescribeEvents": "<p>Returns events related to cache clusters, cache security groups, and cache parameter groups. You can obtain events specific to a particular cache cluster, cache security group, or cache parameter group by providing the name as a parameter.</p> <p>By default, only the events occurring within the last hour are returned; however, you can retrieve up to 14 days' worth of events if necessary.</p>",
+    "DescribeReplicationGroups": "<p>Returns information about a particular replication group. If no identifier is specified, <code>DescribeReplicationGroups</code> returns information about all replication groups.</p> <note> <p>This operation is valid for Redis only.</p> </note>",
+    "DescribeReservedCacheNodes": "<p>Returns information about reserved cache nodes for this account, or about a specified reserved cache node.</p>",
+    "DescribeReservedCacheNodesOfferings": "<p>Lists available reserved cache node offerings.</p>",
+    "DescribeSnapshots": "<p>Returns information about cache cluster or replication group snapshots. By default, <code>DescribeSnapshots</code> lists all of your snapshots; it can optionally describe a single snapshot, or just the snapshots associated with a particular cache cluster.</p> <note> <p>This operation is valid for Redis only.</p> </note>",
+    "ListAllowedNodeTypeModifications": "<p>Lists all available node types that you can scale your Redis cluster's or replication group's current node type up to.</p> <p>When you use the <code>ModifyCacheCluster</code> or <code>ModifyReplicationGroup</code> operations to scale up your cluster or replication group, the value of the <code>CacheNodeType</code> parameter must be one of the node types returned by this operation.</p>",
+    "ListTagsForResource": "<p>Lists all cost allocation tags currently on the named resource. A <code>cost allocation tag</code> is a key-value pair where the key is case-sensitive and the value is optional. You can use cost allocation tags to categorize and track your AWS costs.</p> <p>You can have a maximum of 10 cost allocation tags on an ElastiCache resource. For more information, see <a href=\"http://docs.aws.amazon.com/AmazonElastiCache/latest/UserGuide/BestPractices.html\">Using Cost Allocation Tags in Amazon ElastiCache</a>.</p>",
+    "ModifyCacheCluster": "<p>Modifies the settings for a cache cluster. You can use this operation to change one or more cluster configuration parameters by specifying the parameters and the new values.</p>",
+    "ModifyCacheParameterGroup": "<p>Modifies the parameters of a cache parameter group. You can modify up to 20 parameters in a single request by submitting a list parameter name and value pairs.</p>",
+    "ModifyCacheSubnetGroup": "<p>Modifies an existing cache subnet group.</p>",
+    "ModifyReplicationGroup": "<p>Modifies the settings for a replication group.</p> <important> <p>Due to current limitations on Redis (cluster mode disabled), this operation or parameter is not supported on Redis (cluster mode enabled) replication groups.</p> </important> <note> <p>This operation is valid for Redis only.</p> </note>",
+    "PurchaseReservedCacheNodesOffering": "<p>Allows you to purchase a reserved cache node offering.</p>",
+    "RebootCacheCluster": "<p>Reboots some, or all, of the cache nodes within a provisioned cache cluster. This operation applies any modified cache parameter groups to the cache cluster. The reboot operation takes place as soon as possible, and results in a momentary outage to the cache cluster. During the reboot, the cache cluster status is set to REBOOTING.</p> <p>The reboot causes the contents of the cache (for each cache node being rebooted) to be lost.</p> <p>When the reboot is complete, a cache cluster event is created.</p>",
+    "RemoveTagsFromResource": "<p>Removes the tags identified by the <code>TagKeys</code> list from the named resource.</p>",
+    "ResetCacheParameterGroup": "<p>Modifies the parameters of a cache parameter group to the engine or system default value. You can reset specific parameters by submitting a list of parameter names. To reset the entire cache parameter group, specify the <code>ResetAllParameters</code> and <code>CacheParameterGroupName</code> parameters.</p>",
+    "RevokeCacheSecurityGroupIngress": "<p>Revokes ingress from a cache security group. Use this operation to disallow access from an Amazon EC2 security group that had been previously authorized.</p>"
   },
   "shapes": {
     "AZMode": {
       "base": null,
       "refs": {
-        "CreateCacheClusterMessage$AZMode": "<p>Specifies whether the nodes in this Memcached node group are created in a single Availability Zone or created across multiple Availability Zones in the cluster's region.</p> <p>This parameter is only supported for Memcached cache clusters.</p> <p>If the <code>AZMode</code> and <code>PreferredAvailabilityZones</code> are not specified, ElastiCache assumes <code>single-az</code> mode.</p>",
-        "ModifyCacheClusterMessage$AZMode": "<p>Specifies whether the new nodes in this Memcached cache cluster are all created in a single Availability Zone or created across multiple Availability Zones.</p> <p>Valid values: <code>single-az</code> | <code>cross-az</code>.</p> <p>This option is only supported for Memcached cache clusters.</p> <note> <p>You cannot specify <code>single-az</code> if the Memcached cache cluster already has cache nodes in different Availability Zones. If <code>cross-az</code> is specified, existing Memcached nodes remain in their current Availability Zone.</p> <p>Only newly created nodes will be located in different Availability Zones. For instructions on how to move existing Memcached nodes to different Availability Zones, see the <b>Availability Zone Considerations</b> section of <a href=\"http://docs.aws.amazon.com/AmazonElastiCache/latest/UserGuide/CacheNode.Memcached.html\">Cache Node Considerations for Memcached</a>.</p> </note>"
+        "CreateCacheClusterMessage$AZMode": "<p>Specifies whether the nodes in this Memcached cluster are created in a single Availability Zone or created across multiple Availability Zones in the cluster's region.</p> <p>This parameter is only supported for Memcached cache clusters.</p> <p>If the <code>AZMode</code> and <code>PreferredAvailabilityZones</code> are not specified, ElastiCache assumes <code>single-az</code> mode.</p>",
+        "ModifyCacheClusterMessage$AZMode": "<p>Specifies whether the new nodes in this Memcached cache cluster are all created in a single Availability Zone or created across multiple Availability Zones.</p> <p>Valid values: <code>single-az</code> | <code>cross-az</code>.</p> <p>This option is only supported for Memcached cache clusters.</p> <note> <p>You cannot specify <code>single-az</code> if the Memcached cache cluster already has cache nodes in different Availability Zones. If <code>cross-az</code> is specified, existing Memcached nodes remain in their current Availability Zone.</p> <p>Only newly created nodes are located in different Availability Zones. For instructions on how to move existing Memcached nodes to different Availability Zones, see the <b>Availability Zone Considerations</b> section of <a href=\"http://docs.aws.amazon.com/AmazonElastiCache/latest/UserGuide/CacheNode.Memcached.html\">Cache Node Considerations for Memcached</a>.</p> </note>"
       }
     },
     "AddTagsToResourceMessage": {
-      "base": "<p>Represents the input of an <i>AddTagsToResource</i> action.</p>",
+      "base": "<p>Represents the input of an AddTagsToResource operation.</p>",
       "refs": {
       }
     },
     "AllowedNodeTypeModificationsMessage": {
-      "base": "<p>Represents the allowed node types you can use to modify your cache cluster or replication group.</p>",
+      "base": null,
       "refs": {
       }
     },
@@ -70,7 +70,7 @@
       }
     },
     "AuthorizeCacheSecurityGroupIngressMessage": {
-      "base": "<p>Represents the input of an <i>AuthorizeCacheSecurityGroupIngress</i> action.</p>",
+      "base": "<p>Represents the input of an AuthorizeCacheSecurityGroupIngress operation.</p>",
       "refs": {
       }
     },
@@ -82,7 +82,8 @@
     "AutomaticFailoverStatus": {
       "base": null,
       "refs": {
-        "ReplicationGroup$AutomaticFailover": "<p>Indicates the status of Multi-AZ for this replication group.</p> <note> <p>ElastiCache Multi-AZ replication groups are not supported on:</p> <ul> <li> <p>Redis versions earlier than 2.8.6.</p> </li> <li> <p>T1 and T2 cache node types.</p> </li> </ul> </note>"
+        "ReplicationGroup$AutomaticFailover": "<p>Indicates the status of Multi-AZ for this replication group.</p> <note> <p>ElastiCache Multi-AZ replication groups are not supported on:</p> <ul> <li> <p>Redis versions earlier than 2.8.6.</p> </li> <li> <p>Redis (cluster mode disabled):T1 and T2 cache node types.</p> <p>Redis (cluster mode enabled): T1 node types.</p> </li> </ul> </note>",
+        "Snapshot$AutomaticFailover": "<p>Indicates the status of Multi-AZ for the source replication group.</p> <note> <p>ElastiCache Multi-AZ replication groups are not supported on:</p> <ul> <li> <p>Redis versions earlier than 2.8.6.</p> </li> <li> <p>Redis (cluster mode disabled):T1 and T2 cache node types.</p> <p>Redis (cluster mode enabled): T1 node types.</p> </li> </ul> </note>"
       }
     },
     "AvailabilityZone": {
@@ -94,7 +95,8 @@
     "AvailabilityZonesList": {
       "base": null,
       "refs": {
-        "CreateReplicationGroupMessage$PreferredCacheClusterAZs": "<p>A list of EC2 availability zones in which the replication group's cache clusters will be created. The order of the availability zones in the list is not important.</p> <note> <p>If you are creating your replication group in an Amazon VPC (recommended), you can only locate cache clusters in availability zones associated with the subnets in the selected subnet group.</p> <p>The number of availability zones listed must equal the value of <i>NumCacheClusters</i>.</p> </note> <p>Default: system chosen availability zones.</p> <p>Example: One Redis cache cluster in each of three availability zones. </p> <p> <code>PreferredAvailabilityZones.member.1=us-west-2a PreferredAvailabilityZones.member.2=us-west-2c PreferredAvailabilityZones.member.3=us-west-2c</code> </p>"
+        "CreateReplicationGroupMessage$PreferredCacheClusterAZs": "<p>A list of EC2 Availability Zones in which the replication group's cache clusters are created. The order of the Availability Zones in the list is the order in which clusters are allocated. The primary cluster is created in the first AZ in the list.</p> <p>This parameter is not used if there is more than one node group (shard). You should use <code>NodeGroupConfiguration</code> instead.</p> <note> <p>If you are creating your replication group in an Amazon VPC (recommended), you can only locate cache clusters in Availability Zones associated with the subnets in the selected subnet group.</p> <p>The number of Availability Zones listed must equal the value of <code>NumCacheClusters</code>.</p> </note> <p>Default: system chosen Availability Zones.</p>",
+        "NodeGroupConfiguration$ReplicaAvailabilityZones": "<p>A list of Availability Zones to be used for the read replicas. The number of Availability Zones in this list must match the value of <code>ReplicaCount</code> or <code>ReplicasPerNodeGroup</code> if not specified.</p>"
       }
     },
     "AwsQueryErrorMessage": {
@@ -109,11 +111,11 @@
       "refs": {
         "CacheCluster$AutoMinorVersionUpgrade": "<p>This parameter is currently disabled.</p>",
         "CacheNodeTypeSpecificParameter$IsModifiable": "<p>Indicates whether (<code>true</code>) or not (<code>false</code>) the parameter can be modified. Some parameters have security or operational implications that prevent them from being changed.</p>",
-        "DescribeCacheEngineVersionsMessage$DefaultOnly": "<p>If <i>true</i>, specifies that only the default version of the specified engine or engine and major version combination is to be returned.</p>",
-        "ModifyCacheClusterMessage$ApplyImmediately": "<p>If <code>true</code>, this parameter causes the modifications in this request and any pending modifications to be applied, asynchronously and as soon as possible, regardless of the <i>PreferredMaintenanceWindow</i> setting for the cache cluster.</p> <p>If <code>false</code>, then changes to the cache cluster are applied on the next maintenance reboot, or the next failure reboot, whichever occurs first.</p> <important> <p>If you perform a <code>ModifyCacheCluster</code> before a pending modification is applied, the pending modification is replaced by the newer modification.</p> </important> <p>Valid values: <code>true</code> | <code>false</code> </p> <p>Default: <code>false</code> </p>",
-        "ModifyReplicationGroupMessage$ApplyImmediately": "<p>If <code>true</code>, this parameter causes the modifications in this request and any pending modifications to be applied, asynchronously and as soon as possible, regardless of the <i>PreferredMaintenanceWindow</i> setting for the replication group.</p> <p>If <code>false</code>, then changes to the nodes in the replication group are applied on the next maintenance reboot, or the next failure reboot, whichever occurs first.</p> <p>Valid values: <code>true</code> | <code>false</code> </p> <p>Default: <code>false</code> </p>",
+        "DescribeCacheEngineVersionsMessage$DefaultOnly": "<p>If <code>true</code>, specifies that only the default version of the specified engine or engine and major version combination is to be returned.</p>",
+        "ModifyCacheClusterMessage$ApplyImmediately": "<p>If <code>true</code>, this parameter causes the modifications in this request and any pending modifications to be applied, asynchronously and as soon as possible, regardless of the <code>PreferredMaintenanceWindow</code> setting for the cache cluster.</p> <p>If <code>false</code>, changes to the cache cluster are applied on the next maintenance reboot, or the next failure reboot, whichever occurs first.</p> <important> <p>If you perform a <code>ModifyCacheCluster</code> before a pending modification is applied, the pending modification is replaced by the newer modification.</p> </important> <p>Valid values: <code>true</code> | <code>false</code> </p> <p>Default: <code>false</code> </p>",
+        "ModifyReplicationGroupMessage$ApplyImmediately": "<p>If <code>true</code>, this parameter causes the modifications in this request and any pending modifications to be applied, asynchronously and as soon as possible, regardless of the <code>PreferredMaintenanceWindow</code> setting for the replication group.</p> <p>If <code>false</code>, changes to the nodes in the replication group are applied on the next maintenance reboot, or the next failure reboot, whichever occurs first.</p> <p>Valid values: <code>true</code> | <code>false</code> </p> <p>Default: <code>false</code> </p>",
         "Parameter$IsModifiable": "<p>Indicates whether (<code>true</code>) or not (<code>false</code>) the parameter can be modified. Some parameters have security or operational implications that prevent them from being changed.</p>",
-        "ResetCacheParameterGroupMessage$ResetAllParameters": "<p>If <i>true</i>, all parameters in the cache parameter group will be reset to their default values. If <i>false</i>, only the parameters listed by <i>ParameterNameValues</i> are reset to their default values.</p> <p>Valid values: <code>true</code> | <code>false</code> </p>",
+        "ResetCacheParameterGroupMessage$ResetAllParameters": "<p>If <code>true</code>, all parameters in the cache parameter group are reset to their default values. If <code>false</code>, only the parameters listed by <code>ParameterNameValues</code> are reset to their default values.</p> <p>Valid values: <code>true</code> | <code>false</code> </p>",
         "Snapshot$AutoMinorVersionUpgrade": "<p>This parameter is currently disabled.</p>"
       }
     },
@@ -121,12 +123,13 @@
       "base": null,
       "refs": {
         "CreateCacheClusterMessage$AutoMinorVersionUpgrade": "<p>This parameter is currently disabled.</p>",
-        "CreateReplicationGroupMessage$AutomaticFailoverEnabled": "<p>Specifies whether a read-only replica will be automatically promoted to read/write primary if the existing primary fails.</p> <p>If <code>true</code>, Multi-AZ is enabled for this replication group. If <code>false</code>, Multi-AZ is disabled for this replication group.</p> <p>Default: false</p> <note> <p>ElastiCache Multi-AZ replication groups is not supported on:</p> <ul> <li> <p>Redis versions earlier than 2.8.6.</p> </li> <li> <p>T1 and T2 cache node types.</p> </li> </ul> </note>",
+        "CreateReplicationGroupMessage$AutomaticFailoverEnabled": "<p>Specifies whether a read-only replica is automatically promoted to read/write primary if the existing primary fails.</p> <p>If <code>true</code>, Multi-AZ is enabled for this replication group. If <code>false</code>, Multi-AZ is disabled for this replication group.</p> <p> <code>AutomaticFailoverEnabled</code> must be enabled for Redis (cluster mode enabled) replication groups.</p> <p>Default: false</p> <note> <p>ElastiCache Multi-AZ replication groups is not supported on:</p> <ul> <li> <p>Redis versions earlier than 2.8.6.</p> </li> <li> <p>Redis (cluster mode disabled): T1 and T2 node types.</p> <p>Redis (cluster mode enabled): T2 node types.</p> </li> </ul> </note>",
         "CreateReplicationGroupMessage$AutoMinorVersionUpgrade": "<p>This parameter is currently disabled.</p>",
-        "DeleteReplicationGroupMessage$RetainPrimaryCluster": "<p>If set to <i>true</i>, all of the read replicas will be deleted, but the primary node will be retained.</p>",
+        "DeleteReplicationGroupMessage$RetainPrimaryCluster": "<p>If set to <code>true</code>, all of the read replicas are deleted, but the primary node is retained.</p>",
         "DescribeCacheClustersMessage$ShowCacheNodeInfo": "<p>An optional flag that can be included in the DescribeCacheCluster request to retrieve information about the individual cache nodes.</p>",
+        "DescribeSnapshotsMessage$ShowNodeGroupConfig": "<p>A boolean value which if true, the node group (shard) configuration is included in the snapshot description.</p>",
         "ModifyCacheClusterMessage$AutoMinorVersionUpgrade": "<p>This parameter is currently disabled.</p>",
-        "ModifyReplicationGroupMessage$AutomaticFailoverEnabled": "<p>Whether a read replica will be automatically promoted to read/write primary if the existing primary encounters a failure.</p> <p>Valid values: <code>true</code> | <code>false</code> </p> <note> <p>ElastiCache Multi-AZ replication groups are not supported on:</p> <ul> <li> <p>Redis versions earlier than 2.8.6.</p> </li> <li> <p>T1 and T2 cache node types.</p> </li> </ul> </note>",
+        "ModifyReplicationGroupMessage$AutomaticFailoverEnabled": "<p>Determines whether a read replica is automatically promoted to read/write primary if the existing primary encounters a failure.</p> <p>Valid values: <code>true</code> | <code>false</code> </p> <note> <p>ElastiCache Multi-AZ replication groups are not supported on:</p> <ul> <li> <p>Redis versions earlier than 2.8.6.</p> </li> <li> <p>Redis (cluster mode disabled):T1 and T2 cache node types.</p> <p>Redis (cluster mode enabled): T1 node types.</p> </li> </ul> </note>",
         "ModifyReplicationGroupMessage$AutoMinorVersionUpgrade": "<p>This parameter is currently disabled.</p>"
       }
     },
@@ -152,7 +155,7 @@
       }
     },
     "CacheClusterMessage": {
-      "base": "<p>Represents the output of a <i>DescribeCacheClusters</i> action.</p>",
+      "base": "<p>Represents the output of a <code>DescribeCacheClusters</code> operation.</p>",
       "refs": {
       }
     },
@@ -174,12 +177,12 @@
       }
     },
     "CacheEngineVersionMessage": {
-      "base": "<p>Represents the output of a <a>DescribeCacheEngineVersions</a> action.</p>",
+      "base": "<p>Represents the output of a <a>DescribeCacheEngineVersions</a> operation.</p>",
       "refs": {
       }
     },
     "CacheNode": {
-      "base": "<p>Represents an individual cache node within a cache cluster. Each cache node runs its own instance of the cluster's protocol-compliant caching software - either Memcached or Redis.</p> <p>Valid node types are as follows:</p> <ul> <li> <p>General purpose:</p> <ul> <li> <p>Current generation: <code>cache.t2.micro</code>, <code>cache.t2.small</code>, <code>cache.t2.medium</code>, <code>cache.m3.medium</code>, <code>cache.m3.large</code>, <code>cache.m3.xlarge</code>, <code>cache.m3.2xlarge</code> </p> </li> <li> <p>Previous generation: <code>cache.t1.micro</code>, <code>cache.m1.small</code>, <code>cache.m1.medium</code>, <code>cache.m1.large</code>, <code>cache.m1.xlarge</code> </p> </li> </ul> </li> <li> <p>Compute optimized: <code>cache.c1.xlarge</code> </p> </li> <li> <p>Memory optimized:</p> <ul> <li> <p>Current generation: <code>cache.r3.large</code>, <code>cache.r3.xlarge</code>, <code>cache.r3.2xlarge</code>, <code>cache.r3.4xlarge</code>, <code>cache.r3.8xlarge</code> </p> </li> <li> <p>Previous generation: <code>cache.m2.xlarge</code>, <code>cache.m2.2xlarge</code>, <code>cache.m2.4xlarge</code> </p> </li> </ul> </li> </ul> <p> <b>Notes:</b> </p> <ul> <li> <p>All t2 instances are created in an Amazon Virtual Private Cloud (VPC).</p> </li> <li> <p>Redis backup/restore is not supported for t2 instances.</p> </li> <li> <p>Redis Append-only files (AOF) functionality is not supported for t1 or t2 instances.</p> </li> </ul> <p>For a complete listing of cache node types and specifications, see <a href=\"http://aws.amazon.com/elasticache/details\">Amazon ElastiCache Product Features and Details</a> and either <a href=\"http://docs.aws.amazon.com/AmazonElastiCache/latest/UserGuide/CacheParameterGroups.Memcached.html#CacheParameterGroups.Memcached.NodeSpecific\">Cache Node Type-Specific Parameters for Memcached</a> or <a href=\"http://docs.aws.amazon.com/AmazonElastiCache/latest/UserGuide/CacheParameterGroups.Redis.html#CacheParameterGroups.Redis.NodeSpecific\">Cache Node Type-Specific Parameters for Redis</a>.</p>",
+      "base": "<p>Represents an individual cache node within a cache cluster. Each cache node runs its own instance of the cluster's protocol-compliant caching software - either Memcached or Redis.</p> <p>Valid node types are as follows:</p> <ul> <li> <p>General purpose:</p> <ul> <li> <p>Current generation: <code>cache.t2.micro</code>, <code>cache.t2.small</code>, <code>cache.t2.medium</code>, <code>cache.m3.medium</code>, <code>cache.m3.large</code>, <code>cache.m3.xlarge</code>, <code>cache.m3.2xlarge</code>, <code>cache.m4.large</code>, <code>cache.m4.xlarge</code>, <code>cache.m4.2xlarge</code>, <code>cache.m4.4xlarge</code>, <code>cache.m4.10xlarge</code> </p> </li> <li> <p>Previous generation: <code>cache.t1.micro</code>, <code>cache.m1.small</code>, <code>cache.m1.medium</code>, <code>cache.m1.large</code>, <code>cache.m1.xlarge</code> </p> </li> </ul> </li> <li> <p>Compute optimized: <code>cache.c1.xlarge</code> </p> </li> <li> <p>Memory optimized:</p> <ul> <li> <p>Current generation: <code>cache.r3.large</code>, <code>cache.r3.xlarge</code>, <code>cache.r3.2xlarge</code>, <code>cache.r3.4xlarge</code>, <code>cache.r3.8xlarge</code> </p> </li> <li> <p>Previous generation: <code>cache.m2.xlarge</code>, <code>cache.m2.2xlarge</code>, <code>cache.m2.4xlarge</code> </p> </li> </ul> </li> </ul> <p> <b>Notes:</b> </p> <ul> <li> <p>All T2 instances are created in an Amazon Virtual Private Cloud (Amazon VPC).</p> </li> <li> <p>Redis backup/restore is not supported for Redis (cluster mode disabled) T1 and T2 instances. Backup/restore is supported on Redis (cluster mode enabled) T2 instances.</p> </li> <li> <p>Redis Append-only files (AOF) functionality is not supported for T1 or T2 instances.</p> </li> </ul> <p>For a complete listing of node types and specifications, see <a href=\"http://aws.amazon.com/elasticache/details\">Amazon ElastiCache Product Features and Details</a> and either <a href=\"http://docs.aws.amazon.com/AmazonElastiCache/latest/UserGuide/CacheParameterGroups.Memcached.html#ParameterGroups.Memcached.NodeSpecific\">Cache Node Type-Specific Parameters for Memcached</a> or <a href=\"http://docs.aws.amazon.com/AmazonElastiCache/latest/UserGuide/CacheParameterGroups.Redis.html#ParameterGroups.Redis.NodeSpecific\">Cache Node Type-Specific Parameters for Redis</a>.</p>",
       "refs": {
         "CacheNodeList$member": null
       }
@@ -188,7 +191,7 @@
       "base": null,
       "refs": {
         "CacheParameterGroupStatus$CacheNodeIdsToReboot": "<p>A list of the cache node IDs which need to be rebooted for parameter changes to be applied. A node ID is a numeric identifier (0001, 0002, etc.).</p>",
-        "ModifyCacheClusterMessage$CacheNodeIdsToRemove": "<p>A list of cache node IDs to be removed. A node ID is a numeric identifier (0001, 0002, etc.). This parameter is only valid when <i>NumCacheNodes</i> is less than the existing number of cache nodes. The number of cache node IDs supplied in this parameter must match the difference between the existing number of cache nodes in the cluster or pending cache nodes, whichever is greater, and the value of <i>NumCacheNodes</i> in the request.</p> <p>For example: If you have 3 active cache nodes, 7 pending cache nodes, and the number of cache nodes in this <code>ModifyCacheCluser</code> call is 5, you must list 2 (7 - 5) cache node IDs to remove.</p>",
+        "ModifyCacheClusterMessage$CacheNodeIdsToRemove": "<p>A list of cache node IDs to be removed. A node ID is a numeric identifier (0001, 0002, etc.). This parameter is only valid when <code>NumCacheNodes</code> is less than the existing number of cache nodes. The number of cache node IDs supplied in this parameter must match the difference between the existing number of cache nodes in the cluster or pending cache nodes, whichever is greater, and the value of <code>NumCacheNodes</code> in the request.</p> <p>For example: If you have 3 active cache nodes, 7 pending cache nodes, and the number of cache nodes in this <code>ModifyCacheCluser</code> call is 5, you must list 2 (7 - 5) cache node IDs to remove.</p>",
         "PendingModifiedValues$CacheNodeIdsToRemove": "<p>A list of cache node IDs that are being removed (or will be removed) from the cache cluster. A node ID is a numeric identifier (0001, 0002, etc.).</p>",
         "RebootCacheClusterMessage$CacheNodeIdsToReboot": "<p>A list of cache node IDs to reboot. A node ID is a numeric identifier (0001, 0002, etc.). To reboot an entire cache cluster, specify all of the cache node IDs.</p>"
       }
@@ -200,7 +203,7 @@
       }
     },
     "CacheNodeTypeSpecificParameter": {
-      "base": "<p>A parameter that has a different value for each cache node type it is applied to. For example, in a Redis cache cluster, a <i>cache.m1.large</i> cache node type would have a larger <i>maxmemory</i> value than a <i>cache.m1.small</i> type.</p>",
+      "base": "<p>A parameter that has a different value for each cache node type it is applied to. For example, in a Redis cache cluster, a <code>cache.m1.large</code> cache node type would have a larger <code>maxmemory</code> value than a <code>cache.m1.small</code> type.</p>",
       "refs": {
         "CacheNodeTypeSpecificParametersList$member": null
       }
@@ -225,7 +228,7 @@
       }
     },
     "CacheParameterGroup": {
-      "base": "<p>Represents the output of a <i>CreateCacheParameterGroup</i> action.</p>",
+      "base": "<p>Represents the output of a <code>CreateCacheParameterGroup</code> operation.</p>",
       "refs": {
         "CacheParameterGroupList$member": null,
         "CreateCacheParameterGroupResult$CacheParameterGroup": null
@@ -237,7 +240,7 @@
       }
     },
     "CacheParameterGroupDetails": {
-      "base": "<p>Represents the output of a <i>DescribeCacheParameters</i> action.</p>",
+      "base": "<p>Represents the output of a <code>DescribeCacheParameters</code> operation.</p>",
       "refs": {
       }
     },
@@ -248,7 +251,7 @@
       }
     },
     "CacheParameterGroupNameMessage": {
-      "base": "<p>Represents the output of one of the following actions:</p> <ul> <li> <p> <i>ModifyCacheParameterGroup</i> </p> </li> <li> <p> <i>ResetCacheParameterGroup</i> </p> </li> </ul>",
+      "base": "<p>Represents the output of one of the following operations:</p> <ul> <li> <p> <code>ModifyCacheParameterGroup</code> </p> </li> <li> <p> <code>ResetCacheParameterGroup</code> </p> </li> </ul>",
       "refs": {
       }
     },
@@ -263,18 +266,18 @@
       }
     },
     "CacheParameterGroupStatus": {
-      "base": "<p>The status of the cache parameter group.</p>",
+      "base": "<p>Status of the cache parameter group.</p>",
       "refs": {
         "CacheCluster$CacheParameterGroup": null
       }
     },
     "CacheParameterGroupsMessage": {
-      "base": "<p>Represents the output of a <i>DescribeCacheParameterGroups</i> action.</p>",
+      "base": "<p>Represents the output of a <code>DescribeCacheParameterGroups</code> operation.</p>",
       "refs": {
       }
     },
     "CacheSecurityGroup": {
-      "base": "<p>Represents the output of one of the following actions:</p> <ul> <li> <p> <i>AuthorizeCacheSecurityGroupIngress</i> </p> </li> <li> <p> <i>CreateCacheSecurityGroup</i> </p> </li> <li> <p> <i>RevokeCacheSecurityGroupIngress</i> </p> </li> </ul>",
+      "base": "<p>Represents the output of one of the following operations:</p> <ul> <li> <p> <code>AuthorizeCacheSecurityGroupIngress</code> </p> </li> <li> <p> <code>CreateCacheSecurityGroup</code> </p> </li> <li> <p> <code>RevokeCacheSecurityGroupIngress</code> </p> </li> </ul>",
       "refs": {
         "AuthorizeCacheSecurityGroupIngressResult$CacheSecurityGroup": null,
         "CacheSecurityGroups$member": null,
@@ -300,17 +303,17 @@
       }
     },
     "CacheSecurityGroupMessage": {
-      "base": "<p>Represents the output of a <i>DescribeCacheSecurityGroups</i> action.</p>",
+      "base": "<p>Represents the output of a <code>DescribeCacheSecurityGroups</code> operation.</p>",
       "refs": {
       }
     },
     "CacheSecurityGroupNameList": {
       "base": null,
       "refs": {
-        "CreateCacheClusterMessage$CacheSecurityGroupNames": "<p>A list of security group names to associate with this cache cluster.</p> <p>Use this parameter only when you are creating a cache cluster outside of an Amazon Virtual Private Cloud (VPC).</p>",
+        "CreateCacheClusterMessage$CacheSecurityGroupNames": "<p>A list of security group names to associate with this cache cluster.</p> <p>Use this parameter only when you are creating a cache cluster outside of an Amazon Virtual Private Cloud (Amazon VPC).</p>",
         "CreateReplicationGroupMessage$CacheSecurityGroupNames": "<p>A list of cache security group names to associate with this replication group.</p>",
-        "ModifyCacheClusterMessage$CacheSecurityGroupNames": "<p>A list of cache security group names to authorize on this cache cluster. This change is asynchronously applied as soon as possible.</p> <p>This parameter can be used only with clusters that are created outside of an Amazon Virtual Private Cloud (VPC).</p> <p>Constraints: Must contain no more than 255 alphanumeric characters. Must not be \"Default\".</p>",
-        "ModifyReplicationGroupMessage$CacheSecurityGroupNames": "<p>A list of cache security group names to authorize for the clusters in this replication group. This change is asynchronously applied as soon as possible.</p> <p>This parameter can be used only with replication group containing cache clusters running outside of an Amazon Virtual Private Cloud (VPC).</p> <p>Constraints: Must contain no more than 255 alphanumeric characters. Must not be \"Default\".</p>"
+        "ModifyCacheClusterMessage$CacheSecurityGroupNames": "<p>A list of cache security group names to authorize on this cache cluster. This change is asynchronously applied as soon as possible.</p> <p>You can use this parameter only with clusters that are created outside of an Amazon Virtual Private Cloud (Amazon VPC).</p> <p>Constraints: Must contain no more than 255 alphanumeric characters. Must not be \"Default\".</p>",
+        "ModifyReplicationGroupMessage$CacheSecurityGroupNames": "<p>A list of cache security group names to authorize for the clusters in this replication group. This change is asynchronously applied as soon as possible.</p> <p>This parameter can be used only with replication group containing cache clusters running outside of an Amazon Virtual Private Cloud (Amazon VPC).</p> <p>Constraints: Must contain no more than 255 alphanumeric characters. Must not be <code>Default</code>.</p>"
       }
     },
     "CacheSecurityGroupNotFoundFault": {
@@ -330,7 +333,7 @@
       }
     },
     "CacheSubnetGroup": {
-      "base": "<p>Represents the output of one of the following actions:</p> <ul> <li> <p> <i>CreateCacheSubnetGroup</i> </p> </li> <li> <p> <i>ModifyCacheSubnetGroup</i> </p> </li> </ul>",
+      "base": "<p>Represents the output of one of the following operations:</p> <ul> <li> <p> <code>CreateCacheSubnetGroup</code> </p> </li> <li> <p> <code>ModifyCacheSubnetGroup</code> </p> </li> </ul>",
       "refs": {
         "CacheSubnetGroups$member": null,
         "CreateCacheSubnetGroupResult$CacheSubnetGroup": null,
@@ -348,7 +351,7 @@
       }
     },
     "CacheSubnetGroupMessage": {
-      "base": "<p>Represents the output of a <i>DescribeCacheSubnetGroups</i> action.</p>",
+      "base": "<p>Represents the output of a <code>DescribeCacheSubnetGroups</code> operation.</p>",
       "refs": {
       }
     },
@@ -376,8 +379,8 @@
     "ChangeType": {
       "base": null,
       "refs": {
-        "CacheNodeTypeSpecificParameter$ChangeType": "<p>ChangeType indicates whether a change to the parameter will be applied immediately or requires a reboot for the change to be applied. You can force a reboot or wait until the next maintenance window's reboot. For more information, see <a href=\"http://docs.aws.amazon.com/AmazonElastiCache/latest/UserGuide/Clusters.Rebooting.html\">Rebooting a Cluster</a>.</p>",
-        "Parameter$ChangeType": "<p>ChangeType indicates whether a change to the parameter will be applied immediately or requires a reboot for the change to be applied. You can force a reboot or wait until the next maintenance window's reboot. For more information, see <a href=\"http://docs.aws.amazon.com/AmazonElastiCache/latest/UserGuide/Clusters.Rebooting.html\">Rebooting a Cluster</a>.</p>"
+        "CacheNodeTypeSpecificParameter$ChangeType": "<p>Indicates whether a change to the parameter is applied immediately or requires a reboot for the change to be applied. You can force a reboot or wait until the next maintenance window's reboot. For more information, see <a href=\"http://docs.aws.amazon.com/AmazonElastiCache/latest/UserGuide/Clusters.Rebooting.html\">Rebooting a Cluster</a>.</p>",
+        "Parameter$ChangeType": "<p>Indicates whether a change to the parameter is applied immediately or requires a reboot for the change to be applied. You can force a reboot or wait until the next maintenance window's reboot. For more information, see <a href=\"http://docs.aws.amazon.com/AmazonElastiCache/latest/UserGuide/Clusters.Rebooting.html\">Rebooting a Cluster</a>.</p>"
       }
     },
     "ClusterIdList": {
@@ -392,7 +395,7 @@
       }
     },
     "CopySnapshotMessage": {
-      "base": "<p>Represents the input of a <i>CopySnapshotMessage</i> action.</p>",
+      "base": "<p>Represents the input of a <code>CopySnapshotMessage</code> operation.</p>",
       "refs": {
       }
     },
@@ -402,7 +405,7 @@
       }
     },
     "CreateCacheClusterMessage": {
-      "base": "<p>Represents the input of a <i>CreateCacheCluster</i> action.</p>",
+      "base": "<p>Represents the input of a CreateCacheCluster operation.</p>",
       "refs": {
       }
     },
@@ -412,7 +415,7 @@
       }
     },
     "CreateCacheParameterGroupMessage": {
-      "base": "<p>Represents the input of a <i>CreateCacheParameterGroup</i> action.</p>",
+      "base": "<p>Represents the input of a <code>CreateCacheParameterGroup</code> operation.</p>",
       "refs": {
       }
     },
@@ -422,7 +425,7 @@
       }
     },
     "CreateCacheSecurityGroupMessage": {
-      "base": "<p>Represents the input of a <i>CreateCacheSecurityGroup</i> action.</p>",
+      "base": "<p>Represents the input of a <code>CreateCacheSecurityGroup</code> operation.</p>",
       "refs": {
       }
     },
@@ -432,7 +435,7 @@
       }
     },
     "CreateCacheSubnetGroupMessage": {
-      "base": "<p>Represents the input of a <i>CreateCacheSubnetGroup</i> action.</p>",
+      "base": "<p>Represents the input of a <code>CreateCacheSubnetGroup</code> operation.</p>",
       "refs": {
       }
     },
@@ -442,7 +445,7 @@
       }
     },
     "CreateReplicationGroupMessage": {
-      "base": "<p>Represents the input of a <i>CreateReplicationGroup</i> action.</p>",
+      "base": "<p>Represents the input of a <code>CreateReplicationGroup</code> operation.</p>",
       "refs": {
       }
     },
@@ -452,7 +455,7 @@
       }
     },
     "CreateSnapshotMessage": {
-      "base": "<p>Represents the input of a <i>CreateSnapshot</i> action.</p>",
+      "base": "<p>Represents the input of a <code>CreateSnapshot</code> operation.</p>",
       "refs": {
       }
     },
@@ -462,7 +465,7 @@
       }
     },
     "DeleteCacheClusterMessage": {
-      "base": "<p>Represents the input of a <i>DeleteCacheCluster</i> action.</p>",
+      "base": "<p>Represents the input of a <code>DeleteCacheCluster</code> operation.</p>",
       "refs": {
       }
     },
@@ -472,22 +475,22 @@
       }
     },
     "DeleteCacheParameterGroupMessage": {
-      "base": "<p>Represents the input of a <i>DeleteCacheParameterGroup</i> action.</p>",
+      "base": "<p>Represents the input of a <code>DeleteCacheParameterGroup</code> operation.</p>",
       "refs": {
       }
     },
     "DeleteCacheSecurityGroupMessage": {
-      "base": "<p>Represents the input of a <i>DeleteCacheSecurityGroup</i> action.</p>",
+      "base": "<p>Represents the input of a <code>DeleteCacheSecurityGroup</code> operation.</p>",
       "refs": {
       }
     },
     "DeleteCacheSubnetGroupMessage": {
-      "base": "<p>Represents the input of a <i>DeleteCacheSubnetGroup</i> action.</p>",
+      "base": "<p>Represents the input of a <code>DeleteCacheSubnetGroup</code> operation.</p>",
       "refs": {
       }
     },
     "DeleteReplicationGroupMessage": {
-      "base": "<p>Represents the input of a <i>DeleteReplicationGroup</i> action.</p>",
+      "base": "<p>Represents the input of a <code>DeleteReplicationGroup</code> operation.</p>",
       "refs": {
       }
     },
@@ -497,7 +500,7 @@
       }
     },
     "DeleteSnapshotMessage": {
-      "base": "<p>Represents the input of a <i>DeleteSnapshot</i> action.</p>",
+      "base": "<p>Represents the input of a <code>DeleteSnapshot</code> operation.</p>",
       "refs": {
       }
     },
@@ -507,37 +510,37 @@
       }
     },
     "DescribeCacheClustersMessage": {
-      "base": "<p>Represents the input of a <i>DescribeCacheClusters</i> action.</p>",
+      "base": "<p>Represents the input of a <code>DescribeCacheClusters</code> operation.</p>",
       "refs": {
       }
     },
     "DescribeCacheEngineVersionsMessage": {
-      "base": "<p>Represents the input of a <i>DescribeCacheEngineVersions</i> action.</p>",
+      "base": "<p>Represents the input of a <code>DescribeCacheEngineVersions</code> operation.</p>",
       "refs": {
       }
     },
     "DescribeCacheParameterGroupsMessage": {
-      "base": "<p>Represents the input of a <i>DescribeCacheParameterGroups</i> action.</p>",
+      "base": "<p>Represents the input of a <code>DescribeCacheParameterGroups</code> operation.</p>",
       "refs": {
       }
     },
     "DescribeCacheParametersMessage": {
-      "base": "<p>Represents the input of a <i>DescribeCacheParameters</i> action.</p>",
+      "base": "<p>Represents the input of a <code>DescribeCacheParameters</code> operation.</p>",
       "refs": {
       }
     },
     "DescribeCacheSecurityGroupsMessage": {
-      "base": "<p>Represents the input of a <i>DescribeCacheSecurityGroups</i> action.</p>",
+      "base": "<p>Represents the input of a <code>DescribeCacheSecurityGroups</code> operation.</p>",
       "refs": {
       }
     },
     "DescribeCacheSubnetGroupsMessage": {
-      "base": "<p>Represents the input of a <i>DescribeCacheSubnetGroups</i> action.</p>",
+      "base": "<p>Represents the input of a <code>DescribeCacheSubnetGroups</code> operation.</p>",
       "refs": {
       }
     },
     "DescribeEngineDefaultParametersMessage": {
-      "base": "<p>Represents the input of a <i>DescribeEngineDefaultParameters</i> action.</p>",
+      "base": "<p>Represents the input of a <code>DescribeEngineDefaultParameters</code> operation.</p>",
       "refs": {
       }
     },
@@ -547,32 +550,32 @@
       }
     },
     "DescribeEventsMessage": {
-      "base": "<p>Represents the input of a <i>DescribeEvents</i> action.</p>",
+      "base": "<p>Represents the input of a <code>DescribeEvents</code> operation.</p>",
       "refs": {
       }
     },
     "DescribeReplicationGroupsMessage": {
-      "base": "<p>Represents the input of a <i>DescribeReplicationGroups</i> action.</p>",
+      "base": "<p>Represents the input of a <code>DescribeReplicationGroups</code> operation.</p>",
       "refs": {
       }
     },
     "DescribeReservedCacheNodesMessage": {
-      "base": "<p>Represents the input of a <i>DescribeReservedCacheNodes</i> action.</p>",
+      "base": "<p>Represents the input of a <code>DescribeReservedCacheNodes</code> operation.</p>",
       "refs": {
       }
     },
     "DescribeReservedCacheNodesOfferingsMessage": {
-      "base": "<p>Represents the input of a <i>DescribeReservedCacheNodesOfferings</i> action.</p>",
+      "base": "<p>Represents the input of a <code>DescribeReservedCacheNodesOfferings</code> operation.</p>",
       "refs": {
       }
     },
     "DescribeSnapshotsListMessage": {
-      "base": "<p>Represents the output of a <i>DescribeSnapshots</i> action.</p>",
+      "base": "<p>Represents the output of a <code>DescribeSnapshots</code> operation.</p>",
       "refs": {
       }
     },
     "DescribeSnapshotsMessage": {
-      "base": "<p>Represents the input of a <i>DescribeSnapshotsMessage</i> action.</p>",
+      "base": "<p>Represents the input of a <code>DescribeSnapshotsMessage</code> operation.</p>",
       "refs": {
       }
     },
@@ -603,12 +606,13 @@
       "refs": {
         "CacheCluster$ConfigurationEndpoint": null,
         "CacheNode$Endpoint": "<p>The hostname for connecting to this cache node.</p>",
-        "NodeGroup$PrimaryEndpoint": null,
-        "NodeGroupMember$ReadEndpoint": null
+        "NodeGroup$PrimaryEndpoint": "<p>The endpoint of the primary node in this node group (shard).</p>",
+        "NodeGroupMember$ReadEndpoint": null,
+        "ReplicationGroup$ConfigurationEndpoint": "<p>The configuration endpoint for this replicaiton group. Use the configuration endpoint to connect to this replication group.</p>"
       }
     },
     "EngineDefaults": {
-      "base": "<p>Represents the output of a <i>DescribeEngineDefaultParameters</i> action.</p>",
+      "base": "<p>Represents the output of a <code>DescribeEngineDefaultParameters</code> operation.</p>",
       "refs": {
         "DescribeEngineDefaultParametersResult$EngineDefaults": null
       }
@@ -626,7 +630,7 @@
       }
     },
     "EventsMessage": {
-      "base": "<p>Represents the output of a <i>DescribeEvents</i> action.</p>",
+      "base": "<p>Represents the output of a <code>DescribeEvents</code> operation.</p>",
       "refs": {
       }
     },
@@ -648,17 +652,19 @@
       "base": null,
       "refs": {
         "CacheCluster$NumCacheNodes": "<p>The number of cache nodes in the cache cluster.</p> <p>For clusters running Redis, this value must be 1. For clusters running Memcached, this value must be between 1 and 20.</p>",
-        "CacheCluster$SnapshotRetentionLimit": "<p>The number of days for which ElastiCache will retain automatic cache cluster snapshots before deleting them. For example, if you set <i>SnapshotRetentionLimit</i> to 5, then a snapshot that was taken today will be retained for 5 days before being deleted.</p> <important> <p> If the value of SnapshotRetentionLimit is set to zero (0), backups are turned off.</p> </important>",
-        "CreateCacheClusterMessage$NumCacheNodes": "<p>The initial number of cache nodes that the cache cluster will have.</p> <p>For clusters running Redis, this value must be 1. For clusters running Memcached, this value must be between 1 and 20.</p> <p>If you need more than 20 nodes for your Memcached cluster, please fill out the ElastiCache Limit Increase Request form at <a href=\"http://aws.amazon.com/contact-us/elasticache-node-limit-request/\">http://aws.amazon.com/contact-us/elasticache-node-limit-request/</a>.</p>",
-        "CreateCacheClusterMessage$Port": "<p>The port number on which each of the cache nodes will accept connections.</p>",
-        "CreateCacheClusterMessage$SnapshotRetentionLimit": "<p>The number of days for which ElastiCache will retain automatic snapshots before deleting them. For example, if you set <code>SnapshotRetentionLimit</code> to 5, then a snapshot that was taken today will be retained for 5 days before being deleted.</p> <note> <p>This parameter is only valid if the <code>Engine</code> parameter is <code>redis</code>.</p> </note> <p>Default: 0 (i.e., automatic backups are disabled for this cache cluster).</p>",
-        "CreateReplicationGroupMessage$NumCacheClusters": "<p>The number of cache clusters this replication group will initially have.</p> <p>If <i>Multi-AZ</i> is <code>enabled</code>, the value of this parameter must be at least 2.</p> <p>The maximum permitted value for <i>NumCacheClusters</i> is 6 (primary plus 5 replicas). If you need to exceed this limit, please fill out the ElastiCache Limit Increase Request form at <a href=\"http://aws.amazon.com/contact-us/elasticache-node-limit-request\">http://aws.amazon.com/contact-us/elasticache-node-limit-request</a>.</p>",
-        "CreateReplicationGroupMessage$Port": "<p>The port number on which each member of the replication group will accept connections.</p>",
-        "CreateReplicationGroupMessage$SnapshotRetentionLimit": "<p>The number of days for which ElastiCache will retain automatic snapshots before deleting them. For example, if you set <code>SnapshotRetentionLimit</code> to 5, then a snapshot that was taken today will be retained for 5 days before being deleted.</p> <note> <p>This parameter is only valid if the <code>Engine</code> parameter is <code>redis</code>.</p> </note> <p>Default: 0 (i.e., automatic backups are disabled for this cache cluster).</p>",
+        "CacheCluster$SnapshotRetentionLimit": "<p>The number of days for which ElastiCache retains automatic cache cluster snapshots before deleting them. For example, if you set <code>SnapshotRetentionLimit</code> to 5, a snapshot that was taken today is retained for 5 days before being deleted.</p> <important> <p> If the value of SnapshotRetentionLimit is set to zero (0), backups are turned off.</p> </important>",
+        "CreateCacheClusterMessage$NumCacheNodes": "<p>The initial number of cache nodes that the cache cluster has.</p> <p>For clusters running Redis, this value must be 1. For clusters running Memcached, this value must be between 1 and 20.</p> <p>If you need more than 20 nodes for your Memcached cluster, please fill out the ElastiCache Limit Increase Request form at <a href=\"http://aws.amazon.com/contact-us/elasticache-node-limit-request/\">http://aws.amazon.com/contact-us/elasticache-node-limit-request/</a>.</p>",
+        "CreateCacheClusterMessage$Port": "<p>The port number on which each of the cache nodes accepts connections.</p>",
+        "CreateCacheClusterMessage$SnapshotRetentionLimit": "<p>The number of days for which ElastiCache retains automatic snapshots before deleting them. For example, if you set <code>SnapshotRetentionLimit</code> to 5, a snapshot taken today is retained for 5 days before being deleted.</p> <note> <p>This parameter is only valid if the <code>Engine</code> parameter is <code>redis</code>.</p> </note> <p>Default: 0 (i.e., automatic backups are disabled for this cache cluster).</p>",
+        "CreateReplicationGroupMessage$NumCacheClusters": "<p>The number of clusters this replication group initially has.</p> <p>This parameter is not used if there is more than one node group (shard). You should use <code>ReplicasPerNodeGroup</code> instead.</p> <p>If <code>Multi-AZ</code> is <code>enabled</code>, the value of this parameter must be at least 2.</p> <p>The maximum permitted value for <code>NumCacheClusters</code> is 6 (primary plus 5 replicas). If you need to exceed this limit, fill out the ElastiCache Limit Increase Request form at <a href=\"http://aws.amazon.com/contact-us/elasticache-node-limit-request/\">http://aws.amazon.com/contact-us/elasticache-node-limit-request/</a>.</p>",
+        "CreateReplicationGroupMessage$NumNodeGroups": "<p>An optional parameter that specifies the number of node groups (shards) for this Redis (cluster mode enabled) replication group. For Redis (cluster mode disabled) either omit this parameter or set it to 1.</p> <p>Default: 1</p>",
+        "CreateReplicationGroupMessage$ReplicasPerNodeGroup": "<p>An optional parameter that specifies the number of replica nodes in each node group (shard). Valid values are 0 to 5.</p>",
+        "CreateReplicationGroupMessage$Port": "<p>The port number on which each member of the replication group accepts connections.</p>",
+        "CreateReplicationGroupMessage$SnapshotRetentionLimit": "<p>The number of days for which ElastiCache retains automatic snapshots before deleting them. For example, if you set <code>SnapshotRetentionLimit</code> to 5, a snapshot that was taken today is retained for 5 days before being deleted.</p> <note> <p>This parameter is only valid if the <code>Engine</code> parameter is <code>redis</code>.</p> </note> <p>Default: 0 (i.e., automatic backups are disabled for this cache cluster).</p>",
         "DescribeCacheClustersMessage$MaxRecords": "<p>The maximum number of records to include in the response. If more records exist than the specified <code>MaxRecords</code> value, a marker is included in the response so that the remaining results can be retrieved.</p> <p>Default: 100</p> <p>Constraints: minimum 20; maximum 100.</p>",
         "DescribeCacheEngineVersionsMessage$MaxRecords": "<p>The maximum number of records to include in the response. If more records exist than the specified <code>MaxRecords</code> value, a marker is included in the response so that the remaining results can be retrieved.</p> <p>Default: 100</p> <p>Constraints: minimum 20; maximum 100.</p>",
         "DescribeCacheParameterGroupsMessage$MaxRecords": "<p>The maximum number of records to include in the response. If more records exist than the specified <code>MaxRecords</code> value, a marker is included in the response so that the remaining results can be retrieved.</p> <p>Default: 100</p> <p>Constraints: minimum 20; maximum 100.</p>",
-        "DescribeCacheParametersMessage$MaxRecords": "<p>The maximum number of brecords to include in the response. If more records exist than the specified <code>MaxRecords</code> value, a marker is included in the response so that the remaining results can be retrieved.</p> <p>Default: 100</p> <p>Constraints: minimum 20; maximum 100.</p>",
+        "DescribeCacheParametersMessage$MaxRecords": "<p>The maximum number of records to include in the response. If more records exist than the specified <code>MaxRecords</code> value, a marker is included in the response so that the remaining results can be retrieved.</p> <p>Default: 100</p> <p>Constraints: minimum 20; maximum 100.</p>",
         "DescribeCacheSecurityGroupsMessage$MaxRecords": "<p>The maximum number of records to include in the response. If more records exist than the specified <code>MaxRecords</code> value, a marker is included in the response so that the remaining results can be retrieved.</p> <p>Default: 100</p> <p>Constraints: minimum 20; maximum 100.</p>",
         "DescribeCacheSubnetGroupsMessage$MaxRecords": "<p>The maximum number of records to include in the response. If more records exist than the specified <code>MaxRecords</code> value, a marker is included in the response so that the remaining results can be retrieved.</p> <p>Default: 100</p> <p>Constraints: minimum 20; maximum 100.</p>",
         "DescribeEngineDefaultParametersMessage$MaxRecords": "<p>The maximum number of records to include in the response. If more records exist than the specified <code>MaxRecords</code> value, a marker is included in the response so that the remaining results can be retrieved.</p> <p>Default: 100</p> <p>Constraints: minimum 20; maximum 100.</p>",
@@ -668,14 +674,17 @@
         "DescribeReservedCacheNodesMessage$MaxRecords": "<p>The maximum number of records to include in the response. If more records exist than the specified <code>MaxRecords</code> value, a marker is included in the response so that the remaining results can be retrieved.</p> <p>Default: 100</p> <p>Constraints: minimum 20; maximum 100.</p>",
         "DescribeReservedCacheNodesOfferingsMessage$MaxRecords": "<p>The maximum number of records to include in the response. If more records exist than the specified <code>MaxRecords</code> value, a marker is included in the response so that the remaining results can be retrieved.</p> <p>Default: 100</p> <p>Constraints: minimum 20; maximum 100.</p>",
         "DescribeSnapshotsMessage$MaxRecords": "<p>The maximum number of records to include in the response. If more records exist than the specified <code>MaxRecords</code> value, a marker is included in the response so that the remaining results can be retrieved.</p> <p>Default: 50</p> <p>Constraints: minimum 20; maximum 50.</p>",
-        "ModifyCacheClusterMessage$NumCacheNodes": "<p>The number of cache nodes that the cache cluster should have. If the value for <code>NumCacheNodes</code> is greater than the sum of the number of current cache nodes and the number of cache nodes pending creation (which may be zero), then more nodes will be added. If the value is less than the number of existing cache nodes, then nodes will be removed. If the value is equal to the number of current cache nodes, then any pending add or remove requests are canceled.</p> <p>If you are removing cache nodes, you must use the <code>CacheNodeIdsToRemove</code> parameter to provide the IDs of the specific cache nodes to remove.</p> <p>For clusters running Redis, this value must be 1. For clusters running Memcached, this value must be between 1 and 20.</p> <note> <p>Adding or removing Memcached cache nodes can be applied immediately or as a pending action. See <code>ApplyImmediately</code>.</p> <p>A pending action to modify the number of cache nodes in a cluster during its maintenance window, whether by adding or removing nodes in accordance with the scale out architecture, is not queued. The customer's latest request to add or remove nodes to the cluster overrides any previous pending actions to modify the number of cache nodes in the cluster. For example, a request to remove 2 nodes would override a previous pending action to remove 3 nodes. Similarly, a request to add 2 nodes would override a previous pending action to remove 3 nodes and vice versa. As Memcached cache nodes may now be provisioned in different Availability Zones with flexible cache node placement, a request to add nodes does not automatically override a previous pending action to add nodes. The customer can modify the previous pending action to add more nodes or explicitly cancel the pending request and retry the new request. To cancel pending actions to modify the number of cache nodes in a cluster, use the <code>ModifyCacheCluster</code> request and set <i>NumCacheNodes</i> equal to the number of cache nodes currently in the cache cluster.</p> </note>",
-        "ModifyCacheClusterMessage$SnapshotRetentionLimit": "<p>The number of days for which ElastiCache will retain automatic cache cluster snapshots before deleting them. For example, if you set <i>SnapshotRetentionLimit</i> to 5, then a snapshot that was taken today will be retained for 5 days before being deleted.</p> <note> <p>If the value of SnapshotRetentionLimit is set to zero (0), backups are turned off.</p> </note>",
-        "ModifyReplicationGroupMessage$SnapshotRetentionLimit": "<p>The number of days for which ElastiCache will retain automatic node group snapshots before deleting them. For example, if you set <i>SnapshotRetentionLimit</i> to 5, then a snapshot that was taken today will be retained for 5 days before being deleted.</p> <p> <b>Important</b> If the value of SnapshotRetentionLimit is set to zero (0), backups are turned off.</p>",
+        "ModifyCacheClusterMessage$NumCacheNodes": "<p>The number of cache nodes that the cache cluster should have. If the value for <code>NumCacheNodes</code> is greater than the sum of the number of current cache nodes and the number of cache nodes pending creation (which may be zero), more nodes are added. If the value is less than the number of existing cache nodes, nodes are removed. If the value is equal to the number of current cache nodes, any pending add or remove requests are canceled.</p> <p>If you are removing cache nodes, you must use the <code>CacheNodeIdsToRemove</code> parameter to provide the IDs of the specific cache nodes to remove.</p> <p>For clusters running Redis, this value must be 1. For clusters running Memcached, this value must be between 1 and 20.</p> <note> <p>Adding or removing Memcached cache nodes can be applied immediately or as a pending operation (see <code>ApplyImmediately</code>).</p> <p>A pending operation to modify the number of cache nodes in a cluster during its maintenance window, whether by adding or removing nodes in accordance with the scale out architecture, is not queued. The customer's latest request to add or remove nodes to the cluster overrides any previous pending operations to modify the number of cache nodes in the cluster. For example, a request to remove 2 nodes would override a previous pending operation to remove 3 nodes. Similarly, a request to add 2 nodes would override a previous pending operation to remove 3 nodes and vice versa. As Memcached cache nodes may now be provisioned in different Availability Zones with flexible cache node placement, a request to add nodes does not automatically override a previous pending operation to add nodes. The customer can modify the previous pending operation to add more nodes or explicitly cancel the pending request and retry the new request. To cancel pending operations to modify the number of cache nodes in a cluster, use the <code>ModifyCacheCluster</code> request and set <code>NumCacheNodes</code> equal to the number of cache nodes currently in the cache cluster.</p> </note>",
+        "ModifyCacheClusterMessage$SnapshotRetentionLimit": "<p>The number of days for which ElastiCache retains automatic cache cluster snapshots before deleting them. For example, if you set <code>SnapshotRetentionLimit</code> to 5, a snapshot that was taken today is retained for 5 days before being deleted.</p> <note> <p>If the value of <code>SnapshotRetentionLimit</code> is set to zero (0), backups are turned off.</p> </note>",
+        "ModifyReplicationGroupMessage$SnapshotRetentionLimit": "<p>The number of days for which ElastiCache retains automatic node group (shard) snapshots before deleting them. For example, if you set <code>SnapshotRetentionLimit</code> to 5, a snapshot that was taken today is retained for 5 days before being deleted.</p> <p> <b>Important</b> If the value of SnapshotRetentionLimit is set to zero (0), backups are turned off.</p>",
+        "NodeGroupConfiguration$ReplicaCount": "<p>The number of read replica nodes in this node group (shard).</p>",
         "PendingModifiedValues$NumCacheNodes": "<p>The new number of cache nodes for the cache cluster.</p> <p>For clusters running Redis, this value must be 1. For clusters running Memcached, this value must be between 1 and 20.</p>",
         "PurchaseReservedCacheNodesOfferingMessage$CacheNodeCount": "<p>The number of cache node instances to reserve.</p> <p>Default: <code>1</code> </p>",
+        "ReplicationGroup$SnapshotRetentionLimit": "<p>The number of days for which ElastiCache retains automatic cache cluster snapshots before deleting them. For example, if you set <code>SnapshotRetentionLimit</code> to 5, a snapshot that was taken today is retained for 5 days before being deleted.</p> <important> <p> If the value of <code>SnapshotRetentionLimit</code> is set to zero (0), backups are turned off.</p> </important>",
         "Snapshot$NumCacheNodes": "<p>The number of cache nodes in the source cache cluster.</p> <p>For clusters running Redis, this value must be 1. For clusters running Memcached, this value must be between 1 and 20.</p>",
         "Snapshot$Port": "<p>The port number used by each cache nodes in the source cache cluster.</p>",
-        "Snapshot$SnapshotRetentionLimit": "<p>For an automatic snapshot, the number of days for which ElastiCache will retain the snapshot before deleting it.</p> <p>For manual snapshots, this field reflects the <i>SnapshotRetentionLimit</i> for the source cache cluster when the snapshot was created. This field is otherwise ignored: Manual snapshots do not expire, and can only be deleted using the <i>DeleteSnapshot</i> action. </p> <p> <b>Important</b> If the value of SnapshotRetentionLimit is set to zero (0), backups are turned off.</p>"
+        "Snapshot$SnapshotRetentionLimit": "<p>For an automatic snapshot, the number of days for which ElastiCache retains the snapshot before deleting it.</p> <p>For manual snapshots, this field reflects the <code>SnapshotRetentionLimit</code> for the source cache cluster when the snapshot was created. This field is otherwise ignored: Manual snapshots do not expire, and can only be deleted using the <code>DeleteSnapshot</code> operation. </p> <p> <b>Important</b> If the value of SnapshotRetentionLimit is set to zero (0), backups are turned off.</p>",
+        "Snapshot$NumNodeGroups": "<p>The number of node groups (shards) in this snapshot. When restoring from a snapshot, the number of node groups (shards) in the snapshot and in the restored replication group must be the same.</p>"
       }
     },
     "InvalidARNFault": {
@@ -684,12 +693,12 @@
       }
     },
     "InvalidCacheClusterStateFault": {
-      "base": "<p>The requested cache cluster is not in the <i>available</i> state.</p>",
+      "base": "<p>The requested cache cluster is not in the <code>available</code> state.</p>",
       "refs": {
       }
     },
     "InvalidCacheParameterGroupStateFault": {
-      "base": "<p>The current state of the cache parameter group does not allow the requested action to occur.</p>",
+      "base": "<p>The current state of the cache parameter group does not allow the requested operation to occur.</p>",
       "refs": {
       }
     },
@@ -709,12 +718,12 @@
       }
     },
     "InvalidReplicationGroupStateFault": {
-      "base": "<p>The requested replication group is not in the <i>available</i> state.</p>",
+      "base": "<p>The requested replication group is not in the <code>available</code> state.</p>",
       "refs": {
       }
     },
     "InvalidSnapshotStateFault": {
-      "base": "<p>The current state of the snapshot does not allow the requested action to occur.</p>",
+      "base": "<p>The current state of the snapshot does not allow the requested operation to occur.</p>",
       "refs": {
       }
     },
@@ -731,21 +740,21 @@
     "KeyList": {
       "base": null,
       "refs": {
-        "RemoveTagsFromResourceMessage$TagKeys": "<p>A list of <code>TagKeys</code> identifying the tags you want removed from the named resource. For example, <code>TagKeys.member.1=Region</code> removes the cost allocation tag with the key name <code>Region</code> from the resource named by the <i>ResourceName</i> parameter.</p>"
+        "RemoveTagsFromResourceMessage$TagKeys": "<p>A list of <code>TagKeys</code> identifying the tags you want removed from the named resource.</p>"
       }
     },
     "ListAllowedNodeTypeModificationsMessage": {
-      "base": "<p>The input parameters for the <i>ListAllowedNodeTypeModifications</i> action.</p>",
+      "base": "<p>The input parameters for the <code>ListAllowedNodeTypeModifications</code> operation.</p>",
       "refs": {
       }
     },
     "ListTagsForResourceMessage": {
-      "base": "<p>The input parameters for the <i>ListTagsForResource</i> action.</p>",
+      "base": "<p>The input parameters for the <code>ListTagsForResource</code> operation.</p>",
       "refs": {
       }
     },
     "ModifyCacheClusterMessage": {
-      "base": "<p>Represents the input of a <i>ModifyCacheCluster</i> action.</p>",
+      "base": "<p>Represents the input of a <code>ModifyCacheCluster</code> operation.</p>",
       "refs": {
       }
     },
@@ -755,12 +764,12 @@
       }
     },
     "ModifyCacheParameterGroupMessage": {
-      "base": "<p>Represents the input of a <i>ModifyCacheParameterGroup</i> action.</p>",
+      "base": "<p>Represents the input of a <code>ModifyCacheParameterGroup</code> operation.</p>",
       "refs": {
       }
     },
     "ModifyCacheSubnetGroupMessage": {
-      "base": "<p>Represents the input of a <i>ModifyCacheSubnetGroup</i> action.</p>",
+      "base": "<p>Represents the input of a <code>ModifyCacheSubnetGroup</code> operation.</p>",
       "refs": {
       }
     },
@@ -770,7 +779,7 @@
       }
     },
     "ModifyReplicationGroupMessage": {
-      "base": "<p>Represents the input of a <i>ModifyReplicationGroups</i> action.</p>",
+      "base": "<p>Represents the input of a <code>ModifyReplicationGroups</code> operation.</p>",
       "refs": {
       }
     },
@@ -780,9 +789,22 @@
       }
     },
     "NodeGroup": {
-      "base": "<p>Represents a collection of cache nodes in a replication group.</p>",
+      "base": "<p>Represents a collection of cache nodes in a replication group. One node in the node group is the read/write Primary node. All the other nodes are read-only Replica nodes.</p>",
       "refs": {
         "NodeGroupList$member": null
+      }
+    },
+    "NodeGroupConfiguration": {
+      "base": "<p>node group (shard) configuration options. Each node group (shard) configuration has the following: <code>Slots</code>, <code>PrimaryAvailabilityZone</code>, <code>ReplicaAvailabilityZones</code>, <code>ReplicaCount</code>.</p>",
+      "refs": {
+        "NodeGroupConfigurationList$member": null,
+        "NodeSnapshot$NodeGroupConfiguration": "<p>The configuration for the source node group (shard).</p>"
+      }
+    },
+    "NodeGroupConfigurationList": {
+      "base": null,
+      "refs": {
+        "CreateReplicationGroupMessage$NodeGroupConfiguration": "<p>A list of node group (shard) configuration options. Each node group (shard) configuration has the following: Slots, PrimaryAvailabilityZone, ReplicaAvailabilityZones, ReplicaCount.</p> <p>If you're creating a Redis (cluster mode disabled) or a Redis (cluster mode enabled) replication group, you can use this parameter to configure one node group (shard) or you can omit this parameter.</p>"
       }
     },
     "NodeGroupList": {
@@ -792,7 +814,7 @@
       }
     },
     "NodeGroupMember": {
-      "base": "<p>Represents a single node within a node group.</p>",
+      "base": "<p>Represents a single node within a node group (shard).</p>",
       "refs": {
         "NodeGroupMemberList$member": null
       }
@@ -800,7 +822,12 @@
     "NodeGroupMemberList": {
       "base": null,
       "refs": {
-        "NodeGroup$NodeGroupMembers": "<p>A list containing information about individual nodes within the node group.</p>"
+        "NodeGroup$NodeGroupMembers": "<p>A list containing information about individual nodes within the node group (shard).</p>"
+      }
+    },
+    "NodeGroupsPerReplicationGroupQuotaExceededFault": {
+      "base": "<p>The request cannot be processed because it would exceed the maximum of 15 node groups (shards) in a single replication group.</p>",
+      "refs": {
       }
     },
     "NodeQuotaForClusterExceededFault": {
@@ -828,7 +855,7 @@
     "NodeTypeList": {
       "base": null,
       "refs": {
-        "AllowedNodeTypeModificationsMessage$ScaleUpModifications": "<p>A string list, each element of which specifies a cache node type which you can use to scale your cache cluster or replication group.</p> <p>When scaling up a Redis cluster or replication group using <code>ModifyCacheCluster</code> or <code>ModifyReplicationGroup</code>, use a value from this list for the <i>CacheNodeType</i> parameter.</p>"
+        "AllowedNodeTypeModificationsMessage$ScaleUpModifications": null
       }
     },
     "NotificationConfiguration": {
@@ -853,7 +880,7 @@
       "base": null,
       "refs": {
         "ModifyCacheParameterGroupMessage$ParameterNameValues": "<p>An array of parameter names and values for the parameter update. You must supply at least one parameter name and value; subsequent arguments are optional. A maximum of 20 parameters may be modified per request.</p>",
-        "ResetCacheParameterGroupMessage$ParameterNameValues": "<p>An array of parameter names to reset to their default values. If <i>ResetAllParameters</i> is <i>false</i>, you must specify the name of at least one parameter to reset.</p>"
+        "ResetCacheParameterGroupMessage$ParameterNameValues": "<p>An array of parameter names to reset to their default values. If <code>ResetAllParameters</code> is <code>true</code>, do not use <code>ParameterNameValues</code>. If <code>ResetAllParameters</code> is <code>false</code>, you must specify the name of at least one parameter to reset.</p>"
       }
     },
     "ParametersList": {
@@ -866,11 +893,11 @@
     "PendingAutomaticFailoverStatus": {
       "base": null,
       "refs": {
-        "ReplicationGroupPendingModifiedValues$AutomaticFailoverStatus": "<p>Indicates the status of Multi-AZ for this replication group.</p> <note> <p>ElastiCache Multi-AZ replication groups are not supported on:</p> <ul> <li> <p>Redis versions earlier than 2.8.6.</p> </li> <li> <p>T1 and T2 cache node types.</p> </li> </ul> </note>"
+        "ReplicationGroupPendingModifiedValues$AutomaticFailoverStatus": "<p>Indicates the status of Multi-AZ for this Redis replication group.</p> <note> <p>ElastiCache Multi-AZ replication groups are not supported on:</p> <ul> <li> <p>Redis versions earlier than 2.8.6.</p> </li> <li> <p>Redis (cluster mode disabled):T1 and T2 cache node types.</p> <p>Redis (cluster mode enabled): T1 node types.</p> </li> </ul> </note>"
       }
     },
     "PendingModifiedValues": {
-      "base": "<p>A group of settings that will be applied to the cache cluster in the future, or that are currently being applied.</p>",
+      "base": "<p>A group of settings that are applied to the cache cluster in the future, or that are currently being applied.</p>",
       "refs": {
         "CacheCluster$PendingModifiedValues": null
       }
@@ -878,12 +905,12 @@
     "PreferredAvailabilityZoneList": {
       "base": null,
       "refs": {
-        "CreateCacheClusterMessage$PreferredAvailabilityZones": "<p>A list of the Availability Zones in which cache nodes will be created. The order of the zones in the list is not important.</p> <p>This option is only supported on Memcached.</p> <note> <p>If you are creating your cache cluster in an Amazon VPC (recommended) you can only locate nodes in Availability Zones that are associated with the subnets in the selected subnet group.</p> <p>The number of Availability Zones listed must equal the value of <code>NumCacheNodes</code>.</p> </note> <p>If you want all the nodes in the same Availability Zone, use <code>PreferredAvailabilityZone</code> instead, or repeat the Availability Zone multiple times in the list.</p> <p>Default: System chosen Availability Zones.</p> <p>Example: One Memcached node in each of three different Availability Zones: <code>PreferredAvailabilityZones.member.1=us-west-2a&amp;amp;PreferredAvailabilityZones.member.2=us-west-2b&amp;amp;PreferredAvailabilityZones.member.3=us-west-2c</code> </p> <p>Example: All three Memcached nodes in one Availability Zone: <code>PreferredAvailabilityZones.member.1=us-west-2a&amp;amp;PreferredAvailabilityZones.member.2=us-west-2a&amp;amp;PreferredAvailabilityZones.member.3=us-west-2a</code> </p>",
-        "ModifyCacheClusterMessage$NewAvailabilityZones": "<p>The list of Availability Zones where the new Memcached cache nodes will be created.</p> <p>This parameter is only valid when <i>NumCacheNodes</i> in the request is greater than the sum of the number of active cache nodes and the number of cache nodes pending creation (which may be zero). The number of Availability Zones supplied in this list must match the cache nodes being added in this request.</p> <p>This option is only supported on Memcached clusters.</p> <p>Scenarios:</p> <ul> <li> <p> <b>Scenario 1:</b> You have 3 active nodes and wish to add 2 nodes. Specify <code>NumCacheNodes=5</code> (3 + 2) and optionally specify two Availability Zones for the two new nodes.</p> </li> <li> <p> <b>Scenario 2:</b> You have 3 active nodes and 2 nodes pending creation (from the scenario 1 call) and want to add 1 more node. Specify <code>NumCacheNodes=6</code> ((3 + 2) + 1) and optionally specify an Availability Zone for the new node.</p> </li> <li> <p> <b>Scenario 3:</b> You want to cancel all pending actions. Specify <code>NumCacheNodes=3</code> to cancel all pending actions.</p> </li> </ul> <p>The Availability Zone placement of nodes pending creation cannot be modified. If you wish to cancel any nodes pending creation, add 0 nodes by setting <code>NumCacheNodes</code> to the number of current nodes.</p> <p>If <code>cross-az</code> is specified, existing Memcached nodes remain in their current Availability Zone. Only newly created nodes can be located in different Availability Zones. For guidance on how to move existing Memcached nodes to different Availability Zones, see the <b>Availability Zone Considerations</b> section of <a href=\"http://docs.aws.amazon.com/AmazonElastiCache/latest/UserGuide/CacheNode.Memcached.html\">Cache Node Considerations for Memcached</a>.</p> <p> <b>Impact of new add/remove requests upon pending requests</b> </p> <ul> <li> <p>Scenario-1</p> <ul> <li> <p>Pending Action: Delete</p> </li> <li> <p>New Request: Delete</p> </li> <li> <p>Result: The new delete, pending or immediate, replaces the pending delete.</p> </li> </ul> </li> <li> <p>Scenario-2</p> <ul> <li> <p>Pending Action: Delete</p> </li> <li> <p>New Request: Create</p> </li> <li> <p>Result: The new create, pending or immediate, replaces the pending delete.</p> </li> </ul> </li> <li> <p>Scenario-3</p> <ul> <li> <p>Pending Action: Create</p> </li> <li> <p>New Request: Delete</p> </li> <li> <p>Result: The new delete, pending or immediate, replaces the pending create.</p> </li> </ul> </li> <li> <p>Scenario-4</p> <ul> <li> <p>Pending Action: Create</p> </li> <li> <p>New Request: Create</p> </li> <li> <p>Result: The new create is added to the pending create.</p> <important> <p> <b>Important:</b> If the new create request is <b>Apply Immediately - Yes</b>, all creates are performed immediately. If the new create request is <b>Apply Immediately - No</b>, all creates are pending.</p> </important> </li> </ul> </li> </ul> <p>Example:</p> <p> <code>NewAvailabilityZones.member.1=us-west-2a&amp;amp;NewAvailabilityZones.member.2=us-west-2b&amp;amp;NewAvailabilityZones.member.3=us-west-2c</code> </p>"
+        "CreateCacheClusterMessage$PreferredAvailabilityZones": "<p>A list of the Availability Zones in which cache nodes are created. The order of the zones in the list is not important.</p> <p>This option is only supported on Memcached.</p> <note> <p>If you are creating your cache cluster in an Amazon VPC (recommended) you can only locate nodes in Availability Zones that are associated with the subnets in the selected subnet group.</p> <p>The number of Availability Zones listed must equal the value of <code>NumCacheNodes</code>.</p> </note> <p>If you want all the nodes in the same Availability Zone, use <code>PreferredAvailabilityZone</code> instead, or repeat the Availability Zone multiple times in the list.</p> <p>Default: System chosen Availability Zones.</p>",
+        "ModifyCacheClusterMessage$NewAvailabilityZones": "<p>The list of Availability Zones where the new Memcached cache nodes are created.</p> <p>This parameter is only valid when <code>NumCacheNodes</code> in the request is greater than the sum of the number of active cache nodes and the number of cache nodes pending creation (which may be zero). The number of Availability Zones supplied in this list must match the cache nodes being added in this request.</p> <p>This option is only supported on Memcached clusters.</p> <p>Scenarios:</p> <ul> <li> <p> <b>Scenario 1:</b> You have 3 active nodes and wish to add 2 nodes. Specify <code>NumCacheNodes=5</code> (3 + 2) and optionally specify two Availability Zones for the two new nodes.</p> </li> <li> <p> <b>Scenario 2:</b> You have 3 active nodes and 2 nodes pending creation (from the scenario 1 call) and want to add 1 more node. Specify <code>NumCacheNodes=6</code> ((3 + 2) + 1) and optionally specify an Availability Zone for the new node.</p> </li> <li> <p> <b>Scenario 3:</b> You want to cancel all pending operations. Specify <code>NumCacheNodes=3</code> to cancel all pending operations.</p> </li> </ul> <p>The Availability Zone placement of nodes pending creation cannot be modified. If you wish to cancel any nodes pending creation, add 0 nodes by setting <code>NumCacheNodes</code> to the number of current nodes.</p> <p>If <code>cross-az</code> is specified, existing Memcached nodes remain in their current Availability Zone. Only newly created nodes can be located in different Availability Zones. For guidance on how to move existing Memcached nodes to different Availability Zones, see the <b>Availability Zone Considerations</b> section of <a href=\"http://docs.aws.amazon.com/AmazonElastiCache/latest/UserGuide/CacheNode.Memcached.html\">Cache Node Considerations for Memcached</a>.</p> <p> <b>Impact of new add/remove requests upon pending requests</b> </p> <ul> <li> <p>Scenario-1</p> <ul> <li> <p>Pending Action: Delete</p> </li> <li> <p>New Request: Delete</p> </li> <li> <p>Result: The new delete, pending or immediate, replaces the pending delete.</p> </li> </ul> </li> <li> <p>Scenario-2</p> <ul> <li> <p>Pending Action: Delete</p> </li> <li> <p>New Request: Create</p> </li> <li> <p>Result: The new create, pending or immediate, replaces the pending delete.</p> </li> </ul> </li> <li> <p>Scenario-3</p> <ul> <li> <p>Pending Action: Create</p> </li> <li> <p>New Request: Delete</p> </li> <li> <p>Result: The new delete, pending or immediate, replaces the pending create.</p> </li> </ul> </li> <li> <p>Scenario-4</p> <ul> <li> <p>Pending Action: Create</p> </li> <li> <p>New Request: Create</p> </li> <li> <p>Result: The new create is added to the pending create.</p> <important> <p> <b>Important:</b> If the new create request is <b>Apply Immediately - Yes</b>, all creates are performed immediately. If the new create request is <b>Apply Immediately - No</b>, all creates are pending.</p> </important> </li> </ul> </li> </ul>"
       }
     },
     "PurchaseReservedCacheNodesOfferingMessage": {
-      "base": "<p>Represents the input of a <i>PurchaseReservedCacheNodesOffering</i> action.</p>",
+      "base": "<p>Represents the input of a <code>PurchaseReservedCacheNodesOffering</code> operation.</p>",
       "refs": {
       }
     },
@@ -893,7 +920,7 @@
       }
     },
     "RebootCacheClusterMessage": {
-      "base": "<p>Represents the input of a <i>RebootCacheCluster</i> action.</p>",
+      "base": "<p>Represents the input of a <code>RebootCacheCluster</code> operation.</p>",
       "refs": {
       }
     },
@@ -916,12 +943,12 @@
       }
     },
     "RemoveTagsFromResourceMessage": {
-      "base": "<p>Represents the input of a <i>RemoveTagsFromResource</i> action.</p>",
+      "base": "<p>Represents the input of a <code>RemoveTagsFromResource</code> operation.</p>",
       "refs": {
       }
     },
     "ReplicationGroup": {
-      "base": "<p>Contains all of the attributes of a specific replication group.</p>",
+      "base": "<p>Contains all of the attributes of a specific Redis replication group.</p>",
       "refs": {
         "CreateReplicationGroupResult$ReplicationGroup": null,
         "DeleteReplicationGroupResult$ReplicationGroup": null,
@@ -941,7 +968,7 @@
       }
     },
     "ReplicationGroupMessage": {
-      "base": "<p>Represents the output of a <i>DescribeReplicationGroups</i> action.</p>",
+      "base": "<p>Represents the output of a <code>DescribeReplicationGroups</code> operation.</p>",
       "refs": {
       }
     },
@@ -951,13 +978,13 @@
       }
     },
     "ReplicationGroupPendingModifiedValues": {
-      "base": "<p>The settings to be applied to the replication group, either immediately or during the next maintenance window.</p>",
+      "base": "<p>The settings to be applied to the Redis replication group, either immediately or during the next maintenance window.</p>",
       "refs": {
         "ReplicationGroup$PendingModifiedValues": "<p>A group of settings to be applied to the replication group, either immediately or during the next maintenance window.</p>"
       }
     },
     "ReservedCacheNode": {
-      "base": "<p>Represents the output of a <i>PurchaseReservedCacheNodesOffering</i> action.</p>",
+      "base": "<p>Represents the output of a <code>PurchaseReservedCacheNodesOffering</code> operation.</p>",
       "refs": {
         "PurchaseReservedCacheNodesOfferingResult$ReservedCacheNode": null,
         "ReservedCacheNodeList$member": null
@@ -975,7 +1002,7 @@
       }
     },
     "ReservedCacheNodeMessage": {
-      "base": "<p>Represents the output of a <i>DescribeReservedCacheNodes</i> action.</p>",
+      "base": "<p>Represents the output of a <code>DescribeReservedCacheNodes</code> operation.</p>",
       "refs": {
       }
     },
@@ -1002,7 +1029,7 @@
       }
     },
     "ReservedCacheNodesOfferingMessage": {
-      "base": "<p>Represents the output of a <i>DescribeReservedCacheNodesOfferings</i> action.</p>",
+      "base": "<p>Represents the output of a <code>DescribeReservedCacheNodesOfferings</code> operation.</p>",
       "refs": {
       }
     },
@@ -1012,12 +1039,12 @@
       }
     },
     "ResetCacheParameterGroupMessage": {
-      "base": "<p>Represents the input of a <i>ResetCacheParameterGroup</i> action.</p>",
+      "base": "<p>Represents the input of a <code>ResetCacheParameterGroup</code> operation.</p>",
       "refs": {
       }
     },
     "RevokeCacheSecurityGroupIngressMessage": {
-      "base": "<p>Represents the input of a <i>RevokeCacheSecurityGroupIngress</i> action.</p>",
+      "base": "<p>Represents the input of a <code>RevokeCacheSecurityGroupIngress</code> operation.</p>",
       "refs": {
       }
     },
@@ -1029,10 +1056,10 @@
     "SecurityGroupIdsList": {
       "base": null,
       "refs": {
-        "CreateCacheClusterMessage$SecurityGroupIds": "<p>One or more VPC security groups associated with the cache cluster.</p> <p>Use this parameter only when you are creating a cache cluster in an Amazon Virtual Private Cloud (VPC).</p>",
-        "CreateReplicationGroupMessage$SecurityGroupIds": "<p>One or more Amazon VPC security groups associated with this replication group.</p> <p>Use this parameter only when you are creating a replication group in an Amazon Virtual Private Cloud (VPC).</p>",
-        "ModifyCacheClusterMessage$SecurityGroupIds": "<p>Specifies the VPC Security Groups associated with the cache cluster.</p> <p>This parameter can be used only with clusters that are created in an Amazon Virtual Private Cloud (VPC).</p>",
-        "ModifyReplicationGroupMessage$SecurityGroupIds": "<p>Specifies the VPC Security Groups associated with the cache clusters in the replication group.</p> <p>This parameter can be used only with replication group containing cache clusters running in an Amazon Virtual Private Cloud (VPC).</p>"
+        "CreateCacheClusterMessage$SecurityGroupIds": "<p>One or more VPC security groups associated with the cache cluster.</p> <p>Use this parameter only when you are creating a cache cluster in an Amazon Virtual Private Cloud (Amazon VPC).</p>",
+        "CreateReplicationGroupMessage$SecurityGroupIds": "<p>One or more Amazon VPC security groups associated with this replication group.</p> <p>Use this parameter only when you are creating a replication group in an Amazon Virtual Private Cloud (Amazon VPC).</p>",
+        "ModifyCacheClusterMessage$SecurityGroupIds": "<p>Specifies the VPC Security Groups associated with the cache cluster.</p> <p>This parameter can be used only with clusters that are created in an Amazon Virtual Private Cloud (Amazon VPC).</p>",
+        "ModifyReplicationGroupMessage$SecurityGroupIds": "<p>Specifies the VPC Security Groups associated with the cache clusters in the replication group.</p> <p>This parameter can be used only with replication group containing cache clusters running in an Amazon Virtual Private Cloud (Amazon VPC).</p>"
       }
     },
     "SecurityGroupMembership": {
@@ -1048,7 +1075,7 @@
       }
     },
     "Snapshot": {
-      "base": "<p>Represents a copy of an entire cache cluster as of the time when the snapshot was taken.</p>",
+      "base": "<p>Represents a copy of an entire Redis cache cluster as of the time when the snapshot was taken.</p>",
       "refs": {
         "CopySnapshotResult$Snapshot": null,
         "CreateSnapshotResult$Snapshot": null,
@@ -1064,12 +1091,12 @@
     "SnapshotArnsList": {
       "base": null,
       "refs": {
-        "CreateCacheClusterMessage$SnapshotArns": "<p>A single-element string list containing an Amazon Resource Name (ARN) that uniquely identifies a Redis RDB snapshot file stored in Amazon S3. The snapshot file will be used to populate the node group. The Amazon S3 object name in the ARN cannot contain any commas.</p> <note> <p>This parameter is only valid if the <code>Engine</code> parameter is <code>redis</code>.</p> </note> <p>Example of an Amazon S3 ARN: <code>arn:aws:s3:::my_bucket/snapshot1.rdb</code> </p>",
-        "CreateReplicationGroupMessage$SnapshotArns": "<p>A single-element string list containing an Amazon Resource Name (ARN) that uniquely identifies a Redis RDB snapshot file stored in Amazon S3. The snapshot file will be used to populate the node group. The Amazon S3 object name in the ARN cannot contain any commas.</p> <note> <p>This parameter is only valid if the <code>Engine</code> parameter is <code>redis</code>.</p> </note> <p>Example of an Amazon S3 ARN: <code>arn:aws:s3:::my_bucket/snapshot1.rdb</code> </p>"
+        "CreateCacheClusterMessage$SnapshotArns": "<p>A single-element string list containing an Amazon Resource Name (ARN) that uniquely identifies a Redis RDB snapshot file stored in Amazon S3. The snapshot file is used to populate the node group (shard). The Amazon S3 object name in the ARN cannot contain any commas.</p> <note> <p>This parameter is only valid if the <code>Engine</code> parameter is <code>redis</code>.</p> </note> <p>Example of an Amazon S3 ARN: <code>arn:aws:s3:::my_bucket/snapshot1.rdb</code> </p>",
+        "CreateReplicationGroupMessage$SnapshotArns": "<p>A list of Amazon Resource Names (ARN) that uniquely identify the Redis RDB snapshot files stored in Amazon S3. The snapshot files are used to populate the replication group. The Amazon S3 object name in the ARN cannot contain any commas. The list must match the number of node groups (shards) in the replication group, which means you cannot repartition.</p> <note> <p>This parameter is only valid if the <code>Engine</code> parameter is <code>redis</code>.</p> </note> <p>Example of an Amazon S3 ARN: <code>arn:aws:s3:::my_bucket/snapshot1.rdb</code> </p>"
       }
     },
     "SnapshotFeatureNotSupportedFault": {
-      "base": "<p>You attempted one of the following actions:</p> <ul> <li> <p>Creating a snapshot of a Redis cache cluster running on a <i>t1.micro</i> cache node.</p> </li> <li> <p>Creating a snapshot of a cache cluster that is running Memcached rather than Redis.</p> </li> </ul> <p>Neither of these are supported by ElastiCache.</p>",
+      "base": "<p>You attempted one of the following operations:</p> <ul> <li> <p>Creating a snapshot of a Redis cache cluster running on a <code>cache.t1.micro</code> cache node.</p> </li> <li> <p>Creating a snapshot of a cache cluster that is running Memcached rather than Redis.</p> </li> </ul> <p>Neither of these are supported by ElastiCache.</p>",
       "refs": {
       }
     },
@@ -1092,41 +1119,41 @@
     "SourceType": {
       "base": null,
       "refs": {
-        "DescribeEventsMessage$SourceType": "<p>The event source to retrieve events for. If no value is specified, all events are returned.</p> <p>Valid values are: <code>cache-cluster</code> | <code>cache-parameter-group</code> | <code>cache-security-group</code> | <code>cache-subnet-group</code> </p>",
+        "DescribeEventsMessage$SourceType": "<p>The event source to retrieve events for. If no value is specified, all events are returned.</p>",
         "Event$SourceType": "<p>Specifies the origin of this event - a cache cluster, a parameter group, a security group, etc.</p>"
       }
     },
     "String": {
       "base": null,
       "refs": {
-        "AddTagsToResourceMessage$ResourceName": "<p>The Amazon Resource Name (ARN) of the resource to which the tags are to be added, for example <code>arn:aws:elasticache:us-west-2:0123456789:cluster:myCluster</code> or <code>arn:aws:elasticache:us-west-2:0123456789:snapshot:mySnapshot</code>.</p> <p>For more information on ARNs, go to <a href=\"http://docs.aws.amazon.com/general/latest/gr/aws-arns-and-namespaces.html\">Amazon Resource Names (ARNs) and AWS Service Namespaces</a>.</p>",
-        "AuthorizeCacheSecurityGroupIngressMessage$CacheSecurityGroupName": "<p>The cache security group which will allow network ingress.</p>",
+        "AddTagsToResourceMessage$ResourceName": "<p>The Amazon Resource Name (ARN) of the resource to which the tags are to be added, for example <code>arn:aws:elasticache:us-west-2:0123456789:cluster:myCluster</code> or <code>arn:aws:elasticache:us-west-2:0123456789:snapshot:mySnapshot</code>.</p> <p>For more information about ARNs, see <a href=\"http://docs.aws.amazon.com/general/latest/gr/aws-arns-and-namespaces.html\">Amazon Resource Names (ARNs) and AWS Service Namespaces</a>.</p>",
+        "AuthorizeCacheSecurityGroupIngressMessage$CacheSecurityGroupName": "<p>The cache security group that allows network ingress.</p>",
         "AuthorizeCacheSecurityGroupIngressMessage$EC2SecurityGroupName": "<p>The Amazon EC2 security group to be authorized for ingress to the cache security group.</p>",
         "AuthorizeCacheSecurityGroupIngressMessage$EC2SecurityGroupOwnerId": "<p>The AWS account number of the Amazon EC2 security group owner. Note that this is not the same thing as an AWS access key ID - you must provide a valid AWS account number for this parameter.</p>",
         "AvailabilityZone$Name": "<p>The name of the Availability Zone.</p>",
         "AvailabilityZonesList$member": null,
         "CacheCluster$CacheClusterId": "<p>The user-supplied identifier of the cache cluster. This identifier is a unique key that identifies a cache cluster.</p>",
         "CacheCluster$ClientDownloadLandingPage": "<p>The URL of the web page where you can download the latest ElastiCache client library.</p>",
-        "CacheCluster$CacheNodeType": "<p>The name of the compute and memory capacity node type for the cache cluster.</p> <p>Valid node types are as follows:</p> <ul> <li> <p>General purpose:</p> <ul> <li> <p>Current generation: <code>cache.t2.micro</code>, <code>cache.t2.small</code>, <code>cache.t2.medium</code>, <code>cache.m3.medium</code>, <code>cache.m3.large</code>, <code>cache.m3.xlarge</code>, <code>cache.m3.2xlarge</code> </p> </li> <li> <p>Previous generation: <code>cache.t1.micro</code>, <code>cache.m1.small</code>, <code>cache.m1.medium</code>, <code>cache.m1.large</code>, <code>cache.m1.xlarge</code> </p> </li> </ul> </li> <li> <p>Compute optimized: <code>cache.c1.xlarge</code> </p> </li> <li> <p>Memory optimized:</p> <ul> <li> <p>Current generation: <code>cache.r3.large</code>, <code>cache.r3.xlarge</code>, <code>cache.r3.2xlarge</code>, <code>cache.r3.4xlarge</code>, <code>cache.r3.8xlarge</code> </p> </li> <li> <p>Previous generation: <code>cache.m2.xlarge</code>, <code>cache.m2.2xlarge</code>, <code>cache.m2.4xlarge</code> </p> </li> </ul> </li> </ul> <p> <b>Notes:</b> </p> <ul> <li> <p>All t2 instances are created in an Amazon Virtual Private Cloud (VPC).</p> </li> <li> <p>Redis backup/restore is not supported for t2 instances.</p> </li> <li> <p>Redis Append-only files (AOF) functionality is not supported for t1 or t2 instances.</p> </li> </ul> <p>For a complete listing of cache node types and specifications, see <a href=\"http://aws.amazon.com/elasticache/details\">Amazon ElastiCache Product Features and Details</a> and <a href=\"http://docs.aws.amazon.com/AmazonElastiCache/latest/UserGuide/CacheParameterGroups.Memcached.html#CacheParameterGroups.Memcached.NodeSpecific\">Cache Node Type-Specific Parameters for Memcached</a> or <a href=\"http://docs.aws.amazon.com/AmazonElastiCache/latest/UserGuide/CacheParameterGroups.Redis.html#CacheParameterGroups.Redis.NodeSpecific\">Cache Node Type-Specific Parameters for Redis</a>.</p>",
-        "CacheCluster$Engine": "<p>The name of the cache engine (<i>memcached</i> or <i>redis</i>) to be used for this cache cluster.</p>",
+        "CacheCluster$CacheNodeType": "<p>The name of the compute and memory capacity node type for the cache cluster.</p> <p>Valid node types are as follows:</p> <ul> <li> <p>General purpose:</p> <ul> <li> <p>Current generation: <code>cache.t2.micro</code>, <code>cache.t2.small</code>, <code>cache.t2.medium</code>, <code>cache.m3.medium</code>, <code>cache.m3.large</code>, <code>cache.m3.xlarge</code>, <code>cache.m3.2xlarge</code>, <code>cache.m4.large</code>, <code>cache.m4.xlarge</code>, <code>cache.m4.2xlarge</code>, <code>cache.m4.4xlarge</code>, <code>cache.m4.10xlarge</code> </p> </li> <li> <p>Previous generation: <code>cache.t1.micro</code>, <code>cache.m1.small</code>, <code>cache.m1.medium</code>, <code>cache.m1.large</code>, <code>cache.m1.xlarge</code> </p> </li> </ul> </li> <li> <p>Compute optimized: <code>cache.c1.xlarge</code> </p> </li> <li> <p>Memory optimized:</p> <ul> <li> <p>Current generation: <code>cache.r3.large</code>, <code>cache.r3.xlarge</code>, <code>cache.r3.2xlarge</code>, <code>cache.r3.4xlarge</code>, <code>cache.r3.8xlarge</code> </p> </li> <li> <p>Previous generation: <code>cache.m2.xlarge</code>, <code>cache.m2.2xlarge</code>, <code>cache.m2.4xlarge</code> </p> </li> </ul> </li> </ul> <p> <b>Notes:</b> </p> <ul> <li> <p>All T2 instances are created in an Amazon Virtual Private Cloud (Amazon VPC).</p> </li> <li> <p>Redis backup/restore is not supported for Redis (cluster mode disabled) T1 and T2 instances. Backup/restore is supported on Redis (cluster mode enabled) T2 instances.</p> </li> <li> <p>Redis Append-only files (AOF) functionality is not supported for T1 or T2 instances.</p> </li> </ul> <p>For a complete listing of node types and specifications, see <a href=\"http://aws.amazon.com/elasticache/details\">Amazon ElastiCache Product Features and Details</a> and either <a href=\"http://docs.aws.amazon.com/AmazonElastiCache/latest/UserGuide/CacheParameterGroups.Memcached.html#ParameterGroups.Memcached.NodeSpecific\">Cache Node Type-Specific Parameters for Memcached</a> or <a href=\"http://docs.aws.amazon.com/AmazonElastiCache/latest/UserGuide/CacheParameterGroups.Redis.html#ParameterGroups.Redis.NodeSpecific\">Cache Node Type-Specific Parameters for Redis</a>.</p>",
+        "CacheCluster$Engine": "<p>The name of the cache engine (<code>memcached</code> or <code>redis</code>) to be used for this cache cluster.</p>",
         "CacheCluster$EngineVersion": "<p>The version of the cache engine that is used in this cache cluster.</p>",
-        "CacheCluster$CacheClusterStatus": "<p>The current state of this cache cluster, one of the following values: <i>available</i>, <i>creating</i>, <i>deleted</i>, <i>deleting</i>, <i>incompatible-network</i>, <i>modifying</i>, <i>rebooting cache cluster nodes</i>, <i>restore-failed</i>, or <i>snapshotting</i>.</p>",
+        "CacheCluster$CacheClusterStatus": "<p>The current state of this cache cluster, one of the following values: <code>available</code>, <code>creating</code>, <code>deleted</code>, <code>deleting</code>, <code>incompatible-network</code>, <code>modifying</code>, <code>rebooting cache cluster nodes</code>, <code>restore-failed</code>, or <code>snapshotting</code>.</p>",
         "CacheCluster$PreferredAvailabilityZone": "<p>The name of the Availability Zone in which the cache cluster is located or \"Multiple\" if the cache nodes are located in different Availability Zones.</p>",
-        "CacheCluster$PreferredMaintenanceWindow": "<p>Specifies the weekly time range during which maintenance on the cache cluster is performed. It is specified as a range in the format ddd:hh24:mi-ddd:hh24:mi (24H Clock UTC). The minimum maintenance window is a 60 minute period. Valid values for <code>ddd</code> are:</p> <ul> <li> <p> <code>sun</code> </p> </li> <li> <p> <code>mon</code> </p> </li> <li> <p> <code>tue</code> </p> </li> <li> <p> <code>wed</code> </p> </li> <li> <p> <code>thu</code> </p> </li> <li> <p> <code>fri</code> </p> </li> <li> <p> <code>sat</code> </p> </li> </ul> <p>Example: <code>sun:05:00-sun:09:00</code> </p>",
+        "CacheCluster$PreferredMaintenanceWindow": "<p>Specifies the weekly time range during which maintenance on the cluster is performed. It is specified as a range in the format ddd:hh24:mi-ddd:hh24:mi (24H Clock UTC). The minimum maintenance window is a 60 minute period.</p> <p>Valid values for <code>ddd</code> are:</p> <ul> <li> <p> <code>sun</code> </p> </li> <li> <p> <code>mon</code> </p> </li> <li> <p> <code>tue</code> </p> </li> <li> <p> <code>wed</code> </p> </li> <li> <p> <code>thu</code> </p> </li> <li> <p> <code>fri</code> </p> </li> <li> <p> <code>sat</code> </p> </li> </ul> <p>Example: <code>sun:23:00-mon:01:30</code> </p>",
         "CacheCluster$CacheSubnetGroupName": "<p>The name of the cache subnet group associated with the cache cluster.</p>",
         "CacheCluster$ReplicationGroupId": "<p>The replication group to which this cache cluster belongs. If this field is empty, the cache cluster is not associated with any replication group.</p>",
-        "CacheCluster$SnapshotWindow": "<p>The daily time range (in UTC) during which ElastiCache will begin taking a daily snapshot of your cache cluster.</p> <p>Example: <code>05:00-09:00</code> </p>",
+        "CacheCluster$SnapshotWindow": "<p>The daily time range (in UTC) during which ElastiCache begins taking a daily snapshot of your cache cluster.</p> <p>Example: <code>05:00-09:00</code> </p>",
         "CacheClusterMessage$Marker": "<p>Provides an identifier to allow retrieval of paginated results.</p>",
         "CacheEngineVersion$Engine": "<p>The name of the cache engine.</p>",
         "CacheEngineVersion$EngineVersion": "<p>The version number of the cache engine.</p>",
-        "CacheEngineVersion$CacheParameterGroupFamily": "<p>The name of the cache parameter group family associated with this cache engine.</p>",
+        "CacheEngineVersion$CacheParameterGroupFamily": "<p>The name of the cache parameter group family associated with this cache engine.</p> <p>Valid values are: <code>memcached1.4</code> | <code>redis2.6</code> | <code>redis2.8</code> | <code>redis3.2</code> </p>",
         "CacheEngineVersion$CacheEngineDescription": "<p>The description of the cache engine.</p>",
         "CacheEngineVersion$CacheEngineVersionDescription": "<p>The description of the cache engine version.</p>",
         "CacheEngineVersionMessage$Marker": "<p>Provides an identifier to allow retrieval of paginated results.</p>",
         "CacheNode$CacheNodeId": "<p>The cache node identifier. A node ID is a numeric identifier (0001, 0002, etc.). The combination of cluster ID and node ID uniquely identifies every cache node used in a customer's AWS account.</p>",
         "CacheNode$CacheNodeStatus": "<p>The current state of this cache node.</p>",
         "CacheNode$ParameterGroupStatus": "<p>The status of the parameter group applied to this cache node.</p>",
-        "CacheNode$SourceCacheNodeId": "<p>The ID of the primary node to which this read replica node is synchronized. If this field is empty, then this node is not associated with a primary cache cluster.</p>",
+        "CacheNode$SourceCacheNodeId": "<p>The ID of the primary node to which this read replica node is synchronized. If this field is empty, this node is not associated with a primary cache cluster.</p>",
         "CacheNode$CustomerAvailabilityZone": "<p>The Availability Zone where this node was created and now resides.</p>",
         "CacheNodeIdsList$member": null,
         "CacheNodeTypeSpecificParameter$ParameterName": "<p>The name of the parameter.</p>",
@@ -1138,7 +1165,7 @@
         "CacheNodeTypeSpecificValue$CacheNodeType": "<p>The cache node type for which this value applies.</p>",
         "CacheNodeTypeSpecificValue$Value": "<p>The value for the cache node type.</p>",
         "CacheParameterGroup$CacheParameterGroupName": "<p>The name of the cache parameter group.</p>",
-        "CacheParameterGroup$CacheParameterGroupFamily": "<p>The name of the cache parameter group family that this cache parameter group is compatible with.</p>",
+        "CacheParameterGroup$CacheParameterGroupFamily": "<p>The name of the cache parameter group family that this cache parameter group is compatible with.</p> <p>Valid values are: <code>memcached1.4</code> | <code>redis2.6</code> | <code>redis2.8</code> | <code>redis3.2</code> </p>",
         "CacheParameterGroup$Description": "<p>The description for this cache parameter group.</p>",
         "CacheParameterGroupDetails$Marker": "<p>Provides an identifier to allow retrieval of paginated results.</p>",
         "CacheParameterGroupNameMessage$CacheParameterGroupName": "<p>The name of the cache parameter group.</p>",
@@ -1158,22 +1185,22 @@
         "CacheSubnetGroupMessage$Marker": "<p>Provides an identifier to allow retrieval of paginated results.</p>",
         "ClusterIdList$member": null,
         "CopySnapshotMessage$SourceSnapshotName": "<p>The name of an existing snapshot from which to make a copy.</p>",
-        "CopySnapshotMessage$TargetSnapshotName": "<p>A name for the snapshot copy. ElastiCache does not permit overwriting a snapshot, therefore this name must be unique within its context - ElastiCache or an Amazon S3 bucket if exporting.</p> <p class=\"title\"> <b>Error Message</b> </p> <ul> <li> <p> <b>Error Message:</b> The S3 bucket %s already contains an object with key %s.</p> <p> <b>Solution:</b> Give the <i>TargetSnapshotName</i> a new and unique value. If exporting a snapshot, you could alternatively create a new Amazon S3 bucket and use this same value for <i>TargetSnapshotName</i>.</p> </li> </ul>",
-        "CopySnapshotMessage$TargetBucket": "<p>The Amazon S3 bucket to which the snapshot will be exported. This parameter is used only when exporting a snapshot for external access.</p> <p>When using this parameter to export a snapshot, be sure Amazon ElastiCache has the needed permissions to this S3 bucket. For more information, see <a href=\"http://docs.aws.amazon.com/AmazonElastiCache/AmazonElastiCache/latest/UserGuide/Snapshots.Exporting.html#Snapshots.Exporting.GrantAccess\">Step 2: Grant ElastiCache Access to Your Amazon S3 Bucket</a> in the <i>Amazon ElastiCache User Guide</i>.</p> <p> <b>Error Messages:</b> </p> <p>You could receive one of the following error messages.</p> <p class=\"title\"> <b>Erorr Messages</b> </p> <ul> <li> <p> <b>Error Message: </b> ElastiCache has not been granted READ permissions %s on the S3 Bucket.</p> <p> <b>Solution:</b> Add List and Read permissions on the bucket.</p> </li> <li> <p> <b>Error Message: </b> ElastiCache has not been granted WRITE permissions %s on the S3 Bucket.</p> <p> <b>Solution:</b> Add Upload/Delete permissions on the bucket.</p> </li> <li> <p> <b>Error Message: </b> ElastiCache has not been granted READ_ACP permissions %s on the S3 Bucket.</p> <p> <b>Solution:</b> Add View Permissions permissions on the bucket.</p> </li> <li> <p> <b>Error Message:</b> The S3 bucket %s is outside of the region.</p> <p> <b>Solution:</b> Before exporting your snapshot, create a new Amazon S3 bucket in the same region as your snapshot. For more information, see <a href=\"http://docs.aws.amazon.com/AmazonElastiCache/latest/UserGuide/Snapshots.Exporting.html#Snapshots.Exporting.CreateBucket\">Step 1: Create an Amazon S3 Bucket</a>.</p> </li> <li> <p> <b>Error Message:</b> The S3 bucket %s does not exist.</p> <p> <b>Solution:</b> Create an Amazon S3 bucket in the same region as your snapshot. For more information, see <a href=\"http://docs.aws.amazon.com/AmazonElastiCache/latest/UserGuide/Snapshots.Exporting.html#Snapshots.Exporting.CreateBucket\">Step 1: Create an Amazon S3 Bucket</a>.</p> </li> <li> <p> <b>Error Message:</b> The S3 bucket %s is not owned by the authenticated user.</p> <p> <b>Solution:</b> Create an Amazon S3 bucket in the same region as your snapshot. For more information, see <a href=\"http://docs.aws.amazon.com/AmazonElastiCache/latest/UserGuide/Snapshots.Exporting.html#Snapshots.Exporting.CreateBucket\">Step 1: Create an Amazon S3 Bucket</a>.</p> </li> <li> <p> <b>Error Message:</b> The authenticated user does not have sufficient permissions to perform the desired activity.</p> <p> <b>Solution:</b> Contact your system administrator to get the needed permissions.</p> </li> </ul> <p>For more information, see <a href=\"http://docs.aws.amazon.com/AmazonElastiCache/latest/UserGuide/Snapshots.Exporting.html\">Exporting a Snapshot</a> in the <i>Amazon ElastiCache User Guide</i>.</p>",
-        "CreateCacheClusterMessage$CacheClusterId": "<p>The node group identifier. This parameter is stored as a lowercase string.</p> <p> <b>Constraints:</b> </p> <ul> <li> <p>A name must contain from 1 to 20 alphanumeric characters or hyphens.</p> </li> <li> <p>The first character must be a letter.</p> </li> <li> <p>A name cannot end with a hyphen or contain two consecutive hyphens.</p> </li> </ul>",
-        "CreateCacheClusterMessage$ReplicationGroupId": "<p>The ID of the replication group to which this cache cluster should belong. If this parameter is specified, the cache cluster will be added to the specified replication group as a read replica; otherwise, the cache cluster will be a standalone primary that is not part of any replication group.</p> <p>If the specified replication group is Multi-AZ enabled and the availability zone is not specified, the cache cluster will be created in availability zones that provide the best spread of read replicas across availability zones.</p> <note> <p>This parameter is only valid if the <code>Engine</code> parameter is <code>redis</code>.</p> </note>",
-        "CreateCacheClusterMessage$PreferredAvailabilityZone": "<p>The EC2 Availability Zone in which the cache cluster will be created.</p> <p>All nodes belonging to this Memcached cache cluster are placed in the preferred Availability Zone. If you want to create your nodes across multiple Availability Zones, use <code>PreferredAvailabilityZones</code>.</p> <p>Default: System chosen Availability Zone.</p>",
-        "CreateCacheClusterMessage$CacheNodeType": "<p>The compute and memory capacity of the nodes in the node group.</p> <p>Valid node types are as follows:</p> <ul> <li> <p>General purpose:</p> <ul> <li> <p>Current generation: <code>cache.t2.micro</code>, <code>cache.t2.small</code>, <code>cache.t2.medium</code>, <code>cache.m3.medium</code>, <code>cache.m3.large</code>, <code>cache.m3.xlarge</code>, <code>cache.m3.2xlarge</code> </p> </li> <li> <p>Previous generation: <code>cache.t1.micro</code>, <code>cache.m1.small</code>, <code>cache.m1.medium</code>, <code>cache.m1.large</code>, <code>cache.m1.xlarge</code> </p> </li> </ul> </li> <li> <p>Compute optimized: <code>cache.c1.xlarge</code> </p> </li> <li> <p>Memory optimized:</p> <ul> <li> <p>Current generation: <code>cache.r3.large</code>, <code>cache.r3.xlarge</code>, <code>cache.r3.2xlarge</code>, <code>cache.r3.4xlarge</code>, <code>cache.r3.8xlarge</code> </p> </li> <li> <p>Previous generation: <code>cache.m2.xlarge</code>, <code>cache.m2.2xlarge</code>, <code>cache.m2.4xlarge</code> </p> </li> </ul> </li> </ul> <p> <b>Notes:</b> </p> <ul> <li> <p>All t2 instances are created in an Amazon Virtual Private Cloud (VPC).</p> </li> <li> <p>Redis backup/restore is not supported for t2 instances.</p> </li> <li> <p>Redis Append-only files (AOF) functionality is not supported for t1 or t2 instances.</p> </li> </ul> <p>For a complete listing of cache node types and specifications, see <a href=\"http://aws.amazon.com/elasticache/details\">Amazon ElastiCache Product Features and Details</a> and <a href=\"http://docs.aws.amazon.com/AmazonElastiCache/latest/UserGuide/CacheParameterGroups.Memcached.html#CacheParameterGroups.Memcached.NodeSpecific\">Cache Node Type-Specific Parameters for Memcached</a> or <a href=\"http://docs.aws.amazon.com/AmazonElastiCache/latest/UserGuide/CacheParameterGroups.Redis.html#CacheParameterGroups.Redis.NodeSpecific\">Cache Node Type-Specific Parameters for Redis</a>.</p>",
-        "CreateCacheClusterMessage$Engine": "<p>The name of the cache engine to be used for this cache cluster.</p> <p>Valid values for this parameter are:</p> <p> <code>memcached</code> | <code>redis</code> </p>",
-        "CreateCacheClusterMessage$EngineVersion": "<p>The version number of the cache engine to be used for this cache cluster. To view the supported cache engine versions, use the <i>DescribeCacheEngineVersions</i> action.</p> <p> <b>Important:</b> You can upgrade to a newer engine version (see <a href=\"http://docs.aws.amazon.com/AmazonElastiCache/latest/UserGuide/SelectEngine.html#VersionManagement\">Selecting a Cache Engine and Version</a>), but you cannot downgrade to an earlier engine version. If you want to use an earlier engine version, you must delete the existing cache cluster or replication group and create it anew with the earlier engine version. </p>",
-        "CreateCacheClusterMessage$CacheParameterGroupName": "<p>The name of the parameter group to associate with this cache cluster. If this argument is omitted, the default parameter group for the specified engine is used.</p>",
-        "CreateCacheClusterMessage$CacheSubnetGroupName": "<p>The name of the subnet group to be used for the cache cluster.</p> <p>Use this parameter only when you are creating a cache cluster in an Amazon Virtual Private Cloud (VPC).</p>",
-        "CreateCacheClusterMessage$SnapshotName": "<p>The name of a snapshot from which to restore data into the new node group. The snapshot status changes to <code>restoring</code> while the new node group is being created.</p> <note> <p>This parameter is only valid if the <code>Engine</code> parameter is <code>redis</code>.</p> </note>",
-        "CreateCacheClusterMessage$PreferredMaintenanceWindow": "<p>Specifies the weekly time range during which maintenance on the cache cluster is performed. It is specified as a range in the format ddd:hh24:mi-ddd:hh24:mi (24H Clock UTC). The minimum maintenance window is a 60 minute period. Valid values for <code>ddd</code> are:</p> <ul> <li> <p> <code>sun</code> </p> </li> <li> <p> <code>mon</code> </p> </li> <li> <p> <code>tue</code> </p> </li> <li> <p> <code>wed</code> </p> </li> <li> <p> <code>thu</code> </p> </li> <li> <p> <code>fri</code> </p> </li> <li> <p> <code>sat</code> </p> </li> </ul> <p>Example: <code>sun:05:00-sun:09:00</code> </p>",
-        "CreateCacheClusterMessage$NotificationTopicArn": "<p>The Amazon Resource Name (ARN) of the Amazon Simple Notification Service (SNS) topic to which notifications will be sent.</p> <note> <p>The Amazon SNS topic owner must be the same as the cache cluster owner.</p> </note>",
-        "CreateCacheClusterMessage$SnapshotWindow": "<p>The daily time range (in UTC) during which ElastiCache will begin taking a daily snapshot of your node group.</p> <p>Example: <code>05:00-09:00</code> </p> <p>If you do not specify this parameter, then ElastiCache will automatically choose an appropriate time range.</p> <p> <b>Note:</b> This parameter is only valid if the <code>Engine</code> parameter is <code>redis</code>.</p>",
+        "CopySnapshotMessage$TargetSnapshotName": "<p>A name for the snapshot copy. ElastiCache does not permit overwriting a snapshot, therefore this name must be unique within its context - ElastiCache or an Amazon S3 bucket if exporting.</p>",
+        "CopySnapshotMessage$TargetBucket": "<p>The Amazon S3 bucket to which the snapshot is exported. This parameter is used only when exporting a snapshot for external access.</p> <p>When using this parameter to export a snapshot, be sure Amazon ElastiCache has the needed permissions to this S3 bucket. For more information, see <a href=\"http://docs.aws.amazon.com/AmazonElastiCache/latest/UserGuide/Snapshots.Exporting.html#Snapshots.Exporting.GrantAccess\">Step 2: Grant ElastiCache Access to Your Amazon S3 Bucket</a> in the <i>Amazon ElastiCache User Guide</i>.</p> <p>For more information, see <a href=\"http://docs.aws.amazon.com/AmazonElastiCache/latest/UserGuide/Snapshots.Exporting.html\">Exporting a Snapshot</a> in the <i>Amazon ElastiCache User Guide</i>.</p>",
+        "CreateCacheClusterMessage$CacheClusterId": "<p>The node group (shard) identifier. This parameter is stored as a lowercase string.</p> <p> <b>Constraints:</b> </p> <ul> <li> <p>A name must contain from 1 to 20 alphanumeric characters or hyphens.</p> </li> <li> <p>The first character must be a letter.</p> </li> <li> <p>A name cannot end with a hyphen or contain two consecutive hyphens.</p> </li> </ul>",
+        "CreateCacheClusterMessage$ReplicationGroupId": "<important> <p>Due to current limitations on Redis (cluster mode disabled), this operation or parameter is not supported on Redis (cluster mode enabled) replication groups.</p> </important> <p>The ID of the replication group to which this cache cluster should belong. If this parameter is specified, the cache cluster is added to the specified replication group as a read replica; otherwise, the cache cluster is a standalone primary that is not part of any replication group.</p> <p>If the specified replication group is Multi-AZ enabled and the Availability Zone is not specified, the cache cluster is created in Availability Zones that provide the best spread of read replicas across Availability Zones.</p> <note> <p>This parameter is only valid if the <code>Engine</code> parameter is <code>redis</code>.</p> </note>",
+        "CreateCacheClusterMessage$PreferredAvailabilityZone": "<p>The EC2 Availability Zone in which the cache cluster is created.</p> <p>All nodes belonging to this Memcached cache cluster are placed in the preferred Availability Zone. If you want to create your nodes across multiple Availability Zones, use <code>PreferredAvailabilityZones</code>.</p> <p>Default: System chosen Availability Zone.</p>",
+        "CreateCacheClusterMessage$CacheNodeType": "<p>The compute and memory capacity of the nodes in the node group (shard).</p> <p>Valid node types are as follows:</p> <ul> <li> <p>General purpose:</p> <ul> <li> <p>Current generation: <code>cache.t2.micro</code>, <code>cache.t2.small</code>, <code>cache.t2.medium</code>, <code>cache.m3.medium</code>, <code>cache.m3.large</code>, <code>cache.m3.xlarge</code>, <code>cache.m3.2xlarge</code>, <code>cache.m4.large</code>, <code>cache.m4.xlarge</code>, <code>cache.m4.2xlarge</code>, <code>cache.m4.4xlarge</code>, <code>cache.m4.10xlarge</code> </p> </li> <li> <p>Previous generation: <code>cache.t1.micro</code>, <code>cache.m1.small</code>, <code>cache.m1.medium</code>, <code>cache.m1.large</code>, <code>cache.m1.xlarge</code> </p> </li> </ul> </li> <li> <p>Compute optimized: <code>cache.c1.xlarge</code> </p> </li> <li> <p>Memory optimized:</p> <ul> <li> <p>Current generation: <code>cache.r3.large</code>, <code>cache.r3.xlarge</code>, <code>cache.r3.2xlarge</code>, <code>cache.r3.4xlarge</code>, <code>cache.r3.8xlarge</code> </p> </li> <li> <p>Previous generation: <code>cache.m2.xlarge</code>, <code>cache.m2.2xlarge</code>, <code>cache.m2.4xlarge</code> </p> </li> </ul> </li> </ul> <p> <b>Notes:</b> </p> <ul> <li> <p>All T2 instances are created in an Amazon Virtual Private Cloud (Amazon VPC).</p> </li> <li> <p>Redis backup/restore is not supported for Redis (cluster mode disabled) T1 and T2 instances. Backup/restore is supported on Redis (cluster mode enabled) T2 instances.</p> </li> <li> <p>Redis Append-only files (AOF) functionality is not supported for T1 or T2 instances.</p> </li> </ul> <p>For a complete listing of node types and specifications, see <a href=\"http://aws.amazon.com/elasticache/details\">Amazon ElastiCache Product Features and Details</a> and either <a href=\"http://docs.aws.amazon.com/AmazonElastiCache/latest/UserGuide/CacheParameterGroups.Memcached.html#ParameterGroups.Memcached.NodeSpecific\">Cache Node Type-Specific Parameters for Memcached</a> or <a href=\"http://docs.aws.amazon.com/AmazonElastiCache/latest/UserGuide/CacheParameterGroups.Redis.html#ParameterGroups.Redis.NodeSpecific\">Cache Node Type-Specific Parameters for Redis</a>.</p>",
+        "CreateCacheClusterMessage$Engine": "<p>The name of the cache engine to be used for this cache cluster.</p> <p>Valid values for this parameter are: <code>memcached</code> | <code>redis</code> </p>",
+        "CreateCacheClusterMessage$EngineVersion": "<p>The version number of the cache engine to be used for this cache cluster. To view the supported cache engine versions, use the DescribeCacheEngineVersions operation.</p> <p> <b>Important:</b> You can upgrade to a newer engine version (see <a href=\"http://docs.aws.amazon.com/AmazonElastiCache/latest/UserGuide/SelectEngine.html#VersionManagement\">Selecting a Cache Engine and Version</a>), but you cannot downgrade to an earlier engine version. If you want to use an earlier engine version, you must delete the existing cache cluster or replication group and create it anew with the earlier engine version. </p>",
+        "CreateCacheClusterMessage$CacheParameterGroupName": "<p>The name of the parameter group to associate with this cache cluster. If this argument is omitted, the default parameter group for the specified engine is used. You cannot use any parameter group which has <code>cluster-enabled='yes'</code> when creating a cluster.</p>",
+        "CreateCacheClusterMessage$CacheSubnetGroupName": "<p>The name of the subnet group to be used for the cache cluster.</p> <p>Use this parameter only when you are creating a cache cluster in an Amazon Virtual Private Cloud (Amazon VPC).</p> <important> <p>If you're going to launch your cluster in an Amazon VPC, you need to create a subnet group before you start creating a cluster. For more information, see <a href=\"http://docs.aws.amazon.com/AmazonElastiCache/latest/UserGuide/SubnetGroups.html\">Subnets and Subnet Groups</a>.</p> </important>",
+        "CreateCacheClusterMessage$SnapshotName": "<p>The name of a Redis snapshot from which to restore data into the new node group (shard). The snapshot status changes to <code>restoring</code> while the new node group (shard) is being created.</p> <note> <p>This parameter is only valid if the <code>Engine</code> parameter is <code>redis</code>.</p> </note>",
+        "CreateCacheClusterMessage$PreferredMaintenanceWindow": "<p>Specifies the weekly time range during which maintenance on the cache cluster is performed. It is specified as a range in the format ddd:hh24:mi-ddd:hh24:mi (24H Clock UTC). The minimum maintenance window is a 60 minute period. Valid values for <code>ddd</code> are:</p> <p>Specifies the weekly time range during which maintenance on the cluster is performed. It is specified as a range in the format ddd:hh24:mi-ddd:hh24:mi (24H Clock UTC). The minimum maintenance window is a 60 minute period.</p> <p>Valid values for <code>ddd</code> are:</p> <ul> <li> <p> <code>sun</code> </p> </li> <li> <p> <code>mon</code> </p> </li> <li> <p> <code>tue</code> </p> </li> <li> <p> <code>wed</code> </p> </li> <li> <p> <code>thu</code> </p> </li> <li> <p> <code>fri</code> </p> </li> <li> <p> <code>sat</code> </p> </li> </ul> <p>Example: <code>sun:23:00-mon:01:30</code> </p>",
+        "CreateCacheClusterMessage$NotificationTopicArn": "<p>The Amazon Resource Name (ARN) of the Amazon Simple Notification Service (SNS) topic to which notifications are sent.</p> <note> <p>The Amazon SNS topic owner must be the same as the cache cluster owner.</p> </note>",
+        "CreateCacheClusterMessage$SnapshotWindow": "<p>The daily time range (in UTC) during which ElastiCache begins taking a daily snapshot of your node group (shard).</p> <p>Example: <code>05:00-09:00</code> </p> <p>If you do not specify this parameter, ElastiCache automatically chooses an appropriate time range.</p> <p> <b>Note:</b> This parameter is only valid if the <code>Engine</code> parameter is <code>redis</code>.</p>",
         "CreateCacheParameterGroupMessage$CacheParameterGroupName": "<p>A user-specified name for the cache parameter group.</p>",
-        "CreateCacheParameterGroupMessage$CacheParameterGroupFamily": "<p>The name of the cache parameter group family the cache parameter group can be used with.</p> <p>Valid values are: <code>memcached1.4</code> | <code>redis2.6</code> | <code>redis2.8</code> </p>",
+        "CreateCacheParameterGroupMessage$CacheParameterGroupFamily": "<p>The name of the cache parameter group family that the cache parameter group can be used with.</p> <p>Valid values are: <code>memcached1.4</code> | <code>redis2.6</code> | <code>redis2.8</code> | <code>redis3.2</code> </p>",
         "CreateCacheParameterGroupMessage$Description": "<p>A user-specified description for the cache parameter group.</p>",
         "CreateCacheSecurityGroupMessage$CacheSecurityGroupName": "<p>A name for the cache security group. This value is stored as a lowercase string.</p> <p>Constraints: Must contain no more than 255 alphanumeric characters. Cannot be the word \"Default\".</p> <p>Example: <code>mysecuritygroup</code> </p>",
         "CreateCacheSecurityGroupMessage$Description": "<p>A description for the cache security group.</p>",
@@ -1181,17 +1208,18 @@
         "CreateCacheSubnetGroupMessage$CacheSubnetGroupDescription": "<p>A description for the cache subnet group.</p>",
         "CreateReplicationGroupMessage$ReplicationGroupId": "<p>The replication group identifier. This parameter is stored as a lowercase string.</p> <p>Constraints:</p> <ul> <li> <p>A name must contain from 1 to 20 alphanumeric characters or hyphens.</p> </li> <li> <p>The first character must be a letter.</p> </li> <li> <p>A name cannot end with a hyphen or contain two consecutive hyphens.</p> </li> </ul>",
         "CreateReplicationGroupMessage$ReplicationGroupDescription": "<p>A user-created description for the replication group.</p>",
-        "CreateReplicationGroupMessage$PrimaryClusterId": "<p>The identifier of the cache cluster that will serve as the primary for this replication group. This cache cluster must already exist and have a status of <i>available</i>.</p> <p>This parameter is not required if <i>NumCacheClusters</i> is specified.</p>",
-        "CreateReplicationGroupMessage$CacheNodeType": "<p>The compute and memory capacity of the nodes in the node group.</p> <p>Valid node types are as follows:</p> <ul> <li> <p>General purpose:</p> <ul> <li> <p>Current generation: <code>cache.t2.micro</code>, <code>cache.t2.small</code>, <code>cache.t2.medium</code>, <code>cache.m3.medium</code>, <code>cache.m3.large</code>, <code>cache.m3.xlarge</code>, <code>cache.m3.2xlarge</code> </p> </li> <li> <p>Previous generation: <code>cache.t1.micro</code>, <code>cache.m1.small</code>, <code>cache.m1.medium</code>, <code>cache.m1.large</code>, <code>cache.m1.xlarge</code> </p> </li> </ul> </li> <li> <p>Compute optimized: <code>cache.c1.xlarge</code> </p> </li> <li> <p>Memory optimized:</p> <ul> <li> <p>Current generation: <code>cache.r3.large</code>, <code>cache.r3.xlarge</code>, <code>cache.r3.2xlarge</code>, <code>cache.r3.4xlarge</code>, <code>cache.r3.8xlarge</code> </p> </li> <li> <p>Previous generation: <code>cache.m2.xlarge</code>, <code>cache.m2.2xlarge</code>, <code>cache.m2.4xlarge</code> </p> </li> </ul> </li> </ul> <p> <b>Notes:</b> </p> <ul> <li> <p>All t2 instances are created in an Amazon Virtual Private Cloud (VPC).</p> </li> <li> <p>Redis backup/restore is not supported for t2 instances.</p> </li> <li> <p>Redis Append-only files (AOF) functionality is not supported for t1 or t2 instances.</p> </li> </ul> <p>For a complete listing of cache node types and specifications, see <a href=\"http://aws.amazon.com/elasticache/details\">Amazon ElastiCache Product Features and Details</a> and <a href=\"http://docs.aws.amazon.com/AmazonElastiCache/latest/UserGuide/CacheParameterGroups.Memcached.html#CacheParameterGroups.Memcached.NodeSpecific\">Cache Node Type-Specific Parameters for Memcached</a> or <a href=\"http://docs.aws.amazon.com/AmazonElastiCache/latest/UserGuide/CacheParameterGroups.Redis.html#CacheParameterGroups.Redis.NodeSpecific\">Cache Node Type-Specific Parameters for Redis</a>.</p>",
-        "CreateReplicationGroupMessage$Engine": "<p>The name of the cache engine to be used for the cache clusters in this replication group.</p> <p>Default: redis</p>",
-        "CreateReplicationGroupMessage$EngineVersion": "<p>The version number of the cache engine to be used for the cache clusters in this replication group. To view the supported cache engine versions, use the <i>DescribeCacheEngineVersions</i> action.</p> <p> <b>Important:</b> You can upgrade to a newer engine version (see <a href=\"http://docs.aws.amazon.com/AmazonElastiCache/latest/UserGuide/SelectEngine.html#VersionManagement\">Selecting a Cache Engine and Version</a>) in the <i>ElastiCache User Guide</i>, but you cannot downgrade to an earlier engine version. If you want to use an earlier engine version, you must delete the existing cache cluster or replication group and create it anew with the earlier engine version. </p>",
-        "CreateReplicationGroupMessage$CacheParameterGroupName": "<p>The name of the parameter group to associate with this replication group. If this argument is omitted, the default cache parameter group for the specified engine is used.</p>",
-        "CreateReplicationGroupMessage$CacheSubnetGroupName": "<p>The name of the cache subnet group to be used for the replication group.</p>",
-        "CreateReplicationGroupMessage$SnapshotName": "<p>The name of a snapshot from which to restore data into the new node group. The snapshot status changes to <code>restoring</code> while the new node group is being created.</p> <note> <p>This parameter is only valid if the <code>Engine</code> parameter is <code>redis</code>.</p> </note>",
-        "CreateReplicationGroupMessage$PreferredMaintenanceWindow": "<p>Specifies the weekly time range during which maintenance on the cache cluster is performed. It is specified as a range in the format ddd:hh24:mi-ddd:hh24:mi (24H Clock UTC). The minimum maintenance window is a 60 minute period. Valid values for <code>ddd</code> are:</p> <ul> <li> <p> <code>sun</code> </p> </li> <li> <p> <code>mon</code> </p> </li> <li> <p> <code>tue</code> </p> </li> <li> <p> <code>wed</code> </p> </li> <li> <p> <code>thu</code> </p> </li> <li> <p> <code>fri</code> </p> </li> <li> <p> <code>sat</code> </p> </li> </ul> <p>Example: <code>sun:05:00-sun:09:00</code> </p>",
-        "CreateReplicationGroupMessage$NotificationTopicArn": "<p>The Amazon Resource Name (ARN) of the Amazon Simple Notification Service (SNS) topic to which notifications will be sent.</p> <note> <p>The Amazon SNS topic owner must be the same as the cache cluster owner.</p> </note>",
-        "CreateReplicationGroupMessage$SnapshotWindow": "<p>The daily time range (in UTC) during which ElastiCache will begin taking a daily snapshot of your node group.</p> <p>Example: <code>05:00-09:00</code> </p> <p>If you do not specify this parameter, then ElastiCache will automatically choose an appropriate time range.</p> <note> <p>This parameter is only valid if the <code>Engine</code> parameter is <code>redis</code>.</p> </note>",
-        "CreateSnapshotMessage$CacheClusterId": "<p>The identifier of an existing cache cluster. The snapshot will be created from this cache cluster.</p>",
+        "CreateReplicationGroupMessage$PrimaryClusterId": "<p>The identifier of the cache cluster that serves as the primary for this replication group. This cache cluster must already exist and have a status of <code>available</code>.</p> <p>This parameter is not required if <code>NumCacheClusters</code>, <code>NumNodeGroups</code>, or <code>ReplicasPerNodeGroup</code> is specified.</p>",
+        "CreateReplicationGroupMessage$CacheNodeType": "<p>The compute and memory capacity of the nodes in the node group (shard).</p> <p>Valid node types are as follows:</p> <ul> <li> <p>General purpose:</p> <ul> <li> <p>Current generation: <code>cache.t2.micro</code>, <code>cache.t2.small</code>, <code>cache.t2.medium</code>, <code>cache.m3.medium</code>, <code>cache.m3.large</code>, <code>cache.m3.xlarge</code>, <code>cache.m3.2xlarge</code>, <code>cache.m4.large</code>, <code>cache.m4.xlarge</code>, <code>cache.m4.2xlarge</code>, <code>cache.m4.4xlarge</code>, <code>cache.m4.10xlarge</code> </p> </li> <li> <p>Previous generation: <code>cache.t1.micro</code>, <code>cache.m1.small</code>, <code>cache.m1.medium</code>, <code>cache.m1.large</code>, <code>cache.m1.xlarge</code> </p> </li> </ul> </li> <li> <p>Compute optimized: <code>cache.c1.xlarge</code> </p> </li> <li> <p>Memory optimized:</p> <ul> <li> <p>Current generation: <code>cache.r3.large</code>, <code>cache.r3.xlarge</code>, <code>cache.r3.2xlarge</code>, <code>cache.r3.4xlarge</code>, <code>cache.r3.8xlarge</code> </p> </li> <li> <p>Previous generation: <code>cache.m2.xlarge</code>, <code>cache.m2.2xlarge</code>, <code>cache.m2.4xlarge</code> </p> </li> </ul> </li> </ul> <p> <b>Notes:</b> </p> <ul> <li> <p>All T2 instances are created in an Amazon Virtual Private Cloud (Amazon VPC).</p> </li> <li> <p>Redis backup/restore is not supported for Redis (cluster mode disabled) T1 and T2 instances. Backup/restore is supported on Redis (cluster mode enabled) T2 instances.</p> </li> <li> <p>Redis Append-only files (AOF) functionality is not supported for T1 or T2 instances.</p> </li> </ul> <p>For a complete listing of node types and specifications, see <a href=\"http://aws.amazon.com/elasticache/details\">Amazon ElastiCache Product Features and Details</a> and either <a href=\"http://docs.aws.amazon.com/AmazonElastiCache/latest/UserGuide/CacheParameterGroups.Memcached.html#ParameterGroups.Memcached.NodeSpecific\">Cache Node Type-Specific Parameters for Memcached</a> or <a href=\"http://docs.aws.amazon.com/AmazonElastiCache/latest/UserGuide/CacheParameterGroups.Redis.html#ParameterGroups.Redis.NodeSpecific\">Cache Node Type-Specific Parameters for Redis</a>.</p>",
+        "CreateReplicationGroupMessage$Engine": "<p>The name of the cache engine to be used for the cache clusters in this replication group.</p>",
+        "CreateReplicationGroupMessage$EngineVersion": "<p>The version number of the cache engine to be used for the cache clusters in this replication group. To view the supported cache engine versions, use the <code>DescribeCacheEngineVersions</code> operation.</p> <p> <b>Important:</b> You can upgrade to a newer engine version (see <a href=\"http://docs.aws.amazon.com/AmazonElastiCache/latest/UserGuide/SelectEngine.html#VersionManagement\">Selecting a Cache Engine and Version</a>) in the <i>ElastiCache User Guide</i>, but you cannot downgrade to an earlier engine version. If you want to use an earlier engine version, you must delete the existing cache cluster or replication group and create it anew with the earlier engine version. </p>",
+        "CreateReplicationGroupMessage$CacheParameterGroupName": "<p>The name of the parameter group to associate with this replication group. If this argument is omitted, the default cache parameter group for the specified engine is used.</p> <p>If you are running Redis version 3.2.4 or later, only one node group (shard), and want to use a default parameter group, we recommend that you specify the parameter group by name. </p> <ul> <li> <p>To create a Redis (cluster mode disabled) replication group, use <code>CacheParameterGroupName=default.redis3.2</code>.</p> </li> <li> <p>To create a Redis (cluster mode enabled) replication group, use <code>CacheParameterGroupName=default.redis3.2.cluster.on</code>.</p> </li> </ul>",
+        "CreateReplicationGroupMessage$CacheSubnetGroupName": "<p>The name of the cache subnet group to be used for the replication group.</p> <important> <p>If you're going to launch your cluster in an Amazon VPC, you need to create a subnet group before you start creating a cluster. For more information, see <a href=\"http://docs.aws.amazon.com/AmazonElastiCache/latest/UserGuide/SubnetGroups.html\">Subnets and Subnet Groups</a>.</p> </important>",
+        "CreateReplicationGroupMessage$SnapshotName": "<p>The name of a snapshot from which to restore data into the new replication group. The snapshot status changes to <code>restoring</code> while the new replication group is being created.</p> <note> <p>This parameter is only valid if the <code>Engine</code> parameter is <code>redis</code>.</p> </note>",
+        "CreateReplicationGroupMessage$PreferredMaintenanceWindow": "<p>Specifies the weekly time range during which maintenance on the cache cluster is performed. It is specified as a range in the format ddd:hh24:mi-ddd:hh24:mi (24H Clock UTC). The minimum maintenance window is a 60 minute period. Valid values for <code>ddd</code> are:</p> <p>Specifies the weekly time range during which maintenance on the cluster is performed. It is specified as a range in the format ddd:hh24:mi-ddd:hh24:mi (24H Clock UTC). The minimum maintenance window is a 60 minute period.</p> <p>Valid values for <code>ddd</code> are:</p> <ul> <li> <p> <code>sun</code> </p> </li> <li> <p> <code>mon</code> </p> </li> <li> <p> <code>tue</code> </p> </li> <li> <p> <code>wed</code> </p> </li> <li> <p> <code>thu</code> </p> </li> <li> <p> <code>fri</code> </p> </li> <li> <p> <code>sat</code> </p> </li> </ul> <p>Example: <code>sun:23:00-mon:01:30</code> </p>",
+        "CreateReplicationGroupMessage$NotificationTopicArn": "<p>The Amazon Resource Name (ARN) of the Amazon Simple Notification Service (SNS) topic to which notifications are sent.</p> <note> <p>The Amazon SNS topic owner must be the same as the cache cluster owner.</p> </note>",
+        "CreateReplicationGroupMessage$SnapshotWindow": "<p>The daily time range (in UTC) during which ElastiCache begins taking a daily snapshot of your node group (shard).</p> <p>Example: <code>05:00-09:00</code> </p> <p>If you do not specify this parameter, ElastiCache automatically chooses an appropriate time range.</p> <note> <p>This parameter is only valid if the <code>Engine</code> parameter is <code>redis</code>.</p> </note>",
+        "CreateSnapshotMessage$ReplicationGroupId": "<p>The identifier of an existing replication group. The snapshot is created from this replication group.</p>",
+        "CreateSnapshotMessage$CacheClusterId": "<p>The identifier of an existing cache cluster. The snapshot is created from this cache cluster.</p>",
         "CreateSnapshotMessage$SnapshotName": "<p>A name for the snapshot being created.</p>",
         "DeleteCacheClusterMessage$CacheClusterId": "<p>The cache cluster identifier for the cluster to be deleted. This parameter is not case sensitive.</p>",
         "DeleteCacheClusterMessage$FinalSnapshotIdentifier": "<p>The user-supplied name of a final cache cluster snapshot. This is the unique name that identifies the snapshot. ElastiCache creates the snapshot, and then deletes the cache cluster immediately afterward.</p>",
@@ -1199,88 +1227,94 @@
         "DeleteCacheSecurityGroupMessage$CacheSecurityGroupName": "<p>The name of the cache security group to delete.</p> <note> <p>You cannot delete the default security group.</p> </note>",
         "DeleteCacheSubnetGroupMessage$CacheSubnetGroupName": "<p>The name of the cache subnet group to delete.</p> <p>Constraints: Must contain no more than 255 alphanumeric characters or hyphens.</p>",
         "DeleteReplicationGroupMessage$ReplicationGroupId": "<p>The identifier for the cluster to be deleted. This parameter is not case sensitive.</p>",
-        "DeleteReplicationGroupMessage$FinalSnapshotIdentifier": "<p>The name of a final node group snapshot. ElastiCache creates the snapshot from the primary node in the cluster, rather than one of the replicas; this is to ensure that it captures the freshest data. After the final snapshot is taken, the cluster is immediately deleted.</p>",
+        "DeleteReplicationGroupMessage$FinalSnapshotIdentifier": "<p>The name of a final node group (shard) snapshot. ElastiCache creates the snapshot from the primary node in the cluster, rather than one of the replicas; this is to ensure that it captures the freshest data. After the final snapshot is taken, the replication group is immediately deleted.</p>",
         "DeleteSnapshotMessage$SnapshotName": "<p>The name of the snapshot to be deleted.</p>",
         "DescribeCacheClustersMessage$CacheClusterId": "<p>The user-supplied cluster identifier. If this parameter is specified, only information about that specific cache cluster is returned. This parameter isn't case sensitive.</p>",
-        "DescribeCacheClustersMessage$Marker": "<p>An optional marker returned from a prior request. Use this marker for pagination of results from this action. If this parameter is specified, the response includes only records beyond the marker, up to the value specified by <i>MaxRecords</i>.</p>",
+        "DescribeCacheClustersMessage$Marker": "<p>An optional marker returned from a prior request. Use this marker for pagination of results from this operation. If this parameter is specified, the response includes only records beyond the marker, up to the value specified by <code>MaxRecords</code>.</p>",
         "DescribeCacheEngineVersionsMessage$Engine": "<p>The cache engine to return. Valid values: <code>memcached</code> | <code>redis</code> </p>",
         "DescribeCacheEngineVersionsMessage$EngineVersion": "<p>The cache engine version to return.</p> <p>Example: <code>1.4.14</code> </p>",
-        "DescribeCacheEngineVersionsMessage$CacheParameterGroupFamily": "<p>The name of a specific cache parameter group family to return details for.</p> <p>Constraints:</p> <ul> <li> <p>Must be 1 to 255 alphanumeric characters</p> </li> <li> <p>First character must be a letter</p> </li> <li> <p>Cannot end with a hyphen or contain two consecutive hyphens</p> </li> </ul>",
-        "DescribeCacheEngineVersionsMessage$Marker": "<p>An optional marker returned from a prior request. Use this marker for pagination of results from this action. If this parameter is specified, the response includes only records beyond the marker, up to the value specified by <i>MaxRecords</i>.</p>",
+        "DescribeCacheEngineVersionsMessage$CacheParameterGroupFamily": "<p>The name of a specific cache parameter group family to return details for.</p> <p>Valid values are: <code>memcached1.4</code> | <code>redis2.6</code> | <code>redis2.8</code> | <code>redis3.2</code> </p> <p>Constraints:</p> <ul> <li> <p>Must be 1 to 255 alphanumeric characters</p> </li> <li> <p>First character must be a letter</p> </li> <li> <p>Cannot end with a hyphen or contain two consecutive hyphens</p> </li> </ul>",
+        "DescribeCacheEngineVersionsMessage$Marker": "<p>An optional marker returned from a prior request. Use this marker for pagination of results from this operation. If this parameter is specified, the response includes only records beyond the marker, up to the value specified by <code>MaxRecords</code>.</p>",
         "DescribeCacheParameterGroupsMessage$CacheParameterGroupName": "<p>The name of a specific cache parameter group to return details for.</p>",
-        "DescribeCacheParameterGroupsMessage$Marker": "<p>An optional marker returned from a prior request. Use this marker for pagination of results from this action. If this parameter is specified, the response includes only records beyond the marker, up to the value specified by <i>MaxRecords</i>.</p>",
+        "DescribeCacheParameterGroupsMessage$Marker": "<p>An optional marker returned from a prior request. Use this marker for pagination of results from this operation. If this parameter is specified, the response includes only records beyond the marker, up to the value specified by <code>MaxRecords</code>.</p>",
         "DescribeCacheParametersMessage$CacheParameterGroupName": "<p>The name of a specific cache parameter group to return details for.</p>",
         "DescribeCacheParametersMessage$Source": "<p>The parameter types to return.</p> <p>Valid values: <code>user</code> | <code>system</code> | <code>engine-default</code> </p>",
-        "DescribeCacheParametersMessage$Marker": "<p>An optional marker returned from a prior request. Use this marker for pagination of results from this action. If this parameter is specified, the response includes only records beyond the marker, up to the value specified by <i>MaxRecords</i>.</p>",
+        "DescribeCacheParametersMessage$Marker": "<p>An optional marker returned from a prior request. Use this marker for pagination of results from this operation. If this parameter is specified, the response includes only records beyond the marker, up to the value specified by <code>MaxRecords</code>.</p>",
         "DescribeCacheSecurityGroupsMessage$CacheSecurityGroupName": "<p>The name of the cache security group to return details for.</p>",
-        "DescribeCacheSecurityGroupsMessage$Marker": "<p>An optional marker returned from a prior request. Use this marker for pagination of results from this action. If this parameter is specified, the response includes only records beyond the marker, up to the value specified by <i>MaxRecords</i>.</p>",
+        "DescribeCacheSecurityGroupsMessage$Marker": "<p>An optional marker returned from a prior request. Use this marker for pagination of results from this operation. If this parameter is specified, the response includes only records beyond the marker, up to the value specified by <code>MaxRecords</code>.</p>",
         "DescribeCacheSubnetGroupsMessage$CacheSubnetGroupName": "<p>The name of the cache subnet group to return details for.</p>",
-        "DescribeCacheSubnetGroupsMessage$Marker": "<p>An optional marker returned from a prior request. Use this marker for pagination of results from this action. If this parameter is specified, the response includes only records beyond the marker, up to the value specified by <i>MaxRecords</i>.</p>",
-        "DescribeEngineDefaultParametersMessage$CacheParameterGroupFamily": "<p>The name of the cache parameter group family. Valid values are: <code>memcached1.4</code> | <code>redis2.6</code> | <code>redis2.8</code> </p>",
-        "DescribeEngineDefaultParametersMessage$Marker": "<p>An optional marker returned from a prior request. Use this marker for pagination of results from this action. If this parameter is specified, the response includes only records beyond the marker, up to the value specified by <i>MaxRecords</i>.</p>",
-        "DescribeEventsMessage$SourceIdentifier": "<p>The identifier of the event source for which events will be returned. If not specified, then all sources are included in the response.</p>",
-        "DescribeEventsMessage$Marker": "<p>An optional marker returned from a prior request. Use this marker for pagination of results from this action. If this parameter is specified, the response includes only records beyond the marker, up to the value specified by <i>MaxRecords</i>.</p>",
+        "DescribeCacheSubnetGroupsMessage$Marker": "<p>An optional marker returned from a prior request. Use this marker for pagination of results from this operation. If this parameter is specified, the response includes only records beyond the marker, up to the value specified by <code>MaxRecords</code>.</p>",
+        "DescribeEngineDefaultParametersMessage$CacheParameterGroupFamily": "<p>The name of the cache parameter group family.</p> <p>Valid values are: <code>memcached1.4</code> | <code>redis2.6</code> | <code>redis2.8</code> | <code>redis3.2</code> </p>",
+        "DescribeEngineDefaultParametersMessage$Marker": "<p>An optional marker returned from a prior request. Use this marker for pagination of results from this operation. If this parameter is specified, the response includes only records beyond the marker, up to the value specified by <code>MaxRecords</code>.</p>",
+        "DescribeEventsMessage$SourceIdentifier": "<p>The identifier of the event source for which events are returned. If not specified, all sources are included in the response.</p>",
+        "DescribeEventsMessage$Marker": "<p>An optional marker returned from a prior request. Use this marker for pagination of results from this operation. If this parameter is specified, the response includes only records beyond the marker, up to the value specified by <code>MaxRecords</code>.</p>",
         "DescribeReplicationGroupsMessage$ReplicationGroupId": "<p>The identifier for the replication group to be described. This parameter is not case sensitive.</p> <p>If you do not specify this parameter, information about all replication groups is returned.</p>",
-        "DescribeReplicationGroupsMessage$Marker": "<p>An optional marker returned from a prior request. Use this marker for pagination of results from this action. If this parameter is specified, the response includes only records beyond the marker, up to the value specified by <i>MaxRecords</i>.</p>",
+        "DescribeReplicationGroupsMessage$Marker": "<p>An optional marker returned from a prior request. Use this marker for pagination of results from this operation. If this parameter is specified, the response includes only records beyond the marker, up to the value specified by <code>MaxRecords</code>.</p>",
         "DescribeReservedCacheNodesMessage$ReservedCacheNodeId": "<p>The reserved cache node identifier filter value. Use this parameter to show only the reservation that matches the specified reservation ID.</p>",
         "DescribeReservedCacheNodesMessage$ReservedCacheNodesOfferingId": "<p>The offering identifier filter value. Use this parameter to show only purchased reservations matching the specified offering identifier.</p>",
-        "DescribeReservedCacheNodesMessage$CacheNodeType": "<p>The cache node type filter value. Use this parameter to show only those reservations matching the specified cache node type.</p> <p>Valid node types are as follows:</p> <ul> <li> <p>General purpose:</p> <ul> <li> <p>Current generation: <code>cache.t2.micro</code>, <code>cache.t2.small</code>, <code>cache.t2.medium</code>, <code>cache.m3.medium</code>, <code>cache.m3.large</code>, <code>cache.m3.xlarge</code>, <code>cache.m3.2xlarge</code> </p> </li> <li> <p>Previous generation: <code>cache.t1.micro</code>, <code>cache.m1.small</code>, <code>cache.m1.medium</code>, <code>cache.m1.large</code>, <code>cache.m1.xlarge</code> </p> </li> </ul> </li> <li> <p>Compute optimized: <code>cache.c1.xlarge</code> </p> </li> <li> <p>Memory optimized:</p> <ul> <li> <p>Current generation: <code>cache.r3.large</code>, <code>cache.r3.xlarge</code>, <code>cache.r3.2xlarge</code>, <code>cache.r3.4xlarge</code>, <code>cache.r3.8xlarge</code> </p> </li> <li> <p>Previous generation: <code>cache.m2.xlarge</code>, <code>cache.m2.2xlarge</code>, <code>cache.m2.4xlarge</code> </p> </li> </ul> </li> </ul> <p> <b>Notes:</b> </p> <ul> <li> <p>All t2 instances are created in an Amazon Virtual Private Cloud (VPC).</p> </li> <li> <p>Redis backup/restore is not supported for t2 instances.</p> </li> <li> <p>Redis Append-only files (AOF) functionality is not supported for t1 or t2 instances.</p> </li> </ul> <p>For a complete listing of cache node types and specifications, see <a href=\"http://aws.amazon.com/elasticache/details\">Amazon ElastiCache Product Features and Details</a> and <a href=\"http://docs.aws.amazon.com/AmazonElastiCache/latest/UserGuide/CacheParameterGroups.Memcached.html#CacheParameterGroups.Memcached.NodeSpecific\">Cache Node Type-Specific Parameters for Memcached</a> or <a href=\"http://docs.aws.amazon.com/AmazonElastiCache/latest/UserGuide/CacheParameterGroups.Redis.html#CacheParameterGroups.Redis.NodeSpecific\">Cache Node Type-Specific Parameters for Redis</a>.</p>",
+        "DescribeReservedCacheNodesMessage$CacheNodeType": "<p>The cache node type filter value. Use this parameter to show only those reservations matching the specified cache node type.</p> <p>Valid node types are as follows:</p> <ul> <li> <p>General purpose:</p> <ul> <li> <p>Current generation: <code>cache.t2.micro</code>, <code>cache.t2.small</code>, <code>cache.t2.medium</code>, <code>cache.m3.medium</code>, <code>cache.m3.large</code>, <code>cache.m3.xlarge</code>, <code>cache.m3.2xlarge</code>, <code>cache.m4.large</code>, <code>cache.m4.xlarge</code>, <code>cache.m4.2xlarge</code>, <code>cache.m4.4xlarge</code>, <code>cache.m4.10xlarge</code> </p> </li> <li> <p>Previous generation: <code>cache.t1.micro</code>, <code>cache.m1.small</code>, <code>cache.m1.medium</code>, <code>cache.m1.large</code>, <code>cache.m1.xlarge</code> </p> </li> </ul> </li> <li> <p>Compute optimized: <code>cache.c1.xlarge</code> </p> </li> <li> <p>Memory optimized:</p> <ul> <li> <p>Current generation: <code>cache.r3.large</code>, <code>cache.r3.xlarge</code>, <code>cache.r3.2xlarge</code>, <code>cache.r3.4xlarge</code>, <code>cache.r3.8xlarge</code> </p> </li> <li> <p>Previous generation: <code>cache.m2.xlarge</code>, <code>cache.m2.2xlarge</code>, <code>cache.m2.4xlarge</code> </p> </li> </ul> </li> </ul> <p> <b>Notes:</b> </p> <ul> <li> <p>All T2 instances are created in an Amazon Virtual Private Cloud (Amazon VPC).</p> </li> <li> <p>Redis backup/restore is not supported for Redis (cluster mode disabled) T1 and T2 instances. Backup/restore is supported on Redis (cluster mode enabled) T2 instances.</p> </li> <li> <p>Redis Append-only files (AOF) functionality is not supported for T1 or T2 instances.</p> </li> </ul> <p>For a complete listing of node types and specifications, see <a href=\"http://aws.amazon.com/elasticache/details\">Amazon ElastiCache Product Features and Details</a> and either <a href=\"http://docs.aws.amazon.com/AmazonElastiCache/latest/UserGuide/CacheParameterGroups.Memcached.html#ParameterGroups.Memcached.NodeSpecific\">Cache Node Type-Specific Parameters for Memcached</a> or <a href=\"http://docs.aws.amazon.com/AmazonElastiCache/latest/UserGuide/CacheParameterGroups.Redis.html#ParameterGroups.Redis.NodeSpecific\">Cache Node Type-Specific Parameters for Redis</a>.</p>",
         "DescribeReservedCacheNodesMessage$Duration": "<p>The duration filter value, specified in years or seconds. Use this parameter to show only reservations for this duration.</p> <p>Valid Values: <code>1 | 3 | 31536000 | 94608000</code> </p>",
         "DescribeReservedCacheNodesMessage$ProductDescription": "<p>The product description filter value. Use this parameter to show only those reservations matching the specified product description.</p>",
         "DescribeReservedCacheNodesMessage$OfferingType": "<p>The offering type filter value. Use this parameter to show only the available offerings matching the specified offering type.</p> <p>Valid values: <code>\"Light Utilization\"|\"Medium Utilization\"|\"Heavy Utilization\"</code> </p>",
-        "DescribeReservedCacheNodesMessage$Marker": "<p>An optional marker returned from a prior request. Use this marker for pagination of results from this action. If this parameter is specified, the response includes only records beyond the marker, up to the value specified by <i>MaxRecords</i>.</p>",
+        "DescribeReservedCacheNodesMessage$Marker": "<p>An optional marker returned from a prior request. Use this marker for pagination of results from this operation. If this parameter is specified, the response includes only records beyond the marker, up to the value specified by <code>MaxRecords</code>.</p>",
         "DescribeReservedCacheNodesOfferingsMessage$ReservedCacheNodesOfferingId": "<p>The offering identifier filter value. Use this parameter to show only the available offering that matches the specified reservation identifier.</p> <p>Example: <code>438012d3-4052-4cc7-b2e3-8d3372e0e706</code> </p>",
-        "DescribeReservedCacheNodesOfferingsMessage$CacheNodeType": "<p>The cache node type filter value. Use this parameter to show only the available offerings matching the specified cache node type.</p> <p>Valid node types are as follows:</p> <ul> <li> <p>General purpose:</p> <ul> <li> <p>Current generation: <code>cache.t2.micro</code>, <code>cache.t2.small</code>, <code>cache.t2.medium</code>, <code>cache.m3.medium</code>, <code>cache.m3.large</code>, <code>cache.m3.xlarge</code>, <code>cache.m3.2xlarge</code> </p> </li> <li> <p>Previous generation: <code>cache.t1.micro</code>, <code>cache.m1.small</code>, <code>cache.m1.medium</code>, <code>cache.m1.large</code>, <code>cache.m1.xlarge</code> </p> </li> </ul> </li> <li> <p>Compute optimized: <code>cache.c1.xlarge</code> </p> </li> <li> <p>Memory optimized:</p> <ul> <li> <p>Current generation: <code>cache.r3.large</code>, <code>cache.r3.xlarge</code>, <code>cache.r3.2xlarge</code>, <code>cache.r3.4xlarge</code>, <code>cache.r3.8xlarge</code> </p> </li> <li> <p>Previous generation: <code>cache.m2.xlarge</code>, <code>cache.m2.2xlarge</code>, <code>cache.m2.4xlarge</code> </p> </li> </ul> </li> </ul> <p> <b>Notes:</b> </p> <ul> <li> <p>All t2 instances are created in an Amazon Virtual Private Cloud (VPC).</p> </li> <li> <p>Redis backup/restore is not supported for t2 instances.</p> </li> <li> <p>Redis Append-only files (AOF) functionality is not supported for t1 or t2 instances.</p> </li> </ul> <p>For a complete listing of cache node types and specifications, see <a href=\"http://aws.amazon.com/elasticache/details\">Amazon ElastiCache Product Features and Details</a> and <a href=\"http://docs.aws.amazon.com/AmazonElastiCache/latest/UserGuide/CacheParameterGroups.Memcached.html#CacheParameterGroups.Memcached.NodeSpecific\">Cache Node Type-Specific Parameters for Memcached</a> or <a href=\"http://docs.aws.amazon.com/AmazonElastiCache/latest/UserGuide/CacheParameterGroups.Redis.html#CacheParameterGroups.Redis.NodeSpecific\">Cache Node Type-Specific Parameters for Redis</a>.</p>",
+        "DescribeReservedCacheNodesOfferingsMessage$CacheNodeType": "<p>The cache node type filter value. Use this parameter to show only the available offerings matching the specified cache node type.</p> <p>Valid node types are as follows:</p> <ul> <li> <p>General purpose:</p> <ul> <li> <p>Current generation: <code>cache.t2.micro</code>, <code>cache.t2.small</code>, <code>cache.t2.medium</code>, <code>cache.m3.medium</code>, <code>cache.m3.large</code>, <code>cache.m3.xlarge</code>, <code>cache.m3.2xlarge</code>, <code>cache.m4.large</code>, <code>cache.m4.xlarge</code>, <code>cache.m4.2xlarge</code>, <code>cache.m4.4xlarge</code>, <code>cache.m4.10xlarge</code> </p> </li> <li> <p>Previous generation: <code>cache.t1.micro</code>, <code>cache.m1.small</code>, <code>cache.m1.medium</code>, <code>cache.m1.large</code>, <code>cache.m1.xlarge</code> </p> </li> </ul> </li> <li> <p>Compute optimized: <code>cache.c1.xlarge</code> </p> </li> <li> <p>Memory optimized:</p> <ul> <li> <p>Current generation: <code>cache.r3.large</code>, <code>cache.r3.xlarge</code>, <code>cache.r3.2xlarge</code>, <code>cache.r3.4xlarge</code>, <code>cache.r3.8xlarge</code> </p> </li> <li> <p>Previous generation: <code>cache.m2.xlarge</code>, <code>cache.m2.2xlarge</code>, <code>cache.m2.4xlarge</code> </p> </li> </ul> </li> </ul> <p> <b>Notes:</b> </p> <ul> <li> <p>All T2 instances are created in an Amazon Virtual Private Cloud (Amazon VPC).</p> </li> <li> <p>Redis backup/restore is not supported for Redis (cluster mode disabled) T1 and T2 instances. Backup/restore is supported on Redis (cluster mode enabled) T2 instances.</p> </li> <li> <p>Redis Append-only files (AOF) functionality is not supported for T1 or T2 instances.</p> </li> </ul> <p>For a complete listing of node types and specifications, see <a href=\"http://aws.amazon.com/elasticache/details\">Amazon ElastiCache Product Features and Details</a> and either <a href=\"http://docs.aws.amazon.com/AmazonElastiCache/latest/UserGuide/CacheParameterGroups.Memcached.html#ParameterGroups.Memcached.NodeSpecific\">Cache Node Type-Specific Parameters for Memcached</a> or <a href=\"http://docs.aws.amazon.com/AmazonElastiCache/latest/UserGuide/CacheParameterGroups.Redis.html#ParameterGroups.Redis.NodeSpecific\">Cache Node Type-Specific Parameters for Redis</a>.</p>",
         "DescribeReservedCacheNodesOfferingsMessage$Duration": "<p>Duration filter value, specified in years or seconds. Use this parameter to show only reservations for a given duration.</p> <p>Valid Values: <code>1 | 3 | 31536000 | 94608000</code> </p>",
         "DescribeReservedCacheNodesOfferingsMessage$ProductDescription": "<p>The product description filter value. Use this parameter to show only the available offerings matching the specified product description.</p>",
         "DescribeReservedCacheNodesOfferingsMessage$OfferingType": "<p>The offering type filter value. Use this parameter to show only the available offerings matching the specified offering type.</p> <p>Valid Values: <code>\"Light Utilization\"|\"Medium Utilization\"|\"Heavy Utilization\"</code> </p>",
-        "DescribeReservedCacheNodesOfferingsMessage$Marker": "<p>An optional marker returned from a prior request. Use this marker for pagination of results from this action. If this parameter is specified, the response includes only records beyond the marker, up to the value specified by <i>MaxRecords</i>.</p>",
-        "DescribeSnapshotsListMessage$Marker": "<p>An optional marker returned from a prior request. Use this marker for pagination of results from this action. If this parameter is specified, the response includes only records beyond the marker, up to the value specified by <i>MaxRecords</i>.</p>",
-        "DescribeSnapshotsMessage$CacheClusterId": "<p>A user-supplied cluster identifier. If this parameter is specified, only snapshots associated with that specific cache cluster will be described.</p>",
-        "DescribeSnapshotsMessage$SnapshotName": "<p>A user-supplied name of the snapshot. If this parameter is specified, only this snapshot will be described.</p>",
+        "DescribeReservedCacheNodesOfferingsMessage$Marker": "<p>An optional marker returned from a prior request. Use this marker for pagination of results from this operation. If this parameter is specified, the response includes only records beyond the marker, up to the value specified by <code>MaxRecords</code>.</p>",
+        "DescribeSnapshotsListMessage$Marker": "<p>An optional marker returned from a prior request. Use this marker for pagination of results from this operation. If this parameter is specified, the response includes only records beyond the marker, up to the value specified by <code>MaxRecords</code>.</p>",
+        "DescribeSnapshotsMessage$ReplicationGroupId": "<p>A user-supplied replication group identifier. If this parameter is specified, only snapshots associated with that specific replication group are described.</p>",
+        "DescribeSnapshotsMessage$CacheClusterId": "<p>A user-supplied cluster identifier. If this parameter is specified, only snapshots associated with that specific cache cluster are described.</p>",
+        "DescribeSnapshotsMessage$SnapshotName": "<p>A user-supplied name of the snapshot. If this parameter is specified, only this snapshot are described.</p>",
         "DescribeSnapshotsMessage$SnapshotSource": "<p>If set to <code>system</code>, the output shows snapshots that were automatically created by ElastiCache. If set to <code>user</code> the output shows snapshots that were manually created. If omitted, the output shows both automatically and manually created snapshots.</p>",
-        "DescribeSnapshotsMessage$Marker": "<p>An optional marker returned from a prior request. Use this marker for pagination of results from this action. If this parameter is specified, the response includes only records beyond the marker, up to the value specified by <i>MaxRecords</i>.</p>",
+        "DescribeSnapshotsMessage$Marker": "<p>An optional marker returned from a prior request. Use this marker for pagination of results from this operation. If this parameter is specified, the response includes only records beyond the marker, up to the value specified by <code>MaxRecords</code>.</p>",
         "EC2SecurityGroup$Status": "<p>The status of the Amazon EC2 security group.</p>",
         "EC2SecurityGroup$EC2SecurityGroupName": "<p>The name of the Amazon EC2 security group.</p>",
         "EC2SecurityGroup$EC2SecurityGroupOwnerId": "<p>The AWS account ID of the Amazon EC2 security group owner.</p>",
         "Endpoint$Address": "<p>The DNS hostname of the cache node.</p>",
-        "EngineDefaults$CacheParameterGroupFamily": "<p>Specifies the name of the cache parameter group family to which the engine default parameters apply.</p>",
+        "EngineDefaults$CacheParameterGroupFamily": "<p>Specifies the name of the cache parameter group family to which the engine default parameters apply.</p> <p>Valid values are: <code>memcached1.4</code> | <code>redis2.6</code> | <code>redis2.8</code> | <code>redis3.2</code> </p>",
         "EngineDefaults$Marker": "<p>Provides an identifier to allow retrieval of paginated results.</p>",
         "Event$SourceIdentifier": "<p>The identifier for the source of the event. For example, if the event occurred at the cache cluster level, the identifier would be the name of the cache cluster.</p>",
         "Event$Message": "<p>The text of the event.</p>",
         "EventsMessage$Marker": "<p>Provides an identifier to allow retrieval of paginated results.</p>",
         "KeyList$member": null,
-        "ListAllowedNodeTypeModificationsMessage$CacheClusterId": "<p>The name of the cache cluster you want to scale up to a larger node instanced type. ElastiCache uses the cluster id to identify the current node type of this cluster and from that to to create a list of node types you can scale up to.</p> <important> <p>You must provide a value for either the <i>CacheClusterId</i> or the <i>ReplicationGroupId</i>.</p> </important>",
-        "ListAllowedNodeTypeModificationsMessage$ReplicationGroupId": "<p>The name of the replication group want to scale up to a larger node type. ElastiCache uses the replication group id to identify the current node type being used by this replication group, and from that to create a list of node types you can scale up to.</p> <important> <p>You must provide a value for either the <i>CacheClusterId</i> or the <i>ReplicationGroupId</i>.</p> </important>",
-        "ListTagsForResourceMessage$ResourceName": "<p>The Amazon Resource Name (ARN) of the resource for which you want the list of tags, for example <code>arn:aws:elasticache:us-west-2:0123456789:cluster:myCluster</code> or <code>arn:aws:elasticache:us-west-2:0123456789:snapshot:mySnapshot</code>.</p> <p>For more information on ARNs, go to <a href=\"http://docs.aws.amazon.com/general/latest/gr/aws-arns-and-namespaces.html\">Amazon Resource Names (ARNs) and AWS Service Namespaces</a>.</p>",
+        "ListAllowedNodeTypeModificationsMessage$CacheClusterId": "<p>The name of the cache cluster you want to scale up to a larger node instanced type. ElastiCache uses the cluster id to identify the current node type of this cluster and from that to create a list of node types you can scale up to.</p> <important> <p>You must provide a value for either the <code>CacheClusterId</code> or the <code>ReplicationGroupId</code>.</p> </important>",
+        "ListAllowedNodeTypeModificationsMessage$ReplicationGroupId": "<p>The name of the replication group want to scale up to a larger node type. ElastiCache uses the replication group id to identify the current node type being used by this replication group, and from that to create a list of node types you can scale up to.</p> <important> <p>You must provide a value for either the <code>CacheClusterId</code> or the <code>ReplicationGroupId</code>.</p> </important>",
+        "ListTagsForResourceMessage$ResourceName": "<p>The Amazon Resource Name (ARN) of the resource for which you want the list of tags, for example <code>arn:aws:elasticache:us-west-2:0123456789:cluster:myCluster</code> or <code>arn:aws:elasticache:us-west-2:0123456789:snapshot:mySnapshot</code>.</p> <p>For more information about ARNs, see <a href=\"http://docs.aws.amazon.com/general/latest/gr/aws-arns-and-namespaces.html\">Amazon Resource Names (ARNs) and AWS Service Namespaces</a>.</p>",
         "ModifyCacheClusterMessage$CacheClusterId": "<p>The cache cluster identifier. This value is stored as a lowercase string.</p>",
-        "ModifyCacheClusterMessage$PreferredMaintenanceWindow": "<p>Specifies the weekly time range during which maintenance on the cache cluster is performed. It is specified as a range in the format ddd:hh24:mi-ddd:hh24:mi (24H Clock UTC). The minimum maintenance window is a 60 minute period. Valid values for <code>ddd</code> are:</p> <ul> <li> <p> <code>sun</code> </p> </li> <li> <p> <code>mon</code> </p> </li> <li> <p> <code>tue</code> </p> </li> <li> <p> <code>wed</code> </p> </li> <li> <p> <code>thu</code> </p> </li> <li> <p> <code>fri</code> </p> </li> <li> <p> <code>sat</code> </p> </li> </ul> <p>Example: <code>sun:05:00-sun:09:00</code> </p>",
-        "ModifyCacheClusterMessage$NotificationTopicArn": "<p>The Amazon Resource Name (ARN) of the Amazon SNS topic to which notifications will be sent.</p> <note> <p>The Amazon SNS topic owner must be same as the cache cluster owner.</p> </note>",
-        "ModifyCacheClusterMessage$CacheParameterGroupName": "<p>The name of the cache parameter group to apply to this cache cluster. This change is asynchronously applied as soon as possible for parameters when the <i>ApplyImmediately</i> parameter is specified as <i>true</i> for this request.</p>",
-        "ModifyCacheClusterMessage$NotificationTopicStatus": "<p>The status of the Amazon SNS notification topic. Notifications are sent only if the status is <i>active</i>.</p> <p>Valid values: <code>active</code> | <code>inactive</code> </p>",
+        "ModifyCacheClusterMessage$PreferredMaintenanceWindow": "<p>Specifies the weekly time range during which maintenance on the cluster is performed. It is specified as a range in the format ddd:hh24:mi-ddd:hh24:mi (24H Clock UTC). The minimum maintenance window is a 60 minute period.</p> <p>Valid values for <code>ddd</code> are:</p> <ul> <li> <p> <code>sun</code> </p> </li> <li> <p> <code>mon</code> </p> </li> <li> <p> <code>tue</code> </p> </li> <li> <p> <code>wed</code> </p> </li> <li> <p> <code>thu</code> </p> </li> <li> <p> <code>fri</code> </p> </li> <li> <p> <code>sat</code> </p> </li> </ul> <p>Example: <code>sun:23:00-mon:01:30</code> </p>",
+        "ModifyCacheClusterMessage$NotificationTopicArn": "<p>The Amazon Resource Name (ARN) of the Amazon SNS topic to which notifications are sent.</p> <note> <p>The Amazon SNS topic owner must be same as the cache cluster owner.</p> </note>",
+        "ModifyCacheClusterMessage$CacheParameterGroupName": "<p>The name of the cache parameter group to apply to this cache cluster. This change is asynchronously applied as soon as possible for parameters when the <code>ApplyImmediately</code> parameter is specified as <code>true</code> for this request.</p>",
+        "ModifyCacheClusterMessage$NotificationTopicStatus": "<p>The status of the Amazon SNS notification topic. Notifications are sent only if the status is <code>active</code>.</p> <p>Valid values: <code>active</code> | <code>inactive</code> </p>",
         "ModifyCacheClusterMessage$EngineVersion": "<p>The upgraded version of the cache engine to be run on the cache nodes.</p> <p> <b>Important:</b> You can upgrade to a newer engine version (see <a href=\"http://docs.aws.amazon.com/AmazonElastiCache/latest/UserGuide/SelectEngine.html#VersionManagement\">Selecting a Cache Engine and Version</a>), but you cannot downgrade to an earlier engine version. If you want to use an earlier engine version, you must delete the existing cache cluster and create it anew with the earlier engine version. </p>",
-        "ModifyCacheClusterMessage$SnapshotWindow": "<p>The daily time range (in UTC) during which ElastiCache will begin taking a daily snapshot of your cache cluster. </p>",
-        "ModifyCacheClusterMessage$CacheNodeType": "<p>A valid cache node type that you want to scale this cache cluster to. The value of this parameter must be one of the <i>ScaleUpModifications</i> values returned by the <code>ListAllowedCacheNodeTypeModification</code> action.</p>",
+        "ModifyCacheClusterMessage$SnapshotWindow": "<p>The daily time range (in UTC) during which ElastiCache begins taking a daily snapshot of your cache cluster. </p>",
+        "ModifyCacheClusterMessage$CacheNodeType": "<p>A valid cache node type that you want to scale this cache cluster up to.</p>",
         "ModifyCacheParameterGroupMessage$CacheParameterGroupName": "<p>The name of the cache parameter group to modify.</p>",
         "ModifyCacheSubnetGroupMessage$CacheSubnetGroupName": "<p>The name for the cache subnet group. This value is stored as a lowercase string.</p> <p>Constraints: Must contain no more than 255 alphanumeric characters or hyphens.</p> <p>Example: <code>mysubnetgroup</code> </p>",
-        "ModifyCacheSubnetGroupMessage$CacheSubnetGroupDescription": "<p>A description for the cache subnet group.</p>",
+        "ModifyCacheSubnetGroupMessage$CacheSubnetGroupDescription": "<p>A description of the cache subnet group.</p>",
         "ModifyReplicationGroupMessage$ReplicationGroupId": "<p>The identifier of the replication group to modify.</p>",
         "ModifyReplicationGroupMessage$ReplicationGroupDescription": "<p>A description for the replication group. Maximum length is 255 characters.</p>",
-        "ModifyReplicationGroupMessage$PrimaryClusterId": "<p>If this parameter is specified, ElastiCache will promote the specified cluster in the specified replication group to the primary role. The nodes of all other clusters in the replication group will be read replicas.</p>",
-        "ModifyReplicationGroupMessage$SnapshottingClusterId": "<p>The cache cluster ID that will be used as the daily snapshot source for the replication group.</p>",
-        "ModifyReplicationGroupMessage$PreferredMaintenanceWindow": "<p>Specifies the weekly time range during which maintenance on the cache cluster is performed. It is specified as a range in the format ddd:hh24:mi-ddd:hh24:mi (24H Clock UTC). The minimum maintenance window is a 60 minute period. Valid values for <code>ddd</code> are:</p> <ul> <li> <p> <code>sun</code> </p> </li> <li> <p> <code>mon</code> </p> </li> <li> <p> <code>tue</code> </p> </li> <li> <p> <code>wed</code> </p> </li> <li> <p> <code>thu</code> </p> </li> <li> <p> <code>fri</code> </p> </li> <li> <p> <code>sat</code> </p> </li> </ul> <p>Example: <code>sun:05:00-sun:09:00</code> </p>",
-        "ModifyReplicationGroupMessage$NotificationTopicArn": "<p>The Amazon Resource Name (ARN) of the Amazon SNS topic to which notifications will be sent.</p> <note> <p>The Amazon SNS topic owner must be same as the replication group owner. </p> </note>",
-        "ModifyReplicationGroupMessage$CacheParameterGroupName": "<p>The name of the cache parameter group to apply to all of the clusters in this replication group. This change is asynchronously applied as soon as possible for parameters when the <i>ApplyImmediately</i> parameter is specified as <i>true</i> for this request.</p>",
-        "ModifyReplicationGroupMessage$NotificationTopicStatus": "<p>The status of the Amazon SNS notification topic for the replication group. Notifications are sent only if the status is <i>active</i>.</p> <p>Valid values: <code>active</code> | <code>inactive</code> </p>",
+        "ModifyReplicationGroupMessage$PrimaryClusterId": "<p>For replication groups with a single primary, if this parameter is specified, ElastiCache promotes the specified cluster in the specified replication group to the primary role. The nodes of all other clusters in the replication group are read replicas.</p>",
+        "ModifyReplicationGroupMessage$SnapshottingClusterId": "<p>The cache cluster ID that is used as the daily snapshot source for the replication group. This parameter cannot be set for Redis (cluster mode enabled) replication groups.</p>",
+        "ModifyReplicationGroupMessage$PreferredMaintenanceWindow": "<p>Specifies the weekly time range during which maintenance on the cluster is performed. It is specified as a range in the format ddd:hh24:mi-ddd:hh24:mi (24H Clock UTC). The minimum maintenance window is a 60 minute period.</p> <p>Valid values for <code>ddd</code> are:</p> <ul> <li> <p> <code>sun</code> </p> </li> <li> <p> <code>mon</code> </p> </li> <li> <p> <code>tue</code> </p> </li> <li> <p> <code>wed</code> </p> </li> <li> <p> <code>thu</code> </p> </li> <li> <p> <code>fri</code> </p> </li> <li> <p> <code>sat</code> </p> </li> </ul> <p>Example: <code>sun:23:00-mon:01:30</code> </p>",
+        "ModifyReplicationGroupMessage$NotificationTopicArn": "<p>The Amazon Resource Name (ARN) of the Amazon SNS topic to which notifications are sent.</p> <note> <p>The Amazon SNS topic owner must be same as the replication group owner. </p> </note>",
+        "ModifyReplicationGroupMessage$CacheParameterGroupName": "<p>The name of the cache parameter group to apply to all of the clusters in this replication group. This change is asynchronously applied as soon as possible for parameters when the <code>ApplyImmediately</code> parameter is specified as <code>true</code> for this request.</p>",
+        "ModifyReplicationGroupMessage$NotificationTopicStatus": "<p>The status of the Amazon SNS notification topic for the replication group. Notifications are sent only if the status is <code>active</code>.</p> <p>Valid values: <code>active</code> | <code>inactive</code> </p>",
         "ModifyReplicationGroupMessage$EngineVersion": "<p>The upgraded version of the cache engine to be run on the cache clusters in the replication group.</p> <p> <b>Important:</b> You can upgrade to a newer engine version (see <a href=\"http://docs.aws.amazon.com/AmazonElastiCache/latest/UserGuide/SelectEngine.html#VersionManagement\">Selecting a Cache Engine and Version</a>), but you cannot downgrade to an earlier engine version. If you want to use an earlier engine version, you must delete the existing replication group and create it anew with the earlier engine version. </p>",
-        "ModifyReplicationGroupMessage$SnapshotWindow": "<p>The daily time range (in UTC) during which ElastiCache will begin taking a daily snapshot of the node group specified by <i>SnapshottingClusterId</i>.</p> <p>Example: <code>05:00-09:00</code> </p> <p>If you do not specify this parameter, then ElastiCache will automatically choose an appropriate time range.</p>",
-        "ModifyReplicationGroupMessage$CacheNodeType": "<p>A valid cache node type that you want to scale this replication group to. The value of this parameter must be one of the <i>ScaleUpModifications</i> values returned by the <code>ListAllowedCacheNodeTypeModification</code> action.</p>",
-        "NodeGroup$NodeGroupId": "<p>The identifier for the node group. A replication group contains only one node group; therefore, the node group ID is 0001.</p>",
-        "NodeGroup$Status": "<p>The current state of this replication group - <i>creating</i>, <i>available</i>, etc.</p>",
+        "ModifyReplicationGroupMessage$SnapshotWindow": "<p>The daily time range (in UTC) during which ElastiCache begins taking a daily snapshot of the node group (shard) specified by <code>SnapshottingClusterId</code>.</p> <p>Example: <code>05:00-09:00</code> </p> <p>If you do not specify this parameter, ElastiCache automatically chooses an appropriate time range.</p>",
+        "ModifyReplicationGroupMessage$CacheNodeType": "<p>A valid cache node type that you want to scale this replication group to.</p>",
+        "NodeGroup$NodeGroupId": "<p>The identifier for the node group (shard). A Redis (cluster mode disabled) replication group contains only 1 node group; therefore, the node group ID is 0001. A Redis (cluster mode enabled) replication group contains 1 to 15 node groups numbered 0001 to 0015. </p>",
+        "NodeGroup$Status": "<p>The current state of this replication group - <code>creating</code>, <code>available</code>, etc.</p>",
+        "NodeGroup$Slots": "<p>The keyspace for this node group (shard).</p>",
+        "NodeGroupConfiguration$Slots": "<p>A string that specifies the keyspaces as a series of comma separated values. Keyspaces are 0 to 16,383. The string is in the format <code>startkey-endkey</code>.</p> <p>Example: <code>\"0-3999\"</code> </p>",
+        "NodeGroupConfiguration$PrimaryAvailabilityZone": "<p>The Availability Zone where the primary node of this node group (shard) is launched.</p>",
         "NodeGroupMember$CacheClusterId": "<p>The ID of the cache cluster to which the node belongs.</p>",
         "NodeGroupMember$CacheNodeId": "<p>The ID of the node within its cache cluster. A node ID is a numeric identifier (0001, 0002, etc.).</p>",
         "NodeGroupMember$PreferredAvailabilityZone": "<p>The name of the Availability Zone in which the node is located.</p>",
-        "NodeGroupMember$CurrentRole": "<p>The role that is currently assigned to the node - <i>primary</i> or <i>replica</i>.</p>",
+        "NodeGroupMember$CurrentRole": "<p>The role that is currently assigned to the node - <code>primary</code> or <code>replica</code>.</p>",
+        "NodeSnapshot$CacheClusterId": "<p>A unique identifier for the source cache cluster.</p>",
+        "NodeSnapshot$NodeGroupId": "<p>A unique identifier for the source node group (shard).</p>",
         "NodeSnapshot$CacheNodeId": "<p>The cache node identifier for the node in the source cache cluster.</p>",
         "NodeSnapshot$CacheSize": "<p>The size of the cache on the source cache node.</p>",
         "NodeTypeList$member": null,
@@ -1295,29 +1329,30 @@
         "Parameter$MinimumEngineVersion": "<p>The earliest cache engine version to which the parameter can apply.</p>",
         "ParameterNameValue$ParameterName": "<p>The name of the parameter.</p>",
         "ParameterNameValue$ParameterValue": "<p>The value of the parameter.</p>",
-        "PendingModifiedValues$EngineVersion": "<p>The new cache engine version that the cache cluster will run.</p>",
-        "PendingModifiedValues$CacheNodeType": "<p>The cache node type that this cache cluster or replication group will be scaled to.</p>",
+        "PendingModifiedValues$EngineVersion": "<p>The new cache engine version that the cache cluster runs.</p>",
+        "PendingModifiedValues$CacheNodeType": "<p>The cache node type that this cache cluster or replication group is scaled to.</p>",
         "PreferredAvailabilityZoneList$member": null,
         "PurchaseReservedCacheNodesOfferingMessage$ReservedCacheNodesOfferingId": "<p>The ID of the reserved cache node offering to purchase.</p> <p>Example: <code>438012d3-4052-4cc7-b2e3-8d3372e0e706</code> </p>",
         "PurchaseReservedCacheNodesOfferingMessage$ReservedCacheNodeId": "<p>A customer-specified identifier to track this reservation.</p> <note> <p>The Reserved Cache Node ID is an unique customer-specified identifier to track this reservation. If this parameter is not specified, ElastiCache automatically generates an identifier for the reservation.</p> </note> <p>Example: myreservationID</p>",
         "RebootCacheClusterMessage$CacheClusterId": "<p>The cache cluster identifier. This parameter is stored as a lowercase string.</p>",
         "RecurringCharge$RecurringChargeFrequency": "<p>The frequency of the recurring charge.</p>",
-        "RemoveTagsFromResourceMessage$ResourceName": "<p>The Amazon Resource Name (ARN) of the resource from which you want the tags removed, for example <code>arn:aws:elasticache:us-west-2:0123456789:cluster:myCluster</code> or <code>arn:aws:elasticache:us-west-2:0123456789:snapshot:mySnapshot</code>.</p> <p>For more information on ARNs, go to <a href=\"http://docs.aws.amazon.com/general/latest/gr/aws-arns-and-namespaces.html\">Amazon Resource Names (ARNs) and AWS Service Namespaces</a>.</p>",
+        "RemoveTagsFromResourceMessage$ResourceName": "<p>The Amazon Resource Name (ARN) of the resource from which you want the tags removed, for example <code>arn:aws:elasticache:us-west-2:0123456789:cluster:myCluster</code> or <code>arn:aws:elasticache:us-west-2:0123456789:snapshot:mySnapshot</code>.</p> <p>For more information about ARNs, see <a href=\"http://docs.aws.amazon.com/general/latest/gr/aws-arns-and-namespaces.html\">Amazon Resource Names (ARNs) and AWS Service Namespaces</a>.</p>",
         "ReplicationGroup$ReplicationGroupId": "<p>The identifier for the replication group.</p>",
         "ReplicationGroup$Description": "<p>The description of the replication group.</p>",
-        "ReplicationGroup$Status": "<p>The current state of this replication group - <i>creating</i>, <i>available</i>, etc.</p>",
+        "ReplicationGroup$Status": "<p>The current state of this replication group - <code>creating</code>, <code>available</code>, etc.</p>",
         "ReplicationGroup$SnapshottingClusterId": "<p>The cache cluster ID that is used as the daily snapshot source for the replication group.</p>",
+        "ReplicationGroup$SnapshotWindow": "<p>The daily time range (in UTC) during which ElastiCache begins taking a daily snapshot of your node group (shard).</p> <p>Example: <code>05:00-09:00</code> </p> <p>If you do not specify this parameter, ElastiCache automatically chooses an appropriate time range.</p> <p> <b>Note:</b> This parameter is only valid if the <code>Engine</code> parameter is <code>redis</code>.</p>",
         "ReplicationGroupMessage$Marker": "<p>Provides an identifier to allow retrieval of paginated results.</p>",
-        "ReplicationGroupPendingModifiedValues$PrimaryClusterId": "<p>The primary cluster ID which will be applied immediately (if <code>--apply-immediately</code> was specified), or during the next maintenance window.</p>",
+        "ReplicationGroupPendingModifiedValues$PrimaryClusterId": "<p>The primary cluster ID that is applied immediately (if <code>--apply-immediately</code> was specified), or during the next maintenance window.</p>",
         "ReservedCacheNode$ReservedCacheNodeId": "<p>The unique identifier for the reservation.</p>",
         "ReservedCacheNode$ReservedCacheNodesOfferingId": "<p>The offering identifier.</p>",
-        "ReservedCacheNode$CacheNodeType": "<p>The cache node type for the reserved cache nodes.</p> <p>Valid node types are as follows:</p> <ul> <li> <p>General purpose:</p> <ul> <li> <p>Current generation: <code>cache.t2.micro</code>, <code>cache.t2.small</code>, <code>cache.t2.medium</code>, <code>cache.m3.medium</code>, <code>cache.m3.large</code>, <code>cache.m3.xlarge</code>, <code>cache.m3.2xlarge</code> </p> </li> <li> <p>Previous generation: <code>cache.t1.micro</code>, <code>cache.m1.small</code>, <code>cache.m1.medium</code>, <code>cache.m1.large</code>, <code>cache.m1.xlarge</code> </p> </li> </ul> </li> <li> <p>Compute optimized: <code>cache.c1.xlarge</code> </p> </li> <li> <p>Memory optimized:</p> <ul> <li> <p>Current generation: <code>cache.r3.large</code>, <code>cache.r3.xlarge</code>, <code>cache.r3.2xlarge</code>, <code>cache.r3.4xlarge</code>, <code>cache.r3.8xlarge</code> </p> </li> <li> <p>Previous generation: <code>cache.m2.xlarge</code>, <code>cache.m2.2xlarge</code>, <code>cache.m2.4xlarge</code> </p> </li> </ul> </li> </ul> <p> <b>Notes:</b> </p> <ul> <li> <p>All t2 instances are created in an Amazon Virtual Private Cloud (VPC).</p> </li> <li> <p>Redis backup/restore is not supported for t2 instances.</p> </li> <li> <p>Redis Append-only files (AOF) functionality is not supported for t1 or t2 instances.</p> </li> </ul> <p>For a complete listing of cache node types and specifications, see <a href=\"http://aws.amazon.com/elasticache/details\">Amazon ElastiCache Product Features and Details</a> and <a href=\"http://docs.aws.amazon.com/AmazonElastiCache/latest/UserGuide/CacheParameterGroups.Memcached.html#CacheParameterGroups.Memcached.NodeSpecific\">Cache Node Type-Specific Parameters for Memcached</a> or <a href=\"http://docs.aws.amazon.com/AmazonElastiCache/latest/UserGuide/CacheParameterGroups.Redis.html#CacheParameterGroups.Redis.NodeSpecific\">Cache Node Type-Specific Parameters for Redis</a>.</p>",
+        "ReservedCacheNode$CacheNodeType": "<p>The cache node type for the reserved cache nodes.</p> <p>Valid node types are as follows:</p> <ul> <li> <p>General purpose:</p> <ul> <li> <p>Current generation: <code>cache.t2.micro</code>, <code>cache.t2.small</code>, <code>cache.t2.medium</code>, <code>cache.m3.medium</code>, <code>cache.m3.large</code>, <code>cache.m3.xlarge</code>, <code>cache.m3.2xlarge</code>, <code>cache.m4.large</code>, <code>cache.m4.xlarge</code>, <code>cache.m4.2xlarge</code>, <code>cache.m4.4xlarge</code>, <code>cache.m4.10xlarge</code> </p> </li> <li> <p>Previous generation: <code>cache.t1.micro</code>, <code>cache.m1.small</code>, <code>cache.m1.medium</code>, <code>cache.m1.large</code>, <code>cache.m1.xlarge</code> </p> </li> </ul> </li> <li> <p>Compute optimized: <code>cache.c1.xlarge</code> </p> </li> <li> <p>Memory optimized:</p> <ul> <li> <p>Current generation: <code>cache.r3.large</code>, <code>cache.r3.xlarge</code>, <code>cache.r3.2xlarge</code>, <code>cache.r3.4xlarge</code>, <code>cache.r3.8xlarge</code> </p> </li> <li> <p>Previous generation: <code>cache.m2.xlarge</code>, <code>cache.m2.2xlarge</code>, <code>cache.m2.4xlarge</code> </p> </li> </ul> </li> </ul> <p> <b>Notes:</b> </p> <ul> <li> <p>All T2 instances are created in an Amazon Virtual Private Cloud (Amazon VPC).</p> </li> <li> <p>Redis backup/restore is not supported for Redis (cluster mode disabled) T1 and T2 instances. Backup/restore is supported on Redis (cluster mode enabled) T2 instances.</p> </li> <li> <p>Redis Append-only files (AOF) functionality is not supported for T1 or T2 instances.</p> </li> </ul> <p>For a complete listing of node types and specifications, see <a href=\"http://aws.amazon.com/elasticache/details\">Amazon ElastiCache Product Features and Details</a> and either <a href=\"http://docs.aws.amazon.com/AmazonElastiCache/latest/UserGuide/CacheParameterGroups.Memcached.html#ParameterGroups.Memcached.NodeSpecific\">Cache Node Type-Specific Parameters for Memcached</a> or <a href=\"http://docs.aws.amazon.com/AmazonElastiCache/latest/UserGuide/CacheParameterGroups.Redis.html#ParameterGroups.Redis.NodeSpecific\">Cache Node Type-Specific Parameters for Redis</a>.</p>",
         "ReservedCacheNode$ProductDescription": "<p>The description of the reserved cache node.</p>",
         "ReservedCacheNode$OfferingType": "<p>The offering type of this reserved cache node.</p>",
         "ReservedCacheNode$State": "<p>The state of the reserved cache node.</p>",
         "ReservedCacheNodeMessage$Marker": "<p>Provides an identifier to allow retrieval of paginated results.</p>",
         "ReservedCacheNodesOffering$ReservedCacheNodesOfferingId": "<p>A unique identifier for the reserved cache node offering.</p>",
-        "ReservedCacheNodesOffering$CacheNodeType": "<p>The cache node type for the reserved cache node.</p> <p>Valid node types are as follows:</p> <ul> <li> <p>General purpose:</p> <ul> <li> <p>Current generation: <code>cache.t2.micro</code>, <code>cache.t2.small</code>, <code>cache.t2.medium</code>, <code>cache.m3.medium</code>, <code>cache.m3.large</code>, <code>cache.m3.xlarge</code>, <code>cache.m3.2xlarge</code> </p> </li> <li> <p>Previous generation: <code>cache.t1.micro</code>, <code>cache.m1.small</code>, <code>cache.m1.medium</code>, <code>cache.m1.large</code>, <code>cache.m1.xlarge</code> </p> </li> </ul> </li> <li> <p>Compute optimized: <code>cache.c1.xlarge</code> </p> </li> <li> <p>Memory optimized:</p> <ul> <li> <p>Current generation: <code>cache.r3.large</code>, <code>cache.r3.xlarge</code>, <code>cache.r3.2xlarge</code>, <code>cache.r3.4xlarge</code>, <code>cache.r3.8xlarge</code> </p> </li> <li> <p>Previous generation: <code>cache.m2.xlarge</code>, <code>cache.m2.2xlarge</code>, <code>cache.m2.4xlarge</code> </p> </li> </ul> </li> </ul> <p> <b>Notes:</b> </p> <ul> <li> <p>All t2 instances are created in an Amazon Virtual Private Cloud (VPC).</p> </li> <li> <p>Redis backup/restore is not supported for t2 instances.</p> </li> <li> <p>Redis Append-only files (AOF) functionality is not supported for t1 or t2 instances.</p> </li> </ul> <p>For a complete listing of cache node types and specifications, see <a href=\"http://aws.amazon.com/elasticache/details\">Amazon ElastiCache Product Features and Details</a> and <a href=\"http://docs.aws.amazon.com/AmazonElastiCache/latest/UserGuide/CacheParameterGroups.Memcached.html#CacheParameterGroups.Memcached.NodeSpecific\">Cache Node Type-Specific Parameters for Memcached</a> or <a href=\"http://docs.aws.amazon.com/AmazonElastiCache/latest/UserGuide/CacheParameterGroups.Redis.html#CacheParameterGroups.Redis.NodeSpecific\">Cache Node Type-Specific Parameters for Redis</a>.</p>",
+        "ReservedCacheNodesOffering$CacheNodeType": "<p>The cache node type for the reserved cache node.</p> <p>Valid node types are as follows:</p> <ul> <li> <p>General purpose:</p> <ul> <li> <p>Current generation: <code>cache.t2.micro</code>, <code>cache.t2.small</code>, <code>cache.t2.medium</code>, <code>cache.m3.medium</code>, <code>cache.m3.large</code>, <code>cache.m3.xlarge</code>, <code>cache.m3.2xlarge</code>, <code>cache.m4.large</code>, <code>cache.m4.xlarge</code>, <code>cache.m4.2xlarge</code>, <code>cache.m4.4xlarge</code>, <code>cache.m4.10xlarge</code> </p> </li> <li> <p>Previous generation: <code>cache.t1.micro</code>, <code>cache.m1.small</code>, <code>cache.m1.medium</code>, <code>cache.m1.large</code>, <code>cache.m1.xlarge</code> </p> </li> </ul> </li> <li> <p>Compute optimized: <code>cache.c1.xlarge</code> </p> </li> <li> <p>Memory optimized:</p> <ul> <li> <p>Current generation: <code>cache.r3.large</code>, <code>cache.r3.xlarge</code>, <code>cache.r3.2xlarge</code>, <code>cache.r3.4xlarge</code>, <code>cache.r3.8xlarge</code> </p> </li> <li> <p>Previous generation: <code>cache.m2.xlarge</code>, <code>cache.m2.2xlarge</code>, <code>cache.m2.4xlarge</code> </p> </li> </ul> </li> </ul> <p> <b>Notes:</b> </p> <ul> <li> <p>All T2 instances are created in an Amazon Virtual Private Cloud (Amazon VPC).</p> </li> <li> <p>Redis backup/restore is not supported for Redis (cluster mode disabled) T1 and T2 instances. Backup/restore is supported on Redis (cluster mode enabled) T2 instances.</p> </li> <li> <p>Redis Append-only files (AOF) functionality is not supported for T1 or T2 instances.</p> </li> </ul> <p>For a complete listing of node types and specifications, see <a href=\"http://aws.amazon.com/elasticache/details\">Amazon ElastiCache Product Features and Details</a> and either <a href=\"http://docs.aws.amazon.com/AmazonElastiCache/latest/UserGuide/CacheParameterGroups.Memcached.html#ParameterGroups.Memcached.NodeSpecific\">Cache Node Type-Specific Parameters for Memcached</a> or <a href=\"http://docs.aws.amazon.com/AmazonElastiCache/latest/UserGuide/CacheParameterGroups.Redis.html#ParameterGroups.Redis.NodeSpecific\">Cache Node Type-Specific Parameters for Redis</a>.</p>",
         "ReservedCacheNodesOffering$ProductDescription": "<p>The cache engine used by the offering.</p>",
         "ReservedCacheNodesOffering$OfferingType": "<p>The offering type.</p>",
         "ReservedCacheNodesOfferingMessage$Marker": "<p>Provides an identifier to allow retrieval of paginated results.</p>",
@@ -1328,15 +1363,17 @@
         "SecurityGroupIdsList$member": null,
         "SecurityGroupMembership$SecurityGroupId": "<p>The identifier of the cache security group.</p>",
         "SecurityGroupMembership$Status": "<p>The status of the cache security group membership. The status changes whenever a cache security group is modified, or when the cache security groups assigned to a cache cluster are modified.</p>",
-        "Snapshot$SnapshotName": "<p>The name of a snapshot. For an automatic snapshot, the name is system-generated; for a manual snapshot, this is the user-provided name.</p>",
+        "Snapshot$SnapshotName": "<p>The name of a snapshot. For an automatic snapshot, the name is system-generated. For a manual snapshot, this is the user-provided name.</p>",
+        "Snapshot$ReplicationGroupId": "<p>The unique identifier of the source replication group.</p>",
+        "Snapshot$ReplicationGroupDescription": "<p>A description of the source replication group.</p>",
         "Snapshot$CacheClusterId": "<p>The user-supplied identifier of the source cache cluster.</p>",
         "Snapshot$SnapshotStatus": "<p>The status of the snapshot. Valid values: <code>creating</code> | <code>available</code> | <code>restoring</code> | <code>copying</code> | <code>deleting</code>.</p>",
         "Snapshot$SnapshotSource": "<p>Indicates whether the snapshot is from an automatic backup (<code>automated</code>) or was created manually (<code>manual</code>).</p>",
-        "Snapshot$CacheNodeType": "<p>The name of the compute and memory capacity node type for the source cache cluster.</p> <p>Valid node types are as follows:</p> <ul> <li> <p>General purpose:</p> <ul> <li> <p>Current generation: <code>cache.t2.micro</code>, <code>cache.t2.small</code>, <code>cache.t2.medium</code>, <code>cache.m3.medium</code>, <code>cache.m3.large</code>, <code>cache.m3.xlarge</code>, <code>cache.m3.2xlarge</code> </p> </li> <li> <p>Previous generation: <code>cache.t1.micro</code>, <code>cache.m1.small</code>, <code>cache.m1.medium</code>, <code>cache.m1.large</code>, <code>cache.m1.xlarge</code> </p> </li> </ul> </li> <li> <p>Compute optimized: <code>cache.c1.xlarge</code> </p> </li> <li> <p>Memory optimized:</p> <ul> <li> <p>Current generation: <code>cache.r3.large</code>, <code>cache.r3.xlarge</code>, <code>cache.r3.2xlarge</code>, <code>cache.r3.4xlarge</code>, <code>cache.r3.8xlarge</code> </p> </li> <li> <p>Previous generation: <code>cache.m2.xlarge</code>, <code>cache.m2.2xlarge</code>, <code>cache.m2.4xlarge</code> </p> </li> </ul> </li> </ul> <p> <b>Notes:</b> </p> <ul> <li> <p>All t2 instances are created in an Amazon Virtual Private Cloud (VPC).</p> </li> <li> <p>Redis backup/restore is not supported for t2 instances.</p> </li> <li> <p>Redis Append-only files (AOF) functionality is not supported for t1 or t2 instances.</p> </li> </ul> <p>For a complete listing of cache node types and specifications, see <a href=\"http://aws.amazon.com/elasticache/details\">Amazon ElastiCache Product Features and Details</a> and <a href=\"http://docs.aws.amazon.com/AmazonElastiCache/latest/UserGuide/CacheParameterGroups.Memcached.html#CacheParameterGroups.Memcached.NodeSpecific\">Cache Node Type-Specific Parameters for Memcached</a> or <a href=\"http://docs.aws.amazon.com/AmazonElastiCache/latest/UserGuide/CacheParameterGroups.Redis.html#CacheParameterGroups.Redis.NodeSpecific\">Cache Node Type-Specific Parameters for Redis</a>.</p>",
-        "Snapshot$Engine": "<p>The name of the cache engine (<i>memcached</i> or <i>redis</i>) used by the source cache cluster.</p>",
+        "Snapshot$CacheNodeType": "<p>The name of the compute and memory capacity node type for the source cache cluster.</p> <p>Valid node types are as follows:</p> <ul> <li> <p>General purpose:</p> <ul> <li> <p>Current generation: <code>cache.t2.micro</code>, <code>cache.t2.small</code>, <code>cache.t2.medium</code>, <code>cache.m3.medium</code>, <code>cache.m3.large</code>, <code>cache.m3.xlarge</code>, <code>cache.m3.2xlarge</code>, <code>cache.m4.large</code>, <code>cache.m4.xlarge</code>, <code>cache.m4.2xlarge</code>, <code>cache.m4.4xlarge</code>, <code>cache.m4.10xlarge</code> </p> </li> <li> <p>Previous generation: <code>cache.t1.micro</code>, <code>cache.m1.small</code>, <code>cache.m1.medium</code>, <code>cache.m1.large</code>, <code>cache.m1.xlarge</code> </p> </li> </ul> </li> <li> <p>Compute optimized: <code>cache.c1.xlarge</code> </p> </li> <li> <p>Memory optimized:</p> <ul> <li> <p>Current generation: <code>cache.r3.large</code>, <code>cache.r3.xlarge</code>, <code>cache.r3.2xlarge</code>, <code>cache.r3.4xlarge</code>, <code>cache.r3.8xlarge</code> </p> </li> <li> <p>Previous generation: <code>cache.m2.xlarge</code>, <code>cache.m2.2xlarge</code>, <code>cache.m2.4xlarge</code> </p> </li> </ul> </li> </ul> <p> <b>Notes:</b> </p> <ul> <li> <p>All T2 instances are created in an Amazon Virtual Private Cloud (Amazon VPC).</p> </li> <li> <p>Redis backup/restore is not supported for Redis (cluster mode disabled) T1 and T2 instances. Backup/restore is supported on Redis (cluster mode enabled) T2 instances.</p> </li> <li> <p>Redis Append-only files (AOF) functionality is not supported for T1 or T2 instances.</p> </li> </ul> <p>For a complete listing of node types and specifications, see <a href=\"http://aws.amazon.com/elasticache/details\">Amazon ElastiCache Product Features and Details</a> and either <a href=\"http://docs.aws.amazon.com/AmazonElastiCache/latest/UserGuide/CacheParameterGroups.Memcached.html#ParameterGroups.Memcached.NodeSpecific\">Cache Node Type-Specific Parameters for Memcached</a> or <a href=\"http://docs.aws.amazon.com/AmazonElastiCache/latest/UserGuide/CacheParameterGroups.Redis.html#ParameterGroups.Redis.NodeSpecific\">Cache Node Type-Specific Parameters for Redis</a>.</p>",
+        "Snapshot$Engine": "<p>The name of the cache engine (<code>memcached</code> or <code>redis</code>) used by the source cache cluster.</p>",
         "Snapshot$EngineVersion": "<p>The version of the cache engine version that is used by the source cache cluster.</p>",
         "Snapshot$PreferredAvailabilityZone": "<p>The name of the Availability Zone in which the source cache cluster is located.</p>",
-        "Snapshot$PreferredMaintenanceWindow": "<p>Specifies the weekly time range during which maintenance on the cache cluster is performed. It is specified as a range in the format ddd:hh24:mi-ddd:hh24:mi (24H Clock UTC). The minimum maintenance window is a 60 minute period. Valid values for <code>ddd</code> are:</p> <ul> <li> <p> <code>sun</code> </p> </li> <li> <p> <code>mon</code> </p> </li> <li> <p> <code>tue</code> </p> </li> <li> <p> <code>wed</code> </p> </li> <li> <p> <code>thu</code> </p> </li> <li> <p> <code>fri</code> </p> </li> <li> <p> <code>sat</code> </p> </li> </ul> <p>Example: <code>sun:05:00-sun:09:00</code> </p>",
+        "Snapshot$PreferredMaintenanceWindow": "<p>Specifies the weekly time range during which maintenance on the cluster is performed. It is specified as a range in the format ddd:hh24:mi-ddd:hh24:mi (24H Clock UTC). The minimum maintenance window is a 60 minute period.</p> <p>Valid values for <code>ddd</code> are:</p> <ul> <li> <p> <code>sun</code> </p> </li> <li> <p> <code>mon</code> </p> </li> <li> <p> <code>tue</code> </p> </li> <li> <p> <code>wed</code> </p> </li> <li> <p> <code>thu</code> </p> </li> <li> <p> <code>fri</code> </p> </li> <li> <p> <code>sat</code> </p> </li> </ul> <p>Example: <code>sun:23:00-mon:01:30</code> </p>",
         "Snapshot$TopicArn": "<p>The Amazon Resource Name (ARN) for the topic used by the source cache cluster for publishing notifications.</p>",
         "Snapshot$CacheParameterGroupName": "<p>The cache parameter group that is associated with the source cache cluster.</p>",
         "Snapshot$CacheSubnetGroupName": "<p>The name of the cache subnet group associated with the source cache cluster.</p>",
@@ -1403,7 +1440,7 @@
       }
     },
     "TagListMessage": {
-      "base": "<p>Represents the output from the <i>AddTagsToResource</i>, <i>ListTagsOnResource</i>, and <i>RemoveTagsFromResource</i> actions.</p>",
+      "base": "<p>Represents the output from the <code>AddTagsToResource</code>, <code>ListTagsOnResource</code>, and <code>RemoveTagsFromResource</code> operations.</p>",
       "refs": {
       }
     },

--- a/service/dynamodb/dynamodbattribute/tag_test.go
+++ b/service/dynamodb/dynamodbattribute/tag_test.go
@@ -30,8 +30,8 @@ func TestTagParse(t *testing.T) {
 		{`dynamodbav:",binaryset"`, false, true, tag{AsBinSet: true}},
 		{`dynamodbav:",numberset"`, false, true, tag{AsNumSet: true}},
 		{`dynamodbav:",stringset"`, false, true, tag{AsStrSet: true}},
-		{`dynamodbav:",stringset,omitemptyelem"`, false, true, tag{AsStrSet: true,OmitEmptyElem:true}},
-		{`dynamodbav:"name,stringset,omitemptyelem"`, false, true, tag{Name: "name",AsStrSet: true,OmitEmptyElem: true}},
+		{`dynamodbav:",stringset,omitemptyelem"`, false, true, tag{AsStrSet: true, OmitEmptyElem: true}},
+		{`dynamodbav:"name,stringset,omitemptyelem"`, false, true, tag{Name: "name", AsStrSet: true, OmitEmptyElem: true}},
 	}
 
 	for i, c := range cases {

--- a/service/ecr/api.go
+++ b/service/ecr/api.go
@@ -556,6 +556,87 @@ func (c *ECR) DeleteRepositoryPolicy(input *DeleteRepositoryPolicyInput) (*Delet
 	return out, err
 }
 
+const opDescribeImages = "DescribeImages"
+
+// DescribeImagesRequest generates a "aws/request.Request" representing the
+// client's request for the DescribeImages operation. The "output" return
+// value can be used to capture response data after the request's "Send" method
+// is called.
+//
+// See DescribeImages for usage and error information.
+//
+// Creating a request object using this method should be used when you want to inject
+// custom logic into the request's lifecycle using a custom handler, or if you want to
+// access properties on the request object before or after sending the request. If
+// you just want the service response, call the DescribeImages method directly
+// instead.
+//
+// Note: You must call the "Send" method on the returned request object in order
+// to execute the request.
+//
+//    // Example sending a request using the DescribeImagesRequest method.
+//    req, resp := client.DescribeImagesRequest(params)
+//
+//    err := req.Send()
+//    if err == nil { // resp is now filled
+//        fmt.Println(resp)
+//    }
+//
+func (c *ECR) DescribeImagesRequest(input *DescribeImagesInput) (req *request.Request, output *DescribeImagesOutput) {
+	op := &request.Operation{
+		Name:       opDescribeImages,
+		HTTPMethod: "POST",
+		HTTPPath:   "/",
+	}
+
+	if input == nil {
+		input = &DescribeImagesInput{}
+	}
+
+	req = c.newRequest(op, input, output)
+	output = &DescribeImagesOutput{}
+	req.Data = output
+	return
+}
+
+// DescribeImages API operation for Amazon EC2 Container Registry.
+//
+// Returns metadata about the images in a repository, including image size and
+// creation date.
+//
+//  Beginning with Docker version 1.9, the Docker client compresses image layers
+// before pushing them to a V2 Docker registry. The output of the docker images
+// command shows the uncompressed image size, so it may return a larger image
+// size than the image sizes returned by DescribeImages.
+//
+// Returns awserr.Error for service API and SDK errors. Use runtime type assertions
+// with awserr.Error's Code and Message methods to get detailed information about
+// the error.
+//
+// See the AWS API reference guide for Amazon EC2 Container Registry's
+// API operation DescribeImages for usage and error information.
+//
+// Returned Error Codes:
+//   * ServerException
+//   These errors are usually caused by a server-side issue.
+//
+//   * InvalidParameterException
+//   The specified parameter is invalid. Review the available parameters for the
+//   API request.
+//
+//   * RepositoryNotFoundException
+//   The specified repository could not be found. Check the spelling of the specified
+//   repository and ensure that you are performing operations on the correct registry.
+//
+//   * ImageNotFoundException
+//   The image requested does not exist in the specified repository.
+//
+func (c *ECR) DescribeImages(input *DescribeImagesInput) (*DescribeImagesOutput, error) {
+	req, out := c.DescribeImagesRequest(input)
+	err := req.Send()
+	return out, err
+}
+
 const opDescribeRepositories = "DescribeRepositories"
 
 // DescribeRepositoriesRequest generates a "aws/request.Request" representing the
@@ -1635,7 +1716,7 @@ func (s *CreateRepositoryInput) Validate() error {
 type CreateRepositoryOutput struct {
 	_ struct{} `type:"structure"`
 
-	// An object representing a repository.
+	// The repository that was created.
 	Repository *Repository `locationName:"repository" type:"structure"`
 }
 
@@ -1694,7 +1775,7 @@ func (s *DeleteRepositoryInput) Validate() error {
 type DeleteRepositoryOutput struct {
 	_ struct{} `type:"structure"`
 
-	// An object representing a repository.
+	// The repository that was deleted.
 	Repository *Repository `locationName:"repository" type:"structure"`
 }
 
@@ -1769,6 +1850,116 @@ func (s DeleteRepositoryPolicyOutput) String() string {
 
 // GoString returns the string representation
 func (s DeleteRepositoryPolicyOutput) GoString() string {
+	return s.String()
+}
+
+// An object representing a filter on a DescribeImages operation.
+type DescribeImagesFilter struct {
+	_ struct{} `type:"structure"`
+
+	// The tag status with which to filter your DescribeImages results. You can
+	// filter results based on whether they are TAGGED or UNTAGGED.
+	TagStatus *string `locationName:"tagStatus" type:"string" enum:"TagStatus"`
+}
+
+// String returns the string representation
+func (s DescribeImagesFilter) String() string {
+	return awsutil.Prettify(s)
+}
+
+// GoString returns the string representation
+func (s DescribeImagesFilter) GoString() string {
+	return s.String()
+}
+
+type DescribeImagesInput struct {
+	_ struct{} `type:"structure"`
+
+	// The filter key and value with which to filter your DescribeImages results.
+	Filter *DescribeImagesFilter `locationName:"filter" type:"structure"`
+
+	// The list of image IDs for the requested repository.
+	ImageIds []*ImageIdentifier `locationName:"imageIds" min:"1" type:"list"`
+
+	// The maximum number of repository results returned by DescribeImages in paginated
+	// output. When this parameter is used, DescribeImages only returns maxResults
+	// results in a single page along with a nextToken response element. The remaining
+	// results of the initial request can be seen by sending another DescribeImages
+	// request with the returned nextToken value. This value can be between 1 and
+	// 100. If this parameter is not used, then DescribeImages returns up to 100
+	// results and a nextToken value, if applicable.
+	MaxResults *int64 `locationName:"maxResults" min:"1" type:"integer"`
+
+	// The nextToken value returned from a previous paginated DescribeImages request
+	// where maxResults was used and the results exceeded the value of that parameter.
+	// Pagination continues from the end of the previous results that returned the
+	// nextToken value. This value is null when there are no more results to return.
+	NextToken *string `locationName:"nextToken" type:"string"`
+
+	// The AWS account ID associated with the registry that contains the repository
+	// in which to list images. If you do not specify a registry, the default registry
+	// is assumed.
+	RegistryId *string `locationName:"registryId" type:"string"`
+
+	// A list of repositories to describe. If this parameter is omitted, then all
+	// repositories in a registry are described.
+	//
+	// RepositoryName is a required field
+	RepositoryName *string `locationName:"repositoryName" min:"2" type:"string" required:"true"`
+}
+
+// String returns the string representation
+func (s DescribeImagesInput) String() string {
+	return awsutil.Prettify(s)
+}
+
+// GoString returns the string representation
+func (s DescribeImagesInput) GoString() string {
+	return s.String()
+}
+
+// Validate inspects the fields of the type to determine if they are valid.
+func (s *DescribeImagesInput) Validate() error {
+	invalidParams := request.ErrInvalidParams{Context: "DescribeImagesInput"}
+	if s.ImageIds != nil && len(s.ImageIds) < 1 {
+		invalidParams.Add(request.NewErrParamMinLen("ImageIds", 1))
+	}
+	if s.MaxResults != nil && *s.MaxResults < 1 {
+		invalidParams.Add(request.NewErrParamMinValue("MaxResults", 1))
+	}
+	if s.RepositoryName == nil {
+		invalidParams.Add(request.NewErrParamRequired("RepositoryName"))
+	}
+	if s.RepositoryName != nil && len(*s.RepositoryName) < 2 {
+		invalidParams.Add(request.NewErrParamMinLen("RepositoryName", 2))
+	}
+
+	if invalidParams.Len() > 0 {
+		return invalidParams
+	}
+	return nil
+}
+
+type DescribeImagesOutput struct {
+	_ struct{} `type:"structure"`
+
+	// A list of ImageDetail objects that contain data about the image.
+	ImageDetails []*ImageDetail `locationName:"imageDetails" type:"list"`
+
+	// The nextToken value to include in a future DescribeImages request. When the
+	// results of a DescribeImages request exceed maxResults, this value can be
+	// used to retrieve the next page of results. This value is null when there
+	// are no more results to return.
+	NextToken *string `locationName:"nextToken" type:"string"`
+}
+
+// String returns the string representation
+func (s DescribeImagesOutput) String() string {
+	return awsutil.Prettify(s)
+}
+
+// GoString returns the string representation
+func (s DescribeImagesOutput) GoString() string {
 	return s.String()
 }
 
@@ -2056,6 +2247,45 @@ func (s Image) String() string {
 
 // GoString returns the string representation
 func (s Image) GoString() string {
+	return s.String()
+}
+
+// An object that describes an image returned by a DescribeImages operation.
+type ImageDetail struct {
+	_ struct{} `type:"structure"`
+
+	// The sha256 digest of the image manifest.
+	ImageDigest *string `locationName:"imageDigest" type:"string"`
+
+	// The date and time, expressed in standard JavaScript date format, at which
+	// the current image was pushed to the repository.
+	ImagePushedAt *time.Time `locationName:"imagePushedAt" type:"timestamp" timestampFormat:"unix"`
+
+	// The size, in bytes, of the image in the repository.
+	//
+	//  Beginning with Docker version 1.9, the Docker client compresses image layers
+	// before pushing them to a V2 Docker registry. The output of the docker images
+	// command shows the uncompressed image size, so it may return a larger image
+	// size than the image sizes returned by DescribeImages.
+	ImageSizeInBytes *int64 `locationName:"imageSizeInBytes" type:"long"`
+
+	// The list of tags associated with this image.
+	ImageTags []*string `locationName:"imageTags" type:"list"`
+
+	// The AWS account ID associated with the registry to which this image belongs.
+	RegistryId *string `locationName:"registryId" type:"string"`
+
+	// The name of the repository to which this image belongs.
+	RepositoryName *string `locationName:"repositoryName" min:"2" type:"string"`
+}
+
+// String returns the string representation
+func (s ImageDetail) String() string {
+	return awsutil.Prettify(s)
+}
+
+// GoString returns the string representation
+func (s ImageDetail) GoString() string {
 	return s.String()
 }
 
@@ -2388,6 +2618,10 @@ func (s PutImageOutput) GoString() string {
 // An object representing a repository.
 type Repository struct {
 	_ struct{} `type:"structure"`
+
+	// The date and time, in JavaScript date/time format, when the repository was
+	// created.
+	CreatedAt *time.Time `locationName:"createdAt" type:"timestamp" timestampFormat:"unix"`
 
 	// The AWS account ID associated with the registry that contains the repository.
 	RegistryId *string `locationName:"registryId" type:"string"`

--- a/service/ecr/ecriface/interface.go
+++ b/service/ecr/ecriface/interface.go
@@ -87,6 +87,10 @@ type ECRAPI interface {
 
 	DeleteRepositoryPolicy(*ecr.DeleteRepositoryPolicyInput) (*ecr.DeleteRepositoryPolicyOutput, error)
 
+	DescribeImagesRequest(*ecr.DescribeImagesInput) (*request.Request, *ecr.DescribeImagesOutput)
+
+	DescribeImages(*ecr.DescribeImagesInput) (*ecr.DescribeImagesOutput, error)
+
 	DescribeRepositoriesRequest(*ecr.DescribeRepositoriesInput) (*request.Request, *ecr.DescribeRepositoriesOutput)
 
 	DescribeRepositories(*ecr.DescribeRepositoriesInput) (*ecr.DescribeRepositoriesOutput, error)

--- a/service/ecr/examples_test.go
+++ b/service/ecr/examples_test.go
@@ -220,6 +220,44 @@ func ExampleECR_DeleteRepositoryPolicy() {
 	fmt.Println(resp)
 }
 
+func ExampleECR_DescribeImages() {
+	sess, err := session.NewSession()
+	if err != nil {
+		fmt.Println("failed to create session,", err)
+		return
+	}
+
+	svc := ecr.New(sess)
+
+	params := &ecr.DescribeImagesInput{
+		RepositoryName: aws.String("RepositoryName"), // Required
+		Filter: &ecr.DescribeImagesFilter{
+			TagStatus: aws.String("TagStatus"),
+		},
+		ImageIds: []*ecr.ImageIdentifier{
+			{ // Required
+				ImageDigest: aws.String("ImageDigest"),
+				ImageTag:    aws.String("ImageTag"),
+			},
+			// More values...
+		},
+		MaxResults: aws.Int64(1),
+		NextToken:  aws.String("NextToken"),
+		RegistryId: aws.String("RegistryId"),
+	}
+	resp, err := svc.DescribeImages(params)
+
+	if err != nil {
+		// Print the error, cast err to awserr.Error to get the Code and
+		// Message from an error.
+		fmt.Println(err.Error())
+		return
+	}
+
+	// Pretty-print the response data.
+	fmt.Println(resp)
+}
+
 func ExampleECR_DescribeRepositories() {
 	sess, err := session.NewSession()
 	if err != nil {

--- a/service/elasticache/api.go
+++ b/service/elasticache/api.go
@@ -57,10 +57,9 @@ func (c *ElastiCache) AddTagsToResourceRequest(input *AddTagsToResourceInput) (r
 
 // AddTagsToResource API operation for Amazon ElastiCache.
 //
-// The AddTagsToResource action adds up to 10 cost allocation tags to the named
-// resource. A cost allocation tag is a key-value pair where the key and value
-// are case-sensitive. Cost allocation tags can be used to categorize and track
-// your AWS costs.
+// Adds up to 10 cost allocation tags to the named resource. A cost allocation
+// tag is a key-value pair where the key and value are case-sensitive. You can
+// use cost allocation tags to categorize and track your AWS costs.
 //
 //  When you apply tags to your ElastiCache resources, AWS generates a cost
 // allocation report as a comma-separated value (CSV) file with your usage and
@@ -143,9 +142,9 @@ func (c *ElastiCache) AuthorizeCacheSecurityGroupIngressRequest(input *Authorize
 
 // AuthorizeCacheSecurityGroupIngress API operation for Amazon ElastiCache.
 //
-// The AuthorizeCacheSecurityGroupIngress action allows network ingress to a
-// cache security group. Applications using ElastiCache must be running on Amazon
-// EC2, and Amazon EC2 security groups are used as the authorization mechanism.
+// Allows network ingress to a cache security group. Applications using ElastiCache
+// must be running on Amazon EC2, and Amazon EC2 security groups are used as
+// the authorization mechanism.
 //
 //  You cannot authorize ingress from an Amazon EC2 security group in one region
 // to an ElastiCache cluster in another region.
@@ -226,19 +225,68 @@ func (c *ElastiCache) CopySnapshotRequest(input *CopySnapshotInput) (req *reques
 
 // CopySnapshot API operation for Amazon ElastiCache.
 //
-// The CopySnapshot action makes a copy of an existing snapshot.
+// Makes a copy of an existing snapshot.
 //
-//  Users or groups that have permissions to use the CopySnapshot API can create
-// their own Amazon S3 buckets and copy snapshots to it. To control access to
-// your snapshots, use an IAM policy to control who has the ability to use the
-// CopySnapshot API. For more information about using IAM to control the use
-// of ElastiCache APIs, see Exporting Snapshots (http://docs.aws.amazon.com/ElastiCache/latest/Snapshots.Exporting.html)
-// and Authentication & Access Control (http://docs.aws.amazon.com/ElastiCache/latest/IAM.html).
+//  This operation is valid for Redis only.
 //
-//   Erorr Message:     Error Message: The authenticated user does not have
-// sufficient permissions to perform the desired activity.
+//   Users or groups that have permissions to use the CopySnapshot operation
+// can create their own Amazon S3 buckets and copy snapshots to it. To control
+// access to your snapshots, use an IAM policy to control who has the ability
+// to use the CopySnapshot operation. For more information about using IAM to
+// control the use of ElastiCache operations, see Exporting Snapshots (http://docs.aws.amazon.com/AmazonElastiCache/latest/UserGuide/Snapshots.Exporting.html)
+// and Authentication & Access Control (http://docs.aws.amazon.com/AmazonElastiCache/latest/UserGuide/IAM.html).
+//
+//  You could receive the following error messages.
+//
+//  Error Messages     Error Message: The S3 bucket %s is outside of the region.
+//
+//  Solution: Create an Amazon S3 bucket in the same region as your snapshot.
+// For more information, see Step 1: Create an Amazon S3 Bucket (http://docs.aws.amazon.com/AmazonElastiCache/latest/UserGuide/Snapshots.Exporting.html#Snapshots.Exporting.CreateBucket)
+// in the ElastiCache User Guide.
+//
+//    Error Message: The S3 bucket %s does not exist.
+//
+//  Solution: Create an Amazon S3 bucket in the same region as your snapshot.
+// For more information, see Step 1: Create an Amazon S3 Bucket (http://docs.aws.amazon.com/AmazonElastiCache/latest/UserGuide/Snapshots.Exporting.html#Snapshots.Exporting.CreateBucket)
+// in the ElastiCache User Guide.
+//
+//    Error Message: The S3 bucket %s is not owned by the authenticated user.
+//
+//  Solution: Create an Amazon S3 bucket in the same region as your snapshot.
+// For more information, see Step 1: Create an Amazon S3 Bucket (http://docs.aws.amazon.com/AmazonElastiCache/latest/UserGuide/Snapshots.Exporting.html#Snapshots.Exporting.CreateBucket)
+// in the ElastiCache User Guide.
+//
+//    Error Message: The authenticated user does not have sufficient permissions
+// to perform the desired activity.
 //
 //  Solution: Contact your system administrator to get the needed permissions.
+//
+//    Error Message: The S3 bucket %s already contains an object with key %s.
+//
+//  Solution: Give the TargetSnapshotName a new and unique value. If exporting
+// a snapshot, you could alternatively create a new Amazon S3 bucket and use
+// this same value for TargetSnapshotName.
+//
+//    Error Message:  ElastiCache has not been granted READ permissions %s
+// on the S3 Bucket.
+//
+//  Solution: Add List and Read permissions on the bucket. For more information,
+// see Step 2: Grant ElastiCache Access to Your Amazon S3 Bucket (http://docs.aws.amazon.com/AmazonElastiCache/latest/UserGuide/Snapshots.Exporting.html#Snapshots.Exporting.GrantAccess)
+// in the ElastiCache User Guide.
+//
+//    Error Message:  ElastiCache has not been granted WRITE permissions %s
+// on the S3 Bucket.
+//
+//  Solution: Add Upload/Delete permissions on the bucket. For more information,
+// see Step 2: Grant ElastiCache Access to Your Amazon S3 Bucket (http://docs.aws.amazon.com/AmazonElastiCache/latest/UserGuide/Snapshots.Exporting.html#Snapshots.Exporting.GrantAccess)
+// in the ElastiCache User Guide.
+//
+//    Error Message:  ElastiCache has not been granted READ_ACP permissions
+// %s on the S3 Bucket.
+//
+//  Solution: Add View Permissions on the bucket. For more information, see
+// Step 2: Grant ElastiCache Access to Your Amazon S3 Bucket (http://docs.aws.amazon.com/AmazonElastiCache/latest/UserGuide/Snapshots.Exporting.html#Snapshots.Exporting.GrantAccess)
+// in the ElastiCache User Guide.
 //
 // Returns awserr.Error for service API and SDK errors. Use runtime type assertions
 // with awserr.Error's Code and Message methods to get detailed information about
@@ -259,8 +307,8 @@ func (c *ElastiCache) CopySnapshotRequest(input *CopySnapshotInput) (req *reques
 //   of snapshots.
 //
 //   * InvalidSnapshotState
-//   The current state of the snapshot does not allow the requested action to
-//   occur.
+//   The current state of the snapshot does not allow the requested operation
+//   to occur.
 //
 //   * InvalidParameterValue
 //   The value for a parameter is invalid.
@@ -319,9 +367,12 @@ func (c *ElastiCache) CreateCacheClusterRequest(input *CreateCacheClusterInput) 
 
 // CreateCacheCluster API operation for Amazon ElastiCache.
 //
-// The CreateCacheCluster action creates a cache cluster. All nodes in the cache
-// cluster run the same protocol-compliant cache engine software, either Memcached
-// or Redis.
+// Creates a cache cluster. All nodes in the cache cluster run the same protocol-compliant
+// cache engine software, either Memcached or Redis.
+//
+//  Due to current limitations on Redis (cluster mode disabled), this operation
+// or parameter is not supported on Redis (cluster mode enabled) replication
+// groups.
 //
 // Returns awserr.Error for service API and SDK errors. Use runtime type assertions
 // with awserr.Error's Code and Message methods to get detailed information about
@@ -433,9 +484,8 @@ func (c *ElastiCache) CreateCacheParameterGroupRequest(input *CreateCacheParamet
 
 // CreateCacheParameterGroup API operation for Amazon ElastiCache.
 //
-// The CreateCacheParameterGroup action creates a new cache parameter group.
-// A cache parameter group is a collection of parameters that you apply to all
-// of the nodes in a cache cluster.
+// Creates a new cache parameter group. A cache parameter group is a collection
+// of parameters that you apply to all of the nodes in a cache cluster.
 //
 // Returns awserr.Error for service API and SDK errors. Use runtime type assertions
 // with awserr.Error's Code and Message methods to get detailed information about
@@ -454,7 +504,7 @@ func (c *ElastiCache) CreateCacheParameterGroupRequest(input *CreateCacheParamet
 //
 //   * InvalidCacheParameterGroupState
 //   The current state of the cache parameter group does not allow the requested
-//   action to occur.
+//   operation to occur.
 //
 //   * InvalidParameterValue
 //   The value for a parameter is invalid.
@@ -513,13 +563,13 @@ func (c *ElastiCache) CreateCacheSecurityGroupRequest(input *CreateCacheSecurity
 
 // CreateCacheSecurityGroup API operation for Amazon ElastiCache.
 //
-// The CreateCacheSecurityGroup action creates a new cache security group. Use
-// a cache security group to control access to one or more cache clusters.
+// Creates a new cache security group. Use a cache security group to control
+// access to one or more cache clusters.
 //
 // Cache security groups are only used when you are creating a cache cluster
-// outside of an Amazon Virtual Private Cloud (VPC). If you are creating a cache
-// cluster inside of a VPC, use a cache subnet group instead. For more information,
-// see CreateCacheSubnetGroup (http://docs.aws.amazon.com/AmazonElastiCache/latest/APIReference/API_CreateCacheSubnetGroup.html).
+// outside of an Amazon Virtual Private Cloud (Amazon VPC). If you are creating
+// a cache cluster inside of a VPC, use a cache subnet group instead. For more
+// information, see CreateCacheSubnetGroup (http://docs.aws.amazon.com/AmazonElastiCache/latest/APIReference/API_CreateCacheSubnetGroup.html).
 //
 // Returns awserr.Error for service API and SDK errors. Use runtime type assertions
 // with awserr.Error's Code and Message methods to get detailed information about
@@ -593,10 +643,10 @@ func (c *ElastiCache) CreateCacheSubnetGroupRequest(input *CreateCacheSubnetGrou
 
 // CreateCacheSubnetGroup API operation for Amazon ElastiCache.
 //
-// The CreateCacheSubnetGroup action creates a new cache subnet group.
+// Creates a new cache subnet group.
 //
 // Use this parameter only when you are creating a cluster in an Amazon Virtual
-// Private Cloud (VPC).
+// Private Cloud (Amazon VPC).
 //
 // Returns awserr.Error for service API and SDK errors. Use runtime type assertions
 // with awserr.Error's Code and Message methods to get detailed information about
@@ -672,17 +722,26 @@ func (c *ElastiCache) CreateReplicationGroupRequest(input *CreateReplicationGrou
 
 // CreateReplicationGroup API operation for Amazon ElastiCache.
 //
-// The CreateReplicationGroup action creates a replication group. A replication
-// group is a collection of cache clusters, where one of the cache clusters
-// is a read/write primary and the others are read-only replicas. Writes to
-// the primary are automatically propagated to the replicas.
+// Creates a Redis (cluster mode disabled) or a Redis (cluster mode enabled)
+// replication group.
 //
-// When you create a replication group, you must specify an existing cache
-// cluster that is in the primary role. When the replication group has been
-// successfully created, you can add one or more read replica replicas to it,
-// up to a total of five read replicas.
+// A Redis (cluster mode disabled) replication group is a collection of cache
+// clusters, where one of the cache clusters is a read/write primary and the
+// others are read-only replicas. Writes to the primary are asynchronously propagated
+// to the replicas.
 //
-//  This action is valid only for Redis.
+// A Redis (cluster mode enabled) replication group is a collection of 1 to
+// 15 node groups (shards). Each node group (shard) has one read/write primary
+// node and up to 5 read-only replica nodes. Writes to the primary are asynchronously
+// propagated to the replicas. Redis (cluster mode enabled) replication groups
+// partition the data across node groups (shards).
+//
+// When a Redis (cluster mode disabled) replication group has been successfully
+// created, you can add one or more read replicas to it, up to a total of 5
+// read replicas. You cannot alter a Redis (cluster mode enabled) replication
+// group once it has been created.
+//
+//  This operation is valid for Redis only.
 //
 // Returns awserr.Error for service API and SDK errors. Use runtime type assertions
 // with awserr.Error's Code and Message methods to get detailed information about
@@ -736,6 +795,10 @@ func (c *ElastiCache) CreateReplicationGroupRequest(input *CreateReplicationGrou
 //   The request cannot be processed because it would cause the resource to have
 //   more than the allowed number of tags. The maximum number of tags permitted
 //   on a resource is 10.
+//
+//   * NodeGroupsPerReplicationGroupQuotaExceeded
+//   The request cannot be processed because it would exceed the maximum of 15
+//   node groups (shards) in a single replication group.
 //
 //   * InvalidParameterValue
 //   The value for a parameter is invalid.
@@ -794,8 +857,10 @@ func (c *ElastiCache) CreateSnapshotRequest(input *CreateSnapshotInput) (req *re
 
 // CreateSnapshot API operation for Amazon ElastiCache.
 //
-// The CreateSnapshot action creates a copy of an entire cache cluster at a
-// specific moment in time.
+// Creates a copy of an entire cache cluster or replication group at a specific
+// moment in time.
+//
+//  This operation is valid for Redis only.
 //
 // Returns awserr.Error for service API and SDK errors. Use runtime type assertions
 // with awserr.Error's Code and Message methods to get detailed information about
@@ -811,18 +876,24 @@ func (c *ElastiCache) CreateSnapshotRequest(input *CreateSnapshotInput) (req *re
 //   * CacheClusterNotFound
 //   The requested cache cluster ID does not refer to an existing cache cluster.
 //
+//   * ReplicationGroupNotFoundFault
+//   The specified replication group does not exist.
+//
 //   * InvalidCacheClusterState
 //   The requested cache cluster is not in the available state.
+//
+//   * InvalidReplicationGroupState
+//   The requested replication group is not in the available state.
 //
 //   * SnapshotQuotaExceededFault
 //   The request cannot be processed because it would exceed the maximum number
 //   of snapshots.
 //
 //   * SnapshotFeatureNotSupportedFault
-//   You attempted one of the following actions:
+//   You attempted one of the following operations:
 //
-//     Creating a snapshot of a Redis cache cluster running on a t1.micro cache
-//   node.
+//     Creating a snapshot of a Redis cache cluster running on a cache.t1.micro
+//   cache node.
 //
 //     Creating a snapshot of a cache cluster that is running Memcached rather
 //   than Redis.
@@ -886,14 +957,20 @@ func (c *ElastiCache) DeleteCacheClusterRequest(input *DeleteCacheClusterInput) 
 
 // DeleteCacheCluster API operation for Amazon ElastiCache.
 //
-// The DeleteCacheCluster action deletes a previously provisioned cache cluster.
-// DeleteCacheCluster deletes all associated cache nodes, node endpoints and
-// the cache cluster itself. When you receive a successful response from this
-// action, Amazon ElastiCache immediately begins deleting the cache cluster;
-// you cannot cancel or revert this action.
+// Deletes a previously provisioned cache cluster. DeleteCacheCluster deletes
+// all associated cache nodes, node endpoints and the cache cluster itself.
+// When you receive a successful response from this operation, Amazon ElastiCache
+// immediately begins deleting the cache cluster; you cannot cancel or revert
+// this operation.
 //
-// This API cannot be used to delete a cache cluster that is the last read
-// replica of a replication group that has Multi-AZ mode enabled.
+// This operation cannot be used to delete a cache cluster that is the last
+// read replica of a replication group or node group (shard) that has Multi-AZ
+// mode enabled or a cache cluster from a Redis (cluster mode enabled) replication
+// group.
+//
+//  Due to current limitations on Redis (cluster mode disabled), this operation
+// or parameter is not supported on Redis (cluster mode enabled) replication
+// groups.
 //
 // Returns awserr.Error for service API and SDK errors. Use runtime type assertions
 // with awserr.Error's Code and Message methods to get detailed information about
@@ -913,10 +990,10 @@ func (c *ElastiCache) DeleteCacheClusterRequest(input *DeleteCacheClusterInput) 
 //   You already have a snapshot with the given name.
 //
 //   * SnapshotFeatureNotSupportedFault
-//   You attempted one of the following actions:
+//   You attempted one of the following operations:
 //
-//     Creating a snapshot of a Redis cache cluster running on a t1.micro cache
-//   node.
+//     Creating a snapshot of a Redis cache cluster running on a cache.t1.micro
+//   cache node.
 //
 //     Creating a snapshot of a cache cluster that is running Memcached rather
 //   than Redis.
@@ -986,9 +1063,8 @@ func (c *ElastiCache) DeleteCacheParameterGroupRequest(input *DeleteCacheParamet
 
 // DeleteCacheParameterGroup API operation for Amazon ElastiCache.
 //
-// The DeleteCacheParameterGroup action deletes the specified cache parameter
-// group. You cannot delete a cache parameter group if it is associated with
-// any cache clusters.
+// Deletes the specified cache parameter group. You cannot delete a cache parameter
+// group if it is associated with any cache clusters.
 //
 // Returns awserr.Error for service API and SDK errors. Use runtime type assertions
 // with awserr.Error's Code and Message methods to get detailed information about
@@ -1000,7 +1076,7 @@ func (c *ElastiCache) DeleteCacheParameterGroupRequest(input *DeleteCacheParamet
 // Returned Error Codes:
 //   * InvalidCacheParameterGroupState
 //   The current state of the cache parameter group does not allow the requested
-//   action to occur.
+//   operation to occur.
 //
 //   * CacheParameterGroupNotFound
 //   The requested cache parameter group name does not refer to an existing cache
@@ -1065,7 +1141,7 @@ func (c *ElastiCache) DeleteCacheSecurityGroupRequest(input *DeleteCacheSecurity
 
 // DeleteCacheSecurityGroup API operation for Amazon ElastiCache.
 //
-// The DeleteCacheSecurityGroup action deletes a cache security group.
+// Deletes a cache security group.
 //
 //  You cannot delete a cache security group if it is associated with any cache
 // clusters.
@@ -1144,7 +1220,7 @@ func (c *ElastiCache) DeleteCacheSubnetGroupRequest(input *DeleteCacheSubnetGrou
 
 // DeleteCacheSubnetGroup API operation for Amazon ElastiCache.
 //
-// The DeleteCacheSubnetGroup action deletes a cache subnet group.
+// Deletes a cache subnet group.
 //
 //  You cannot delete a cache subnet group if it is associated with any cache
 // clusters.
@@ -1215,14 +1291,17 @@ func (c *ElastiCache) DeleteReplicationGroupRequest(input *DeleteReplicationGrou
 
 // DeleteReplicationGroup API operation for Amazon ElastiCache.
 //
-// The DeleteReplicationGroup action deletes an existing replication group.
-// By default, this action deletes the entire replication group, including the
-// primary cluster and all of the read replicas. You can optionally delete only
-// the read replicas, while retaining the primary cluster.
+// Deletes an existing replication group. By default, this operation deletes
+// the entire replication group, including the primary/primaries and all of
+// the read replicas. If the replication group has only one primary, you can
+// optionally delete only the read replicas, while retaining the primary by
+// setting RetainPrimaryCluster=true.
 //
-// When you receive a successful response from this action, Amazon ElastiCache
+// When you receive a successful response from this operation, Amazon ElastiCache
 // immediately begins deleting the selected resources; you cannot cancel or
-// revert this action.
+// revert this operation.
+//
+//  This operation is valid for Redis only.
 //
 // Returns awserr.Error for service API and SDK errors. Use runtime type assertions
 // with awserr.Error's Code and Message methods to get detailed information about
@@ -1242,10 +1321,10 @@ func (c *ElastiCache) DeleteReplicationGroupRequest(input *DeleteReplicationGrou
 //   You already have a snapshot with the given name.
 //
 //   * SnapshotFeatureNotSupportedFault
-//   You attempted one of the following actions:
+//   You attempted one of the following operations:
 //
-//     Creating a snapshot of a Redis cache cluster running on a t1.micro cache
-//   node.
+//     Creating a snapshot of a Redis cache cluster running on a cache.t1.micro
+//   cache node.
 //
 //     Creating a snapshot of a cache cluster that is running Memcached rather
 //   than Redis.
@@ -1313,9 +1392,11 @@ func (c *ElastiCache) DeleteSnapshotRequest(input *DeleteSnapshotInput) (req *re
 
 // DeleteSnapshot API operation for Amazon ElastiCache.
 //
-// The DeleteSnapshot action deletes an existing snapshot. When you receive
-// a successful response from this action, ElastiCache immediately begins deleting
-// the snapshot; you cannot cancel or revert this action.
+// Deletes an existing snapshot. When you receive a successful response from
+// this operation, ElastiCache immediately begins deleting the snapshot; you
+// cannot cancel or revert this operation.
+//
+//  This operation is valid for Redis only.
 //
 // Returns awserr.Error for service API and SDK errors. Use runtime type assertions
 // with awserr.Error's Code and Message methods to get detailed information about
@@ -1329,8 +1410,8 @@ func (c *ElastiCache) DeleteSnapshotRequest(input *DeleteSnapshotInput) (req *re
 //   The requested snapshot name does not refer to an existing snapshot.
 //
 //   * InvalidSnapshotState
-//   The current state of the snapshot does not allow the requested action to
-//   occur.
+//   The current state of the snapshot does not allow the requested operation
+//   to occur.
 //
 //   * InvalidParameterValue
 //   The value for a parameter is invalid.
@@ -1395,23 +1476,23 @@ func (c *ElastiCache) DescribeCacheClustersRequest(input *DescribeCacheClustersI
 
 // DescribeCacheClusters API operation for Amazon ElastiCache.
 //
-// The DescribeCacheClusters action returns information about all provisioned
-// cache clusters if no cache cluster identifier is specified, or about a specific
-// cache cluster if a cache cluster identifier is supplied.
+// Returns information about all provisioned cache clusters if no cache cluster
+// identifier is specified, or about a specific cache cluster if a cache cluster
+// identifier is supplied.
 //
-// By default, abbreviated information about the cache clusters(s) will be
-// returned. You can use the optional ShowDetails flag to retrieve detailed
-// information about the cache nodes associated with the cache clusters. These
-// details include the DNS address and port for the cache node endpoint.
+// By default, abbreviated information about the cache clusters are returned.
+// You can use the optional ShowDetails flag to retrieve detailed information
+// about the cache nodes associated with the cache clusters. These details include
+// the DNS address and port for the cache node endpoint.
 //
-// If the cluster is in the CREATING state, only cluster level information
-// will be displayed until all of the nodes are successfully provisioned.
+// If the cluster is in the CREATING state, only cluster-level information
+// is displayed until all of the nodes are successfully provisioned.
 //
-// If the cluster is in the DELETING state, only cluster level information
-// will be displayed.
+// If the cluster is in the DELETING state, only cluster-level information
+// is displayed.
 //
 // If cache nodes are currently being added to the cache cluster, node endpoint
-// information and creation time for the additional nodes will not be displayed
+// information and creation time for the additional nodes are not displayed
 // until they are completely provisioned. When the cache cluster state is available,
 // the cluster is ready for use.
 //
@@ -1517,8 +1598,7 @@ func (c *ElastiCache) DescribeCacheEngineVersionsRequest(input *DescribeCacheEng
 
 // DescribeCacheEngineVersions API operation for Amazon ElastiCache.
 //
-// The DescribeCacheEngineVersions action returns a list of the available cache
-// engines and their versions.
+// Returns a list of the available cache engines and their versions.
 //
 // Returns awserr.Error for service API and SDK errors. Use runtime type assertions
 // with awserr.Error's Code and Message methods to get detailed information about
@@ -1608,9 +1688,9 @@ func (c *ElastiCache) DescribeCacheParameterGroupsRequest(input *DescribeCachePa
 
 // DescribeCacheParameterGroups API operation for Amazon ElastiCache.
 //
-// The DescribeCacheParameterGroups action returns a list of cache parameter
-// group descriptions. If a cache parameter group name is specified, the list
-// will contain only the descriptions for that group.
+// Returns a list of cache parameter group descriptions. If a cache parameter
+// group name is specified, the list contains only the descriptions for that
+// group.
 //
 // Returns awserr.Error for service API and SDK errors. Use runtime type assertions
 // with awserr.Error's Code and Message methods to get detailed information about
@@ -1712,8 +1792,7 @@ func (c *ElastiCache) DescribeCacheParametersRequest(input *DescribeCacheParamet
 
 // DescribeCacheParameters API operation for Amazon ElastiCache.
 //
-// The DescribeCacheParameters action returns the detailed parameter list for
-// a particular cache parameter group.
+// Returns the detailed parameter list for a particular cache parameter group.
 //
 // Returns awserr.Error for service API and SDK errors. Use runtime type assertions
 // with awserr.Error's Code and Message methods to get detailed information about
@@ -1815,9 +1894,8 @@ func (c *ElastiCache) DescribeCacheSecurityGroupsRequest(input *DescribeCacheSec
 
 // DescribeCacheSecurityGroups API operation for Amazon ElastiCache.
 //
-// The DescribeCacheSecurityGroups action returns a list of cache security group
-// descriptions. If a cache security group name is specified, the list will
-// contain only the description of that group.
+// Returns a list of cache security group descriptions. If a cache security
+// group name is specified, the list contains only the description of that group.
 //
 // Returns awserr.Error for service API and SDK errors. Use runtime type assertions
 // with awserr.Error's Code and Message methods to get detailed information about
@@ -1919,9 +1997,8 @@ func (c *ElastiCache) DescribeCacheSubnetGroupsRequest(input *DescribeCacheSubne
 
 // DescribeCacheSubnetGroups API operation for Amazon ElastiCache.
 //
-// The DescribeCacheSubnetGroups action returns a list of cache subnet group
-// descriptions. If a subnet group name is specified, the list will contain
-// only the description of that group.
+// Returns a list of cache subnet group descriptions. If a subnet group name
+// is specified, the list contains only the description of that group.
 //
 // Returns awserr.Error for service API and SDK errors. Use runtime type assertions
 // with awserr.Error's Code and Message methods to get detailed information about
@@ -2017,8 +2094,8 @@ func (c *ElastiCache) DescribeEngineDefaultParametersRequest(input *DescribeEngi
 
 // DescribeEngineDefaultParameters API operation for Amazon ElastiCache.
 //
-// The DescribeEngineDefaultParameters action returns the default engine and
-// system parameter information for the specified cache engine.
+// Returns the default engine and system parameter information for the specified
+// cache engine.
 //
 // Returns awserr.Error for service API and SDK errors. Use runtime type assertions
 // with awserr.Error's Code and Message methods to get detailed information about
@@ -2116,10 +2193,10 @@ func (c *ElastiCache) DescribeEventsRequest(input *DescribeEventsInput) (req *re
 
 // DescribeEvents API operation for Amazon ElastiCache.
 //
-// The DescribeEvents action returns events related to cache clusters, cache
-// security groups, and cache parameter groups. You can obtain events specific
-// to a particular cache cluster, cache security group, or cache parameter group
-// by providing the name as a parameter.
+// Returns events related to cache clusters, cache security groups, and cache
+// parameter groups. You can obtain events specific to a particular cache cluster,
+// cache security group, or cache parameter group by providing the name as a
+// parameter.
 //
 // By default, only the events occurring within the last hour are returned;
 // however, you can retrieve up to 14 days' worth of events if necessary.
@@ -2220,9 +2297,11 @@ func (c *ElastiCache) DescribeReplicationGroupsRequest(input *DescribeReplicatio
 
 // DescribeReplicationGroups API operation for Amazon ElastiCache.
 //
-// The DescribeReplicationGroups action returns information about a particular
-// replication group. If no identifier is specified, DescribeReplicationGroups
-// returns information about all replication groups.
+// Returns information about a particular replication group. If no identifier
+// is specified, DescribeReplicationGroups returns information about all replication
+// groups.
+//
+//  This operation is valid for Redis only.
 //
 // Returns awserr.Error for service API and SDK errors. Use runtime type assertions
 // with awserr.Error's Code and Message methods to get detailed information about
@@ -2323,8 +2402,8 @@ func (c *ElastiCache) DescribeReservedCacheNodesRequest(input *DescribeReservedC
 
 // DescribeReservedCacheNodes API operation for Amazon ElastiCache.
 //
-// The DescribeReservedCacheNodes action returns information about reserved
-// cache nodes for this account, or about a specified reserved cache node.
+// Returns information about reserved cache nodes for this account, or about
+// a specified reserved cache node.
 //
 // Returns awserr.Error for service API and SDK errors. Use runtime type assertions
 // with awserr.Error's Code and Message methods to get detailed information about
@@ -2425,8 +2504,7 @@ func (c *ElastiCache) DescribeReservedCacheNodesOfferingsRequest(input *Describe
 
 // DescribeReservedCacheNodesOfferings API operation for Amazon ElastiCache.
 //
-// The DescribeReservedCacheNodesOfferings action lists available reserved cache
-// node offerings.
+// Lists available reserved cache node offerings.
 //
 // Returns awserr.Error for service API and SDK errors. Use runtime type assertions
 // with awserr.Error's Code and Message methods to get detailed information about
@@ -2527,10 +2605,12 @@ func (c *ElastiCache) DescribeSnapshotsRequest(input *DescribeSnapshotsInput) (r
 
 // DescribeSnapshots API operation for Amazon ElastiCache.
 //
-// The DescribeSnapshots action returns information about cache cluster snapshots.
-// By default, DescribeSnapshots lists all of your snapshots; it can optionally
+// Returns information about cache cluster or replication group snapshots. By
+// default, DescribeSnapshots lists all of your snapshots; it can optionally
 // describe a single snapshot, or just the snapshots associated with a particular
 // cache cluster.
+//
+//  This operation is valid for Redis only.
 //
 // Returns awserr.Error for service API and SDK errors. Use runtime type assertions
 // with awserr.Error's Code and Message methods to get detailed information about
@@ -2628,13 +2708,12 @@ func (c *ElastiCache) ListAllowedNodeTypeModificationsRequest(input *ListAllowed
 
 // ListAllowedNodeTypeModifications API operation for Amazon ElastiCache.
 //
-// The ListAllowedNodeTypeModifications action lists all available node types
-// that you can scale your Redis cluster's or replication group's current node
-// type up to.
+// Lists all available node types that you can scale your Redis cluster's or
+// replication group's current node type up to.
 //
-// When you use the ModifyCacheCluster or ModifyReplicationGroup APIs to scale
-// up your cluster or replication group, the value of the CacheNodeType parameter
-// must be one of the node types returned by this action.
+// When you use the ModifyCacheCluster or ModifyReplicationGroup operations
+// to scale up your cluster or replication group, the value of the CacheNodeType
+// parameter must be one of the node types returned by this operation.
 //
 // Returns awserr.Error for service API and SDK errors. Use runtime type assertions
 // with awserr.Error's Code and Message methods to get detailed information about
@@ -2707,10 +2786,10 @@ func (c *ElastiCache) ListTagsForResourceRequest(input *ListTagsForResourceInput
 
 // ListTagsForResource API operation for Amazon ElastiCache.
 //
-// The ListTagsForResource action lists all cost allocation tags currently on
-// the named resource. A cost allocation tag is a key-value pair where the key
-// is case-sensitive and the value is optional. Cost allocation tags can be
-// used to categorize and track your AWS costs.
+// Lists all cost allocation tags currently on the named resource. A cost allocation
+// tag is a key-value pair where the key is case-sensitive and the value is
+// optional. You can use cost allocation tags to categorize and track your AWS
+// costs.
 //
 // You can have a maximum of 10 cost allocation tags on an ElastiCache resource.
 // For more information, see Using Cost Allocation Tags in Amazon ElastiCache
@@ -2784,9 +2863,9 @@ func (c *ElastiCache) ModifyCacheClusterRequest(input *ModifyCacheClusterInput) 
 
 // ModifyCacheCluster API operation for Amazon ElastiCache.
 //
-// The ModifyCacheCluster action modifies the settings for a cache cluster.
-// You can use this action to change one or more cluster configuration parameters
-// by specifying the parameters and the new values.
+// Modifies the settings for a cache cluster. You can use this operation to
+// change one or more cluster configuration parameters by specifying the parameters
+// and the new values.
 //
 // Returns awserr.Error for service API and SDK errors. Use runtime type assertions
 // with awserr.Error's Code and Message methods to get detailed information about
@@ -2885,9 +2964,9 @@ func (c *ElastiCache) ModifyCacheParameterGroupRequest(input *ModifyCacheParamet
 
 // ModifyCacheParameterGroup API operation for Amazon ElastiCache.
 //
-// The ModifyCacheParameterGroup action modifies the parameters of a cache parameter
-// group. You can modify up to 20 parameters in a single request by submitting
-// a list parameter name and value pairs.
+// Modifies the parameters of a cache parameter group. You can modify up to
+// 20 parameters in a single request by submitting a list parameter name and
+// value pairs.
 //
 // Returns awserr.Error for service API and SDK errors. Use runtime type assertions
 // with awserr.Error's Code and Message methods to get detailed information about
@@ -2903,7 +2982,7 @@ func (c *ElastiCache) ModifyCacheParameterGroupRequest(input *ModifyCacheParamet
 //
 //   * InvalidCacheParameterGroupState
 //   The current state of the cache parameter group does not allow the requested
-//   action to occur.
+//   operation to occur.
 //
 //   * InvalidParameterValue
 //   The value for a parameter is invalid.
@@ -2962,7 +3041,7 @@ func (c *ElastiCache) ModifyCacheSubnetGroupRequest(input *ModifyCacheSubnetGrou
 
 // ModifyCacheSubnetGroup API operation for Amazon ElastiCache.
 //
-// The ModifyCacheSubnetGroup action modifies an existing cache subnet group.
+// Modifies an existing cache subnet group.
 //
 // Returns awserr.Error for service API and SDK errors. Use runtime type assertions
 // with awserr.Error's Code and Message methods to get detailed information about
@@ -3037,8 +3116,13 @@ func (c *ElastiCache) ModifyReplicationGroupRequest(input *ModifyReplicationGrou
 
 // ModifyReplicationGroup API operation for Amazon ElastiCache.
 //
-// The ModifyReplicationGroup action modifies the settings for a replication
-// group.
+// Modifies the settings for a replication group.
+//
+//  Due to current limitations on Redis (cluster mode disabled), this operation
+// or parameter is not supported on Redis (cluster mode enabled) replication
+// groups.
+//
+//   This operation is valid for Redis only.
 //
 // Returns awserr.Error for service API and SDK errors. Use runtime type assertions
 // with awserr.Error's Code and Message methods to get detailed information about
@@ -3143,8 +3227,7 @@ func (c *ElastiCache) PurchaseReservedCacheNodesOfferingRequest(input *PurchaseR
 
 // PurchaseReservedCacheNodesOffering API operation for Amazon ElastiCache.
 //
-// The PurchaseReservedCacheNodesOffering action allows you to purchase a reserved
-// cache node offering.
+// Allows you to purchase a reserved cache node offering.
 //
 // Returns awserr.Error for service API and SDK errors. Use runtime type assertions
 // with awserr.Error's Code and Message methods to get detailed information about
@@ -3221,11 +3304,11 @@ func (c *ElastiCache) RebootCacheClusterRequest(input *RebootCacheClusterInput) 
 
 // RebootCacheCluster API operation for Amazon ElastiCache.
 //
-// The RebootCacheCluster action reboots some, or all, of the cache nodes within
-// a provisioned cache cluster. This API will apply any modified cache parameter
-// groups to the cache cluster. The reboot action takes place as soon as possible,
-// and results in a momentary outage to the cache cluster. During the reboot,
-// the cache cluster status is set to REBOOTING.
+// Reboots some, or all, of the cache nodes within a provisioned cache cluster.
+// This operation applies any modified cache parameter groups to the cache cluster.
+// The reboot operation takes place as soon as possible, and results in a momentary
+// outage to the cache cluster. During the reboot, the cache cluster status
+// is set to REBOOTING.
 //
 // The reboot causes the contents of the cache (for each cache node being rebooted)
 // to be lost.
@@ -3297,8 +3380,7 @@ func (c *ElastiCache) RemoveTagsFromResourceRequest(input *RemoveTagsFromResourc
 
 // RemoveTagsFromResource API operation for Amazon ElastiCache.
 //
-// The RemoveTagsFromResource action removes the tags identified by the TagKeys
-// list from the named resource.
+// Removes the tags identified by the TagKeys list from the named resource.
 //
 // Returns awserr.Error for service API and SDK errors. Use runtime type assertions
 // with awserr.Error's Code and Message methods to get detailed information about
@@ -3371,10 +3453,10 @@ func (c *ElastiCache) ResetCacheParameterGroupRequest(input *ResetCacheParameter
 
 // ResetCacheParameterGroup API operation for Amazon ElastiCache.
 //
-// The ResetCacheParameterGroup action modifies the parameters of a cache parameter
-// group to the engine or system default value. You can reset specific parameters
-// by submitting a list of parameter names. To reset the entire cache parameter
-// group, specify the ResetAllParameters and CacheParameterGroupName parameters.
+// Modifies the parameters of a cache parameter group to the engine or system
+// default value. You can reset specific parameters by submitting a list of
+// parameter names. To reset the entire cache parameter group, specify the ResetAllParameters
+// and CacheParameterGroupName parameters.
 //
 // Returns awserr.Error for service API and SDK errors. Use runtime type assertions
 // with awserr.Error's Code and Message methods to get detailed information about
@@ -3386,7 +3468,7 @@ func (c *ElastiCache) ResetCacheParameterGroupRequest(input *ResetCacheParameter
 // Returned Error Codes:
 //   * InvalidCacheParameterGroupState
 //   The current state of the cache parameter group does not allow the requested
-//   action to occur.
+//   operation to occur.
 //
 //   * CacheParameterGroupNotFound
 //   The requested cache parameter group name does not refer to an existing cache
@@ -3449,9 +3531,8 @@ func (c *ElastiCache) RevokeCacheSecurityGroupIngressRequest(input *RevokeCacheS
 
 // RevokeCacheSecurityGroupIngress API operation for Amazon ElastiCache.
 //
-// The RevokeCacheSecurityGroupIngress action revokes ingress from a cache security
-// group. Use this action to disallow access from an Amazon EC2 security group
-// that had been previously authorized.
+// Revokes ingress from a cache security group. Use this operation to disallow
+// access from an Amazon EC2 security group that had been previously authorized.
 //
 // Returns awserr.Error for service API and SDK errors. Use runtime type assertions
 // with awserr.Error's Code and Message methods to get detailed information about
@@ -3484,7 +3565,7 @@ func (c *ElastiCache) RevokeCacheSecurityGroupIngress(input *RevokeCacheSecurity
 	return out, err
 }
 
-// Represents the input of an AddTagsToResource action.
+// Represents the input of an AddTagsToResource operation.
 type AddTagsToResourceInput struct {
 	_ struct{} `type:"structure"`
 
@@ -3492,7 +3573,7 @@ type AddTagsToResourceInput struct {
 	// added, for example arn:aws:elasticache:us-west-2:0123456789:cluster:myCluster
 	// or arn:aws:elasticache:us-west-2:0123456789:snapshot:mySnapshot.
 	//
-	// For more information on ARNs, go to Amazon Resource Names (ARNs) and AWS
+	// For more information about ARNs, see Amazon Resource Names (ARNs) and AWS
 	// Service Namespaces (http://docs.aws.amazon.com/general/latest/gr/aws-arns-and-namespaces.html).
 	//
 	// ResourceName is a required field
@@ -3531,11 +3612,11 @@ func (s *AddTagsToResourceInput) Validate() error {
 	return nil
 }
 
-// Represents the input of an AuthorizeCacheSecurityGroupIngress action.
+// Represents the input of an AuthorizeCacheSecurityGroupIngress operation.
 type AuthorizeCacheSecurityGroupIngressInput struct {
 	_ struct{} `type:"structure"`
 
-	// The cache security group which will allow network ingress.
+	// The cache security group that allows network ingress.
 	//
 	// CacheSecurityGroupName is a required field
 	CacheSecurityGroupName *string `type:"string" required:"true"`
@@ -3586,7 +3667,7 @@ func (s *AuthorizeCacheSecurityGroupIngressInput) Validate() error {
 type AuthorizeCacheSecurityGroupIngressOutput struct {
 	_ struct{} `type:"structure"`
 
-	// Represents the output of one of the following actions:
+	// Represents the output of one of the following operations:
 	//
 	//    AuthorizeCacheSecurityGroupIngress
 	//
@@ -3650,7 +3731,8 @@ type CacheCluster struct {
 	//   General purpose:
 	//
 	//   Current generation: cache.t2.micro, cache.t2.small, cache.t2.medium, cache.m3.medium,
-	// cache.m3.large, cache.m3.xlarge, cache.m3.2xlarge
+	// cache.m3.large, cache.m3.xlarge, cache.m3.2xlarge, cache.m4.large, cache.m4.xlarge,
+	// cache.m4.2xlarge, cache.m4.4xlarge, cache.m4.10xlarge
 	//
 	//   Previous generation: cache.t1.micro, cache.m1.small, cache.m1.medium,
 	// cache.m1.large, cache.m1.xlarge
@@ -3666,23 +3748,26 @@ type CacheCluster struct {
 	//
 	//      Notes:
 	//
-	//   All t2 instances are created in an Amazon Virtual Private Cloud (VPC).
+	//   All T2 instances are created in an Amazon Virtual Private Cloud (Amazon
+	// VPC).
 	//
-	//   Redis backup/restore is not supported for t2 instances.
+	//   Redis backup/restore is not supported for Redis (cluster mode disabled)
+	// T1 and T2 instances. Backup/restore is supported on Redis (cluster mode enabled)
+	// T2 instances.
 	//
-	//   Redis Append-only files (AOF) functionality is not supported for t1 or
-	// t2 instances.
+	//   Redis Append-only files (AOF) functionality is not supported for T1 or
+	// T2 instances.
 	//
-	//   For a complete listing of cache node types and specifications, see Amazon
-	// ElastiCache Product Features and Details (http://aws.amazon.com/elasticache/details)
-	// and Cache Node Type-Specific Parameters for Memcached (http://docs.aws.amazon.com/AmazonElastiCache/latest/UserGuide/CacheParameterGroups.Memcached.html#CacheParameterGroups.Memcached.NodeSpecific)
-	// or Cache Node Type-Specific Parameters for Redis (http://docs.aws.amazon.com/AmazonElastiCache/latest/UserGuide/CacheParameterGroups.Redis.html#CacheParameterGroups.Redis.NodeSpecific).
+	//   For a complete listing of node types and specifications, see Amazon ElastiCache
+	// Product Features and Details (http://aws.amazon.com/elasticache/details)
+	// and either Cache Node Type-Specific Parameters for Memcached (http://docs.aws.amazon.com/AmazonElastiCache/latest/UserGuide/CacheParameterGroups.Memcached.html#ParameterGroups.Memcached.NodeSpecific)
+	// or Cache Node Type-Specific Parameters for Redis (http://docs.aws.amazon.com/AmazonElastiCache/latest/UserGuide/CacheParameterGroups.Redis.html#ParameterGroups.Redis.NodeSpecific).
 	CacheNodeType *string `type:"string"`
 
 	// A list of cache nodes that are members of the cache cluster.
 	CacheNodes []*CacheNode `locationNameList:"CacheNode" type:"list"`
 
-	// The status of the cache parameter group.
+	// Status of the cache parameter group.
 	CacheParameterGroup *CacheParameterGroupStatus `type:"structure"`
 
 	// A list of cache security group elements, composed of name and status sub-elements.
@@ -3717,7 +3802,7 @@ type CacheCluster struct {
 	// this value must be between 1 and 20.
 	NumCacheNodes *int64 `type:"integer"`
 
-	// A group of settings that will be applied to the cache cluster in the future,
+	// A group of settings that are applied to the cache cluster in the future,
 	// or that are currently being applied.
 	PendingModifiedValues *PendingModifiedValues `type:"structure"`
 
@@ -3725,10 +3810,11 @@ type CacheCluster struct {
 	// "Multiple" if the cache nodes are located in different Availability Zones.
 	PreferredAvailabilityZone *string `type:"string"`
 
-	// Specifies the weekly time range during which maintenance on the cache cluster
-	// is performed. It is specified as a range in the format ddd:hh24:mi-ddd:hh24:mi
-	// (24H Clock UTC). The minimum maintenance window is a 60 minute period. Valid
-	// values for ddd are:
+	// Specifies the weekly time range during which maintenance on the cluster is
+	// performed. It is specified as a range in the format ddd:hh24:mi-ddd:hh24:mi
+	// (24H Clock UTC). The minimum maintenance window is a 60 minute period.
+	//
+	// Valid values for ddd are:
 	//
 	//    sun
 	//
@@ -3744,7 +3830,7 @@ type CacheCluster struct {
 	//
 	//    sat
 	//
-	//   Example: sun:05:00-sun:09:00
+	//   Example: sun:23:00-mon:01:30
 	PreferredMaintenanceWindow *string `type:"string"`
 
 	// The replication group to which this cache cluster belongs. If this field
@@ -3754,17 +3840,17 @@ type CacheCluster struct {
 	// A list of VPC Security Groups associated with the cache cluster.
 	SecurityGroups []*SecurityGroupMembership `type:"list"`
 
-	// The number of days for which ElastiCache will retain automatic cache cluster
+	// The number of days for which ElastiCache retains automatic cache cluster
 	// snapshots before deleting them. For example, if you set SnapshotRetentionLimit
-	// to 5, then a snapshot that was taken today will be retained for 5 days before
-	// being deleted.
+	// to 5, a snapshot that was taken today is retained for 5 days before being
+	// deleted.
 	//
 	//   If the value of SnapshotRetentionLimit is set to zero (0), backups are
 	// turned off.
 	SnapshotRetentionLimit *int64 `type:"integer"`
 
-	// The daily time range (in UTC) during which ElastiCache will begin taking
-	// a daily snapshot of your cache cluster.
+	// The daily time range (in UTC) during which ElastiCache begins taking a daily
+	// snapshot of your cache cluster.
 	//
 	// Example: 05:00-09:00
 	SnapshotWindow *string `type:"string"`
@@ -3791,6 +3877,8 @@ type CacheEngineVersion struct {
 	CacheEngineVersionDescription *string `type:"string"`
 
 	// The name of the cache parameter group family associated with this cache engine.
+	//
+	// Valid values are: memcached1.4 | redis2.6 | redis2.8 | redis3.2
 	CacheParameterGroupFamily *string `type:"string"`
 
 	// The name of the cache engine.
@@ -3819,7 +3907,8 @@ func (s CacheEngineVersion) GoString() string {
 //   General purpose:
 //
 //   Current generation: cache.t2.micro, cache.t2.small, cache.t2.medium, cache.m3.medium,
-// cache.m3.large, cache.m3.xlarge, cache.m3.2xlarge
+// cache.m3.large, cache.m3.xlarge, cache.m3.2xlarge, cache.m4.large, cache.m4.xlarge,
+// cache.m4.2xlarge, cache.m4.4xlarge, cache.m4.10xlarge
 //
 //   Previous generation: cache.t1.micro, cache.m1.small, cache.m1.medium,
 // cache.m1.large, cache.m1.xlarge
@@ -3835,17 +3924,20 @@ func (s CacheEngineVersion) GoString() string {
 //
 //      Notes:
 //
-//   All t2 instances are created in an Amazon Virtual Private Cloud (VPC).
+//   All T2 instances are created in an Amazon Virtual Private Cloud (Amazon
+// VPC).
 //
-//   Redis backup/restore is not supported for t2 instances.
+//   Redis backup/restore is not supported for Redis (cluster mode disabled)
+// T1 and T2 instances. Backup/restore is supported on Redis (cluster mode enabled)
+// T2 instances.
 //
-//   Redis Append-only files (AOF) functionality is not supported for t1 or
-// t2 instances.
+//   Redis Append-only files (AOF) functionality is not supported for T1 or
+// T2 instances.
 //
-//   For a complete listing of cache node types and specifications, see Amazon
-// ElastiCache Product Features and Details (http://aws.amazon.com/elasticache/details)
-// and either Cache Node Type-Specific Parameters for Memcached (http://docs.aws.amazon.com/AmazonElastiCache/latest/UserGuide/CacheParameterGroups.Memcached.html#CacheParameterGroups.Memcached.NodeSpecific)
-// or Cache Node Type-Specific Parameters for Redis (http://docs.aws.amazon.com/AmazonElastiCache/latest/UserGuide/CacheParameterGroups.Redis.html#CacheParameterGroups.Redis.NodeSpecific).
+//   For a complete listing of node types and specifications, see Amazon ElastiCache
+// Product Features and Details (http://aws.amazon.com/elasticache/details)
+// and either Cache Node Type-Specific Parameters for Memcached (http://docs.aws.amazon.com/AmazonElastiCache/latest/UserGuide/CacheParameterGroups.Memcached.html#ParameterGroups.Memcached.NodeSpecific)
+// or Cache Node Type-Specific Parameters for Redis (http://docs.aws.amazon.com/AmazonElastiCache/latest/UserGuide/CacheParameterGroups.Redis.html#ParameterGroups.Redis.NodeSpecific).
 type CacheNode struct {
 	_ struct{} `type:"structure"`
 
@@ -3870,7 +3962,7 @@ type CacheNode struct {
 	ParameterGroupStatus *string `type:"string"`
 
 	// The ID of the primary node to which this read replica node is synchronized.
-	// If this field is empty, then this node is not associated with a primary cache
+	// If this field is empty, this node is not associated with a primary cache
 	// cluster.
 	SourceCacheNodeId *string `type:"string"`
 }
@@ -3897,10 +3989,10 @@ type CacheNodeTypeSpecificParameter struct {
 	// A list of cache node types and their corresponding values for this parameter.
 	CacheNodeTypeSpecificValues []*CacheNodeTypeSpecificValue `locationNameList:"CacheNodeTypeSpecificValue" type:"list"`
 
-	// ChangeType indicates whether a change to the parameter will be applied immediately
-	// or requires a reboot for the change to be applied. You can force a reboot
-	// or wait until the next maintenance window's reboot. For more information,
-	// see Rebooting a Cluster (http://docs.aws.amazon.com/AmazonElastiCache/latest/UserGuide/Clusters.Rebooting.html).
+	// Indicates whether a change to the parameter is applied immediately or requires
+	// a reboot for the change to be applied. You can force a reboot or wait until
+	// the next maintenance window's reboot. For more information, see Rebooting
+	// a Cluster (http://docs.aws.amazon.com/AmazonElastiCache/latest/UserGuide/Clusters.Rebooting.html).
 	ChangeType *string `type:"string" enum:"ChangeType"`
 
 	// The valid data type for the parameter.
@@ -3955,12 +4047,14 @@ func (s CacheNodeTypeSpecificValue) GoString() string {
 	return s.String()
 }
 
-// Represents the output of a CreateCacheParameterGroup action.
+// Represents the output of a CreateCacheParameterGroup operation.
 type CacheParameterGroup struct {
 	_ struct{} `type:"structure"`
 
 	// The name of the cache parameter group family that this cache parameter group
 	// is compatible with.
+	//
+	// Valid values are: memcached1.4 | redis2.6 | redis2.8 | redis3.2
 	CacheParameterGroupFamily *string `type:"string"`
 
 	// The name of the cache parameter group.
@@ -3980,7 +4074,7 @@ func (s CacheParameterGroup) GoString() string {
 	return s.String()
 }
 
-// Represents the output of one of the following actions:
+// Represents the output of one of the following operations:
 //
 //    ModifyCacheParameterGroup
 //
@@ -4002,7 +4096,7 @@ func (s CacheParameterGroupNameMessage) GoString() string {
 	return s.String()
 }
 
-// The status of the cache parameter group.
+// Status of the cache parameter group.
 type CacheParameterGroupStatus struct {
 	_ struct{} `type:"structure"`
 
@@ -4027,7 +4121,7 @@ func (s CacheParameterGroupStatus) GoString() string {
 	return s.String()
 }
 
-// Represents the output of one of the following actions:
+// Represents the output of one of the following operations:
 //
 //    AuthorizeCacheSecurityGroupIngress
 //
@@ -4084,7 +4178,7 @@ func (s CacheSecurityGroupMembership) GoString() string {
 	return s.String()
 }
 
-// Represents the output of one of the following actions:
+// Represents the output of one of the following operations:
 //
 //    CreateCacheSubnetGroup
 //
@@ -4116,7 +4210,7 @@ func (s CacheSubnetGroup) GoString() string {
 	return s.String()
 }
 
-// Represents the input of a CopySnapshotMessage action.
+// Represents the input of a CopySnapshotMessage operation.
 type CopySnapshotInput struct {
 	_ struct{} `type:"structure"`
 
@@ -4125,68 +4219,21 @@ type CopySnapshotInput struct {
 	// SourceSnapshotName is a required field
 	SourceSnapshotName *string `type:"string" required:"true"`
 
-	// The Amazon S3 bucket to which the snapshot will be exported. This parameter
-	// is used only when exporting a snapshot for external access.
+	// The Amazon S3 bucket to which the snapshot is exported. This parameter is
+	// used only when exporting a snapshot for external access.
 	//
 	// When using this parameter to export a snapshot, be sure Amazon ElastiCache
 	// has the needed permissions to this S3 bucket. For more information, see Step
-	// 2: Grant ElastiCache Access to Your Amazon S3 Bucket (http://docs.aws.amazon.com/AmazonElastiCache/AmazonElastiCache/latest/UserGuide/Snapshots.Exporting.html#Snapshots.Exporting.GrantAccess)
+	// 2: Grant ElastiCache Access to Your Amazon S3 Bucket (http://docs.aws.amazon.com/AmazonElastiCache/latest/UserGuide/Snapshots.Exporting.html#Snapshots.Exporting.GrantAccess)
 	// in the Amazon ElastiCache User Guide.
 	//
-	//  Error Messages:
-	//
-	// You could receive one of the following error messages.
-	//
-	//  Erorr Messages     Error Message:  ElastiCache has not been granted READ
-	// permissions %s on the S3 Bucket.
-	//
-	//  Solution: Add List and Read permissions on the bucket.
-	//
-	//    Error Message:  ElastiCache has not been granted WRITE permissions %s
-	// on the S3 Bucket.
-	//
-	//  Solution: Add Upload/Delete permissions on the bucket.
-	//
-	//    Error Message:  ElastiCache has not been granted READ_ACP permissions
-	// %s on the S3 Bucket.
-	//
-	//  Solution: Add View Permissions permissions on the bucket.
-	//
-	//    Error Message: The S3 bucket %s is outside of the region.
-	//
-	//  Solution: Before exporting your snapshot, create a new Amazon S3 bucket
-	// in the same region as your snapshot. For more information, see Step 1: Create
-	// an Amazon S3 Bucket (http://docs.aws.amazon.com/AmazonElastiCache/latest/UserGuide/Snapshots.Exporting.html#Snapshots.Exporting.CreateBucket).
-	//
-	//    Error Message: The S3 bucket %s does not exist.
-	//
-	//  Solution: Create an Amazon S3 bucket in the same region as your snapshot.
-	// For more information, see Step 1: Create an Amazon S3 Bucket (http://docs.aws.amazon.com/AmazonElastiCache/latest/UserGuide/Snapshots.Exporting.html#Snapshots.Exporting.CreateBucket).
-	//
-	//    Error Message: The S3 bucket %s is not owned by the authenticated user.
-	//
-	//  Solution: Create an Amazon S3 bucket in the same region as your snapshot.
-	// For more information, see Step 1: Create an Amazon S3 Bucket (http://docs.aws.amazon.com/AmazonElastiCache/latest/UserGuide/Snapshots.Exporting.html#Snapshots.Exporting.CreateBucket).
-	//
-	//    Error Message: The authenticated user does not have sufficient permissions
-	// to perform the desired activity.
-	//
-	//  Solution: Contact your system administrator to get the needed permissions.
-	//
-	//   For more information, see Exporting a Snapshot (http://docs.aws.amazon.com/AmazonElastiCache/latest/UserGuide/Snapshots.Exporting.html)
+	// For more information, see Exporting a Snapshot (http://docs.aws.amazon.com/AmazonElastiCache/latest/UserGuide/Snapshots.Exporting.html)
 	// in the Amazon ElastiCache User Guide.
 	TargetBucket *string `type:"string"`
 
 	// A name for the snapshot copy. ElastiCache does not permit overwriting a snapshot,
 	// therefore this name must be unique within its context - ElastiCache or an
 	// Amazon S3 bucket if exporting.
-	//
-	//  Error Message     Error Message: The S3 bucket %s already contains an object
-	// with key %s.
-	//
-	//  Solution: Give the TargetSnapshotName a new and unique value. If exporting
-	// a snapshot, you could alternatively create a new Amazon S3 bucket and use
-	// this same value for TargetSnapshotName.
 	//
 	// TargetSnapshotName is a required field
 	TargetSnapshotName *string `type:"string" required:"true"`
@@ -4221,8 +4268,8 @@ func (s *CopySnapshotInput) Validate() error {
 type CopySnapshotOutput struct {
 	_ struct{} `type:"structure"`
 
-	// Represents a copy of an entire cache cluster as of the time when the snapshot
-	// was taken.
+	// Represents a copy of an entire Redis cache cluster as of the time when the
+	// snapshot was taken.
 	Snapshot *Snapshot `type:"structure"`
 }
 
@@ -4236,13 +4283,13 @@ func (s CopySnapshotOutput) GoString() string {
 	return s.String()
 }
 
-// Represents the input of a CreateCacheCluster action.
+// Represents the input of a CreateCacheCluster operation.
 type CreateCacheClusterInput struct {
 	_ struct{} `type:"structure"`
 
-	// Specifies whether the nodes in this Memcached node group are created in a
-	// single Availability Zone or created across multiple Availability Zones in
-	// the cluster's region.
+	// Specifies whether the nodes in this Memcached cluster are created in a single
+	// Availability Zone or created across multiple Availability Zones in the cluster's
+	// region.
 	//
 	// This parameter is only supported for Memcached cache clusters.
 	//
@@ -4253,7 +4300,8 @@ type CreateCacheClusterInput struct {
 	// This parameter is currently disabled.
 	AutoMinorVersionUpgrade *bool `type:"boolean"`
 
-	// The node group identifier. This parameter is stored as a lowercase string.
+	// The node group (shard) identifier. This parameter is stored as a lowercase
+	// string.
 	//
 	//  Constraints:
 	//
@@ -4266,14 +4314,15 @@ type CreateCacheClusterInput struct {
 	// CacheClusterId is a required field
 	CacheClusterId *string `type:"string" required:"true"`
 
-	// The compute and memory capacity of the nodes in the node group.
+	// The compute and memory capacity of the nodes in the node group (shard).
 	//
 	// Valid node types are as follows:
 	//
 	//   General purpose:
 	//
 	//   Current generation: cache.t2.micro, cache.t2.small, cache.t2.medium, cache.m3.medium,
-	// cache.m3.large, cache.m3.xlarge, cache.m3.2xlarge
+	// cache.m3.large, cache.m3.xlarge, cache.m3.2xlarge, cache.m4.large, cache.m4.xlarge,
+	// cache.m4.2xlarge, cache.m4.4xlarge, cache.m4.10xlarge
 	//
 	//   Previous generation: cache.t1.micro, cache.m1.small, cache.m1.medium,
 	// cache.m1.large, cache.m1.xlarge
@@ -4289,46 +4338,52 @@ type CreateCacheClusterInput struct {
 	//
 	//      Notes:
 	//
-	//   All t2 instances are created in an Amazon Virtual Private Cloud (VPC).
+	//   All T2 instances are created in an Amazon Virtual Private Cloud (Amazon
+	// VPC).
 	//
-	//   Redis backup/restore is not supported for t2 instances.
+	//   Redis backup/restore is not supported for Redis (cluster mode disabled)
+	// T1 and T2 instances. Backup/restore is supported on Redis (cluster mode enabled)
+	// T2 instances.
 	//
-	//   Redis Append-only files (AOF) functionality is not supported for t1 or
-	// t2 instances.
+	//   Redis Append-only files (AOF) functionality is not supported for T1 or
+	// T2 instances.
 	//
-	//   For a complete listing of cache node types and specifications, see Amazon
-	// ElastiCache Product Features and Details (http://aws.amazon.com/elasticache/details)
-	// and Cache Node Type-Specific Parameters for Memcached (http://docs.aws.amazon.com/AmazonElastiCache/latest/UserGuide/CacheParameterGroups.Memcached.html#CacheParameterGroups.Memcached.NodeSpecific)
-	// or Cache Node Type-Specific Parameters for Redis (http://docs.aws.amazon.com/AmazonElastiCache/latest/UserGuide/CacheParameterGroups.Redis.html#CacheParameterGroups.Redis.NodeSpecific).
+	//   For a complete listing of node types and specifications, see Amazon ElastiCache
+	// Product Features and Details (http://aws.amazon.com/elasticache/details)
+	// and either Cache Node Type-Specific Parameters for Memcached (http://docs.aws.amazon.com/AmazonElastiCache/latest/UserGuide/CacheParameterGroups.Memcached.html#ParameterGroups.Memcached.NodeSpecific)
+	// or Cache Node Type-Specific Parameters for Redis (http://docs.aws.amazon.com/AmazonElastiCache/latest/UserGuide/CacheParameterGroups.Redis.html#ParameterGroups.Redis.NodeSpecific).
 	CacheNodeType *string `type:"string"`
 
 	// The name of the parameter group to associate with this cache cluster. If
 	// this argument is omitted, the default parameter group for the specified engine
-	// is used.
+	// is used. You cannot use any parameter group which has cluster-enabled='yes'
+	// when creating a cluster.
 	CacheParameterGroupName *string `type:"string"`
 
 	// A list of security group names to associate with this cache cluster.
 	//
 	// Use this parameter only when you are creating a cache cluster outside of
-	// an Amazon Virtual Private Cloud (VPC).
+	// an Amazon Virtual Private Cloud (Amazon VPC).
 	CacheSecurityGroupNames []*string `locationNameList:"CacheSecurityGroupName" type:"list"`
 
 	// The name of the subnet group to be used for the cache cluster.
 	//
 	// Use this parameter only when you are creating a cache cluster in an Amazon
-	// Virtual Private Cloud (VPC).
+	// Virtual Private Cloud (Amazon VPC).
+	//
+	//  If you're going to launch your cluster in an Amazon VPC, you need to create
+	// a subnet group before you start creating a cluster. For more information,
+	// see Subnets and Subnet Groups (http://docs.aws.amazon.com/AmazonElastiCache/latest/UserGuide/SubnetGroups.html).
 	CacheSubnetGroupName *string `type:"string"`
 
 	// The name of the cache engine to be used for this cache cluster.
 	//
-	// Valid values for this parameter are:
-	//
-	//  memcached | redis
+	// Valid values for this parameter are: memcached | redis
 	Engine *string `type:"string"`
 
 	// The version number of the cache engine to be used for this cache cluster.
 	// To view the supported cache engine versions, use the DescribeCacheEngineVersions
-	// action.
+	// operation.
 	//
 	//  Important: You can upgrade to a newer engine version (see Selecting a Cache
 	// Engine and Version (http://docs.aws.amazon.com/AmazonElastiCache/latest/UserGuide/SelectEngine.html#VersionManagement)),
@@ -4338,12 +4393,12 @@ type CreateCacheClusterInput struct {
 	EngineVersion *string `type:"string"`
 
 	// The Amazon Resource Name (ARN) of the Amazon Simple Notification Service
-	// (SNS) topic to which notifications will be sent.
+	// (SNS) topic to which notifications are sent.
 	//
 	//  The Amazon SNS topic owner must be the same as the cache cluster owner.
 	NotificationTopicArn *string `type:"string"`
 
-	// The initial number of cache nodes that the cache cluster will have.
+	// The initial number of cache nodes that the cache cluster has.
 	//
 	// For clusters running Redis, this value must be 1. For clusters running Memcached,
 	// this value must be between 1 and 20.
@@ -4353,10 +4408,10 @@ type CreateCacheClusterInput struct {
 	// (http://aws.amazon.com/contact-us/elasticache-node-limit-request/).
 	NumCacheNodes *int64 `type:"integer"`
 
-	// The port number on which each of the cache nodes will accept connections.
+	// The port number on which each of the cache nodes accepts connections.
 	Port *int64 `type:"integer"`
 
-	// The EC2 Availability Zone in which the cache cluster will be created.
+	// The EC2 Availability Zone in which the cache cluster is created.
 	//
 	// All nodes belonging to this Memcached cache cluster are placed in the preferred
 	// Availability Zone. If you want to create your nodes across multiple Availability
@@ -4365,8 +4420,8 @@ type CreateCacheClusterInput struct {
 	// Default: System chosen Availability Zone.
 	PreferredAvailabilityZone *string `type:"string"`
 
-	// A list of the Availability Zones in which cache nodes will be created. The
-	// order of the zones in the list is not important.
+	// A list of the Availability Zones in which cache nodes are created. The order
+	// of the zones in the list is not important.
 	//
 	// This option is only supported on Memcached.
 	//
@@ -4380,17 +4435,18 @@ type CreateCacheClusterInput struct {
 	// instead, or repeat the Availability Zone multiple times in the list.
 	//
 	// Default: System chosen Availability Zones.
-	//
-	// Example: One Memcached node in each of three different Availability Zones:
-	// PreferredAvailabilityZones.member.1=us-west-2a&amp;PreferredAvailabilityZones.member.2=us-west-2b&amp;PreferredAvailabilityZones.member.3=us-west-2c
-	//
-	// Example: All three Memcached nodes in one Availability Zone: PreferredAvailabilityZones.member.1=us-west-2a&amp;PreferredAvailabilityZones.member.2=us-west-2a&amp;PreferredAvailabilityZones.member.3=us-west-2a
 	PreferredAvailabilityZones []*string `locationNameList:"PreferredAvailabilityZone" type:"list"`
 
 	// Specifies the weekly time range during which maintenance on the cache cluster
 	// is performed. It is specified as a range in the format ddd:hh24:mi-ddd:hh24:mi
 	// (24H Clock UTC). The minimum maintenance window is a 60 minute period. Valid
 	// values for ddd are:
+	//
+	// Specifies the weekly time range during which maintenance on the cluster
+	// is performed. It is specified as a range in the format ddd:hh24:mi-ddd:hh24:mi
+	// (24H Clock UTC). The minimum maintenance window is a 60 minute period.
+	//
+	// Valid values for ddd are:
 	//
 	//    sun
 	//
@@ -4406,17 +4462,21 @@ type CreateCacheClusterInput struct {
 	//
 	//    sat
 	//
-	//   Example: sun:05:00-sun:09:00
+	//   Example: sun:23:00-mon:01:30
 	PreferredMaintenanceWindow *string `type:"string"`
 
-	// The ID of the replication group to which this cache cluster should belong.
-	// If this parameter is specified, the cache cluster will be added to the specified
-	// replication group as a read replica; otherwise, the cache cluster will be
-	// a standalone primary that is not part of any replication group.
+	// Due to current limitations on Redis (cluster mode disabled), this operation
+	// or parameter is not supported on Redis (cluster mode enabled) replication
+	// groups.
 	//
-	// If the specified replication group is Multi-AZ enabled and the availability
-	// zone is not specified, the cache cluster will be created in availability
-	// zones that provide the best spread of read replicas across availability zones.
+	//  The ID of the replication group to which this cache cluster should belong.
+	// If this parameter is specified, the cache cluster is added to the specified
+	// replication group as a read replica; otherwise, the cache cluster is a standalone
+	// primary that is not part of any replication group.
+	//
+	// If the specified replication group is Multi-AZ enabled and the Availability
+	// Zone is not specified, the cache cluster is created in Availability Zones
+	// that provide the best spread of read replicas across Availability Zones.
 	//
 	//  This parameter is only valid if the Engine parameter is redis.
 	ReplicationGroupId *string `type:"string"`
@@ -4424,43 +4484,42 @@ type CreateCacheClusterInput struct {
 	// One or more VPC security groups associated with the cache cluster.
 	//
 	// Use this parameter only when you are creating a cache cluster in an Amazon
-	// Virtual Private Cloud (VPC).
+	// Virtual Private Cloud (Amazon VPC).
 	SecurityGroupIds []*string `locationNameList:"SecurityGroupId" type:"list"`
 
 	// A single-element string list containing an Amazon Resource Name (ARN) that
 	// uniquely identifies a Redis RDB snapshot file stored in Amazon S3. The snapshot
-	// file will be used to populate the node group. The Amazon S3 object name in
-	// the ARN cannot contain any commas.
+	// file is used to populate the node group (shard). The Amazon S3 object name
+	// in the ARN cannot contain any commas.
 	//
 	//  This parameter is only valid if the Engine parameter is redis.
 	//
 	//  Example of an Amazon S3 ARN: arn:aws:s3:::my_bucket/snapshot1.rdb
 	SnapshotArns []*string `locationNameList:"SnapshotArn" type:"list"`
 
-	// The name of a snapshot from which to restore data into the new node group.
-	// The snapshot status changes to restoring while the new node group is being
-	// created.
+	// The name of a Redis snapshot from which to restore data into the new node
+	// group (shard). The snapshot status changes to restoring while the new node
+	// group (shard) is being created.
 	//
 	//  This parameter is only valid if the Engine parameter is redis.
 	SnapshotName *string `type:"string"`
 
-	// The number of days for which ElastiCache will retain automatic snapshots
-	// before deleting them. For example, if you set SnapshotRetentionLimit to 5,
-	// then a snapshot that was taken today will be retained for 5 days before being
-	// deleted.
+	// The number of days for which ElastiCache retains automatic snapshots before
+	// deleting them. For example, if you set SnapshotRetentionLimit to 5, a snapshot
+	// taken today is retained for 5 days before being deleted.
 	//
 	//  This parameter is only valid if the Engine parameter is redis.
 	//
 	//  Default: 0 (i.e., automatic backups are disabled for this cache cluster).
 	SnapshotRetentionLimit *int64 `type:"integer"`
 
-	// The daily time range (in UTC) during which ElastiCache will begin taking
-	// a daily snapshot of your node group.
+	// The daily time range (in UTC) during which ElastiCache begins taking a daily
+	// snapshot of your node group (shard).
 	//
 	// Example: 05:00-09:00
 	//
-	// If you do not specify this parameter, then ElastiCache will automatically
-	// choose an appropriate time range.
+	// If you do not specify this parameter, ElastiCache automatically chooses
+	// an appropriate time range.
 	//
 	//  Note: This parameter is only valid if the Engine parameter is redis.
 	SnapshotWindow *string `type:"string"`
@@ -4510,14 +4569,14 @@ func (s CreateCacheClusterOutput) GoString() string {
 	return s.String()
 }
 
-// Represents the input of a CreateCacheParameterGroup action.
+// Represents the input of a CreateCacheParameterGroup operation.
 type CreateCacheParameterGroupInput struct {
 	_ struct{} `type:"structure"`
 
-	// The name of the cache parameter group family the cache parameter group can
-	// be used with.
+	// The name of the cache parameter group family that the cache parameter group
+	// can be used with.
 	//
-	// Valid values are: memcached1.4 | redis2.6 | redis2.8
+	// Valid values are: memcached1.4 | redis2.6 | redis2.8 | redis3.2
 	//
 	// CacheParameterGroupFamily is a required field
 	CacheParameterGroupFamily *string `type:"string" required:"true"`
@@ -4565,7 +4624,7 @@ func (s *CreateCacheParameterGroupInput) Validate() error {
 type CreateCacheParameterGroupOutput struct {
 	_ struct{} `type:"structure"`
 
-	// Represents the output of a CreateCacheParameterGroup action.
+	// Represents the output of a CreateCacheParameterGroup operation.
 	CacheParameterGroup *CacheParameterGroup `type:"structure"`
 }
 
@@ -4579,7 +4638,7 @@ func (s CreateCacheParameterGroupOutput) GoString() string {
 	return s.String()
 }
 
-// Represents the input of a CreateCacheSecurityGroup action.
+// Represents the input of a CreateCacheSecurityGroup operation.
 type CreateCacheSecurityGroupInput struct {
 	_ struct{} `type:"structure"`
 
@@ -4629,7 +4688,7 @@ func (s *CreateCacheSecurityGroupInput) Validate() error {
 type CreateCacheSecurityGroupOutput struct {
 	_ struct{} `type:"structure"`
 
-	// Represents the output of one of the following actions:
+	// Represents the output of one of the following operations:
 	//
 	//    AuthorizeCacheSecurityGroupIngress
 	//
@@ -4649,7 +4708,7 @@ func (s CreateCacheSecurityGroupOutput) GoString() string {
 	return s.String()
 }
 
-// Represents the input of a CreateCacheSubnetGroup action.
+// Represents the input of a CreateCacheSubnetGroup operation.
 type CreateCacheSubnetGroupInput struct {
 	_ struct{} `type:"structure"`
 
@@ -4705,7 +4764,7 @@ func (s *CreateCacheSubnetGroupInput) Validate() error {
 type CreateCacheSubnetGroupOutput struct {
 	_ struct{} `type:"structure"`
 
-	// Represents the output of one of the following actions:
+	// Represents the output of one of the following operations:
 	//
 	//    CreateCacheSubnetGroup
 	//
@@ -4723,18 +4782,21 @@ func (s CreateCacheSubnetGroupOutput) GoString() string {
 	return s.String()
 }
 
-// Represents the input of a CreateReplicationGroup action.
+// Represents the input of a CreateReplicationGroup operation.
 type CreateReplicationGroupInput struct {
 	_ struct{} `type:"structure"`
 
 	// This parameter is currently disabled.
 	AutoMinorVersionUpgrade *bool `type:"boolean"`
 
-	// Specifies whether a read-only replica will be automatically promoted to read/write
+	// Specifies whether a read-only replica is automatically promoted to read/write
 	// primary if the existing primary fails.
 	//
 	// If true, Multi-AZ is enabled for this replication group. If false, Multi-AZ
 	// is disabled for this replication group.
+	//
+	//  AutomaticFailoverEnabled must be enabled for Redis (cluster mode enabled)
+	// replication groups.
 	//
 	// Default: false
 	//
@@ -4742,17 +4804,20 @@ type CreateReplicationGroupInput struct {
 	//
 	//   Redis versions earlier than 2.8.6.
 	//
-	//   T1 and T2 cache node types.
+	//   Redis (cluster mode disabled): T1 and T2 node types.
+	//
+	// Redis (cluster mode enabled): T2 node types.
 	AutomaticFailoverEnabled *bool `type:"boolean"`
 
-	// The compute and memory capacity of the nodes in the node group.
+	// The compute and memory capacity of the nodes in the node group (shard).
 	//
 	// Valid node types are as follows:
 	//
 	//   General purpose:
 	//
 	//   Current generation: cache.t2.micro, cache.t2.small, cache.t2.medium, cache.m3.medium,
-	// cache.m3.large, cache.m3.xlarge, cache.m3.2xlarge
+	// cache.m3.large, cache.m3.xlarge, cache.m3.2xlarge, cache.m4.large, cache.m4.xlarge,
+	// cache.m4.2xlarge, cache.m4.4xlarge, cache.m4.10xlarge
 	//
 	//   Previous generation: cache.t1.micro, cache.m1.small, cache.m1.medium,
 	// cache.m1.large, cache.m1.xlarge
@@ -4768,39 +4833,52 @@ type CreateReplicationGroupInput struct {
 	//
 	//      Notes:
 	//
-	//   All t2 instances are created in an Amazon Virtual Private Cloud (VPC).
+	//   All T2 instances are created in an Amazon Virtual Private Cloud (Amazon
+	// VPC).
 	//
-	//   Redis backup/restore is not supported for t2 instances.
+	//   Redis backup/restore is not supported for Redis (cluster mode disabled)
+	// T1 and T2 instances. Backup/restore is supported on Redis (cluster mode enabled)
+	// T2 instances.
 	//
-	//   Redis Append-only files (AOF) functionality is not supported for t1 or
-	// t2 instances.
+	//   Redis Append-only files (AOF) functionality is not supported for T1 or
+	// T2 instances.
 	//
-	//   For a complete listing of cache node types and specifications, see Amazon
-	// ElastiCache Product Features and Details (http://aws.amazon.com/elasticache/details)
-	// and Cache Node Type-Specific Parameters for Memcached (http://docs.aws.amazon.com/AmazonElastiCache/latest/UserGuide/CacheParameterGroups.Memcached.html#CacheParameterGroups.Memcached.NodeSpecific)
-	// or Cache Node Type-Specific Parameters for Redis (http://docs.aws.amazon.com/AmazonElastiCache/latest/UserGuide/CacheParameterGroups.Redis.html#CacheParameterGroups.Redis.NodeSpecific).
+	//   For a complete listing of node types and specifications, see Amazon ElastiCache
+	// Product Features and Details (http://aws.amazon.com/elasticache/details)
+	// and either Cache Node Type-Specific Parameters for Memcached (http://docs.aws.amazon.com/AmazonElastiCache/latest/UserGuide/CacheParameterGroups.Memcached.html#ParameterGroups.Memcached.NodeSpecific)
+	// or Cache Node Type-Specific Parameters for Redis (http://docs.aws.amazon.com/AmazonElastiCache/latest/UserGuide/CacheParameterGroups.Redis.html#ParameterGroups.Redis.NodeSpecific).
 	CacheNodeType *string `type:"string"`
 
 	// The name of the parameter group to associate with this replication group.
 	// If this argument is omitted, the default cache parameter group for the specified
 	// engine is used.
+	//
+	// If you are running Redis version 3.2.4 or later, only one node group (shard),
+	// and want to use a default parameter group, we recommend that you specify
+	// the parameter group by name.
+	//
+	//   To create a Redis (cluster mode disabled) replication group, use CacheParameterGroupName=default.redis3.2.
+	//
+	//   To create a Redis (cluster mode enabled) replication group, use CacheParameterGroupName=default.redis3.2.cluster.on.
 	CacheParameterGroupName *string `type:"string"`
 
 	// A list of cache security group names to associate with this replication group.
 	CacheSecurityGroupNames []*string `locationNameList:"CacheSecurityGroupName" type:"list"`
 
 	// The name of the cache subnet group to be used for the replication group.
+	//
+	//  If you're going to launch your cluster in an Amazon VPC, you need to create
+	// a subnet group before you start creating a cluster. For more information,
+	// see Subnets and Subnet Groups (http://docs.aws.amazon.com/AmazonElastiCache/latest/UserGuide/SubnetGroups.html).
 	CacheSubnetGroupName *string `type:"string"`
 
 	// The name of the cache engine to be used for the cache clusters in this replication
 	// group.
-	//
-	// Default: redis
 	Engine *string `type:"string"`
 
 	// The version number of the cache engine to be used for the cache clusters
 	// in this replication group. To view the supported cache engine versions, use
-	// the DescribeCacheEngineVersions action.
+	// the DescribeCacheEngineVersions operation.
 	//
 	//  Important: You can upgrade to a newer engine version (see Selecting a Cache
 	// Engine and Version (http://docs.aws.amazon.com/AmazonElastiCache/latest/UserGuide/SelectEngine.html#VersionManagement))
@@ -4810,47 +4888,71 @@ type CreateReplicationGroupInput struct {
 	// engine version.
 	EngineVersion *string `type:"string"`
 
+	// A list of node group (shard) configuration options. Each node group (shard)
+	// configuration has the following: Slots, PrimaryAvailabilityZone, ReplicaAvailabilityZones,
+	// ReplicaCount.
+	//
+	// If you're creating a Redis (cluster mode disabled) or a Redis (cluster mode
+	// enabled) replication group, you can use this parameter to configure one node
+	// group (shard) or you can omit this parameter.
+	NodeGroupConfiguration []*NodeGroupConfiguration `locationNameList:"NodeGroupConfiguration" type:"list"`
+
 	// The Amazon Resource Name (ARN) of the Amazon Simple Notification Service
-	// (SNS) topic to which notifications will be sent.
+	// (SNS) topic to which notifications are sent.
 	//
 	//  The Amazon SNS topic owner must be the same as the cache cluster owner.
 	NotificationTopicArn *string `type:"string"`
 
-	// The number of cache clusters this replication group will initially have.
+	// The number of clusters this replication group initially has.
+	//
+	// This parameter is not used if there is more than one node group (shard).
+	// You should use ReplicasPerNodeGroup instead.
 	//
 	// If Multi-AZ is enabled, the value of this parameter must be at least 2.
 	//
 	// The maximum permitted value for NumCacheClusters is 6 (primary plus 5 replicas).
-	// If you need to exceed this limit, please fill out the ElastiCache Limit Increase
-	// Request form at http://aws.amazon.com/contact-us/elasticache-node-limit-request
-	// (http://aws.amazon.com/contact-us/elasticache-node-limit-request).
+	// If you need to exceed this limit, fill out the ElastiCache Limit Increase
+	// Request form at http://aws.amazon.com/contact-us/elasticache-node-limit-request/
+	// (http://aws.amazon.com/contact-us/elasticache-node-limit-request/).
 	NumCacheClusters *int64 `type:"integer"`
 
-	// The port number on which each member of the replication group will accept
-	// connections.
+	// An optional parameter that specifies the number of node groups (shards) for
+	// this Redis (cluster mode enabled) replication group. For Redis (cluster mode
+	// disabled) either omit this parameter or set it to 1.
+	//
+	// Default: 1
+	NumNodeGroups *int64 `type:"integer"`
+
+	// The port number on which each member of the replication group accepts connections.
 	Port *int64 `type:"integer"`
 
-	// A list of EC2 availability zones in which the replication group's cache clusters
-	// will be created. The order of the availability zones in the list is not important.
+	// A list of EC2 Availability Zones in which the replication group's cache clusters
+	// are created. The order of the Availability Zones in the list is the order
+	// in which clusters are allocated. The primary cluster is created in the first
+	// AZ in the list.
+	//
+	// This parameter is not used if there is more than one node group (shard).
+	// You should use NodeGroupConfiguration instead.
 	//
 	//  If you are creating your replication group in an Amazon VPC (recommended),
-	// you can only locate cache clusters in availability zones associated with
+	// you can only locate cache clusters in Availability Zones associated with
 	// the subnets in the selected subnet group.
 	//
-	// The number of availability zones listed must equal the value of NumCacheClusters.
+	// The number of Availability Zones listed must equal the value of NumCacheClusters.
 	//
-	//  Default: system chosen availability zones.
-	//
-	// Example: One Redis cache cluster in each of three availability zones.
-	//
-	//  PreferredAvailabilityZones.member.1=us-west-2a PreferredAvailabilityZones.member.2=us-west-2c
-	// PreferredAvailabilityZones.member.3=us-west-2c
+	//  Default: system chosen Availability Zones.
 	PreferredCacheClusterAZs []*string `locationNameList:"AvailabilityZone" type:"list"`
 
 	// Specifies the weekly time range during which maintenance on the cache cluster
 	// is performed. It is specified as a range in the format ddd:hh24:mi-ddd:hh24:mi
 	// (24H Clock UTC). The minimum maintenance window is a 60 minute period. Valid
 	// values for ddd are:
+	//
+	// Specifies the weekly time range during which maintenance on the cluster
+	// is performed. It is specified as a range in the format ddd:hh24:mi-ddd:hh24:mi
+	// (24H Clock UTC). The minimum maintenance window is a 60 minute period.
+	//
+	// Valid values for ddd are:
 	//
 	//    sun
 	//
@@ -4866,15 +4968,19 @@ type CreateReplicationGroupInput struct {
 	//
 	//    sat
 	//
-	//   Example: sun:05:00-sun:09:00
+	//   Example: sun:23:00-mon:01:30
 	PreferredMaintenanceWindow *string `type:"string"`
 
-	// The identifier of the cache cluster that will serve as the primary for this
-	// replication group. This cache cluster must already exist and have a status
-	// of available.
+	// The identifier of the cache cluster that serves as the primary for this replication
+	// group. This cache cluster must already exist and have a status of available.
 	//
-	// This parameter is not required if NumCacheClusters is specified.
+	// This parameter is not required if NumCacheClusters, NumNodeGroups, or ReplicasPerNodeGroup
+	// is specified.
 	PrimaryClusterId *string `type:"string"`
+
+	// An optional parameter that specifies the number of replica nodes in each
+	// node group (shard). Valid values are 0 to 5.
+	ReplicasPerNodeGroup *int64 `type:"integer"`
 
 	// A user-created description for the replication group.
 	//
@@ -4898,43 +5004,43 @@ type CreateReplicationGroupInput struct {
 	// One or more Amazon VPC security groups associated with this replication group.
 	//
 	// Use this parameter only when you are creating a replication group in an
-	// Amazon Virtual Private Cloud (VPC).
+	// Amazon Virtual Private Cloud (Amazon VPC).
 	SecurityGroupIds []*string `locationNameList:"SecurityGroupId" type:"list"`
 
-	// A single-element string list containing an Amazon Resource Name (ARN) that
-	// uniquely identifies a Redis RDB snapshot file stored in Amazon S3. The snapshot
-	// file will be used to populate the node group. The Amazon S3 object name in
-	// the ARN cannot contain any commas.
+	// A list of Amazon Resource Names (ARN) that uniquely identify the Redis RDB
+	// snapshot files stored in Amazon S3. The snapshot files are used to populate
+	// the replication group. The Amazon S3 object name in the ARN cannot contain
+	// any commas. The list must match the number of node groups (shards) in the
+	// replication group, which means you cannot repartition.
 	//
 	//  This parameter is only valid if the Engine parameter is redis.
 	//
 	//  Example of an Amazon S3 ARN: arn:aws:s3:::my_bucket/snapshot1.rdb
 	SnapshotArns []*string `locationNameList:"SnapshotArn" type:"list"`
 
-	// The name of a snapshot from which to restore data into the new node group.
-	// The snapshot status changes to restoring while the new node group is being
-	// created.
+	// The name of a snapshot from which to restore data into the new replication
+	// group. The snapshot status changes to restoring while the new replication
+	// group is being created.
 	//
 	//  This parameter is only valid if the Engine parameter is redis.
 	SnapshotName *string `type:"string"`
 
-	// The number of days for which ElastiCache will retain automatic snapshots
-	// before deleting them. For example, if you set SnapshotRetentionLimit to 5,
-	// then a snapshot that was taken today will be retained for 5 days before being
-	// deleted.
+	// The number of days for which ElastiCache retains automatic snapshots before
+	// deleting them. For example, if you set SnapshotRetentionLimit to 5, a snapshot
+	// that was taken today is retained for 5 days before being deleted.
 	//
 	//  This parameter is only valid if the Engine parameter is redis.
 	//
 	//  Default: 0 (i.e., automatic backups are disabled for this cache cluster).
 	SnapshotRetentionLimit *int64 `type:"integer"`
 
-	// The daily time range (in UTC) during which ElastiCache will begin taking
-	// a daily snapshot of your node group.
+	// The daily time range (in UTC) during which ElastiCache begins taking a daily
+	// snapshot of your node group (shard).
 	//
 	// Example: 05:00-09:00
 	//
-	// If you do not specify this parameter, then ElastiCache will automatically
-	// choose an appropriate time range.
+	// If you do not specify this parameter, ElastiCache automatically chooses
+	// an appropriate time range.
 	//
 	//  This parameter is only valid if the Engine parameter is redis.
 	SnapshotWindow *string `type:"string"`
@@ -4973,7 +5079,7 @@ func (s *CreateReplicationGroupInput) Validate() error {
 type CreateReplicationGroupOutput struct {
 	_ struct{} `type:"structure"`
 
-	// Contains all of the attributes of a specific replication group.
+	// Contains all of the attributes of a specific Redis replication group.
 	ReplicationGroup *ReplicationGroup `type:"structure"`
 }
 
@@ -4987,15 +5093,17 @@ func (s CreateReplicationGroupOutput) GoString() string {
 	return s.String()
 }
 
-// Represents the input of a CreateSnapshot action.
+// Represents the input of a CreateSnapshot operation.
 type CreateSnapshotInput struct {
 	_ struct{} `type:"structure"`
 
-	// The identifier of an existing cache cluster. The snapshot will be created
-	// from this cache cluster.
-	//
-	// CacheClusterId is a required field
-	CacheClusterId *string `type:"string" required:"true"`
+	// The identifier of an existing cache cluster. The snapshot is created from
+	// this cache cluster.
+	CacheClusterId *string `type:"string"`
+
+	// The identifier of an existing replication group. The snapshot is created
+	// from this replication group.
+	ReplicationGroupId *string `type:"string"`
 
 	// A name for the snapshot being created.
 	//
@@ -5016,9 +5124,6 @@ func (s CreateSnapshotInput) GoString() string {
 // Validate inspects the fields of the type to determine if they are valid.
 func (s *CreateSnapshotInput) Validate() error {
 	invalidParams := request.ErrInvalidParams{Context: "CreateSnapshotInput"}
-	if s.CacheClusterId == nil {
-		invalidParams.Add(request.NewErrParamRequired("CacheClusterId"))
-	}
 	if s.SnapshotName == nil {
 		invalidParams.Add(request.NewErrParamRequired("SnapshotName"))
 	}
@@ -5032,8 +5137,8 @@ func (s *CreateSnapshotInput) Validate() error {
 type CreateSnapshotOutput struct {
 	_ struct{} `type:"structure"`
 
-	// Represents a copy of an entire cache cluster as of the time when the snapshot
-	// was taken.
+	// Represents a copy of an entire Redis cache cluster as of the time when the
+	// snapshot was taken.
 	Snapshot *Snapshot `type:"structure"`
 }
 
@@ -5047,7 +5152,7 @@ func (s CreateSnapshotOutput) GoString() string {
 	return s.String()
 }
 
-// Represents the input of a DeleteCacheCluster action.
+// Represents the input of a DeleteCacheCluster operation.
 type DeleteCacheClusterInput struct {
 	_ struct{} `type:"structure"`
 
@@ -5103,7 +5208,7 @@ func (s DeleteCacheClusterOutput) GoString() string {
 	return s.String()
 }
 
-// Represents the input of a DeleteCacheParameterGroup action.
+// Represents the input of a DeleteCacheParameterGroup operation.
 type DeleteCacheParameterGroupInput struct {
 	_ struct{} `type:"structure"`
 
@@ -5153,7 +5258,7 @@ func (s DeleteCacheParameterGroupOutput) GoString() string {
 	return s.String()
 }
 
-// Represents the input of a DeleteCacheSecurityGroup action.
+// Represents the input of a DeleteCacheSecurityGroup operation.
 type DeleteCacheSecurityGroupInput struct {
 	_ struct{} `type:"structure"`
 
@@ -5202,7 +5307,7 @@ func (s DeleteCacheSecurityGroupOutput) GoString() string {
 	return s.String()
 }
 
-// Represents the input of a DeleteCacheSubnetGroup action.
+// Represents the input of a DeleteCacheSubnetGroup operation.
 type DeleteCacheSubnetGroupInput struct {
 	_ struct{} `type:"structure"`
 
@@ -5251,14 +5356,14 @@ func (s DeleteCacheSubnetGroupOutput) GoString() string {
 	return s.String()
 }
 
-// Represents the input of a DeleteReplicationGroup action.
+// Represents the input of a DeleteReplicationGroup operation.
 type DeleteReplicationGroupInput struct {
 	_ struct{} `type:"structure"`
 
-	// The name of a final node group snapshot. ElastiCache creates the snapshot
-	// from the primary node in the cluster, rather than one of the replicas; this
-	// is to ensure that it captures the freshest data. After the final snapshot
-	// is taken, the cluster is immediately deleted.
+	// The name of a final node group (shard) snapshot. ElastiCache creates the
+	// snapshot from the primary node in the cluster, rather than one of the replicas;
+	// this is to ensure that it captures the freshest data. After the final snapshot
+	// is taken, the replication group is immediately deleted.
 	FinalSnapshotIdentifier *string `type:"string"`
 
 	// The identifier for the cluster to be deleted. This parameter is not case
@@ -5267,8 +5372,8 @@ type DeleteReplicationGroupInput struct {
 	// ReplicationGroupId is a required field
 	ReplicationGroupId *string `type:"string" required:"true"`
 
-	// If set to true, all of the read replicas will be deleted, but the primary
-	// node will be retained.
+	// If set to true, all of the read replicas are deleted, but the primary node
+	// is retained.
 	RetainPrimaryCluster *bool `type:"boolean"`
 }
 
@@ -5298,7 +5403,7 @@ func (s *DeleteReplicationGroupInput) Validate() error {
 type DeleteReplicationGroupOutput struct {
 	_ struct{} `type:"structure"`
 
-	// Contains all of the attributes of a specific replication group.
+	// Contains all of the attributes of a specific Redis replication group.
 	ReplicationGroup *ReplicationGroup `type:"structure"`
 }
 
@@ -5312,7 +5417,7 @@ func (s DeleteReplicationGroupOutput) GoString() string {
 	return s.String()
 }
 
-// Represents the input of a DeleteSnapshot action.
+// Represents the input of a DeleteSnapshot operation.
 type DeleteSnapshotInput struct {
 	_ struct{} `type:"structure"`
 
@@ -5348,8 +5453,8 @@ func (s *DeleteSnapshotInput) Validate() error {
 type DeleteSnapshotOutput struct {
 	_ struct{} `type:"structure"`
 
-	// Represents a copy of an entire cache cluster as of the time when the snapshot
-	// was taken.
+	// Represents a copy of an entire Redis cache cluster as of the time when the
+	// snapshot was taken.
 	Snapshot *Snapshot `type:"structure"`
 }
 
@@ -5363,7 +5468,7 @@ func (s DeleteSnapshotOutput) GoString() string {
 	return s.String()
 }
 
-// Represents the input of a DescribeCacheClusters action.
+// Represents the input of a DescribeCacheClusters operation.
 type DescribeCacheClustersInput struct {
 	_ struct{} `type:"structure"`
 
@@ -5373,7 +5478,7 @@ type DescribeCacheClustersInput struct {
 	CacheClusterId *string `type:"string"`
 
 	// An optional marker returned from a prior request. Use this marker for pagination
-	// of results from this action. If this parameter is specified, the response
+	// of results from this operation. If this parameter is specified, the response
 	// includes only records beyond the marker, up to the value specified by MaxRecords.
 	Marker *string `type:"string"`
 
@@ -5401,7 +5506,7 @@ func (s DescribeCacheClustersInput) GoString() string {
 	return s.String()
 }
 
-// Represents the output of a DescribeCacheClusters action.
+// Represents the output of a DescribeCacheClusters operation.
 type DescribeCacheClustersOutput struct {
 	_ struct{} `type:"structure"`
 
@@ -5423,11 +5528,13 @@ func (s DescribeCacheClustersOutput) GoString() string {
 	return s.String()
 }
 
-// Represents the input of a DescribeCacheEngineVersions action.
+// Represents the input of a DescribeCacheEngineVersions operation.
 type DescribeCacheEngineVersionsInput struct {
 	_ struct{} `type:"structure"`
 
 	// The name of a specific cache parameter group family to return details for.
+	//
+	// Valid values are: memcached1.4 | redis2.6 | redis2.8 | redis3.2
 	//
 	// Constraints:
 	//
@@ -5451,7 +5558,7 @@ type DescribeCacheEngineVersionsInput struct {
 	EngineVersion *string `type:"string"`
 
 	// An optional marker returned from a prior request. Use this marker for pagination
-	// of results from this action. If this parameter is specified, the response
+	// of results from this operation. If this parameter is specified, the response
 	// includes only records beyond the marker, up to the value specified by MaxRecords.
 	Marker *string `type:"string"`
 
@@ -5475,7 +5582,7 @@ func (s DescribeCacheEngineVersionsInput) GoString() string {
 	return s.String()
 }
 
-// Represents the output of a DescribeCacheEngineVersions action.
+// Represents the output of a DescribeCacheEngineVersions operation.
 type DescribeCacheEngineVersionsOutput struct {
 	_ struct{} `type:"structure"`
 
@@ -5497,7 +5604,7 @@ func (s DescribeCacheEngineVersionsOutput) GoString() string {
 	return s.String()
 }
 
-// Represents the input of a DescribeCacheParameterGroups action.
+// Represents the input of a DescribeCacheParameterGroups operation.
 type DescribeCacheParameterGroupsInput struct {
 	_ struct{} `type:"structure"`
 
@@ -5505,7 +5612,7 @@ type DescribeCacheParameterGroupsInput struct {
 	CacheParameterGroupName *string `type:"string"`
 
 	// An optional marker returned from a prior request. Use this marker for pagination
-	// of results from this action. If this parameter is specified, the response
+	// of results from this operation. If this parameter is specified, the response
 	// includes only records beyond the marker, up to the value specified by MaxRecords.
 	Marker *string `type:"string"`
 
@@ -5529,7 +5636,7 @@ func (s DescribeCacheParameterGroupsInput) GoString() string {
 	return s.String()
 }
 
-// Represents the output of a DescribeCacheParameterGroups action.
+// Represents the output of a DescribeCacheParameterGroups operation.
 type DescribeCacheParameterGroupsOutput struct {
 	_ struct{} `type:"structure"`
 
@@ -5551,7 +5658,7 @@ func (s DescribeCacheParameterGroupsOutput) GoString() string {
 	return s.String()
 }
 
-// Represents the input of a DescribeCacheParameters action.
+// Represents the input of a DescribeCacheParameters operation.
 type DescribeCacheParametersInput struct {
 	_ struct{} `type:"structure"`
 
@@ -5561,11 +5668,11 @@ type DescribeCacheParametersInput struct {
 	CacheParameterGroupName *string `type:"string" required:"true"`
 
 	// An optional marker returned from a prior request. Use this marker for pagination
-	// of results from this action. If this parameter is specified, the response
+	// of results from this operation. If this parameter is specified, the response
 	// includes only records beyond the marker, up to the value specified by MaxRecords.
 	Marker *string `type:"string"`
 
-	// The maximum number of brecords to include in the response. If more records
+	// The maximum number of records to include in the response. If more records
 	// exist than the specified MaxRecords value, a marker is included in the response
 	// so that the remaining results can be retrieved.
 	//
@@ -5603,7 +5710,7 @@ func (s *DescribeCacheParametersInput) Validate() error {
 	return nil
 }
 
-// Represents the output of a DescribeCacheParameters action.
+// Represents the output of a DescribeCacheParameters operation.
 type DescribeCacheParametersOutput struct {
 	_ struct{} `type:"structure"`
 
@@ -5628,7 +5735,7 @@ func (s DescribeCacheParametersOutput) GoString() string {
 	return s.String()
 }
 
-// Represents the input of a DescribeCacheSecurityGroups action.
+// Represents the input of a DescribeCacheSecurityGroups operation.
 type DescribeCacheSecurityGroupsInput struct {
 	_ struct{} `type:"structure"`
 
@@ -5636,7 +5743,7 @@ type DescribeCacheSecurityGroupsInput struct {
 	CacheSecurityGroupName *string `type:"string"`
 
 	// An optional marker returned from a prior request. Use this marker for pagination
-	// of results from this action. If this parameter is specified, the response
+	// of results from this operation. If this parameter is specified, the response
 	// includes only records beyond the marker, up to the value specified by MaxRecords.
 	Marker *string `type:"string"`
 
@@ -5660,7 +5767,7 @@ func (s DescribeCacheSecurityGroupsInput) GoString() string {
 	return s.String()
 }
 
-// Represents the output of a DescribeCacheSecurityGroups action.
+// Represents the output of a DescribeCacheSecurityGroups operation.
 type DescribeCacheSecurityGroupsOutput struct {
 	_ struct{} `type:"structure"`
 
@@ -5682,7 +5789,7 @@ func (s DescribeCacheSecurityGroupsOutput) GoString() string {
 	return s.String()
 }
 
-// Represents the input of a DescribeCacheSubnetGroups action.
+// Represents the input of a DescribeCacheSubnetGroups operation.
 type DescribeCacheSubnetGroupsInput struct {
 	_ struct{} `type:"structure"`
 
@@ -5690,7 +5797,7 @@ type DescribeCacheSubnetGroupsInput struct {
 	CacheSubnetGroupName *string `type:"string"`
 
 	// An optional marker returned from a prior request. Use this marker for pagination
-	// of results from this action. If this parameter is specified, the response
+	// of results from this operation. If this parameter is specified, the response
 	// includes only records beyond the marker, up to the value specified by MaxRecords.
 	Marker *string `type:"string"`
 
@@ -5714,7 +5821,7 @@ func (s DescribeCacheSubnetGroupsInput) GoString() string {
 	return s.String()
 }
 
-// Represents the output of a DescribeCacheSubnetGroups action.
+// Represents the output of a DescribeCacheSubnetGroups operation.
 type DescribeCacheSubnetGroupsOutput struct {
 	_ struct{} `type:"structure"`
 
@@ -5736,18 +5843,19 @@ func (s DescribeCacheSubnetGroupsOutput) GoString() string {
 	return s.String()
 }
 
-// Represents the input of a DescribeEngineDefaultParameters action.
+// Represents the input of a DescribeEngineDefaultParameters operation.
 type DescribeEngineDefaultParametersInput struct {
 	_ struct{} `type:"structure"`
 
-	// The name of the cache parameter group family. Valid values are: memcached1.4
-	// | redis2.6 | redis2.8
+	// The name of the cache parameter group family.
+	//
+	// Valid values are: memcached1.4 | redis2.6 | redis2.8 | redis3.2
 	//
 	// CacheParameterGroupFamily is a required field
 	CacheParameterGroupFamily *string `type:"string" required:"true"`
 
 	// An optional marker returned from a prior request. Use this marker for pagination
-	// of results from this action. If this parameter is specified, the response
+	// of results from this operation. If this parameter is specified, the response
 	// includes only records beyond the marker, up to the value specified by MaxRecords.
 	Marker *string `type:"string"`
 
@@ -5787,7 +5895,7 @@ func (s *DescribeEngineDefaultParametersInput) Validate() error {
 type DescribeEngineDefaultParametersOutput struct {
 	_ struct{} `type:"structure"`
 
-	// Represents the output of a DescribeEngineDefaultParameters action.
+	// Represents the output of a DescribeEngineDefaultParameters operation.
 	EngineDefaults *EngineDefaults `type:"structure"`
 }
 
@@ -5801,7 +5909,7 @@ func (s DescribeEngineDefaultParametersOutput) GoString() string {
 	return s.String()
 }
 
-// Represents the input of a DescribeEvents action.
+// Represents the input of a DescribeEvents operation.
 type DescribeEventsInput struct {
 	_ struct{} `type:"structure"`
 
@@ -5813,7 +5921,7 @@ type DescribeEventsInput struct {
 	EndTime *time.Time `type:"timestamp" timestampFormat:"iso8601"`
 
 	// An optional marker returned from a prior request. Use this marker for pagination
-	// of results from this action. If this parameter is specified, the response
+	// of results from this operation. If this parameter is specified, the response
 	// includes only records beyond the marker, up to the value specified by MaxRecords.
 	Marker *string `type:"string"`
 
@@ -5826,15 +5934,12 @@ type DescribeEventsInput struct {
 	// Constraints: minimum 20; maximum 100.
 	MaxRecords *int64 `type:"integer"`
 
-	// The identifier of the event source for which events will be returned. If
-	// not specified, then all sources are included in the response.
+	// The identifier of the event source for which events are returned. If not
+	// specified, all sources are included in the response.
 	SourceIdentifier *string `type:"string"`
 
 	// The event source to retrieve events for. If no value is specified, all events
 	// are returned.
-	//
-	// Valid values are: cache-cluster | cache-parameter-group | cache-security-group
-	// | cache-subnet-group
 	SourceType *string `type:"string" enum:"SourceType"`
 
 	// The beginning of the time interval to retrieve events for, specified in ISO
@@ -5852,7 +5957,7 @@ func (s DescribeEventsInput) GoString() string {
 	return s.String()
 }
 
-// Represents the output of a DescribeEvents action.
+// Represents the output of a DescribeEvents operation.
 type DescribeEventsOutput struct {
 	_ struct{} `type:"structure"`
 
@@ -5874,12 +5979,12 @@ func (s DescribeEventsOutput) GoString() string {
 	return s.String()
 }
 
-// Represents the input of a DescribeReplicationGroups action.
+// Represents the input of a DescribeReplicationGroups operation.
 type DescribeReplicationGroupsInput struct {
 	_ struct{} `type:"structure"`
 
 	// An optional marker returned from a prior request. Use this marker for pagination
-	// of results from this action. If this parameter is specified, the response
+	// of results from this operation. If this parameter is specified, the response
 	// includes only records beyond the marker, up to the value specified by MaxRecords.
 	Marker *string `type:"string"`
 
@@ -5910,7 +6015,7 @@ func (s DescribeReplicationGroupsInput) GoString() string {
 	return s.String()
 }
 
-// Represents the output of a DescribeReplicationGroups action.
+// Represents the output of a DescribeReplicationGroups operation.
 type DescribeReplicationGroupsOutput struct {
 	_ struct{} `type:"structure"`
 
@@ -5932,7 +6037,7 @@ func (s DescribeReplicationGroupsOutput) GoString() string {
 	return s.String()
 }
 
-// Represents the input of a DescribeReservedCacheNodes action.
+// Represents the input of a DescribeReservedCacheNodes operation.
 type DescribeReservedCacheNodesInput struct {
 	_ struct{} `type:"structure"`
 
@@ -5944,7 +6049,8 @@ type DescribeReservedCacheNodesInput struct {
 	//   General purpose:
 	//
 	//   Current generation: cache.t2.micro, cache.t2.small, cache.t2.medium, cache.m3.medium,
-	// cache.m3.large, cache.m3.xlarge, cache.m3.2xlarge
+	// cache.m3.large, cache.m3.xlarge, cache.m3.2xlarge, cache.m4.large, cache.m4.xlarge,
+	// cache.m4.2xlarge, cache.m4.4xlarge, cache.m4.10xlarge
 	//
 	//   Previous generation: cache.t1.micro, cache.m1.small, cache.m1.medium,
 	// cache.m1.large, cache.m1.xlarge
@@ -5960,17 +6066,20 @@ type DescribeReservedCacheNodesInput struct {
 	//
 	//      Notes:
 	//
-	//   All t2 instances are created in an Amazon Virtual Private Cloud (VPC).
+	//   All T2 instances are created in an Amazon Virtual Private Cloud (Amazon
+	// VPC).
 	//
-	//   Redis backup/restore is not supported for t2 instances.
+	//   Redis backup/restore is not supported for Redis (cluster mode disabled)
+	// T1 and T2 instances. Backup/restore is supported on Redis (cluster mode enabled)
+	// T2 instances.
 	//
-	//   Redis Append-only files (AOF) functionality is not supported for t1 or
-	// t2 instances.
+	//   Redis Append-only files (AOF) functionality is not supported for T1 or
+	// T2 instances.
 	//
-	//   For a complete listing of cache node types and specifications, see Amazon
-	// ElastiCache Product Features and Details (http://aws.amazon.com/elasticache/details)
-	// and Cache Node Type-Specific Parameters for Memcached (http://docs.aws.amazon.com/AmazonElastiCache/latest/UserGuide/CacheParameterGroups.Memcached.html#CacheParameterGroups.Memcached.NodeSpecific)
-	// or Cache Node Type-Specific Parameters for Redis (http://docs.aws.amazon.com/AmazonElastiCache/latest/UserGuide/CacheParameterGroups.Redis.html#CacheParameterGroups.Redis.NodeSpecific).
+	//   For a complete listing of node types and specifications, see Amazon ElastiCache
+	// Product Features and Details (http://aws.amazon.com/elasticache/details)
+	// and either Cache Node Type-Specific Parameters for Memcached (http://docs.aws.amazon.com/AmazonElastiCache/latest/UserGuide/CacheParameterGroups.Memcached.html#ParameterGroups.Memcached.NodeSpecific)
+	// or Cache Node Type-Specific Parameters for Redis (http://docs.aws.amazon.com/AmazonElastiCache/latest/UserGuide/CacheParameterGroups.Redis.html#ParameterGroups.Redis.NodeSpecific).
 	CacheNodeType *string `type:"string"`
 
 	// The duration filter value, specified in years or seconds. Use this parameter
@@ -5980,7 +6089,7 @@ type DescribeReservedCacheNodesInput struct {
 	Duration *string `type:"string"`
 
 	// An optional marker returned from a prior request. Use this marker for pagination
-	// of results from this action. If this parameter is specified, the response
+	// of results from this operation. If this parameter is specified, the response
 	// includes only records beyond the marker, up to the value specified by MaxRecords.
 	Marker *string `type:"string"`
 
@@ -6022,7 +6131,7 @@ func (s DescribeReservedCacheNodesInput) GoString() string {
 	return s.String()
 }
 
-// Represents the input of a DescribeReservedCacheNodesOfferings action.
+// Represents the input of a DescribeReservedCacheNodesOfferings operation.
 type DescribeReservedCacheNodesOfferingsInput struct {
 	_ struct{} `type:"structure"`
 
@@ -6034,7 +6143,8 @@ type DescribeReservedCacheNodesOfferingsInput struct {
 	//   General purpose:
 	//
 	//   Current generation: cache.t2.micro, cache.t2.small, cache.t2.medium, cache.m3.medium,
-	// cache.m3.large, cache.m3.xlarge, cache.m3.2xlarge
+	// cache.m3.large, cache.m3.xlarge, cache.m3.2xlarge, cache.m4.large, cache.m4.xlarge,
+	// cache.m4.2xlarge, cache.m4.4xlarge, cache.m4.10xlarge
 	//
 	//   Previous generation: cache.t1.micro, cache.m1.small, cache.m1.medium,
 	// cache.m1.large, cache.m1.xlarge
@@ -6050,17 +6160,20 @@ type DescribeReservedCacheNodesOfferingsInput struct {
 	//
 	//      Notes:
 	//
-	//   All t2 instances are created in an Amazon Virtual Private Cloud (VPC).
+	//   All T2 instances are created in an Amazon Virtual Private Cloud (Amazon
+	// VPC).
 	//
-	//   Redis backup/restore is not supported for t2 instances.
+	//   Redis backup/restore is not supported for Redis (cluster mode disabled)
+	// T1 and T2 instances. Backup/restore is supported on Redis (cluster mode enabled)
+	// T2 instances.
 	//
-	//   Redis Append-only files (AOF) functionality is not supported for t1 or
-	// t2 instances.
+	//   Redis Append-only files (AOF) functionality is not supported for T1 or
+	// T2 instances.
 	//
-	//   For a complete listing of cache node types and specifications, see Amazon
-	// ElastiCache Product Features and Details (http://aws.amazon.com/elasticache/details)
-	// and Cache Node Type-Specific Parameters for Memcached (http://docs.aws.amazon.com/AmazonElastiCache/latest/UserGuide/CacheParameterGroups.Memcached.html#CacheParameterGroups.Memcached.NodeSpecific)
-	// or Cache Node Type-Specific Parameters for Redis (http://docs.aws.amazon.com/AmazonElastiCache/latest/UserGuide/CacheParameterGroups.Redis.html#CacheParameterGroups.Redis.NodeSpecific).
+	//   For a complete listing of node types and specifications, see Amazon ElastiCache
+	// Product Features and Details (http://aws.amazon.com/elasticache/details)
+	// and either Cache Node Type-Specific Parameters for Memcached (http://docs.aws.amazon.com/AmazonElastiCache/latest/UserGuide/CacheParameterGroups.Memcached.html#ParameterGroups.Memcached.NodeSpecific)
+	// or Cache Node Type-Specific Parameters for Redis (http://docs.aws.amazon.com/AmazonElastiCache/latest/UserGuide/CacheParameterGroups.Redis.html#ParameterGroups.Redis.NodeSpecific).
 	CacheNodeType *string `type:"string"`
 
 	// Duration filter value, specified in years or seconds. Use this parameter
@@ -6070,7 +6183,7 @@ type DescribeReservedCacheNodesOfferingsInput struct {
 	Duration *string `type:"string"`
 
 	// An optional marker returned from a prior request. Use this marker for pagination
-	// of results from this action. If this parameter is specified, the response
+	// of results from this operation. If this parameter is specified, the response
 	// includes only records beyond the marker, up to the value specified by MaxRecords.
 	Marker *string `type:"string"`
 
@@ -6110,7 +6223,7 @@ func (s DescribeReservedCacheNodesOfferingsInput) GoString() string {
 	return s.String()
 }
 
-// Represents the output of a DescribeReservedCacheNodesOfferings action.
+// Represents the output of a DescribeReservedCacheNodesOfferings operation.
 type DescribeReservedCacheNodesOfferingsOutput struct {
 	_ struct{} `type:"structure"`
 
@@ -6132,7 +6245,7 @@ func (s DescribeReservedCacheNodesOfferingsOutput) GoString() string {
 	return s.String()
 }
 
-// Represents the output of a DescribeReservedCacheNodes action.
+// Represents the output of a DescribeReservedCacheNodes operation.
 type DescribeReservedCacheNodesOutput struct {
 	_ struct{} `type:"structure"`
 
@@ -6154,16 +6267,16 @@ func (s DescribeReservedCacheNodesOutput) GoString() string {
 	return s.String()
 }
 
-// Represents the input of a DescribeSnapshotsMessage action.
+// Represents the input of a DescribeSnapshotsMessage operation.
 type DescribeSnapshotsInput struct {
 	_ struct{} `type:"structure"`
 
 	// A user-supplied cluster identifier. If this parameter is specified, only
-	// snapshots associated with that specific cache cluster will be described.
+	// snapshots associated with that specific cache cluster are described.
 	CacheClusterId *string `type:"string"`
 
 	// An optional marker returned from a prior request. Use this marker for pagination
-	// of results from this action. If this parameter is specified, the response
+	// of results from this operation. If this parameter is specified, the response
 	// includes only records beyond the marker, up to the value specified by MaxRecords.
 	Marker *string `type:"string"`
 
@@ -6176,8 +6289,16 @@ type DescribeSnapshotsInput struct {
 	// Constraints: minimum 20; maximum 50.
 	MaxRecords *int64 `type:"integer"`
 
+	// A user-supplied replication group identifier. If this parameter is specified,
+	// only snapshots associated with that specific replication group are described.
+	ReplicationGroupId *string `type:"string"`
+
+	// A boolean value which if true, the node group (shard) configuration is included
+	// in the snapshot description.
+	ShowNodeGroupConfig *bool `type:"boolean"`
+
 	// A user-supplied name of the snapshot. If this parameter is specified, only
-	// this snapshot will be described.
+	// this snapshot are described.
 	SnapshotName *string `type:"string"`
 
 	// If set to system, the output shows snapshots that were automatically created
@@ -6197,12 +6318,12 @@ func (s DescribeSnapshotsInput) GoString() string {
 	return s.String()
 }
 
-// Represents the output of a DescribeSnapshots action.
+// Represents the output of a DescribeSnapshots operation.
 type DescribeSnapshotsOutput struct {
 	_ struct{} `type:"structure"`
 
 	// An optional marker returned from a prior request. Use this marker for pagination
-	// of results from this action. If this parameter is specified, the response
+	// of results from this operation. If this parameter is specified, the response
 	// includes only records beyond the marker, up to the value specified by MaxRecords.
 	Marker *string `type:"string"`
 
@@ -6267,7 +6388,7 @@ func (s Endpoint) GoString() string {
 	return s.String()
 }
 
-// Represents the output of a DescribeEngineDefaultParameters action.
+// Represents the output of a DescribeEngineDefaultParameters operation.
 type EngineDefaults struct {
 	_ struct{} `type:"structure"`
 
@@ -6277,6 +6398,8 @@ type EngineDefaults struct {
 
 	// Specifies the name of the cache parameter group family to which the engine
 	// default parameters apply.
+	//
+	// Valid values are: memcached1.4 | redis2.6 | redis2.8 | redis3.2
 	CacheParameterGroupFamily *string `type:"string"`
 
 	// Provides an identifier to allow retrieval of paginated results.
@@ -6328,14 +6451,14 @@ func (s Event) GoString() string {
 	return s.String()
 }
 
-// The input parameters for the ListAllowedNodeTypeModifications action.
+// The input parameters for the ListAllowedNodeTypeModifications operation.
 type ListAllowedNodeTypeModificationsInput struct {
 	_ struct{} `type:"structure"`
 
 	// The name of the cache cluster you want to scale up to a larger node instanced
 	// type. ElastiCache uses the cluster id to identify the current node type of
-	// this cluster and from that to to create a list of node types you can scale
-	// up to.
+	// this cluster and from that to create a list of node types you can scale up
+	// to.
 	//
 	//  You must provide a value for either the CacheClusterId or the ReplicationGroupId.
 	CacheClusterId *string `type:"string"`
@@ -6359,17 +6482,9 @@ func (s ListAllowedNodeTypeModificationsInput) GoString() string {
 	return s.String()
 }
 
-// Represents the allowed node types you can use to modify your cache cluster
-// or replication group.
 type ListAllowedNodeTypeModificationsOutput struct {
 	_ struct{} `type:"structure"`
 
-	// A string list, each element of which specifies a cache node type which you
-	// can use to scale your cache cluster or replication group.
-	//
-	// When scaling up a Redis cluster or replication group using ModifyCacheCluster
-	// or ModifyReplicationGroup, use a value from this list for the CacheNodeType
-	// parameter.
 	ScaleUpModifications []*string `type:"list"`
 }
 
@@ -6383,7 +6498,7 @@ func (s ListAllowedNodeTypeModificationsOutput) GoString() string {
 	return s.String()
 }
 
-// The input parameters for the ListTagsForResource action.
+// The input parameters for the ListTagsForResource operation.
 type ListTagsForResourceInput struct {
 	_ struct{} `type:"structure"`
 
@@ -6391,7 +6506,7 @@ type ListTagsForResourceInput struct {
 	// of tags, for example arn:aws:elasticache:us-west-2:0123456789:cluster:myCluster
 	// or arn:aws:elasticache:us-west-2:0123456789:snapshot:mySnapshot.
 	//
-	// For more information on ARNs, go to Amazon Resource Names (ARNs) and AWS
+	// For more information about ARNs, see Amazon Resource Names (ARNs) and AWS
 	// Service Namespaces (http://docs.aws.amazon.com/general/latest/gr/aws-arns-and-namespaces.html).
 	//
 	// ResourceName is a required field
@@ -6421,7 +6536,7 @@ func (s *ListTagsForResourceInput) Validate() error {
 	return nil
 }
 
-// Represents the input of a ModifyCacheCluster action.
+// Represents the input of a ModifyCacheCluster operation.
 type ModifyCacheClusterInput struct {
 	_ struct{} `type:"structure"`
 
@@ -6436,8 +6551,8 @@ type ModifyCacheClusterInput struct {
 	// cache nodes in different Availability Zones. If cross-az is specified, existing
 	// Memcached nodes remain in their current Availability Zone.
 	//
-	// Only newly created nodes will be located in different Availability Zones.
-	// For instructions on how to move existing Memcached nodes to different Availability
+	// Only newly created nodes are located in different Availability Zones. For
+	// instructions on how to move existing Memcached nodes to different Availability
 	// Zones, see the Availability Zone Considerations section of Cache Node Considerations
 	// for Memcached (http://docs.aws.amazon.com/AmazonElastiCache/latest/UserGuide/CacheNode.Memcached.html).
 	AZMode *string `type:"string" enum:"AZMode"`
@@ -6446,7 +6561,7 @@ type ModifyCacheClusterInput struct {
 	// pending modifications to be applied, asynchronously and as soon as possible,
 	// regardless of the PreferredMaintenanceWindow setting for the cache cluster.
 	//
-	// If false, then changes to the cache cluster are applied on the next maintenance
+	// If false, changes to the cache cluster are applied on the next maintenance
 	// reboot, or the next failure reboot, whichever occurs first.
 	//
 	//  If you perform a ModifyCacheCluster before a pending modification is applied,
@@ -6477,9 +6592,7 @@ type ModifyCacheClusterInput struct {
 	// 2 (7 - 5) cache node IDs to remove.
 	CacheNodeIdsToRemove []*string `locationNameList:"CacheNodeId" type:"list"`
 
-	// A valid cache node type that you want to scale this cache cluster to. The
-	// value of this parameter must be one of the ScaleUpModifications values returned
-	// by the ListAllowedCacheNodeTypeModification action.
+	// A valid cache node type that you want to scale this cache cluster up to.
 	CacheNodeType *string `type:"string"`
 
 	// The name of the cache parameter group to apply to this cache cluster. This
@@ -6490,8 +6603,8 @@ type ModifyCacheClusterInput struct {
 	// A list of cache security group names to authorize on this cache cluster.
 	// This change is asynchronously applied as soon as possible.
 	//
-	// This parameter can be used only with clusters that are created outside of
-	// an Amazon Virtual Private Cloud (VPC).
+	// You can use this parameter only with clusters that are created outside of
+	// an Amazon Virtual Private Cloud (Amazon VPC).
 	//
 	// Constraints: Must contain no more than 255 alphanumeric characters. Must
 	// not be "Default".
@@ -6506,8 +6619,7 @@ type ModifyCacheClusterInput struct {
 	// create it anew with the earlier engine version.
 	EngineVersion *string `type:"string"`
 
-	// The list of Availability Zones where the new Memcached cache nodes will be
-	// created.
+	// The list of Availability Zones where the new Memcached cache nodes are created.
 	//
 	// This parameter is only valid when NumCacheNodes in the request is greater
 	// than the sum of the number of active cache nodes and the number of cache
@@ -6526,8 +6638,8 @@ type ModifyCacheClusterInput struct {
 	// the scenario 1 call) and want to add 1 more node. Specify NumCacheNodes=6
 	// ((3 + 2) + 1) and optionally specify an Availability Zone for the new node.
 	//
-	//    Scenario 3: You want to cancel all pending actions. Specify NumCacheNodes=3
-	// to cancel all pending actions.
+	//    Scenario 3: You want to cancel all pending operations. Specify NumCacheNodes=3
+	// to cancel all pending operations.
 	//
 	//   The Availability Zone placement of nodes pending creation cannot be modified.
 	// If you wish to cancel any nodes pending creation, add 0 nodes by setting
@@ -6576,14 +6688,10 @@ type ModifyCacheClusterInput struct {
 	//   Important: If the new create request is Apply Immediately - Yes, all creates
 	// are performed immediately. If the new create request is Apply Immediately
 	// - No, all creates are pending.
-	//
-	//      Example:
-	//
-	//  NewAvailabilityZones.member.1=us-west-2a&amp;NewAvailabilityZones.member.2=us-west-2b&amp;NewAvailabilityZones.member.3=us-west-2c
 	NewAvailabilityZones []*string `locationNameList:"PreferredAvailabilityZone" type:"list"`
 
 	// The Amazon Resource Name (ARN) of the Amazon SNS topic to which notifications
-	// will be sent.
+	// are sent.
 	//
 	//  The Amazon SNS topic owner must be same as the cache cluster owner.
 	NotificationTopicArn *string `type:"string"`
@@ -6597,9 +6705,9 @@ type ModifyCacheClusterInput struct {
 	// The number of cache nodes that the cache cluster should have. If the value
 	// for NumCacheNodes is greater than the sum of the number of current cache
 	// nodes and the number of cache nodes pending creation (which may be zero),
-	// then more nodes will be added. If the value is less than the number of existing
-	// cache nodes, then nodes will be removed. If the value is equal to the number
-	// of current cache nodes, then any pending add or remove requests are canceled.
+	// more nodes are added. If the value is less than the number of existing cache
+	// nodes, nodes are removed. If the value is equal to the number of current
+	// cache nodes, any pending add or remove requests are canceled.
 	//
 	// If you are removing cache nodes, you must use the CacheNodeIdsToRemove parameter
 	// to provide the IDs of the specific cache nodes to remove.
@@ -6608,29 +6716,30 @@ type ModifyCacheClusterInput struct {
 	// this value must be between 1 and 20.
 	//
 	//  Adding or removing Memcached cache nodes can be applied immediately or
-	// as a pending action. See ApplyImmediately.
+	// as a pending operation (see ApplyImmediately).
 	//
-	// A pending action to modify the number of cache nodes in a cluster during
+	// A pending operation to modify the number of cache nodes in a cluster during
 	// its maintenance window, whether by adding or removing nodes in accordance
 	// with the scale out architecture, is not queued. The customer's latest request
-	// to add or remove nodes to the cluster overrides any previous pending actions
+	// to add or remove nodes to the cluster overrides any previous pending operations
 	// to modify the number of cache nodes in the cluster. For example, a request
-	// to remove 2 nodes would override a previous pending action to remove 3 nodes.
-	// Similarly, a request to add 2 nodes would override a previous pending action
-	// to remove 3 nodes and vice versa. As Memcached cache nodes may now be provisioned
-	// in different Availability Zones with flexible cache node placement, a request
-	// to add nodes does not automatically override a previous pending action to
-	// add nodes. The customer can modify the previous pending action to add more
-	// nodes or explicitly cancel the pending request and retry the new request.
-	// To cancel pending actions to modify the number of cache nodes in a cluster,
-	// use the ModifyCacheCluster request and set NumCacheNodes equal to the number
-	// of cache nodes currently in the cache cluster.
+	// to remove 2 nodes would override a previous pending operation to remove 3
+	// nodes. Similarly, a request to add 2 nodes would override a previous pending
+	// operation to remove 3 nodes and vice versa. As Memcached cache nodes may
+	// now be provisioned in different Availability Zones with flexible cache node
+	// placement, a request to add nodes does not automatically override a previous
+	// pending operation to add nodes. The customer can modify the previous pending
+	// operation to add more nodes or explicitly cancel the pending request and
+	// retry the new request. To cancel pending operations to modify the number
+	// of cache nodes in a cluster, use the ModifyCacheCluster request and set NumCacheNodes
+	// equal to the number of cache nodes currently in the cache cluster.
 	NumCacheNodes *int64 `type:"integer"`
 
-	// Specifies the weekly time range during which maintenance on the cache cluster
-	// is performed. It is specified as a range in the format ddd:hh24:mi-ddd:hh24:mi
-	// (24H Clock UTC). The minimum maintenance window is a 60 minute period. Valid
-	// values for ddd are:
+	// Specifies the weekly time range during which maintenance on the cluster is
+	// performed. It is specified as a range in the format ddd:hh24:mi-ddd:hh24:mi
+	// (24H Clock UTC). The minimum maintenance window is a 60 minute period.
+	//
+	// Valid values for ddd are:
 	//
 	//    sun
 	//
@@ -6646,26 +6755,26 @@ type ModifyCacheClusterInput struct {
 	//
 	//    sat
 	//
-	//   Example: sun:05:00-sun:09:00
+	//   Example: sun:23:00-mon:01:30
 	PreferredMaintenanceWindow *string `type:"string"`
 
 	// Specifies the VPC Security Groups associated with the cache cluster.
 	//
 	// This parameter can be used only with clusters that are created in an Amazon
-	// Virtual Private Cloud (VPC).
+	// Virtual Private Cloud (Amazon VPC).
 	SecurityGroupIds []*string `locationNameList:"SecurityGroupId" type:"list"`
 
-	// The number of days for which ElastiCache will retain automatic cache cluster
+	// The number of days for which ElastiCache retains automatic cache cluster
 	// snapshots before deleting them. For example, if you set SnapshotRetentionLimit
-	// to 5, then a snapshot that was taken today will be retained for 5 days before
-	// being deleted.
+	// to 5, a snapshot that was taken today is retained for 5 days before being
+	// deleted.
 	//
 	//  If the value of SnapshotRetentionLimit is set to zero (0), backups are
 	// turned off.
 	SnapshotRetentionLimit *int64 `type:"integer"`
 
-	// The daily time range (in UTC) during which ElastiCache will begin taking
-	// a daily snapshot of your cache cluster.
+	// The daily time range (in UTC) during which ElastiCache begins taking a daily
+	// snapshot of your cache cluster.
 	SnapshotWindow *string `type:"string"`
 }
 
@@ -6709,7 +6818,7 @@ func (s ModifyCacheClusterOutput) GoString() string {
 	return s.String()
 }
 
-// Represents the input of a ModifyCacheParameterGroup action.
+// Represents the input of a ModifyCacheParameterGroup operation.
 type ModifyCacheParameterGroupInput struct {
 	_ struct{} `type:"structure"`
 
@@ -6752,11 +6861,11 @@ func (s *ModifyCacheParameterGroupInput) Validate() error {
 	return nil
 }
 
-// Represents the input of a ModifyCacheSubnetGroup action.
+// Represents the input of a ModifyCacheSubnetGroup operation.
 type ModifyCacheSubnetGroupInput struct {
 	_ struct{} `type:"structure"`
 
-	// A description for the cache subnet group.
+	// A description of the cache subnet group.
 	CacheSubnetGroupDescription *string `type:"string"`
 
 	// The name for the cache subnet group. This value is stored as a lowercase
@@ -6799,7 +6908,7 @@ func (s *ModifyCacheSubnetGroupInput) Validate() error {
 type ModifyCacheSubnetGroupOutput struct {
 	_ struct{} `type:"structure"`
 
-	// Represents the output of one of the following actions:
+	// Represents the output of one of the following operations:
 	//
 	//    CreateCacheSubnetGroup
 	//
@@ -6817,7 +6926,7 @@ func (s ModifyCacheSubnetGroupOutput) GoString() string {
 	return s.String()
 }
 
-// Represents the input of a ModifyReplicationGroups action.
+// Represents the input of a ModifyReplicationGroups operation.
 type ModifyReplicationGroupInput struct {
 	_ struct{} `type:"structure"`
 
@@ -6826,9 +6935,8 @@ type ModifyReplicationGroupInput struct {
 	// regardless of the PreferredMaintenanceWindow setting for the replication
 	// group.
 	//
-	// If false, then changes to the nodes in the replication group are applied
-	// on the next maintenance reboot, or the next failure reboot, whichever occurs
-	// first.
+	// If false, changes to the nodes in the replication group are applied on the
+	// next maintenance reboot, or the next failure reboot, whichever occurs first.
 	//
 	// Valid values: true | false
 	//
@@ -6838,8 +6946,8 @@ type ModifyReplicationGroupInput struct {
 	// This parameter is currently disabled.
 	AutoMinorVersionUpgrade *bool `type:"boolean"`
 
-	// Whether a read replica will be automatically promoted to read/write primary
-	// if the existing primary encounters a failure.
+	// Determines whether a read replica is automatically promoted to read/write
+	// primary if the existing primary encounters a failure.
 	//
 	// Valid values: true | false
 	//
@@ -6847,12 +6955,12 @@ type ModifyReplicationGroupInput struct {
 	//
 	//   Redis versions earlier than 2.8.6.
 	//
-	//   T1 and T2 cache node types.
+	//   Redis (cluster mode disabled):T1 and T2 cache node types.
+	//
+	// Redis (cluster mode enabled): T1 node types.
 	AutomaticFailoverEnabled *bool `type:"boolean"`
 
 	// A valid cache node type that you want to scale this replication group to.
-	// The value of this parameter must be one of the ScaleUpModifications values
-	// returned by the ListAllowedCacheNodeTypeModification action.
 	CacheNodeType *string `type:"string"`
 
 	// The name of the cache parameter group to apply to all of the clusters in
@@ -6865,10 +6973,10 @@ type ModifyReplicationGroupInput struct {
 	// replication group. This change is asynchronously applied as soon as possible.
 	//
 	// This parameter can be used only with replication group containing cache
-	// clusters running outside of an Amazon Virtual Private Cloud (VPC).
+	// clusters running outside of an Amazon Virtual Private Cloud (Amazon VPC).
 	//
 	// Constraints: Must contain no more than 255 alphanumeric characters. Must
-	// not be "Default".
+	// not be Default.
 	CacheSecurityGroupNames []*string `locationNameList:"CacheSecurityGroupName" type:"list"`
 
 	// The upgraded version of the cache engine to be run on the cache clusters
@@ -6882,7 +6990,7 @@ type ModifyReplicationGroupInput struct {
 	EngineVersion *string `type:"string"`
 
 	// The Amazon Resource Name (ARN) of the Amazon SNS topic to which notifications
-	// will be sent.
+	// are sent.
 	//
 	//  The Amazon SNS topic owner must be same as the replication group owner.
 	NotificationTopicArn *string `type:"string"`
@@ -6893,10 +7001,11 @@ type ModifyReplicationGroupInput struct {
 	// Valid values: active | inactive
 	NotificationTopicStatus *string `type:"string"`
 
-	// Specifies the weekly time range during which maintenance on the cache cluster
-	// is performed. It is specified as a range in the format ddd:hh24:mi-ddd:hh24:mi
-	// (24H Clock UTC). The minimum maintenance window is a 60 minute period. Valid
-	// values for ddd are:
+	// Specifies the weekly time range during which maintenance on the cluster is
+	// performed. It is specified as a range in the format ddd:hh24:mi-ddd:hh24:mi
+	// (24H Clock UTC). The minimum maintenance window is a 60 minute period.
+	//
+	// Valid values for ddd are:
 	//
 	//    sun
 	//
@@ -6912,12 +7021,13 @@ type ModifyReplicationGroupInput struct {
 	//
 	//    sat
 	//
-	//   Example: sun:05:00-sun:09:00
+	//   Example: sun:23:00-mon:01:30
 	PreferredMaintenanceWindow *string `type:"string"`
 
-	// If this parameter is specified, ElastiCache will promote the specified cluster
-	// in the specified replication group to the primary role. The nodes of all
-	// other clusters in the replication group will be read replicas.
+	// For replication groups with a single primary, if this parameter is specified,
+	// ElastiCache promotes the specified cluster in the specified replication group
+	// to the primary role. The nodes of all other clusters in the replication group
+	// are read replicas.
 	PrimaryClusterId *string `type:"string"`
 
 	// A description for the replication group. Maximum length is 255 characters.
@@ -6932,29 +7042,30 @@ type ModifyReplicationGroupInput struct {
 	// replication group.
 	//
 	// This parameter can be used only with replication group containing cache
-	// clusters running in an Amazon Virtual Private Cloud (VPC).
+	// clusters running in an Amazon Virtual Private Cloud (Amazon VPC).
 	SecurityGroupIds []*string `locationNameList:"SecurityGroupId" type:"list"`
 
-	// The number of days for which ElastiCache will retain automatic node group
+	// The number of days for which ElastiCache retains automatic node group (shard)
 	// snapshots before deleting them. For example, if you set SnapshotRetentionLimit
-	// to 5, then a snapshot that was taken today will be retained for 5 days before
-	// being deleted.
+	// to 5, a snapshot that was taken today is retained for 5 days before being
+	// deleted.
 	//
 	//  Important If the value of SnapshotRetentionLimit is set to zero (0), backups
 	// are turned off.
 	SnapshotRetentionLimit *int64 `type:"integer"`
 
-	// The daily time range (in UTC) during which ElastiCache will begin taking
-	// a daily snapshot of the node group specified by SnapshottingClusterId.
+	// The daily time range (in UTC) during which ElastiCache begins taking a daily
+	// snapshot of the node group (shard) specified by SnapshottingClusterId.
 	//
 	// Example: 05:00-09:00
 	//
-	// If you do not specify this parameter, then ElastiCache will automatically
-	// choose an appropriate time range.
+	// If you do not specify this parameter, ElastiCache automatically chooses
+	// an appropriate time range.
 	SnapshotWindow *string `type:"string"`
 
-	// The cache cluster ID that will be used as the daily snapshot source for the
-	// replication group.
+	// The cache cluster ID that is used as the daily snapshot source for the replication
+	// group. This parameter cannot be set for Redis (cluster mode enabled) replication
+	// groups.
 	SnapshottingClusterId *string `type:"string"`
 }
 
@@ -6984,7 +7095,7 @@ func (s *ModifyReplicationGroupInput) Validate() error {
 type ModifyReplicationGroupOutput struct {
 	_ struct{} `type:"structure"`
 
-	// Contains all of the attributes of a specific replication group.
+	// Contains all of the attributes of a specific Redis replication group.
 	ReplicationGroup *ReplicationGroup `type:"structure"`
 }
 
@@ -6998,20 +7109,27 @@ func (s ModifyReplicationGroupOutput) GoString() string {
 	return s.String()
 }
 
-// Represents a collection of cache nodes in a replication group.
+// Represents a collection of cache nodes in a replication group. One node in
+// the node group is the read/write Primary node. All the other nodes are read-only
+// Replica nodes.
 type NodeGroup struct {
 	_ struct{} `type:"structure"`
 
-	// The identifier for the node group. A replication group contains only one
-	// node group; therefore, the node group ID is 0001.
+	// The identifier for the node group (shard). A Redis (cluster mode disabled)
+	// replication group contains only 1 node group; therefore, the node group ID
+	// is 0001. A Redis (cluster mode enabled) replication group contains 1 to 15
+	// node groups numbered 0001 to 0015.
 	NodeGroupId *string `type:"string"`
 
-	// A list containing information about individual nodes within the node group.
+	// A list containing information about individual nodes within the node group
+	// (shard).
 	NodeGroupMembers []*NodeGroupMember `locationNameList:"NodeGroupMember" type:"list"`
 
-	// Represents the information required for client programs to connect to a cache
-	// node.
+	// The endpoint of the primary node in this node group (shard).
 	PrimaryEndpoint *Endpoint `type:"structure"`
+
+	// The keyspace for this node group (shard).
+	Slots *string `type:"string"`
 
 	// The current state of this replication group - creating, available, etc.
 	Status *string `type:"string"`
@@ -7027,7 +7145,42 @@ func (s NodeGroup) GoString() string {
 	return s.String()
 }
 
-// Represents a single node within a node group.
+// node group (shard) configuration options. Each node group (shard) configuration
+// has the following: Slots, PrimaryAvailabilityZone, ReplicaAvailabilityZones,
+// ReplicaCount.
+type NodeGroupConfiguration struct {
+	_ struct{} `type:"structure"`
+
+	// The Availability Zone where the primary node of this node group (shard) is
+	// launched.
+	PrimaryAvailabilityZone *string `type:"string"`
+
+	// A list of Availability Zones to be used for the read replicas. The number
+	// of Availability Zones in this list must match the value of ReplicaCount or
+	// ReplicasPerNodeGroup if not specified.
+	ReplicaAvailabilityZones []*string `locationNameList:"AvailabilityZone" type:"list"`
+
+	// The number of read replica nodes in this node group (shard).
+	ReplicaCount *int64 `type:"integer"`
+
+	// A string that specifies the keyspaces as a series of comma separated values.
+	// Keyspaces are 0 to 16,383. The string is in the format startkey-endkey.
+	//
+	// Example: "0-3999"
+	Slots *string `type:"string"`
+}
+
+// String returns the string representation
+func (s NodeGroupConfiguration) String() string {
+	return awsutil.Prettify(s)
+}
+
+// GoString returns the string representation
+func (s NodeGroupConfiguration) GoString() string {
+	return s.String()
+}
+
+// Represents a single node within a node group (shard).
 type NodeGroupMember struct {
 	_ struct{} `type:"structure"`
 
@@ -7063,6 +7216,9 @@ func (s NodeGroupMember) GoString() string {
 type NodeSnapshot struct {
 	_ struct{} `type:"structure"`
 
+	// A unique identifier for the source cache cluster.
+	CacheClusterId *string `type:"string"`
+
 	// The date and time when the cache node was created in the source cache cluster.
 	CacheNodeCreateTime *time.Time `type:"timestamp" timestampFormat:"iso8601"`
 
@@ -7071,6 +7227,12 @@ type NodeSnapshot struct {
 
 	// The size of the cache on the source cache node.
 	CacheSize *string `type:"string"`
+
+	// The configuration for the source node group (shard).
+	NodeGroupConfiguration *NodeGroupConfiguration `type:"structure"`
+
+	// A unique identifier for the source node group (shard).
+	NodeGroupId *string `type:"string"`
 
 	// The date and time when the source node's metadata and cache data set was
 	// obtained for the snapshot.
@@ -7118,10 +7280,10 @@ type Parameter struct {
 	// The valid range of values for the parameter.
 	AllowedValues *string `type:"string"`
 
-	// ChangeType indicates whether a change to the parameter will be applied immediately
-	// or requires a reboot for the change to be applied. You can force a reboot
-	// or wait until the next maintenance window's reboot. For more information,
-	// see Rebooting a Cluster (http://docs.aws.amazon.com/AmazonElastiCache/latest/UserGuide/Clusters.Rebooting.html).
+	// Indicates whether a change to the parameter is applied immediately or requires
+	// a reboot for the change to be applied. You can force a reboot or wait until
+	// the next maintenance window's reboot. For more information, see Rebooting
+	// a Cluster (http://docs.aws.amazon.com/AmazonElastiCache/latest/UserGuide/Clusters.Rebooting.html).
 	ChangeType *string `type:"string" enum:"ChangeType"`
 
 	// The valid data type for the parameter.
@@ -7179,7 +7341,7 @@ func (s ParameterNameValue) GoString() string {
 	return s.String()
 }
 
-// A group of settings that will be applied to the cache cluster in the future,
+// A group of settings that are applied to the cache cluster in the future,
 // or that are currently being applied.
 type PendingModifiedValues struct {
 	_ struct{} `type:"structure"`
@@ -7188,11 +7350,11 @@ type PendingModifiedValues struct {
 	// the cache cluster. A node ID is a numeric identifier (0001, 0002, etc.).
 	CacheNodeIdsToRemove []*string `locationNameList:"CacheNodeId" type:"list"`
 
-	// The cache node type that this cache cluster or replication group will be
-	// scaled to.
+	// The cache node type that this cache cluster or replication group is scaled
+	// to.
 	CacheNodeType *string `type:"string"`
 
-	// The new cache engine version that the cache cluster will run.
+	// The new cache engine version that the cache cluster runs.
 	EngineVersion *string `type:"string"`
 
 	// The new number of cache nodes for the cache cluster.
@@ -7212,7 +7374,7 @@ func (s PendingModifiedValues) GoString() string {
 	return s.String()
 }
 
-// Represents the input of a PurchaseReservedCacheNodesOffering action.
+// Represents the input of a PurchaseReservedCacheNodesOffering operation.
 type PurchaseReservedCacheNodesOfferingInput struct {
 	_ struct{} `type:"structure"`
 
@@ -7264,7 +7426,7 @@ func (s *PurchaseReservedCacheNodesOfferingInput) Validate() error {
 type PurchaseReservedCacheNodesOfferingOutput struct {
 	_ struct{} `type:"structure"`
 
-	// Represents the output of a PurchaseReservedCacheNodesOffering action.
+	// Represents the output of a PurchaseReservedCacheNodesOffering operation.
 	ReservedCacheNode *ReservedCacheNode `type:"structure"`
 }
 
@@ -7278,7 +7440,7 @@ func (s PurchaseReservedCacheNodesOfferingOutput) GoString() string {
 	return s.String()
 }
 
-// Represents the input of a RebootCacheCluster action.
+// Represents the input of a RebootCacheCluster operation.
 type RebootCacheClusterInput struct {
 	_ struct{} `type:"structure"`
 
@@ -7360,7 +7522,7 @@ func (s RecurringCharge) GoString() string {
 	return s.String()
 }
 
-// Represents the input of a RemoveTagsFromResource action.
+// Represents the input of a RemoveTagsFromResource operation.
 type RemoveTagsFromResourceInput struct {
 	_ struct{} `type:"structure"`
 
@@ -7368,15 +7530,13 @@ type RemoveTagsFromResourceInput struct {
 	// removed, for example arn:aws:elasticache:us-west-2:0123456789:cluster:myCluster
 	// or arn:aws:elasticache:us-west-2:0123456789:snapshot:mySnapshot.
 	//
-	// For more information on ARNs, go to Amazon Resource Names (ARNs) and AWS
+	// For more information about ARNs, see Amazon Resource Names (ARNs) and AWS
 	// Service Namespaces (http://docs.aws.amazon.com/general/latest/gr/aws-arns-and-namespaces.html).
 	//
 	// ResourceName is a required field
 	ResourceName *string `type:"string" required:"true"`
 
 	// A list of TagKeys identifying the tags you want removed from the named resource.
-	// For example, TagKeys.member.1=Region removes the cost allocation tag with
-	// the key name Region from the resource named by the ResourceName parameter.
 	//
 	// TagKeys is a required field
 	TagKeys []*string `type:"list" required:"true"`
@@ -7408,7 +7568,7 @@ func (s *RemoveTagsFromResourceInput) Validate() error {
 	return nil
 }
 
-// Contains all of the attributes of a specific replication group.
+// Contains all of the attributes of a specific Redis replication group.
 type ReplicationGroup struct {
 	_ struct{} `type:"structure"`
 
@@ -7418,8 +7578,14 @@ type ReplicationGroup struct {
 	//
 	//   Redis versions earlier than 2.8.6.
 	//
-	//   T1 and T2 cache node types.
+	//   Redis (cluster mode disabled):T1 and T2 cache node types.
+	//
+	// Redis (cluster mode enabled): T1 node types.
 	AutomaticFailover *string `type:"string" enum:"AutomaticFailoverStatus"`
+
+	// The configuration endpoint for this replicaiton group. Use the configuration
+	// endpoint to connect to this replication group.
+	ConfigurationEndpoint *Endpoint `type:"structure"`
 
 	// The description of the replication group.
 	Description *string `type:"string"`
@@ -7437,6 +7603,26 @@ type ReplicationGroup struct {
 
 	// The identifier for the replication group.
 	ReplicationGroupId *string `type:"string"`
+
+	// The number of days for which ElastiCache retains automatic cache cluster
+	// snapshots before deleting them. For example, if you set SnapshotRetentionLimit
+	// to 5, a snapshot that was taken today is retained for 5 days before being
+	// deleted.
+	//
+	//   If the value of SnapshotRetentionLimit is set to zero (0), backups are
+	// turned off.
+	SnapshotRetentionLimit *int64 `type:"integer"`
+
+	// The daily time range (in UTC) during which ElastiCache begins taking a daily
+	// snapshot of your node group (shard).
+	//
+	// Example: 05:00-09:00
+	//
+	// If you do not specify this parameter, ElastiCache automatically chooses
+	// an appropriate time range.
+	//
+	//  Note: This parameter is only valid if the Engine parameter is redis.
+	SnapshotWindow *string `type:"string"`
 
 	// The cache cluster ID that is used as the daily snapshot source for the replication
 	// group.
@@ -7456,21 +7642,23 @@ func (s ReplicationGroup) GoString() string {
 	return s.String()
 }
 
-// The settings to be applied to the replication group, either immediately or
-// during the next maintenance window.
+// The settings to be applied to the Redis replication group, either immediately
+// or during the next maintenance window.
 type ReplicationGroupPendingModifiedValues struct {
 	_ struct{} `type:"structure"`
 
-	// Indicates the status of Multi-AZ for this replication group.
+	// Indicates the status of Multi-AZ for this Redis replication group.
 	//
 	//  ElastiCache Multi-AZ replication groups are not supported on:
 	//
 	//   Redis versions earlier than 2.8.6.
 	//
-	//   T1 and T2 cache node types.
+	//   Redis (cluster mode disabled):T1 and T2 cache node types.
+	//
+	// Redis (cluster mode enabled): T1 node types.
 	AutomaticFailoverStatus *string `type:"string" enum:"PendingAutomaticFailoverStatus"`
 
-	// The primary cluster ID which will be applied immediately (if --apply-immediately
+	// The primary cluster ID that is applied immediately (if --apply-immediately
 	// was specified), or during the next maintenance window.
 	PrimaryClusterId *string `type:"string"`
 }
@@ -7485,7 +7673,7 @@ func (s ReplicationGroupPendingModifiedValues) GoString() string {
 	return s.String()
 }
 
-// Represents the output of a PurchaseReservedCacheNodesOffering action.
+// Represents the output of a PurchaseReservedCacheNodesOffering operation.
 type ReservedCacheNode struct {
 	_ struct{} `type:"structure"`
 
@@ -7499,7 +7687,8 @@ type ReservedCacheNode struct {
 	//   General purpose:
 	//
 	//   Current generation: cache.t2.micro, cache.t2.small, cache.t2.medium, cache.m3.medium,
-	// cache.m3.large, cache.m3.xlarge, cache.m3.2xlarge
+	// cache.m3.large, cache.m3.xlarge, cache.m3.2xlarge, cache.m4.large, cache.m4.xlarge,
+	// cache.m4.2xlarge, cache.m4.4xlarge, cache.m4.10xlarge
 	//
 	//   Previous generation: cache.t1.micro, cache.m1.small, cache.m1.medium,
 	// cache.m1.large, cache.m1.xlarge
@@ -7515,17 +7704,20 @@ type ReservedCacheNode struct {
 	//
 	//      Notes:
 	//
-	//   All t2 instances are created in an Amazon Virtual Private Cloud (VPC).
+	//   All T2 instances are created in an Amazon Virtual Private Cloud (Amazon
+	// VPC).
 	//
-	//   Redis backup/restore is not supported for t2 instances.
+	//   Redis backup/restore is not supported for Redis (cluster mode disabled)
+	// T1 and T2 instances. Backup/restore is supported on Redis (cluster mode enabled)
+	// T2 instances.
 	//
-	//   Redis Append-only files (AOF) functionality is not supported for t1 or
-	// t2 instances.
+	//   Redis Append-only files (AOF) functionality is not supported for T1 or
+	// T2 instances.
 	//
-	//   For a complete listing of cache node types and specifications, see Amazon
-	// ElastiCache Product Features and Details (http://aws.amazon.com/elasticache/details)
-	// and Cache Node Type-Specific Parameters for Memcached (http://docs.aws.amazon.com/AmazonElastiCache/latest/UserGuide/CacheParameterGroups.Memcached.html#CacheParameterGroups.Memcached.NodeSpecific)
-	// or Cache Node Type-Specific Parameters for Redis (http://docs.aws.amazon.com/AmazonElastiCache/latest/UserGuide/CacheParameterGroups.Redis.html#CacheParameterGroups.Redis.NodeSpecific).
+	//   For a complete listing of node types and specifications, see Amazon ElastiCache
+	// Product Features and Details (http://aws.amazon.com/elasticache/details)
+	// and either Cache Node Type-Specific Parameters for Memcached (http://docs.aws.amazon.com/AmazonElastiCache/latest/UserGuide/CacheParameterGroups.Memcached.html#ParameterGroups.Memcached.NodeSpecific)
+	// or Cache Node Type-Specific Parameters for Redis (http://docs.aws.amazon.com/AmazonElastiCache/latest/UserGuide/CacheParameterGroups.Redis.html#ParameterGroups.Redis.NodeSpecific).
 	CacheNodeType *string `type:"string"`
 
 	// The duration of the reservation in seconds.
@@ -7580,7 +7772,8 @@ type ReservedCacheNodesOffering struct {
 	//   General purpose:
 	//
 	//   Current generation: cache.t2.micro, cache.t2.small, cache.t2.medium, cache.m3.medium,
-	// cache.m3.large, cache.m3.xlarge, cache.m3.2xlarge
+	// cache.m3.large, cache.m3.xlarge, cache.m3.2xlarge, cache.m4.large, cache.m4.xlarge,
+	// cache.m4.2xlarge, cache.m4.4xlarge, cache.m4.10xlarge
 	//
 	//   Previous generation: cache.t1.micro, cache.m1.small, cache.m1.medium,
 	// cache.m1.large, cache.m1.xlarge
@@ -7596,17 +7789,20 @@ type ReservedCacheNodesOffering struct {
 	//
 	//      Notes:
 	//
-	//   All t2 instances are created in an Amazon Virtual Private Cloud (VPC).
+	//   All T2 instances are created in an Amazon Virtual Private Cloud (Amazon
+	// VPC).
 	//
-	//   Redis backup/restore is not supported for t2 instances.
+	//   Redis backup/restore is not supported for Redis (cluster mode disabled)
+	// T1 and T2 instances. Backup/restore is supported on Redis (cluster mode enabled)
+	// T2 instances.
 	//
-	//   Redis Append-only files (AOF) functionality is not supported for t1 or
-	// t2 instances.
+	//   Redis Append-only files (AOF) functionality is not supported for T1 or
+	// T2 instances.
 	//
-	//   For a complete listing of cache node types and specifications, see Amazon
-	// ElastiCache Product Features and Details (http://aws.amazon.com/elasticache/details)
-	// and Cache Node Type-Specific Parameters for Memcached (http://docs.aws.amazon.com/AmazonElastiCache/latest/UserGuide/CacheParameterGroups.Memcached.html#CacheParameterGroups.Memcached.NodeSpecific)
-	// or Cache Node Type-Specific Parameters for Redis (http://docs.aws.amazon.com/AmazonElastiCache/latest/UserGuide/CacheParameterGroups.Redis.html#CacheParameterGroups.Redis.NodeSpecific).
+	//   For a complete listing of node types and specifications, see Amazon ElastiCache
+	// Product Features and Details (http://aws.amazon.com/elasticache/details)
+	// and either Cache Node Type-Specific Parameters for Memcached (http://docs.aws.amazon.com/AmazonElastiCache/latest/UserGuide/CacheParameterGroups.Memcached.html#ParameterGroups.Memcached.NodeSpecific)
+	// or Cache Node Type-Specific Parameters for Redis (http://docs.aws.amazon.com/AmazonElastiCache/latest/UserGuide/CacheParameterGroups.Redis.html#ParameterGroups.Redis.NodeSpecific).
 	CacheNodeType *string `type:"string"`
 
 	// The duration of the offering. in seconds.
@@ -7641,7 +7837,7 @@ func (s ReservedCacheNodesOffering) GoString() string {
 	return s.String()
 }
 
-// Represents the input of a ResetCacheParameterGroup action.
+// Represents the input of a ResetCacheParameterGroup operation.
 type ResetCacheParameterGroupInput struct {
 	_ struct{} `type:"structure"`
 
@@ -7651,12 +7847,13 @@ type ResetCacheParameterGroupInput struct {
 	CacheParameterGroupName *string `type:"string" required:"true"`
 
 	// An array of parameter names to reset to their default values. If ResetAllParameters
-	// is false, you must specify the name of at least one parameter to reset.
+	// is true, do not use ParameterNameValues. If ResetAllParameters is false,
+	// you must specify the name of at least one parameter to reset.
 	ParameterNameValues []*ParameterNameValue `locationNameList:"ParameterNameValue" type:"list"`
 
-	// If true, all parameters in the cache parameter group will be reset to their
-	// default values. If false, only the parameters listed by ParameterNameValues
-	// are reset to their default values.
+	// If true, all parameters in the cache parameter group are reset to their default
+	// values. If false, only the parameters listed by ParameterNameValues are reset
+	// to their default values.
 	//
 	// Valid values: true | false
 	ResetAllParameters *bool `type:"boolean"`
@@ -7685,7 +7882,7 @@ func (s *ResetCacheParameterGroupInput) Validate() error {
 	return nil
 }
 
-// Represents the input of a RevokeCacheSecurityGroupIngress action.
+// Represents the input of a RevokeCacheSecurityGroupIngress operation.
 type RevokeCacheSecurityGroupIngressInput struct {
 	_ struct{} `type:"structure"`
 
@@ -7739,7 +7936,7 @@ func (s *RevokeCacheSecurityGroupIngressInput) Validate() error {
 type RevokeCacheSecurityGroupIngressOutput struct {
 	_ struct{} `type:"structure"`
 
-	// Represents the output of one of the following actions:
+	// Represents the output of one of the following operations:
 	//
 	//    AuthorizeCacheSecurityGroupIngress
 	//
@@ -7782,13 +7979,24 @@ func (s SecurityGroupMembership) GoString() string {
 	return s.String()
 }
 
-// Represents a copy of an entire cache cluster as of the time when the snapshot
-// was taken.
+// Represents a copy of an entire Redis cache cluster as of the time when the
+// snapshot was taken.
 type Snapshot struct {
 	_ struct{} `type:"structure"`
 
 	// This parameter is currently disabled.
 	AutoMinorVersionUpgrade *bool `type:"boolean"`
+
+	// Indicates the status of Multi-AZ for the source replication group.
+	//
+	//  ElastiCache Multi-AZ replication groups are not supported on:
+	//
+	//   Redis versions earlier than 2.8.6.
+	//
+	//   Redis (cluster mode disabled):T1 and T2 cache node types.
+	//
+	// Redis (cluster mode enabled): T1 node types.
+	AutomaticFailover *string `type:"string" enum:"AutomaticFailoverStatus"`
 
 	// The date and time when the source cache cluster was created.
 	CacheClusterCreateTime *time.Time `type:"timestamp" timestampFormat:"iso8601"`
@@ -7804,7 +8012,8 @@ type Snapshot struct {
 	//   General purpose:
 	//
 	//   Current generation: cache.t2.micro, cache.t2.small, cache.t2.medium, cache.m3.medium,
-	// cache.m3.large, cache.m3.xlarge, cache.m3.2xlarge
+	// cache.m3.large, cache.m3.xlarge, cache.m3.2xlarge, cache.m4.large, cache.m4.xlarge,
+	// cache.m4.2xlarge, cache.m4.4xlarge, cache.m4.10xlarge
 	//
 	//   Previous generation: cache.t1.micro, cache.m1.small, cache.m1.medium,
 	// cache.m1.large, cache.m1.xlarge
@@ -7820,17 +8029,20 @@ type Snapshot struct {
 	//
 	//      Notes:
 	//
-	//   All t2 instances are created in an Amazon Virtual Private Cloud (VPC).
+	//   All T2 instances are created in an Amazon Virtual Private Cloud (Amazon
+	// VPC).
 	//
-	//   Redis backup/restore is not supported for t2 instances.
+	//   Redis backup/restore is not supported for Redis (cluster mode disabled)
+	// T1 and T2 instances. Backup/restore is supported on Redis (cluster mode enabled)
+	// T2 instances.
 	//
-	//   Redis Append-only files (AOF) functionality is not supported for t1 or
-	// t2 instances.
+	//   Redis Append-only files (AOF) functionality is not supported for T1 or
+	// T2 instances.
 	//
-	//   For a complete listing of cache node types and specifications, see Amazon
-	// ElastiCache Product Features and Details (http://aws.amazon.com/elasticache/details)
-	// and Cache Node Type-Specific Parameters for Memcached (http://docs.aws.amazon.com/AmazonElastiCache/latest/UserGuide/CacheParameterGroups.Memcached.html#CacheParameterGroups.Memcached.NodeSpecific)
-	// or Cache Node Type-Specific Parameters for Redis (http://docs.aws.amazon.com/AmazonElastiCache/latest/UserGuide/CacheParameterGroups.Redis.html#CacheParameterGroups.Redis.NodeSpecific).
+	//   For a complete listing of node types and specifications, see Amazon ElastiCache
+	// Product Features and Details (http://aws.amazon.com/elasticache/details)
+	// and either Cache Node Type-Specific Parameters for Memcached (http://docs.aws.amazon.com/AmazonElastiCache/latest/UserGuide/CacheParameterGroups.Memcached.html#ParameterGroups.Memcached.NodeSpecific)
+	// or Cache Node Type-Specific Parameters for Redis (http://docs.aws.amazon.com/AmazonElastiCache/latest/UserGuide/CacheParameterGroups.Redis.html#ParameterGroups.Redis.NodeSpecific).
 	CacheNodeType *string `type:"string"`
 
 	// The cache parameter group that is associated with the source cache cluster.
@@ -7856,16 +8068,22 @@ type Snapshot struct {
 	// this value must be between 1 and 20.
 	NumCacheNodes *int64 `type:"integer"`
 
+	// The number of node groups (shards) in this snapshot. When restoring from
+	// a snapshot, the number of node groups (shards) in the snapshot and in the
+	// restored replication group must be the same.
+	NumNodeGroups *int64 `type:"integer"`
+
 	// The port number used by each cache nodes in the source cache cluster.
 	Port *int64 `type:"integer"`
 
 	// The name of the Availability Zone in which the source cache cluster is located.
 	PreferredAvailabilityZone *string `type:"string"`
 
-	// Specifies the weekly time range during which maintenance on the cache cluster
-	// is performed. It is specified as a range in the format ddd:hh24:mi-ddd:hh24:mi
-	// (24H Clock UTC). The minimum maintenance window is a 60 minute period. Valid
-	// values for ddd are:
+	// Specifies the weekly time range during which maintenance on the cluster is
+	// performed. It is specified as a range in the format ddd:hh24:mi-ddd:hh24:mi
+	// (24H Clock UTC). The minimum maintenance window is a 60 minute period.
+	//
+	// Valid values for ddd are:
 	//
 	//    sun
 	//
@@ -7881,20 +8099,26 @@ type Snapshot struct {
 	//
 	//    sat
 	//
-	//   Example: sun:05:00-sun:09:00
+	//   Example: sun:23:00-mon:01:30
 	PreferredMaintenanceWindow *string `type:"string"`
 
-	// The name of a snapshot. For an automatic snapshot, the name is system-generated;
-	// for a manual snapshot, this is the user-provided name.
+	// A description of the source replication group.
+	ReplicationGroupDescription *string `type:"string"`
+
+	// The unique identifier of the source replication group.
+	ReplicationGroupId *string `type:"string"`
+
+	// The name of a snapshot. For an automatic snapshot, the name is system-generated.
+	// For a manual snapshot, this is the user-provided name.
 	SnapshotName *string `type:"string"`
 
-	// For an automatic snapshot, the number of days for which ElastiCache will
-	// retain the snapshot before deleting it.
+	// For an automatic snapshot, the number of days for which ElastiCache retains
+	// the snapshot before deleting it.
 	//
 	// For manual snapshots, this field reflects the SnapshotRetentionLimit for
 	// the source cache cluster when the snapshot was created. This field is otherwise
 	// ignored: Manual snapshots do not expire, and can only be deleted using the
-	// DeleteSnapshot action.
+	// DeleteSnapshot operation.
 	//
 	//  Important If the value of SnapshotRetentionLimit is set to zero (0), backups
 	// are turned off.
@@ -7978,7 +8202,7 @@ func (s Tag) GoString() string {
 }
 
 // Represents the output from the AddTagsToResource, ListTagsOnResource, and
-// RemoveTagsFromResource actions.
+// RemoveTagsFromResource operations.
 type TagListMessage struct {
 	_ struct{} `type:"structure"`
 
@@ -8046,4 +8270,7 @@ const (
 
 	// SourceTypeCacheSubnetGroup is a SourceType enum value
 	SourceTypeCacheSubnetGroup = "cache-subnet-group"
+
+	// SourceTypeReplicationGroup is a SourceType enum value
+	SourceTypeReplicationGroup = "replication-group"
 )

--- a/service/elasticache/examples_test.go
+++ b/service/elasticache/examples_test.go
@@ -271,8 +271,21 @@ func ExampleElastiCache_CreateReplicationGroup() {
 		CacheSubnetGroupName: aws.String("String"),
 		Engine:               aws.String("String"),
 		EngineVersion:        aws.String("String"),
+		NodeGroupConfiguration: []*elasticache.NodeGroupConfiguration{
+			{ // Required
+				PrimaryAvailabilityZone: aws.String("String"),
+				ReplicaAvailabilityZones: []*string{
+					aws.String("String"), // Required
+					// More values...
+				},
+				ReplicaCount: aws.Int64(1),
+				Slots:        aws.String("String"),
+			},
+			// More values...
+		},
 		NotificationTopicArn: aws.String("String"),
 		NumCacheClusters:     aws.Int64(1),
+		NumNodeGroups:        aws.Int64(1),
 		Port:                 aws.Int64(1),
 		PreferredCacheClusterAZs: []*string{
 			aws.String("String"), // Required
@@ -280,6 +293,7 @@ func ExampleElastiCache_CreateReplicationGroup() {
 		},
 		PreferredMaintenanceWindow: aws.String("String"),
 		PrimaryClusterId:           aws.String("String"),
+		ReplicasPerNodeGroup:       aws.Int64(1),
 		SecurityGroupIds: []*string{
 			aws.String("String"), // Required
 			// More values...
@@ -322,8 +336,9 @@ func ExampleElastiCache_CreateSnapshot() {
 	svc := elasticache.New(sess)
 
 	params := &elasticache.CreateSnapshotInput{
-		CacheClusterId: aws.String("String"), // Required
-		SnapshotName:   aws.String("String"), // Required
+		SnapshotName:       aws.String("String"), // Required
+		CacheClusterId:     aws.String("String"),
+		ReplicationGroupId: aws.String("String"),
 	}
 	resp, err := svc.CreateSnapshot(params)
 
@@ -816,11 +831,13 @@ func ExampleElastiCache_DescribeSnapshots() {
 	svc := elasticache.New(sess)
 
 	params := &elasticache.DescribeSnapshotsInput{
-		CacheClusterId: aws.String("String"),
-		Marker:         aws.String("String"),
-		MaxRecords:     aws.Int64(1),
-		SnapshotName:   aws.String("String"),
-		SnapshotSource: aws.String("String"),
+		CacheClusterId:      aws.String("String"),
+		Marker:              aws.String("String"),
+		MaxRecords:          aws.Int64(1),
+		ReplicationGroupId:  aws.String("String"),
+		ShowNodeGroupConfig: aws.Bool(true),
+		SnapshotName:        aws.String("String"),
+		SnapshotSource:      aws.String("String"),
 	}
 	resp, err := svc.DescribeSnapshots(params)
 

--- a/service/elasticache/service.go
+++ b/service/elasticache/service.go
@@ -14,9 +14,9 @@ import (
 // Amazon ElastiCache is a web service that makes it easier to set up, operate,
 // and scale a distributed cache in the cloud.
 //
-// With ElastiCache, customers gain all of the benefits of a high-performance,
-// in-memory cache with far less of the administrative burden of launching and
-// managing a distributed cache. The service makes setup, scaling, and cluster
+// With ElastiCache, customers get all of the benefits of a high-performance,
+// in-memory cache with less of the administrative burden involved in launching
+// and managing a distributed cache. The service makes setup, scaling, and cluster
 // failure handling much simpler than in a self-managed cache deployment.
 //
 // In addition, through integration with Amazon CloudWatch, customers get enhanced


### PR DESCRIPTION
Release v1.4.16
===

Service Model Updates
---
* `service/ecr`: Update Amazon EC2 Container Registry service model
  * DescribeImages is a new api used to expose image metadata which today includes image size and image creation timestamp.
* `service/elasticache`: Update Amazon ElastiCache service model
  * Elasticache is launching a new major engine release of Redis, 3.2 (providing stability updates and new command sets over 2.8), as well as ElasticSupport for enabling Redis Cluster in 3.2, which provides support for multiple node groups to horizontally scale data, as well as superior engine failover capabilities

SDK Bug Fixes
---
* `aws/session`: Skip shared config on read errors (#883)
* `aws/signer/v4`: Add support for URL.EscapedPath to signer (#885)

SDK Features
---
* `private/model/api`: Add docs for errors to API operations (#881)
* `private/model/api`: Improve field and waiter doc strings (#879)
* `service/dynamodb/dynamodbattribute`: Allow multiple struct tag elements (#886)
* Add build tags to internal SDK tools (#880)