### PR TITLE
Convert dynamo large Numeric value to Int64 when UseNumber is true

### DIFF
--- a/service/dynamodb/dynamodbattribute/decode.go
+++ b/service/dynamodb/dynamodbattribute/decode.go
@@ -346,11 +346,11 @@ func (d *Decoder) decodeNumber(n *string, v reflect.Value) error {
 
 func (d *Decoder) decodeNumberToInterface(n *string) (interface{}, error) {
 	if d.UseNumber {
-		return Number(*n), nil
+		return Number(*n).Int64()
 	}
 
 	// Default to float64 for all numbers
-	return strconv.ParseFloat(*n, 64)
+	return Number(*n).Float64()
 }
 
 func (d *Decoder) decodeNumberSet(ns []*string, v reflect.Value) error {

--- a/service/dynamodb/dynamodbattribute/decode_test.go
+++ b/service/dynamodb/dynamodbattribute/decode_test.go
@@ -415,9 +415,11 @@ func TestDecodeUseNumber(t *testing.T) {
 	assert.NoError(t, err)
 
 	assert.Equal(t, "value", u["abc"])
-	n, ok := u["def"].(Number)
+
+	n, ok := u["def"]
+
 	assert.True(t, ok)
-	assert.Equal(t, "123", n.String())
+	assert.Equal(t, int64(123), n)
 	assert.Equal(t, true, u["ghi"])
 }
 


### PR DESCRIPTION
This fixes an issue related with number unmarshaling where large Dynamo Numeric values are converted into strings instead of the appropriated Integer type when UseNumber was set to true on the decoder.
