### PR TITLE
Changed refs for session.New to session.NewSession

### DIFF
--- a/README.md
+++ b/README.md
@@ -17,7 +17,7 @@ If you are using Go 1.5 with the `GO15VENDOREXPERIMENT=1` vendoring flag, or 1.6
 
     go get -u github.com/aws/aws-sdk-go
 
-Otherwise if your Go environment does not have vendoring support enabled, or you do not want to include the vendored SDK's dependencies you can use the following command to retrieve the SDK and its non-testing dependencies using `go get`. 
+Otherwise if your Go environment does not have vendoring support enabled, or you do not want to include the vendored SDK's dependencies you can use the following command to retrieve the SDK and its non-testing dependencies using `go get`.
 
     go get -u github.com/aws/aws-sdk-go/aws/...
     go get -u github.com/aws/aws-sdk-go/service/...
@@ -25,7 +25,7 @@ Otherwise if your Go environment does not have vendoring support enabled, or you
 If you're looking to retrieve just the SDK without any dependencies use the following command.
 
     go get -d github.com/aws/aws-sdk-go/
- 
+
 These two processes will still include the `vendor` folder and it should be deleted if its not going to be used by your environment.
 
     rm -rf $GOPATH/src/github.com/aws/aws-sdk-go/vendor
@@ -87,7 +87,7 @@ func main() {
 	// Create an EC2 service object in the "us-west-2" region
 	// Note that you can also configure your region globally by
 	// exporting the AWS_REGION environment variable
-	svc := ec2.New(session.New(), &aws.Config{Region: aws.String("us-west-2")})
+	svc := ec2.New(session.NewSession(), &aws.Config{Region: aws.String("us-west-2")})
 
 	// Call the DescribeInstances Operation
 	resp, err := svc.DescribeInstances(nil)

--- a/aws/session/doc.go
+++ b/aws/session/doc.go
@@ -66,7 +66,7 @@ through code instead of being driven by environment variables only.
 Use NewSessionWithOptions when you want to provide the config profile, or
 override the shared config state (AWS_SDK_LOAD_CONFIG).
 
-	// Equivalent to session.New
+	// Equivalent to session.NewSession()
 	sess, err := session.NewSessionWithOptions(session.Options{})
 
 	// Specify profile to load for the session's config


### PR DESCRIPTION
Changed some references of the deprecated `session.New` in the documentation to `session.NewSession`.

Also dropped trailing spaces in README.md