### PR TITLE
Fix codegen build tags to be used in all cases not just main files

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -47,16 +47,15 @@ gen-endpoints:
 
 build:
 	@echo "go build SDK and vendor packages"
-	@go build ${SDK_ONLY_PKGS}
-	@go build -tags example ./example/...
+	@go build -tags example,codegen ${SDK_ONLY_PKGS}
 
 unit: get-deps-tests build verify
 	@echo "go test SDK and vendor packages"
-	@go test $(SDK_ONLY_PKGS)
+	@go test -tags example,codegen $(SDK_ONLY_PKGS)
 
 unit-with-race-cover: get-deps-tests build verify
 	@echo "go test SDK and vendor packages"
-	@go test -race -cpu=1,2,4 $(SDK_ONLY_PKGS)
+	@go test -tags example,codegen -race -cpu=1,2,4 $(SDK_ONLY_PKGS)
 
 integration: get-deps-tests integ-custom smoke-tests performance
 

--- a/awsmigrate/awsmigrate-renamer/renamer.go
+++ b/awsmigrate/awsmigrate-renamer/renamer.go
@@ -2,7 +2,7 @@
 
 package main
 
-//go:generate go run gen/gen.go
+//go:generate go run -tags deprecated gen/gen.go
 
 import (
 	"os"

--- a/private/endpoints/endpoints.go
+++ b/private/endpoints/endpoints.go
@@ -1,7 +1,7 @@
 // Package endpoints validates regional endpoints for services.
 package endpoints
 
-//go:generate go run ../model/cli/gen-endpoints/main.go endpoints.json endpoints_map.go
+//go:generate go run -tags codegen ../model/cli/gen-endpoints/main.go endpoints.json endpoints_map.go
 //go:generate gofmt -s -w endpoints_map.go
 
 import (

--- a/private/model/api/api.go
+++ b/private/model/api/api.go
@@ -1,3 +1,5 @@
+// +build codegen
+
 // Package api represents API abstractions for rendering service generated files.
 package api
 

--- a/private/model/api/api_test.go
+++ b/private/model/api/api_test.go
@@ -1,4 +1,4 @@
-// +build 1.6
+// +build 1.6,codegen
 
 package api
 

--- a/private/model/api/customization_passes.go
+++ b/private/model/api/customization_passes.go
@@ -1,3 +1,5 @@
+// +build codegen
+
 package api
 
 import (

--- a/private/model/api/docstring.go
+++ b/private/model/api/docstring.go
@@ -1,3 +1,5 @@
+// +build codegen
+
 package api
 
 import (

--- a/private/model/api/exportable_name.go
+++ b/private/model/api/exportable_name.go
@@ -1,3 +1,5 @@
+// +build codegen
+
 package api
 
 import "strings"

--- a/private/model/api/load.go
+++ b/private/model/api/load.go
@@ -1,3 +1,5 @@
+// +build codegen
+
 package api
 
 import (

--- a/private/model/api/load_test.go
+++ b/private/model/api/load_test.go
@@ -1,4 +1,4 @@
-// +build 1.6
+// +build 1.6,codegen
 
 package api
 

--- a/private/model/api/operation.go
+++ b/private/model/api/operation.go
@@ -1,3 +1,5 @@
+// +build codegen
+
 package api
 
 import (

--- a/private/model/api/pagination.go
+++ b/private/model/api/pagination.go
@@ -1,3 +1,5 @@
+// +build codegen
+
 package api
 
 import (

--- a/private/model/api/param_filler.go
+++ b/private/model/api/param_filler.go
@@ -1,3 +1,5 @@
+// +build codegen
+
 package api
 
 import (

--- a/private/model/api/passes.go
+++ b/private/model/api/passes.go
@@ -1,3 +1,5 @@
+// +build codegen
+
 package api
 
 import (

--- a/private/model/api/shape.go
+++ b/private/model/api/shape.go
@@ -1,3 +1,5 @@
+// +build codegen
+
 package api
 
 import (

--- a/private/model/api/shape_validation.go
+++ b/private/model/api/shape_validation.go
@@ -1,3 +1,5 @@
+// +build codegen
+
 package api
 
 import (

--- a/private/model/api/shapetag_test.go
+++ b/private/model/api/shapetag_test.go
@@ -1,4 +1,4 @@
-// +build 1.6
+// +build 1.6,codegen
 
 package api_test
 

--- a/private/model/api/waiters.go
+++ b/private/model/api/waiters.go
@@ -1,3 +1,5 @@
+// +build codegen
+
 package api
 
 import (

--- a/private/model/endpoints.go
+++ b/private/model/endpoints.go
@@ -1,3 +1,5 @@
+// +build codegen
+
 package model
 
 import (

--- a/private/protocol/ec2query/build.go
+++ b/private/protocol/ec2query/build.go
@@ -1,7 +1,7 @@
 // Package ec2query provides serialization of AWS EC2 requests and responses.
 package ec2query
 
-//go:generate go run ../../../models/protocol_tests/generate.go ../../../models/protocol_tests/input/ec2.json build_test.go
+//go:generate go run -tags codegen ../../../models/protocol_tests/generate.go ../../../models/protocol_tests/input/ec2.json build_test.go
 
 import (
 	"net/url"

--- a/private/protocol/ec2query/unmarshal.go
+++ b/private/protocol/ec2query/unmarshal.go
@@ -1,6 +1,6 @@
 package ec2query
 
-//go:generate go run ../../../models/protocol_tests/generate.go ../../../models/protocol_tests/output/ec2.json unmarshal_test.go
+//go:generate go run -tags codegen ../../../models/protocol_tests/generate.go ../../../models/protocol_tests/output/ec2.json unmarshal_test.go
 
 import (
 	"encoding/xml"

--- a/private/protocol/jsonrpc/jsonrpc.go
+++ b/private/protocol/jsonrpc/jsonrpc.go
@@ -2,8 +2,8 @@
 // requests and responses.
 package jsonrpc
 
-//go:generate go run ../../../models/protocol_tests/generate.go ../../../models/protocol_tests/input/json.json build_test.go
-//go:generate go run ../../../models/protocol_tests/generate.go ../../../models/protocol_tests/output/json.json unmarshal_test.go
+//go:generate go run -tags codegen ../../../models/protocol_tests/generate.go ../../../models/protocol_tests/input/json.json build_test.go
+//go:generate go run -tags codegen ../../../models/protocol_tests/generate.go ../../../models/protocol_tests/output/json.json unmarshal_test.go
 
 import (
 	"encoding/json"

--- a/private/protocol/query/build.go
+++ b/private/protocol/query/build.go
@@ -1,7 +1,7 @@
 // Package query provides serialization of AWS query requests, and responses.
 package query
 
-//go:generate go run ../../../models/protocol_tests/generate.go ../../../models/protocol_tests/input/query.json build_test.go
+//go:generate go run -tags codegen ../../../models/protocol_tests/generate.go ../../../models/protocol_tests/input/query.json build_test.go
 
 import (
 	"net/url"

--- a/private/protocol/query/unmarshal.go
+++ b/private/protocol/query/unmarshal.go
@@ -1,6 +1,6 @@
 package query
 
-//go:generate go run ../../../models/protocol_tests/generate.go ../../../models/protocol_tests/output/query.json unmarshal_test.go
+//go:generate go run -tags codegen ../../../models/protocol_tests/generate.go ../../../models/protocol_tests/output/query.json unmarshal_test.go
 
 import (
 	"encoding/xml"

--- a/private/protocol/restjson/restjson.go
+++ b/private/protocol/restjson/restjson.go
@@ -2,8 +2,8 @@
 // requests and responses.
 package restjson
 
-//go:generate go run ../../../models/protocol_tests/generate.go ../../../models/protocol_tests/input/rest-json.json build_test.go
-//go:generate go run ../../../models/protocol_tests/generate.go ../../../models/protocol_tests/output/rest-json.json unmarshal_test.go
+//go:generate go run -tags codegen ../../../models/protocol_tests/generate.go ../../../models/protocol_tests/input/rest-json.json build_test.go
+//go:generate go run -tags codegen ../../../models/protocol_tests/generate.go ../../../models/protocol_tests/output/rest-json.json unmarshal_test.go
 
 import (
 	"encoding/json"

--- a/private/protocol/restxml/restxml.go
+++ b/private/protocol/restxml/restxml.go
@@ -2,8 +2,8 @@
 // requests and responses.
 package restxml
 
-//go:generate go run ../../../models/protocol_tests/generate.go ../../../models/protocol_tests/input/rest-xml.json build_test.go
-//go:generate go run ../../../models/protocol_tests/generate.go ../../../models/protocol_tests/output/rest-xml.json unmarshal_test.go
+//go:generate go run -tags codegen ../../../models/protocol_tests/generate.go ../../../models/protocol_tests/input/rest-xml.json build_test.go
+//go:generate go run -tags codegen ../../../models/protocol_tests/generate.go ../../../models/protocol_tests/output/rest-xml.json unmarshal_test.go
 
 import (
 	"bytes"

--- a/service/generate.go
+++ b/service/generate.go
@@ -1,5 +1,5 @@
 // Package service contains automatically generated AWS clients.
 package service
 
-//go:generate go run ../private/model/cli/gen-api/main.go -path=../service ../models/apis/*/*/api-2.json
+//go:generate go run -tags codegen ../private/model/cli/gen-api/main.go -path=../service ../models/apis/*/*/api-2.json
 //go:generate gofmt -s -w ../service


### PR DESCRIPTION
Adds build tags for all of the SDK's code gen logic. Since the code gen is only for SDK development this will prevents the code gen packages and dependencies from impacting normal usage runtime environments.

Any non-std lib dependency added to the code gen packages will need to be explicitly retrieved because `go get` will ignore the tagged files.

e.g.

```makefile
get-codegen-deps:
    @go get golang.org/x/net/html
```