### PR TITLE
Fix Test for Go Tip

### DIFF
--- a/aws/corehandlers/handlers_test.go
+++ b/aws/corehandlers/handlers_test.go
@@ -161,7 +161,9 @@ func setupContentLengthTestServer(t *testing.T, hasContentLength bool, contentLe
 	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 		_, ok := r.Header["Content-Length"]
 		assert.Equal(t, hasContentLength, ok, "expect content length to be set, %t", hasContentLength)
-		assert.Equal(t, contentLength, r.ContentLength)
+		if hasContentLength {
+			assert.Equal(t, contentLength, r.ContentLength)
+		}
 
 		b, err := ioutil.ReadAll(r.Body)
 		assert.NoError(t, err)

--- a/awstesting/sandbox/Dockerfile.golang-tip
+++ b/awstesting/sandbox/Dockerfile.golang-tip
@@ -3,8 +3,7 @@
 # https://github.com/docker-library/golang/blob/master/1.6/wheezy/Dockerfile
 FROM buildpack-deps:wheezy-scm
 
-ENV GOLANG_VERSION tip
-ENV GOLANG_SRC_REPO_URL https://go.googlesource.com/go
+ENV GOLANG_SRC_REPO_URL https://github.com/golang/go
 
 ENV GOLANG_BOOTSTRAP_URL https://storage.googleapis.com/golang/go1.4.3.linux-amd64.tar.gz
 ENV GOLANG_BOOTSTRAP_SHA256 ce3140662f45356eb78bc16a88fc7cfb29fb00e18d7c632608245b789b2086d2


### PR DESCRIPTION
Test was incorrectly checking the content length value when it shouldn't of have.